### PR TITLE
LibWeb: Remove CubicBezier cached sample inline cache

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
@@ -57,7 +57,7 @@ public:
             double t;
         };
 
-        mutable Vector<CachedSample, 64> m_cached_x_samples {};
+        mutable Vector<CachedSample> m_cached_x_samples {};
 
         bool operator==(CubicBezier const&) const;
 


### PR DESCRIPTION
This reduces the size of CubicBezier objects from 1592 bytes to 56 bytes.

Allocations of this object showed up when profiling Speedometer2.