### PR TITLE
LibWeb: Copy IDBDatabase object stores through `Vector(ReadonlySpan)`

### DIFF
--- a/Libraries/LibWeb/IndexedDB/IDBDatabase.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBDatabase.cpp
@@ -21,7 +21,7 @@ IDBDatabase::IDBDatabase(JS::Realm& realm, Database& db)
     , m_associated_database(db)
 {
     db.associate(*this);
-    db.object_stores().copy_to(m_object_store_set);
+    m_object_store_set = Vector<GC::Ref<ObjectStore>> { db.object_stores() };
 }
 
 IDBDatabase::~IDBDatabase() = default;


### PR DESCRIPTION
Prevents a crash because `ReadonlySpan.copy_to()` was trying to copy to an empty vector.

Fixes #4127.