### PR TITLE
LibWeb: Avoid allocating DOMRect objects for internal engine use

### DIFF
--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -254,8 +254,11 @@ public:
     bool is_void_element() const;
     bool serializes_as_void() const;
 
-    GC::Ref<Geometry::DOMRect> get_bounding_client_rect() const;
-    GC::Ref<Geometry::DOMRectList> get_client_rects() const;
+    [[nodiscard]] CSSPixelRect get_bounding_client_rect() const;
+    [[nodiscard]] GC::Ref<Geometry::DOMRect> get_bounding_client_rect_for_bindings() const;
+
+    [[nodiscard]] Vector<CSSPixelRect> get_client_rects() const;
+    [[nodiscard]] GC::Ref<Geometry::DOMRectList> get_client_rects_for_bindings() const;
 
     virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>);
     virtual void adjust_computed_style(CSS::ComputedProperties&) { }

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -84,8 +84,8 @@ interface Element : Node {
     readonly attribute Element? previousElementSibling;
 
     // https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface
-    DOMRectList getClientRects();
-    DOMRect getBoundingClientRect();
+    [ImplementedAs=get_client_rects_for_bindings] DOMRectList getClientRects();
+    [ImplementedAs=get_bounding_client_rect_for_bindings] DOMRect getBoundingClientRect();
 
     boolean checkVisibility(optional CheckVisibilityOptions options = {});
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -1180,11 +1180,9 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
             // areas returned by invoking getClientRects() on the element.
             if (contains_node(*node) && !contains_node(*node->parent())) {
                 auto const& element = static_cast<DOM::Element const&>(*node);
-                GC::Ref<Geometry::DOMRectList> const element_rects = element.get_client_rects();
-                for (u32 i = 0; i < element_rects->length(); i++) {
-                    auto rect = element_rects->item(i);
-                    rects.append(Geometry::DOMRect::create(realm(),
-                        Gfx::FloatRect(rect->x(), rect->y(), rect->width(), rect->height())));
+                auto const element_rects = element.get_client_rects();
+                for (auto& rect : element_rects) {
+                    rects.append(MUST(Geometry::DOMRect::construct_impl(realm(), static_cast<double>(rect.x()), static_cast<double>(rect.y()), static_cast<double>(rect.width()), static_cast<double>(rect.height()))));
                 }
             }
         } else if (node_type == NodeType::TEXT_NODE) {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1238,7 +1238,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
         double minimum = *min();
         double maximum = *max();
         // FIXME: Snap new value to input steps
-        MUST(set_value_as_number(clamp(round(((client_x - rect->left()) / rect->width()) * (maximum - minimum) + minimum), minimum, maximum)));
+        MUST(set_value_as_number(clamp(round(((client_x - rect.left().to_double()) / rect.width().to_double()) * (maximum - minimum) + minimum), minimum, maximum)));
         user_interaction_did_change_input_value();
     };
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -499,8 +499,8 @@ void HTMLSelectElement::show_the_picker_if_applicable()
     // Request select dropdown
     auto weak_element = make_weak_ptr<HTMLSelectElement>();
     auto rect = get_bounding_client_rect();
-    auto position = document().navigable()->to_top_level_position(Web::CSSPixelPoint { rect->x(), rect->y() + rect->height() });
-    document().page().did_request_select_dropdown(weak_element, position, CSSPixels(rect->width()), m_select_items);
+    auto position = document().navigable()->to_top_level_position(Web::CSSPixelPoint { rect.x(), rect.bottom() });
+    document().page().did_request_select_dropdown(weak_element, position, rect.width(), m_select_items);
     set_is_open(true);
 }
 

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -283,8 +283,7 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
 
         // Otherwise,
         //    it’s the result of getting the bounding box for the intersection root.
-        auto bounding_client_rect = element->get_bounding_client_rect();
-        rect = CSSPixelRect(bounding_client_rect->x(), bounding_client_rect->y(), bounding_client_rect->width(), bounding_client_rect->height());
+        rect = element->get_bounding_client_rect();
     }
 
     // When calculating the root intersection rectangle for a same-origin-domain target, the rectangle is then

