### PR TITLE
LibWeb: Ignore non-box element while collecting abspos nodes for layout

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1329,7 +1329,7 @@ void Document::update_layout(UpdateLayoutReason reason)
     });
 
     // Assign each box that establishes a formatting context a list of absolutely positioned children it should take care of during layout
-    m_layout_root->for_each_in_inclusive_subtree([&](auto& child) {
+    m_layout_root->for_each_in_inclusive_subtree_of_type<Layout::Box>([&](auto& child) {
         if (!child.is_absolutely_positioned())
             return TraversalDecision::Continue;
         if (auto* containing_block = child.containing_block()) {

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-br.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-br.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
+          "a"
+      frag 1 from TextNode start: 0, length: 1, rect: [17.34375,8 9.46875x17] baseline: 13.296875
+          "b"
+      TextNode <#text>
+      BreakNode <br>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-br.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-br.html
@@ -1,0 +1,1 @@
+a<br style="position:absolute;">b


### PR DESCRIPTION
All abspos boxes are expected to be blockified, so we are certain that we can ignore non-box elements when collecting abspos nodes for layout.

Fixes a crash caused by an attempt to cast a BreakNode to a Box while performing abspos layout.