### PR TITLE
Get rid of most DeprecatedFlyString use

### DIFF
--- a/AK/StringBase.cpp
+++ b/AK/StringBase.cpp
@@ -18,7 +18,7 @@ ReadonlyBytes ShortString::bytes() const
 
 size_t ShortString::byte_count() const
 {
-    return byte_count_and_short_string_flag >> 1;
+    return byte_count_and_short_string_flag >> StringBase::SHORT_STRING_BYTE_COUNT_SHIFT_COUNT;
 }
 
 StringBase::StringBase(NonnullRefPtr<Detail::StringData const> data)
@@ -78,7 +78,7 @@ size_t StringBase::byte_count() const
 {
     ASSERT(!is_invalid());
     if (is_short_string())
-        return m_short_string.byte_count_and_short_string_flag >> 1;
+        return m_short_string.byte_count_and_short_string_flag >> StringBase::SHORT_STRING_BYTE_COUNT_SHIFT_COUNT;
     return m_data->byte_count();
 }
 

--- a/AK/StringBase.h
+++ b/AK/StringBase.h
@@ -103,9 +103,11 @@ protected:
 private:
     friend class ::AK::String;
     friend class ::AK::FlyString;
+    friend struct ::AK::Detail::ShortString;
 
     // NOTE: If the least significant bit of the pointer is set, this is a short string.
     static constexpr uintptr_t SHORT_STRING_FLAG = 1;
+    static constexpr unsigned SHORT_STRING_BYTE_COUNT_SHIFT_COUNT = 2;
 
     explicit StringBase(NonnullRefPtr<Detail::StringData const>);
 
@@ -127,7 +129,7 @@ private:
         VERIFY(byte_count <= MAX_SHORT_STRING_BYTE_COUNT);
 
         m_short_string = ShortString {};
-        m_short_string.byte_count_and_short_string_flag = (byte_count << 1) | SHORT_STRING_FLAG;
+        m_short_string.byte_count_and_short_string_flag = (byte_count << SHORT_STRING_BYTE_COUNT_SHIFT_COUNT) | SHORT_STRING_FLAG;
         return { m_short_string.storage, byte_count };
     }
 

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -63,7 +63,7 @@ static void print_indent(int indent)
     out("{}", ByteString::repeated(' ', indent * 2));
 }
 
-static void update_function_name(Value value, DeprecatedFlyString const& name)
+static void update_function_name(Value value, FlyString const& name)
 {
     if (!value.is_function())
         return;
@@ -87,15 +87,15 @@ void LabelledStatement::dump(int indent) const
 }
 
 // 15.2.5 Runtime Semantics: InstantiateOrdinaryFunctionExpression, https://tc39.es/ecma262/#sec-runtime-semantics-instantiateordinaryfunctionexpression
