### PR TITLE
Tests: Remove print statement from crash test

### DIFF
--- a/Tests/LibWeb/Crash/JS/finalization-registry-basic.html
+++ b/Tests/LibWeb/Crash/JS/finalization-registry-basic.html
@@ -14,6 +14,4 @@ makeGarbage();
 
 if (window.internals !== undefined)
     internals.gc();
-
-println("PASS");
 </script>


### PR DESCRIPTION
Print statements aren't necessary in crash tests and will cause a Javascript error when used.