### PR TITLE
Tests: Update FileWatcher's test timeouts

### DIFF
--- a/Tests/LibCore/TestLibCoreFileWatcher.cpp
+++ b/Tests/LibCore/TestLibCoreFileWatcher.cpp
@@ -16,9 +16,9 @@
 #include <unistd.h>
 
 #ifdef AK_OS_MACOS
-constexpr int TIMEOUT_PER_STEP_IN_MS = 500;
+constexpr int TIMEOUT_PER_STEP_IN_MS = 350;
 #else
-constexpr int TIMEOUT_PER_STEP_IN_MS = 50;
+constexpr int TIMEOUT_PER_STEP_IN_MS = 75;
 #endif
 
 TEST_CASE(file_watcher_child_events)


### PR DESCRIPTION
Increase the step timeouts on Linux from 50 to 75 milliseconds, since we're seeing the occasional timeout on CI. For macOS, we should probably be able to execute the tests a bit quicker than 500ms per step.