### PR TITLE
LibWeb: Improve font property parsing

### DIFF
--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -68,7 +68,7 @@ String CSSFontFaceRule::serialized() const
             if (source.local_or_url.has<URL::URL>()) {
                 serialize_a_url(builder, source.local_or_url.get<URL::URL>().to_string());
             } else {
-                builder.appendff("local({})", source.local_or_url.get<String>());
+                builder.appendff("local({})", source.local_or_url.get<FlyString>());
             }
 
             // NOTE: No spec currently exists for format()

--- a/Libraries/LibWeb/CSS/ParsedFontFace.h
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.h
@@ -19,7 +19,7 @@ namespace Web::CSS {
 class ParsedFontFace {
 public:
     struct Source {
-        Variant<String, URL::URL> local_or_url;
+        Variant<FlyString, URL::URL> local_or_url;
         // FIXME: Do we need to keep this around, or is it only needed to discard unwanted formats during parsing?
         Optional<FlyString> format;
     };

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -379,6 +379,7 @@ private:
     RefPtr<CSSStyleValue> parse_flex_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_flex_flow_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_font_value(TokenStream<ComponentValue>&);
+    RefPtr<CSSStyleValue> parse_family_name_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_font_family_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_font_language_override_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_font_feature_settings_value(TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -2490,81 +2490,37 @@ RefPtr<CSSStyleValue> Parser::parse_font_value(TokenStream<ComponentValue>& toke
         });
 }
 
+// https://drafts.csswg.org/css-fonts-4/#font-family-prop
 RefPtr<CSSStyleValue> Parser::parse_font_family_value(TokenStream<ComponentValue>& tokens)
 {
-    auto next_is_comma_or_eof = [&]() -> bool {
-        return !tokens.has_next_token() || tokens.next_token().is(Token::Type::Comma);
-    };
+    // [ <family-name> | <generic-family> ]#
+    // FIXME: We currently require font-family to always be a list, even with one item.
+    //        Maybe change that?
+    auto result = parse_comma_separated_value_list(tokens, [this](auto& inner_tokens) -> RefPtr<CSSStyleValue> {
+        inner_tokens.discard_whitespace();
 
-    // Note: Font-family names can either be a quoted string, or a keyword, or a series of custom-idents.
-    // eg, these are equivalent:
-    //     font-family: my cool     font\!, serif;
-    //     font-family: "my cool font!", serif;
-    StyleValueVector font_families;
-    Vector<String> current_name_parts;
-    while (tokens.has_next_token()) {
-        auto const& peek = tokens.next_token();
-
-        if (peek.is(Token::Type::String)) {
-            // `font-family: my cool "font";` is invalid.
-            if (!current_name_parts.is_empty())
-                return nullptr;
-            tokens.discard_a_token(); // String
-            if (!next_is_comma_or_eof())
-                return nullptr;
-            font_families.append(StringStyleValue::create(peek.token().string()));
-            tokens.discard_a_token(); // Comma
-            continue;
-        }
-
-        if (peek.is(Token::Type::Ident)) {
-            // If this is a valid identifier, it's NOT a custom-ident and can't be part of a larger name.
-
-            // CSS-wide keywords are not allowed
-            if (auto builtin = parse_builtin_value(tokens))
-                return nullptr;
-
-            auto maybe_keyword = keyword_from_string(peek.token().ident());
-            // Can't have a generic-font-name as a token in an unquoted font name.
+        // <generic-family>
+        if (inner_tokens.next_token().is(Token::Type::Ident)) {
+            auto maybe_keyword = keyword_from_string(inner_tokens.next_token().token().ident());
             if (maybe_keyword.has_value() && keyword_to_generic_font_family(maybe_keyword.value()).has_value()) {
-                if (!current_name_parts.is_empty())
-                    return nullptr;
-                tokens.discard_a_token(); // Ident
-                if (!next_is_comma_or_eof())
-                    return nullptr;
-                font_families.append(CSSKeywordValue::create(maybe_keyword.value()));
-                tokens.discard_a_token(); // Comma
-                continue;
+                inner_tokens.discard_a_token(); // Ident
+                inner_tokens.discard_whitespace();
+                return CSSKeywordValue::create(maybe_keyword.value());
             }
-            current_name_parts.append(tokens.consume_a_token().token().ident().to_string());
-            continue;
         }
 
-        if (peek.is(Token::Type::Comma)) {
-            if (current_name_parts.is_empty())
-                return nullptr;
-            tokens.discard_a_token(); // Comma
-            // This is really a series of custom-idents, not just one. But for the sake of simplicity we'll make it one.
-            font_families.append(CustomIdentStyleValue::create(MUST(String::join(' ', current_name_parts))));
-            current_name_parts.clear();
-            // Can't have a trailing comma
-            if (!tokens.has_next_token())
-                return nullptr;
-            continue;
-        }
+        // <family-name>
+        return parse_family_name_value(inner_tokens);
+    });
 
+    if (!result)
         return nullptr;
-    }
 
-    if (!current_name_parts.is_empty()) {
-        // This is really a series of custom-idents, not just one. But for the sake of simplicity we'll make it one.
-        font_families.append(CustomIdentStyleValue::create(MUST(String::join(' ', current_name_parts))));
-        current_name_parts.clear();
-    }
+    if (result->is_value_list())
+        return result.release_nonnull();
 
-    if (font_families.is_empty())
-        return nullptr;
-    return StyleValueList::create(move(font_families), StyleValueList::Separator::Comma);
+    // It's a single value, so wrap it in a list - see FIXME above.
+    return StyleValueList::create(StyleValueVector { result.release_nonnull() }, StyleValueList::Separator::Comma);
 }
 
 RefPtr<CSSStyleValue> Parser::parse_font_language_override_value(TokenStream<ComponentValue>& tokens)

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -672,7 +672,7 @@ Vector<ParsedFontFace::Source> Parser::parse_font_face_src(TokenStream<T>& compo
             if (first.function().value.is_empty()) {
                 continue;
             }
-            supported_sources.empend(first.function().value.first().to_string(), Optional<FlyString> {});
+            supported_sources.empend(FlyString { first.function().value.first().to_string() }, Optional<FlyString> {});
             continue;
         }
 

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -715,7 +715,7 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
         if (source.local_or_url.has<URL::URL>())
             builder.appendff("url={}, format={}\n", source.local_or_url.get<URL::URL>(), source.format.value_or("???"_string));
         else
-            builder.appendff("local={}\n", source.local_or_url.get<AK::String>());
+            builder.appendff("local={}\n", source.local_or_url.get<FlyString>());
     }
 
     indent(builder, indent_levels + 1);


### PR DESCRIPTION
A couple of tweaks here, as preparation for parsing at-rule descriptors in a similar way to how we currently parse properties. The last commit also makes us parse and serialize `local(...)` sources more correctly, but I haven't checked if it helps on WPT.