### PR TITLE
AK: Inline more of the String and FlyString member functions

### DIFF
--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -79,16 +79,6 @@ FlyString& FlyString::operator=(String const& string)
     return *this;
 }
 
-bool FlyString::is_empty() const
-{
-    return bytes_as_string_view().is_empty();
-}
-
-unsigned FlyString::hash() const
-{
-    return m_data.hash();
-}
-
 u32 FlyString::ascii_case_insensitive_hash() const
 {
     return case_insensitive_string_hash(reinterpret_cast<char const*>(bytes().data()), bytes().size());
@@ -108,21 +98,6 @@ String FlyString::to_string() const
 Utf8View FlyString::code_points() const
 {
     return Utf8View { bytes_as_string_view() };
-}
-
-ReadonlyBytes FlyString::bytes() const
-{
-    return bytes_as_string_view().bytes();
-}
-
-StringView FlyString::bytes_as_string_view() const
-{
-    return m_data.bytes();
-}
-
-bool FlyString::operator==(String const& other) const
-{
-    return m_data == other;
 }
 
 bool FlyString::operator==(StringView string) const

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -32,19 +32,19 @@ public:
     FlyString(String const&);
     FlyString& operator=(String const&);
 
-    [[nodiscard]] bool is_empty() const;
-    [[nodiscard]] unsigned hash() const;
+    [[nodiscard]] bool is_empty() const { return m_data.byte_count() == 0; }
+    [[nodiscard]] unsigned hash() const { return m_data.hash(); }
     [[nodiscard]] u32 ascii_case_insensitive_hash() const;
 
     explicit operator String() const;
     String to_string() const;
 
     [[nodiscard]] Utf8View code_points() const;
-    [[nodiscard]] ReadonlyBytes bytes() const;
-    [[nodiscard]] StringView bytes_as_string_view() const;
+    [[nodiscard]] ReadonlyBytes bytes() const { return m_data.bytes(); }
+    [[nodiscard]] StringView bytes_as_string_view() const { return m_data.bytes(); }
 
     [[nodiscard]] ALWAYS_INLINE bool operator==(FlyString const& other) const { return m_data.raw({}) == other.m_data.raw({}); }
-    [[nodiscard]] bool operator==(String const&) const;
+    [[nodiscard]] bool operator==(String const& other) const { return m_data == other; }
     [[nodiscard]] bool operator==(StringView) const;
     [[nodiscard]] bool operator==(char const*) const;
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -156,16 +156,6 @@ ErrorOr<String> String::repeated(u32 code_point, size_t count)
     return result;
 }
 
-StringView String::bytes_as_string_view() const&
-{
-    return StringView(bytes());
-}
-
-bool String::is_empty() const
-{
-    return bytes().size() == 0;
-}
-
 ErrorOr<String> String::vformatted(StringView fmtstr, TypeErasedFormatParams& params)
 {
     StringBuilder builder;

--- a/AK/String.h
+++ b/AK/String.h
@@ -138,10 +138,10 @@ public:
     [[nodiscard]] Utf8View code_points() const&& = delete;
 
     // Returns true if the String is zero-length.
-    [[nodiscard]] bool is_empty() const;
+    [[nodiscard]] bool is_empty() const { return byte_count() == 0; }
 
     // Returns a StringView covering the full length of the string. Note that iterating this will go byte-at-a-time, not code-point-at-a-time.
-    [[nodiscard]] StringView bytes_as_string_view() const&;
+    [[nodiscard]] StringView bytes_as_string_view() const& { return StringView(bytes()); }
     [[nodiscard]] StringView bytes_as_string_view() const&& = delete;
 
     [[nodiscard]] size_t count(StringView needle) const { return StringUtils::count(bytes_as_string_view(), needle); }


### PR DESCRIPTION
This is to help recover some of the performance regression from no longer using DeprecatedFlyString (which was aggressively inlined.)