### PR TITLE
LibWeb: Pass along the init dictionary for error / buffer change events

### DIFF
--- a/Libraries/LibWeb/HTML/ErrorEvent.cpp
+++ b/Libraries/LibWeb/HTML/ErrorEvent.cpp
@@ -25,7 +25,7 @@ WebIDL::ExceptionOr<GC::Ref<ErrorEvent>> ErrorEvent::construct_impl(JS::Realm& r
 }
 
 ErrorEvent::ErrorEvent(JS::Realm& realm, FlyString const& event_name, ErrorEventInit const& event_init)
-    : DOM::Event(realm, event_name)
+    : DOM::Event(realm, event_name, event_init)
     , m_message(event_init.message)
     , m_filename(event_init.filename)
     , m_lineno(event_init.lineno)

--- a/Libraries/LibWeb/MediaSourceExtensions/BufferedChangeEvent.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/BufferedChangeEvent.cpp
@@ -17,8 +17,8 @@ WebIDL::ExceptionOr<GC::Ref<BufferedChangeEvent>> BufferedChangeEvent::construct
     return realm.create<BufferedChangeEvent>(realm, type, event_init);
 }
 
-BufferedChangeEvent::BufferedChangeEvent(JS::Realm& realm, AK::FlyString const& type, BufferedChangeEventInit const&)
-    : DOM::Event(realm, type)
+BufferedChangeEvent::BufferedChangeEvent(JS::Realm& realm, AK::FlyString const& type, BufferedChangeEventInit const& event_init)
+    : DOM::Event(realm, type, event_init)
 {
 }
 

--- a/Tests/LibWeb/Text/expected/DOM/cancelable-events.txt
+++ b/Tests/LibWeb/Text/expected/DOM/cancelable-events.txt
@@ -1,0 +1,4 @@
+event=test1 cancelable=false
+event=test2 cancelable=true
+event=test3 cancelable=false
+event=test4 cancelable=true

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/events/event-global.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/events/event-global.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 8 tests
 
-7 Pass
-1 Fail
+8 Pass
 Pass	event exists on window, which is initially set to undefined
 Pass	window.event is only defined during dispatch
 Pass	window.event is undefined if the target is in a shadow tree (event dispatched outside shadow tree)
 Pass	window.event is undefined if the target is in a shadow tree (event dispatched inside shadow tree)
-Fail	window.event is undefined inside window.onerror if the target is in a shadow tree (ErrorEvent dispatched inside shadow tree)
+Pass	window.event is undefined inside window.onerror if the target is in a shadow tree (ErrorEvent dispatched inside shadow tree)
 Pass	window.event is set to the current event during dispatch
 Pass	window.event is set to the current event, which is the event passed to dispatch
 Pass	window.event is set to the current event, which is the event passed to dispatch (2)

--- a/Tests/LibWeb/Text/input/DOM/cancelable-events.html
+++ b/Tests/LibWeb/Text/input/DOM/cancelable-events.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const printEvent = event => {
+            println(`event=${event.type} cancelable=${event.cancelable}`);
+        };
+
+        printEvent(new ErrorEvent("test1"));
+        printEvent(new ErrorEvent("test2", { cancelable: true }));
+
+        printEvent(new BufferedChangeEvent("test3"));
+        printEvent(new BufferedChangeEvent("test4", { cancelable: true }));
+    });
+</script>


### PR DESCRIPTION
Otherwise, information stored in the base event init dictionary will be dropped.