--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -160,8 +160,8 @@ static CSSPixelPoint get_parent_offset(HTML::BrowsingContext const& browsing_con
         // 9. Add containerRect.left + borderLeftWidth to offsetLeft.
         // 10. Add containerRect.top + borderTopWidth to offsetTop.
         offset.translate_by(
-            CSSPixels { container_rect->left() } + border_left_width,
-            CSSPixels { container_rect->top() } + border_top_width);
+            container_rect.left() + border_left_width,
+            container_rect.top() + border_top_width);
     }
 
     // 5. Return (offsetLeft, offsetTop).

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -393,7 +393,7 @@ GC::RootVector<GC::Ref<Web::DOM::Element>> pointer_interactable_tree(Web::HTML::
     auto rectangles = element.get_client_rects();
 
     // 3. If rectangles has the length of 0, return an empty sequence.
-    if (rectangles->length() == 0)
+    if (rectangles.is_empty())
         return GC::RootVector<GC::Ref<Web::DOM::Element>>(browsing_context.heap());
 
     // 4. Let center point be the in-view center point of the first indexed element in rectangles.
@@ -530,20 +530,19 @@ String element_rendered_text(DOM::Node& node)
 CSSPixelPoint in_view_center_point(DOM::Element const& element, CSSPixelRect viewport)
 {
     // 1. Let rectangle be the first element of the DOMRect sequence returned by calling getClientRects() on element.
-    auto const* rectangle = element.get_client_rects()->item(0);
-    VERIFY(rectangle);
+    auto rectangle = element.get_client_rects().first();
 
     // 2. Let left be max(0, min(x coordinate, x coordinate + width dimension)).
-    auto left = max(0.0, min(rectangle->x(), rectangle->x() + rectangle->width()));
+    auto left = max(CSSPixels(0), min(rectangle.x(), rectangle.x() + rectangle.width()));
 
     // 3. Let right be min(innerWidth, max(x coordinate, x coordinate + width dimension)).
-    auto right = min(viewport.width().to_double(), max(rectangle->x(), rectangle->x() + rectangle->width()));
+    auto right = min(viewport.width(), max(rectangle.x(), rectangle.x() + rectangle.width()));
 
     // 4. Let top be max(0, min(y coordinate, y coordinate + height dimension)).
-    auto top = max(0.0, min(rectangle->y(), rectangle->y() + rectangle->height()));
+    auto top = max(CSSPixels(0), min(rectangle.y(), rectangle.y() + rectangle.height()));
 
     // 5. Let bottom be min(innerHeight, max(y coordinate, y coordinate + height dimension)).
-    auto bottom = min(viewport.height().to_double(), max(rectangle->y(), rectangle->y() + rectangle->height()));
+    auto bottom = min(viewport.height(), max(rectangle.y(), rectangle.y() + rectangle.height()));
 
     // 6. Let x be floor((left + right) ÷ 2.0).
     auto x = floor((left + right) / 2.0);

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -3090,7 +3090,7 @@ void WebDriverConnection::delete_cookies(Optional<StringView> const& name)
 }
 
 // https://w3c.github.io/webdriver/#dfn-calculate-the-absolute-position
-Gfx::IntPoint WebDriverConnection::calculate_absolute_position_of_element(GC::Ref<Web::Geometry::DOMRect> rect)
+Gfx::IntPoint WebDriverConnection::calculate_absolute_position_of_element(Web::CSSPixelRect rect)
 {
     // 1. Let rect be the value returned by calling getBoundingClientRect().
 
@@ -3098,10 +3098,10 @@ Gfx::IntPoint WebDriverConnection::calculate_absolute_position_of_element(GC::Re
     auto const* window = current_top_level_browsing_context()->active_window();
 
     // 3. Let x be (scrollX of window + rect’s x coordinate).
-    auto x = (window ? static_cast<int>(window->scroll_x()) : 0) + static_cast<int>(rect->x());
+    auto x = (window ? static_cast<int>(window->scroll_x()) : 0) + static_cast<int>(rect.x());
 
     // 4. Let y be (scrollY of window + rect’s y coordinate).
-    auto y = (window ? static_cast<int>(window->scroll_y()) : 0) + static_cast<int>(rect->y());
+    auto y = (window ? static_cast<int>(window->scroll_y()) : 0) + static_cast<int>(rect.y());
 
     // 5. Return a pair of (x, y).
     return { x, y };
@@ -3115,8 +3115,8 @@ Gfx::IntRect WebDriverConnection::calculate_absolute_rect_of_element(Web::DOM::E
     return {
         coordinates.x(),
         coordinates.y(),
-        static_cast<int>(bounding_rect->width()),
-        static_cast<int>(bounding_rect->height())
+        static_cast<int>(bounding_rect.width()),
+        static_cast<int>(bounding_rect.height())
     };
 }
 

--- a/Services/WebContent/WebDriverConnection.h
+++ b/Services/WebContent/WebDriverConnection.h
@@ -137,7 +137,7 @@ private:
     using OnNavigationComplete = GC::Ref<GC::Function<void(Web::WebDriver::Response)>>;
     void wait_for_navigation_to_complete(OnNavigationComplete);
 
-    Gfx::IntPoint calculate_absolute_position_of_element(GC::Ref<Web::Geometry::DOMRect> rect);
+    Gfx::IntPoint calculate_absolute_position_of_element(Web::CSSPixelRect);
     Gfx::IntRect calculate_absolute_rect_of_element(Web::DOM::Element const& element);
 
     using GetStartNode = GC::Ref<GC::Function<ErrorOr<GC::Ref<Web::DOM::ParentNode>, Web::WebDriver::Error>()>>;


### PR DESCRIPTION
Instead of bothering the GC heap with a bunch of DOMRect allocations, we can just pass around CSSPixelRect internally in many cases.

Before this change, we were generating so much DOMRect garbage that we had to do a garbage collection *every frame* on the Immich demo. This was due to the large number of intersection observers checked.

We still need to relax way more when idle, but for comparison, before this change, when doing nothing for 10 seconds on Immich, we'd spend 2.5 seconds updating intersection observers. After this change, we now spend 600 ms.