### PR TITLE
LibWeb: Don't assume length-percentage is always a length [GFC]

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2563,7 +2563,7 @@ CSSPixels GridFormattingContext::content_based_minimum_size(GridItem const& item
             spans_only_tracks_with_limited_max_track_sizing_function = false;
             break;
         }
-        sum_of_max_sizing_functions += track.max_track_sizing_function.length_percentage().length().to_px(item.box);
+        sum_of_max_sizing_functions += track.max_track_sizing_function.length_percentage().to_px(item.box, m_available_space->width.to_px_or_zero());
     }
     if (spans_only_tracks_with_limited_max_track_sizing_function) {
         result = min(result, sum_of_max_sizing_functions);

--- a/Tests/LibWeb/Layout/expected/grid/minmax-with-percentage-max.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-with-percentage-max.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  Box <html> at (0,0) content-size 800x16 [GFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 184x0 [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableBox (Box<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 184x0]

--- a/Tests/LibWeb/Layout/input/grid/minmax-with-percentage-max.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-with-percentage-max.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+html {
+    display: grid;
+    grid-template-columns: minmax(auto, 25%);
+}
+</style>


### PR DESCRIPTION
Fixes crashing when trying to get length from LengthPercentage with percentage value.