### PR TITLE
LibJS: Optimize away Mov instructions when the source is the destination

### DIFF
--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -334,7 +334,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> LogicalExpression::gene
 
     generator.switch_to_basic_block(rhs_block);
 
-    auto rhs = TRY(m_rhs->generate_bytecode(generator)).value();
+    auto rhs = TRY(m_rhs->generate_bytecode(generator, dst)).value();
 
     generator.emit_mov(dst, rhs);
     generator.emit<Bytecode::Op::Jump>(Bytecode::Label { end_block });

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -127,6 +127,18 @@ public:
         emit_with_extra_slots<OpType, Value>(extra_operand_slots, forward<Args>(args)...);
     }
 
+    void emit_mov(ScopedOperand const& dst, ScopedOperand const& src)
+    {
+        // Optimize away when the source is the destination
+        if (dst != src)
+            emit<Op::Mov>(dst, src);
+    }
+
+    void emit_mov(Operand const& dst, Operand const& src)
+    {
+        emit<Op::Mov>(dst, src);
+    }
+
     void emit_jump_if(ScopedOperand const& condition, Label true_target, Label false_target);
 
     struct ReferenceOperands {


### PR DESCRIPTION
I noticed that around ~30% of `Mov` instructions generated are redundant because the source and the destination is the same `ScopedOperand`.

Here are some numbers I gathered:

ReactJS homepage: 1987/7352 = 27% redundancy
LibJS test suite: 1492/5026 = 30% redundancy

My theory is that it is due to this kind of successive calls:
```c++
auto dst = choose_dst(generator, preferred_dst);
auto lhs = TRY(m_lhs->generate_bytecode(generator, preferred_dst)).value();
generator.emit_mov(dst, lhs);
```
where `generate_bytecode` tries to put his output in `dst` and the `Mov` should act as a fallback (if I understand correctly).

To test my theory I added a preferred destination in another place where I saw the pattern above (in my subsequent commit).
The number of `Mov`s between scoped operands in LibJS test suite went from `5018` to `3530` !!