### PR TITLE
LibJS: Skip allocation of temp object for primitive types in Value::get

### DIFF
--- a/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Libraries/LibJS/Runtime/PropertyKey.h
@@ -105,6 +105,8 @@ public:
         return StringOrSymbol(as_symbol());
     }
 
+    bool operator==(PropertyKey const&) const = default;
+
 private:
     friend Traits<JS::PropertyKey>;
 


### PR DESCRIPTION
Previously, `String.prototype.split()` caused the construction of a temporary StringObject when a string primitive was passed as an argument, solely to perform a Symbol.split lookup. This change allows skipping that allocation by looking directly into the prototype of primitive values.

As a result, we can avoid ~200000 StringObject allocations in a single test from the Speedometer 2 benchmark.