### PR TITLE
LibWeb: Alter the baseline of text with `vertical-align` `super` and `sub`

### DIFF
--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -297,6 +297,12 @@ void LineBuilder::update_last_line()
                 auto const x_height = CSSPixels::nearest_value_for(m_context.containing_block().first_available_font().pixel_metrics().x_height);
                 return m_current_block_offset + line_box_baseline + ((effective_box_top_offset - effective_box_bottom_offset - x_height - fragment.height()) / 2);
             }
+            case CSS::VerticalAlign::Sub:
+                // https://drafts.csswg.org/css-inline/#valdef-baseline-shift-sub
+                // Lower by the offset appropriate for subscripts of the parent’s box.
+                // The UA may use the parent’s font metrics to find this offset; otherwise it defaults to dropping by one fifth of the parent’s used font-size.
+                // FIXME: Use font metrics to find a more appropriate offset, if possible
+                return alphabetic_baseline + m_context.containing_block().computed_values().font_size() / 5;
             case CSS::VerticalAlign::Super:
                 // https://drafts.csswg.org/css-inline/#valdef-baseline-shift-super
                 // Raise by the offset appropriate for superscripts of the parent’s box.
@@ -304,7 +310,6 @@ void LineBuilder::update_last_line()
                 // FIXME: Use font metrics to find a more appropriate offset, if possible
                 return alphabetic_baseline - m_context.containing_block().computed_values().font_size() / 3;
             case CSS::VerticalAlign::Bottom:
-            case CSS::VerticalAlign::Sub:
             case CSS::VerticalAlign::TextBottom:
             case CSS::VerticalAlign::TextTop:
                 // FIXME: These are all 'baseline'

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -297,9 +297,14 @@ void LineBuilder::update_last_line()
                 auto const x_height = CSSPixels::nearest_value_for(m_context.containing_block().first_available_font().pixel_metrics().x_height);
                 return m_current_block_offset + line_box_baseline + ((effective_box_top_offset - effective_box_bottom_offset - x_height - fragment.height()) / 2);
             }
+            case CSS::VerticalAlign::Super:
+                // https://drafts.csswg.org/css-inline/#valdef-baseline-shift-super
+                // Raise by the offset appropriate for superscripts of the parent’s box.
+                // The UA may use the parent’s font metrics to find this offset; otherwise it defaults to raising by one third of the parent’s used font-size.
+                // FIXME: Use font metrics to find a more appropriate offset, if possible
+                return alphabetic_baseline - m_context.containing_block().computed_values().font_size() / 3;
             case CSS::VerticalAlign::Bottom:
             case CSS::VerticalAlign::Sub:
-            case CSS::VerticalAlign::Super:
             case CSS::VerticalAlign::TextBottom:
             case CSS::VerticalAlign::TextTop:
                 // FIXME: These are all 'baseline'


### PR DESCRIPTION
Unfortunately, this doesn't work the citation links on Wikipedia :sob:, it also leads to selections looking slightly odd.

Leads to a visual improvement in: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup   

Before:
![image](https://github.com/user-attachments/assets/d17f86d1-0fb1-4e44-bdde-8c96c04a048e)

After:
![image](https://github.com/user-attachments/assets/d003ca88-82d8-461f-9cf5-44f513d897ec)

and https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub

Before:
![image](https://github.com/user-attachments/assets/96d3676b-7b08-49bd-a35f-bb0a919600e7)

After:
![image](https://github.com/user-attachments/assets/2939c576-98dc-4d22-9e3e-a70776119c84)
