### PR TITLE
Meta: Increase max open file descriptors in WPT.sh

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -184,6 +184,11 @@ update_wpt() {
 }
 
 execute_wpt() {
+    # Ensure open files limit is at least 1024, so the WPT runner does not run out of descriptors
+    if [ "$(ulimit -n)" -lt 1024 ]; then
+        ulimit -S -n 1024
+    fi
+
     pushd "${WPT_SOURCE_DIR}" > /dev/null
         for certificate_path in "${WPT_CERTIFICATES[@]}"; do
             if [ ! -f "${certificate_path}" ]; then


### PR DESCRIPTION
On some macs, the default maximum number of file descriptors is 256. This quickly makes the WPT runner run out of descriptors, so let's check the active value and increase the soft limit if necessary.