### PR TITLE
LibWeb/Layout: Properly remove layout nodes

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -448,6 +448,10 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
             dom_node.for_each_in_inclusive_subtree([&](auto& node) {
                 node.set_needs_layout_tree_update(false);
                 node.set_child_needs_layout_tree_update(false);
+                auto layout_node = node.layout_node();
+                if (layout_node && layout_node->parent()) {
+                    layout_node->remove();
+                }
                 node.detach_layout_node({});
                 node.clear_paintable();
                 if (is<DOM::Element>(node))

--- a/Tests/LibWeb/Crash/wpt-import/accessibility/crashtests/aria-owns-fallback-content.html
+++ b/Tests/LibWeb/Crash/wpt-import/accessibility/crashtests/aria-owns-fallback-content.html
@@ -1,0 +1,19 @@
+<html class="test-wait">
+<body>
+<div aria-owns="id1"></div>
+<video>
+  <mark>
+    <span id='id1'></span>
+  </mark>
+</video>
+</body>
+<script>
+window.onload = () => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document.documentElement.style.display = 'none';
+      document.documentElement.className = '';
+    });
+  });
+}
+</script>


### PR DESCRIPTION
This properly remove the old layout node subtree when no new layout node is created during layout update.

This prevents ladybird from crashing when the document element has no layout node, e.g. when `display: none`. Previously, the layout node of the document element and its descendants were not removed from the layout tree and ladybird crashed when trying to resolve lengths in that subtree.