-Value FunctionExpression::instantiate_ordinary_function_expression(VM& vm, DeprecatedFlyString given_name) const
+Value FunctionExpression::instantiate_ordinary_function_expression(VM& vm, FlyString given_name) const
 {
     auto& realm = *vm.current_realm();
 
     if (given_name.is_empty())
-        given_name = "";
+        given_name = ""_fly_string;
     auto has_own_name = !name().is_empty();
 
-    auto const used_name = has_own_name ? name() : given_name.view();
+    auto const used_name = has_own_name ? name() : given_name;
     auto environment = GC::Ref { *vm.running_execution_context().lexical_environment };
     if (has_own_name) {
         VERIFY(environment);
@@ -117,10 +117,10 @@ Value FunctionExpression::instantiate_ordinary_function_expression(VM& vm, Depre
     return closure;
 }
 
-Optional<ByteString> CallExpression::expression_string() const
+Optional<String> CallExpression::expression_string() const
 {
     if (is<Identifier>(*m_callee))
-        return static_cast<Identifier const&>(*m_callee).string();
+        return static_cast<Identifier const&>(*m_callee).string().to_string();
 
     if (is<MemberExpression>(*m_callee))
         return static_cast<MemberExpression const&>(*m_callee).to_string_approximation();
@@ -159,21 +159,20 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassMethod::class_element_evaluatio
 
     auto set_function_name = [&](ByteString prefix = "") {
         auto name = property_key_or_private_name.visit(
-            [&](PropertyKey const& property_key) -> ByteString {
+            [&](PropertyKey const& property_key) -> String {
                 if (property_key.is_symbol()) {
                     auto description = property_key.as_symbol()->description();
                     if (!description.has_value() || description->is_empty())
-                        return "";
-                    return ByteString::formatted("[{}]", *description);
-                } else {
-                    return property_key.to_string();
+                        return ""_string;
+                    return MUST(String::formatted("[{}]", *description));
                 }
+                return property_key.to_string();
             },
-            [&](PrivateName const& private_name) -> ByteString {
-                return private_name.description;
+            [&](PrivateName const& private_name) -> String {
+                return private_name.description.to_string();
             });
 
-        update_function_name(method_value, ByteString::formatted("{}{}{}", prefix, prefix.is_empty() ? "" : " ", name));
+        update_function_name(method_value, MUST(String::formatted("{}{}{}", prefix, prefix.is_empty() ? "" : " ", name)));
     };
 
     if (property_key_or_private_name.has<PropertyKey>()) {
@@ -230,11 +229,11 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassField::class_element_evaluation
     if (m_initializer) {
         auto copy_initializer = m_initializer;
         auto name = property_key_or_private_name.visit(
-            [&](PropertyKey const& property_key) -> ByteString {
+            [&](PropertyKey const& property_key) -> String {
                 return property_key.is_number() ? property_key.to_string() : property_key.to_string_or_symbol().to_display_string();
             },
-            [&](PrivateName const& private_name) -> ByteString {
-                return private_name.description;
+            [&](PrivateName const& private_name) -> String {
+                return private_name.description.to_string();
             });
 
         // FIXME: A potential optimization is not creating the functions here since these are never directly accessible.
@@ -242,7 +241,7 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassField::class_element_evaluation
         FunctionParsingInsights parsing_insights;
         parsing_insights.uses_this_from_environment = true;
         parsing_insights.uses_this = true;
-        initializer = ECMAScriptFunctionObject::create(realm, "field", ByteString::empty(), *function_code, {}, 0, {}, vm.lexical_environment(), vm.running_execution_context().private_environment, FunctionKind::Normal, true, parsing_insights, false, property_key_or_private_name);
+        initializer = ECMAScriptFunctionObject::create(realm, "field"_string, ByteString::empty(), *function_code, {}, 0, {}, vm.lexical_environment(), vm.running_execution_context().private_environment, FunctionKind::Normal, true, parsing_insights, false, property_key_or_private_name);
         initializer->make_method(target);
     }
 
@@ -254,19 +253,19 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassField::class_element_evaluation
     };
 }
 
-static Optional<DeprecatedFlyString> nullopt_or_private_identifier_description(Expression const& expression)
+static Optional<FlyString> nullopt_or_private_identifier_description(Expression const& expression)
 {
     if (is<PrivateIdentifier>(expression))
         return static_cast<PrivateIdentifier const&>(expression).string();
     return {};
 }
 
-Optional<DeprecatedFlyString> ClassField::private_bound_identifier() const
+Optional<FlyString> ClassField::private_bound_identifier() const
 {
     return nullopt_or_private_identifier_description(*m_key);
 }
 
-Optional<DeprecatedFlyString> ClassMethod::private_bound_identifier() const
+Optional<FlyString> ClassMethod::private_bound_identifier() const
 {
     return nullopt_or_private_identifier_description(*m_key);
 }
@@ -289,7 +288,7 @@ ThrowCompletionOr<ClassElement::ClassValue> StaticInitializer::class_element_eva
     FunctionParsingInsights parsing_insights;
     parsing_insights.uses_this_from_environment = true;
     parsing_insights.uses_this = true;
-    auto body_function = ECMAScriptFunctionObject::create(realm, ByteString::empty(), ByteString::empty(), *m_function_body, {}, 0, m_function_body->local_variables_names(), lexical_environment, private_environment, FunctionKind::Normal, true, parsing_insights, false);
+    auto body_function = ECMAScriptFunctionObject::create(realm, ""_string, ByteString::empty(), *m_function_body, {}, 0, m_function_body->local_variables_names(), lexical_environment, private_environment, FunctionKind::Normal, true, parsing_insights, false);
 
     // 6. Perform MakeMethod(bodyFunction, homeObject).
     body_function->make_method(home_object);
@@ -298,7 +297,7 @@ ThrowCompletionOr<ClassElement::ClassValue> StaticInitializer::class_element_eva
     return ClassValue { normal_completion(body_function) };
 }
 
-ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_constructor(VM& vm, Environment* class_environment, Environment* environment, Value super_class, ReadonlySpan<Value> element_keys, Optional<DeprecatedFlyString> const& binding_name, DeprecatedFlyString const& class_name) const
+ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_constructor(VM& vm, Environment* class_environment, Environment* environment, Value super_class, ReadonlySpan<Value> element_keys, Optional<FlyString> const& binding_name, FlyString const& class_name) const
 {
     auto& realm = *vm.current_realm();
 
@@ -1209,16 +1208,16 @@ void MemberExpression::dump(int indent) const
     m_property->dump(indent + 1);
 }
 
-ByteString MemberExpression::to_string_approximation() const
+String MemberExpression::to_string_approximation() const
 {
-    ByteString object_string = "<object>";
+    String object_string = "<object>"_string;
     if (is<Identifier>(*m_object))
-        object_string = static_cast<Identifier const&>(*m_object).string();
+        object_string = static_cast<Identifier const&>(*m_object).string().to_string();
     if (is_computed())
-        return ByteString::formatted("{}[<computed>]", object_string);
+        return MUST(String::formatted("{}[<computed>]", object_string));
     if (is<PrivateIdentifier>(*m_property))
-        return ByteString::formatted("{}.{}", object_string, as<PrivateIdentifier>(*m_property).string());
-    return ByteString::formatted("{}.{}", object_string, as<Identifier>(*m_property).string());
+        return MUST(String::formatted("{}.{}", object_string, as<PrivateIdentifier>(*m_property).string()));
+    return MUST(String::formatted("{}.{}", object_string, as<Identifier>(*m_property).string()));
 }
 
 bool MemberExpression::ends_in_private_name() const
@@ -1349,7 +1348,7 @@ void CatchClause::dump(int indent) const
 {
     print_indent(indent);
     m_parameter.visit(
-        [&](DeprecatedFlyString const& parameter) {
+        [&](FlyString const& parameter) {
             if (parameter.is_empty())
                 outln("CatchClause");
             else
@@ -1498,7 +1497,7 @@ void ScopeNode::add_hoisted_function(NonnullRefPtr<FunctionDeclaration const> de
     m_functions_hoistable_with_annexB_extension.append(move(declaration));
 }
 
-DeprecatedFlyString ExportStatement::local_name_for_default = "*default*";
+FlyString ExportStatement::local_name_for_default = "*default*"_fly_string;
 
 static void dump_assert_clauses(ModuleRequest const& request)
 {
@@ -1516,7 +1515,7 @@ void ExportStatement::dump(int indent) const
     print_indent(indent + 1);
     outln("(ExportEntries)");
 
-    auto string_or_null = [](Optional<DeprecatedFlyString> const& string) -> ByteString {
+    auto string_or_null = [](Optional<FlyString> const& string) -> ByteString {
         if (!string.has_value()) {
             return "null";
         }
@@ -1564,7 +1563,7 @@ void ImportStatement::dump(int indent) const
     }
 }
 
-bool ExportStatement::has_export(DeprecatedFlyString const& export_name) const
+bool ExportStatement::has_export(FlyString const& export_name) const
 {
     return any_of(m_entries.begin(), m_entries.end(), [&](auto& entry) {
         // Make sure that empty exported names does not overlap with anything
@@ -1574,7 +1573,7 @@ bool ExportStatement::has_export(DeprecatedFlyString const& export_name) const
     });
 }
 
-bool ImportStatement::has_bound_name(DeprecatedFlyString const& name) const
+bool ImportStatement::has_bound_name(FlyString const& name) const
 {
     return any_of(m_entries.begin(), m_entries.end(), [&](auto& entry) {
         return entry.local_name == name;
@@ -1688,7 +1687,7 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
     Vector<FunctionDeclaration const&> functions_to_initialize;
 
     // 7. Let declaredFunctionNames be a new empty List.
-    HashTable<DeprecatedFlyString> declared_function_names;
+    HashTable<FlyString> declared_function_names;
 
     // 8. For each element d of varDeclarations, in reverse List order, do
 
@@ -1723,7 +1722,7 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
     }));
 
     // 9. Let declaredVarNames be a new empty List.
-    HashTable<DeprecatedFlyString> declared_var_names;
+    HashTable<FlyString> declared_var_names;
 
     // 10. For each element d of varDeclarations, do
     TRY(for_each_var_scoped_variable_declaration([&](Declaration const& declaration) {
@@ -1853,7 +1852,7 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
     return {};
 }
 
-ModuleRequest::ModuleRequest(DeprecatedFlyString module_specifier_, Vector<ImportAttribute> attributes)
+ModuleRequest::ModuleRequest(FlyString module_specifier_, Vector<ImportAttribute> attributes)
     : module_specifier(move(module_specifier_))
     , attributes(move(attributes))
 {

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Variant.h>
@@ -168,7 +168,7 @@ private:
 // 14.13 Labelled Statements, https://tc39.es/ecma262/#sec-labelled-statements
 class LabelledStatement final : public Statement {
 public:
-    LabelledStatement(SourceRange source_range, DeprecatedFlyString label, NonnullRefPtr<Statement const> labelled_item)
+    LabelledStatement(SourceRange source_range, FlyString label, NonnullRefPtr<Statement const> labelled_item)
         : Statement(move(source_range))
         , m_label(move(label))
         , m_labelled_item(move(labelled_item))
@@ -177,16 +177,16 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
-    DeprecatedFlyString const& label() const { return m_label; }
-    DeprecatedFlyString& label() { return m_label; }
+    FlyString const& label() const { return m_label; }
+    FlyString& label() { return m_label; }
     NonnullRefPtr<Statement const> const& labelled_item() const { return m_labelled_item; }
 
 private:
     virtual bool is_labelled_statement() const final { return true; }
 
-    DeprecatedFlyString m_label;
+    FlyString m_label;
     NonnullRefPtr<Statement const> m_labelled_item;
 };
 
@@ -194,18 +194,18 @@ class LabelableStatement : public Statement {
 public:
     using Statement::Statement;
 
-    Vector<DeprecatedFlyString> const& labels() const { return m_labels; }
-    virtual void add_label(DeprecatedFlyString string) { m_labels.append(move(string)); }
+    Vector<FlyString> const& labels() const { return m_labels; }
+    virtual void add_label(FlyString string) { m_labels.append(move(string)); }
 
 protected:
-    Vector<DeprecatedFlyString> m_labels;
+    Vector<FlyString> m_labels;
 };
 
 class IterationStatement : public Statement {
 public:
     using Statement::Statement;
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
 private:
     virtual bool is_iteration_statement() const final { return true; }
@@ -325,8 +325,8 @@ public:
 
     ThrowCompletionOr<void> for_each_function_hoistable_with_annexB_extension(ThrowCompletionOrVoidCallback<FunctionDeclaration&>&& callback) const;
 
-    Vector<DeprecatedFlyString> const& local_variables_names() const { return m_local_variables_names; }
-    size_t add_local_variable(DeprecatedFlyString name)
+    Vector<FlyString> const& local_variables_names() const { return m_local_variables_names; }
+    size_t add_local_variable(FlyString name)
     {
         auto index = m_local_variables_names.size();
         m_local_variables_names.append(move(name));
@@ -348,15 +348,15 @@ private:
 
     Vector<NonnullRefPtr<FunctionDeclaration const>> m_functions_hoistable_with_annexB_extension;
 
-    Vector<DeprecatedFlyString> m_local_variables_names;
+    Vector<FlyString> m_local_variables_names;
 };
 
 // ImportEntry Record, https://tc39.es/ecma262/#table-importentry-record-fields
 struct ImportEntry {
-    Optional<DeprecatedFlyString> import_name; // [[ImportName]]: stored string if Optional is not empty, NAMESPACE-OBJECT otherwise
-    DeprecatedFlyString local_name;            // [[LocalName]]
+    Optional<FlyString> import_name; // [[ImportName]]: stored string if Optional is not empty, NAMESPACE-OBJECT otherwise
+    FlyString local_name;            // [[LocalName]]
 
-    ImportEntry(Optional<DeprecatedFlyString> import_name_, DeprecatedFlyString local_name_)
+    ImportEntry(Optional<FlyString> import_name_, FlyString local_name_)
         : import_name(move(import_name_))
         , local_name(move(local_name_))
     {
@@ -390,7 +390,7 @@ public:
 
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
-    bool has_bound_name(DeprecatedFlyString const& name) const;
+    bool has_bound_name(FlyString const& name) const;
     Vector<ImportEntry> const& entries() const { return m_entries; }
     ModuleRequest const& module_request() const { return m_module_request; }
 
@@ -412,10 +412,10 @@ struct ExportEntry {
         EmptyNamedExport,
     } kind;
 
-    Optional<DeprecatedFlyString> export_name;          // [[ExportName]]
-    Optional<DeprecatedFlyString> local_or_import_name; // Either [[ImportName]] or [[LocalName]]
+    Optional<FlyString> export_name;          // [[ExportName]]
+    Optional<FlyString> local_or_import_name; // Either [[ImportName]] or [[LocalName]]
 
-    ExportEntry(Kind export_kind, Optional<DeprecatedFlyString> export_name_, Optional<DeprecatedFlyString> local_or_import_name_)
+    ExportEntry(Kind export_kind, Optional<FlyString> export_name_, Optional<FlyString> local_or_import_name_)
         : kind(export_kind)
         , export_name(move(export_name_))
         , local_or_import_name(move(local_or_import_name_))
@@ -427,7 +427,7 @@ struct ExportEntry {
         return m_module_request != nullptr;
     }
 
-    static ExportEntry indirect_export_entry(ModuleRequest const& module_request, Optional<DeprecatedFlyString> export_name, Optional<DeprecatedFlyString> import_name)
+    static ExportEntry indirect_export_entry(ModuleRequest const& module_request, Optional<FlyString> export_name, Optional<FlyString> import_name)
     {
         ExportEntry entry { Kind::NamedExport, move(export_name), move(import_name) };
         entry.m_module_request = &module_request;
@@ -445,7 +445,7 @@ private:
     friend class ExportStatement;
 
 public:
-    static ExportEntry named_export(DeprecatedFlyString export_name, DeprecatedFlyString local_name)
+    static ExportEntry named_export(FlyString export_name, FlyString local_name)
     {
         return ExportEntry { Kind::NamedExport, move(export_name), move(local_name) };
     }
@@ -455,7 +455,7 @@ public:
         return ExportEntry { Kind::ModuleRequestAllButDefault, {}, {} };
     }
 
-    static ExportEntry all_module_request(DeprecatedFlyString export_name)
+    static ExportEntry all_module_request(FlyString export_name)
     {
         return ExportEntry { Kind::ModuleRequestAll, move(export_name), {} };
     }
@@ -468,7 +468,7 @@ public:
 
 class ExportStatement final : public Statement {
 public:
-    static DeprecatedFlyString local_name_for_default;
+    static FlyString local_name_for_default;
 
     ExportStatement(SourceRange source_range, RefPtr<ASTNode const> statement, Vector<ExportEntry> entries, bool is_default_export, Optional<ModuleRequest> module_request)
         : Statement(move(source_range))
@@ -487,7 +487,7 @@ public:
 
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
-    bool has_export(DeprecatedFlyString const& export_name) const;
+    bool has_export(FlyString const& export_name) const;
 
     bool has_statement() const { return m_statement; }
     Vector<ExportEntry> const& entries() const { return m_entries; }
@@ -654,13 +654,13 @@ struct BindingPattern : RefCounted<BindingPattern> {
 
 class Identifier final : public Expression {
 public:
-    explicit Identifier(SourceRange source_range, DeprecatedFlyString string)
+    explicit Identifier(SourceRange source_range, FlyString string)
         : Expression(move(source_range))
         , m_string(move(string))
     {
     }
 
-    DeprecatedFlyString const& string() const { return m_string; }
+    FlyString const& string() const { return m_string; }
 
     bool is_local() const { return m_local_variable_index.has_value(); }
     size_t local_variable_index() const
@@ -679,7 +679,7 @@ public:
 private:
     virtual bool is_identifier() const override { return true; }
 
-    DeprecatedFlyString m_string;
+    FlyString m_string;
 
     Optional<size_t> m_local_variable_index;
     bool m_is_global { false };
@@ -701,13 +701,13 @@ struct FunctionParsingInsights {
 
 class FunctionNode {
 public:
-    StringView name() const { return m_name ? m_name->string().view() : ""sv; }
+    FlyString name() const { return m_name ? m_name->string() : ""_fly_string; }
     RefPtr<Identifier const> name_identifier() const { return m_name; }
     ByteString const& source_text() const { return m_source_text; }
     Statement const& body() const { return *m_body; }
     Vector<FunctionParameter> const& parameters() const { return m_parameters; }
     i32 function_length() const { return m_function_length; }
-    Vector<DeprecatedFlyString> const& local_variables_names() const { return m_local_variables_names; }
+    Vector<FlyString> const& local_variables_names() const { return m_local_variables_names; }
     bool is_strict_mode() const { return m_is_strict_mode; }
     bool might_need_arguments_object() const { return m_parsing_insights.might_need_arguments_object; }
     bool contains_direct_call_to_eval() const { return m_parsing_insights.contains_direct_call_to_eval; }
@@ -717,12 +717,12 @@ public:
     bool uses_this_from_environment() const { return m_parsing_insights.uses_this_from_environment; }
 
     virtual bool has_name() const = 0;
-    virtual Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString given_name) const = 0;
+    virtual Value instantiate_ordinary_function_expression(VM&, FlyString given_name) const = 0;
 
     virtual ~FunctionNode() { }
 
 protected:
-    FunctionNode(RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights parsing_insights, bool is_arrow_function, Vector<DeprecatedFlyString> local_variables_names)
+    FunctionNode(RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights parsing_insights, bool is_arrow_function, Vector<FlyString> local_variables_names)
         : m_name(move(name))
         , m_source_text(move(source_text))
         , m_body(move(body))
@@ -752,7 +752,7 @@ private:
     bool m_is_arrow_function : 1 { false };
     FunctionParsingInsights m_parsing_insights;
 
-    Vector<DeprecatedFlyString> m_local_variables_names;
+    Vector<FlyString> m_local_variables_names;
 };
 
 class FunctionDeclaration final
@@ -761,7 +761,7 @@ class FunctionDeclaration final
 public:
     static bool must_have_name() { return true; }
 
-    FunctionDeclaration(SourceRange source_range, RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights insights, Vector<DeprecatedFlyString> local_variables_names)
+    FunctionDeclaration(SourceRange source_range, RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights insights, Vector<FlyString> local_variables_names)
         : Declaration(move(source_range))
         , FunctionNode(move(name), move(source_text), move(body), move(parameters), function_length, kind, is_strict_mode, insights, false, move(local_variables_names))
     {
@@ -777,7 +777,7 @@ public:
     void set_should_do_additional_annexB_steps() { m_is_hoisted = true; }
 
     bool has_name() const override { return true; }
-    Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString) const override { VERIFY_NOT_REACHED(); }
+    Value instantiate_ordinary_function_expression(VM&, FlyString) const override { VERIFY_NOT_REACHED(); }
 
     virtual ~FunctionDeclaration() { }
 
@@ -791,7 +791,7 @@ class FunctionExpression final
 public:
     static bool must_have_name() { return false; }
 
-    FunctionExpression(SourceRange source_range, RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights insights, Vector<DeprecatedFlyString> local_variables_names, bool is_arrow_function = false)
+    FunctionExpression(SourceRange source_range, RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights insights, Vector<FlyString> local_variables_names, bool is_arrow_function = false)
         : Expression(move(source_range))
         , FunctionNode(move(name), move(source_text), move(body), move(parameters), function_length, kind, is_strict_mode, insights, is_arrow_function, move(local_variables_names))
     {
@@ -804,7 +804,7 @@ public:
 
     bool has_name() const override { return !name().is_empty(); }
 
-    Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString given_name) const override;
+    Value instantiate_ordinary_function_expression(VM&, FlyString given_name) const override;
 
     virtual ~FunctionExpression() { }
 
@@ -909,7 +909,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_test;
@@ -930,7 +930,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     NonnullRefPtr<Expression const> m_test;
@@ -975,7 +975,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
     RefPtr<ASTNode const> m_init;
@@ -999,7 +999,7 @@ public:
     Statement const& body() const { return *m_body; }
 
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
     virtual void dump(int indent) const override;
 
 private:
@@ -1023,7 +1023,7 @@ public:
     Statement const& body() const { return *m_body; }
 
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
     virtual void dump(int indent) const override;
 
 private:
@@ -1043,7 +1043,7 @@ public:
     }
 
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
     virtual void dump(int indent) const override;
 
 private:
@@ -1228,7 +1228,7 @@ private:
 
 class StringLiteral final : public Expression {
 public:
-    explicit StringLiteral(SourceRange source_range, ByteString value)
+    explicit StringLiteral(SourceRange source_range, String value)
         : Expression(move(source_range))
         , m_value(move(value))
     {
@@ -1237,12 +1237,12 @@ public:
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
-    ByteString const& value() const { return m_value; }
+    String const& value() const { return m_value; }
 
 private:
     virtual bool is_string_literal() const override { return true; }
 
-    ByteString m_value;
+    String m_value;
 };
 
 class NullLiteral final : public PrimitiveLiteral {
@@ -1260,7 +1260,7 @@ public:
 
 class RegExpLiteral final : public Expression {
 public:
-    RegExpLiteral(SourceRange source_range, regex::Parser::Result parsed_regex, ByteString parsed_pattern, regex::RegexOptions<ECMAScriptFlags> parsed_flags, ByteString pattern, ByteString flags)
+    RegExpLiteral(SourceRange source_range, regex::Parser::Result parsed_regex, String parsed_pattern, regex::RegexOptions<ECMAScriptFlags> parsed_flags, String pattern, String flags)
         : Expression(move(source_range))
         , m_parsed_regex(move(parsed_regex))
         , m_parsed_pattern(move(parsed_pattern))
@@ -1274,35 +1274,35 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     regex::Parser::Result const& parsed_regex() const { return m_parsed_regex; }
-    ByteString const& parsed_pattern() const { return m_parsed_pattern; }
+    String const& parsed_pattern() const { return m_parsed_pattern; }
     regex::RegexOptions<ECMAScriptFlags> const& parsed_flags() const { return m_parsed_flags; }
-    ByteString const& pattern() const { return m_pattern; }
-    ByteString const& flags() const { return m_flags; }
+    String const& pattern() const { return m_pattern; }
+    String const& flags() const { return m_flags; }
 
 private:
     regex::Parser::Result m_parsed_regex;
-    ByteString m_parsed_pattern;
+    String m_parsed_pattern;
     regex::RegexOptions<ECMAScriptFlags> m_parsed_flags;
-    ByteString m_pattern;
-    ByteString m_flags;
+    String m_pattern;
+    String m_flags;
 };
 
 class PrivateIdentifier final : public Expression {
 public:
-    explicit PrivateIdentifier(SourceRange source_range, DeprecatedFlyString string)
+    explicit PrivateIdentifier(SourceRange source_range, FlyString string)
         : Expression(move(source_range))
         , m_string(move(string))
     {
     }
 
-    DeprecatedFlyString const& string() const { return m_string; }
+    FlyString const& string() const { return m_string; }
 
     virtual void dump(int indent) const override;
 
     virtual bool is_private_identifier() const override { return true; }
 
 private:
-    DeprecatedFlyString m_string;
+    FlyString m_string;
 };
 
 class ClassElement : public ASTNode {
@@ -1326,7 +1326,7 @@ public:
     using ClassValue = Variant<ClassFieldDefinition, Completion, PrivateElement>;
     virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object, Value) const = 0;
 
-    virtual Optional<DeprecatedFlyString> private_bound_identifier() const { return {}; }
+    virtual Optional<FlyString> private_bound_identifier() const { return {}; }
 
 private:
     bool m_is_static { false };
@@ -1354,7 +1354,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object, Value property_key) const override;
-    virtual Optional<DeprecatedFlyString> private_bound_identifier() const override;
+    virtual Optional<FlyString> private_bound_identifier() const override;
 
 private:
     virtual bool is_class_method() const override { return true; }
@@ -1381,7 +1381,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual ThrowCompletionOr<ClassValue> class_element_evaluation(VM&, Object& home_object, Value property_key) const override;
-    virtual Optional<DeprecatedFlyString> private_bound_identifier() const override;
+    virtual Optional<FlyString> private_bound_identifier() const override;
 
 private:
     NonnullRefPtr<Expression const> m_key;
@@ -1433,7 +1433,7 @@ public:
     {
     }
 
-    StringView name() const { return m_name ? m_name->string().view() : ""sv; }
+    FlyString name() const { return m_name ? m_name->string() : ""_fly_string; }
 
     ByteString const& source_text() const { return m_source_text; }
     RefPtr<FunctionExpression const> constructor() const { return m_constructor; }
@@ -1444,7 +1444,7 @@ public:
 
     bool has_name() const { return m_name; }
 
-    ThrowCompletionOr<ECMAScriptFunctionObject*> create_class_constructor(VM&, Environment* class_environment, Environment* environment, Value super_class, ReadonlySpan<Value> element_keys, Optional<DeprecatedFlyString> const& binding_name = {}, DeprecatedFlyString const& class_name = {}) const;
+    ThrowCompletionOr<ECMAScriptFunctionObject*> create_class_constructor(VM&, Environment* class_environment, Environment* environment, Value super_class, ReadonlySpan<Value> element_keys, Optional<FlyString> const& binding_name = {}, FlyString const& class_name = {}) const;
 
 private:
     virtual bool is_class_expression() const override { return true; }
@@ -1473,7 +1473,7 @@ public:
 
     virtual bool is_lexical_declaration() const override { return true; }
 
-    StringView name() const { return m_class_expression->name(); }
+    FlyString name() const { return m_class_expression->name(); }
 
 private:
     virtual bool is_class_declaration() const override { return true; }
@@ -1487,7 +1487,7 @@ private:
 // 10.2.1.3 Runtime Semantics: EvaluateBody, https://tc39.es/ecma262/#sec-runtime-semantics-evaluatebody
 class ClassFieldInitializerStatement final : public Statement {
 public:
-    ClassFieldInitializerStatement(SourceRange source_range, NonnullRefPtr<Expression const> expression, DeprecatedFlyString field_name)
+    ClassFieldInitializerStatement(SourceRange source_range, NonnullRefPtr<Expression const> expression, FlyString field_name)
         : Statement(move(source_range))
         , m_expression(move(expression))
         , m_class_field_identifier_name(move(field_name))
@@ -1499,7 +1499,7 @@ public:
 
 private:
     NonnullRefPtr<Expression const> m_expression;
-    DeprecatedFlyString m_class_field_identifier_name; // [[ClassFieldIdentifierName]]
+    FlyString m_class_field_identifier_name; // [[ClassFieldIdentifierName]]
 };
 
 class SpreadExpression final : public Expression {
@@ -1575,7 +1575,7 @@ protected:
 
     virtual bool is_call_expression() const override { return true; }
 
-    Optional<ByteString> expression_string() const;
+    Optional<String> expression_string() const;
 
     NonnullRefPtr<Expression const> m_callee;
 };
@@ -1924,7 +1924,7 @@ public:
     Expression const& object() const { return *m_object; }
     Expression const& property() const { return *m_property; }
 
-    ByteString to_string_approximation() const;
+    [[nodiscard]] String to_string_approximation() const;
 
     bool ends_in_private_name() const;
 
@@ -2040,7 +2040,7 @@ private:
 
 class CatchClause final : public ASTNode {
 public:
-    CatchClause(SourceRange source_range, DeprecatedFlyString parameter, NonnullRefPtr<BlockStatement const> body)
+    CatchClause(SourceRange source_range, FlyString parameter, NonnullRefPtr<BlockStatement const> body)
         : ASTNode(move(source_range))
         , m_parameter(move(parameter))
         , m_body(move(body))
@@ -2060,7 +2060,7 @@ public:
     virtual void dump(int indent) const override;
 
 private:
-    Variant<DeprecatedFlyString, NonnullRefPtr<BindingPattern const>> m_parameter;
+    Variant<FlyString, NonnullRefPtr<BindingPattern const>> m_parameter;
     NonnullRefPtr<BlockStatement const> m_body;
 };
 
@@ -2130,7 +2130,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<DeprecatedFlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     void add_case(NonnullRefPtr<SwitchCase const> switch_case) { m_cases.append(move(switch_case)); }
 
@@ -2141,22 +2141,22 @@ private:
 
 class BreakStatement final : public Statement {
 public:
-    BreakStatement(SourceRange source_range, Optional<DeprecatedFlyString> target_label)
+    BreakStatement(SourceRange source_range, Optional<FlyString> target_label)
         : Statement(move(source_range))
         , m_target_label(move(target_label))
     {
     }
 
-    Optional<DeprecatedFlyString> const& target_label() const { return m_target_label; }
+    Optional<FlyString> const& target_label() const { return m_target_label; }
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
-    Optional<DeprecatedFlyString> m_target_label;
+    Optional<FlyString> m_target_label;
 };
 
 class ContinueStatement final : public Statement {
 public:
-    ContinueStatement(SourceRange source_range, Optional<DeprecatedFlyString> target_label)
+    ContinueStatement(SourceRange source_range, Optional<FlyString> target_label)
         : Statement(move(source_range))
         , m_target_label(move(target_label))
     {
@@ -2164,10 +2164,10 @@ public:
 
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
-    Optional<DeprecatedFlyString> const& target_label() const { return m_target_label; }
+    Optional<FlyString> const& target_label() const { return m_target_label; }
 
 private:
-    Optional<DeprecatedFlyString> m_target_label;
+    Optional<FlyString> m_target_label;
 };
 
 class DebuggerStatement final : public Statement {

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
@@ -60,7 +60,7 @@ public:
 
     virtual ~Executable() override;
 
-    DeprecatedFlyString name;
+    FlyString name;
     Vector<u8> bytecode;
     Vector<PropertyLookupCache> property_lookup_caches;
     Vector<GlobalVariableCache> global_variable_caches;
@@ -85,15 +85,15 @@ public:
 
     HashMap<size_t, SourceRecord> source_map;
 
-    Vector<DeprecatedFlyString> local_variable_names;
+    Vector<FlyString> local_variable_names;
     size_t local_index_base { 0 };
 
     Optional<IdentifierTableIndex> length_identifier;
 
-    ByteString const& get_string(StringTableIndex index) const { return string_table->get(index); }
-    DeprecatedFlyString const& get_identifier(IdentifierTableIndex index) const { return identifier_table->get(index); }
+    String const& get_string(StringTableIndex index) const { return string_table->get(index); }
+    FlyString const& get_identifier(IdentifierTableIndex index) const { return identifier_table->get(index); }
 
-    Optional<DeprecatedFlyString const&> get_identifier(Optional<IdentifierTableIndex> const& index) const
+    Optional<FlyString const&> get_identifier(Optional<IdentifierTableIndex> const& index) const
     {
         if (!index.has_value())
             return {};

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -153,9 +153,9 @@ public:
 
     CodeGenerationErrorOr<Optional<ScopedOperand>> emit_named_evaluation_if_anonymous_function(Expression const&, Optional<IdentifierTableIndex> lhs_name, Optional<ScopedOperand> preferred_dst = {});
 
-    void begin_continuable_scope(Label continue_target, Vector<DeprecatedFlyString> const& language_label_set);
+    void begin_continuable_scope(Label continue_target, Vector<FlyString> const& language_label_set);
     void end_continuable_scope();
-    void begin_breakable_scope(Label breakable_target, Vector<DeprecatedFlyString> const& language_label_set);
+    void begin_breakable_scope(Label breakable_target, Vector<FlyString> const& language_label_set);
     void end_breakable_scope();
 
     [[nodiscard]] Label nearest_continuable_scope() const;
@@ -188,7 +188,7 @@ public:
         return m_current_basic_block->is_terminated();
     }
 
-    StringTableIndex intern_string(ByteString string)
+    StringTableIndex intern_string(String string)
     {
         return m_string_table->insert(move(string));
     }
@@ -198,7 +198,7 @@ public:
         return m_regex_table->insert(move(regex));
     }
 
-    IdentifierTableIndex intern_identifier(DeprecatedFlyString string)
+    IdentifierTableIndex intern_identifier(FlyString string)
     {
         return m_identifier_table->insert(move(string));
     }
@@ -265,10 +265,10 @@ public:
     bool must_enter_finalizer() const { return m_boundaries.contains_slow(BlockBoundaryType::ReturnToFinally); }
 
     void generate_break();
-    void generate_break(DeprecatedFlyString const& break_label);
+    void generate_break(FlyString const& break_label);
 
     void generate_continue();
-    void generate_continue(DeprecatedFlyString const& continue_label);
+    void generate_continue(FlyString const& continue_label);
 
     template<typename OpType>
     void emit_return(ScopedOperand value)
@@ -343,14 +343,14 @@ public:
 private:
     VM& m_vm;
 
-    static CodeGenerationErrorOr<GC::Ref<Executable>> compile(VM&, ASTNode const&, FunctionKind, GC::Ptr<ECMAScriptFunctionObject const>, MustPropagateCompletion, Vector<DeprecatedFlyString> local_variable_names);
+    static CodeGenerationErrorOr<GC::Ref<Executable>> compile(VM&, ASTNode const&, FunctionKind, GC::Ptr<ECMAScriptFunctionObject const>, MustPropagateCompletion, Vector<FlyString> local_variable_names);
 
     enum class JumpType {
         Continue,
         Break,
     };
     void generate_scoped_jump(JumpType);
-    void generate_labelled_jump(JumpType, DeprecatedFlyString const& label);
+    void generate_labelled_jump(JumpType, FlyString const& label);
 
     Generator(VM&, GC::Ptr<ECMAScriptFunctionObject const>, MustPropagateCompletion);
     ~Generator() = default;
@@ -362,7 +362,7 @@ private:
 
     struct LabelableScope {
         Label bytecode_target;
-        Vector<DeprecatedFlyString> language_label_set;
+        Vector<FlyString> language_label_set;
     };
 
     BasicBlock* m_current_basic_block { nullptr };

--- a/Libraries/LibJS/Bytecode/IdentifierTable.cpp
+++ b/Libraries/LibJS/Bytecode/IdentifierTable.cpp
@@ -8,14 +8,14 @@
 
 namespace JS::Bytecode {
 
-IdentifierTableIndex IdentifierTable::insert(DeprecatedFlyString string)
+IdentifierTableIndex IdentifierTable::insert(FlyString string)
 {
     m_identifiers.append(move(string));
     VERIFY(m_identifiers.size() <= NumericLimits<u32>::max());
     return { static_cast<u32>(m_identifiers.size() - 1) };
 }
 
-DeprecatedFlyString const& IdentifierTable::get(IdentifierTableIndex index) const
+FlyString const& IdentifierTable::get(IdentifierTableIndex index) const
 {
     return m_identifiers[index.value];
 }

--- a/Libraries/LibJS/Bytecode/IdentifierTable.h
+++ b/Libraries/LibJS/Bytecode/IdentifierTable.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/DistinctNumeric.h>
+#include <AK/FlyString.h>
 #include <AK/Vector.h>
 
 namespace JS::Bytecode {
@@ -24,13 +24,13 @@ class IdentifierTable {
 public:
     IdentifierTable() = default;
 
-    IdentifierTableIndex insert(DeprecatedFlyString);
-    DeprecatedFlyString const& get(IdentifierTableIndex) const;
+    IdentifierTableIndex insert(FlyString);
+    FlyString const& get(IdentifierTableIndex) const;
     void dump() const;
     bool is_empty() const { return m_identifiers.is_empty(); }
 
 private:
-    Vector<DeprecatedFlyString> m_identifiers;
+    Vector<FlyString> m_identifiers;
 };
 
 }

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -833,7 +833,7 @@ void Interpreter::enter_object_environment(Object& object)
     running_execution_context().lexical_environment = new_object_environment(object, true, old_environment);
 }
 
-ThrowCompletionOr<GC::Ref<Bytecode::Executable>> compile(VM& vm, ASTNode const& node, FunctionKind kind, DeprecatedFlyString const& name)
+ThrowCompletionOr<GC::Ref<Bytecode::Executable>> compile(VM& vm, ASTNode const& node, FunctionKind kind, FlyString const& name)
 {
     auto executable_result = Bytecode::Generator::generate_from_ast_node(vm, node, kind);
     if (executable_result.is_error())
@@ -1199,7 +1199,7 @@ inline ThrowCompletionOr<Value> get_global(Interpreter& interpreter, IdentifierT
     return vm.throw_completion<ReferenceError>(ErrorType::UnknownIdentifier, identifier);
 }
 
-inline ThrowCompletionOr<void> put_by_property_key(VM& vm, Value base, Value this_value, Value value, Optional<DeprecatedFlyString const&> const& base_identifier, PropertyKey name, Op::PropertyKind kind, PropertyLookupCache* cache = nullptr)
+inline ThrowCompletionOr<void> put_by_property_key(VM& vm, Value base, Value this_value, Value value, Optional<FlyString const&> const& base_identifier, PropertyKey name, Op::PropertyKind kind, PropertyLookupCache* cache = nullptr)
 {
     // Better error message than to_object would give
     if (vm.in_strict_mode() && base.is_nullish())
@@ -1219,14 +1219,14 @@ inline ThrowCompletionOr<void> put_by_property_key(VM& vm, Value base, Value thi
     case Op::PropertyKind::Getter: {
         auto& function = value.as_function();
         if (function.name().is_empty() && is<ECMAScriptFunctionObject>(function))
-            static_cast<ECMAScriptFunctionObject*>(&function)->set_name(ByteString::formatted("get {}", name));
+            static_cast<ECMAScriptFunctionObject*>(&function)->set_name(MUST(String::formatted("get {}", name)));
         object->define_direct_accessor(name, &function, nullptr, Attribute::Configurable | Attribute::Enumerable);
         break;
     }
     case Op::PropertyKind::Setter: {
         auto& function = value.as_function();
         if (function.name().is_empty() && is<ECMAScriptFunctionObject>(function))
-            static_cast<ECMAScriptFunctionObject*>(&function)->set_name(ByteString::formatted("set {}", name));
+            static_cast<ECMAScriptFunctionObject*>(&function)->set_name(MUST(String::formatted("set {}", name)));
         object->define_direct_accessor(name, nullptr, &function, Attribute::Configurable | Attribute::Enumerable);
         break;
     }
@@ -1306,7 +1306,7 @@ inline Value new_function(VM& vm, FunctionNode const& function_node, Optional<Id
     Value value;
 
     if (!function_node.has_name()) {
-        DeprecatedFlyString name = {};
+        FlyString name;
         if (lhs_name.has_value())
             name = vm.bytecode_interpreter().current_executable().get_identifier(lhs_name.value());
         value = function_node.instantiate_ordinary_function_expression(vm, name);
@@ -1323,7 +1323,7 @@ inline Value new_function(VM& vm, FunctionNode const& function_node, Optional<Id
     return value;
 }
 
-inline ThrowCompletionOr<void> put_by_value(VM& vm, Value base, Optional<DeprecatedFlyString const&> const& base_identifier, Value property_key_value, Value value, Op::PropertyKind kind)
+inline ThrowCompletionOr<void> put_by_value(VM& vm, Value base, Optional<FlyString const&> const& base_identifier, Value property_key_value, Value value, Op::PropertyKind kind)
 {
     // OPTIMIZATION: Fast path for simple Int32 indexes in array-like objects.
     if ((kind == Op::PropertyKind::KeyValue || kind == Op::PropertyKind::DirectKeyValue)
@@ -1426,7 +1426,7 @@ struct CalleeAndThis {
     Value this_value;
 };
 
-inline ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Bytecode::Interpreter& interpreter, DeprecatedFlyString const& name, EnvironmentCoordinate& cache)
+inline ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Bytecode::Interpreter& interpreter, FlyString const& name, EnvironmentCoordinate& cache)
 {
     auto& vm = interpreter.vm();
 
@@ -1472,14 +1472,14 @@ inline ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Byt
 }
 
 // 13.2.7.3 Runtime Semantics: Evaluation, https://tc39.es/ecma262/#sec-regular-expression-literals-runtime-semantics-evaluation
-inline Value new_regexp(VM& vm, ParsedRegex const& parsed_regex, ByteString const& pattern, ByteString const& flags)
+inline Value new_regexp(VM& vm, ParsedRegex const& parsed_regex, String const& pattern, String const& flags)
 {
     // 1. Let pattern be CodePointsToString(BodyText of RegularExpressionLiteral).
     // 2. Let flags be CodePointsToString(FlagText of RegularExpressionLiteral).
 
     // 3. Return ! RegExpCreate(pattern, flags).
     auto& realm = *vm.current_realm();
-    Regex<ECMA262> regex(parsed_regex.regex, parsed_regex.pattern, parsed_regex.flags);
+    Regex<ECMA262> regex(parsed_regex.regex, parsed_regex.pattern.to_byte_string(), parsed_regex.flags);
     // NOTE: We bypass RegExpCreate and subsequently RegExpAlloc as an optimization to use the already parsed values.
     auto regexp_object = RegExpObject::create(realm, move(regex), pattern, flags);
     // RegExpAlloc has these two steps from the 'Legacy RegExp features' proposal.
@@ -1514,7 +1514,7 @@ inline GC::RootVector<Value> argument_list_evaluation(VM& vm, Value arguments)
     return argument_values;
 }
 
-inline ThrowCompletionOr<void> create_variable(VM& vm, DeprecatedFlyString const& name, Op::EnvironmentMode mode, bool is_global, bool is_immutable, bool is_strict)
+inline ThrowCompletionOr<void> create_variable(VM& vm, FlyString const& name, Op::EnvironmentMode mode, bool is_global, bool is_immutable, bool is_strict)
 {
     if (mode == Op::EnvironmentMode::Lexical) {
         VERIFY(!is_global);
@@ -1549,13 +1549,13 @@ inline ThrowCompletionOr<ECMAScriptFunctionObject*> new_class(VM& vm, Value supe
     auto* class_environment = vm.lexical_environment();
     vm.running_execution_context().lexical_environment = vm.running_execution_context().saved_lexical_environments.take_last();
 
-    Optional<DeprecatedFlyString> binding_name;
-    DeprecatedFlyString class_name;
+    Optional<FlyString> binding_name;
+    FlyString class_name;
     if (!class_expression.has_name() && lhs_name.has_value()) {
         class_name = interpreter.current_executable().get_identifier(lhs_name.value());
     } else {
         binding_name = name;
-        class_name = name.is_null() ? ""sv : name;
+        class_name = name;
     }
 
     return TRY(class_expression.create_class_constructor(vm, class_environment, vm.lexical_environment(), super_class, element_keys, binding_name, class_name));

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -193,16 +193,16 @@ ALWAYS_INLINE void Interpreter::set(Operand op, Value value)
 ALWAYS_INLINE Value Interpreter::do_yield(Value value, Optional<Label> continuation)
 {
     auto object = Object::create(realm(), nullptr);
-    object->define_direct_property("result", value, JS::default_attributes);
+    object->define_direct_property(m_vm.names.result, value, JS::default_attributes);
 
     if (continuation.has_value())
         // FIXME: If we get a pointer, which is not accurately representable as a double
         //        will cause this to explode
-        object->define_direct_property("continuation", Value(continuation->address()), JS::default_attributes);
+        object->define_direct_property(m_vm.names.continuation, Value(continuation->address()), JS::default_attributes);
     else
-        object->define_direct_property("continuation", js_null(), JS::default_attributes);
+        object->define_direct_property(m_vm.names.continuation, js_null(), JS::default_attributes);
 
-    object->define_direct_property("isAwait", Value(false), JS::default_attributes);
+    object->define_direct_property(m_vm.names.isAwait, Value(false), JS::default_attributes);
     return object;
 }
 
@@ -2842,13 +2842,14 @@ void PrepareYield::execute_impl(Bytecode::Interpreter& interpreter) const
 
 void Await::execute_impl(Bytecode::Interpreter& interpreter) const
 {
+    auto& vm = interpreter.vm();
     auto yielded_value = interpreter.get(m_argument).value_or(js_undefined());
     auto object = Object::create(interpreter.realm(), nullptr);
-    object->define_direct_property("result", yielded_value, JS::default_attributes);
+    object->define_direct_property(vm.names.result, yielded_value, JS::default_attributes);
     // FIXME: If we get a pointer, which is not accurately representable as a double
     //        will cause this to explode
-    object->define_direct_property("continuation", Value(m_continuation_label.address()), JS::default_attributes);
-    object->define_direct_property("isAwait", Value(true), JS::default_attributes);
+    object->define_direct_property(vm.names.continuation, Value(m_continuation_label.address()), JS::default_attributes);
+    object->define_direct_property(vm.names.isAwait, Value(true), JS::default_attributes);
     interpreter.do_return(object);
 }
 

--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -109,7 +109,7 @@ private:
 
 extern bool g_dump_bytecode;
 
-ThrowCompletionOr<GC::Ref<Bytecode::Executable>> compile(VM&, ASTNode const&, JS::FunctionKind kind, DeprecatedFlyString const& name);
+ThrowCompletionOr<GC::Ref<Bytecode::Executable>> compile(VM&, ASTNode const&, JS::FunctionKind kind, FlyString const& name);
 ThrowCompletionOr<GC::Ref<Bytecode::Executable>> compile(VM&, ECMAScriptFunctionObject const&);
 
 }

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -1336,8 +1336,6 @@ public:
     Operand base() const { return m_base; }
     Operand property() const { return m_property; }
 
-    Optional<DeprecatedFlyString const&> base_identifier(Bytecode::Interpreter const&) const;
-
 private:
     Operand m_dst;
     Operand m_base;

--- a/Libraries/LibJS/Bytecode/RegexTable.h
+++ b/Libraries/LibJS/Bytecode/RegexTable.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/DistinctNumeric.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibRegex/RegexParser.h>
 
@@ -17,7 +17,7 @@ AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, RegexTableIndex, Comparison);
 
 struct ParsedRegex {
     regex::Parser::Result regex;
-    ByteString pattern;
+    String pattern;
     regex::RegexOptions<ECMAScriptFlags> flags;
 };
 

--- a/Libraries/LibJS/Bytecode/StringTable.cpp
+++ b/Libraries/LibJS/Bytecode/StringTable.cpp
@@ -8,13 +8,13 @@
 
 namespace JS::Bytecode {
 
-StringTableIndex StringTable::insert(ByteString string)
+StringTableIndex StringTable::insert(String string)
 {
     m_strings.append(move(string));
     return m_strings.size() - 1;
 }
 
-ByteString const& StringTable::get(StringTableIndex index) const
+String const& StringTable::get(StringTableIndex index) const
 {
     return m_strings[index.value()];
 }

--- a/Libraries/LibJS/Bytecode/StringTable.h
+++ b/Libraries/LibJS/Bytecode/StringTable.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/DistinctNumeric.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 
 namespace JS::Bytecode {
@@ -21,13 +21,13 @@ class StringTable {
 public:
     StringTable() = default;
 
-    StringTableIndex insert(ByteString);
-    ByteString const& get(StringTableIndex) const;
+    StringTableIndex insert(String);
+    String const& get(StringTableIndex) const;
     void dump() const;
     bool is_empty() const { return m_strings.is_empty(); }
 
 private:
-    Vector<ByteString> m_strings;
+    Vector<String> m_strings;
 };
 
 }

--- a/Libraries/LibJS/Console.cpp
+++ b/Libraries/LibJS/Console.cpp
@@ -172,7 +172,7 @@ static ThrowCompletionOr<GC::Ref<Object>> create_table_row(Realm& realm, Value r
 
     // 2. Set `row["(index)"]` to `rowIndex`
     {
-        auto key = PropertyKey { "(index)", PropertyKey::StringMayBeNumber::No };
+        auto key = PropertyKey { "(index)"_fly_string, PropertyKey::StringMayBeNumber::No };
         TRY(row->set(key, row_index, Object::ShouldThrowExceptions::No));
 
         add_column(key);

--- a/Libraries/LibJS/Contrib/Test262/262Object.cpp
+++ b/Libraries/LibJS/Contrib/Test262/262Object.cpp
@@ -36,15 +36,15 @@ void $262Object::initialize(Realm& realm)
     m_is_htmldda = realm.create<IsHTMLDDA>(realm);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_native_function(realm, "clearKeptObjects", clear_kept_objects, 0, attr);
-    define_native_function(realm, "createRealm", create_realm, 0, attr);
-    define_native_function(realm, "detachArrayBuffer", detach_array_buffer, 1, attr);
-    define_native_function(realm, "evalScript", eval_script, 1, attr);
+    define_native_function(realm, "clearKeptObjects"_fly_string, clear_kept_objects, 0, attr);
+    define_native_function(realm, "createRealm"_fly_string, create_realm, 0, attr);
+    define_native_function(realm, "detachArrayBuffer"_fly_string, detach_array_buffer, 1, attr);
+    define_native_function(realm, "evalScript"_fly_string, eval_script, 1, attr);
 
-    define_direct_property("agent", m_agent, attr);
-    define_direct_property("gc", realm.global_object().get_without_side_effects("gc"), attr);
-    define_direct_property("global", &realm.global_object(), attr);
-    define_direct_property("IsHTMLDDA", m_is_htmldda, attr);
+    define_direct_property("agent"_fly_string, m_agent, attr);
+    define_direct_property("gc"_fly_string, realm.global_object().get_without_side_effects("gc"_fly_string), attr);
+    define_direct_property("global"_fly_string, &realm.global_object(), attr);
+    define_direct_property("IsHTMLDDA"_fly_string, m_is_htmldda, attr);
 }
 
 void $262Object::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibJS/Contrib/Test262/AgentObject.cpp
+++ b/Libraries/LibJS/Contrib/Test262/AgentObject.cpp
@@ -24,8 +24,8 @@ void AgentObject::initialize(JS::Realm& realm)
     Base::initialize(realm);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_native_function(realm, "monotonicNow", monotonic_now, 0, attr);
-    define_native_function(realm, "sleep", sleep, 1, attr);
+    define_native_function(realm, "monotonicNow"_fly_string, monotonic_now, 0, attr);
+    define_native_function(realm, "sleep"_fly_string, sleep, 1, attr);
     // TODO: broadcast
     // TODO: getReport
     // TODO: start

--- a/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
+++ b/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
@@ -24,8 +24,8 @@ void GlobalObject::initialize(Realm& realm)
 
     // https://github.com/tc39/test262/blob/master/INTERPRETING.md#host-defined-functions
     u8 attr = Attribute::Writable | Attribute::Configurable;
-    define_native_function(realm, "print", print, 1, attr);
-    define_direct_property("$262", m_$262, attr);
+    define_native_function(realm, "print"_fly_string, print, 1, attr);
+    define_direct_property("$262"_fly_string, m_$262, attr);
 }
 
 void GlobalObject::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
+++ b/Libraries/LibJS/Contrib/Test262/IsHTMLDDA.cpp
@@ -13,7 +13,7 @@ GC_DEFINE_ALLOCATOR(IsHTMLDDA);
 
 IsHTMLDDA::IsHTMLDDA(Realm& realm)
     // NativeFunction without prototype is currently not possible (only due to the lack of a ctor that supports it)
-    : NativeFunction("IsHTMLDDA", realm.intrinsics().function_prototype())
+    : NativeFunction("IsHTMLDDA"_fly_string, realm.intrinsics().function_prototype())
 {
 }
 

--- a/Libraries/LibJS/CyclicModule.cpp
+++ b/Libraries/LibJS/CyclicModule.cpp
@@ -611,7 +611,7 @@ void CyclicModule::execute_async_module(VM& vm)
     };
 
     // 5. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 0, "", « »).
-    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 0, "");
+    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 0);
 
     // 6. Let rejectedClosure be a new Abstract Closure with parameters (error) that captures module and performs the following steps when called:
     auto rejected_closure = [&](VM& vm) -> ThrowCompletionOr<Value> {
@@ -625,7 +625,7 @@ void CyclicModule::execute_async_module(VM& vm)
     };
 
     // 7. Let onRejected be CreateBuiltinFunction(rejectedClosure, 0, "", « »).
-    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 0, "");
+    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 0);
 
     // 8. Perform PerformPromiseThen(capability.[[Promise]], onFulfilled, onRejected).
     as<Promise>(capability->promise().ptr())->perform_then(on_fulfilled, on_rejected, {});
@@ -863,7 +863,7 @@ void continue_dynamic_import(GC::Ref<PromiseCapability> promise_capability, Thro
     };
 
     // 5. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    auto on_rejected = NativeFunction::create(*vm.current_realm(), move(reject_closure), 1, "");
+    auto on_rejected = NativeFunction::create(*vm.current_realm(), move(reject_closure), 1);
 
     // 6. Let linkAndEvaluateClosure be a new Abstract Closure with no parameters that captures module, promiseCapability,
     //    and onRejected and performs the following steps when called:
@@ -897,7 +897,7 @@ void continue_dynamic_import(GC::Ref<PromiseCapability> promise_capability, Thro
         };
 
         // e. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 0, "", « »).
-        auto on_fulfilled = NativeFunction::create(*vm.current_realm(), move(fulfilled_closure), 0, "");
+        auto on_fulfilled = NativeFunction::create(*vm.current_realm(), move(fulfilled_closure), 0);
 
         // f. Perform PerformPromiseThen(evaluatePromise, onFulfilled, onRejected).
         evaluate_promise.value()->perform_then(on_fulfilled, on_rejected, {});
@@ -907,7 +907,7 @@ void continue_dynamic_import(GC::Ref<PromiseCapability> promise_capability, Thro
     };
 
     // 7. Let linkAndEvaluate be CreateBuiltinFunction(linkAndEvaluateClosure, 0, "", « »).
-    auto link_and_evaluate = NativeFunction::create(*vm.current_realm(), move(link_and_evaluate_closure), 0, "");
+    auto link_and_evaluate = NativeFunction::create(*vm.current_realm(), move(link_and_evaluate_closure), 0);
 
     // 8. Perform PerformPromiseThen(loadPromise, linkAndEvaluate, onRejected).
     // FIXME: This is likely a spec bug, see load_requested_modules.

--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -16,7 +16,7 @@
 
 namespace JS {
 
-HashMap<DeprecatedFlyString, TokenType> Lexer::s_keywords;
+HashMap<FlyString, TokenType> Lexer::s_keywords;
 
 static constexpr TokenType parse_two_char_token(StringView view)
 {
@@ -231,46 +231,46 @@ Lexer::Lexer(StringView source, StringView filename, size_t line_number, size_t 
     , m_parsed_identifiers(adopt_ref(*new ParsedIdentifiers))
 {
     if (s_keywords.is_empty()) {
-        s_keywords.set("async", TokenType::Async);
-        s_keywords.set("await", TokenType::Await);
-        s_keywords.set("break", TokenType::Break);
-        s_keywords.set("case", TokenType::Case);
-        s_keywords.set("catch", TokenType::Catch);
-        s_keywords.set("class", TokenType::Class);
-        s_keywords.set("const", TokenType::Const);
-        s_keywords.set("continue", TokenType::Continue);
-        s_keywords.set("debugger", TokenType::Debugger);
-        s_keywords.set("default", TokenType::Default);
-        s_keywords.set("delete", TokenType::Delete);
-        s_keywords.set("do", TokenType::Do);
-        s_keywords.set("else", TokenType::Else);
-        s_keywords.set("enum", TokenType::Enum);
-        s_keywords.set("export", TokenType::Export);
-        s_keywords.set("extends", TokenType::Extends);
-        s_keywords.set("false", TokenType::BoolLiteral);
-        s_keywords.set("finally", TokenType::Finally);
-        s_keywords.set("for", TokenType::For);
-        s_keywords.set("function", TokenType::Function);
-        s_keywords.set("if", TokenType::If);
-        s_keywords.set("import", TokenType::Import);
-        s_keywords.set("in", TokenType::In);
-        s_keywords.set("instanceof", TokenType::Instanceof);
-        s_keywords.set("let", TokenType::Let);
-        s_keywords.set("new", TokenType::New);
-        s_keywords.set("null", TokenType::NullLiteral);
-        s_keywords.set("return", TokenType::Return);
-        s_keywords.set("super", TokenType::Super);
-        s_keywords.set("switch", TokenType::Switch);
-        s_keywords.set("this", TokenType::This);
-        s_keywords.set("throw", TokenType::Throw);
-        s_keywords.set("true", TokenType::BoolLiteral);
-        s_keywords.set("try", TokenType::Try);
-        s_keywords.set("typeof", TokenType::Typeof);
-        s_keywords.set("var", TokenType::Var);
-        s_keywords.set("void", TokenType::Void);
-        s_keywords.set("while", TokenType::While);
-        s_keywords.set("with", TokenType::With);
-        s_keywords.set("yield", TokenType::Yield);
+        s_keywords.set("async"_fly_string, TokenType::Async);
+        s_keywords.set("await"_fly_string, TokenType::Await);
+        s_keywords.set("break"_fly_string, TokenType::Break);
+        s_keywords.set("case"_fly_string, TokenType::Case);
+        s_keywords.set("catch"_fly_string, TokenType::Catch);
+        s_keywords.set("class"_fly_string, TokenType::Class);
+        s_keywords.set("const"_fly_string, TokenType::Const);
+        s_keywords.set("continue"_fly_string, TokenType::Continue);
+        s_keywords.set("debugger"_fly_string, TokenType::Debugger);
+        s_keywords.set("default"_fly_string, TokenType::Default);
+        s_keywords.set("delete"_fly_string, TokenType::Delete);
+        s_keywords.set("do"_fly_string, TokenType::Do);
+        s_keywords.set("else"_fly_string, TokenType::Else);
+        s_keywords.set("enum"_fly_string, TokenType::Enum);
+        s_keywords.set("export"_fly_string, TokenType::Export);
+        s_keywords.set("extends"_fly_string, TokenType::Extends);
+        s_keywords.set("false"_fly_string, TokenType::BoolLiteral);
+        s_keywords.set("finally"_fly_string, TokenType::Finally);
+        s_keywords.set("for"_fly_string, TokenType::For);
+        s_keywords.set("function"_fly_string, TokenType::Function);
+        s_keywords.set("if"_fly_string, TokenType::If);
+        s_keywords.set("import"_fly_string, TokenType::Import);
+        s_keywords.set("in"_fly_string, TokenType::In);
+        s_keywords.set("instanceof"_fly_string, TokenType::Instanceof);
+        s_keywords.set("let"_fly_string, TokenType::Let);
+        s_keywords.set("new"_fly_string, TokenType::New);
+        s_keywords.set("null"_fly_string, TokenType::NullLiteral);
+        s_keywords.set("return"_fly_string, TokenType::Return);
+        s_keywords.set("super"_fly_string, TokenType::Super);
+        s_keywords.set("switch"_fly_string, TokenType::Switch);
+        s_keywords.set("this"_fly_string, TokenType::This);
+        s_keywords.set("throw"_fly_string, TokenType::Throw);
+        s_keywords.set("true"_fly_string, TokenType::BoolLiteral);
+        s_keywords.set("try"_fly_string, TokenType::Try);
+        s_keywords.set("typeof"_fly_string, TokenType::Typeof);
+        s_keywords.set("var"_fly_string, TokenType::Var);
+        s_keywords.set("void"_fly_string, TokenType::Void);
+        s_keywords.set("while"_fly_string, TokenType::While);
+        s_keywords.set("with"_fly_string, TokenType::With);
+        s_keywords.set("yield"_fly_string, TokenType::Yield);
     }
 
     consume();
@@ -699,7 +699,7 @@ Token Lexer::next()
     // bunch of Invalid* tokens (bad numeric literals, unterminated comments etc.)
     StringView token_message;
 
-    Optional<DeprecatedFlyString> identifier;
+    Optional<FlyString> identifier;
     size_t identifier_length = 0;
 
     if (m_current_token.type() == TokenType::RegexLiteral && !is_eof() && is_ascii_alpha(m_current_char) && !did_consume_whitespace_or_comments) {
@@ -767,7 +767,7 @@ Token Lexer::next()
                 code_point = is_identifier_middle(identifier_length);
             } while (code_point.has_value());
 
-            identifier = builder.string_view();
+            identifier = builder.to_string_without_validation();
             token_type = TokenType::PrivateIdentifier;
 
             m_parsed_identifiers->identifiers.set(*identifier);
@@ -789,7 +789,7 @@ Token Lexer::next()
             code_point = is_identifier_middle(identifier_length);
         } while (code_point.has_value());
 
-        identifier = builder.string_view();
+        identifier = builder.to_string_without_validation();
         m_parsed_identifiers->identifiers.set(*identifier);
 
         auto it = s_keywords.find(identifier->hash(), [&](auto& entry) { return entry.key == identifier; });

--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -80,12 +80,12 @@ private:
 
     Optional<size_t> m_hit_invalid_unicode;
 
-    static HashMap<DeprecatedFlyString, TokenType> s_keywords;
+    static HashMap<FlyString, TokenType> s_keywords;
 
     struct ParsedIdentifiers : public RefCounted<ParsedIdentifiers> {
         // Resolved identifiers must be kept alive for the duration of the parsing stage, otherwise
         // the only references to these strings are deleted by the Token destructor.
-        HashTable<DeprecatedFlyString> identifiers;
+        HashTable<FlyString> identifiers;
     };
 
     RefPtr<ParsedIdentifiers> m_parsed_identifiers;

--- a/Libraries/LibJS/Module.cpp
+++ b/Libraries/LibJS/Module.cpp
@@ -101,7 +101,7 @@ void finish_loading_imported_module(ImportedModuleReferrer referrer, ModuleReque
 
                 // i. Append the Record { [[Specifier]]: specifier, [[Module]]: result.[[Value]] } to referrer.[[LoadedModules]].
                 loaded_modules.append(ModuleWithSpecifier {
-                    .specifier = module_request.module_specifier,
+                    .specifier = module_request.module_specifier.to_string(),
                     .module = GC::Ref<Module>(*module) });
             }
         }
@@ -136,7 +136,7 @@ ThrowCompletionOr<Object*> Module::get_module_namespace(VM& vm)
         auto exported_names = TRY(get_exported_names(vm));
 
         // b. Let unambiguousNames be a new empty List.
-        Vector<DeprecatedFlyString> unambiguous_names;
+        Vector<FlyString> unambiguous_names;
 
         // c. For each element name of exportedNames, do
         for (auto& name : exported_names) {
@@ -159,7 +159,7 @@ ThrowCompletionOr<Object*> Module::get_module_namespace(VM& vm)
 }
 
 // 10.4.6.12 ModuleNamespaceCreate ( module, exports ), https://tc39.es/ecma262/#sec-modulenamespacecreate
-Object* Module::module_namespace_create(Vector<DeprecatedFlyString> unambiguous_names)
+Object* Module::module_namespace_create(Vector<FlyString> unambiguous_names)
 {
     auto& realm = this->realm();
 

--- a/Libraries/LibJS/Module.h
+++ b/Libraries/LibJS/Module.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <LibGC/Ptr.h>
 #include <LibJS/ModuleLoading.h>
 #include <LibJS/Runtime/Environment.h>
@@ -38,7 +38,7 @@ struct ResolvedBinding {
 
     Type type { Null };
     GC::Ptr<Module> module;
-    DeprecatedFlyString export_name;
+    FlyString export_name;
 
     bool is_valid() const
     {
@@ -109,8 +109,8 @@ public:
     virtual ThrowCompletionOr<void> link(VM& vm) = 0;
     virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) = 0;
 
-    virtual ThrowCompletionOr<Vector<DeprecatedFlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set = {}) = 0;
-    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, DeprecatedFlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) = 0;
+    virtual ThrowCompletionOr<Vector<FlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set = {}) = 0;
+    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) = 0;
 
     virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index);
     virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index);
@@ -128,7 +128,7 @@ protected:
     }
 
 private:
-    Object* module_namespace_create(Vector<DeprecatedFlyString> unambiguous_names);
+    Object* module_namespace_create(Vector<FlyString> unambiguous_names);
 
     // These handles are only safe as long as the VM they live in is valid.
     // But evaluated modules SHOULD be stored in the VM so unless you intentionally

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -243,7 +243,7 @@ private:
     bool match(TokenType type) const;
     bool done() const;
     void expected(char const* what);
-    void syntax_error(ByteString const& message, Optional<Position> = {});
+    void syntax_error(String const& message, Optional<Position> = {});
     Token consume();
     Token consume_and_allow_division();
     Token consume_identifier();
@@ -260,7 +260,7 @@ private:
 
     Token next_token(size_t steps = 1) const;
 
-    void check_identifier_name_for_assignment_validity(DeprecatedFlyString const&, bool force_strict = false);
+    void check_identifier_name_for_assignment_validity(FlyString const&, bool force_strict = false);
 
     bool try_parse_arrow_function_expression_failed_at_position(Position const&) const;
     void set_try_parse_arrow_function_expression_failed_at_position(Position const&, bool);
@@ -270,7 +270,7 @@ private:
     bool parse_directive(ScopeNode& body);
     void parse_statement_list(ScopeNode& output_node, AllowLabelledFunction allow_labelled_functions = AllowLabelledFunction::No);
 
-    DeprecatedFlyString consume_string_value();
+    FlyString consume_string_value();
     ModuleRequest parse_module_request();
 
     struct RulePosition {
@@ -308,9 +308,9 @@ private:
         Vector<ParserError> errors;
         ScopePusher* current_scope_pusher { nullptr };
 
-        HashMap<StringView, Optional<Position>> labels_in_scope;
+        HashMap<FlyString, Optional<Position>> labels_in_scope;
         HashMap<size_t, Position> invalid_property_range_in_object_expression;
-        HashTable<StringView>* referenced_private_names { nullptr };
+        HashTable<FlyString>* referenced_private_names { nullptr };
 
         bool strict_mode { false };
         bool allow_super_property_lookup { false };
@@ -333,7 +333,7 @@ private:
         ParserState(Lexer, Program::Type);
     };
 
-    [[nodiscard]] NonnullRefPtr<Identifier const> create_identifier_and_register_in_current_scope(SourceRange range, DeprecatedFlyString string, Optional<DeclarationKind> = {});
+    [[nodiscard]] NonnullRefPtr<Identifier const> create_identifier_and_register_in_current_scope(SourceRange range, FlyString string, Optional<DeclarationKind> = {});
 
     NonnullRefPtr<SourceCode const> m_source_code;
     Vector<Position> m_rule_starts;

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -338,7 +338,6 @@ private:
     NonnullRefPtr<SourceCode const> m_source_code;
     Vector<Position> m_rule_starts;
     ParserState m_state;
-    DeprecatedFlyString m_filename;
     Vector<ParserState> m_saved_state;
     HashMap<size_t, TokenMemoization> m_token_memoizations;
     Program::Type m_program_type;

--- a/Libraries/LibJS/ParserError.cpp
+++ b/Libraries/LibJS/ParserError.cpp
@@ -15,14 +15,14 @@ namespace JS {
 String ParserError::to_string() const
 {
     if (!position.has_value())
-        return MUST(String::from_byte_string(message));
+        return message;
     return MUST(String::formatted("{} (line: {}, column: {})", message, position.value().line, position.value().column));
 }
 
 ByteString ParserError::to_byte_string() const
 {
     if (!position.has_value())
-        return message;
+        return message.to_byte_string();
     return ByteString::formatted("{} (line: {}, column: {})", message, position.value().line, position.value().column);
 }
 

--- a/Libraries/LibJS/ParserError.h
+++ b/Libraries/LibJS/ParserError.h
@@ -16,7 +16,7 @@
 namespace JS {
 
 struct ParserError {
-    ByteString message;
+    String message;
     Optional<Position> position;
 
     String to_string() const;

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1363,7 +1363,7 @@ ThrowCompletionOr<String> get_substitution(VM& vm, Utf16View const& matched, Utf
 
                 // 2. Let groupName be the substring of templateRemainder from 2 to gtPos.
                 auto group_name_view = template_remainder.substring_view(2, *greater_than_position - 2);
-                auto group_name = MUST(group_name_view.to_byte_string(Utf16View::AllowInvalidCodeUnits::Yes));
+                auto group_name = MUST(group_name_view.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
 
                 // 3. Assert: namedCaptures is an Object.
                 VERIFY(named_captures.is_object());

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -233,7 +233,7 @@ ThrowCompletionOr<void> initialize_bound_name(VM& vm, DeprecatedFlyString const&
 bool is_compatible_property_descriptor(bool extensible, PropertyDescriptor const& descriptor, Optional<PropertyDescriptor> const& current)
 {
     // 1. Return ValidateAndApplyPropertyDescriptor(undefined, "", Extensible, Desc, Current).
-    return validate_and_apply_property_descriptor(nullptr, "", extensible, descriptor, current);
+    return validate_and_apply_property_descriptor(nullptr, FlyString {}, extensible, descriptor, current);
 }
 
 // 10.1.6.3 ValidateAndApplyPropertyDescriptor ( O, P, extensible, Desc, current ), https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor
@@ -1544,7 +1544,7 @@ ThrowCompletionOr<GC::Ptr<FunctionObject>> get_dispose_method(VM& vm, Value valu
                 //    thrown synchronously.
 
                 // 3. Return CreateBuiltinFunction(closure, 0, "", « »).
-                return NativeFunction::create(realm, move(closure), 0, "");
+                return NativeFunction::create(realm, move(closure), 0);
             }
         }
     }

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -206,7 +206,7 @@ ThrowCompletionOr<Realm*> get_function_realm(VM& vm, FunctionObject const& funct
 }
 
 // 8.5.2.1 InitializeBoundName ( name, value, environment ), https://tc39.es/ecma262/#sec-initializeboundname
-ThrowCompletionOr<void> initialize_bound_name(VM& vm, DeprecatedFlyString const& name, Value value, Environment* environment)
+ThrowCompletionOr<void> initialize_bound_name(VM& vm, FlyString const& name, Value value, Environment* environment)
 {
     // 1. If environment is not undefined, then
     if (environment) {
@@ -692,7 +692,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
         return vm.throw_completion<InternalError>(ErrorType::NotImplemented, TRY_OR_THROW_OOM(vm, executable_result.error().to_string()));
 
     auto executable = executable_result.release_value();
-    executable->name = "eval"sv;
+    executable->name = "eval"_fly_string;
     if (Bytecode::g_dump_bytecode)
         executable->dump();
     auto result_or_error = vm.bytecode_interpreter().run_executable(*executable, {});
@@ -779,7 +779,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
     Vector<FunctionDeclaration const&> functions_to_initialize;
 
     // 9. Let declaredFunctionNames be a new empty List.
-    HashTable<DeprecatedFlyString> declared_function_names;
+    HashTable<FlyString> declared_function_names;
 
     // 10. For each element d of varDeclarations, in reverse List order, do
     TRY(program.for_each_var_function_declaration_in_reverse_order([&](FunctionDeclaration const& function) -> ThrowCompletionOr<void> {
@@ -820,7 +820,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
     if (!strict) {
         // a. Let declaredFunctionOrVarNames be the list-concatenation of declaredFunctionNames and declaredVarNames.
         // The spec here uses 'declaredVarNames' but that has not been declared yet.
-        HashTable<DeprecatedFlyString> hoisted_functions;
+        HashTable<FlyString> hoisted_functions;
 
         // b. For each FunctionDeclaration f that is directly contained in the StatementList of a Block, CaseClause, or DefaultClause Contained within body, do
         TRY(program.for_each_function_hoistable_with_annexB_extension([&](FunctionDeclaration& function_declaration) -> ThrowCompletionOr<void> {
@@ -911,7 +911,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
     }
 
     // 12. Let declaredVarNames be a new empty List.
-    HashTable<DeprecatedFlyString> declared_var_names;
+    HashTable<FlyString> declared_var_names;
 
     // 13. For each element d of varDeclarations, do
     TRY(program.for_each_var_scoped_variable_declaration([&](VariableDeclaration const& declaration) {
@@ -1109,7 +1109,7 @@ Object* create_mapped_arguments_object(VM& vm, FunctionObject& function, Vector<
     MUST(object->define_property_or_throw(vm.names.length, { .value = Value(length), .writable = true, .enumerable = false, .configurable = true }));
 
     // 17. Let mappedNames be a new empty List.
-    HashTable<DeprecatedFlyString> mapped_names;
+    HashTable<FlyString> mapped_names;
 
     // 18. Set index to numberOfParameters - 1.
     // 19. Repeat, while index ≥ 0,
@@ -1178,19 +1178,21 @@ CanonicalIndex canonical_numeric_index_string(PropertyKey const& property_key, C
     if (argument.is_empty())
         return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
     u32 current_index = 0;
-    if (argument.characters()[current_index] == '-') {
+    auto const* characters = argument.bytes_as_string_view().characters_without_null_termination();
+    auto const length = argument.bytes_as_string_view().length();
+    if (characters[current_index] == '-') {
         current_index++;
-        if (current_index == argument.length())
+        if (current_index == length)
             return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
     }
-    if (argument.characters()[current_index] == '0') {
+    if (characters[current_index] == '0') {
         current_index++;
-        if (current_index == argument.length())
+        if (current_index == length)
             return CanonicalIndex(CanonicalIndex::Type::Numeric, 0);
-        if (argument.characters()[current_index] != '.')
+        if (characters[current_index] != '.')
             return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
         current_index++;
-        if (current_index == argument.length())
+        if (current_index == length)
             return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
     }
 
@@ -1199,17 +1201,17 @@ CanonicalIndex canonical_numeric_index_string(PropertyKey const& property_key, C
         return CanonicalIndex(CanonicalIndex::Type::Numeric, 0);
 
     // Short circuit any string that doesn't start with digits
-    if (char first_non_zero = argument.characters()[current_index]; first_non_zero < '0' || first_non_zero > '9')
+    if (char first_non_zero = characters[current_index]; first_non_zero < '0' || first_non_zero > '9')
         return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
 
     // 2. Let n be ! ToNumber(argument).
-    auto maybe_double = argument.to_number<double>(AK::TrimWhitespace::No);
+    auto maybe_double = argument.bytes_as_string_view().to_number<double>(AK::TrimWhitespace::No);
     if (!maybe_double.has_value())
         return CanonicalIndex(CanonicalIndex::Type::Undefined, 0);
 
     // FIXME: We return 0 instead of n but it might not observable?
     // 3. If SameValue(! ToString(n), argument) is true, return n.
-    if (number_to_string(*maybe_double) == argument.view())
+    if (number_to_string(*maybe_double) == argument)
         return CanonicalIndex(CanonicalIndex::Type::Numeric, 0);
 
     // 4. Return undefined.
@@ -1724,7 +1726,7 @@ ThrowCompletionOr<Value> perform_import_call(VM& vm, Value specifier, Value opti
 
     // 8. Let specifierString be Completion(ToString(specifier)).
     // 9. IfAbruptRejectPromise(specifierString, promiseCapability).
-    auto specifier_string = TRY_OR_REJECT_WITH_VALUE(vm, promise_capability, specifier.to_byte_string(vm));
+    auto specifier_string = TRY_OR_REJECT_WITH_VALUE(vm, promise_capability, specifier.to_string(vm));
 
     // 10. Let attributes be a new empty List.
     Vector<ImportAttribute> attributes;
@@ -1780,7 +1782,7 @@ ThrowCompletionOr<Value> perform_import_call(VM& vm, Value specifier, Value opti
                 }
 
                 // 4. Append the ImportAttribute Record { [[Key]]: key, [[Value]]: value } to attributes.
-                attributes.empend(key.as_string().byte_string(), value.as_string().byte_string());
+                attributes.empend(key.as_string().utf8_string(), value.as_string().utf8_string());
             }
         }
 

--- a/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -38,7 +38,7 @@ ThrowCompletionOr<size_t> length_of_array_like(VM&, Object const&);
 ThrowCompletionOr<GC::RootVector<Value>> create_list_from_array_like(VM&, Value, Function<ThrowCompletionOr<void>(Value)> = {});
 ThrowCompletionOr<FunctionObject*> species_constructor(VM&, Object const&, FunctionObject& default_constructor);
 ThrowCompletionOr<Realm*> get_function_realm(VM&, FunctionObject const&);
-ThrowCompletionOr<void> initialize_bound_name(VM&, DeprecatedFlyString const&, Value, Environment*);
+ThrowCompletionOr<void> initialize_bound_name(VM&, FlyString const&, Value, Environment*);
 bool is_compatible_property_descriptor(bool extensible, PropertyDescriptor const&, Optional<PropertyDescriptor> const& current);
 bool validate_and_apply_property_descriptor(Object*, PropertyKey const&, bool extensible, PropertyDescriptor const&, Optional<PropertyDescriptor> const& current);
 ThrowCompletionOr<Object*> get_prototype_from_constructor(VM&, FunctionObject const& constructor, GC::Ref<Object> (Intrinsics::*intrinsic_default_prototype)());

--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -243,10 +243,10 @@ ThrowCompletionOr<double> compare_array_elements(VM& vm, Value x, Value y, Funct
     }
 
     // 5. Let xString be ? ToString(x).
-    auto x_string = PrimitiveString::create(vm, TRY(x.to_byte_string(vm)));
+    auto x_string = PrimitiveString::create(vm, TRY(x.to_string(vm)));
 
     // 6. Let yString be ? ToString(y).
-    auto y_string = PrimitiveString::create(vm, TRY(y.to_byte_string(vm)));
+    auto y_string = PrimitiveString::create(vm, TRY(y.to_string(vm)));
 
     // 7. Let xSmaller be ! IsLessThan(xString, yString, true).
     auto x_smaller = MUST(is_less_than(vm, x_string, y_string, true));

--- a/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -838,9 +838,9 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::join)
     };
 
     auto length = TRY(length_of_array_like(vm, this_object));
-    ByteString separator = ",";
+    String separator = ","_string;
     if (!vm.argument(0).is_undefined())
-        separator = TRY(vm.argument(0).to_byte_string(vm));
+        separator = TRY(vm.argument(0).to_string(vm));
     StringBuilder builder;
     for (size_t i = 0; i < length; ++i) {
         if (i > 0)
@@ -848,11 +848,11 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::join)
         auto value = TRY(this_object->get(i));
         if (value.is_nullish())
             continue;
-        auto string = TRY(value.to_byte_string(vm));
+        auto string = TRY(value.to_string(vm));
         builder.append(string);
     }
 
-    return PrimitiveString::create(vm, builder.to_byte_string());
+    return PrimitiveString::create(vm, builder.to_string_without_validation());
 }
 
 // 23.1.3.19 Array.prototype.keys ( ), https://tc39.es/ecma262/#sec-array.prototype.keys
@@ -1650,7 +1650,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::to_locale_string)
             auto locale_string_result = TRY(value.invoke(vm, vm.names.toLocaleString, locales, options));
 
             // ii. Set R to the string-concatenation of R and S.
-            auto string = TRY(locale_string_result.to_byte_string(vm));
+            auto string = TRY(locale_string_result.to_string(vm));
             builder.append(string);
         }
 
@@ -1658,7 +1658,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::to_locale_string)
     }
 
     // 7. Return R.
-    return PrimitiveString::create(vm, builder.to_byte_string());
+    return PrimitiveString::create(vm, builder.to_string_without_validation());
 }
 
 // 23.1.3.33 Array.prototype.toReversed ( ), https://tc39.es/ecma262/#sec-array.prototype.toreversed

--- a/Libraries/LibJS/Runtime/AsyncDisposableStackPrototype.cpp
+++ b/Libraries/LibJS/Runtime/AsyncDisposableStackPrototype.cpp
@@ -68,7 +68,7 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncDisposableStackPrototype::adopt)
     };
 
     // 6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
-    auto function = NativeFunction::create(realm, move(closure), 0, "");
+    auto function = NativeFunction::create(realm, move(closure), 0);
 
     // 7. Perform ? AddDisposableResource(asyncDisposableStack.[[DisposeCapability]], undefined, async-dispose, F).
     TRY(add_disposable_resource(vm, async_disposable_stack->dispose_capability(), js_undefined(), Environment::InitializeBindingHint::AsyncDispose, function));

--- a/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -58,7 +58,7 @@ static Object* async_from_sync_iterator_continuation(VM& vm, Object& result, Pro
 
     // 9. Let onFulfilled be CreateBuiltinFunction(unwrap, 1, "", « »).
     // 10. NOTE: onFulfilled is used when processing the "value" property of an IteratorResult object in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" IteratorResult object.
-    auto on_fulfilled = NativeFunction::create(realm, move(unwrap), 1, "");
+    auto on_fulfilled = NativeFunction::create(realm, move(unwrap), 1);
 
     // 11. Perform PerformPromiseThen(valueWrapper, onFulfilled, undefined, promiseCapability).
     as<Promise>(value_wrapper)->perform_then(move(on_fulfilled), js_undefined(), &promise_capability);

--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -75,7 +75,7 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
     };
 
     // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1, "");
+    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
 
     // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the
     //    following steps when called:
@@ -103,7 +103,7 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
     };
 
     // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1, "");
+    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
 
     // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
     m_current_promise = as<Promise>(promise_object);

--- a/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -104,7 +104,7 @@ ThrowCompletionOr<void> AsyncGenerator::await(Value value)
     };
 
     // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1, "");
+    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
 
     // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the
     //    following steps when called:
@@ -131,7 +131,7 @@ ThrowCompletionOr<void> AsyncGenerator::await(Value value)
     };
 
     // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1, "");
+    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
 
     // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
     m_current_promise = as<Promise>(promise_object);
@@ -155,15 +155,15 @@ void AsyncGenerator::execute(VM& vm, Completion completion)
         // Loosely based on step 4 of https://tc39.es/ecma262/#sec-asyncgeneratorstart
         VERIFY(completion.value().has_value());
 
-        auto generated_value = [](Value value) -> Value {
+        auto generated_value = [&vm](Value value) -> Value {
             if (value.is_object())
-                return value.as_object().get_without_side_effects("result");
+                return value.as_object().get_without_side_effects(vm.names.result);
             return value.is_empty() ? js_undefined() : value;
         };
 
         auto generated_continuation = [&](Value value) -> Optional<size_t> {
             if (value.is_object()) {
-                auto number_value = value.as_object().get_without_side_effects("continuation");
+                auto number_value = value.as_object().get_without_side_effects(vm.names.continuation);
                 if (number_value.is_null())
                     return {};
                 return static_cast<size_t>(number_value.as_double());
@@ -171,9 +171,9 @@ void AsyncGenerator::execute(VM& vm, Completion completion)
             return {};
         };
 
-        auto generated_is_await = [](Value value) -> bool {
+        auto generated_is_await = [&vm](Value value) -> bool {
             if (value.is_object())
-                return value.as_object().get_without_side_effects("isAwait").as_bool();
+                return value.as_object().get_without_side_effects(vm.names.isAwait).as_bool();
             return false;
         };
 
@@ -393,7 +393,7 @@ void AsyncGenerator::await_return()
     };
 
     // 11. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1, "");
+    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
 
     // 12. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures generator and performs
     //    the following steps when called:
@@ -415,7 +415,7 @@ void AsyncGenerator::await_return()
     };
 
     // 13. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1, "");
+    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
 
     // 14. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
     // NOTE: await_return should only be called when the generator is in SuspendedStart or Completed state,

--- a/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -40,7 +40,7 @@ BoundFunction::BoundFunction(Realm& realm, FunctionObject& bound_target_function
     , m_bound_this(bound_this)
     , m_bound_arguments(move(bound_arguments))
     // FIXME: Non-standard and redundant, remove.
-    , m_name(ByteString::formatted("bound {}", bound_target_function.name()))
+    , m_name(MUST(String::formatted("bound {}", bound_target_function.name())))
 {
 }
 

--- a/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Libraries/LibJS/Runtime/BoundFunction.h
@@ -23,7 +23,7 @@ public:
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
-    virtual DeprecatedFlyString const& name() const override { return m_name; }
+    virtual FlyString const& name() const override { return m_name; }
     virtual bool is_strict_mode() const override { return m_bound_target_function->is_strict_mode(); }
     virtual bool has_constructor() const override { return m_bound_target_function->has_constructor(); }
 
@@ -40,7 +40,7 @@ private:
     Value m_bound_this;                              // [[BoundThis]]
     Vector<Value> m_bound_arguments;                 // [[BoundArguments]]
 
-    DeprecatedFlyString m_name;
+    FlyString m_name;
 };
 
 }

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -92,6 +92,7 @@ namespace JS {
     P(construct)                             \
     P(constructor)                           \
     P(containing)                            \
+    P(continuation)                          \
     P(copyWithin)                            \
     P(cos)                                   \
     P(cosh)                                  \
@@ -277,6 +278,7 @@ namespace JS {
     P(Intl)                                  \
     P(is)                                    \
     P(isArray)                               \
+    P(isAwait)                               \
     P(isDisjointFrom)                        \
     P(isError)                               \
     P(isExtensible)                          \
@@ -408,6 +410,7 @@ namespace JS {
     P(reason)                                \
     P(reduce)                                \
     P(reduceRight)                           \
+    P(result)                                \
     P(Reflect)                               \
     P(RegExp)                                \
     P(region)                                \

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/PropertyKey.h>
 

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -608,35 +608,35 @@ namespace JS {
     P(zonedDateTimeISO)
 
 struct CommonPropertyNames {
-    PropertyKey and_ { "and", PropertyKey::StringMayBeNumber::No };
-    PropertyKey catch_ { "catch", PropertyKey::StringMayBeNumber::No };
-    PropertyKey delete_ { "delete", PropertyKey::StringMayBeNumber::No };
-    PropertyKey for_ { "for", PropertyKey::StringMayBeNumber::No };
-    PropertyKey or_ { "or", PropertyKey::StringMayBeNumber::No };
-    PropertyKey register_ { "register", PropertyKey::StringMayBeNumber::No };
-    PropertyKey return_ { "return", PropertyKey::StringMayBeNumber::No };
-    PropertyKey throw_ { "throw", PropertyKey::StringMayBeNumber::No };
-    PropertyKey try_ { "try", PropertyKey::StringMayBeNumber::No };
-    PropertyKey union_ { "union", PropertyKey::StringMayBeNumber::No };
-    PropertyKey xor_ { "xor", PropertyKey::StringMayBeNumber::No };
-    PropertyKey inputAlias { "$_", PropertyKey::StringMayBeNumber::No };
-    PropertyKey lastMatchAlias { "$&", PropertyKey::StringMayBeNumber::No };
-    PropertyKey lastParenAlias { "$+", PropertyKey::StringMayBeNumber::No };
-    PropertyKey leftContextAlias { "$`", PropertyKey::StringMayBeNumber::No };
-    PropertyKey rightContextAlias { "$'", PropertyKey::StringMayBeNumber::No };
-#define __ENUMERATE(x) PropertyKey x { #x, PropertyKey::StringMayBeNumber::No };
+    PropertyKey and_ { "and"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey catch_ { "catch"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey delete_ { "delete"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey for_ { "for"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey or_ { "or"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey register_ { "register"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey return_ { "return"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey throw_ { "throw"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey try_ { "try"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey union_ { "union"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey xor_ { "xor"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey inputAlias { "$_"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey lastMatchAlias { "$&"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey lastParenAlias { "$+"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey leftContextAlias { "$`"_fly_string, PropertyKey::StringMayBeNumber::No };
+    PropertyKey rightContextAlias { "$'"_fly_string, PropertyKey::StringMayBeNumber::No };
+#define __ENUMERATE(x) PropertyKey x { #x##_fly_string, PropertyKey::StringMayBeNumber::No };
     ENUMERATE_STANDARD_PROPERTY_NAMES(__ENUMERATE)
 #undef __ENUMERATE
-#define __JS_ENUMERATE(x, a, b, c, t) PropertyKey x { #x, PropertyKey::StringMayBeNumber::No };
+#define __JS_ENUMERATE(x, a, b, c, t) PropertyKey x { #x##_fly_string, PropertyKey::StringMayBeNumber::No };
     JS_ENUMERATE_BUILTIN_TYPES
 #undef __JS_ENUMERATE
-#define __JS_ENUMERATE(x, a, b, c) PropertyKey x { #x, PropertyKey::StringMayBeNumber::No };
+#define __JS_ENUMERATE(x, a, b, c) PropertyKey x { #x##_fly_string, PropertyKey::StringMayBeNumber::No };
     JS_ENUMERATE_INTL_OBJECTS
 #undef __JS_ENUMERATE
-#define __JS_ENUMERATE(x, a, b, c) PropertyKey x { #x, PropertyKey::StringMayBeNumber::No };
+#define __JS_ENUMERATE(x, a, b, c) PropertyKey x { #x##_fly_string, PropertyKey::StringMayBeNumber::No };
     JS_ENUMERATE_TEMPORAL_OBJECTS
 #undef __JS_ENUMERATE
-#define __JS_ENUMERATE(x, a) PropertyKey x { #x, PropertyKey::StringMayBeNumber::No };
+#define __JS_ENUMERATE(x, a) PropertyKey x { #x##_fly_string, PropertyKey::StringMayBeNumber::No };
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
 };

--- a/Libraries/LibJS/Runtime/Completion.cpp
+++ b/Libraries/LibJS/Runtime/Completion.cpp
@@ -66,7 +66,7 @@ ThrowCompletionOr<Value> await(VM& vm, Value value)
     };
 
     // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1, "");
+    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
 
     // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the following steps when called:
     auto rejected_closure = [&success, &result](VM& vm) -> ThrowCompletionOr<Value> {
@@ -90,7 +90,7 @@ ThrowCompletionOr<Value> await(VM& vm, Value value)
     };
 
     // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1, "");
+    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
 
     // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
     auto promise = as<Promise>(promise_object);

--- a/Libraries/LibJS/Runtime/Completion.h
+++ b/Libraries/LibJS/Runtime/Completion.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/Optional.h>
 #include <AK/Try.h>
 #include <AK/TypeCasts.h>

--- a/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -52,7 +52,7 @@ void DeclarativeEnvironment::visit_edges(Visitor& visitor)
 }
 
 // 9.1.1.1.1 HasBinding ( N ), https://tc39.es/ecma262/#sec-declarative-environment-records-hasbinding-n
-ThrowCompletionOr<bool> DeclarativeEnvironment::has_binding(DeprecatedFlyString const& name, Optional<size_t>* out_index) const
+ThrowCompletionOr<bool> DeclarativeEnvironment::has_binding(FlyString const& name, Optional<size_t>* out_index) const
 {
     auto binding_and_index = find_binding_and_index(name);
     if (!binding_and_index.has_value())
@@ -63,7 +63,7 @@ ThrowCompletionOr<bool> DeclarativeEnvironment::has_binding(DeprecatedFlyString 
 }
 
 // 9.1.1.1.2 CreateMutableBinding ( N, D ), https://tc39.es/ecma262/#sec-declarative-environment-records-createmutablebinding-n-d
-ThrowCompletionOr<void> DeclarativeEnvironment::create_mutable_binding(VM&, DeprecatedFlyString const& name, bool can_be_deleted)
+ThrowCompletionOr<void> DeclarativeEnvironment::create_mutable_binding(VM&, FlyString const& name, bool can_be_deleted)
 {
     // 1. Assert: envRec does not already have a binding for N.
     // NOTE: We skip this to avoid O(n) traversal of m_bindings.
@@ -86,7 +86,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_mutable_binding(VM&, Depr
 }
 
 // 9.1.1.1.3 CreateImmutableBinding ( N, S ), https://tc39.es/ecma262/#sec-declarative-environment-records-createimmutablebinding-n-s
-ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(VM&, DeprecatedFlyString const& name, bool strict)
+ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(VM&, FlyString const& name, bool strict)
 {
     // 1. Assert: envRec does not already have a binding for N.
     // NOTE: We skip this to avoid O(n) traversal of m_bindings.
@@ -110,7 +110,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(VM&, De
 
 // 9.1.1.1.4 InitializeBinding ( N, V ), https://tc39.es/ecma262/#sec-declarative-environment-records-initializebinding-n-v
 // 4.1.1.1.1 InitializeBinding ( N, V, hint ), https://tc39.es/proposal-explicit-resource-management/#sec-declarative-environment-records
-ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding(VM& vm, DeprecatedFlyString const& name, Value value, Environment::InitializeBindingHint hint)
+ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding(VM& vm, FlyString const& name, Value value, Environment::InitializeBindingHint hint)
 {
     return initialize_binding_direct(vm, find_binding_and_index(name)->index().value(), value, hint);
 }
@@ -137,7 +137,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding_direct(VM& vm
 }
 
 // 9.1.1.1.5 SetMutableBinding ( N, V, S ), https://tc39.es/ecma262/#sec-declarative-environment-records-setmutablebinding-n-v-s
-ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding(VM& vm, DeprecatedFlyString const& name, Value value, bool strict)
+ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding(VM& vm, FlyString const& name, Value value, bool strict)
 {
     // 1. If envRec does not have a binding for N, then
     auto binding_and_index = find_binding_and_index(name);
@@ -187,7 +187,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::set_mutable_binding_direct(VM& v
 }
 
 // 9.1.1.1.6 GetBindingValue ( N, S ), https://tc39.es/ecma262/#sec-declarative-environment-records-getbindingvalue-n-s
-ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value(VM& vm, DeprecatedFlyString const& name, [[maybe_unused]] bool strict)
+ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value(VM& vm, FlyString const& name, [[maybe_unused]] bool strict)
 {
     // 1. Assert: envRec has a binding for N.
     auto binding_and_index = find_binding_and_index(name);
@@ -198,7 +198,7 @@ ThrowCompletionOr<Value> DeclarativeEnvironment::get_binding_value(VM& vm, Depre
 }
 
 // 9.1.1.1.7 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-declarative-environment-records-deletebinding-n
-ThrowCompletionOr<bool> DeclarativeEnvironment::delete_binding(VM&, DeprecatedFlyString const& name)
+ThrowCompletionOr<bool> DeclarativeEnvironment::delete_binding(VM&, FlyString const& name)
 {
     // 1. Assert: envRec has a binding for the name that is the value of N.
     auto binding_and_index = find_binding_and_index(name);
@@ -218,7 +218,7 @@ ThrowCompletionOr<bool> DeclarativeEnvironment::delete_binding(VM&, DeprecatedFl
     return true;
 }
 
-ThrowCompletionOr<void> DeclarativeEnvironment::initialize_or_set_mutable_binding(VM& vm, DeprecatedFlyString const& name, Value value)
+ThrowCompletionOr<void> DeclarativeEnvironment::initialize_or_set_mutable_binding(VM& vm, FlyString const& name, Value value)
 {
     auto binding_and_index = find_binding_and_index(name);
     VERIFY(binding_and_index.has_value());
@@ -230,7 +230,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::initialize_or_set_mutable_bindin
     return {};
 }
 
-void DeclarativeEnvironment::initialize_or_set_mutable_binding(Badge<ScopeNode>, VM& vm, DeprecatedFlyString const& name, Value value)
+void DeclarativeEnvironment::initialize_or_set_mutable_binding(Badge<ScopeNode>, VM& vm, FlyString const& name, Value value)
 {
     MUST(initialize_or_set_mutable_binding(vm, name, value));
 }

--- a/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Completion.h>
@@ -20,7 +20,7 @@ class DeclarativeEnvironment : public Environment {
     GC_DECLARE_ALLOCATOR(DeclarativeEnvironment);
 
     struct Binding {
-        DeprecatedFlyString name;
+        FlyString name;
         Value value;
         bool strict { false };
         bool mutable_ { false };
@@ -33,21 +33,21 @@ public:
 
     virtual ~DeclarativeEnvironment() override = default;
 
-    virtual ThrowCompletionOr<bool> has_binding(DeprecatedFlyString const& name, Optional<size_t>* = nullptr) const override final;
-    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, DeprecatedFlyString const& name, bool can_be_deleted) override final;
-    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, DeprecatedFlyString const& name, bool strict) override final;
-    virtual ThrowCompletionOr<void> initialize_binding(VM&, DeprecatedFlyString const& name, Value, InitializeBindingHint) override final;
-    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, DeprecatedFlyString const& name, Value, bool strict) override final;
-    virtual ThrowCompletionOr<Value> get_binding_value(VM&, DeprecatedFlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<bool> delete_binding(VM&, DeprecatedFlyString const& name) override;
+    virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override final;
+    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, FlyString const& name, bool can_be_deleted) override final;
+    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, FlyString const& name, bool strict) override final;
+    virtual ThrowCompletionOr<void> initialize_binding(VM&, FlyString const& name, Value, InitializeBindingHint) override final;
+    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, FlyString const& name, Value, bool strict) override final;
+    virtual ThrowCompletionOr<Value> get_binding_value(VM&, FlyString const& name, bool strict) override;
+    virtual ThrowCompletionOr<bool> delete_binding(VM&, FlyString const& name) override;
 
-    void initialize_or_set_mutable_binding(Badge<ScopeNode>, VM&, DeprecatedFlyString const& name, Value value);
-    ThrowCompletionOr<void> initialize_or_set_mutable_binding(VM&, DeprecatedFlyString const& name, Value value);
+    void initialize_or_set_mutable_binding(Badge<ScopeNode>, VM&, FlyString const& name, Value value);
+    ThrowCompletionOr<void> initialize_or_set_mutable_binding(VM&, FlyString const& name, Value value);
 
     // This is not a method defined in the spec! Do not use this in any LibJS (or other spec related) code.
-    [[nodiscard]] Vector<DeprecatedFlyString> bindings() const
+    [[nodiscard]] Vector<FlyString> bindings() const
     {
-        Vector<DeprecatedFlyString> names;
+        Vector<FlyString> names;
         names.ensure_capacity(m_bindings.size());
 
         for (auto const& binding : m_bindings)
@@ -113,7 +113,7 @@ protected:
 
     friend class ModuleEnvironment;
 
-    virtual Optional<BindingAndIndex> find_binding_and_index(DeprecatedFlyString const& name) const
+    virtual Optional<BindingAndIndex> find_binding_and_index(FlyString const& name) const
     {
         if (auto it = m_bindings_assoc.find(name); it != m_bindings_assoc.end()) {
             return BindingAndIndex { const_cast<Binding*>(&m_bindings.at(it->value)), it->value };
@@ -124,7 +124,7 @@ protected:
 
 private:
     Vector<Binding> m_bindings;
-    HashMap<DeprecatedFlyString, size_t> m_bindings_assoc;
+    HashMap<FlyString, size_t> m_bindings_assoc;
     DisposeCapability m_dispose_capability;
 
     u64 m_environment_serial_number { 0 };

--- a/Libraries/LibJS/Runtime/DisposableStackPrototype.cpp
+++ b/Libraries/LibJS/Runtime/DisposableStackPrototype.cpp
@@ -67,7 +67,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisposableStackPrototype::adopt)
     };
 
     // 6. Let F be CreateBuiltinFunction(closure, 0, "", « »).
-    auto function = NativeFunction::create(realm, move(closure), 0, "");
+    auto function = NativeFunction::create(realm, move(closure), 0);
 
     // 7. Perform ? AddDisposableResource(disposableStack.[[DisposeCapability]], undefined, sync-dispose, F).
     TRY(add_disposable_resource(vm, disposable_stack->dispose_capability(), js_undefined(), Environment::InitializeBindingHint::SyncDispose, function));

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -39,8 +39,8 @@ public:
         Global,
     };
 
-    static GC::Ref<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
-    static GC::Ref<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static GC::Ref<ECMAScriptFunctionObject> create(Realm&, FlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<FlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static GC::Ref<ECMAScriptFunctionObject> create(Realm&, FlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<FlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
 
     virtual void initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
@@ -56,8 +56,8 @@ public:
     Statement const& ecmascript_code() const { return m_ecmascript_code; }
     Vector<FunctionParameter> const& formal_parameters() const override { return m_formal_parameters; }
 
-    virtual DeprecatedFlyString const& name() const override { return m_name; }
-    void set_name(DeprecatedFlyString const& name);
+    virtual FlyString const& name() const override { return m_name; }
+    void set_name(FlyString const& name);
 
     void set_is_class_constructor() { m_is_class_constructor = true; }
 
@@ -89,7 +89,7 @@ public:
     // Equivalent to absence of [[Construct]]
     virtual bool has_constructor() const override { return m_kind == FunctionKind::Normal && !m_is_arrow_function; }
 
-    virtual Vector<DeprecatedFlyString> const& local_variables_names() const override { return m_local_variables_names; }
+    virtual Vector<FlyString> const& local_variables_names() const override { return m_local_variables_names; }
 
     FunctionKind kind() const { return m_kind; }
 
@@ -109,7 +109,7 @@ protected:
     virtual Completion ordinary_call_evaluate_body();
 
 private:
-    ECMAScriptFunctionObject(DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
+    ECMAScriptFunctionObject(FlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<FlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
 
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;
@@ -117,12 +117,12 @@ private:
     ThrowCompletionOr<void> prepare_for_ordinary_call(ExecutionContext& callee_context, Object* new_target);
     void ordinary_call_bind_this(ExecutionContext&, Value this_argument);
 
-    DeprecatedFlyString m_name;
+    FlyString m_name;
     GC::Ptr<PrimitiveString> m_name_string;
 
     GC::Ptr<Bytecode::Executable> m_bytecode_executable;
     i32 m_function_length { 0 };
-    Vector<DeprecatedFlyString> m_local_variables_names;
+    Vector<FlyString> m_local_variables_names;
 
     // Internal Slots of ECMAScript Function Objects, https://tc39.es/ecma262/#table-internal-slots-of-ecmascript-function-objects
     GC::Ptr<Environment> m_environment;                                      // [[Environment]]
@@ -159,14 +159,14 @@ private:
         No,
         Yes,
     };
-    HashMap<DeprecatedFlyString, ParameterIsLocal> m_parameter_names;
+    HashMap<FlyString, ParameterIsLocal> m_parameter_names;
     Vector<FunctionDeclaration const&> m_functions_to_initialize;
     bool m_arguments_object_needed { false };
     bool m_is_module_wrapper { false };
     bool m_function_environment_needed { false };
     bool m_uses_this { false };
     Vector<VariableNameToInitialize> m_var_names_to_initialize_binding;
-    Vector<DeprecatedFlyString> m_function_names_to_initialize_binding;
+    Vector<FlyString> m_function_names_to_initialize_binding;
 
     size_t m_function_environment_bindings_count { 0 };
     size_t m_var_environment_bindings_count { 0 };

--- a/Libraries/LibJS/Runtime/Environment.h
+++ b/Libraries/LibJS/Runtime/Environment.h
@@ -34,13 +34,13 @@ public:
 
     virtual Object* with_base_object() const { return nullptr; }
 
-    virtual ThrowCompletionOr<bool> has_binding([[maybe_unused]] DeprecatedFlyString const& name, [[maybe_unused]] Optional<size_t>* out_index = nullptr) const { return false; }
-    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, [[maybe_unused]] DeprecatedFlyString const& name, [[maybe_unused]] bool can_be_deleted) { return {}; }
-    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, [[maybe_unused]] DeprecatedFlyString const& name, [[maybe_unused]] bool strict) { return {}; }
-    virtual ThrowCompletionOr<void> initialize_binding(VM&, [[maybe_unused]] DeprecatedFlyString const& name, Value, InitializeBindingHint) { return {}; }
-    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, [[maybe_unused]] DeprecatedFlyString const& name, Value, [[maybe_unused]] bool strict) { return {}; }
-    virtual ThrowCompletionOr<Value> get_binding_value(VM&, [[maybe_unused]] DeprecatedFlyString const& name, [[maybe_unused]] bool strict) { return Value {}; }
-    virtual ThrowCompletionOr<bool> delete_binding(VM&, [[maybe_unused]] DeprecatedFlyString const& name) { return false; }
+    virtual ThrowCompletionOr<bool> has_binding([[maybe_unused]] FlyString const& name, [[maybe_unused]] Optional<size_t>* out_index = nullptr) const { return false; }
+    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, [[maybe_unused]] FlyString const& name, [[maybe_unused]] bool can_be_deleted) { return {}; }
+    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, [[maybe_unused]] FlyString const& name, [[maybe_unused]] bool strict) { return {}; }
+    virtual ThrowCompletionOr<void> initialize_binding(VM&, [[maybe_unused]] FlyString const& name, Value, InitializeBindingHint) { return {}; }
+    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, [[maybe_unused]] FlyString const& name, Value, [[maybe_unused]] bool strict) { return {}; }
+    virtual ThrowCompletionOr<Value> get_binding_value(VM&, [[maybe_unused]] FlyString const& name, [[maybe_unused]] bool strict) { return Value {}; }
+    virtual ThrowCompletionOr<bool> delete_binding(VM&, [[maybe_unused]] FlyString const& name) { return false; }
 
     // [[OuterEnv]]
     Environment* outer_environment() { return m_outer_environment; }

--- a/Libraries/LibJS/Runtime/Error.cpp
+++ b/Libraries/LibJS/Runtime/Error.cpp
@@ -84,7 +84,7 @@ void Error::populate_stack()
     for (auto& element : stack_trace) {
         auto* context = element.execution_context;
         TracebackFrame frame {
-            .function_name = context->function_name ? context->function_name->byte_string() : "",
+            .function_name = context->function_name ? context->function_name->utf8_string() : ""_string,
             .cached_source_range = element.source_range,
         };
 
@@ -111,7 +111,7 @@ String Error::stack_string(CompactTraceback compact) const
             else
                 stack_string_builder.appendff("    at {} ({}:{}:{})\n", function_name, source_range.filename(), source_range.start.line, source_range.start.column);
         } else {
-            stack_string_builder.appendff("    at {}\n", function_name.is_empty() ? "<unknown>"sv : function_name.view());
+            stack_string_builder.appendff("    at {}\n", function_name.is_empty() ? "<unknown>"sv : function_name);
         }
     };
 

--- a/Libraries/LibJS/Runtime/Error.h
+++ b/Libraries/LibJS/Runtime/Error.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/String.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Object.h>
@@ -16,7 +15,7 @@
 namespace JS {
 
 struct TracebackFrame {
-    DeprecatedFlyString function_name;
+    FlyString function_name;
     [[nodiscard]] SourceRange const& source_range() const;
 
     RefPtr<CachedSourceRange> cached_source_range;

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/StringView.h>
 
 #define JS_ENUMERATE_ERROR_TYPES(M)                                                                                                 \
@@ -309,18 +310,18 @@ public:
     JS_ENUMERATE_ERROR_TYPES(__ENUMERATE_JS_ERROR)
 #undef __ENUMERATE_JS_ERROR
 
-    StringView message() const
+    String message() const
     {
         return m_message;
     }
 
 private:
     explicit ErrorType(StringView message)
-        : m_message(message)
+        : m_message(MUST(String::from_utf8(message)))
     {
     }
 
-    StringView m_message;
+    String m_message;
 };
 
 }

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
 #include <AK/WeakPtr.h>
 #include <LibJS/Bytecode/BasicBlock.h>
 #include <LibJS/Forward.h>

--- a/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -218,7 +218,7 @@ ThrowCompletionOr<GC::Ref<ECMAScriptFunctionObject>> FunctionConstructor::create
 
     // 28. Let F be OrdinaryFunctionCreate(proto, sourceText, parameters, body, non-lexical-this, env, privateEnv).
     parsing_insights.might_need_arguments_object = true;
-    auto function = ECMAScriptFunctionObject::create(realm, "anonymous", *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), expr->local_variables_names(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), parsing_insights);
+    auto function = ECMAScriptFunctionObject::create(realm, "anonymous"_fly_string, *prototype, move(source_text), expr->body(), expr->parameters(), expr->function_length(), expr->local_variables_names(), &environment, private_environment, expr->kind(), expr->is_strict_mode(), parsing_insights);
 
     // FIXME: Remove the name argument from create() and do this instead.
     // 29. Perform SetFunctionName(F, "anonymous").

--- a/Libraries/LibJS/Runtime/FunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/FunctionObject.cpp
@@ -32,7 +32,7 @@ void FunctionObject::set_function_name(Variant<PropertyKey, PrivateName> const& 
     VERIFY(m_is_extensible);
     VERIFY(!storage_has(vm.names.name));
 
-    ByteString name;
+    String name;
 
     // 2. If Type(name) is Symbol, then
     if (auto const* property_key = name_arg.get_pointer<PropertyKey>(); property_key && property_key->is_symbol()) {
@@ -41,15 +41,15 @@ void FunctionObject::set_function_name(Variant<PropertyKey, PrivateName> const& 
 
         // b. If description is undefined, set name to the empty String.
         if (!description.has_value())
-            name = ByteString::empty();
+            name = ""_string;
         // c. Else, set name to the string-concatenation of "[", description, and "]".
         else
-            name = ByteString::formatted("[{}]", *description);
+            name = MUST(String::formatted("[{}]", *description));
     }
     // 3. Else if name is a Private Name, then
     else if (auto const* private_name = name_arg.get_pointer<PrivateName>()) {
         // a. Set name to name.[[Description]].
-        name = private_name->description;
+        name = private_name->description.to_string();
     }
     // NOTE: This is necessary as we use a different parameter name.
     else {
@@ -65,7 +65,7 @@ void FunctionObject::set_function_name(Variant<PropertyKey, PrivateName> const& 
     // 5. If prefix is present, then
     if (prefix.has_value()) {
         // a. Set name to the string-concatenation of prefix, the code unit 0x0020 (SPACE), and name.
-        name = ByteString::formatted("{} {}", *prefix, name);
+        name = MUST(String::formatted("{} {}", *prefix, name));
 
         // b. If F has an [[InitialName]] internal slot, then
         if (is<NativeFunction>(this)) {

--- a/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Libraries/LibJS/Runtime/FunctionObject.h
@@ -26,7 +26,7 @@ public:
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) = 0;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct([[maybe_unused]] ReadonlySpan<Value> arguments_list, [[maybe_unused]] FunctionObject& new_target) { VERIFY_NOT_REACHED(); }
 
-    virtual DeprecatedFlyString const& name() const = 0;
+    virtual FlyString const& name() const = 0;
 
     void set_function_name(Variant<PropertyKey, PrivateName> const& name_arg, Optional<StringView> const& prefix = {});
     void set_function_length(double length);
@@ -38,7 +38,7 @@ public:
     // [[Realm]]
     virtual Realm* realm() const { return nullptr; }
 
-    virtual Vector<DeprecatedFlyString> const& local_variables_names() const { VERIFY_NOT_REACHED(); }
+    virtual Vector<FlyString> const& local_variables_names() const { VERIFY_NOT_REACHED(); }
 
     virtual Vector<FunctionParameter> const& formal_parameters() const { VERIFY_NOT_REACHED(); }
 

--- a/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -19,7 +19,7 @@ public:
     virtual ~FunctionPrototype() override = default;
 
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
-    virtual DeprecatedFlyString const& name() const override { return m_name; }
+    virtual FlyString const& name() const override { return m_name; }
 
 private:
     explicit FunctionPrototype(Realm&);
@@ -31,7 +31,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(symbol_has_instance);
 
     // 20.2.3: The Function prototype object has a "name" property whose value is the empty String.
-    DeprecatedFlyString m_name;
+    FlyString m_name;
 };
 
 }

--- a/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -82,15 +82,15 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
 
     VERIFY(completion.value().has_value());
 
-    auto generated_value = [](Value value) -> Value {
+    auto generated_value = [&vm](Value value) -> Value {
         if (value.is_object())
-            return value.as_object().get_without_side_effects("result");
+            return value.as_object().get_without_side_effects(vm.names.result);
         return value.is_empty() ? js_undefined() : value;
     };
 
     auto generated_continuation = [&](Value value) -> Optional<size_t> {
         if (value.is_object()) {
-            auto number_value = value.as_object().get_without_side_effects("continuation");
+            auto number_value = value.as_object().get_without_side_effects(vm.names.continuation);
             if (number_value.is_null())
                 return {};
             return static_cast<u64>(number_value.as_double());

--- a/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
@@ -41,7 +41,7 @@ ThrowCompletionOr<Value> GlobalEnvironment::get_this_binding(VM&) const
 }
 
 // 9.1.1.4.1 HasBinding ( N ), https://tc39.es/ecma262/#sec-global-environment-records-hasbinding-n
-ThrowCompletionOr<bool> GlobalEnvironment::has_binding(DeprecatedFlyString const& name, Optional<size_t>*) const
+ThrowCompletionOr<bool> GlobalEnvironment::has_binding(FlyString const& name, Optional<size_t>*) const
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. If ! DclRec.HasBinding(N) is true, return true.
@@ -54,7 +54,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::has_binding(DeprecatedFlyString const
 }
 
 // 9.1.1.4.2 CreateMutableBinding ( N, D ), https://tc39.es/ecma262/#sec-global-environment-records-createmutablebinding-n-d
-ThrowCompletionOr<void> GlobalEnvironment::create_mutable_binding(VM& vm, DeprecatedFlyString const& name, bool can_be_deleted)
+ThrowCompletionOr<void> GlobalEnvironment::create_mutable_binding(VM& vm, FlyString const& name, bool can_be_deleted)
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. If ! DclRec.HasBinding(N) is true, throw a TypeError exception.
@@ -66,7 +66,7 @@ ThrowCompletionOr<void> GlobalEnvironment::create_mutable_binding(VM& vm, Deprec
 }
 
 // 9.1.1.4.3 CreateImmutableBinding ( N, S ), https://tc39.es/ecma262/#sec-global-environment-records-createimmutablebinding-n-s
-ThrowCompletionOr<void> GlobalEnvironment::create_immutable_binding(VM& vm, DeprecatedFlyString const& name, bool strict)
+ThrowCompletionOr<void> GlobalEnvironment::create_immutable_binding(VM& vm, FlyString const& name, bool strict)
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. If ! DclRec.HasBinding(N) is true, throw a TypeError exception.
@@ -78,7 +78,7 @@ ThrowCompletionOr<void> GlobalEnvironment::create_immutable_binding(VM& vm, Depr
 }
 
 // 9.1.1.4.4 InitializeBinding ( N, V, hint ), https://tc39.es/ecma262/#sec-global-environment-records-initializebinding-n-v
-ThrowCompletionOr<void> GlobalEnvironment::initialize_binding(VM& vm, DeprecatedFlyString const& name, Value value, InitializeBindingHint hint)
+ThrowCompletionOr<void> GlobalEnvironment::initialize_binding(VM& vm, FlyString const& name, Value value, InitializeBindingHint hint)
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. If ! DclRec.HasBinding(N) is true, then
@@ -96,7 +96,7 @@ ThrowCompletionOr<void> GlobalEnvironment::initialize_binding(VM& vm, Deprecated
 }
 
 // 9.1.1.4.5 SetMutableBinding ( N, V, S ), https://tc39.es/ecma262/#sec-global-environment-records-setmutablebinding-n-v-s
-ThrowCompletionOr<void> GlobalEnvironment::set_mutable_binding(VM& vm, DeprecatedFlyString const& name, Value value, bool strict)
+ThrowCompletionOr<void> GlobalEnvironment::set_mutable_binding(VM& vm, FlyString const& name, Value value, bool strict)
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. If ! DclRec.HasBinding(N) is true, then
@@ -111,7 +111,7 @@ ThrowCompletionOr<void> GlobalEnvironment::set_mutable_binding(VM& vm, Deprecate
 }
 
 // 9.1.1.4.6 GetBindingValue ( N, S ), https://tc39.es/ecma262/#sec-global-environment-records-getbindingvalue-n-s
-ThrowCompletionOr<Value> GlobalEnvironment::get_binding_value(VM& vm, DeprecatedFlyString const& name, bool strict)
+ThrowCompletionOr<Value> GlobalEnvironment::get_binding_value(VM& vm, FlyString const& name, bool strict)
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. If ! DclRec.HasBinding(N) is true, then
@@ -129,7 +129,7 @@ ThrowCompletionOr<Value> GlobalEnvironment::get_binding_value(VM& vm, Deprecated
 }
 
 // 9.1.1.4.7 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-global-environment-records-deletebinding-n
-ThrowCompletionOr<bool> GlobalEnvironment::delete_binding(VM& vm, DeprecatedFlyString const& name)
+ThrowCompletionOr<bool> GlobalEnvironment::delete_binding(VM& vm, FlyString const& name)
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. If ! DclRec.HasBinding(N) is true, then
@@ -165,7 +165,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::delete_binding(VM& vm, DeprecatedFlyS
 }
 
 // 9.1.1.4.12 HasVarDeclaration ( N ), https://tc39.es/ecma262/#sec-hasvardeclaration
-bool GlobalEnvironment::has_var_declaration(DeprecatedFlyString const& name) const
+bool GlobalEnvironment::has_var_declaration(FlyString const& name) const
 {
     // 1. Let varDeclaredNames be envRec.[[VarNames]].
     // 2. If varDeclaredNames contains N, return true.
@@ -174,7 +174,7 @@ bool GlobalEnvironment::has_var_declaration(DeprecatedFlyString const& name) con
 }
 
 // 9.1.1.4.13 HasLexicalDeclaration ( N ), https://tc39.es/ecma262/#sec-haslexicaldeclaration
-bool GlobalEnvironment::has_lexical_declaration(DeprecatedFlyString const& name) const
+bool GlobalEnvironment::has_lexical_declaration(FlyString const& name) const
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
     // 2. Return ! DclRec.HasBinding(N).
@@ -182,7 +182,7 @@ bool GlobalEnvironment::has_lexical_declaration(DeprecatedFlyString const& name)
 }
 
 // 9.1.1.4.14 HasRestrictedGlobalProperty ( N ), https://tc39.es/ecma262/#sec-hasrestrictedglobalproperty
-ThrowCompletionOr<bool> GlobalEnvironment::has_restricted_global_property(DeprecatedFlyString const& name) const
+ThrowCompletionOr<bool> GlobalEnvironment::has_restricted_global_property(FlyString const& name) const
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
     // 2. Let globalObject be ObjRec.[[BindingObject]].
@@ -204,7 +204,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::has_restricted_global_property(Deprec
 }
 
 // 9.1.1.4.15 CanDeclareGlobalVar ( N ), https://tc39.es/ecma262/#sec-candeclareglobalvar
-ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_var(DeprecatedFlyString const& name) const
+ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_var(FlyString const& name) const
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
     // 2. Let globalObject be ObjRec.[[BindingObject]].
@@ -222,7 +222,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_var(DeprecatedFlyS
 }
 
 // 9.1.1.4.16 CanDeclareGlobalFunction ( N ), https://tc39.es/ecma262/#sec-candeclareglobalfunction
-ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_function(DeprecatedFlyString const& name) const
+ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_function(FlyString const& name) const
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
     // 2. Let globalObject be ObjRec.[[BindingObject]].
@@ -248,7 +248,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_function(Deprecate
 }
 
 // 9.1.1.4.17 CreateGlobalVarBinding ( N, D ), https://tc39.es/ecma262/#sec-createglobalvarbinding
-ThrowCompletionOr<void> GlobalEnvironment::create_global_var_binding(DeprecatedFlyString const& name, bool can_be_deleted)
+ThrowCompletionOr<void> GlobalEnvironment::create_global_var_binding(FlyString const& name, bool can_be_deleted)
 {
     auto& vm = this->vm();
 
@@ -283,7 +283,7 @@ ThrowCompletionOr<void> GlobalEnvironment::create_global_var_binding(DeprecatedF
 }
 
 // 9.1.1.4.18 CreateGlobalFunctionBinding ( N, V, D ), https://tc39.es/ecma262/#sec-createglobalfunctionbinding
-ThrowCompletionOr<void> GlobalEnvironment::create_global_function_binding(DeprecatedFlyString const& name, Value value, bool can_be_deleted)
+ThrowCompletionOr<void> GlobalEnvironment::create_global_function_binding(FlyString const& name, Value value, bool can_be_deleted)
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
     // 2. Let globalObject be ObjRec.[[BindingObject]].

--- a/Libraries/LibJS/Runtime/GlobalEnvironment.h
+++ b/Libraries/LibJS/Runtime/GlobalEnvironment.h
@@ -18,25 +18,25 @@ public:
     virtual bool has_this_binding() const final { return true; }
     virtual ThrowCompletionOr<Value> get_this_binding(VM&) const final;
 
-    virtual ThrowCompletionOr<bool> has_binding(DeprecatedFlyString const& name, Optional<size_t>* = nullptr) const override;
-    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, DeprecatedFlyString const& name, bool can_be_deleted) override;
-    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, DeprecatedFlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<void> initialize_binding(VM&, DeprecatedFlyString const& name, Value, Environment::InitializeBindingHint) override;
-    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, DeprecatedFlyString const& name, Value, bool strict) override;
-    virtual ThrowCompletionOr<Value> get_binding_value(VM&, DeprecatedFlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<bool> delete_binding(VM&, DeprecatedFlyString const& name) override;
+    virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
+    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, FlyString const& name, bool can_be_deleted) override;
+    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, FlyString const& name, bool strict) override;
+    virtual ThrowCompletionOr<void> initialize_binding(VM&, FlyString const& name, Value, Environment::InitializeBindingHint) override;
+    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, FlyString const& name, Value, bool strict) override;
+    virtual ThrowCompletionOr<Value> get_binding_value(VM&, FlyString const& name, bool strict) override;
+    virtual ThrowCompletionOr<bool> delete_binding(VM&, FlyString const& name) override;
 
     ObjectEnvironment& object_record() { return *m_object_record; }
     Object& global_this_value() { return *m_global_this_value; }
     DeclarativeEnvironment& declarative_record() { return *m_declarative_record; }
 
-    bool has_var_declaration(DeprecatedFlyString const& name) const;
-    bool has_lexical_declaration(DeprecatedFlyString const& name) const;
-    ThrowCompletionOr<bool> has_restricted_global_property(DeprecatedFlyString const& name) const;
-    ThrowCompletionOr<bool> can_declare_global_var(DeprecatedFlyString const& name) const;
-    ThrowCompletionOr<bool> can_declare_global_function(DeprecatedFlyString const& name) const;
-    ThrowCompletionOr<void> create_global_var_binding(DeprecatedFlyString const& name, bool can_be_deleted);
-    ThrowCompletionOr<void> create_global_function_binding(DeprecatedFlyString const& name, Value, bool can_be_deleted);
+    bool has_var_declaration(FlyString const& name) const;
+    bool has_lexical_declaration(FlyString const& name) const;
+    ThrowCompletionOr<bool> has_restricted_global_property(FlyString const& name) const;
+    ThrowCompletionOr<bool> can_declare_global_var(FlyString const& name) const;
+    ThrowCompletionOr<bool> can_declare_global_function(FlyString const& name) const;
+    ThrowCompletionOr<void> create_global_var_binding(FlyString const& name, bool can_be_deleted);
+    ThrowCompletionOr<void> create_global_function_binding(FlyString const& name, Value, bool can_be_deleted);
 
 private:
     GlobalEnvironment(Object&, Object& this_value);
@@ -47,7 +47,7 @@ private:
     GC::Ptr<ObjectEnvironment> m_object_record;           // [[ObjectRecord]]
     GC::Ptr<Object> m_global_this_value;                  // [[GlobalThisValue]]
     GC::Ptr<DeclarativeEnvironment> m_declarative_record; // [[DeclarativeRecord]]
-    Vector<DeprecatedFlyString> m_var_names;              // [[VarNames]]
+    Vector<FlyString> m_var_names;                        // [[VarNames]]
 };
 
 template<>

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -264,7 +264,7 @@ ThrowCompletionOr<DurationFormat::DurationUnitOptions> get_duration_unit_options
     auto display_field = MUST(String::formatted("{}Display", unit_property_key));
 
     // 6. Let display be ? GetOption(options, displayField, STRING, « "auto", "always" », displayDefault).
-    auto display_value = TRY(get_option(vm, options, display_field.to_byte_string(), OptionType::String, { "auto"sv, "always"sv }, display_default));
+    auto display_value = TRY(get_option(vm, options, display_field, OptionType::String, { "auto"sv, "always"sv }, display_default));
     auto display = DurationFormat::display_from_string(display_value.as_string().utf8_string());
 
     // 7. Perform ? ValidateDurationUnitStyle(unit, style, display, prevStyle).

--- a/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -246,7 +246,7 @@ void Intrinsics::initialize_intrinsics(Realm& realm)
         realm, [](VM& vm) {
             return vm.throw_completion<TypeError>(ErrorType::RestrictedFunctionPropertiesAccess);
         },
-        0, "", &realm);
+        0, FlyString {}, &realm);
     m_throw_type_error_function->define_direct_property(vm.names.length, Value(0), 0);
     m_throw_type_error_function->define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), 0);
     MUST(m_throw_type_error_function->internal_prevent_extensions());

--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -239,7 +239,7 @@ ThrowCompletionOr<String> JSONObject::serialize_json_object(VM& vm, StringifySta
         if (serialized_property_string.has_value()) {
             property_strings.append(MUST(String::formatted(
                 "{}:{}{}",
-                quote_json_string(MUST(String::from_byte_string(key.to_string()))),
+                quote_json_string(key.to_string()),
                 state.gap.is_empty() ? "" : " ",
                 serialized_property_string)));
         }

--- a/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Libraries/LibJS/Runtime/JSONObject.h
@@ -20,7 +20,7 @@ public:
 
     // The base implementation of stringify is exposed because it is used by
     // test-js to communicate between the JS tests and the C++ test runner.
-    static ThrowCompletionOr<Optional<ByteString>> stringify_impl(VM&, Value value, Value replacer, Value space);
+    static ThrowCompletionOr<Optional<String>> stringify_impl(VM&, Value value, Value replacer, Value space);
 
     static Value parse_json_value(VM&, JsonValue const&);
 
@@ -30,16 +30,16 @@ private:
     struct StringifyState {
         GC::Ptr<FunctionObject> replacer_function;
         HashTable<GC::Ptr<Object>> seen_objects;
-        ByteString indent { ByteString::empty() };
-        ByteString gap;
-        Optional<Vector<ByteString>> property_list;
+        String indent;
+        String gap;
+        Optional<Vector<String>> property_list;
     };
 
     // Stringify helpers
-    static ThrowCompletionOr<Optional<ByteString>> serialize_json_property(VM&, StringifyState&, PropertyKey const& key, Object* holder);
-    static ThrowCompletionOr<ByteString> serialize_json_object(VM&, StringifyState&, Object&);
-    static ThrowCompletionOr<ByteString> serialize_json_array(VM&, StringifyState&, Object&);
-    static ByteString quote_json_string(ByteString);
+    static ThrowCompletionOr<Optional<String>> serialize_json_property(VM&, StringifyState&, PropertyKey const& key, Object* holder);
+    static ThrowCompletionOr<String> serialize_json_object(VM&, StringifyState&, Object&);
+    static ThrowCompletionOr<String> serialize_json_array(VM&, StringifyState&, Object&);
+    static String quote_json_string(String);
 
     // Parse helpers
     static Object* parse_json_object(VM&, JsonObject const&);

--- a/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/ModuleEnvironment.cpp
@@ -20,7 +20,7 @@ ModuleEnvironment::ModuleEnvironment(Environment* outer_environment)
 }
 
 // 9.1.1.5.1 GetBindingValue ( N, S ), https://tc39.es/ecma262/#sec-module-environment-records-getbindingvalue-n-s
-ThrowCompletionOr<Value> ModuleEnvironment::get_binding_value(VM& vm, DeprecatedFlyString const& name, bool strict)
+ThrowCompletionOr<Value> ModuleEnvironment::get_binding_value(VM& vm, FlyString const& name, bool strict)
 {
     // 1. Assert: S is true.
     VERIFY(strict);
@@ -51,7 +51,7 @@ ThrowCompletionOr<Value> ModuleEnvironment::get_binding_value(VM& vm, Deprecated
 }
 
 // 9.1.1.5.2 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-module-environment-records-deletebinding-n
-ThrowCompletionOr<bool> ModuleEnvironment::delete_binding(VM&, DeprecatedFlyString const&)
+ThrowCompletionOr<bool> ModuleEnvironment::delete_binding(VM&, FlyString const&)
 {
     // The DeleteBinding concrete method of a module Environment Record is never used within this specification.
     VERIFY_NOT_REACHED();
@@ -65,7 +65,7 @@ ThrowCompletionOr<Value> ModuleEnvironment::get_this_binding(VM&) const
 }
 
 // 9.1.1.5.5 CreateImportBinding ( N, M, N2 ), https://tc39.es/ecma262/#sec-createimportbinding
-ThrowCompletionOr<void> ModuleEnvironment::create_import_binding(DeprecatedFlyString name, Module* module, DeprecatedFlyString binding_name)
+ThrowCompletionOr<void> ModuleEnvironment::create_import_binding(FlyString name, Module* module, FlyString binding_name)
 {
     // 1. Assert: envRec does not already have a binding for N.
     VERIFY(!get_indirect_binding(name));
@@ -82,7 +82,7 @@ ThrowCompletionOr<void> ModuleEnvironment::create_import_binding(DeprecatedFlySt
     return {};
 }
 
-ModuleEnvironment::IndirectBinding const* ModuleEnvironment::get_indirect_binding(DeprecatedFlyString const& name) const
+ModuleEnvironment::IndirectBinding const* ModuleEnvironment::get_indirect_binding(FlyString const& name) const
 {
     auto binding_or_end = m_indirect_bindings.find_if([&](IndirectBinding const& binding) {
         return binding.name == name;
@@ -93,7 +93,7 @@ ModuleEnvironment::IndirectBinding const* ModuleEnvironment::get_indirect_bindin
     return &(*binding_or_end);
 }
 
-Optional<ModuleEnvironment::BindingAndIndex> ModuleEnvironment::find_binding_and_index(DeprecatedFlyString const& name) const
+Optional<ModuleEnvironment::BindingAndIndex> ModuleEnvironment::find_binding_and_index(FlyString const& name) const
 {
     auto* indirect_binding = get_indirect_binding(name);
     if (indirect_binding != nullptr) {

--- a/Libraries/LibJS/Runtime/ModuleEnvironment.h
+++ b/Libraries/LibJS/Runtime/ModuleEnvironment.h
@@ -22,11 +22,11 @@ public:
     //       in Table 18 and share the same specifications for all of those methods except for
     //       GetBindingValue, DeleteBinding, HasThisBinding and GetThisBinding.
     //       In addition, module Environment Records support the methods listed in Table 24.
-    virtual ThrowCompletionOr<Value> get_binding_value(VM&, DeprecatedFlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<bool> delete_binding(VM&, DeprecatedFlyString const& name) override;
+    virtual ThrowCompletionOr<Value> get_binding_value(VM&, FlyString const& name, bool strict) override;
+    virtual ThrowCompletionOr<bool> delete_binding(VM&, FlyString const& name) override;
     virtual bool has_this_binding() const final { return true; }
     virtual ThrowCompletionOr<Value> get_this_binding(VM&) const final;
-    ThrowCompletionOr<void> create_import_binding(DeprecatedFlyString name, Module* module, DeprecatedFlyString binding_name);
+    ThrowCompletionOr<void> create_import_binding(FlyString name, Module* module, FlyString binding_name);
 
 private:
     explicit ModuleEnvironment(Environment* outer_environment);
@@ -34,13 +34,13 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     struct IndirectBinding {
-        DeprecatedFlyString name;
+        FlyString name;
         GC::Ptr<Module> module;
-        DeprecatedFlyString binding_name;
+        FlyString binding_name;
     };
-    IndirectBinding const* get_indirect_binding(DeprecatedFlyString const& name) const;
+    IndirectBinding const* get_indirect_binding(FlyString const& name) const;
 
-    virtual Optional<BindingAndIndex> find_binding_and_index(DeprecatedFlyString const& name) const override;
+    virtual Optional<BindingAndIndex> find_binding_and_index(FlyString const& name) const override;
 
     // FIXME: Since we always access this via the name this could be a map.
     Vector<IndirectBinding> m_indirect_bindings;

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -13,15 +13,15 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(ModuleNamespaceObject);
 
-ModuleNamespaceObject::ModuleNamespaceObject(Realm& realm, Module* module, Vector<DeprecatedFlyString> exports)
+ModuleNamespaceObject::ModuleNamespaceObject(Realm& realm, Module* module, Vector<FlyString> exports)
     : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype(), MayInterfereWithIndexedPropertyAccess::Yes)
     , m_module(module)
     , m_exports(move(exports))
 {
     // Note: We just perform step 6 of 10.4.6.12 ModuleNamespaceCreate ( module, exports ), https://tc39.es/ecma262/#sec-modulenamespacecreate
     // 6. Let sortedExports be a List whose elements are the elements of exports ordered as if an Array of the same values had been sorted using %Array.prototype.sort% using undefined as comparefn.
-    quick_sort(m_exports, [&](DeprecatedFlyString const& lhs, DeprecatedFlyString const& rhs) {
-        return lhs.view() < rhs.view();
+    quick_sort(m_exports, [&](FlyString const& lhs, FlyString const& rhs) {
+        return lhs.bytes_as_string_view() < rhs.bytes_as_string_view();
     });
 }
 

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -33,12 +33,12 @@ public:
     virtual void initialize(Realm&) override;
 
 private:
-    ModuleNamespaceObject(Realm&, Module* module, Vector<DeprecatedFlyString> exports);
+    ModuleNamespaceObject(Realm&, Module* module, Vector<FlyString> exports);
 
     virtual void visit_edges(Visitor&) override;
 
-    GC::Ptr<Module> m_module;              // [[Module]]
-    Vector<DeprecatedFlyString> m_exports; // [[Exports]]
+    GC::Ptr<Module> m_module;    // [[Module]]
+    Vector<FlyString> m_exports; // [[Exports]]
 };
 
 }

--- a/Libraries/LibJS/Runtime/ModuleRequest.h
+++ b/Libraries/LibJS/Runtime/ModuleRequest.h
@@ -7,21 +7,21 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/Vector.h>
 #include <LibJS/Module.h>
 
 namespace JS {
 
 struct ModuleWithSpecifier {
-    ByteString specifier;   // [[Specifier]]
+    String specifier;       // [[Specifier]]
     GC::Ref<Module> module; // [[Module]]
 };
 
 // https://tc39.es/proposal-import-attributes/#importattribute-record
 struct ImportAttribute {
-    ByteString key;
-    ByteString value;
+    String key;
+    String value;
 
     bool operator==(ImportAttribute const&) const = default;
 };
@@ -30,20 +30,20 @@ struct ImportAttribute {
 struct ModuleRequest {
     ModuleRequest() = default;
 
-    explicit ModuleRequest(DeprecatedFlyString specifier)
+    explicit ModuleRequest(FlyString specifier)
         : module_specifier(move(specifier))
     {
     }
 
-    ModuleRequest(DeprecatedFlyString specifier, Vector<ImportAttribute> attributes);
+    ModuleRequest(FlyString specifier, Vector<ImportAttribute> attributes);
 
-    void add_attribute(ByteString key, ByteString value)
+    void add_attribute(String key, String value)
     {
         attributes.empend(move(key), move(value));
     }
 
-    DeprecatedFlyString module_specifier; // [[Specifier]]
-    Vector<ImportAttribute> attributes;   // [[Attributes]]
+    FlyString module_specifier;         // [[Specifier]]
+    Vector<ImportAttribute> attributes; // [[Attributes]]
 
     bool operator==(ModuleRequest const&) const = default;
 };

--- a/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -68,7 +68,7 @@ GC::Ref<NativeFunction> NativeFunction::create(Realm& allocating_realm, Function
     return function;
 }
 
-GC::Ref<NativeFunction> NativeFunction::create(Realm& realm, DeprecatedFlyString const& name, Function<ThrowCompletionOr<Value>(VM&)> function)
+GC::Ref<NativeFunction> NativeFunction::create(Realm& realm, FlyString const& name, Function<ThrowCompletionOr<Value>(VM&)> function)
 {
     return realm.create<NativeFunction>(name, GC::create_function(realm.heap(), move(function)), realm.intrinsics().function_prototype());
 }
@@ -90,7 +90,7 @@ NativeFunction::NativeFunction(Object& prototype)
 {
 }
 
-NativeFunction::NativeFunction(DeprecatedFlyString name, GC::Ptr<GC::Function<ThrowCompletionOr<Value>(VM&)>> native_function, Object& prototype)
+NativeFunction::NativeFunction(FlyString name, GC::Ptr<GC::Function<ThrowCompletionOr<Value>(VM&)>> native_function, Object& prototype)
     : FunctionObject(prototype)
     , m_name(move(name))
     , m_native_function(move(native_function))
@@ -98,7 +98,7 @@ NativeFunction::NativeFunction(DeprecatedFlyString name, GC::Ptr<GC::Function<Th
 {
 }
 
-NativeFunction::NativeFunction(DeprecatedFlyString name, Object& prototype)
+NativeFunction::NativeFunction(FlyString name, Object& prototype)
     : FunctionObject(prototype)
     , m_name(move(name))
     , m_realm(&prototype.shape().realm())

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -22,7 +22,7 @@ class NativeFunction : public FunctionObject {
 
 public:
     static GC::Ref<NativeFunction> create(Realm&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name = FlyString {}, Optional<Realm*> = {}, Optional<Object*> prototype = {}, Optional<StringView> const& prefix = {});
-    static GC::Ref<NativeFunction> create(Realm&, DeprecatedFlyString const& name, ESCAPING Function<ThrowCompletionOr<Value>(VM&)>);
+    static GC::Ref<NativeFunction> create(Realm&, FlyString const& name, ESCAPING Function<ThrowCompletionOr<Value>(VM&)>);
 
     virtual ~NativeFunction() override = default;
 
@@ -34,18 +34,18 @@ public:
     virtual ThrowCompletionOr<Value> call();
     virtual ThrowCompletionOr<GC::Ref<Object>> construct(FunctionObject& new_target);
 
-    virtual DeprecatedFlyString const& name() const override { return m_name; }
+    virtual FlyString const& name() const override { return m_name; }
     virtual bool is_strict_mode() const override;
     virtual bool has_constructor() const override { return false; }
     virtual Realm* realm() const override { return m_realm; }
 
-    Optional<DeprecatedFlyString> const& initial_name() const { return m_initial_name; }
-    void set_initial_name(Badge<FunctionObject>, DeprecatedFlyString initial_name) { m_initial_name = move(initial_name); }
+    Optional<FlyString> const& initial_name() const { return m_initial_name; }
+    void set_initial_name(Badge<FunctionObject>, FlyString initial_name) { m_initial_name = move(initial_name); }
 
 protected:
-    NativeFunction(DeprecatedFlyString name, Object& prototype);
+    NativeFunction(FlyString name, Object& prototype);
     NativeFunction(GC::Ptr<GC::Function<ThrowCompletionOr<Value>(VM&)>>, Object* prototype, Realm& realm);
-    NativeFunction(DeprecatedFlyString name, GC::Ptr<GC::Function<ThrowCompletionOr<Value>(VM&)>>, Object& prototype);
+    NativeFunction(FlyString name, GC::Ptr<GC::Function<ThrowCompletionOr<Value>(VM&)>>, Object& prototype);
     explicit NativeFunction(Object& prototype);
 
     virtual void initialize(Realm&) override;
@@ -54,9 +54,9 @@ protected:
 private:
     virtual bool is_native_function() const final { return true; }
 
-    DeprecatedFlyString m_name;
+    FlyString m_name;
     GC::Ptr<PrimitiveString> m_name_string;
-    Optional<DeprecatedFlyString> m_initial_name; // [[InitialName]]
+    Optional<FlyString> m_initial_name; // [[InitialName]]
     GC::Ptr<GC::Function<ThrowCompletionOr<Value>(VM&)>> m_native_function;
     GC::Ptr<Realm> m_realm;
 };

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -21,7 +21,7 @@ class NativeFunction : public FunctionObject {
     GC_DECLARE_ALLOCATOR(NativeFunction);
 
 public:
-    static GC::Ref<NativeFunction> create(Realm&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name, Optional<Realm*> = {}, Optional<Object*> prototype = {}, Optional<StringView> const& prefix = {});
+    static GC::Ref<NativeFunction> create(Realm&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> behaviour, i32 length, PropertyKey const& name = FlyString {}, Optional<Realm*> = {}, Optional<Object*> prototype = {}, Optional<StringView> const& prefix = {});
     static GC::Ref<NativeFunction> create(Realm&, DeprecatedFlyString const& name, ESCAPING Function<ThrowCompletionOr<Value>(VM&)>);
 
     virtual ~NativeFunction() override = default;

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -25,7 +25,7 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(Object);
 
-static HashMap<GC::Ptr<Object const>, HashMap<DeprecatedFlyString, Object::IntrinsicAccessor>> s_intrinsics;
+static HashMap<GC::Ptr<Object const>, HashMap<FlyString, Object::IntrinsicAccessor>> s_intrinsics;
 
 // 10.1.12 OrdinaryObjectCreate ( proto [ , additionalInternalSlotsList ] ), https://tc39.es/ecma262/#sec-ordinaryobjectcreate
 GC::Ref<Object> Object::create(Realm& realm, Object* prototype)
@@ -1369,7 +1369,7 @@ Optional<Completion> Object::enumerate_object_properties(Function<Optional<Compl
     //    * Enumerating the properties of the target object includes enumerating properties of its prototype, and the prototype of the prototype, and so on, recursively.
     //    * A property of a prototype is not processed if it has the same name as a property that has already been processed.
 
-    HashTable<DeprecatedFlyString> visited;
+    HashTable<FlyString> visited;
 
     auto const* target = this;
     while (target) {
@@ -1377,7 +1377,7 @@ Optional<Completion> Object::enumerate_object_properties(Function<Optional<Compl
         for (auto& key : own_keys) {
             if (!key.is_string())
                 continue;
-            DeprecatedFlyString property_key = key.as_string().byte_string();
+            FlyString property_key = key.as_string().utf8_string();
             if (visited.contains(property_key))
                 continue;
             auto descriptor = TRY(target->internal_get_own_property(property_key));

--- a/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
@@ -27,7 +27,7 @@ void ObjectEnvironment::visit_edges(Cell::Visitor& visitor)
 }
 
 // 9.1.1.2.1 HasBinding ( N ), https://tc39.es/ecma262/#sec-object-environment-records-hasbinding-n
-ThrowCompletionOr<bool> ObjectEnvironment::has_binding(DeprecatedFlyString const& name, Optional<size_t>*) const
+ThrowCompletionOr<bool> ObjectEnvironment::has_binding(FlyString const& name, Optional<size_t>*) const
 {
     auto& vm = this->vm();
 
@@ -62,7 +62,7 @@ ThrowCompletionOr<bool> ObjectEnvironment::has_binding(DeprecatedFlyString const
 }
 
 // 9.1.1.2.2 CreateMutableBinding ( N, D ), https://tc39.es/ecma262/#sec-object-environment-records-createmutablebinding-n-d
-ThrowCompletionOr<void> ObjectEnvironment::create_mutable_binding(VM&, DeprecatedFlyString const& name, bool can_be_deleted)
+ThrowCompletionOr<void> ObjectEnvironment::create_mutable_binding(VM&, FlyString const& name, bool can_be_deleted)
 {
     // 1. Let bindingObject be envRec.[[BindingObject]].
     // 2. Perform ? DefinePropertyOrThrow(bindingObject, N, PropertyDescriptor { [[Value]]: undefined, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: D }).
@@ -73,14 +73,14 @@ ThrowCompletionOr<void> ObjectEnvironment::create_mutable_binding(VM&, Deprecate
 }
 
 // 9.1.1.2.3 CreateImmutableBinding ( N, S ), https://tc39.es/ecma262/#sec-object-environment-records-createimmutablebinding-n-s
-ThrowCompletionOr<void> ObjectEnvironment::create_immutable_binding(VM&, DeprecatedFlyString const&, bool)
+ThrowCompletionOr<void> ObjectEnvironment::create_immutable_binding(VM&, FlyString const&, bool)
 {
     // "The CreateImmutableBinding concrete method of an object Environment Record is never used within this specification."
     VERIFY_NOT_REACHED();
 }
 
 // 9.1.1.2.4 InitializeBinding ( N, V ), https://tc39.es/ecma262/#sec-object-environment-records-initializebinding-n-v
-ThrowCompletionOr<void> ObjectEnvironment::initialize_binding(VM& vm, DeprecatedFlyString const& name, Value value, Environment::InitializeBindingHint hint)
+ThrowCompletionOr<void> ObjectEnvironment::initialize_binding(VM& vm, FlyString const& name, Value value, Environment::InitializeBindingHint hint)
 {
     // 1. Assert: hint is normal.
     VERIFY(hint == Environment::InitializeBindingHint::Normal);
@@ -93,7 +93,7 @@ ThrowCompletionOr<void> ObjectEnvironment::initialize_binding(VM& vm, Deprecated
 }
 
 // 9.1.1.2.5 SetMutableBinding ( N, V, S ), https://tc39.es/ecma262/#sec-object-environment-records-setmutablebinding-n-v-s
-ThrowCompletionOr<void> ObjectEnvironment::set_mutable_binding(VM&, DeprecatedFlyString const& name, Value value, bool strict)
+ThrowCompletionOr<void> ObjectEnvironment::set_mutable_binding(VM&, FlyString const& name, Value value, bool strict)
 {
     auto& vm = this->vm();
 
@@ -135,7 +135,7 @@ ThrowCompletionOr<void> ObjectEnvironment::set_mutable_binding(VM&, DeprecatedFl
 }
 
 // 9.1.1.2.6 GetBindingValue ( N, S ), https://tc39.es/ecma262/#sec-object-environment-records-getbindingvalue-n-s
-ThrowCompletionOr<Value> ObjectEnvironment::get_binding_value(VM&, DeprecatedFlyString const& name, bool strict)
+ThrowCompletionOr<Value> ObjectEnvironment::get_binding_value(VM&, FlyString const& name, bool strict)
 {
     auto& vm = this->vm();
 
@@ -164,7 +164,7 @@ ThrowCompletionOr<Value> ObjectEnvironment::get_binding_value(VM&, DeprecatedFly
 }
 
 // 9.1.1.2.7 DeleteBinding ( N ), https://tc39.es/ecma262/#sec-object-environment-records-deletebinding-n
-ThrowCompletionOr<bool> ObjectEnvironment::delete_binding(VM&, DeprecatedFlyString const& name)
+ThrowCompletionOr<bool> ObjectEnvironment::delete_binding(VM&, FlyString const& name)
 {
     // 1. Let bindingObject be envRec.[[BindingObject]].
     // 2. Return ? bindingObject.[[Delete]](N).

--- a/Libraries/LibJS/Runtime/ObjectEnvironment.h
+++ b/Libraries/LibJS/Runtime/ObjectEnvironment.h
@@ -20,13 +20,13 @@ public:
         Yes,
     };
 
-    virtual ThrowCompletionOr<bool> has_binding(DeprecatedFlyString const& name, Optional<size_t>* = nullptr) const override;
-    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, DeprecatedFlyString const& name, bool can_be_deleted) override;
-    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, DeprecatedFlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<void> initialize_binding(VM&, DeprecatedFlyString const& name, Value, Environment::InitializeBindingHint) override;
-    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, DeprecatedFlyString const& name, Value, bool strict) override;
-    virtual ThrowCompletionOr<Value> get_binding_value(VM&, DeprecatedFlyString const& name, bool strict) override;
-    virtual ThrowCompletionOr<bool> delete_binding(VM&, DeprecatedFlyString const& name) override;
+    virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
+    virtual ThrowCompletionOr<void> create_mutable_binding(VM&, FlyString const& name, bool can_be_deleted) override;
+    virtual ThrowCompletionOr<void> create_immutable_binding(VM&, FlyString const& name, bool strict) override;
+    virtual ThrowCompletionOr<void> initialize_binding(VM&, FlyString const& name, Value, Environment::InitializeBindingHint) override;
+    virtual ThrowCompletionOr<void> set_mutable_binding(VM&, FlyString const& name, Value, bool strict) override;
+    virtual ThrowCompletionOr<Value> get_binding_value(VM&, FlyString const& name, bool strict) override;
+    virtual ThrowCompletionOr<bool> delete_binding(VM&, FlyString const& name) override;
 
     // 9.1.1.2.10 WithBaseObject ( ), https://tc39.es/ecma262/#sec-object-environment-records-withbaseobject
     virtual Object* with_base_object() const override

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -229,11 +229,6 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, ByteString string)
     return *it->value;
 }
 
-GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, DeprecatedFlyString const& string)
-{
-    return create(vm, ByteString { string });
-}
-
 GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, PrimitiveString& lhs, PrimitiveString& rhs)
 {
     // We're here to concatenate two strings into a new rope string.

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -29,7 +29,6 @@ public:
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, String);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, FlyString const&);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, ByteString);
-    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, DeprecatedFlyString const&);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, PrimitiveString&, PrimitiveString&);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, StringView);
 

--- a/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/PrivateEnvironment.cpp
@@ -21,7 +21,7 @@ PrivateEnvironment::PrivateEnvironment(PrivateEnvironment* parent)
 // Note: we start at one such that 0 can be invalid / default initialized.
 u64 PrivateEnvironment::s_next_id = 1u;
 
-PrivateName PrivateEnvironment::resolve_private_identifier(DeprecatedFlyString const& identifier) const
+PrivateName PrivateEnvironment::resolve_private_identifier(FlyString const& identifier) const
 {
     auto name_or_end = find_private_name(identifier);
 
@@ -34,7 +34,7 @@ PrivateName PrivateEnvironment::resolve_private_identifier(DeprecatedFlyString c
     return m_outer_environment->resolve_private_identifier(identifier);
 }
 
-void PrivateEnvironment::add_private_name(DeprecatedFlyString description)
+void PrivateEnvironment::add_private_name(FlyString description)
 {
     if (!find_private_name(description).is_end())
         return;

--- a/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibGC/CellAllocator.h>
@@ -16,14 +16,14 @@ namespace JS {
 
 struct PrivateName {
     PrivateName() = default;
-    PrivateName(u64 unique_id, DeprecatedFlyString description)
+    PrivateName(u64 unique_id, FlyString description)
         : unique_id(unique_id)
         , description(move(description))
     {
     }
 
     u64 unique_id { 0 };
-    DeprecatedFlyString description;
+    FlyString description;
 
     bool operator==(PrivateName const& rhs) const;
 };
@@ -33,9 +33,9 @@ class PrivateEnvironment : public Cell {
     GC_DECLARE_ALLOCATOR(PrivateEnvironment);
 
 public:
-    PrivateName resolve_private_identifier(DeprecatedFlyString const& identifier) const;
+    PrivateName resolve_private_identifier(FlyString const& identifier) const;
 
-    void add_private_name(DeprecatedFlyString description);
+    void add_private_name(FlyString description);
 
     PrivateEnvironment* outer_environment() { return m_outer_environment; }
     PrivateEnvironment const* outer_environment() const { return m_outer_environment; }
@@ -45,7 +45,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    auto find_private_name(DeprecatedFlyString const& description) const
+    auto find_private_name(FlyString const& description) const
     {
         return m_private_names.find_if([&](PrivateName const& private_name) {
             return private_name.description == description;

--- a/Libraries/LibJS/Runtime/PromiseCapability.cpp
+++ b/Libraries/LibJS/Runtime/PromiseCapability.cpp
@@ -90,7 +90,7 @@ ThrowCompletionOr<GC::Ref<PromiseCapability>> new_promise_capability(VM& vm, Val
     };
 
     // 5. Let executor be CreateBuiltinFunction(executorClosure, 2, "", « »).
-    auto executor = NativeFunction::create(realm, move(executor_closure), 2, "");
+    auto executor = NativeFunction::create(realm, move(executor_closure), 2);
 
     // 6. Let promise be ? Construct(C, « executor »).
     auto promise = TRY(construct(vm, constructor.as_function(), executor));

--- a/Libraries/LibJS/Runtime/PromisePrototype.cpp
+++ b/Libraries/LibJS/Runtime/PromisePrototype.cpp
@@ -121,14 +121,14 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
             };
 
             // iv. Let valueThunk be CreateBuiltinFunction(returnValue, 0, "", « »).
-            auto value_thunk = NativeFunction::create(realm, move(return_value), 0, "");
+            auto value_thunk = NativeFunction::create(realm, move(return_value), 0);
 
             // v. Return ? Invoke(promise, "then", « valueThunk »).
             return TRY(Value(promise).invoke(vm, vm.names.then, value_thunk));
         };
 
         // b. Let thenFinally be CreateBuiltinFunction(thenFinallyClosure, 1, "", « »).
-        then_finally = NativeFunction::create(realm, move(then_finally_closure), 1, "");
+        then_finally = NativeFunction::create(realm, move(then_finally_closure), 1);
 
         // c. Let catchFinallyClosure be a new Abstract Closure with parameters (reason) that captures onFinally and C and performs the following steps when called:
         auto catch_finally_closure = [constructor, on_finally](auto& vm) -> ThrowCompletionOr<Value> {
@@ -148,14 +148,14 @@ JS_DEFINE_NATIVE_FUNCTION(PromisePrototype::finally)
             };
 
             // iv. Let thrower be CreateBuiltinFunction(throwReason, 0, "", « »).
-            auto thrower = NativeFunction::create(realm, move(throw_reason), 0, "");
+            auto thrower = NativeFunction::create(realm, move(throw_reason), 0);
 
             // v. Return ? Invoke(promise, "then", « thrower »).
             return TRY(Value(promise).invoke(vm, vm.names.then, thrower));
         };
 
         // d. Let catchFinally be CreateBuiltinFunction(catchFinallyClosure, 1, "", « »).
-        catch_finally = NativeFunction::create(realm, move(catch_finally_closure), 1, "");
+        catch_finally = NativeFunction::create(realm, move(catch_finally_closure), 1);
     }
 
     // 7. Return ? Invoke(promise, "then", « thenFinally, catchFinally »).

--- a/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Libraries/LibJS/Runtime/PropertyKey.h
@@ -61,9 +61,8 @@ public:
     {
     }
 
-    template<size_t N>
-    PropertyKey(char const (&chars)[N])
-        : PropertyKey(DeprecatedFlyString(chars))
+    PropertyKey(FlyString const& string)
+        : PropertyKey(string.to_deprecated_fly_string())
     {
     }
 

--- a/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Libraries/LibJS/Runtime/PropertyKey.h
@@ -56,8 +56,8 @@ public:
     {
     }
 
-    PropertyKey(ByteString const& string)
-        : PropertyKey(DeprecatedFlyString(string))
+    PropertyKey(String const& string)
+        : PropertyKey(DeprecatedFlyString(string.to_byte_string()))
     {
     }
 

--- a/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -108,7 +108,7 @@ JS_DEFINE_NATIVE_FUNCTION(ProxyConstructor::revocable)
 
     // 3. Let revoker be CreateBuiltinFunction(revokerClosure, 0, "", « [[RevocableProxy]] »).
     // 4. Set revoker.[[RevocableProxy]] to p.
-    auto revoker = NativeFunction::create(realm, move(revoker_closure), 0, "");
+    auto revoker = NativeFunction::create(realm, move(revoker_closure), 0);
 
     // 5. Let result be OrdinaryObjectCreate(%Object.prototype%).
     auto result = Object::create(realm, realm.intrinsics().object_prototype());

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -899,7 +899,7 @@ void ProxyObject::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_handler);
 }
 
-DeprecatedFlyString const& ProxyObject::name() const
+FlyString const& ProxyObject::name() const
 {
     VERIFY(is_function());
     return static_cast<FunctionObject&>(*m_target).name();

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -21,7 +21,7 @@ public:
 
     virtual ~ProxyObject() override = default;
 
-    virtual DeprecatedFlyString const& name() const override;
+    virtual FlyString const& name() const override;
     virtual bool has_constructor() const override;
 
     Object const& target() const { return m_target; }

--- a/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Libraries/LibJS/Runtime/Reference.cpp
@@ -208,7 +208,7 @@ ThrowCompletionOr<void> Reference::initialize_referenced_binding(VM& vm, Value v
 }
 
 // 6.2.4.9 MakePrivateReference ( baseValue, privateIdentifier ), https://tc39.es/ecma262/#sec-makeprivatereference
-Reference make_private_reference(VM& vm, Value base_value, DeprecatedFlyString const& private_identifier)
+Reference make_private_reference(VM& vm, Value base_value, FlyString const& private_identifier)
 {
     // 1. Let privEnv be the running execution context's PrivateEnvironment.
     auto private_environment = vm.running_execution_context().private_environment;

--- a/Libraries/LibJS/Runtime/Reference.h
+++ b/Libraries/LibJS/Runtime/Reference.h
@@ -13,7 +13,7 @@
 
 namespace JS {
 
-Reference make_private_reference(VM&, Value base_value, DeprecatedFlyString const& private_identifier);
+Reference make_private_reference(VM&, Value base_value, FlyString const& private_identifier);
 
 class Reference {
 public:
@@ -39,7 +39,7 @@ public:
     {
     }
 
-    Reference(Environment& base, DeprecatedFlyString referenced_name, bool strict = false, Optional<EnvironmentCoordinate> environment_coordinate = {})
+    Reference(Environment& base, FlyString referenced_name, bool strict = false, Optional<EnvironmentCoordinate> environment_coordinate = {})
         : m_base_type(BaseType::Environment)
         , m_base_environment(&base)
         , m_name(move(referenced_name))

--- a/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Libraries/LibJS/Runtime/RegExpObject.h
@@ -18,12 +18,12 @@ namespace JS {
 ThrowCompletionOr<GC::Ref<RegExpObject>> regexp_create(VM&, Value pattern, Value flags);
 ThrowCompletionOr<GC::Ref<RegExpObject>> regexp_alloc(VM&, FunctionObject& new_target);
 
-Result<regex::RegexOptions<ECMAScriptFlags>, ByteString> regex_flags_from_string(StringView flags);
+Result<regex::RegexOptions<ECMAScriptFlags>, String> regex_flags_from_string(StringView flags);
 struct ParseRegexPatternError {
-    ByteString error;
+    String error;
 };
-ErrorOr<ByteString, ParseRegexPatternError> parse_regex_pattern(StringView pattern, bool unicode, bool unicode_sets);
-ThrowCompletionOr<ByteString> parse_regex_pattern(VM& vm, StringView pattern, bool unicode, bool unicode_sets);
+ErrorOr<String, ParseRegexPatternError> parse_regex_pattern(StringView pattern, bool unicode, bool unicode_sets);
+ThrowCompletionOr<String> parse_regex_pattern(VM& vm, StringView pattern, bool unicode, bool unicode_sets);
 
 class RegExpObject : public Object {
     JS_OBJECT(RegExpObject, Object);
@@ -51,16 +51,16 @@ public:
     };
 
     static GC::Ref<RegExpObject> create(Realm&);
-    static GC::Ref<RegExpObject> create(Realm&, Regex<ECMA262> regex, ByteString pattern, ByteString flags);
+    static GC::Ref<RegExpObject> create(Realm&, Regex<ECMA262> regex, String pattern, String flags);
 
     ThrowCompletionOr<GC::Ref<RegExpObject>> regexp_initialize(VM&, Value pattern, Value flags);
-    ByteString escape_regexp_pattern() const;
+    String escape_regexp_pattern() const;
 
     virtual void initialize(Realm&) override;
     virtual ~RegExpObject() override = default;
 
-    ByteString const& pattern() const { return m_pattern; }
-    ByteString const& flags() const { return m_flags; }
+    String const& pattern() const { return m_pattern; }
+    String const& flags() const { return m_flags; }
     Flags flag_bits() const { return m_flag_bits; }
     Regex<ECMA262> const& regex() { return *m_regex; }
     Regex<ECMA262> const& regex() const { return *m_regex; }
@@ -72,12 +72,12 @@ public:
 
 private:
     RegExpObject(Object& prototype);
-    RegExpObject(Regex<ECMA262> regex, ByteString pattern, ByteString flags, Object& prototype);
+    RegExpObject(Regex<ECMA262> regex, String pattern, String flags, Object& prototype);
 
     virtual void visit_edges(Visitor&) override;
 
-    ByteString m_pattern;
-    ByteString m_flags;
+    String m_pattern;
+    String m_flags;
     Flags m_flag_bits { 0 };
     bool m_legacy_features_enabled { false }; // [[LegacyFeaturesEnabled]]
     // Note: This is initialized in RegExpAlloc, but will be non-null afterwards

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -99,7 +99,7 @@ static Value get_match_index_par(VM& vm, Utf16View const& string, Match const& m
 }
 
 // 22.2.7.8 MakeMatchIndicesIndexPairArray ( S, indices, groupNames, hasGroups ), https://tc39.es/ecma262/#sec-makematchindicesindexpairarray
-static Value make_match_indices_index_pair_array(VM& vm, Utf16View const& string, Vector<Optional<Match>> const& indices, HashMap<DeprecatedFlyString, Match> const& group_names, bool has_groups)
+static Value make_match_indices_index_pair_array(VM& vm, Utf16View const& string, Vector<Optional<Match>> const& indices, HashMap<FlyString, Match> const& group_names, bool has_groups)
 {
     // Note: This implementation differs from the spec, but has the same behavior.
     //
@@ -186,7 +186,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
     // 5. If flags contains "y", let sticky be true; else let sticky be false.
     bool sticky = regex.options().has_flag_set(ECMAScriptFlags::Sticky);
     // 6. If flags contains "d", let hasIndices be true, else let hasIndices be false.
-    bool has_indices = regexp_object.flags().find('d').has_value();
+    bool has_indices = regexp_object.flags().bytes_as_string_view().find('d').has_value();
 
     // 7. If global is false and sticky is false, set lastIndex to 0.
     if (!global && !sticky)
@@ -273,7 +273,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
     Vector<Utf16String> captured_values;
 
     // 26. Let groupNames be a new empty List.
-    HashMap<DeprecatedFlyString, Match> group_names;
+    HashMap<FlyString, Match> group_names;
 
     // 27. Add match as the last element of indices.
     indices.append(move(match_indices));

--- a/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -253,7 +253,7 @@ ThrowCompletionOr<Value> shadow_realm_import_value(VM& vm, String specifier_stri
 
     // 10. Let onFulfilled be CreateBuiltinFunction(steps, 1, "", « [[ExportNameString]] », callerRealm).
     // 11. Set onFulfilled.[[ExportNameString]] to exportNameString.
-    auto on_fulfilled = NativeFunction::create(realm, move(steps), 1, "", &caller_realm);
+    auto on_fulfilled = NativeFunction::create(realm, move(steps), 1, FlyString {}, &caller_realm);
 
     // 12. Let promiseCapability be ! NewPromiseCapability(%Promise%).
     auto promise_capability = MUST(new_promise_capability(vm, realm.intrinsics().promise_constructor()));

--- a/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -87,7 +87,7 @@ ThrowCompletionOr<void> copy_name_and_length(VM& vm, FunctionObject& function, F
         target_name = PrimitiveString::create(vm, String {});
 
     // 8. Perform SetFunctionName(F, targetName, prefix).
-    function.set_function_name({ target_name.as_string().byte_string() }, move(prefix));
+    function.set_function_name({ target_name.as_string().utf8_string() }, move(prefix));
 
     return {};
 }
@@ -190,7 +190,7 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
 }
 
 // 3.1.4 ShadowRealmImportValue ( specifierString: a String, exportNameString: a String, callerRealm: a Realm Record, evalRealm: a Realm Record, evalContext: an execution context, ), https://tc39.es/proposal-shadowrealm/#sec-shadowrealmimportvalue
-ThrowCompletionOr<Value> shadow_realm_import_value(VM& vm, ByteString specifier_string, ByteString export_name_string, Realm& caller_realm, Realm& eval_realm)
+ThrowCompletionOr<Value> shadow_realm_import_value(VM& vm, String specifier_string, String export_name_string, Realm& caller_realm, Realm& eval_realm)
 {
     auto& realm = *vm.current_realm();
 
@@ -211,7 +211,7 @@ ThrowCompletionOr<Value> shadow_realm_import_value(VM& vm, ByteString specifier_
     auto referrer = GC::Ref { *eval_context->realm };
 
     // 7. Perform HostLoadImportedModule(referrer, specifierString, empty, innerCapability).
-    vm.host_load_imported_module(referrer, ModuleRequest { specifier_string }, nullptr, inner_capability);
+    vm.host_load_imported_module(referrer, ModuleRequest { specifier_string.to_byte_string() }, nullptr, inner_capability);
 
     // 7. Suspend evalContext and remove it from the execution context stack.
     // NOTE: We don't support this concept yet.

--- a/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -147,7 +147,7 @@ ThrowCompletionOr<Value> perform_shadow_realm_eval(VM& vm, StringView source_tex
     // 11. If result.[[Type]] is normal, then
     if (!eval_result.is_throw_completion()) {
         // a. Set result to the result of evaluating body.
-        auto maybe_executable = Bytecode::compile(vm, program, FunctionKind::Normal, "ShadowRealmEval"sv);
+        auto maybe_executable = Bytecode::compile(vm, program, FunctionKind::Normal, "ShadowRealmEval"_fly_string);
         if (maybe_executable.is_error()) {
             result = maybe_executable.release_error();
         } else {
@@ -211,7 +211,7 @@ ThrowCompletionOr<Value> shadow_realm_import_value(VM& vm, String specifier_stri
     auto referrer = GC::Ref { *eval_context->realm };
 
     // 7. Perform HostLoadImportedModule(referrer, specifierString, empty, innerCapability).
-    vm.host_load_imported_module(referrer, ModuleRequest { specifier_string.to_byte_string() }, nullptr, inner_capability);
+    vm.host_load_imported_module(referrer, ModuleRequest { specifier_string }, nullptr, inner_capability);
 
     // 7. Suspend evalContext and remove it from the execution context stack.
     // NOTE: We don't support this concept yet.

--- a/Libraries/LibJS/Runtime/ShadowRealm.h
+++ b/Libraries/LibJS/Runtime/ShadowRealm.h
@@ -35,7 +35,7 @@ private:
 
 ThrowCompletionOr<void> copy_name_and_length(VM&, FunctionObject& function, FunctionObject& target, Optional<StringView> prefix = {}, Optional<unsigned> arg_count = {});
 ThrowCompletionOr<Value> perform_shadow_realm_eval(VM&, StringView source_text, Realm& caller_realm, Realm& eval_realm);
-ThrowCompletionOr<Value> shadow_realm_import_value(VM&, ByteString specifier_string, ByteString export_name_string, Realm& caller_realm, Realm& eval_realm);
+ThrowCompletionOr<Value> shadow_realm_import_value(VM&, String specifier_string, String export_name_string, Realm& caller_realm, Realm& eval_realm);
 ThrowCompletionOr<Value> get_wrapped_value(VM&, Realm& caller_realm, Value);
 NonnullOwnPtr<ExecutionContext> get_shadow_realm_context(Realm& shadow_realm, bool strict_eval);
 

--- a/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
@@ -65,7 +65,7 @@ JS_DEFINE_NATIVE_FUNCTION(ShadowRealmPrototype::import_value)
     auto object = TRY(typed_this_object(vm));
 
     // 3. Let specifierString be ? ToString(specifier).
-    auto specifier_string = TRY(specifier.to_byte_string(vm));
+    auto specifier_string = TRY(specifier.to_string(vm));
 
     // 4. If Type(exportName) is not String, throw a TypeError exception.
     if (!export_name.is_string())
@@ -78,7 +78,7 @@ JS_DEFINE_NATIVE_FUNCTION(ShadowRealmPrototype::import_value)
     auto& eval_realm = object->shadow_realm();
 
     // 7. Return ShadowRealmImportValue(specifierString, exportName, callerRealm, evalRealm).
-    return shadow_realm_import_value(vm, move(specifier_string), export_name.as_string().byte_string(), *caller_realm, eval_realm);
+    return shadow_realm_import_value(vm, move(specifier_string), export_name.as_string().utf8_string(), *caller_realm, eval_realm);
 }
 
 }

--- a/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -167,13 +167,11 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::raw)
     // 7. Let nextIndex be 0.
     // 8. Repeat,
     for (size_t i = 0; i < literal_count; ++i) {
-        auto next_key = ByteString::number(i);
-
         // a. Let nextLiteralVal be ? Get(literals, ! ToString(𝔽(nextIndex))).
-        auto next_literal_value = TRY(literals->get(next_key));
+        auto next_literal_value = TRY(literals->get(PropertyKey(i)));
 
         // b. Let nextLiteral be ? ToString(nextLiteralVal).
-        auto next_literal = TRY(next_literal_value.to_byte_string(vm));
+        auto next_literal = TRY(next_literal_value.to_string(vm));
 
         // c. Set R to the string-concatenation of R and nextLiteral.
         builder.append(next_literal);
@@ -188,7 +186,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringConstructor::raw)
             auto next_substitution_value = vm.argument(i + 1);
 
             // ii. Let nextSub be ? ToString(nextSubVal).
-            auto next_substitution = TRY(next_substitution_value.to_byte_string(vm));
+            auto next_substitution = TRY(next_substitution_value.to_string(vm));
 
             // iii. Set R to the string-concatenation of R and nextSub.
             builder.append(next_substitution);

--- a/Libraries/LibJS/Runtime/StringOrSymbol.h
+++ b/Libraries/LibJS/Runtime/StringOrSymbol.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/Symbol.h>
 #include <LibJS/Runtime/Value.h>
@@ -20,7 +20,7 @@ public:
     {
     }
 
-    StringOrSymbol(DeprecatedFlyString const& string)
+    StringOrSymbol(FlyString const& string)
         : m_string(string)
     {
     }
@@ -28,7 +28,7 @@ public:
     ~StringOrSymbol()
     {
         if (is_string())
-            m_string.~DeprecatedFlyString();
+            m_string.~FlyString();
     }
 
     StringOrSymbol(Symbol const* symbol)
@@ -40,7 +40,7 @@ public:
     StringOrSymbol(StringOrSymbol const& other)
     {
         if (other.is_string())
-            new (&m_string) DeprecatedFlyString(other.m_string);
+            new (&m_string) FlyString(other.m_string);
         else
             m_bits = other.m_bits;
     }
@@ -48,7 +48,7 @@ public:
     StringOrSymbol(StringOrSymbol&& other)
     {
         if (other.is_string())
-            new (&m_string) DeprecatedFlyString(move(other.m_string));
+            new (&m_string) FlyString(move(other.m_string));
         else
             m_bits = exchange(other.m_bits, 0);
     }
@@ -57,7 +57,7 @@ public:
     ALWAYS_INLINE bool is_symbol() const { return is_valid() && (m_bits & 2); }
     ALWAYS_INLINE bool is_string() const { return is_valid() && !(m_bits & 2); }
 
-    ALWAYS_INLINE DeprecatedFlyString as_string() const
+    ALWAYS_INLINE FlyString as_string() const
     {
         VERIFY(is_string());
         return m_string;
@@ -69,12 +69,12 @@ public:
         return reinterpret_cast<Symbol const*>(m_bits & ~2ULL);
     }
 
-    ByteString to_display_string() const
+    String to_display_string() const
     {
         if (is_string())
-            return as_string();
+            return as_string().to_string();
         if (is_symbol())
-            return as_symbol()->descriptive_string().release_value_but_fixme_should_propagate_errors().to_byte_string();
+            return MUST(as_symbol()->descriptive_string());
         VERIFY_NOT_REACHED();
     }
 
@@ -134,7 +134,7 @@ private:
     }
 
     union {
-        DeprecatedFlyString m_string;
+        FlyString m_string;
         Symbol const* m_symbol_with_tag;
         uintptr_t m_bits;
     };

--- a/Libraries/LibJS/Runtime/StringOrSymbol.h
+++ b/Libraries/LibJS/Runtime/StringOrSymbol.h
@@ -20,16 +20,6 @@ public:
     {
     }
 
-    StringOrSymbol(char const* chars)
-        : StringOrSymbol(DeprecatedFlyString(chars))
-    {
-    }
-
-    StringOrSymbol(ByteString const& string)
-        : StringOrSymbol(DeprecatedFlyString(string))
-    {
-    }
-
     StringOrSymbol(DeprecatedFlyString const& string)
         : m_string(string)
     {

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -603,7 +603,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match_all)
         // b. If isRegExp is true, then
         if (is_regexp) {
             // i. Let flags be ? Get(regexp, "flags").
-            auto flags = TRY(regexp.as_object().get("flags"));
+            auto flags = TRY(regexp.as_object().get(vm.names.flags));
 
             // ii. Perform ? RequireObjectCoercible(flags).
             auto flags_object = TRY(require_object_coercible(vm, flags));

--- a/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -482,7 +482,7 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
     {                                                                                                                       \
     }                                                                                                                       \
                                                                                                                             \
-    DeprecatedFlyString const& ClassName::element_name() const                                                              \
+    FlyString const& ClassName::element_name() const                                                                        \
     {                                                                                                                       \
         return vm().names.ClassName.as_string();                                                                            \
     }                                                                                                                       \

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -52,7 +52,7 @@ public:
     [[nodiscard]] Kind kind() const { return m_kind; }
 
     u32 element_size() const { return m_element_size; }
-    virtual DeprecatedFlyString const& element_name() const = 0;
+    virtual FlyString const& element_name() const = 0;
 
     // 25.1.3.11 IsUnclampedIntegerElementType ( type ), https://tc39.es/ecma262/#sec-isunclampedintegerelementtype
     virtual bool is_unclamped_integer_element_type() const = 0;
@@ -526,7 +526,7 @@ ThrowCompletionOr<double> compare_typed_array_elements(VM&, Value x, Value y, Fu
         static ThrowCompletionOr<GC::Ref<ClassName>> create(Realm&, u32 length, FunctionObject& new_target); \
         static ThrowCompletionOr<GC::Ref<ClassName>> create(Realm&, u32 length);                             \
         static GC::Ref<ClassName> create(Realm&, u32 length, ArrayBuffer& buffer);                           \
-        virtual DeprecatedFlyString const& element_name() const override;                                    \
+        virtual FlyString const& element_name() const override;                                              \
                                                                                                              \
     protected:                                                                                               \
         ClassName(Object& prototype, u32 length, ArrayBuffer& array_buffer);                                 \

--- a/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -13,7 +13,7 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(TypedArrayConstructor);
 
-TypedArrayConstructor::TypedArrayConstructor(DeprecatedFlyString const& name, Object& prototype)
+TypedArrayConstructor::TypedArrayConstructor(FlyString const& name, Object& prototype)
     : NativeFunction(name, prototype)
 {
 }

--- a/Libraries/LibJS/Runtime/TypedArrayConstructor.h
+++ b/Libraries/LibJS/Runtime/TypedArrayConstructor.h
@@ -23,7 +23,7 @@ public:
     virtual ThrowCompletionOr<GC::Ref<Object>> construct(FunctionObject& new_target) override;
 
 protected:
-    TypedArrayConstructor(DeprecatedFlyString const& name, Object& prototype);
+    TypedArrayConstructor(FlyString const& name, Object& prototype);
 
 private:
     virtual bool has_constructor() const override { return true; }

--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1987,7 +1987,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_locale_string)
         if (!next_element.is_nullish()) {
             // i. Let S be ? ToString(? Invoke(nextElement, "toLocaleString", « locales, options »)).
             auto locale_string_value = TRY(next_element.invoke(vm, vm.names.toLocaleString, locales, options));
-            auto locale_string = TRY(locale_string_value.to_byte_string(vm));
+            auto locale_string = TRY(locale_string_value.to_string(vm));
 
             // ii. Set R to the string-concatenation of R and S.
             builder.append(locale_string);
@@ -1997,7 +1997,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::to_locale_string)
     }
 
     // 7. Return R.
-    return PrimitiveString::create(vm, builder.to_byte_string());
+    return PrimitiveString::create(vm, builder.to_string_without_validation());
 }
 
 // 23.2.3.32 %TypedArray%.prototype.toReversed ( ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.toreversed

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/RefCounted.h>
@@ -197,8 +197,8 @@ public:
     u32 execution_generation() const { return m_execution_generation; }
     void finish_execution_generation() { ++m_execution_generation; }
 
-    ThrowCompletionOr<Reference> resolve_binding(DeprecatedFlyString const&, Environment* = nullptr);
-    ThrowCompletionOr<Reference> get_identifier_reference(Environment*, DeprecatedFlyString, bool strict, size_t hops = 0);
+    ThrowCompletionOr<Reference> resolve_binding(FlyString const&, Environment* = nullptr);
+    ThrowCompletionOr<Reference> get_identifier_reference(Environment*, FlyString, bool strict, size_t hops = 0);
 
     // 5.2.3.2 Throw an Exception, https://tc39.es/ecma262/#sec-throw-an-exception
     template<typename T, typename... Args>
@@ -274,7 +274,7 @@ public:
     Function<HashMap<PropertyKey, Value>(SourceTextModule&)> host_get_import_meta_properties;
     Function<void(Object*, SourceTextModule const&)> host_finalize_import_meta;
 
-    Function<Vector<ByteString>()> host_get_supported_import_attributes;
+    Function<Vector<String>()> host_get_supported_import_attributes;
 
     void set_dynamic_imports_allowed(bool value) { m_dynamic_imports_allowed = value; }
 
@@ -335,12 +335,12 @@ private:
     struct StoredModule {
         ImportedModuleReferrer referrer;
         ByteString filename;
-        ByteString type;
+        String type;
         GC::Root<Module> module;
         bool has_once_started_linking { false };
     };
 
-    StoredModule* get_stored_module(ImportedModuleReferrer const& script_or_module, ByteString const& filename, ByteString const& type);
+    StoredModule* get_stored_module(ImportedModuleReferrer const& script_or_module, ByteString const& filename, String const& type);
 
     Vector<StoredModule> m_loaded_modules;
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -898,6 +898,10 @@ ThrowCompletionOr<PropertyKey> Value::to_property_key(VM& vm) const
     if (is_int32() && as_i32() >= 0)
         return PropertyKey { as_i32() };
 
+    // OPTIMIZATION: If this is already a string, we can skip all the ceremony.
+    if (is_string())
+        return PropertyKey { as_string().utf8_string() };
+
     // 1. Let key be ? ToPrimitive(argument, string).
     auto key = TRY(to_primitive(vm, PreferredType::String));
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -912,7 +912,7 @@ ThrowCompletionOr<PropertyKey> Value::to_property_key(VM& vm) const
     }
 
     // 3. Return ! ToString(key).
-    return MUST(key.to_byte_string(vm));
+    return MUST(key.to_string(vm));
 }
 
 // 7.1.6 ToInt32 ( argument ), https://tc39.es/ecma262/#sec-toint32

--- a/Libraries/LibJS/Runtime/WrappedFunction.h
+++ b/Libraries/LibJS/Runtime/WrappedFunction.h
@@ -23,7 +23,7 @@ public:
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
 
     // FIXME: Remove this (and stop inventing random internal slots that shouldn't exist, jeez)
-    virtual DeprecatedFlyString const& name() const override { return m_wrapped_target_function->name(); }
+    virtual FlyString const& name() const override { return m_wrapped_target_function->name(); }
 
     virtual Realm* realm() const override { return m_realm; }
 

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -261,7 +261,7 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse(S
 }
 
 // 16.2.1.6.2 GetExportedNames ( [ exportStarSet ] ), https://tc39.es/ecma262/#sec-getexportednames
-ThrowCompletionOr<Vector<DeprecatedFlyString>> SourceTextModule::get_exported_names(VM& vm, Vector<Module*> export_star_set)
+ThrowCompletionOr<Vector<FlyString>> SourceTextModule::get_exported_names(VM& vm, Vector<Module*> export_star_set)
 {
     dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] get_export_names of {}", filename());
     // 1. Assert: module.[[Status]] is not new.
@@ -276,14 +276,14 @@ ThrowCompletionOr<Vector<DeprecatedFlyString>> SourceTextModule::get_exported_na
         // FIXME: How do we check that?
 
         // b. Return a new empty List.
-        return Vector<DeprecatedFlyString> {};
+        return Vector<FlyString> {};
     }
 
     // 4. Append module to exportStarSet.
     export_star_set.append(this);
 
     // 5. Let exportedNames be a new empty List.
-    Vector<DeprecatedFlyString> exported_names;
+    Vector<FlyString> exported_names;
 
     // 6. For each ExportEntry Record e of module.[[LocalExportEntries]], do
     for (auto& entry : m_local_export_entries) {
@@ -443,7 +443,7 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
     // Note: We just loop through them in step 21.
 
     // 20. Let declaredVarNames be a new empty List.
-    Vector<DeprecatedFlyString> declared_var_names;
+    Vector<FlyString> declared_var_names;
 
     // 21. For each element d of varDeclarations, do
     // a. For each element dn of the BoundNames of d, do
@@ -497,9 +497,9 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
                 // 1. Let fo be InstantiateFunctionObject of d with arguments env and privateEnv.
                 // NOTE: Special case if the function is a default export of an anonymous function
                 //       it has name "*default*" but internally should have name "default".
-                DeprecatedFlyString function_name = function_declaration.name();
+                FlyString function_name = function_declaration.name();
                 if (function_name == ExportStatement::local_name_for_default)
-                    function_name = "default"sv;
+                    function_name = "default"_fly_string;
                 auto function = ECMAScriptFunctionObject::create(realm(), function_name, function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(),
                     function_declaration.parsing_insights());
 
@@ -537,7 +537,7 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
 }
 
 // 16.2.1.6.3 ResolveExport ( exportName [ , resolveSet ] ), https://tc39.es/ecma262/#sec-resolveexport
-ThrowCompletionOr<ResolvedBinding> SourceTextModule::resolve_export(VM& vm, DeprecatedFlyString const& export_name, Vector<ResolvedBinding> resolve_set)
+ThrowCompletionOr<ResolvedBinding> SourceTextModule::resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set)
 {
     // 1. Assert: module.[[Status]] is not new.
     VERIFY(m_status != ModuleStatus::New);
@@ -716,7 +716,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GC::Ptr<Promise
         // c. Let result be the result of evaluating module.[[ECMAScriptCode]].
         Completion result;
 
-        auto maybe_executable = Bytecode::compile(vm, m_ecmascript_code, FunctionKind::Normal, "ShadowRealmEval"sv);
+        auto maybe_executable = Bytecode::compile(vm, m_ecmascript_code, FunctionKind::Normal, "ShadowRealmEval"_fly_string);
         if (maybe_executable.is_error())
             result = maybe_executable.release_error();
         else {
@@ -769,7 +769,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GC::Ptr<Promise
         parsing_insights.uses_this_from_environment = true;
         parsing_insights.uses_this = true;
         auto module_wrapper_function = ECMAScriptFunctionObject::create(
-            realm(), "module code with top-level await", StringView {}, this->m_ecmascript_code,
+            realm(), "module code with top-level await"_fly_string, StringView {}, this->m_ecmascript_code,
             {}, 0, {}, environment(), nullptr, FunctionKind::Async, true, parsing_insights);
         module_wrapper_function->set_is_module_wrapper(true);
 

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -25,8 +25,8 @@ public:
 
     Program const& parse_node() const { return *m_ecmascript_code; }
 
-    virtual ThrowCompletionOr<Vector<DeprecatedFlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set) override;
-    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, DeprecatedFlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) override;
+    virtual ThrowCompletionOr<Vector<FlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set) override;
+    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) override;
 
     Object* import_meta() { return m_import_meta; }
     void set_import_meta(Badge<VM>, Object* import_meta) { m_import_meta = import_meta; }

--- a/Libraries/LibJS/SyntheticModule.cpp
+++ b/Libraries/LibJS/SyntheticModule.cpp
@@ -18,7 +18,7 @@ namespace JS {
 GC_DEFINE_ALLOCATOR(SyntheticModule);
 
 // 1.2.1 CreateSyntheticModule ( exportNames, evaluationSteps, realm, hostDefined ), https://tc39.es/proposal-json-modules/#sec-createsyntheticmodule
-SyntheticModule::SyntheticModule(Vector<DeprecatedFlyString> export_names, SyntheticModule::EvaluationFunction evaluation_steps, Realm& realm, StringView filename)
+SyntheticModule::SyntheticModule(Vector<FlyString> export_names, SyntheticModule::EvaluationFunction evaluation_steps, Realm& realm, StringView filename)
     : Module(realm, filename)
     , m_export_names(move(export_names))
     , m_evaluation_steps(move(evaluation_steps))
@@ -27,14 +27,14 @@ SyntheticModule::SyntheticModule(Vector<DeprecatedFlyString> export_names, Synth
 }
 
 // 1.2.3.1 GetExportedNames( exportStarSet ), https://tc39.es/proposal-json-modules/#sec-smr-getexportednames
-ThrowCompletionOr<Vector<DeprecatedFlyString>> SyntheticModule::get_exported_names(VM&, Vector<Module*>)
+ThrowCompletionOr<Vector<FlyString>> SyntheticModule::get_exported_names(VM&, Vector<Module*>)
 {
     // 1. Return module.[[ExportNames]].
     return m_export_names;
 }
 
 // 1.2.3.2 ResolveExport( exportName, resolveSet ), https://tc39.es/proposal-json-modules/#sec-smr-resolveexport
-ThrowCompletionOr<ResolvedBinding> SyntheticModule::resolve_export(VM&, DeprecatedFlyString const& export_name, Vector<ResolvedBinding>)
+ThrowCompletionOr<ResolvedBinding> SyntheticModule::resolve_export(VM&, FlyString const& export_name, Vector<ResolvedBinding>)
 {
     // 1. If module.[[ExportNames]] does not contain exportName, return null.
     if (!m_export_names.contains_slow(export_name))
@@ -123,7 +123,7 @@ ThrowCompletionOr<Promise*> SyntheticModule::evaluate(VM& vm)
 }
 
 // 1.2.2 SetSyntheticModuleExport ( module, exportName, exportValue ), https://tc39.es/proposal-json-modules/#sec-setsyntheticmoduleexport
-ThrowCompletionOr<void> SyntheticModule::set_synthetic_module_export(DeprecatedFlyString const& export_name, Value export_value)
+ThrowCompletionOr<void> SyntheticModule::set_synthetic_module_export(FlyString const& export_name, Value export_value)
 {
     auto& vm = this->realm().vm();
 
@@ -139,11 +139,11 @@ GC::Ref<SyntheticModule> SyntheticModule::create_default_export_synthetic_module
     // 1. Let closure be the a Abstract Closure with parameters (module) that captures defaultExport and performs the following steps when called:
     auto closure = [default_export = make_root(default_export)](SyntheticModule& module) -> ThrowCompletionOr<void> {
         // a. Return ? module.SetSyntheticExport("default", defaultExport).
-        return module.set_synthetic_module_export("default", default_export.value());
+        return module.set_synthetic_module_export("default"_fly_string, default_export.value());
     };
 
     // 2. Return CreateSyntheticModule("default", closure, realm)
-    return realm.heap().allocate<SyntheticModule>(Vector<DeprecatedFlyString> { "default" }, move(closure), realm, filename);
+    return realm.heap().allocate<SyntheticModule>(Vector<FlyString> { "default"_fly_string }, move(closure), realm, filename);
 }
 
 // 1.4 ParseJSONModule ( source ), https://tc39.es/proposal-json-modules/#sec-parse-json-module

--- a/Libraries/LibJS/SyntheticModule.h
+++ b/Libraries/LibJS/SyntheticModule.h
@@ -20,19 +20,19 @@ public:
 
     static GC::Ref<SyntheticModule> create_default_export_synthetic_module(Value default_export, Realm& realm, StringView filename);
 
-    ThrowCompletionOr<void> set_synthetic_module_export(DeprecatedFlyString const& export_name, Value export_value);
+    ThrowCompletionOr<void> set_synthetic_module_export(FlyString const& export_name, Value export_value);
 
     virtual ThrowCompletionOr<void> link(VM& vm) override;
     virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override;
-    virtual ThrowCompletionOr<Vector<DeprecatedFlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set) override;
-    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, DeprecatedFlyString const& export_name, Vector<ResolvedBinding> resolve_set) override;
+    virtual ThrowCompletionOr<Vector<FlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set) override;
+    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set) override;
     virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) override;
 
 private:
-    SyntheticModule(Vector<DeprecatedFlyString> export_names, EvaluationFunction evaluation_steps, Realm& realm, StringView filename);
+    SyntheticModule(Vector<FlyString> export_names, EvaluationFunction evaluation_steps, Realm& realm, StringView filename);
 
-    Vector<DeprecatedFlyString> m_export_names; // [[ExportNames]]
-    EvaluationFunction m_evaluation_steps;      // [[EvaluationSteps]]
+    Vector<FlyString> m_export_names;      // [[ExportNames]]
+    EvaluationFunction m_evaluation_steps; // [[EvaluationSteps]]
 };
 
 ThrowCompletionOr<GC::Ref<Module>> parse_json_module(StringView source_text, Realm& realm, StringView filename);

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Variant.h>
@@ -208,16 +208,16 @@ public:
     {
         return m_value.visit(
             [](StringView view) { return view; },
-            [](DeprecatedFlyString const& identifier) { return identifier.view(); },
+            [](FlyString const& identifier) { return identifier.bytes_as_string_view(); },
             [](Empty) -> StringView { VERIFY_NOT_REACHED(); });
     }
 
-    DeprecatedFlyString DeprecatedFlyString_value() const
+    FlyString fly_string_value() const
     {
         return m_value.visit(
-            [](StringView view) -> DeprecatedFlyString { return view; },
-            [](DeprecatedFlyString const& identifier) -> DeprecatedFlyString { return identifier; },
-            [](Empty) -> DeprecatedFlyString { VERIFY_NOT_REACHED(); });
+            [](StringView view) -> FlyString { return MUST(FlyString::from_utf8(view)); },
+            [](FlyString const& identifier) -> FlyString { return identifier; },
+            [](Empty) -> FlyString { VERIFY_NOT_REACHED(); });
     }
 
     size_t line_number() const { return m_line_number; }
@@ -236,7 +236,7 @@ public:
     ByteString string_value(StringValueStatus& status) const;
     ByteString raw_template_value() const;
 
-    void set_identifier_value(DeprecatedFlyString value)
+    void set_identifier_value(FlyString value)
     {
         m_value = move(value);
     }
@@ -249,7 +249,7 @@ private:
     StringView m_message;
     StringView m_trivia;
     StringView m_original_value;
-    Variant<Empty, StringView, DeprecatedFlyString> m_value {};
+    Variant<Empty, StringView, FlyString> m_value {};
     size_t m_line_number { 0 };
     size_t m_line_column { 0 };
     size_t m_offset { 0 };

--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -387,13 +387,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput c
 
     VERIFY(start_position + length <= input.view.length());
 
-    auto view = input.view.substring_view(start_position, length);
-
-    if (input.regex_options & AllFlags::StringCopyMatches) {
-        match = { view.to_byte_string(), input.line, start_position, input.global_offset + start_position }; // create a copy of the original string
-    } else {
-        match = { view, input.line, start_position, input.global_offset + start_position }; // take view to original string
-    }
+    match = { input.view.substring_view(start_position, length), input.line, start_position, input.global_offset + start_position };
 
     return ExecutionResult::Continue;
 }
@@ -414,11 +408,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchIn
 
     auto view = input.view.substring_view(start_position, length);
 
-    if (input.regex_options & AllFlags::StringCopyMatches) {
-        match = { view.to_byte_string(), name(), input.line, start_position, input.global_offset + start_position }; // create a copy of the original string
-    } else {
-        match = { view, name(), input.line, start_position, input.global_offset + start_position }; // take view to original string
-    }
+    match = { view, name(), input.line, start_position, input.global_offset + start_position };
 
     return ExecutionResult::Continue;
 }

--- a/Libraries/LibRegex/RegexDefs.h
+++ b/Libraries/LibRegex/RegexDefs.h
@@ -40,7 +40,6 @@ enum __RegexAllFlags {
     __Regex_MatchNotBeginOfLine = __Regex_Global << 6,           // Pattern is not forced to ^ -> search in whole string!
     __Regex_MatchNotEndOfLine = __Regex_Global << 7,             // Don't Force the dollar sign, $, to always match end of the string, instead of end of the line. This option is ignored if the Multiline-flag is set
     __Regex_SkipSubExprResults = __Regex_Global << 8,            // Do not return sub expressions in the result
-    __Regex_StringCopyMatches = __Regex_Global << 9,             // Do explicitly copy results into new allocated string instead of StringView to original string.
     __Regex_SingleLine = __Regex_Global << 10,                   // Dot matches newline characters
     __Regex_Sticky = __Regex_Global << 11,                       // Force the pattern to only match consecutive matches from where the previous match ended.
     __Regex_Multiline = __Regex_Global << 12,                    // Handle newline characters. Match each line, one by one.

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -12,7 +12,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/COWVector.h>
-#include <AK/DeprecatedFlyString.h>
+#include <AK/FlyString.h>
 #include <AK/MemMem.h>
 #include <AK/RedBlackTree.h>
 #include <AK/StringBuilder.h>
@@ -476,7 +476,7 @@ private:
 
 class Match final {
 private:
-    Optional<DeprecatedFlyString> string;
+    Optional<FlyString> string;
 
 public:
     Match() = default;
@@ -491,9 +491,9 @@ public:
     {
     }
 
-    Match(ByteString string_, size_t const line_, size_t const column_, size_t const global_offset_)
+    Match(String string_, size_t const line_, size_t const column_, size_t const global_offset_)
         : string(move(string_))
-        , view(string.value().view())
+        , view(string.value().bytes_as_string_view())
         , line(line_)
         , column(column_)
         , global_offset(global_offset_)
@@ -502,7 +502,7 @@ public:
 
     Match(RegexStringView const view_, StringView capture_group_name_, size_t const line_, size_t const column_, size_t const global_offset_)
         : view(view_)
-        , capture_group_name(capture_group_name_)
+        , capture_group_name(MUST(FlyString::from_utf8(capture_group_name_)))
         , line(line_)
         , column(column_)
         , global_offset(global_offset_)
@@ -521,7 +521,7 @@ public:
     }
 
     RegexStringView view {};
-    Optional<DeprecatedFlyString> capture_group_name {};
+    Optional<FlyString> capture_group_name {};
     size_t line { 0 };
     size_t column { 0 };
     size_t global_offset { 0 };

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -59,7 +59,8 @@ public:
     {
     }
 
-    explicit RegexStringView(ByteString&&) = delete;
+    RegexStringView(ByteString&&) = delete;
+    RegexStringView(String&&) = delete;
 
     bool is_string_view() const
     {

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -197,11 +197,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             state.matches.empend();
 
         VERIFY(start_position + state.string_position - start_position <= input.view.length());
-        if (input.regex_options.has_flag_set(AllFlags::StringCopyMatches)) {
-            state.matches.mutable_at(input.match_index) = { input.view.substring_view(start_position, state.string_position - start_position).to_byte_string(), input.line, start_position, input.global_offset + start_position };
-        } else { // let the view point to the original string ...
-            state.matches.mutable_at(input.match_index) = { input.view.substring_view(start_position, state.string_position - start_position), input.line, start_position, input.global_offset + start_position };
-        }
+        state.matches.mutable_at(input.match_index) = { input.view.substring_view(start_position, state.string_position - start_position), input.line, start_position, input.global_offset + start_position };
     };
 
 #if REGEX_DEBUG

--- a/Libraries/LibRegex/RegexOptions.h
+++ b/Libraries/LibRegex/RegexOptions.h
@@ -25,7 +25,6 @@ enum class AllFlags {
     MatchNotBeginOfLine = __Regex_MatchNotBeginOfLine,                   // Pattern is not forced to ^ -> search in whole string!
     MatchNotEndOfLine = __Regex_MatchNotEndOfLine,                       // Don't Force the dollar sign, $, to always match end of the string, instead of end of the line. This option is ignored if the Multiline-flag is set
     SkipSubExprResults = __Regex_SkipSubExprResults,                     // Do not return sub expressions in the result
-    StringCopyMatches = __Regex_StringCopyMatches,                       // Do explicitly copy results into new allocated string instead of StringView to original string.
     SingleLine = __Regex_SingleLine,                                     // Dot matches newline characters
     Sticky = __Regex_Sticky,                                             // Force the pattern to only match consecutive matches from where the previous match ended.
     Multiline = __Regex_Multiline,                                       // Handle newline characters. Match each line, one by one.
@@ -53,7 +52,6 @@ enum class PosixFlags : FlagsUnderlyingType {
     SkipTrimEmptyMatches = (FlagsUnderlyingType)AllFlags::SkipTrimEmptyMatches,
     Multiline = (FlagsUnderlyingType)AllFlags::Multiline,
     SingleMatch = (FlagsUnderlyingType)AllFlags::SingleMatch,
-    StringCopyMatches = (FlagsUnderlyingType)AllFlags::StringCopyMatches,
 };
 
 enum class ECMAScriptFlags : FlagsUnderlyingType {
@@ -67,7 +65,6 @@ enum class ECMAScriptFlags : FlagsUnderlyingType {
     SingleLine = (FlagsUnderlyingType)AllFlags::SingleLine,
     Sticky = (FlagsUnderlyingType)AllFlags::Sticky,
     Multiline = (FlagsUnderlyingType)AllFlags::Multiline,
-    StringCopyMatches = (FlagsUnderlyingType)AllFlags::StringCopyMatches,
     UnicodeSets = (FlagsUnderlyingType)AllFlags::UnicodeSets,
     BrowserExtended = (FlagsUnderlyingType)AllFlags::Internal_BrowserExtended,
 };

--- a/Libraries/LibRegex/RegexParser.cpp
+++ b/Libraries/LibRegex/RegexParser.cpp
@@ -11,6 +11,7 @@
 #include <AK/ByteString.h>
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
+#include <AK/DeprecatedFlyString.h>
 #include <AK/GenericLexer.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>

--- a/Libraries/LibRegex/RegexParser.h
+++ b/Libraries/LibRegex/RegexParser.h
@@ -11,6 +11,7 @@
 #include "RegexLexer.h"
 #include "RegexOptions.h"
 
+#include <AK/DeprecatedFlyString.h>
 #include <AK/Forward.h>
 #include <AK/HashMap.h>
 #include <AK/Types.h>

--- a/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Libraries/LibTest/JavaScriptTestRunner.h
@@ -58,9 +58,9 @@
         }                                                                                                                                       \
     } __testjs_register_##fn {};
 
-#define TESTJS_GLOBAL_FUNCTION(function, exposed_name, ...)                    \
-    JS_DECLARE_NATIVE_FUNCTION(function);                                      \
-    __TESTJS_REGISTER_GLOBAL_FUNCTION(#exposed_name, function, ##__VA_ARGS__); \
+#define TESTJS_GLOBAL_FUNCTION(function, exposed_name, ...)                             \
+    JS_DECLARE_NATIVE_FUNCTION(function);                                               \
+    __TESTJS_REGISTER_GLOBAL_FUNCTION(#exposed_name##_string, function, ##__VA_ARGS__); \
     JS_DEFINE_NATIVE_FUNCTION(function)
 
 #define TESTJS_MAIN_HOOK()                  \
@@ -117,7 +117,7 @@ struct FunctionWithLength {
     JS::ThrowCompletionOr<JS::Value> (*function)(JS::VM&);
     size_t length { 0 };
 };
-extern HashMap<ByteString, FunctionWithLength> s_exposed_global_functions;
+extern HashMap<String, FunctionWithLength> s_exposed_global_functions;
 extern ByteString g_test_root_fragment;
 extern ByteString g_test_root;
 extern int g_test_argc;

--- a/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Libraries/LibTest/JavaScriptTestRunner.h
@@ -185,7 +185,7 @@ inline void TestRunnerGlobalObject::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_direct_property("global", this, JS::Attribute::Enumerable);
+    define_direct_property("global"_fly_string, this, JS::Attribute::Enumerable);
     for (auto& entry : s_exposed_global_functions) {
         define_native_function(
             realm,
@@ -242,7 +242,7 @@ inline AK::Result<GC::Ref<JS::SourceTextModule>, ParserError> parse_module(Strin
 
 inline ErrorOr<JsonValue> get_test_results(JS::Realm& realm)
 {
-    auto results = MUST(realm.global_object().get("__TestResults__"));
+    auto results = MUST(realm.global_object().get("__TestResults__"_fly_string));
     auto maybe_json_string = MUST(JS::JSONObject::stringify_impl(*g_vm, results, JS::js_undefined(), JS::js_undefined()));
     if (maybe_json_string.has_value())
         return JsonValue::from_string(*maybe_json_string);
@@ -362,7 +362,7 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
     JSFileResult file_result { test_path.substring(m_test_root.length() + 1, test_path.length() - m_test_root.length() - 1) };
 
     // Collect logged messages
-    auto user_output = MUST(realm->global_object().get("__UserOutput__"));
+    auto user_output = MUST(realm->global_object().get("__UserOutput__"_fly_string));
 
     auto& arr = user_output.as_array();
     for (auto& entry : arr.indexed_properties()) {

--- a/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -21,7 +21,7 @@ namespace JS {
 RefPtr<::JS::VM> g_vm;
 bool g_collect_on_every_allocation = false;
 ByteString g_currently_running_test;
-HashMap<ByteString, FunctionWithLength> s_exposed_global_functions;
+HashMap<String, FunctionWithLength> s_exposed_global_functions;
 Function<void()> g_main_hook;
 HashMap<bool*, Tuple<ByteString, ByteString, char>> g_extra_args;
 IntermediateRunFileResult (*g_run_file)(ByteString const&, JS::Realm&, JS::ExecutionContext&) = nullptr;

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -104,13 +104,13 @@ static WebIDL::ExceptionOr<KeyframeType<AL>> process_a_keyframe_like_object(JS::
         return keyframe_output;
 
     auto& keyframe_object = keyframe_input.as_object();
-    auto composite = TRY(keyframe_object.get("composite"));
+    auto composite = TRY(keyframe_object.get("composite"_fly_string));
     if (composite.is_undefined())
         composite = JS::PrimitiveString::create(vm, "auto"_string);
-    auto easing = TRY(keyframe_object.get("easing"));
+    auto easing = TRY(keyframe_object.get("easing"_fly_string));
     if (easing.is_undefined())
         easing = JS::PrimitiveString::create(vm, "linear"_string);
-    auto offset = TRY(keyframe_object.get("offset"));
+    auto offset = TRY(keyframe_object.get("offset"_fly_string));
 
     if constexpr (AL == AllowLists::Yes) {
         keyframe_output.composite = TRY(convert_value_to_maybe_list(realm, composite, to_composite_operation));

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -185,7 +185,7 @@ static WebIDL::ExceptionOr<KeyframeType<AL>> process_a_keyframe_like_object(JS::
         // 1. Let raw value be the result of calling the [[Get]] internal method on keyframe input, with property name
         //    as the property key and keyframe input as the receiver.
         // 2. Check the completion record of raw value.
-        JS::PropertyKey key { property_name.to_byte_string(), JS::PropertyKey::StringMayBeNumber::No };
+        JS::PropertyKey key { property_name, JS::PropertyKey::StringMayBeNumber::No };
         auto raw_value = TRY(keyframe_object.has_property(key)) ? TRY(keyframe_object.get(key)) : *all_value;
 
         using PropertyValuesType = Conditional<AL == AllowLists::Yes, Vector<String>, String>;
@@ -827,7 +827,7 @@ WebIDL::ExceptionOr<GC::RootVector<JS::Object*>> KeyframeEffect::get_keyframes()
 
             for (auto const& [id, value] : keyframe.parsed_properties()) {
                 auto value_string = JS::PrimitiveString::create(vm, value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
-                TRY(object->set(JS::PropertyKey { DeprecatedFlyString(CSS::camel_case_string_from_property_id(id)), JS::PropertyKey::StringMayBeNumber::No }, value_string, ShouldThrowExceptions::Yes));
+                TRY(object->set(JS::PropertyKey { CSS::camel_case_string_from_property_id(id), JS::PropertyKey::StringMayBeNumber::No }, value_string, ShouldThrowExceptions::Yes));
             }
 
             m_keyframe_objects.append(object);

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -369,7 +369,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
 
             // 2. Let url be the result of resolving a module specifier given moduleScript and specifier.
             auto url = TRY(Bindings::throw_dom_exception_if_needed(vm, [&] {
-                return HTML::resolve_module_specifier(*module_script, specifier_string.to_byte_string());
+                return HTML::resolve_module_specifier(*module_script, specifier_string);
             }));
 
             // 3. Return the serialization of url.
@@ -388,9 +388,9 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
     };
 
     // 8.1.6.7.2 HostGetSupportedImportAttributes(), https://html.spec.whatwg.org/multipage/webappapis.html#hostgetsupportedimportassertions
-    s_main_thread_vm->host_get_supported_import_attributes = []() -> Vector<ByteString> {
+    s_main_thread_vm->host_get_supported_import_attributes = []() -> Vector<String> {
         // 1. Return « "type" ».
-        return { "type"sv };
+        return { "type"_string };
     };
 
     // 8.1.6.7.3 HostLoadImportedModule(referrer, moduleRequest, loadState, payload), https://html.spec.whatwg.org/multipage/webappapis.html#hostloadimportedmodule
@@ -460,7 +460,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
 
                 // 2. Resolve a module specifier given referencingScript and moduleRequest.[[Specifier]], catching any
                 //    exceptions. If they throw an exception, let resolutionError be the thrown exception.
-                auto maybe_exception = HTML::resolve_module_specifier(referencing_script, module_request.module_specifier);
+                auto maybe_exception = HTML::resolve_module_specifier(referencing_script, module_request.module_specifier.to_string());
 
                 // 3. If the previous step threw an exception, then:
                 if (maybe_exception.is_exception()) {
@@ -500,7 +500,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
 
         // 8. Let url be the result of resolving a module specifier given referencingScript and moduleRequest.[[Specifier]],
         //    catching any exceptions. If they throw an exception, let resolutionError be the thrown exception.
-        auto url = HTML::resolve_module_specifier(referencing_script, module_request.module_specifier);
+        auto url = HTML::resolve_module_specifier(referencing_script, module_request.module_specifier.to_string());
 
         // 9. If the previous step threw an exception, then:
         if (url.is_exception()) {

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -381,8 +381,8 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
 
         // 5. Return « Record { [[Key]]: "url", [[Value]]: urlString }, Record { [[Key]]: "resolve", [[Value]]: resolveFunction } ».
         HashMap<JS::PropertyKey, JS::Value> meta;
-        meta.set("url", JS::PrimitiveString::create(vm, move(url_string)));
-        meta.set("resolve", resolve_function);
+        meta.set("url"_fly_string, JS::PrimitiveString::create(vm, move(url_string)));
+        meta.set("resolve"_fly_string, resolve_function);
 
         return meta;
     };

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -41,7 +41,7 @@ JS::ThrowCompletionOr<bool> PlatformObject::is_named_property_exposed_on_object(
 
     // 1. If P is not a supported property name of O, then return false.
     // NOTE: This is in it's own variable to enforce the type.
-    if (!is_supported_property_name(MUST(String::from_byte_string(property_key.to_string()))))
+    if (!is_supported_property_name(property_key.to_string()))
         return false;
 
     // 2. If O has an own property named P, then return false.
@@ -118,7 +118,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> PlatformObject::legacy_p
         // 1. If the result of running the named property visibility algorithm with property name P and object O is true, then:
         if (TRY(is_named_property_exposed_on_object(property_name))) {
             // FIXME: It's unfortunate that this is done twice, once in is_named_property_exposed_on_object and here.
-            auto property_name_string = MUST(FlyString::from_deprecated_fly_string(property_name.to_string()));
+            auto property_name_string = property_name.to_string();
 
             // 1. Let operation be the operation used to declare the named property getter.
             // 2. Let value be an uninitialized variable.
@@ -236,7 +236,7 @@ JS::ThrowCompletionOr<bool> PlatformObject::internal_set(JS::PropertyKey const& 
         // 2. If O implements an interface with a named property setter and P is a String, then:
         if (m_legacy_platform_object_flags->has_named_property_setter && property_name.is_string()) {
             // 1. Invoke the named property setter on O with P and V.
-            TRY(throw_dom_exception_if_needed(vm, [&] { return invoke_named_property_setter(MUST(String::from_byte_string(property_name.as_string())), value); }));
+            TRY(throw_dom_exception_if_needed(vm, [&] { return invoke_named_property_setter(property_name.as_string(), value); }));
 
             // 2. Return true.
             return true;
@@ -282,7 +282,7 @@ JS::ThrowCompletionOr<bool> PlatformObject::internal_define_own_property(JS::Pro
     // 2. If O supports named properties, O does not implement an interface with the [Global] extended attribute, P is a String, and P is not an unforgeable property name of O, then:
     // FIXME: Check if P is not an unforgeable property name of O
     if (m_legacy_platform_object_flags->supports_named_properties && !m_legacy_platform_object_flags->has_global_interface_extended_attribute && property_name.is_string()) {
-        auto const property_name_as_string = MUST(FlyString::from_deprecated_fly_string(property_name.as_string()));
+        auto const property_name_as_string = property_name.as_string();
 
         // 1. Let creating be true if P is not a supported property name, and false otherwise.
         bool creating = !is_supported_property_name(property_name_as_string);
@@ -360,7 +360,7 @@ JS::ThrowCompletionOr<bool> PlatformObject::internal_delete(JS::PropertyKey cons
         // 4. Otherwise, operation was defined with an identifier:
         //    1. Perform method steps of operation with O as this and « P » as the argument values.
         //    2. If operation was declared with a return type of boolean and the steps returned false, then return false.
-        auto did_deletion_fail = TRY(throw_dom_exception_if_needed(vm, [&] { return delete_value(MUST(String::from_byte_string(property_name_string))); }));
+        auto did_deletion_fail = TRY(throw_dom_exception_if_needed(vm, [&] { return delete_value(property_name_string); }));
         if (!m_legacy_platform_object_flags->named_property_deleter_has_identifier)
             VERIFY(did_deletion_fail != DidDeletionFail::NotRelevant);
 
@@ -423,7 +423,7 @@ JS::ThrowCompletionOr<GC::RootVector<JS::Value>> PlatformObject::internal_own_pr
     // 3. If O supports named properties, then for each P of O’s supported property names that is visible according to the named property visibility algorithm, append P to keys.
     if (m_legacy_platform_object_flags->supports_named_properties) {
         for (auto& named_property : supported_property_names()) {
-            if (TRY(is_named_property_exposed_on_object(named_property.to_deprecated_fly_string())))
+            if (TRY(is_named_property_exposed_on_object(named_property)))
                 keys.append(JS::PrimitiveString::create(vm, named_property));
         }
     }

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -337,7 +337,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesCbcParams::from_value(J
 {
     auto& object = value.as_object();
 
-    auto iv_value = TRY(object.get("iv"));
+    auto iv_value = TRY(object.get("iv"_fly_string));
     if (!iv_value.is_object() || !(is<JS::TypedArrayBase>(iv_value.as_object()) || is<JS::ArrayBuffer>(iv_value.as_object()) || is<JS::DataView>(iv_value.as_object())))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
     auto iv = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(iv_value.as_object()));
@@ -351,12 +351,12 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesCtrParams::from_value(J
 {
     auto& object = value.as_object();
 
-    auto iv_value = TRY(object.get("counter"));
+    auto iv_value = TRY(object.get("counter"_fly_string));
     if (!iv_value.is_object() || !(is<JS::TypedArrayBase>(iv_value.as_object()) || is<JS::ArrayBuffer>(iv_value.as_object()) || is<JS::DataView>(iv_value.as_object())))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
     auto iv = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(iv_value.as_object()));
 
-    auto length_value = TRY(object.get("length"));
+    auto length_value = TRY(object.get("length"_fly_string));
     auto length = TRY(length_value.to_u8(vm));
 
     return adopt_own<AlgorithmParams>(*new AesCtrParams { iv, length });
@@ -368,22 +368,22 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesGcmParams::from_value(J
 {
     auto& object = value.as_object();
 
-    auto iv_value = TRY(object.get("iv"));
+    auto iv_value = TRY(object.get("iv"_fly_string));
     if (!iv_value.is_object() || !(is<JS::TypedArrayBase>(iv_value.as_object()) || is<JS::ArrayBuffer>(iv_value.as_object()) || is<JS::DataView>(iv_value.as_object())))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
     auto iv = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(iv_value.as_object()));
 
     auto maybe_additional_data = Optional<ByteBuffer> {};
-    if (MUST(object.has_property("additionalData"))) {
-        auto additional_data_value = TRY(object.get("additionalData"));
+    if (MUST(object.has_property("additionalData"_fly_string))) {
+        auto additional_data_value = TRY(object.get("additionalData"_fly_string));
         if (!additional_data_value.is_object() || !(is<JS::TypedArrayBase>(additional_data_value.as_object()) || is<JS::ArrayBuffer>(additional_data_value.as_object()) || is<JS::DataView>(additional_data_value.as_object())))
             return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
         maybe_additional_data = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(additional_data_value.as_object()));
     }
 
     auto maybe_tag_length = Optional<u8> {};
-    if (MUST(object.has_property("tagLength"))) {
-        auto tag_length_value = TRY(object.get("tagLength"));
+    if (MUST(object.has_property("tagLength"_fly_string))) {
+        auto tag_length_value = TRY(object.get("tagLength"_fly_string));
         maybe_tag_length = TRY(tag_length_value.to_u8(vm));
     }
 
@@ -396,15 +396,15 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HKDFParams::from_value(JS:
 {
     auto& object = value.as_object();
 
-    auto hash_value = TRY(object.get("hash"));
+    auto hash_value = TRY(object.get("hash"_fly_string));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
-    auto salt_value = TRY(object.get("salt"));
+    auto salt_value = TRY(object.get("salt"_fly_string));
     if (!salt_value.is_object() || !(is<JS::TypedArrayBase>(salt_value.as_object()) || is<JS::ArrayBuffer>(salt_value.as_object()) || is<JS::DataView>(salt_value.as_object())))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
     auto salt = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(salt_value.as_object()));
 
-    auto info_value = TRY(object.get("info"));
+    auto info_value = TRY(object.get("info"_fly_string));
     if (!info_value.is_object() || !(is<JS::TypedArrayBase>(info_value.as_object()) || is<JS::ArrayBuffer>(info_value.as_object()) || is<JS::DataView>(info_value.as_object())))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
     auto info = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(info_value.as_object()));
@@ -418,17 +418,17 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> PBKDF2Params::from_value(J
 {
     auto& object = value.as_object();
 
-    auto salt_value = TRY(object.get("salt"));
+    auto salt_value = TRY(object.get("salt"_fly_string));
 
     if (!salt_value.is_object() || !(is<JS::TypedArrayBase>(salt_value.as_object()) || is<JS::ArrayBuffer>(salt_value.as_object()) || is<JS::DataView>(salt_value.as_object())))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
 
     auto salt = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(salt_value.as_object()));
 
-    auto iterations_value = TRY(object.get("iterations"));
+    auto iterations_value = TRY(object.get("iterations"_fly_string));
     auto iterations = TRY(iterations_value.to_u32(vm));
 
-    auto hash_value = TRY(object.get("hash"));
+    auto hash_value = TRY(object.get("hash"_fly_string));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
     return adopt_own<AlgorithmParams>(*new PBKDF2Params { salt, iterations, hash });
@@ -440,10 +440,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaKeyGenParams::from_valu
 {
     auto& object = value.as_object();
 
-    auto modulus_length_value = TRY(object.get("modulusLength"));
+    auto modulus_length_value = TRY(object.get("modulusLength"_fly_string));
     auto modulus_length = TRY(modulus_length_value.to_u32(vm));
 
-    auto public_exponent_value = TRY(object.get("publicExponent"));
+    auto public_exponent_value = TRY(object.get("publicExponent"_fly_string));
     GC::Ptr<JS::Uint8Array> public_exponent;
 
     if (!public_exponent_value.is_object() || !is<JS::Uint8Array>(public_exponent_value.as_object()))
@@ -460,10 +460,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedKeyGenParams::fro
 {
     auto& object = value.as_object();
 
-    auto modulus_length_value = TRY(object.get("modulusLength"));
+    auto modulus_length_value = TRY(object.get("modulusLength"_fly_string));
     auto modulus_length = TRY(modulus_length_value.to_u32(vm));
 
-    auto public_exponent_value = TRY(object.get("publicExponent"));
+    auto public_exponent_value = TRY(object.get("publicExponent"_fly_string));
     GC::Ptr<JS::Uint8Array> public_exponent;
 
     if (!public_exponent_value.is_object() || !is<JS::Uint8Array>(public_exponent_value.as_object()))
@@ -471,7 +471,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedKeyGenParams::fro
 
     public_exponent = static_cast<JS::Uint8Array&>(public_exponent_value.as_object());
 
-    auto hash_value = TRY(object.get("hash"));
+    auto hash_value = TRY(object.get("hash"_fly_string));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
     return adopt_own<AlgorithmParams>(*new RsaHashedKeyGenParams { modulus_length, big_integer_from_api_big_integer(public_exponent), hash });
@@ -483,7 +483,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedImportParams::fro
 {
     auto& object = value.as_object();
 
-    auto hash_value = TRY(object.get("hash"));
+    auto hash_value = TRY(object.get("hash"_fly_string));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
     return adopt_own<AlgorithmParams>(*new RsaHashedImportParams { hash });
@@ -495,7 +495,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaOaepParams::from_value(
 {
     auto& object = value.as_object();
 
-    auto label_value = TRY(object.get("label"));
+    auto label_value = TRY(object.get("label"_fly_string));
 
     ByteBuffer label;
     if (!label_value.is_nullish()) {
@@ -515,7 +515,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaPssParams::from_value(J
 {
     auto& object = value.as_object();
 
-    auto salt_length_value = TRY(object.get("saltLength"));
+    auto salt_length_value = TRY(object.get("saltLength"_fly_string));
     auto salt_length = TRY(salt_length_value.to_u32(vm));
 
     return adopt_own<AlgorithmParams>(*new RsaPssParams { salt_length });
@@ -527,7 +527,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdsaParams::from_value(JS
 {
     auto& object = value.as_object();
 
-    auto hash_value = TRY(object.get("hash"));
+    auto hash_value = TRY(object.get("hash"_fly_string));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
     return adopt_own<AlgorithmParams>(*new EcdsaParams { hash });
@@ -539,7 +539,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcKeyGenParams::from_value
 {
     auto& object = value.as_object();
 
-    auto curve_value = TRY(object.get("namedCurve"));
+    auto curve_value = TRY(object.get("namedCurve"_fly_string));
     auto curve = TRY(curve_value.to_string(vm));
 
     return adopt_own<AlgorithmParams>(*new EcKeyGenParams { curve });
@@ -551,7 +551,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesKeyGenParams::from_valu
 {
     auto& object = value.as_object();
 
-    auto length_value = TRY(object.get("length"));
+    auto length_value = TRY(object.get("length"_fly_string));
     auto length = TRY(length_value.to_u16(vm));
 
     return adopt_own<AlgorithmParams>(*new AesKeyGenParams { length });
@@ -563,7 +563,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesDerivedKeyParams::from_
 {
     auto& object = value.as_object();
 
-    auto length_value = TRY(object.get("length"));
+    auto length_value = TRY(object.get("length"_fly_string));
     auto length = TRY(length_value.to_u16(vm));
 
     return adopt_own<AlgorithmParams>(*new AesDerivedKeyParams { length });
@@ -575,7 +575,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdhKeyDeriveParams::from_
 {
     auto& object = value.as_object();
 
-    auto key_value = TRY(object.get("public"));
+    auto key_value = TRY(object.get("public"_fly_string));
     auto key_object = TRY(key_value.to_object(vm));
 
     if (!is<CryptoKey>(*key_object)) {
@@ -593,7 +593,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcKeyImportParams::from_va
 {
     auto& object = value.as_object();
 
-    auto named_curve_value = TRY(object.get("namedCurve"));
+    auto named_curve_value = TRY(object.get("namedCurve"_fly_string));
     auto named_curve = TRY(named_curve_value.to_string(vm));
 
     return adopt_own<AlgorithmParams>(*new EcKeyImportParams { named_curve });
@@ -605,12 +605,12 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HmacImportParams::from_val
 {
     auto& object = value.as_object();
 
-    auto hash_value = TRY(object.get("hash"));
+    auto hash_value = TRY(object.get("hash"_fly_string));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
     auto maybe_length = Optional<WebIDL::UnsignedLong> {};
-    if (MUST(object.has_property("length"))) {
-        auto length_value = TRY(object.get("length"));
+    if (MUST(object.has_property("length"_fly_string))) {
+        auto length_value = TRY(object.get("length"_fly_string));
         maybe_length = TRY(length_value.to_u32(vm));
     }
 
@@ -623,12 +623,12 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HmacKeyGenParams::from_val
 {
     auto& object = value.as_object();
 
-    auto hash_value = TRY(object.get("hash"));
+    auto hash_value = TRY(object.get("hash"_fly_string));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
     auto maybe_length = Optional<WebIDL::UnsignedLong> {};
-    if (MUST(object.has_property("length"))) {
-        auto length_value = TRY(object.get("length"));
+    if (MUST(object.has_property("length"_fly_string))) {
+        auto length_value = TRY(object.get("length"_fly_string));
         maybe_length = TRY(length_value.to_u32(vm));
     }
 
@@ -642,8 +642,8 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> Ed448Params::from_value(JS
     auto& object = value.as_object();
 
     auto maybe_context = Optional<ByteBuffer> {};
-    if (MUST(object.has_property("context"))) {
-        auto context_value = TRY(object.get("context"));
+    if (MUST(object.has_property("context"_fly_string))) {
+        auto context_value = TRY(object.get("context"_fly_string));
         if (!context_value.is_object() || !(is<JS::TypedArrayBase>(context_value.as_object()) || is<JS::ArrayBuffer>(context_value.as_object()) || is<JS::DataView>(context_value.as_object())))
             return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
         maybe_context = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(context_value.as_object()));

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -34,7 +34,7 @@ struct HashAlgorithmIdentifier : public AlgorithmIdentifier {
         auto value = visit(
             [](String const& name) -> JS::ThrowCompletionOr<String> { return name; },
             [&](GC::Root<JS::Object> const& obj) -> JS::ThrowCompletionOr<String> {
-                auto name_property = TRY(obj->get("name"));
+                auto name_property = TRY(obj->get("name"_fly_string));
                 return name_property.to_string(vm);
             });
 

--- a/Libraries/LibWeb/Crypto/CryptoBindings.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoBindings.cpp
@@ -91,63 +91,63 @@ JS::ThrowCompletionOr<GC::Ref<JS::Object>> JsonWebKey::to_object(JS::Realm& real
     auto object = JS::Object::create(realm, realm.intrinsics().object_prototype());
 
     if (kty.has_value())
-        TRY(object->create_data_property("kty", JS::PrimitiveString::create(vm, kty.value())));
+        TRY(object->create_data_property("kty"_fly_string, JS::PrimitiveString::create(vm, kty.value())));
 
     if (use.has_value())
-        TRY(object->create_data_property("use", JS::PrimitiveString::create(vm, use.value())));
+        TRY(object->create_data_property("use"_fly_string, JS::PrimitiveString::create(vm, use.value())));
 
     if (key_ops.has_value()) {
         auto key_ops_array = JS::Array::create_from<String>(realm, key_ops.value().span(), [&](auto& key_usage) -> JS::Value {
             return JS::PrimitiveString::create(realm.vm(), key_usage);
         });
-        TRY(object->create_data_property("key_ops", move(key_ops_array)));
+        TRY(object->create_data_property("key_ops"_fly_string, move(key_ops_array)));
     }
 
     if (alg.has_value())
-        TRY(object->create_data_property("alg", JS::PrimitiveString::create(vm, alg.value())));
+        TRY(object->create_data_property("alg"_fly_string, JS::PrimitiveString::create(vm, alg.value())));
 
     if (ext.has_value())
-        TRY(object->create_data_property("ext", JS::Value(ext.value())));
+        TRY(object->create_data_property("ext"_fly_string, JS::Value(ext.value())));
 
     if (crv.has_value())
-        TRY(object->create_data_property("crv", JS::PrimitiveString::create(vm, crv.value())));
+        TRY(object->create_data_property("crv"_fly_string, JS::PrimitiveString::create(vm, crv.value())));
 
     if (x.has_value())
-        TRY(object->create_data_property("x", JS::PrimitiveString::create(vm, x.value())));
+        TRY(object->create_data_property("x"_fly_string, JS::PrimitiveString::create(vm, x.value())));
 
     if (y.has_value())
-        TRY(object->create_data_property("y", JS::PrimitiveString::create(vm, y.value())));
+        TRY(object->create_data_property("y"_fly_string, JS::PrimitiveString::create(vm, y.value())));
 
     if (d.has_value())
-        TRY(object->create_data_property("d", JS::PrimitiveString::create(vm, d.value())));
+        TRY(object->create_data_property("d"_fly_string, JS::PrimitiveString::create(vm, d.value())));
 
     if (n.has_value())
-        TRY(object->create_data_property("n", JS::PrimitiveString::create(vm, n.value())));
+        TRY(object->create_data_property("n"_fly_string, JS::PrimitiveString::create(vm, n.value())));
 
     if (e.has_value())
-        TRY(object->create_data_property("e", JS::PrimitiveString::create(vm, e.value())));
+        TRY(object->create_data_property("e"_fly_string, JS::PrimitiveString::create(vm, e.value())));
 
     if (p.has_value())
-        TRY(object->create_data_property("p", JS::PrimitiveString::create(vm, p.value())));
+        TRY(object->create_data_property("p"_fly_string, JS::PrimitiveString::create(vm, p.value())));
 
     if (q.has_value())
-        TRY(object->create_data_property("q", JS::PrimitiveString::create(vm, q.value())));
+        TRY(object->create_data_property("q"_fly_string, JS::PrimitiveString::create(vm, q.value())));
 
     if (dp.has_value())
-        TRY(object->create_data_property("dp", JS::PrimitiveString::create(vm, dp.value())));
+        TRY(object->create_data_property("dp"_fly_string, JS::PrimitiveString::create(vm, dp.value())));
 
     if (dq.has_value())
-        TRY(object->create_data_property("dq", JS::PrimitiveString::create(vm, dq.value())));
+        TRY(object->create_data_property("dq"_fly_string, JS::PrimitiveString::create(vm, dq.value())));
 
     if (qi.has_value())
-        TRY(object->create_data_property("qi", JS::PrimitiveString::create(vm, qi.value())));
+        TRY(object->create_data_property("qi"_fly_string, JS::PrimitiveString::create(vm, qi.value())));
 
     if (oth.has_value()) {
         TODO();
     }
 
     if (k.has_value())
-        TRY(object->create_data_property("k", JS::PrimitiveString::create(vm, k.value())));
+        TRY(object->create_data_property("k"_fly_string, JS::PrimitiveString::create(vm, k.value())));
 
     return object;
 }

--- a/Libraries/LibWeb/Crypto/CryptoKey.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoKey.cpp
@@ -75,7 +75,7 @@ void CryptoKey::set_usages(Vector<Bindings::KeyUsage> usages)
 String CryptoKey::algorithm_name() const
 {
     if (m_algorithm_name.is_empty()) {
-        auto name = MUST(m_algorithm->get("name"));
+        auto name = MUST(m_algorithm->get("name"_fly_string));
         m_algorithm_name = MUST(name.to_string(vm()));
     }
     return m_algorithm_name;
@@ -95,8 +95,8 @@ CryptoKeyPair::CryptoKeyPair(JS::Realm& realm, GC::Ref<CryptoKey> public_key, GC
 
 void CryptoKeyPair::initialize(JS::Realm& realm)
 {
-    define_native_accessor(realm, "publicKey", public_key_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    define_native_accessor(realm, "privateKey", private_key_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "publicKey"_fly_string, public_key_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "privateKey"_fly_string, private_key_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 
     Base::initialize(realm);
 }

--- a/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
@@ -49,7 +49,7 @@ KeyAlgorithm::KeyAlgorithm(JS::Realm& realm)
 
 void KeyAlgorithm::initialize(JS::Realm& realm)
 {
-    define_native_accessor(realm, "name", name_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "name"_fly_string, name_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
     Base::initialize(realm);
 }
 
@@ -81,8 +81,8 @@ void RsaKeyAlgorithm::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_native_accessor(realm, "modulusLength", modulus_length_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    define_native_accessor(realm, "publicExponent", public_exponent_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "modulusLength"_fly_string, modulus_length_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "publicExponent"_fly_string, public_exponent_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 }
 
 void RsaKeyAlgorithm::visit_edges(Visitor& visitor)
@@ -146,7 +146,7 @@ void EcKeyAlgorithm::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_native_accessor(realm, "namedCurve", named_curve_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "namedCurve"_fly_string, named_curve_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(EcKeyAlgorithm::named_curve_getter)
@@ -170,7 +170,7 @@ void RsaHashedKeyAlgorithm::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_native_accessor(realm, "hash", hash_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "hash"_fly_string, hash_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(RsaHashedKeyAlgorithm::hash_getter)
@@ -204,7 +204,7 @@ void AesKeyAlgorithm::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_native_accessor(realm, "length", length_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "length"_fly_string, length_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(AesKeyAlgorithm::length_getter)
@@ -227,8 +227,8 @@ HmacKeyAlgorithm::HmacKeyAlgorithm(JS::Realm& realm)
 void HmacKeyAlgorithm::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
-    define_native_accessor(realm, "hash", hash_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
-    define_native_accessor(realm, "length", length_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "hash"_fly_string, hash_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
+    define_native_accessor(realm, "length"_fly_string, length_getter, {}, JS::Attribute::Enumerable | JS::Attribute::Configurable);
 }
 
 void HmacKeyAlgorithm::visit_edges(JS::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -71,7 +71,7 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
         // Return the result of running the normalize an algorithm algorithm,
         // with the alg set to a new Algorithm dictionary whose name attribute is alg, and with the op set to op.
         auto dictionary = GC::make_root(JS::Object::create(realm, realm.intrinsics().object_prototype()));
-        TRY(dictionary->create_data_property("name", JS::PrimitiveString::create(vm, algorithm.get<String>())));
+        TRY(dictionary->create_data_property("name"_fly_string, JS::PrimitiveString::create(vm, algorithm.get<String>())));
 
         return normalize_an_algorithm(realm, dictionary, operation);
     }
@@ -88,7 +88,7 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
     // 3. If an error occurred, return the error and terminate this algorithm.
     // Note: We're not going to bother creating an Algorithm object, all we want is the name attribute so that we can
     //       fetch the actual algorithm factory from the registeredAlgorithms map.
-    auto initial_algorithm = TRY(algorithm.get<GC::Root<JS::Object>>()->get("name"));
+    auto initial_algorithm = TRY(algorithm.get<GC::Root<JS::Object>>()->get("name"_fly_string));
 
     if (initial_algorithm.is_undefined()) {
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "Algorithm");

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -843,7 +843,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::wrap_key(Bindings::KeyFormat format, GC::
             }
 
             // 3. Let bytes be the result of UTF-8 encoding json.
-            bytes = maybe_json.release_value()->to_byte_buffer();
+            bytes = MUST(ByteBuffer::copy(maybe_json.value()->bytes()));
         } else {
             VERIFY_NOT_REACHED();
         }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4737,7 +4737,7 @@ void Document::start_intersection_observing_a_lazy_loading_element(Element& elem
     // 2. If doc's lazy load intersection observer is null, set it to a new IntersectionObserver instance, initialized as follows:
     if (!m_lazy_load_intersection_observer) {
         // - The callback is these steps, with arguments entries and observer:
-        auto callback = JS::NativeFunction::create(realm, "", [this](JS::VM& vm) -> JS::ThrowCompletionOr<JS::Value> {
+        auto callback = JS::NativeFunction::create(realm, ""_fly_string, [this](JS::VM& vm) -> JS::ThrowCompletionOr<JS::Value> {
             // For each entry in entries using a method of iteration which does not trigger developer-modifiable array accessors or iteration hooks:
             auto& entries = as<JS::Array>(vm.argument(0).as_object());
             auto entries_length = MUST(MUST(entries.get(vm.names.length)).to_length(vm));

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -513,7 +513,7 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
 
         //  6. Return scope. (NOTE: Not necessary)
 
-        auto function = JS::ECMAScriptFunctionObject::create(realm, name.to_deprecated_fly_string(), builder.to_byte_string(), program->body(), program->parameters(), program->function_length(), program->local_variables_names(), scope, nullptr, JS::FunctionKind::Normal, program->is_strict_mode(),
+        auto function = JS::ECMAScriptFunctionObject::create(realm, name, builder.to_byte_string(), program->body(), program->parameters(), program->function_length(), program->local_variables_names(), scope, nullptr, JS::FunctionKind::Normal, program->is_strict_mode(),
             program->parsing_insights(), is_arrow_function);
 
         // 10. Remove settings object's realm execution context from the JavaScript execution context stack.

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -614,7 +614,7 @@ void EventTarget::activate_event_handler(FlyString const& name, HTML::EventHandl
             TRY(event_target->process_event_handler_for_event(name, event));
             return JS::js_undefined();
         },
-        0, "", &realm);
+        0, FlyString {}, &realm);
 
     // NOTE: As per the spec, the callback context is arbitrary.
     auto callback = realm.heap().allocate<WebIDL::CallbackType>(*callback_function, realm);

--- a/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -59,8 +59,8 @@ Vector<CrossOriginProperty> cross_origin_properties(Variant<HTML::Location const
 bool is_cross_origin_accessible_window_property_name(JS::PropertyKey const& property_key)
 {
     // A JavaScript property name P is a cross-origin accessible window property name if it is "window", "self", "location", "close", "closed", "focus", "blur", "frames", "length", "top", "opener", "parent", "postMessage", or an array index property name.
-    static Array<DeprecatedFlyString, 13> property_names {
-        "window"sv, "self"sv, "location"sv, "close"sv, "closed"sv, "focus"sv, "blur"sv, "frames"sv, "length"sv, "top"sv, "opener"sv, "parent"sv, "postMessage"sv
+    static Array<FlyString, 13> property_names {
+        "window"_fly_string, "self"_fly_string, "location"_fly_string, "close"_fly_string, "closed"_fly_string, "focus"_fly_string, "blur"_fly_string, "frames"_fly_string, "length"_fly_string, "top"_fly_string, "opener"_fly_string, "parent"_fly_string, "postMessage"_fly_string
     };
     return (property_key.is_string() && any_of(property_names, [&](auto const& name) { return property_key.as_string() == name; })) || property_key.is_number();
 }
@@ -108,7 +108,7 @@ Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<HT
     if (!property_key.is_string()) {
         return {};
     }
-    auto const& property_key_string = MUST(FlyString::from_deprecated_fly_string(property_key.as_string()));
+    auto const& property_key_string = property_key.as_string();
 
     // 2. For each e of CrossOriginProperties(O):
     for (auto const& entry : cross_origin_properties(object_const_variant)) {

--- a/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -139,7 +139,7 @@ Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<HT
                     realm, [function = GC::make_root(*value)](auto& vm) {
                         return JS::call(vm, function.value(), JS::js_undefined(), vm.running_execution_context().arguments.span());
                     },
-                    0, "");
+                    0);
             }
 
             // 3. Set crossOriginDesc to PropertyDescriptor{ [[Value]]: value, [[Enumerable]]: false, [[Writable]]: false, [[Configurable]]: true }.
@@ -156,7 +156,7 @@ Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<HT
                     realm, [object_ptr, getter = GC::make_root(*original_descriptor->get)](auto& vm) {
                         return JS::call(vm, getter.cell(), object_ptr, vm.running_execution_context().arguments.span());
                     },
-                    0, "");
+                    0);
             }
 
             // 3. Let crossOriginSet be undefined.
@@ -168,7 +168,7 @@ Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<HT
                     realm, [object_ptr, setter = GC::make_root(*original_descriptor->set)](auto& vm) {
                         return JS::call(vm, setter.cell(), object_ptr, vm.running_execution_context().arguments.span());
                     },
-                    0, "");
+                    0);
             }
 
             // 5. Set crossOriginDesc to PropertyDescriptor{ [[Get]]: crossOriginGet, [[Set]]: crossOriginSet, [[Enumerable]]: false, [[Configurable]]: true }.

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -208,7 +208,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
         // 4. For each callbackName of the keys of lifecycleCallbacks:
         for (auto const& callback_name : { CustomElementReactionNames::connectedCallback, CustomElementReactionNames::disconnectedCallback, CustomElementReactionNames::adoptedCallback, CustomElementReactionNames::attributeChangedCallback }) {
             // 1. Let callbackValue be ? Get(prototype, callbackName).
-            auto callback_value = TRY(prototype.get(callback_name.to_deprecated_fly_string()));
+            auto callback_value = TRY(prototype.get(callback_name));
 
             // 2. If callbackValue is not undefined, then set the value of the entry in lifecycleCallbacks with key callbackName to the result of
             //    converting callbackValue to the Web IDL Function callback type.
@@ -259,7 +259,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
         if (form_associated) {
             for (auto const& callback_name : { CustomElementReactionNames::formAssociatedCallback, CustomElementReactionNames::formResetCallback, CustomElementReactionNames::formDisabledCallback, CustomElementReactionNames::formStateRestoreCallback }) {
                 // 1. Let callbackValue be ? Get(prototype, callbackName).
-                auto callback_value = TRY(prototype.get(callback_name.to_deprecated_fly_string()));
+                auto callback_value = TRY(prototype.get(callback_name));
 
                 // 2. If callbackValue is not undefined, then set lifecycleCallbacks[callbackName] to the result of converting callbackValue
                 //    to the Web IDL Function callback type.

--- a/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
@@ -118,7 +118,7 @@ Variant<GC::Ref<DOM::HTMLCollection>, GC::Ref<DOM::Element>, Empty> HTMLAllColle
         return Empty {};
 
     // 2. Return the result of getting the "all"-indexed or named element(s) from this, given nameOrIndex.
-    return get_the_all_indexed_or_named_elements(name_or_index.value().to_deprecated_fly_string());
+    return get_the_all_indexed_or_named_elements(name_or_index.value());
 }
 
 // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlallcollection-nameditem
@@ -211,7 +211,7 @@ Variant<GC::Ref<DOM::HTMLCollection>, GC::Ref<DOM::Element>, Empty> HTMLAllColle
     }
 
     // 2. Return the result of getting the "all"-named element(s) from collection given nameOrIndex.
-    return get_the_all_named_elements(MUST(FlyString::from_deprecated_fly_string(name_or_index.as_string())));
+    return get_the_all_named_elements(name_or_index.as_string());
 }
 
 Optional<JS::Value> HTMLAllCollection::item_value(size_t index) const

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -385,7 +385,7 @@ void HTMLDialogElement::set_close_watcher()
                 event.prevent_default();
             return JS::js_undefined();
         },
-        0, "", &realm());
+        0, ""_fly_string, &realm());
     auto cancel_callback = realm().heap().allocate<WebIDL::CallbackType>(*cancel_callback_function, realm());
     m_close_watcher->add_event_listener_without_options(HTML::EventNames::cancel, DOM::IDLEventListener::create(realm(), cancel_callback));
     // - closeAction being to close the dialog given dialog and dialog's request close return value.
@@ -395,7 +395,7 @@ void HTMLDialogElement::set_close_watcher()
 
             return JS::js_undefined();
         },
-        0, "", &realm());
+        0, ""_fly_string, &realm());
     auto close_callback = realm().heap().allocate<WebIDL::CallbackType>(*close_callback_function, realm());
     m_close_watcher->add_event_listener_without_options(HTML::EventNames::close, DOM::IDLEventListener::create(realm(), close_callback));
     // - getEnabledState being to return true if dialog's enable close watcher for requestClose() is true or dialog's computed closed-by state is not None; otherwise false.

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1332,7 +1332,7 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
 
                 return JS::js_undefined();
             },
-            0, "", &realm());
+            0, FlyString {}, &realm());
         auto close_callback = realm().heap().allocate<WebIDL::CallbackType>(*close_callback_function, realm());
         m_popover_close_watcher->add_event_listener_without_options(HTML::EventNames::close, DOM::IDLEventListener::create(realm(), close_callback));
         // - getEnabledState being to return true.

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1051,7 +1051,7 @@ void HTMLInputElement::create_text_input_shadow_tree()
                 commit_pending_changes();
                 return JS::js_undefined();
             },
-            0, "", &realm());
+            0, FlyString {}, &realm());
         auto mouseup_callback = realm().heap().allocate<WebIDL::CallbackType>(*mouseup_callback_function, realm());
         DOM::AddEventListenerOptions mouseup_listener_options;
         mouseup_listener_options.once = true;
@@ -1064,7 +1064,7 @@ void HTMLInputElement::create_text_input_shadow_tree()
                 }
                 return JS::js_undefined();
             },
-            0, "", &realm());
+            0, FlyString {}, &realm());
         auto step_up_callback = realm().heap().allocate<WebIDL::CallbackType>(*up_callback_function, realm());
         up_button->add_event_listener_without_options(UIEvents::EventNames::mousedown, DOM::IDLEventListener::create(realm(), step_up_callback));
         up_button->add_event_listener_without_options(UIEvents::EventNames::mouseup, DOM::IDLEventListener::create(realm(), mouseup_callback));
@@ -1086,7 +1086,7 @@ void HTMLInputElement::create_text_input_shadow_tree()
                 }
                 return JS::js_undefined();
             },
-            0, "", &realm());
+            0, FlyString {}, &realm());
         auto step_down_callback = realm().heap().allocate<WebIDL::CallbackType>(*down_callback_function, realm());
         down_button->add_event_listener_without_options(UIEvents::EventNames::mousedown, DOM::IDLEventListener::create(realm(), step_down_callback));
         down_button->add_event_listener_without_options(UIEvents::EventNames::mouseup, DOM::IDLEventListener::create(realm(), mouseup_callback));
@@ -1147,7 +1147,7 @@ void HTMLInputElement::create_file_input_shadow_tree()
         return JS::js_undefined();
     };
 
-    auto on_button_click_function = JS::NativeFunction::create(realm, move(on_button_click), 0, "", &realm);
+    auto on_button_click_function = JS::NativeFunction::create(realm, move(on_button_click), 0, FlyString {}, &realm);
     auto on_button_click_callback = realm.heap().allocate<WebIDL::CallbackType>(on_button_click_function, realm);
     m_file_button->add_event_listener_without_options(UIEvents::EventNames::click, DOM::IDLEventListener::create(realm, on_button_click_callback));
 
@@ -1198,7 +1198,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
 
     auto keydown_callback_function = JS::NativeFunction::create(
         realm(), [this](JS::VM& vm) {
-            auto key = MUST(vm.argument(0).get(vm, "key")).as_string().utf8_string();
+            auto key = MUST(vm.argument(0).get(vm, "key"_fly_string)).as_string().utf8_string();
 
             if (key == "ArrowLeft" || key == "ArrowDown")
                 MUST(step_down());
@@ -1213,13 +1213,13 @@ void HTMLInputElement::create_range_input_shadow_tree()
             user_interaction_did_change_input_value();
             return JS::js_undefined();
         },
-        0, "", &realm());
+        0, ""_fly_string, &realm());
     auto keydown_callback = realm().heap().allocate<WebIDL::CallbackType>(*keydown_callback_function, realm());
     add_event_listener_without_options(UIEvents::EventNames::keydown, DOM::IDLEventListener::create(realm(), keydown_callback));
 
     auto wheel_callback_function = JS::NativeFunction::create(
         realm(), [this](JS::VM& vm) {
-            auto delta_y = MUST(vm.argument(0).get(vm, "deltaY")).as_i32();
+            auto delta_y = MUST(vm.argument(0).get(vm, "deltaY"_fly_string)).as_i32();
             if (delta_y > 0) {
                 MUST(step_down());
             } else {
@@ -1228,12 +1228,12 @@ void HTMLInputElement::create_range_input_shadow_tree()
             user_interaction_did_change_input_value();
             return JS::js_undefined();
         },
-        0, "", &realm());
+        0, ""_fly_string, &realm());
     auto wheel_callback = realm().heap().allocate<WebIDL::CallbackType>(*wheel_callback_function, realm());
     add_event_listener_without_options(UIEvents::EventNames::wheel, DOM::IDLEventListener::create(realm(), wheel_callback));
 
     auto update_slider_by_mouse = [this](JS::VM& vm) {
-        auto client_x = MUST(vm.argument(0).get(vm, "clientX")).as_double();
+        auto client_x = MUST(vm.argument(0).get(vm, "clientX"_fly_string)).as_double();
         auto rect = get_bounding_client_rect();
         double minimum = *min();
         double maximum = *max();
@@ -1251,7 +1251,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
                     update_slider_by_mouse(vm);
                     return JS::js_undefined();
                 },
-                0, "", &realm());
+                0, ""_fly_string, &realm());
             auto mousemove_callback = realm().heap().allocate<WebIDL::CallbackType>(*mousemove_callback_function, realm());
             auto mousemove_listener = DOM::IDLEventListener::create(realm(), mousemove_callback);
             auto& window = static_cast<HTML::Window&>(relevant_global_object(*this));
@@ -1263,7 +1263,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
                     window.remove_event_listener_without_options(UIEvents::EventNames::mousemove, mousemove_listener);
                     return JS::js_undefined();
                 },
-                0, "", &realm());
+                0, ""_fly_string, &realm());
             auto mouseup_callback = realm().heap().allocate<WebIDL::CallbackType>(*mouseup_callback_function, realm());
             DOM::AddEventListenerOptions mouseup_listener_options;
             mouseup_listener_options.once = true;
@@ -1271,7 +1271,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
 
             return JS::js_undefined();
         },
-        0, "", &realm());
+        0, ""_fly_string, &realm());
     auto mousedown_callback = realm().heap().allocate<WebIDL::CallbackType>(*mousedown_callback_function, realm());
     add_event_listener_without_options(UIEvents::EventNames::mousedown, DOM::IDLEventListener::create(realm(), mousedown_callback));
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2923,7 +2923,7 @@ void HTMLTokenizer::switch_to(Badge<HTMLParser>, State new_state)
 void HTMLTokenizer::will_emit(HTMLToken& token)
 {
     if (token.is_start_tag())
-        m_last_emitted_start_tag_name = token.tag_name().to_deprecated_fly_string();
+        m_last_emitted_start_tag_name = token.tag_name();
 
     auto is_start_or_end_tag = token.type() == HTMLToken::Type::StartTag || token.type() == HTMLToken::Type::EndTag;
     token.set_end_position({}, nth_last_position(is_start_or_end_tag ? 1 : 0));
@@ -2937,7 +2937,7 @@ bool HTMLTokenizer::current_end_tag_token_is_appropriate() const
     VERIFY(m_current_token.is_end_tag());
     if (!m_last_emitted_start_tag_name.has_value())
         return false;
-    return m_current_token.tag_name().to_deprecated_fly_string() == m_last_emitted_start_tag_name.value();
+    return m_current_token.tag_name() == m_last_emitted_start_tag_name.value();
 }
 
 bool HTMLTokenizer::consumed_as_part_of_an_attribute() const

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -214,7 +214,7 @@ private:
 
     NamedCharacterReferenceMatcher m_named_character_reference_matcher;
 
-    Optional<ByteString> m_last_emitted_start_tag_name;
+    Optional<FlyString> m_last_emitted_start_tag_name;
 
     bool m_explicit_eof_inserted { false };
     bool m_has_emitted_eof { false };

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -82,8 +82,8 @@ private:
     }
 };
 
-ByteString module_type_from_module_request(JS::ModuleRequest const&);
-WebIDL::ExceptionOr<URL::URL> resolve_module_specifier(Optional<Script&> referring_script, ByteString const& specifier);
+String module_type_from_module_request(JS::ModuleRequest const&);
+WebIDL::ExceptionOr<URL::URL> resolve_module_specifier(Optional<Script&> referring_script, String const& specifier);
 WebIDL::ExceptionOr<Optional<URL::URL>> resolve_imports_match(ByteString const& normalized_specifier, Optional<URL::URL> as_url, ModuleSpecifierMap const&);
 Optional<URL::URL> resolve_url_like_module_specifier(ByteString const& specifier, URL::URL const& base_url);
 ScriptFetchOptions get_descendant_script_fetch_options(ScriptFetchOptions const& original_options, URL::URL const& url, EnvironmentSettingsObject& settings_object);

--- a/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
@@ -34,8 +34,8 @@ WebIDL::ExceptionOr<ImportMap> parse_import_map_string(JS::Realm& realm, ByteStr
     ModuleSpecifierMap sorted_and_normalised_imports;
 
     // 4. If parsed["imports"] exists, then:
-    if (TRY(parsed_object.has_property("imports"))) {
-        auto imports = TRY(parsed_object.get("imports"));
+    if (TRY(parsed_object.has_property("imports"_fly_string))) {
+        auto imports = TRY(parsed_object.get("imports"_fly_string));
 
         // If parsed["imports"] is not an ordered map, then throw a TypeError indicating that the value for the "imports" top-level key needs to be a JSON object.
         if (!imports.is_object())
@@ -49,8 +49,8 @@ WebIDL::ExceptionOr<ImportMap> parse_import_map_string(JS::Realm& realm, ByteStr
     HashMap<URL::URL, ModuleSpecifierMap> sorted_and_normalised_scopes;
 
     // 6. If parsed["scopes"] exists, then:
-    if (TRY(parsed_object.has_property("scopes"))) {
-        auto scopes = TRY(parsed_object.get("scopes"));
+    if (TRY(parsed_object.has_property("scopes"_fly_string))) {
+        auto scopes = TRY(parsed_object.get("scopes"_fly_string));
 
         // If parsed["scopes"] is not an ordered map, then throw a TypeError indicating that the value for the "scopes" top-level key needs to be a JSON object.
         if (!scopes.is_object())
@@ -64,8 +64,8 @@ WebIDL::ExceptionOr<ImportMap> parse_import_map_string(JS::Realm& realm, ByteStr
     ModuleIntegrityMap normalised_integrity;
 
     // 8. If parsed["integrity"] exists, then:
-    if (TRY(parsed_object.has_property("integrity"))) {
-        auto integrity = TRY(parsed_object.get("integrity"));
+    if (TRY(parsed_object.has_property("integrity"_fly_string))) {
+        auto integrity = TRY(parsed_object.get("integrity"_fly_string));
 
         // 1. If parsed["integrity"] is not an ordered map, then throw a TypeError indicating that the value for the "integrity" top-level key needs to be a JSON object.
         if (!integrity.is_object())

--- a/Libraries/LibWeb/HTML/Scripting/ImportMap.h
+++ b/Libraries/LibWeb/HTML/Scripting/ImportMap.h
@@ -13,8 +13,8 @@
 
 namespace Web::HTML {
 
-using ModuleSpecifierMap = HashMap<ByteString, Optional<URL::URL>>;
-using ModuleIntegrityMap = HashMap<URL::URL, ByteString>;
+using ModuleSpecifierMap = HashMap<String, Optional<URL::URL>>;
+using ModuleIntegrityMap = HashMap<URL::URL, String>;
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#import-map
 class ImportMap {
@@ -40,7 +40,7 @@ private:
 };
 
 WebIDL::ExceptionOr<ImportMap> parse_import_map_string(JS::Realm& realm, ByteString const& input, URL::URL base_url);
-Optional<DeprecatedFlyString> normalise_specifier_key(JS::Realm& realm, DeprecatedFlyString specifier_key, URL::URL base_url);
+Optional<FlyString> normalize_specifier_key(JS::Realm& realm, FlyString specifier_key, URL::URL base_url);
 WebIDL::ExceptionOr<ModuleSpecifierMap> sort_and_normalise_module_specifier_map(JS::Realm& realm, JS::Object& original_map, URL::URL base_url);
 WebIDL::ExceptionOr<HashMap<URL::URL, ModuleSpecifierMap>> sort_and_normalise_scopes(JS::Realm& realm, JS::Object& original_map, URL::URL base_url);
 WebIDL::ExceptionOr<ModuleIntegrityMap> normalize_module_integrity_map(JS::Realm& realm, JS::Object& original_map, URL::URL base_url);

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -547,9 +547,9 @@ WebIDL::ExceptionOr<void> serialize_bytes(JS::VM& vm, Vector<u32>& vector, Reado
     return {};
 }
 
-WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, DeprecatedFlyString const& string)
+WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, StringView string)
 {
-    return serialize_bytes(vm, vector, string.view().bytes());
+    return serialize_bytes(vm, vector, string.bytes());
 }
 
 WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, String const& string)

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -1018,7 +1018,7 @@ public:
                     auto deserialized_value = TRY(deserialize());
 
                     // 2. Let result be ! CreateDataProperty(value, entry.[[Key]], deserializedValue).
-                    auto result = MUST(object.create_data_property(key.to_byte_string(), deserialized_value));
+                    auto result = MUST(object.create_data_property(key, deserialized_value));
 
                     // 3. Assert: result is true.
                     VERIFY(result);

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -521,8 +521,8 @@ WebIDL::ExceptionOr<void> serialize_reg_exp_object(JS::VM& vm, SerializationReco
     // Note: A Regex<ECMA262> object is perfectly happy to be reconstructed with just the source+flags
     //       In the future, we could optimize the work being done on the deserialize step by serializing
     //       more of the internal state (the [[RegExpMatcher]] internal slot)
-    TRY(serialize_string(vm, serialized, TRY_OR_THROW_OOM(vm, String::from_byte_string(regexp_object.pattern()))));
-    TRY(serialize_string(vm, serialized, TRY_OR_THROW_OOM(vm, String::from_byte_string(regexp_object.flags()))));
+    TRY(serialize_string(vm, serialized, regexp_object.pattern()));
+    TRY(serialize_string(vm, serialized, regexp_object.flags()));
     return {};
 }
 
@@ -684,8 +684,8 @@ WebIDL::ExceptionOr<void> serialize_viewed_array_buffer(JS::VM& vm, Vector<u32>&
         //    [[ArrayBufferSerialized]]: bufferSerialized, [[ByteLength]]: value.[[ByteLength]],
         //    [[ByteOffset]]: value.[[ByteOffset]], [[ArrayLength]]: value.[[ArrayLength]] }.
         serialize_enum(vector, ValueTag::ArrayBufferView);
-        vector.extend(move(buffer_serialized));                 // [[ArrayBufferSerialized]]
-        TRY(serialize_string(vm, vector, view.element_name())); // [[Constructor]]
+        vector.extend(move(buffer_serialized));                             // [[ArrayBufferSerialized]]
+        TRY(serialize_string(vm, vector, view.element_name().to_string())); // [[Constructor]]
         serialize_primitive_type(vector, JS::typed_array_byte_length(view_record));
         serialize_primitive_type(vector, view.byte_offset());
         serialize_primitive_type(vector, JS::typed_array_length(view_record));

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -88,7 +88,7 @@ void serialize_enum(SerializationRecord& serialized, T value)
 }
 
 WebIDL::ExceptionOr<void> serialize_bytes(JS::VM& vm, Vector<u32>& vector, ReadonlyBytes bytes);
-WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, DeprecatedFlyString const& string);
+WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, StringView);
 WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, String const& string);
 WebIDL::ExceptionOr<void> serialize_string(JS::VM& vm, Vector<u32>& vector, JS::PrimitiveString const& primitive_string);
 WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, Vector<u32>& vector, JS::ArrayBuffer const& array_buffer, bool for_storage);

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
@@ -121,7 +121,7 @@ GC::Ref<WebIDL::CallbackType> UniversalGlobalScopeMixin::count_queuing_strategy_
         };
 
         // 2. Let F be ! CreateBuiltinFunction(steps, 0, "size", « », globalObject’s relevant Realm).
-        auto function = JS::NativeFunction::create(realm, move(steps), 0, "size", &realm);
+        auto function = JS::NativeFunction::create(realm, move(steps), 0, "size"_fly_string, &realm);
 
         // 3. Set globalObject’s count queuing strategy size function to a Function that represents a reference to F, with callback context equal to globalObject’s relevant settings object.
         // FIXME: Update spec comment to pass globalObject's relevant realm once Streams spec is updated for ShadowRealm spec
@@ -146,7 +146,7 @@ GC::Ref<WebIDL::CallbackType> UniversalGlobalScopeMixin::byte_length_queuing_str
         };
 
         // 2. Let F be ! CreateBuiltinFunction(steps, 1, "size", « », globalObject’s relevant Realm).
-        auto function = JS::NativeFunction::create(realm, move(steps), 1, "size", &realm);
+        auto function = JS::NativeFunction::create(realm, move(steps), 1, "size"_fly_string, &realm);
 
         // 3. Set globalObject’s byte length queuing strategy size function to a Function that represents a reference to F, with callback context equal to globalObject’s relevant settings object.
         // FIXME: Update spec comment to pass globalObject's relevant realm once Streams spec is updated for ShadowRealm spec

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -734,7 +734,7 @@ WebIDL::ExceptionOr<void> Window::initialize_web_interfaces(Badge<WindowEnvironm
     WindowOrWorkerGlobalScopeMixin::initialize(realm);
 
     if (s_internals_object_exposed)
-        define_direct_property("internals", realm.create<Internals::Internals>(realm), JS::default_attributes);
+        define_direct_property("internals"_fly_string, realm.create<Internals::Internals>(realm), JS::default_attributes);
 
     if (url.scheme() == "about"sv && url.paths().size() == 1) {
         auto const& path = url.paths().first();

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -740,9 +740,9 @@ WebIDL::ExceptionOr<void> Window::initialize_web_interfaces(Badge<WindowEnvironm
         auto const& path = url.paths().first();
 
         if (path == "processes"sv)
-            define_direct_property("processes", realm.create<Internals::Processes>(realm), JS::default_attributes);
+            define_direct_property("processes"_fly_string, realm.create<Internals::Processes>(realm), JS::default_attributes);
         else if (path == "settings"sv)
-            define_direct_property("settings", realm.create<Internals::Settings>(realm), JS::default_attributes);
+            define_direct_property("settings"_fly_string, realm.create<Internals::Settings>(realm), JS::default_attributes);
     }
 
     return {};

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -633,7 +633,7 @@ void WindowOrWorkerGlobalScopeMixin::queue_the_performance_observer_task()
             //    droppedEntriesCount if droppedEntriesCount is not null, otherwise unset.
             auto callback_options = JS::Object::create(realm, realm.intrinsics().object_prototype());
             if (dropped_entries_count.has_value())
-                MUST(callback_options->create_data_property("droppedEntriesCount", JS::Value(dropped_entries_count.value())));
+                MUST(callback_options->create_data_property("droppedEntriesCount"_fly_string, JS::Value(dropped_entries_count.value())));
 
             // 9. Call po’s observer callback with observerEntryList as the first argument, with po as the second
             //    argument and as callback this value, and with callbackOptions as the third argument.

--- a/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -119,7 +119,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_ge
     auto navigable_property_set = m_window->document_tree_child_navigable_target_name_property_set();
     auto property_key_string = property_key.to_string();
 
-    if (auto navigable = navigable_property_set.get(property_key_string.view()); navigable.has_value()) {
+    if (auto navigable = navigable_property_set.get(property_key_string); navigable.has_value()) {
         // 1. Let value be the active WindowProxy of the named object of W with the name P.
         auto value = navigable.value()->active_window_proxy();
 

--- a/Libraries/LibWeb/IndexedDB/IDBFactory.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBFactory.cpp
@@ -215,8 +215,8 @@ GC::Ref<WebIDL::Promise> IDBFactory::databases()
             // 2. Set info’s name dictionary member to db’s name.
             // 3. Set info’s version dictionary member to db’s version.
             auto info = JS::Object::create(realm, realm.intrinsics().object_prototype());
-            MUST(info->create_data_property("name", JS::PrimitiveString::create(realm.vm(), db->name())));
-            MUST(info->create_data_property("version", JS::Value(db->version())));
+            MUST(info->create_data_property("name"_fly_string, JS::PrimitiveString::create(realm.vm(), db->name())));
+            MUST(info->create_data_property("version"_fly_string, JS::Value(db->version())));
 
             // 4. Append info to result.
             MUST(result->create_data_property_or_throw(i, info));

--- a/Libraries/LibWeb/Infra/JSON.cpp
+++ b/Libraries/LibWeb/Infra/JSON.cpp
@@ -137,7 +137,7 @@ WebIDL::ExceptionOr<ByteBuffer> serialize_javascript_value_to_json_bytes(JS::VM&
         auto map_value_js_value = convert_an_infra_value_to_a_json_compatible_javascript_value(realm, map_entry.value);
 
         // 3. Perform ! CreateDataPropertyOrThrow(jsValue, mapKey, mapValueJSValue).
-        MUST(js_value->create_data_property_or_throw(map_entry.key.to_byte_string(), map_value_js_value));
+        MUST(js_value->create_data_property_or_throw(map_entry.key, map_value_js_value));
     }
 
     // 6. Return jsValue.

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -63,8 +63,8 @@ JS::Object* Internals::hit_test(double x, double y)
     auto result = active_document.paintable_box()->hit_test({ x, y }, Painting::HitTestType::Exact);
     if (result.has_value()) {
         auto hit_tеsting_result = JS::Object::create(realm(), nullptr);
-        hit_tеsting_result->define_direct_property("node", result->dom_node(), JS::default_attributes);
-        hit_tеsting_result->define_direct_property("indexInNode", JS::Value(result->index_in_node), JS::default_attributes);
+        hit_tеsting_result->define_direct_property("node"_fly_string, result->dom_node(), JS::default_attributes);
+        hit_tеsting_result->define_direct_property("indexInNode"_fly_string, JS::Value(result->index_in_node), JS::default_attributes);
         return hit_tеsting_result;
     }
     return nullptr;

--- a/Libraries/LibWeb/MediaCapabilitiesAPI/MediaCapabilities.cpp
+++ b/Libraries/LibWeb/MediaCapabilitiesAPI/MediaCapabilities.cpp
@@ -236,9 +236,9 @@ GC::Ref<JS::Object> MediaCapabilitiesDecodingInfo::to_object(JS::Realm& realm)
 
     // FIXME: Also include configuration in this object.
 
-    MUST(object->create_data_property("supported", JS::BooleanObject::create(realm, supported)));
-    MUST(object->create_data_property("smooth", JS::BooleanObject::create(realm, smooth)));
-    MUST(object->create_data_property("powerEfficent", JS::BooleanObject::create(realm, power_efficient)));
+    MUST(object->create_data_property("supported"_fly_string, JS::BooleanObject::create(realm, supported)));
+    MUST(object->create_data_property("smooth"_fly_string, JS::BooleanObject::create(realm, smooth)));
+    MUST(object->create_data_property("powerEfficent"_fly_string, JS::BooleanObject::create(realm, power_efficient)));
 
     return object;
 }

--- a/Libraries/LibWeb/Streams/Transformer.cpp
+++ b/Libraries/LibWeb/Streams/Transformer.cpp
@@ -19,19 +19,19 @@ JS::ThrowCompletionOr<Transformer> Transformer::from_value(JS::VM& vm, JS::Value
     auto& object = value.as_object();
 
     Transformer transformer {
-        .start = TRY(WebIDL::property_to_callback(vm, value, "start", WebIDL::OperationReturnsPromise::No)),
-        .transform = TRY(WebIDL::property_to_callback(vm, value, "transform", WebIDL::OperationReturnsPromise::Yes)),
-        .flush = TRY(WebIDL::property_to_callback(vm, value, "flush", WebIDL::OperationReturnsPromise::Yes)),
-        .cancel = TRY(WebIDL::property_to_callback(vm, value, "cancel", WebIDL::OperationReturnsPromise::Yes)),
+        .start = TRY(WebIDL::property_to_callback(vm, value, "start"_fly_string, WebIDL::OperationReturnsPromise::No)),
+        .transform = TRY(WebIDL::property_to_callback(vm, value, "transform"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
+        .flush = TRY(WebIDL::property_to_callback(vm, value, "flush"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
+        .cancel = TRY(WebIDL::property_to_callback(vm, value, "cancel"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
         .readable_type = {},
         .writable_type = {},
     };
 
-    if (TRY(object.has_property("readableType")))
-        transformer.readable_type = TRY(object.get("readableType"));
+    if (TRY(object.has_property("readableType"_fly_string)))
+        transformer.readable_type = TRY(object.get("readableType"_fly_string));
 
-    if (TRY(object.has_property("writableType")))
-        transformer.writable_type = TRY(object.get("writableType"));
+    if (TRY(object.has_property("writableType"_fly_string)))
+        transformer.writable_type = TRY(object.get("writableType"_fly_string));
 
     return transformer;
 }

--- a/Libraries/LibWeb/Streams/UnderlyingSink.cpp
+++ b/Libraries/LibWeb/Streams/UnderlyingSink.cpp
@@ -19,15 +19,15 @@ JS::ThrowCompletionOr<UnderlyingSink> UnderlyingSink::from_value(JS::VM& vm, JS:
     auto& object = value.as_object();
 
     UnderlyingSink underlying_sink {
-        .start = TRY(WebIDL::property_to_callback(vm, value, "start", WebIDL::OperationReturnsPromise::No)),
-        .write = TRY(WebIDL::property_to_callback(vm, value, "write", WebIDL::OperationReturnsPromise::Yes)),
-        .close = TRY(WebIDL::property_to_callback(vm, value, "close", WebIDL::OperationReturnsPromise::Yes)),
-        .abort = TRY(WebIDL::property_to_callback(vm, value, "abort", WebIDL::OperationReturnsPromise::Yes)),
+        .start = TRY(WebIDL::property_to_callback(vm, value, "start"_fly_string, WebIDL::OperationReturnsPromise::No)),
+        .write = TRY(WebIDL::property_to_callback(vm, value, "write"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
+        .close = TRY(WebIDL::property_to_callback(vm, value, "close"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
+        .abort = TRY(WebIDL::property_to_callback(vm, value, "abort"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
         .type = {},
     };
 
-    if (TRY(object.has_property("type")))
-        underlying_sink.type = TRY(object.get("type"));
+    if (TRY(object.has_property("type"_fly_string)))
+        underlying_sink.type = TRY(object.get("type"_fly_string));
 
     return underlying_sink;
 }

--- a/Libraries/LibWeb/Streams/UnderlyingSource.cpp
+++ b/Libraries/LibWeb/Streams/UnderlyingSource.cpp
@@ -22,14 +22,14 @@ JS::ThrowCompletionOr<UnderlyingSource> UnderlyingSource::from_value(JS::VM& vm,
     auto& object = value.as_object();
 
     UnderlyingSource underlying_source {
-        .start = TRY(WebIDL::property_to_callback(vm, value, "start", WebIDL::OperationReturnsPromise::No)),
-        .pull = TRY(WebIDL::property_to_callback(vm, value, "pull", WebIDL::OperationReturnsPromise::Yes)),
-        .cancel = TRY(WebIDL::property_to_callback(vm, value, "cancel", WebIDL::OperationReturnsPromise::Yes)),
+        .start = TRY(WebIDL::property_to_callback(vm, value, "start"_fly_string, WebIDL::OperationReturnsPromise::No)),
+        .pull = TRY(WebIDL::property_to_callback(vm, value, "pull"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
+        .cancel = TRY(WebIDL::property_to_callback(vm, value, "cancel"_fly_string, WebIDL::OperationReturnsPromise::Yes)),
         .type = {},
         .auto_allocate_chunk_size = {},
     };
 
-    auto type_value = TRY(object.get("type"));
+    auto type_value = TRY(object.get("type"_fly_string));
     if (!type_value.is_undefined()) {
         auto type_string = TRY(type_value.to_string(vm));
         if (type_string == "bytes"sv)
@@ -38,8 +38,8 @@ JS::ThrowCompletionOr<UnderlyingSource> UnderlyingSource::from_value(JS::VM& vm,
             return vm.throw_completion<JS::TypeError>(MUST(String::formatted("Unknown stream type '{}'", type_value)));
     }
 
-    if (TRY(object.has_property("autoAllocateChunkSize"))) {
-        auto value = TRY(object.get("autoAllocateChunkSize"));
+    if (TRY(object.has_property("autoAllocateChunkSize"_fly_string))) {
+        auto value = TRY(object.get("autoAllocateChunkSize"_fly_string));
         underlying_source.auto_allocate_chunk_size = TRY(WebIDL::convert_to_int<WebIDL::UnsignedLongLong>(vm, value, WebIDL::EnforceRange::Yes));
     }
 

--- a/Libraries/LibWeb/WebAssembly/Instance.cpp
+++ b/Libraries/LibWeb/WebAssembly/Instance.cpp
@@ -58,7 +58,7 @@ void Instance::initialize(JS::Realm& realm)
                     m_function_instances.set(address, *object);
                 }
 
-                m_exports->define_direct_property(export_.name(), *object, JS::default_attributes);
+                m_exports->define_direct_property(MUST(String::from_byte_string(export_.name())), *object, JS::default_attributes);
             },
             [&](Wasm::GlobalAddress const& address) {
                 Optional<GC::Ptr<Global>> object = cache.get_global_instance(address);
@@ -66,7 +66,7 @@ void Instance::initialize(JS::Realm& realm)
                     object = realm.create<Global>(realm, address);
                 }
 
-                m_exports->define_direct_property(export_.name(), *object, JS::default_attributes);
+                m_exports->define_direct_property(MUST(String::from_byte_string(export_.name())), *object, JS::default_attributes);
             },
             [&](Wasm::MemoryAddress const& address) {
                 Optional<GC::Ptr<Memory>> object = m_memory_instances.get(address);
@@ -75,7 +75,7 @@ void Instance::initialize(JS::Realm& realm)
                     m_memory_instances.set(address, *object);
                 }
 
-                m_exports->define_direct_property(export_.name(), *object, JS::default_attributes);
+                m_exports->define_direct_property(MUST(String::from_byte_string(export_.name())), *object, JS::default_attributes);
             },
             [&](Wasm::TableAddress const& address) {
                 Optional<GC::Ptr<Table>> object = m_table_instances.get(address);
@@ -84,7 +84,7 @@ void Instance::initialize(JS::Realm& realm)
                     m_table_instances.set(address, *object);
                 }
 
-                m_exports->define_direct_property(export_.name(), *object, JS::default_attributes);
+                m_exports->define_direct_property(MUST(String::from_byte_string(export_.name())), *object, JS::default_attributes);
             });
     }
 

--- a/Libraries/LibWeb/WebAssembly/Instance.cpp
+++ b/Libraries/LibWeb/WebAssembly/Instance.cpp
@@ -54,7 +54,7 @@ void Instance::initialize(JS::Realm& realm)
             [&](Wasm::FunctionAddress const& address) {
                 Optional<GC::Ptr<JS::FunctionObject>> object = m_function_instances.get(address);
                 if (!object.has_value()) {
-                    object = Detail::create_native_function(vm, address, export_.name(), this);
+                    object = Detail::create_native_function(vm, address, MUST(String::from_byte_string(export_.name())), this);
                     m_function_instances.set(address, *object);
                 }
 

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -372,7 +372,7 @@ JS::ThrowCompletionOr<NonnullRefPtr<CompiledWebAssemblyModule>> compile_a_webass
 
 GC_DEFINE_ALLOCATOR(ExportedWasmFunction);
 
-GC::Ref<ExportedWasmFunction> ExportedWasmFunction::create(JS::Realm& realm, DeprecatedFlyString const& name, Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)> behavior, Wasm::FunctionAddress exported_address)
+GC::Ref<ExportedWasmFunction> ExportedWasmFunction::create(JS::Realm& realm, FlyString const& name, Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)> behavior, Wasm::FunctionAddress exported_address)
 {
     auto& vm = realm.vm();
     auto prototype = realm.intrinsics().function_prototype();
@@ -383,13 +383,13 @@ GC::Ref<ExportedWasmFunction> ExportedWasmFunction::create(JS::Realm& realm, Dep
         prototype);
 }
 
-ExportedWasmFunction::ExportedWasmFunction(DeprecatedFlyString name, GC::Ptr<GC::Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)>> behavior, Wasm::FunctionAddress exported_address, JS::Object& prototype)
+ExportedWasmFunction::ExportedWasmFunction(FlyString name, GC::Ptr<GC::Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)>> behavior, Wasm::FunctionAddress exported_address, JS::Object& prototype)
     : NativeFunction(move(name), move(behavior), prototype)
     , m_exported_address(exported_address)
 {
 }
 
-JS::NativeFunction* create_native_function(JS::VM& vm, Wasm::FunctionAddress address, ByteString const& name, Instance* instance)
+JS::NativeFunction* create_native_function(JS::VM& vm, Wasm::FunctionAddress address, String const& name, Instance* instance)
 {
     auto& realm = *vm.current_realm();
     Optional<Wasm::FunctionType> type;
@@ -545,7 +545,7 @@ JS::Value to_js_value(JS::VM& vm, Wasm::Value& wasm_value, Wasm::ValueType type)
             [](Wasm::HostFunction& host_function) {
                 return host_function.name();
             });
-        return create_native_function(vm, address, name);
+        return create_native_function(vm, address, MUST(String::from_byte_string(name)));
     }
     case Wasm::ValueType::ExternReference: {
         auto ref_ = wasm_value.to<Wasm::Reference>();

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -172,7 +172,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<Wasm::ModuleInstance>> instantiate_module(JS
         for (Wasm::Linker::Name const& import_name : linker.unresolved_imports()) {
             dbgln_if(LIBWEB_WASM_DEBUG, "Trying to resolve {}::{}", import_name.module, import_name.name);
             // 3.1. Let o be ? Get(importObject, moduleName).
-            auto value_or_error = import_object->get(import_name.module);
+            auto value_or_error = import_object->get(MUST(String::from_byte_string(import_name.module)));
             if (value_or_error.is_error())
                 break;
             auto value = value_or_error.release_value();
@@ -182,7 +182,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<Wasm::ModuleInstance>> instantiate_module(JS
                 break;
             auto object = object_or_error.release_value();
             // 3.3. Let v be ? Get(o, componentName).
-            auto import_or_error = object->get(import_name.name);
+            auto import_or_error = object->get(MUST(String::from_byte_string(import_name.name)));
             if (import_or_error.is_error())
                 break;
             auto import_ = import_or_error.release_value();

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -674,8 +674,8 @@ GC::Ref<WebIDL::Promise> instantiate_promise_of_module(JS::VM& vm, GC::Ref<WebID
 
             // 1. Let result be the WebAssemblyInstantiatedSource value «[ "module" → module, "instance" → instance ]».
             auto result = JS::Object::create(realm, nullptr);
-            result->define_direct_property("module", module, JS::default_attributes);
-            result->define_direct_property("instance", instance, JS::default_attributes);
+            result->define_direct_property("module"_fly_string, module, JS::default_attributes);
+            result->define_direct_property("instance"_fly_string, instance, JS::default_attributes);
 
             // 2. Resolve promise with result.
             WebIDL::resolve_promise(realm, promise, result);

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -71,13 +71,13 @@ class ExportedWasmFunction final : public JS::NativeFunction {
     GC_DECLARE_ALLOCATOR(ExportedWasmFunction);
 
 public:
-    static GC::Ref<ExportedWasmFunction> create(JS::Realm&, DeprecatedFlyString const& name, ESCAPING Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)>, Wasm::FunctionAddress);
+    static GC::Ref<ExportedWasmFunction> create(JS::Realm&, FlyString const& name, ESCAPING Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)>, Wasm::FunctionAddress);
     virtual ~ExportedWasmFunction() override = default;
 
     Wasm::FunctionAddress exported_address() const { return m_exported_address; }
 
 protected:
-    ExportedWasmFunction(DeprecatedFlyString name, GC::Ptr<GC::Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)>>, Wasm::FunctionAddress, Object& prototype);
+    ExportedWasmFunction(FlyString name, GC::Ptr<GC::Function<JS::ThrowCompletionOr<JS::Value>(JS::VM&)>>, Wasm::FunctionAddress, Object& prototype);
 
 private:
     Wasm::FunctionAddress m_exported_address;
@@ -87,7 +87,7 @@ WebAssemblyCache& get_cache(JS::Realm&);
 
 JS::ThrowCompletionOr<NonnullOwnPtr<Wasm::ModuleInstance>> instantiate_module(JS::VM&, Wasm::Module const&, GC::Ptr<JS::Object> import_object);
 JS::ThrowCompletionOr<NonnullRefPtr<CompiledWebAssemblyModule>> compile_a_webassembly_module(JS::VM&, ByteBuffer);
-JS::NativeFunction* create_native_function(JS::VM&, Wasm::FunctionAddress address, ByteString const& name, Instance* instance = nullptr);
+JS::NativeFunction* create_native_function(JS::VM&, Wasm::FunctionAddress address, String const& name, Instance* instance = nullptr);
 JS::ThrowCompletionOr<Wasm::Value> to_webassembly_value(JS::VM&, JS::Value value, Wasm::ValueType const& type);
 Wasm::Value default_webassembly_value(JS::VM&, Wasm::ValueType type);
 JS::Value to_js_value(JS::VM&, Wasm::Value& wasm_value, Wasm::ValueType type);

--- a/Libraries/LibWeb/WebDriver/Contexts.cpp
+++ b/Libraries/LibWeb/WebDriver/Contexts.cpp
@@ -14,10 +14,10 @@
 namespace Web::WebDriver {
 
 // https://w3c.github.io/webdriver/#dfn-web-window-identifier
-static JS::PropertyKey const WEB_WINDOW_IDENTIFIER { "window-fcc6-11e5-b4f8-330a88ab9d7f" };
+static JS::PropertyKey const WEB_WINDOW_IDENTIFIER { "window-fcc6-11e5-b4f8-330a88ab9d7f"_fly_string };
 
 // https://w3c.github.io/webdriver/#dfn-web-frame-identifier
-static JS::PropertyKey const WEB_FRAME_IDENTIFIER { "frame-075b-4da1-b6ba-e579c2d3230a" };
+static JS::PropertyKey const WEB_FRAME_IDENTIFIER { "frame-075b-4da1-b6ba-e579c2d3230a"_fly_string };
 
 // https://w3c.github.io/webdriver/#dfn-windowproxy-reference-object
 JsonObject window_proxy_reference_object(HTML::WindowProxy const& window)

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -26,11 +26,11 @@ namespace Web::WebDriver {
 
 // https://w3c.github.io/webdriver/#dfn-web-element-identifier
 static String const web_element_identifier = "element-6066-11e4-a52e-4f735466cecf"_string;
-static JS::PropertyKey web_element_identifier_key { web_element_identifier.to_byte_string() };
+static JS::PropertyKey web_element_identifier_key { web_element_identifier };
 
 // https://w3c.github.io/webdriver/#dfn-shadow-root-identifier
 static String const shadow_root_identifier = "shadow-6066-11e4-a52e-4f735466cecf"_string;
-static JS::PropertyKey shadow_root_identifier_key { shadow_root_identifier.to_byte_string() };
+static JS::PropertyKey shadow_root_identifier_key { shadow_root_identifier };
 
 // https://w3c.github.io/webdriver/#dfn-browsing-context-group-node-map
 static HashMap<GC::RawPtr<HTML::BrowsingContextGroup const>, HashTable<String>> browsing_context_group_node_map;

--- a/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -67,7 +67,7 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingCo
     //    The result of parsing global scope above.
     // strict
     //    The result of parsing strict above.
-    auto function = JS::ECMAScriptFunctionObject::create(realm, "", move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), function_expression->local_variables_names(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(), function_expression->parsing_insights());
+    auto function = JS::ECMAScriptFunctionObject::create(realm, ""_fly_string, move(source_text), function_expression->body(), function_expression->parameters(), function_expression->function_length(), function_expression->local_variables_names(), &global_scope, nullptr, function_expression->kind(), function_expression->is_strict_mode(), function_expression->parsing_insights());
 
     // 9. Let completion be Function.[[Call]](window, parameters) with function as the this value.
     // NOTE: This is not entirely clear, but I don't think they mean actually passing `function` as

--- a/Libraries/LibWeb/WebGL/WebGLContextAttributes.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLContextAttributes.cpp
@@ -23,7 +23,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         alpha = JS::js_undefined();
     else
-        alpha = TRY(value.as_object().get("alpha"));
+        alpha = TRY(value.as_object().get("alpha"_fly_string));
 
     bool alpha_value;
     if (!alpha.is_undefined())
@@ -37,7 +37,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         antialias = JS::js_undefined();
     else
-        antialias = TRY(value.as_object().get("antialias"));
+        antialias = TRY(value.as_object().get("antialias"_fly_string));
 
     bool antialias_value;
     if (!antialias.is_undefined())
@@ -51,7 +51,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         depth = JS::js_undefined();
     else
-        depth = TRY(value.as_object().get("depth"));
+        depth = TRY(value.as_object().get("depth"_fly_string));
 
     bool depth_value;
     if (!depth.is_undefined())
@@ -65,7 +65,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         desynchronized = JS::js_undefined();
     else
-        desynchronized = TRY(value.as_object().get("desynchronized"));
+        desynchronized = TRY(value.as_object().get("desynchronized"_fly_string));
 
     bool desynchronized_value;
 
@@ -80,7 +80,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         fail_if_major_performance_caveat = JS::js_undefined();
     else
-        fail_if_major_performance_caveat = TRY(value.as_object().get("failIfMajorPerformanceCaveat"));
+        fail_if_major_performance_caveat = TRY(value.as_object().get("failIfMajorPerformanceCaveat"_fly_string));
 
     bool fail_if_major_performance_caveat_value;
     if (!fail_if_major_performance_caveat.is_undefined())
@@ -94,7 +94,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         power_preference = JS::js_undefined();
     else
-        power_preference = TRY(value.as_object().get("powerPreference"));
+        power_preference = TRY(value.as_object().get("powerPreference"_fly_string));
 
     Bindings::WebGLPowerPreference power_preference_value { Bindings::WebGLPowerPreference::Default };
 
@@ -117,7 +117,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         premultiplied_alpha = JS::js_undefined();
     else
-        premultiplied_alpha = TRY(value.as_object().get("premultipliedAlpha"));
+        premultiplied_alpha = TRY(value.as_object().get("premultipliedAlpha"_fly_string));
 
     bool premultiplied_alpha_value;
 
@@ -132,7 +132,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         preserve_drawing_buffer = JS::js_undefined();
     else
-        preserve_drawing_buffer = TRY(value.as_object().get("preserveDrawingBuffer"));
+        preserve_drawing_buffer = TRY(value.as_object().get("preserveDrawingBuffer"_fly_string));
 
     bool preserve_drawing_buffer_value;
     if (!preserve_drawing_buffer.is_undefined())
@@ -146,7 +146,7 @@ JS::ThrowCompletionOr<WebGLContextAttributes> convert_value_to_context_attribute
     if (value.is_nullish())
         stencil = JS::js_undefined();
     else
-        stencil = TRY(value.as_object().get("stencil"));
+        stencil = TRY(value.as_object().get("stencil"_fly_string));
 
     bool stencil_value;
 

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -171,7 +171,7 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
     // 9. If ! IsCallable(O) is false, then:
     if (!object->is_function()) {
         // 1. Let getResult be Get(O, opName).
-        auto get_result = object->get(operation_name.to_byte_string());
+        auto get_result = object->get(operation_name);
 
         // 2. If getResult is an abrupt completion, set completion to getResult and jump to the step labeled return.
         if (get_result.is_throw_completion()) {

--- a/Libraries/LibWeb/WebIDL/ExceptionOr.h
+++ b/Libraries/LibWeb/WebIDL/ExceptionOr.h
@@ -170,7 +170,7 @@ struct Formatter<Web::WebIDL::Exception> : Formatter<FormatString> {
 
                 if (value.is_object()) {
                     auto& object = value.as_object();
-                    static const JS::PropertyKey message_property_key { "message" };
+                    static const JS::PropertyKey message_property_key { "message"_fly_string };
                     auto has_message_or_error = object.has_own_property(message_property_key);
                     if (!has_message_or_error.is_error() && has_message_or_error.value()) {
                         auto message_object = object.get_without_side_effects(message_property_key);

--- a/Libraries/LibWeb/WebIDL/OverloadResolution.cpp
+++ b/Libraries/LibWeb/WebIDL/OverloadResolution.cpp
@@ -228,7 +228,7 @@ JS::ThrowCompletionOr<ResolvedOverload> resolve_overload(JS::VM& vm, IDL::Effect
         //    then remove from S all other entries.
         else if (value.is_object() && value.as_object().is_typed_array()
             && has_overload_with_argument_type_or_subtype_matching(overloads, i, [&](IDL::Type const& type) {
-                   if (type.is_plain() && (type.name() == static_cast<JS::TypedArrayBase const&>(value.as_object()).element_name() || type.name() == "BufferSource" || type.name() == "ArrayBufferView"))
+                   if (type.is_plain() && (type.name() == static_cast<JS::TypedArrayBase const&>(value.as_object()).element_name().bytes_as_string_view() || type.name() == "BufferSource" || type.name() == "ArrayBufferView"))
                        return true;
                    if (type.is_object())
                        return true;

--- a/Libraries/LibWeb/WebIDL/Promise.cpp
+++ b/Libraries/LibWeb/WebIDL/Promise.cpp
@@ -112,7 +112,7 @@ GC::Ref<Promise> react_to_promise(Promise const& promise, GC::Ptr<ReactionSteps>
     };
 
     // 2. Let onFulfilled be CreateBuiltinFunction(onFulfilledSteps, « »):
-    auto on_fulfilled = JS::NativeFunction::create(realm, move(on_fulfilled_steps), 1, "");
+    auto on_fulfilled = JS::NativeFunction::create(realm, move(on_fulfilled_steps), 1);
 
     // 3. Let onRejectedSteps be the following steps given argument R:
     auto on_rejected_steps = [&realm, on_rejected_callback = move(on_rejected_callback)](JS::VM& vm) -> JS::ThrowCompletionOr<JS::Value> {
@@ -129,7 +129,7 @@ GC::Ref<Promise> react_to_promise(Promise const& promise, GC::Ptr<ReactionSteps>
     };
 
     // 4. Let onRejected be CreateBuiltinFunction(onRejectedSteps, « »):
-    auto on_rejected = JS::NativeFunction::create(realm, move(on_rejected_steps), 1, "");
+    auto on_rejected = JS::NativeFunction::create(realm, move(on_rejected_steps), 1);
 
     // 5. Let constructor be promise.[[Promise]].[[Realm]].[[Intrinsics]].[[%Promise%]].
     auto constructor = realm.intrinsics().promise_constructor();
@@ -232,7 +232,7 @@ void wait_for_all(JS::Realm& realm, Vector<GC::Ref<Promise>> const& promises, Fu
     };
 
     // 4. Let rejectionHandler be CreateBuiltinFunction(rejectionHandlerSteps, « »):
-    auto rejection_handler = JS::NativeFunction::create(realm, move(rejection_handler_steps), 1, "");
+    auto rejection_handler = JS::NativeFunction::create(realm, move(rejection_handler_steps), 1);
 
     // 5. Let total be promises’s size.
     auto total = promises.size();
@@ -280,7 +280,7 @@ void wait_for_all(JS::Realm& realm, Vector<GC::Ref<Promise>> const& promises, Fu
         };
 
         // 3. Let fulfillmentHandler be CreateBuiltinFunction(fulfillmentHandler, « »):
-        auto fulfillment_handler = JS::NativeFunction::create(realm, move(fulfillment_handler_steps), 1, "");
+        auto fulfillment_handler = JS::NativeFunction::create(realm, move(fulfillment_handler_steps), 1);
 
         // 4. Perform PerformPromiseThen(promise, fulfillmentHandler, rejectionHandler).
         static_cast<JS::Promise&>(*promise->promise()).perform_then(fulfillment_handler, rejection_handler, nullptr);

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -106,7 +106,7 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
             if (namespaces.find_if([&](auto const& namespace_and_prefix) { return namespace_and_prefix.prefix == prefix; }) != namespaces.end())
                 continue;
 
-            namespaces.append({ MUST(FlyString::from_deprecated_fly_string(namespace_)), prefix });
+            namespaces.append({ FlyString(MUST(String::from_byte_string(namespace_))), prefix });
         }
     }
 
@@ -118,7 +118,7 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
 
     auto namespace_ = namespace_for_element(name);
 
-    auto qualified_name_or_error = DOM::validate_and_extract(m_document->realm(), namespace_, MUST(FlyString::from_deprecated_fly_string(name)));
+    auto qualified_name_or_error = DOM::validate_and_extract(m_document->realm(), namespace_, FlyString(MUST(String::from_byte_string(name))));
 
     if (qualified_name_or_error.is_error()) {
         m_has_error = true;
@@ -157,7 +157,7 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
             auto name = attribute.key;
             if (!name.is_one_of("xmlns:"sv, "xmlns:xmlns"sv)) {
                 // The prefix xmlns is used only to declare namespace bindings and is by definition bound to the namespace name http://www.w3.org/2000/xmlns/.
-                MUST(node->set_attribute_ns(Namespace::XMLNS, MUST(FlyString::from_deprecated_fly_string(name)), MUST(String::from_byte_string(attribute.value))));
+                MUST(node->set_attribute_ns(Namespace::XMLNS, MUST(String::from_byte_string(name)), MUST(String::from_byte_string(attribute.value))));
             } else {
                 m_has_error = true;
             }
@@ -166,7 +166,7 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
                 m_has_error = true;
             }
         }
-        MUST(node->set_attribute(MUST(FlyString::from_deprecated_fly_string(attribute.key)), MUST(String::from_byte_string(attribute.value))));
+        MUST(node->set_attribute(MUST(String::from_byte_string(attribute.key)), MUST(String::from_byte_string(attribute.value))));
     }
 
     m_current_node = node.ptr();

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -177,8 +177,8 @@ JS_DEFINE_NATIVE_FUNCTION(TestRunnerGlobalObject::fuzzilli)
 void TestRunnerGlobalObject::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
-    define_direct_property("global", this, JS::Attribute::Enumerable);
-    define_native_function(realm, "fuzzilli", fuzzilli, 2, JS::default_attributes);
+    define_direct_property("global"_fly_string, this, JS::Attribute::Enumerable);
+    define_native_function(realm, "fuzzilli"_fly_string, fuzzilli, 2, JS::default_attributes);
 }
 
 int main(int, char**)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1889,7 +1889,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
         // 2. For each key → value of D:
         for (auto const& [key, value] : @value@) {
             // 1. Let jsKey be key converted to a JavaScript value.
-            auto js_key = JS::PropertyKey { key.to_byte_string() };
+            auto js_key = JS::PropertyKey { key };
 
             // 2. Let jsValue be value converted to a JavaScript value.
 )~~~");
@@ -3263,7 +3263,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> @named_properties_class@
 
     // 4. If the result of running the named property visibility algorithm with property name P and object object is true, then:
     if (TRY(object.is_named_property_exposed_on_object(property_name))) {
-        auto property_name_string = MUST(FlyString::from_deprecated_fly_string(property_name.to_string()));
+        auto property_name_string = property_name.to_string();
 
         // 1. Let operation be the operation used to declare the named property getter.
         // 2. Let value be an uninitialized variable.
@@ -4179,7 +4179,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     auto value = vm.argument(0);
 
     auto receiver = TRY(throw_dom_exception_if_needed(vm, [&]() { return impl->@attribute.cpp_name@(); }));
-    TRY(receiver->set(JS::PropertyKey { "@put_forwards_identifier@", JS::PropertyKey::StringMayBeNumber::No }, value, JS::Object::ShouldThrowExceptions::Yes));
+    TRY(receiver->set(JS::PropertyKey { "@put_forwards_identifier@"_fly_string, JS::PropertyKey::StringMayBeNumber::No }, value, JS::Object::ShouldThrowExceptions::Yes));
 
     return JS::js_undefined();
 }
@@ -4818,7 +4818,7 @@ namespace Web::Bindings {
 GC_DEFINE_ALLOCATOR(@constructor_class@);
 
 @constructor_class@::@constructor_class@(JS::Realm& realm)
-    : NativeFunction("@name@"sv, realm.intrinsics().function_prototype())
+    : NativeFunction("@name@"_fly_string, realm.intrinsics().function_prototype())
 {
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -116,7 +116,7 @@ void Intrinsics::create_web_namespace<@namespace_class@>(JS::Realm& realm)
             gen.set("owned_prototype_class", interface.prototype_class);
 
             gen.append(R"~~~(
-    namespace_object->define_intrinsic_accessor("@owned_interface_name@", attr, [](auto& realm) -> JS::Value { return &Bindings::ensure_web_constructor<@owned_prototype_class@>(realm, "@interface_name@.@owned_interface_name@"_fly_string); });)~~~");
+    namespace_object->define_intrinsic_accessor("@owned_interface_name@"_fly_string, attr, [](auto& realm) -> JS::Value { return &Bindings::ensure_web_constructor<@owned_prototype_class@>(realm, "@interface_name@.@owned_interface_name@"_fly_string); });)~~~");
         }
 
         gen.append(R"~~~(
@@ -267,7 +267,7 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global)
         gen.set("prototype_class", prototype_class);
 
         gen.append(R"~~~(
-    global.define_intrinsic_accessor("@interface_name@", attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@interface_name@"_fly_string); });)~~~");
+    global.define_intrinsic_accessor("@interface_name@"_fly_string, attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@interface_name@"_fly_string); });)~~~");
 
         // https://webidl.spec.whatwg.org/#LegacyWindowAlias
         if (legacy_alias_name.has_value()) {
@@ -276,19 +276,19 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global)
                 for (auto legacy_alias_name : legacy_alias_names) {
                     gen.set("interface_alias_name", legacy_alias_name.trim_whitespace());
                     gen.append(R"~~~(
-    global.define_intrinsic_accessor("@interface_alias_name@", attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@interface_name@"_fly_string); });)~~~");
+    global.define_intrinsic_accessor("@interface_alias_name@"_fly_string, attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@interface_name@"_fly_string); });)~~~");
                 }
             } else {
                 gen.set("interface_alias_name", *legacy_alias_name);
                 gen.append(R"~~~(
-    global.define_intrinsic_accessor("@interface_alias_name@", attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@interface_name@"_fly_string); });)~~~");
+    global.define_intrinsic_accessor("@interface_alias_name@"_fly_string, attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@interface_name@"_fly_string); });)~~~");
             }
         }
 
         if (legacy_constructor.has_value()) {
             gen.set("legacy_interface_name", legacy_constructor->name);
             gen.append(R"~~~(
-    global.define_intrinsic_accessor("@legacy_interface_name@", attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@legacy_interface_name@"_fly_string); });)~~~");
+    global.define_intrinsic_accessor("@legacy_interface_name@"_fly_string, attr, [](auto& realm) -> JS::Value { return &ensure_web_constructor<@prototype_class@>(realm, "@legacy_interface_name@"_fly_string); });)~~~");
         }
     };
 
@@ -297,7 +297,7 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global)
         gen.set("namespace_class", namespace_class);
 
         gen.append(R"~~~(
-    global.define_intrinsic_accessor("@interface_name@", attr, [](auto& realm) -> JS::Value { return &ensure_web_namespace<@namespace_class@>(realm, "@interface_name@"_fly_string); });)~~~");
+    global.define_intrinsic_accessor("@interface_name@"_fly_string, attr, [](auto& realm) -> JS::Value { return &ensure_web_namespace<@namespace_class@>(realm, "@interface_name@"_fly_string); });)~~~");
     };
 
     for (auto& interface : exposed_interfaces) {

--- a/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
+++ b/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
@@ -27,10 +27,10 @@ void ConsoleGlobalEnvironmentExtensions::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_native_accessor(realm, "$0", $0_getter, nullptr, 0);
-    define_native_accessor(realm, "$_", $__getter, nullptr, 0);
-    define_native_function(realm, "$", $_function, 2, JS::default_attributes);
-    define_native_function(realm, "$$", $$_function, 2, JS::default_attributes);
+    define_native_accessor(realm, "$0"_fly_string, $0_getter, nullptr, 0);
+    define_native_accessor(realm, "$_"_fly_string, $__getter, nullptr, 0);
+    define_native_function(realm, "$"_fly_string, $_function, 2, JS::default_attributes);
+    define_native_function(realm, "$$"_fly_string, $$_function, 2, JS::default_attributes);
 }
 
 void ConsoleGlobalEnvironmentExtensions::visit_edges(Visitor& visitor)

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -1342,7 +1342,7 @@ Messages::WebDriverClient::GetElementPropertyResponse WebDriverConnection::get_e
         // 5. Let property be the result of calling the Object.[[GetProperty]](name) on element.
         Web::HTML::TemporaryExecutionContext execution_context { current_browsing_context().active_document()->realm() };
 
-        if (auto property_or_error = element->get(name.to_byte_string()); !property_or_error.is_throw_completion()) {
+        if (auto property_or_error = element->get(name); !property_or_error.is_throw_completion()) {
             auto property = property_or_error.release_value();
 
             // 6. Let result be the value of property if not undefined, or null.

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -26,7 +26,7 @@ TESTJS_GLOBAL_FUNCTION(is_strict_mode, isStrictMode, 0)
 
 TESTJS_GLOBAL_FUNCTION(can_parse_source, canParseSource)
 {
-    auto source = TRY(vm.argument(0).to_byte_string(vm));
+    auto source = TRY(vm.argument(0).to_string(vm));
     auto parser = JS::Parser(JS::Lexer(source));
     (void)parser.parse_program();
     return JS::Value(!parser.has_errors());

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -71,7 +71,7 @@ TESTJS_GLOBAL_FUNCTION(mark_as_garbage, markAsGarbage)
     if (!outer_environment.has_value())
         return vm.throw_completion<JS::ReferenceError>(JS::ErrorType::UnknownIdentifier, variable_name.byte_string());
 
-    auto reference = TRY(vm.resolve_binding(variable_name.byte_string(), outer_environment.value()->lexical_environment));
+    auto reference = TRY(vm.resolve_binding(variable_name.utf8_string(), outer_environment.value()->lexical_environment));
 
     auto value = TRY(reference.get_value(vm));
 

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -90,19 +90,19 @@ static ErrorOr<void, TestError> run_program(InterpreterT& interpreter, ScriptOrM
         if (error_value.is_object()) {
             auto& object = error_value.as_object();
 
-            auto name = object.get_without_side_effects("name");
+            auto name = object.get_without_side_effects("name"_fly_string);
             if (!name.is_empty() && !name.is_accessor()) {
                 error.type = name.to_string_without_side_effects();
             } else {
-                auto constructor = object.get_without_side_effects("constructor");
+                auto constructor = object.get_without_side_effects("constructor"_fly_string);
                 if (constructor.is_object()) {
-                    name = constructor.as_object().get_without_side_effects("name");
+                    name = constructor.as_object().get_without_side_effects("name"_fly_string);
                     if (!name.is_undefined())
                         error.type = name.to_string_without_side_effects();
                 }
             }
 
-            auto message = object.get_without_side_effects("message");
+            auto message = object.get_without_side_effects("message"_fly_string);
             if (!message.is_empty() && !message.is_accessor())
                 error.details = message.to_string_without_side_effects();
         }

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -264,10 +264,10 @@ TEST_CASE(char_utf8)
 
 TEST_CASE(catch_all_newline)
 {
-    Regex<PosixExtended> re("^.*$", PosixFlags::Multiline | PosixFlags::StringCopyMatches);
+    Regex<PosixExtended> re("^.*$", PosixFlags::Multiline);
     RegexResult result;
-    auto lambda = [&result, &re]() {
-        ByteString aaa = "Hello World\nTest\n1234\n";
+    ByteString aaa = "Hello World\nTest\n1234\n";
+    auto lambda = [&]() {
         result = match(aaa, re);
         EXPECT_EQ(result.success, true);
     };
@@ -297,7 +297,7 @@ TEST_CASE(catch_all_newline_2)
 {
     Regex<PosixExtended> re("^.*$");
     RegexResult result;
-    result = match("Hello World\nTest\n1234\n"sv, re, PosixFlags::Multiline | PosixFlags::StringCopyMatches);
+    result = match("Hello World\nTest\n1234\n"sv, re, PosixFlags::Multiline);
     EXPECT_EQ(result.success, true);
     EXPECT_EQ(result.count, 3u);
     EXPECT_EQ(result.matches.at(0).view, "Hello World");
@@ -314,7 +314,7 @@ TEST_CASE(match_all_character_class)
 {
     Regex<PosixExtended> re("[[:alpha:]]");
     ByteString str = "[Window]\nOpacity=255\nAudibleBeep=0\n";
-    RegexResult result = match(str, re, PosixFlags::Global | PosixFlags::StringCopyMatches);
+    RegexResult result = match(str, re, PosixFlags::Global);
 
     EXPECT_EQ(result.success, true);
     EXPECT_EQ(result.count, 24u);
@@ -1005,7 +1005,8 @@ TEST_CASE(case_insensitive_match)
 TEST_CASE(extremely_long_fork_chain)
 {
     Regex<ECMA262> re("(?:aa)*");
-    auto result = re.match(ByteString::repeated('a', 1000));
+    auto input = ByteString::repeated('a', 1000);
+    auto result = re.match(input);
     EXPECT_EQ(result.success, true);
 }
 
@@ -1048,7 +1049,8 @@ BENCHMARK_CASE(fork_performance)
     }
     {
         Regex<ECMA262> re("^(a|a?)+$");
-        auto result = re.match(ByteString::formatted("{}b", g_lots_of_a_s.substring_view(0, 100)));
+        auto input = ByteString::formatted("{}b", g_lots_of_a_s.substring_view(0, 100));
+        auto result = re.match(input);
         EXPECT_EQ(result.success, false);
     }
 }

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -21,7 +21,7 @@ TESTJS_GLOBAL_FUNCTION(read_binary_wasm_file, readBinaryWasmFile)
         return StringView { error_string, strlen(error_string) };
     };
 
-    auto filename = TRY(vm.argument(0).to_byte_string(vm));
+    auto filename = TRY(vm.argument(0).to_string(vm));
     auto file = Core::File::open(filename, Core::File::OpenMode::Read);
     if (file.is_error())
         return vm.throw_completion<JS::TypeError>(error_code_to_string(file.error().code()));

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -178,7 +178,7 @@ TESTJS_GLOBAL_FUNCTION(parse_webassembly_module, parseWebAssemblyModule)
             auto& module_object = static_cast<WebAssemblyModule&>(value.as_object());
             for (auto& entry : module_object.module_instance().exports()) {
                 // FIXME: Don't pretend that everything is a function
-                imports.set({ property.key.as_string(), entry.name(), Wasm::TypeIndex(0) }, entry.value());
+                imports.set({ property.key.as_string().to_string().to_byte_string(), entry.name(), Wasm::TypeIndex(0) }, entry.value());
             }
         }
     }

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -243,7 +243,7 @@ TESTJS_GLOBAL_FUNCTION(test_simd_vector, testSIMDVector)
     if (!is<JS::TypedArrayBase>(*got))
         return vm.throw_completion<JS::TypeError>("Expected a TypedArray"sv);
     auto& got_array = static_cast<JS::TypedArrayBase&>(*got);
-    auto element_size = 128 / TRY(TRY(expected_array.get("length")).to_u32(vm));
+    auto element_size = 128 / TRY(TRY(expected_array.get("length"_fly_string)).to_u32(vm));
     size_t i = 0;
     for (auto it = expected_array.indexed_properties().begin(false); it != expected_array.indexed_properties().end(); ++it) {
         auto got_value = TRY(got_array.get(i++));
@@ -277,8 +277,8 @@ TESTJS_GLOBAL_FUNCTION(test_simd_vector, testSIMDVector)
 void WebAssemblyModule::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
-    define_native_function(realm, "getExport", get_export, 1, JS::default_attributes);
-    define_native_function(realm, "invoke", wasm_invoke, 1, JS::default_attributes);
+    define_native_function(realm, "getExport"_fly_string, get_export, 1, JS::default_attributes);
+    define_native_function(realm, "invoke"_fly_string, wasm_invoke, 1, JS::default_attributes);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::get_export)

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -294,9 +294,9 @@ static JS::ThrowCompletionOr<JS::Value> load_ini_impl(JS::VM& vm)
         auto group_object = JS::Object::create(realm, realm.intrinsics().object_prototype());
         for (auto const& key : config_file->keys(group)) {
             auto entry = config_file->read_entry(group, key);
-            group_object->define_direct_property(key, JS::PrimitiveString::create(vm, move(entry)), JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
+            group_object->define_direct_property(MUST(String::from_byte_string(key)), JS::PrimitiveString::create(vm, move(entry)), JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
         }
-        object->define_direct_property(group, group_object, JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
+        object->define_direct_property(MUST(String::from_byte_string(group)), group_object, JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable);
     }
     return object;
 }

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -323,18 +323,18 @@ void ReplObject::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_direct_property("global", this, JS::Attribute::Enumerable);
+    define_direct_property("global"_fly_string, this, JS::Attribute::Enumerable);
     u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
-    define_native_function(realm, "exit", exit_interpreter, 0, attr);
-    define_native_function(realm, "help", repl_help, 0, attr);
-    define_native_function(realm, "save", save_to_file, 1, attr);
-    define_native_function(realm, "loadINI", load_ini, 1, attr);
-    define_native_function(realm, "loadJSON", load_json, 1, attr);
-    define_native_function(realm, "print", print, 1, attr);
+    define_native_function(realm, "exit"_fly_string, exit_interpreter, 0, attr);
+    define_native_function(realm, "help"_fly_string, repl_help, 0, attr);
+    define_native_function(realm, "save"_fly_string, save_to_file, 1, attr);
+    define_native_function(realm, "loadINI"_fly_string, load_ini, 1, attr);
+    define_native_function(realm, "loadJSON"_fly_string, load_json, 1, attr);
+    define_native_function(realm, "print"_fly_string, print, 1, attr);
 
     define_native_accessor(
         realm,
-        "_",
+        "_"_fly_string,
         [](JS::VM&) {
             return g_last_value.value();
         },
@@ -410,11 +410,11 @@ void ScriptObject::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
 
-    define_direct_property("global", this, JS::Attribute::Enumerable);
+    define_direct_property("global"_fly_string, this, JS::Attribute::Enumerable);
     u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
-    define_native_function(realm, "loadINI", load_ini, 1, attr);
-    define_native_function(realm, "loadJSON", load_json, 1, attr);
-    define_native_function(realm, "print", print, 1, attr);
+    define_native_function(realm, "loadINI"_fly_string, load_ini, 1, attr);
+    define_native_function(realm, "loadJSON"_fly_string, load_json, 1, attr);
+    define_native_function(realm, "print"_fly_string, print, 1, attr);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ScriptObject::load_ini)


### PR DESCRIPTION
Lots of mechanical work here, but basically this is using FlyString instead of DeprecatedFlyString almost everywhere. By doing this, we avoid a ton of churn conversion between UTF-8 and maybe-UTF-8. ~4% speedup on Speedometer :)