### PR TITLE
CI: Make JS Benchmarks use the JS repl from the job with the same commit

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -35,6 +35,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v9
         with:
           workflow: js-artifacts.yml
+          commit: ${{ github.sha }}
           name: ladybird-js-Linux-x86_64
           path: js-repl
 


### PR DESCRIPTION
In practice this does not make a big difference, but technically it could happen that a second JS Repl artifact was built before the first JS Benchmarks job is executed. So make sure to filter on commit ID.