### PR TITLE
AK: Don't try to free(UINTPTR_MAX) in StringData::operator delete()

### DIFF
--- a/AK/StringData.h
+++ b/AK/StringData.h
@@ -66,7 +66,12 @@ public:
 
     void operator delete(void* ptr)
     {
-        free(ptr);
+        if (is_constant_evaluated()) {
+            if (reinterpret_cast<uintptr_t>(ptr) != UINTPTR_MAX)
+                free(ptr);
+        } else {
+            free(ptr);
+        }
     }
 
     ~StringData()


### PR DESCRIPTION
Hopefully this will make GCC happier about building test262-runner and pals.