### PR TITLE
Respect min/max-content available size in auto width calculation

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -265,6 +265,12 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
                     } else {
                         width = zero_value;
                     }
+                } else if (available_space.width.is_min_content()) {
+                    width = CSS::Length::make_px(calculate_min_content_width(box));
+                } else if (available_space.width.is_max_content()) {
+                    width = CSS::Length::make_px(calculate_max_content_width(box));
+                } else {
+                    VERIFY_NOT_REACHED();
                 }
             } else {
                 if (!margin_left.is_auto() && !margin_right.is_auto()) {
@@ -304,8 +310,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto max_width = calculate_inner_width(box, remaining_available_space.width, computed_values.max_width());
-        auto used_width_px = used_width.is_auto() ? CSSPixels { 0 } : used_width.to_px(box);
-        if (used_width_px > max_width) {
+        if (used_width.to_px(box) > max_width) {
             used_width = try_compute_width(CSS::Length::make_px(max_width));
         }
     }

--- a/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-block-level-box-that-creates-fc.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/max-width-on-block-level-box-that-creates-fc.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div.a> at (8,8) content-size 100x85 positioned [BFC] children: not-inline
+        Box <div.b> at (8,8) content-size 100x85 flex-container(row) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (8,8) content-size 105.5625x85 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 11, rect: [8,8 98x17] baseline: 13.296875
+                "foo bar baz"
+            frag 1 from TextNode start: 12, length: 11, rect: [8,25 97.640625x17] baseline: 13.296875
+                "lorem ipsum"
+            frag 2 from TextNode start: 24, length: 9, rect: [8,42 70.40625x17] baseline: 13.296875
+                "dolor sit"
+            frag 3 from TextNode start: 34, length: 4, rect: [8,59 37.125x17] baseline: 13.296875
+                "amet"
+            frag 4 from TextNode start: 39, length: 12, rect: [8,76 105.5625x17] baseline: 13.296875
+                "consectetuer"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.a) [8,8 100x85] overflow: [8,8 105.5625x85]
+        PaintableBox (Box<DIV>.b) [8,8 100x85] overflow: [8,8 105.5625x85]
+          PaintableWithLines (BlockContainer(anonymous)) [8,8 105.5625x85]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/max-width-on-block-level-box-that-creates-fc.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/max-width-on-block-level-box-that-creates-fc.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+.a {
+    background: red;
+    position: fixed;
+}
+.b {
+    background: green;
+    display: flex;
+    max-width: 100px;
+}
+</style>
+<div class="a"><div class="b">foo bar baz lorem ipsum dolor sit amet consectetuer


### PR DESCRIPTION
...for block level boxes. Otherwise we end up resolving auto width as
zero during intrinsic layout, which leads to incorrectly applied
max-width constraint.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4123