### PR TITLE
LibWeb: Cache "has size containment" flag in Layout::Box

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1321,6 +1321,9 @@ void Document::update_layout(UpdateLayoutReason reason)
     }
 
     m_layout_root->for_each_in_inclusive_subtree_of_type<Layout::Box>([&](auto& child) {
+        if (auto dom_node = child.dom_node(); dom_node && dom_node->is_element()) {
+            child.set_has_size_containment(as<Element>(*dom_node).has_size_containment());
+        }
         bool needs_layout_update = child.dom_node() && child.dom_node()->needs_layout_update();
         if (needs_layout_update || child.is_anonymous()) {
             child.reset_cached_intrinsic_sizes();

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -33,9 +33,8 @@ Optional<CSSPixels> Box::natural_width() const
     // https://drafts.csswg.org/css-contain-2/#containment-size
     // Replaced elements must be treated as having a natural width and height of 0 and no natural aspect
     // ratio.
-    if (dom_node() && dom_node()->is_element() && as<DOM::Element>(dom_node())->has_size_containment())
+    if (m_has_size_containment)
         return 0;
-
     return m_natural_width;
 }
 Optional<CSSPixels> Box::natural_height() const
@@ -43,9 +42,8 @@ Optional<CSSPixels> Box::natural_height() const
     // https://drafts.csswg.org/css-contain-2/#containment-size
     // Replaced elements must be treated as having a natural width and height of 0 and no natural aspect
     // ratio.
-    if (dom_node() && dom_node()->is_element() && as<DOM::Element>(dom_node())->has_size_containment())
+    if (m_has_size_containment)
         return 0;
-
     return m_natural_height;
 }
 Optional<CSSPixelFraction> Box::natural_aspect_ratio() const
@@ -53,9 +51,8 @@ Optional<CSSPixelFraction> Box::natural_aspect_ratio() const
     // https://drafts.csswg.org/css-contain-2/#containment-size
     // Replaced elements must be treated as having a natural width and height of 0 and no natural aspect
     // ratio.
-    if (dom_node() && dom_node()->is_element() && as<DOM::Element>(dom_node())->has_size_containment())
+    if (m_has_size_containment)
         return {};
-
     return m_natural_aspect_ratio;
 }
 

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -40,6 +40,9 @@ public:
     bool has_natural_height() const { return natural_height().has_value(); }
     bool has_natural_aspect_ratio() const { return natural_aspect_ratio().has_value(); }
 
+    bool has_size_containment() const { return m_has_size_containment; }
+    void set_has_size_containment(bool value) { m_has_size_containment = value; }
+
     void set_natural_width(Optional<CSSPixels> width) { m_natural_width = width; }
     void set_natural_height(Optional<CSSPixels> height) { m_natural_height = height; }
     void set_natural_aspect_ratio(Optional<CSSPixelFraction> ratio) { m_natural_aspect_ratio = ratio; }
@@ -78,6 +81,8 @@ private:
     Optional<CSSPixels> m_natural_width;
     Optional<CSSPixels> m_natural_height;
     Optional<CSSPixelFraction> m_natural_aspect_ratio;
+
+    bool m_has_size_containment { false };
 
     Vector<GC::Ref<Node>> m_contained_abspos_children;
 


### PR DESCRIPTION
Allows us to avoid DOM node lookup whenever we need to query natural size of a box during layout.

Makes 3-4% of `Box::preferred_aspect_ratio()` go away from profiles on www.nyan.cat