### PR TITLE
LibWeb: Fix and improve float positioning behavior

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-initial-available-space-vs-height.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-initial-available-space-vs-height.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x413 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x5 children: not-inline
+      BlockContainer <div.a> at (8,8) content-size 100x5 children: inline
+        frag 0 from TextNode start: 1, length: 1, rect: [8,8 4.328125x5] baseline: 4
+            "H"
+        TextNode <#text>
+        BlockContainer <div.b.l> at (8,13) content-size 100x100 floating [BFC] children: not-inline
+        TextNode <#text>
+        BlockContainer <div.c.l> at (8,113) content-size 30x300 floating [BFC] children: not-inline
+        TextNode <#text>
+        BlockContainer <div.c.r> at (78,113) content-size 30x300 floating [BFC] children: not-inline
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,13) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x413]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x5]
+      PaintableWithLines (BlockContainer<DIV>.a) [8,8 100x5]
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.b.l) [8,13 100x100]
+        PaintableWithLines (BlockContainer<DIV>.c.l) [8,113 30x300]
+        PaintableWithLines (BlockContainer<DIV>.c.r) [78,113 30x300]
+      PaintableWithLines (BlockContainer(anonymous)) [8,13 784x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-vertical-clearance-ignores-opposite-side.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-vertical-clearance-ignores-opposite-side.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
+      BlockContainer <div.a> at (8,8) content-size 500x200 children: inline
+        TextNode <#text>
+        BlockContainer <div.b> at (8,8) content-size 200x150 floating [BFC] children: not-inline
+        TextNode <#text>
+        BlockContainer <div.c> at (308,8) content-size 200x100 floating [BFC] children: not-inline
+        TextNode <#text>
+        BlockContainer <div.d> at (308,108) content-size 200x100 floating [BFC] children: not-inline
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>.a) [8,8 500x200]
+        PaintableWithLines (BlockContainer<DIV>.b) [8,8 200x150]
+        PaintableWithLines (BlockContainer<DIV>.c) [308,8 200x100]
+        PaintableWithLines (BlockContainer<DIV>.d) [308,108 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-initial-available-space-vs-height.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-initial-available-space-vs-height.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+.a {
+    font-size: 5px;
+    width: 100px;
+}
+.b {
+    background-color: blue;
+    height: 100px;
+    width: 100px;
+}
+.c {
+    background-color: yellow;
+    height: 300px;
+    width: 30px;
+}
+.l {
+    float: left;
+}
+.r {
+    float: right;
+}
+</style>
+<div class="a">
+    H
+    <div class="b l"></div>
+    <div class="c l"></div>
+    <div class="c r"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-vertical-clearance-ignores-opposite-side.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-vertical-clearance-ignores-opposite-side.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style>
+.a {
+    height: 200px;
+    width: 500px;
+}
+.b {
+    float: left;
+    background: red;
+    height: 150px;
+    width: 200px;
+}
+.c {
+    float: right;
+    background: green;
+    height: 100px;
+    width: 200px;
+}
+.d {
+    float: right;
+    background: blue;
+    height: 100px;
+    width: 200px;
+}
+</style>
+<div class="a">
+    <div class="b"></div>
+    <div class="c"></div>
+    <div class="d"></div>
+</div>


### PR DESCRIPTION
Our recent change to get rid of the "move 1px at a time" algorithm in the float positioning logic introduced the issue that potentially intersecting float boxes were not evaluated in order anymore. This could result in float boxes being pushed down further than strictly necessary.

By finding the highest point we can move the floating box to and repeating the process until we're no longer intersecting any floating box, we also solve some edge cases like intersecting with very long floating boxes whose edges lay outside the current box' edges.

This is by no means the most efficient solution, but it is more correct than what we had until now.

Fixes #4110.