### PR TITLE
LibWeb: Fix scroll offset application for SVG root box

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -103,11 +103,11 @@ void StackingContext::paint_svg(PaintContext& context, PaintableBox const& paint
     if (phase != PaintPhase::Foreground)
         return;
 
-    paintable.apply_clip_overflow_rect(context, PaintPhase::Foreground);
+    paintable.before_paint(context, PaintPhase::Foreground);
     paint_node(paintable, context, PaintPhase::Background);
     paint_node(paintable, context, PaintPhase::Border);
     SVGSVGPaintable::paint_svg_box(context, paintable, phase);
-    paintable.clear_clip_overflow_rect(context, PaintPhase::Foreground);
+    paintable.after_paint(context, PaintPhase::Foreground);
 }
 
 void StackingContext::paint_descendants(PaintContext& context, Paintable const& paintable, StackingContextPaintPhase phase)

--- a/Tests/LibWeb/Ref/expected/scrolled-svg-path-with-transform.html
+++ b/Tests/LibWeb/Ref/expected/scrolled-svg-path-with-transform.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<style>
+body {
+    margin: 0px;
+    height: 5000px;
+    transform: translate(0, -100px);
+}
+.rotate {
+    transform: rotate(180deg);
+    outline: 1px solid black;
+}
+</style><body style="overflow: auto"><svg class="rotate"><path d="M22 13.5H6.3l5.5 7.5H8.3l-6.5-9 6.5-9h3.5l-5.5 7.5H22v3z">

--- a/Tests/LibWeb/Ref/input/scrolled-svg-path-with-transform.html
+++ b/Tests/LibWeb/Ref/input/scrolled-svg-path-with-transform.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<link rel="match" href="../expected/scrolled-svg-path-with-transform.html" />
+<style>
+body {
+    margin: 0px;
+    height: 5000px;
+}
+.rotate {
+    transform: rotate(180deg);
+    outline: 1px solid black;
+}
+</style><body style="overflow: auto"><svg class="rotate"><path d="M22 13.5H6.3l5.5 7.5H8.3l-6.5-9 6.5-9h3.5l-5.5 7.5H22v3z">
+<script>
+    window.scrollBy(0, 100);
+</script>


### PR DESCRIPTION
Now we use `before_paint()` and `after_paint()` calls for SVG root box to make sure that both clip and scroll are applied.

Fixes painting of SVG arrows on www.ubereats.com