### PR TITLE
LibJS: Make IteratorRecord inherit from Cell, not Object

### DIFF
--- a/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -211,7 +211,7 @@ GC::Ref<IteratorRecord> create_async_from_sync_iterator(VM& vm, GC::Ref<Iterator
     auto next_method = MUST(async_iterator->get(vm.names.next));
 
     // 4. Let iteratorRecord be the Iterator Record { [[Iterator]]: asyncIterator, [[NextMethod]]: nextMethod, [[Done]]: false }.
-    auto iterator_record = realm.create<IteratorRecord>(realm, async_iterator, next_method, false);
+    auto iterator_record = vm.heap().allocate<IteratorRecord>(async_iterator, next_method, false);
 
     // 5. Return iteratorRecord.
     return iterator_record;

--- a/Libraries/LibJS/Runtime/Iterator.cpp
+++ b/Libraries/LibJS/Runtime/Iterator.cpp
@@ -31,7 +31,7 @@ Iterator::Iterator(Object& prototype, GC::Ref<IteratorRecord> iterated)
 }
 
 Iterator::Iterator(Object& prototype)
-    : Iterator(prototype, prototype.shape().realm().create<IteratorRecord>(prototype.shape().realm(), nullptr, js_undefined(), false))
+    : Iterator(prototype, prototype.heap().allocate<IteratorRecord>(nullptr, js_undefined(), false))
 {
 }
 
@@ -43,8 +43,7 @@ ThrowCompletionOr<GC::Ref<IteratorRecord>> get_iterator_direct(VM& vm, Object& o
 
     // 2. Let iteratorRecord be Record { [[Iterator]]: obj, [[NextMethod]]: nextMethod, [[Done]]: false }.
     // 3. Return iteratorRecord.
-    auto& realm = *vm.current_realm();
-    return realm.create<IteratorRecord>(realm, object, next_method, false);
+    return vm.heap().allocate<IteratorRecord>(object, next_method, false);
 }
 
 // 7.4.3 GetIteratorFromMethod ( obj, method ), https://tc39.es/ecma262/#sec-getiteratorfrommethod
@@ -61,8 +60,7 @@ ThrowCompletionOr<GC::Ref<IteratorRecord>> get_iterator_from_method(VM& vm, Valu
     auto next_method = TRY(iterator.get(vm, vm.names.next));
 
     // 4. Let iteratorRecord be the Iterator Record { [[Iterator]]: iterator, [[NextMethod]]: nextMethod, [[Done]]: false }.
-    auto& realm = *vm.current_realm();
-    auto iterator_record = realm.create<IteratorRecord>(realm, iterator.as_object(), next_method, false);
+    auto iterator_record = vm.heap().allocate<IteratorRecord>(iterator.as_object(), next_method, false);
 
     // 5. Return iteratorRecord.
     return iterator_record;

--- a/Libraries/LibJS/Runtime/Iterator.h
+++ b/Libraries/LibJS/Runtime/Iterator.h
@@ -17,14 +17,13 @@
 namespace JS {
 
 // 7.4.1 Iterator Records, https://tc39.es/ecma262/#sec-iterator-records
-class IteratorRecord final : public Object {
-    JS_OBJECT(IteratorRecord, Object);
+class IteratorRecord final : public Cell {
+    GC_CELL(IteratorRecord, Cell);
     GC_DECLARE_ALLOCATOR(IteratorRecord);
 
 public:
-    IteratorRecord(Realm& realm, GC::Ptr<Object> iterator, Value next_method, bool done)
-        : Object(ConstructWithoutPrototypeTag::Tag, realm)
-        , iterator(iterator)
+    IteratorRecord(GC::Ptr<Object> iterator, Value next_method, bool done)
+        : iterator(iterator)
         , next_method(next_method)
         , done(done)
     {
@@ -36,11 +35,7 @@ public:
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;
-    virtual bool is_iterator_record() const override { return true; }
 };
-
-template<>
-inline bool Object::fast_is<IteratorRecord>() const { return is_iterator_record(); }
 
 class Iterator : public Object {
     JS_OBJECT(Iterator, Object);

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -195,7 +195,6 @@ public:
     virtual bool is_proxy_object() const { return false; }
     virtual bool is_native_function() const { return false; }
     virtual bool is_ecmascript_function_object() const { return false; }
-    virtual bool is_iterator_record() const { return false; }
     virtual bool is_array_iterator() const { return false; }
 
     // B.3.7 The [[IsHTMLDDA]] Internal Slot, https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -214,6 +214,11 @@ public:
     {
     }
 
+    Value(Cell const* cell)
+        : Value(GC::IS_CELL_BIT << GC::TAG_SHIFT, reinterpret_cast<void const*>(cell))
+    {
+    }
+
     Value(Object const* object)
         : Value(OBJECT_TAG << GC::TAG_SHIFT, reinterpret_cast<void const*>(object))
     {


### PR DESCRIPTION
This shaves its size down from 104 bytes to 48 bytes, cutting GC pressure caused by this type in more than half.

Iteration helper objects are a major contributor to GC thrashing on https://demo.immich.app/