### PR TITLE
CI: Do not cancel in-progress JS artifact builds

### DIFF
--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -27,7 +27,6 @@ jobs:
 
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.os_name }}
-      cancel-in-progress: true
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird


### PR DESCRIPTION
It might be useful to have these artifacts, even for older commits. As an added bonus, this causes the JS benchmarks to run as well giving us more datapoints.