### PR TITLE
LibWeb/Layout: Vector lookup overflow on responsive resize

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -316,14 +316,17 @@ void LayoutState::commit(Box& root)
         auto& paintable = as<Painting::PaintableBox>(*node.first_paintable());
         CSSPixelPoint offset;
 
-        if (used_values.containing_line_box_fragment.has_value()) {
+        if (used_values.containing_line_box_fragment.has_value() && get(*node.containing_block()).line_boxes.size() > 0) {
             // Atomic inline case:
             // We know that `node` is an atomic inline because `containing_line_box_fragments` refers to the
             // line box fragment in the parent block container that contains it.
             auto const& containing_line_box_fragment = used_values.containing_line_box_fragment.value();
             auto const& containing_block = *node.containing_block();
             auto const& containing_block_used_values = get(containing_block);
-            auto const& fragment = containing_block_used_values.line_boxes[containing_line_box_fragment.line_box_index].fragments()[containing_line_box_fragment.fragment_index];
+
+            auto const& fragments = containing_block_used_values.line_boxes[containing_line_box_fragment.line_box_index].fragments();
+            // FIXME: Maybe protect or assert below against vector overflow.
+            auto const& fragment = fragments[containing_line_box_fragment.fragment_index];
 
             // The fragment has the final offset for the atomic inline, so we just need to copy it from there.
             offset = fragment.offset();

--- a/Tests/LibWeb/Layout/expected/crash-tests/image-body-style-cssfloat-change.txt
+++ b/Tests/LibWeb/Layout/expected/crash-tests/image-body-style-cssfloat-change.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x150 [BFC] children: inline
+    frag 0 from ImageBox start: 0, length: 0, rect: [0,0 300x150] baseline: 150
+    TextNode <#text>
+    BlockContainer <body.right.none> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+      ImageBox <img#red_dot> at (0,0) content-size 300x150 children: not-inline
+        (SVG-as-image isolated context)
+        Viewport <#document> at (0,0) content-size 300x150 [BFC] children: not-inline
+          SVGSVGBox <svg> at (0,0) content-size 300x150 [SVG] children: not-inline
+            SVGGeometryBox <circle> at (0,0) content-size 40x40 children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x150]
+    PaintableWithLines (BlockContainer<BODY>.right.none) [0,0 800x0]
+      ImagePaintable (ImageBox<IMG>#red_dot) [0,0 300x150]

--- a/Tests/LibWeb/Layout/input/crash-tests/image-body-style-cssfloat-change.html
+++ b/Tests/LibWeb/Layout/input/crash-tests/image-body-style-cssfloat-change.html
@@ -1,0 +1,22 @@
+<!doctype html>
+  <head>
+    <style>
+      .right {
+        float: right;
+      }
+      .none {
+        float: none;
+      }
+    </style>
+    <script>
+      function onBodyLoad(){
+        // Confirms that a change to body.style.cssFloat (body contains an image) after the body was loaded no longer results in a Vector index overflow.
+        const r = document.getElementById("red_dot").getBoundingClientRect(); // For some reason, without this line, the script terminates before crashing most of the time.
+        document.body.classList.add("none"); // Regression: Vector index overflow.
+      }
+    </script>
+  </head>
+  <body class="right" onload="onBodyLoad()">
+    <img id="red_dot" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><circle style='fill:red' cx='20' cy='20' r='20'/></svg>"/>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #3976:
- Triggered on relayout when changing the size or zoom level for a responsive document.
- An image node's containing block switches between alignments on a new size.
- The image node is not included in the containing block's line boxes.

There is another unprotected vector lookup below. Seems like that one is logically sound (`fragment_index` from `linebox_index`) so I didn't protect or assert that, but added a FIXME.

Added a test (crash before; success now).