### PR TITLE
CI: Reduce js-benchmarks artifact retention to 90 days

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -58,4 +58,4 @@ jobs:
         with:
           name: js-benchmarks-results
           path: js-benchmarks/results.json
-          retention-days: 93
+          retention-days: 90


### PR DESCRIPTION
This is GitHub's default maximum. Prevents generating a warning on each workflow run.