### PR TITLE
LibJS: Remove ByteString internals from PrimitiveString

### DIFF
--- a/Libraries/LibJS/Contrib/Test262/262Object.cpp
+++ b/Libraries/LibJS/Contrib/Test262/262Object.cpp
@@ -87,7 +87,7 @@ JS_DEFINE_NATIVE_FUNCTION($262Object::detach_array_buffer)
 
 JS_DEFINE_NATIVE_FUNCTION($262Object::eval_script)
 {
-    auto source_text = TRY(vm.argument(0).to_byte_string(vm));
+    auto source_text = TRY(vm.argument(0).to_string(vm));
 
     // 1. Let hostDefined be any host-defined values for the provided sourceText (obtained in an implementation dependent manner)
 

--- a/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
+++ b/Libraries/LibJS/Contrib/Test262/GlobalObject.cpp
@@ -36,7 +36,7 @@ void GlobalObject::visit_edges(Cell::Visitor& visitor)
 
 JS_DEFINE_NATIVE_FUNCTION(GlobalObject::print)
 {
-    auto string = TRY(vm.argument(0).to_byte_string(vm));
+    auto string = TRY(vm.argument(0).to_string(vm));
     outln("{}", string);
     return js_undefined();
 }

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -583,7 +583,7 @@ ThrowCompletionOr<Value> perform_eval(VM& vm, Value x, CallerMode strict_caller,
         .in_class_field_initializer = in_class_field_initializer,
     };
 
-    Parser parser { Lexer { code_string.byte_string() }, Program::Type::Script, move(initial_state) };
+    Parser parser { Lexer { code_string.utf8_string_view() }, Program::Type::Script, move(initial_state) };
     auto program = parser.parse_program(strict_caller == CallerMode::Strict);
 
     //     b. If script is a List of errors, throw a SyntaxError exception.

--- a/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
@@ -55,7 +55,7 @@ ThrowCompletionOr<GC::Ref<Object>> AggregateErrorConstructor::construct(Function
     // 3. If message is not undefined, then
     if (!message.is_undefined()) {
         // a. Let msg be ? ToString(message).
-        auto msg = TRY(message.to_byte_string(vm));
+        auto msg = TRY(message.to_string(vm));
 
         // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
         aggregate_error->create_non_enumerable_data_property_or_throw(vm.names.message, PrimitiveString::create(vm, msg));

--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -1213,11 +1213,11 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::symbol_to_primitive)
     auto hint_value = vm.argument(0);
     if (!hint_value.is_string())
         return vm.throw_completion<TypeError>(ErrorType::InvalidHint, hint_value.to_string_without_side_effects());
-    auto hint = hint_value.as_string().byte_string();
+    auto hint = hint_value.as_string().utf8_string_view();
     Value::PreferredType try_first;
-    if (hint == "string" || hint == "default")
+    if (hint == "string"sv || hint == "default"sv)
         try_first = Value::PreferredType::String;
-    else if (hint == "number")
+    else if (hint == "number"sv)
         try_first = Value::PreferredType::Number;
     else
         return vm.throw_completion<TypeError>(ErrorType::InvalidHint, hint);

--- a/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -92,7 +92,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_exponential)
 
     // 4. If x is not finite, return Number::toString(x).
     if (!number_value.is_finite_number())
-        return PrimitiveString::create(vm, MUST(number_value.to_byte_string(vm)));
+        return PrimitiveString::create(vm, MUST(number_value.to_string(vm)));
 
     // 5. If f < 0 or f > 100, throw a RangeError exception.
     if (fraction_digits < 0 || fraction_digits > 100)
@@ -220,7 +220,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_fixed)
 
     // 6. If x is not finite, return Number::toString(x).
     if (!number_value.is_finite_number())
-        return PrimitiveString::create(vm, TRY(number_value.to_byte_string(vm)));
+        return PrimitiveString::create(vm, TRY(number_value.to_string(vm)));
 
     // 7. Set x to ℝ(x).
     auto number = number_value.as_double();
@@ -236,7 +236,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_fixed)
     // 10. If x ≥ 10^21, then
     //     a. Let m be ! ToString(𝔽(x)).
     if (number >= 1e+21)
-        return PrimitiveString::create(vm, MUST(number_value.to_byte_string(vm)));
+        return PrimitiveString::create(vm, MUST(number_value.to_string(vm)));
 
     // 11. Else,
     //     a. Let n be an integer for which n / (10^f) - x is as close to zero as possible. If there are two such n, pick the larger n.
@@ -289,14 +289,14 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_precision)
 
     // 2. If precision is undefined, return ! ToString(x).
     if (precision_value.is_undefined())
-        return PrimitiveString::create(vm, MUST(number_value.to_byte_string(vm)));
+        return PrimitiveString::create(vm, MUST(number_value.to_string(vm)));
 
     // 3. Let p be ? ToIntegerOrInfinity(precision).
     auto precision = TRY(precision_value.to_integer_or_infinity(vm));
 
     // 4. If x is not finite, return Number::toString(x).
     if (!number_value.is_finite_number())
-        return PrimitiveString::create(vm, MUST(number_value.to_byte_string(vm)));
+        return PrimitiveString::create(vm, MUST(number_value.to_string(vm)));
 
     // 5. If p < 1 or p > 100, throw a RangeError exception.
     if ((precision < 1) || (precision > 100))
@@ -428,7 +428,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_string)
 
     // 5. If radixMV = 10, return ! ToString(x).
     if (radix_mv == 10)
-        return PrimitiveString::create(vm, MUST(number_value.to_byte_string(vm)));
+        return PrimitiveString::create(vm, MUST(number_value.to_string(vm)));
 
     // 6. Return the String representation of this Number value using the radix specified by radixMV. Letters a-z are used for digits with values 10 through 35. The precise algorithm is implementation-defined, however the algorithm should be a generalization of that specified in 6.1.6.1.20.
     if (number_value.is_positive_infinity())

--- a/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -147,53 +147,53 @@ JS_DEFINE_NATIVE_FUNCTION(ObjectPrototype::to_string)
     // 4. Let isArray be ? IsArray(O).
     auto is_array = TRY(Value(object).is_array(vm));
 
-    ByteString builtin_tag;
+    StringView builtin_tag;
 
     // 5. If isArray is true, let builtinTag be "Array".
     if (is_array)
-        builtin_tag = "Array";
+        builtin_tag = "Array"sv;
     // 6. Else if O has a [[ParameterMap]] internal slot, let builtinTag be "Arguments".
     else if (object->has_parameter_map())
-        builtin_tag = "Arguments";
+        builtin_tag = "Arguments"sv;
     // 7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
     else if (object->is_function())
-        builtin_tag = "Function";
+        builtin_tag = "Function"sv;
     // 8. Else if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
     else if (is<Error>(*object))
-        builtin_tag = "Error";
+        builtin_tag = "Error"sv;
     // 9. Else if O has a [[BooleanData]] internal slot, let builtinTag be "Boolean".
     else if (is<BooleanObject>(*object))
-        builtin_tag = "Boolean";
+        builtin_tag = "Boolean"sv;
     // 10. Else if O has a [[NumberData]] internal slot, let builtinTag be "Number".
     else if (is<NumberObject>(*object))
-        builtin_tag = "Number";
+        builtin_tag = "Number"sv;
     // 11. Else if O has a [[StringData]] internal slot, let builtinTag be "String".
     else if (is<StringObject>(*object))
-        builtin_tag = "String";
+        builtin_tag = "String"sv;
     // 12. Else if O has a [[DateValue]] internal slot, let builtinTag be "Date".
     else if (is<Date>(*object))
-        builtin_tag = "Date";
+        builtin_tag = "Date"sv;
     // 13. Else if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
     else if (is<RegExpObject>(*object))
-        builtin_tag = "RegExp";
+        builtin_tag = "RegExp"sv;
     // 14. Else, let builtinTag be "Object".
     else
-        builtin_tag = "Object";
+        builtin_tag = "Object"sv;
 
     // 15. Let tag be ? Get(O, @@toStringTag).
     auto to_string_tag = TRY(object->get(vm.well_known_symbol_to_string_tag()));
 
     // Optimization: Instead of creating another PrimitiveString from builtin_tag, we separate tag and to_string_tag and add an additional branch to step 16.
-    ByteString tag;
+    StringView tag;
 
     // 16. If Type(tag) is not String, set tag to builtinTag.
     if (!to_string_tag.is_string())
-        tag = move(builtin_tag);
+        tag = builtin_tag;
     else
-        tag = to_string_tag.as_string().byte_string();
+        tag = to_string_tag.as_string().utf8_string_view();
 
     // 17. Return the string-concatenation of "[object ", tag, and "]".
-    return PrimitiveString::create(vm, ByteString::formatted("[object {}]", tag));
+    return PrimitiveString::create(vm, MUST(String::formatted("[object {}]", tag)));
 }
 
 // 20.1.3.7 Object.prototype.valueOf ( ), https://tc39.es/ecma262/#sec-object.prototype.valueof

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2020-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
@@ -28,7 +27,6 @@ public:
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, Utf16String);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, String);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, FlyString const&);
-    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, ByteString);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, PrimitiveString&, PrimitiveString&);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, StringView);
 
@@ -43,9 +41,6 @@ public:
     [[nodiscard]] StringView utf8_string_view() const;
     bool has_utf8_string() const { return m_utf8_string.has_value(); }
 
-    [[nodiscard]] ByteString byte_string() const;
-    bool has_byte_string() const { return m_byte_string.has_value(); }
-
     [[nodiscard]] Utf16String utf16_string() const;
     [[nodiscard]] Utf16View utf16_string_view() const;
     bool has_utf16_string() const { return m_utf16_string.has_value(); }
@@ -55,7 +50,6 @@ public:
 private:
     explicit PrimitiveString(PrimitiveString&, PrimitiveString&);
     explicit PrimitiveString(String);
-    explicit PrimitiveString(ByteString);
     explicit PrimitiveString(Utf16String);
 
     virtual void visit_edges(Cell::Visitor&) override;
@@ -72,7 +66,6 @@ private:
     mutable GC::Ptr<PrimitiveString> m_rhs;
 
     mutable Optional<String> m_utf8_string;
-    mutable Optional<ByteString> m_byte_string;
     mutable Optional<Utf16String> m_utf16_string;
 };
 

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -481,7 +481,6 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::exec)
 // 22.2.6.4 get RegExp.prototype.flags, https://tc39.es/ecma262/#sec-get-regexp.prototype.flags
 JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::flags)
 {
-
     // 1. Let R be the this value.
     // 2. If Type(R) is not Object, throw a TypeError exception.
     auto regexp_object = TRY(this_object(vm));
@@ -513,7 +512,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::flags)
 #undef __JS_ENUMERATE
 
     // 20. Return result.
-    return PrimitiveString::create(vm, builder.to_byte_string());
+    return PrimitiveString::create(vm, builder.to_string_without_validation());
 }
 
 // 22.2.6.8 RegExp.prototype [ @@match ] ( string ), https://tc39.es/ecma262/#sec-regexp.prototype-@@match
@@ -530,7 +529,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
 
     // 4. Let flags be ? ToString(? Get(rx, "flags")).
     auto flags_value = TRY(regexp_object->get(vm.names.flags));
-    auto flags = TRY(flags_value.to_byte_string(vm));
+    auto flags = TRY(flags_value.to_string(vm));
 
     // 5. If flags does not contain "g", then
     if (!flags.contains('g')) {
@@ -573,7 +572,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match)
 
         // 1. Let matchStr be ? ToString(? Get(result, "0")).
         auto match_value = TRY(result.get(0));
-        auto match_str = TRY(match_value.to_byte_string(vm));
+        auto match_str = TRY(match_value.to_string(vm));
 
         // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), matchStr).
         MUST(array->create_data_property_or_throw(n, PrimitiveString::create(vm, match_str)));
@@ -606,7 +605,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_match_all)
 
     // 5. Let flags be ? ToString(? Get(R, "flags")).
     auto flags_value = TRY(regexp_object->get(vm.names.flags));
-    auto flags = TRY(flags_value.to_byte_string(vm));
+    auto flags = TRY(flags_value.to_string(vm));
 
     // Steps 9-12 are performed early so that flags can be moved.
 
@@ -651,13 +650,13 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
     // 6. If functionalReplace is false, then
     if (!replace_value.is_function()) {
         // a. Set replaceValue to ? ToString(replaceValue).
-        auto replace_string = TRY(replace_value.to_byte_string(vm));
+        auto replace_string = TRY(replace_value.to_string(vm));
         replace_value = PrimitiveString::create(vm, move(replace_string));
     }
 
     // 7. Let flags be ? ToString(? Get(rx, "flags")).
     auto flags_value = TRY(regexp_object->get(vm.names.flags));
-    auto flags = TRY(flags_value.to_byte_string(vm));
+    auto flags = TRY(flags_value.to_string(vm));
 
     // 8. If flags contains "g", let global be true. Otherwise, let global be false.
     bool global = flags.contains('g');
@@ -694,7 +693,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
 
         // 1. Let matchStr be ? ToString(? Get(result, "0")).
         auto match_value = TRY(result.get(vm, 0));
-        auto match_str = TRY(match_value.to_byte_string(vm));
+        auto match_str = TRY(match_value.to_string(vm));
 
         // 2. If matchStr is the empty String, then
         if (match_str.is_empty()) {
@@ -746,7 +745,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
             // ii. If capN is not undefined, then
             if (!capture.is_undefined()) {
                 // 1. Set capN to ? ToString(capN).
-                capture = PrimitiveString::create(vm, TRY(capture.to_byte_string(vm)));
+                capture = PrimitiveString::create(vm, TRY(capture.to_string(vm)));
             }
 
             // iii. Append capN as the last element of captures.
@@ -810,13 +809,13 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_replace)
 
     // 16. If nextSourcePosition ≥ lengthS, return accumulatedResult.
     if (next_source_position >= string.length_in_code_units())
-        return PrimitiveString::create(vm, accumulated_result.to_byte_string());
+        return PrimitiveString::create(vm, accumulated_result.to_string_without_validation());
 
     // 17. Return the string-concatenation of accumulatedResult and the substring of S from nextSourcePosition.
     auto substring = string.substring_view(next_source_position);
     accumulated_result.append(substring);
 
-    return PrimitiveString::create(vm, accumulated_result.to_byte_string());
+    return PrimitiveString::create(vm, accumulated_result.to_string_without_validation());
 }
 
 // 22.2.6.12 RegExp.prototype [ @@search ] ( string ), https://tc39.es/ecma262/#sec-regexp.prototype-@@search
@@ -901,7 +900,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
 
     // 5. Let flags be ? ToString(? Get(rx, "flags")).
     auto flags_value = TRY(regexp_object->get(vm.names.flags));
-    auto flags = TRY(flags_value.to_byte_string(vm));
+    auto flags = TRY(flags_value.to_string(vm));
 
     // 6. If flags contains "u" or flags contains "v", let unicodeMatching be true.
     // 7. Else, let unicodeMatching be false.
@@ -909,7 +908,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::symbol_split)
 
     // 8. If flags contains "y", let newFlags be flags.
     // 9. Else, let newFlags be the string-concatenation of flags and "y".
-    auto new_flags = flags.find('y').has_value() ? move(flags) : ByteString::formatted("{}y", flags);
+    auto new_flags = flags.bytes_as_string_view().find('y').has_value() ? move(flags) : MUST(String::formatted("{}y", flags));
 
     // 10. Let splitter be ? Construct(C, « rx, newFlags »).
     auto splitter = TRY(construct(vm, *constructor, regexp_object, PrimitiveString::create(vm, move(new_flags))));
@@ -1066,11 +1065,11 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpPrototype::to_string)
 
     // 3. Let pattern be ? ToString(? Get(R, "source")).
     auto source_attr = TRY(regexp_object->get(vm.names.source));
-    auto pattern = TRY(source_attr.to_byte_string(vm));
+    auto pattern = TRY(source_attr.to_string(vm));
 
     // 4. Let flags be ? ToString(? Get(R, "flags")).
     auto flags_attr = TRY(regexp_object->get(vm.names.flags));
-    auto flags = TRY(flags_attr.to_byte_string(vm));
+    auto flags = TRY(flags_attr.to_string(vm));
 
     // 5. Let result be the string-concatenation of "/", pattern, "/", and flags.
     // 6. Return result.

--- a/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
@@ -53,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpStringIteratorPrototype::next)
 
     auto match_object = TRY(match.to_object(vm));
     auto match_string_value = TRY(match_object->get(0));
-    auto match_string = TRY(match_string_value.to_byte_string(vm));
+    auto match_string = TRY(match_string_value.to_string(vm));
     if (match_string.is_empty()) {
         auto last_index_value = TRY(iterator->regexp_object().get(vm.names.lastIndex));
         auto last_index = TRY(last_index_value.to_length(vm));

--- a/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
@@ -51,7 +51,7 @@ JS_DEFINE_NATIVE_FUNCTION(ShadowRealmPrototype::evaluate)
     auto& eval_realm = object->shadow_realm();
 
     // 6. Return ? PerformShadowRealmEval(sourceText, callerRealm, evalRealm).
-    return perform_shadow_realm_eval(vm, source_text.as_string().byte_string(), *caller_realm, eval_realm);
+    return perform_shadow_realm_eval(vm, source_text.as_string().utf8_string_view(), *caller_realm, eval_realm);
 }
 
 // 3.4.2 ShadowRealm.prototype.importValue ( specifier, exportName ), https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.importvalue

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -75,14 +75,14 @@ VM::VM(OwnPtr<CustomData> custom_data, ErrorMessages error_messages)
     m_empty_string = m_heap.allocate<PrimitiveString>(String {});
 
     typeof_strings = {
-        .number = m_heap.allocate<PrimitiveString>("number"),
-        .undefined = m_heap.allocate<PrimitiveString>("undefined"),
-        .object = m_heap.allocate<PrimitiveString>("object"),
-        .string = m_heap.allocate<PrimitiveString>("string"),
-        .symbol = m_heap.allocate<PrimitiveString>("symbol"),
-        .boolean = m_heap.allocate<PrimitiveString>("boolean"),
-        .bigint = m_heap.allocate<PrimitiveString>("bigint"),
-        .function = m_heap.allocate<PrimitiveString>("function"),
+        .number = m_heap.allocate<PrimitiveString>("number"_string),
+        .undefined = m_heap.allocate<PrimitiveString>("undefined"_string),
+        .object = m_heap.allocate<PrimitiveString>("object"_string),
+        .string = m_heap.allocate<PrimitiveString>("string"_string),
+        .symbol = m_heap.allocate<PrimitiveString>("symbol"_string),
+        .boolean = m_heap.allocate<PrimitiveString>("boolean"_string),
+        .bigint = m_heap.allocate<PrimitiveString>("bigint"_string),
+        .function = m_heap.allocate<PrimitiveString>("function"_string),
     };
 
     for (size_t i = 0; i < single_ascii_character_strings.size(); ++i)

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -77,11 +77,6 @@ public:
         return m_string_cache;
     }
 
-    HashMap<ByteString, GC::Ptr<PrimitiveString>>& byte_string_cache()
-    {
-        return m_byte_string_cache;
-    }
-
     HashMap<Utf16String, GC::Ptr<PrimitiveString>>& utf16_string_cache()
     {
         return m_utf16_string_cache;
@@ -310,7 +305,6 @@ private:
     void set_well_known_symbols(WellKnownSymbols well_known_symbols) { m_well_known_symbols = move(well_known_symbols); }
 
     HashMap<String, GC::Ptr<PrimitiveString>> m_string_cache;
-    HashMap<ByteString, GC::Ptr<PrimitiveString>> m_byte_string_cache;
     HashMap<Utf16String, GC::Ptr<PrimitiveString>> m_utf16_string_cache;
 
     GC::Heap m_heap;

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -724,7 +724,7 @@ ThrowCompletionOr<Value> Value::to_number_slow_case(VM& vm) const
         return Value(as_bool() ? 1 : 0);
     // 6. If argument is a String, return StringToNumber(argument).
     case STRING_TAG:
-        return string_to_number(as_string().byte_string());
+        return string_to_number(as_string().utf8_string_view());
     // 7. Assert: argument is an Object.
     case OBJECT_TAG: {
         // 8. Let primValue be ? ToPrimitive(argument, number).
@@ -778,7 +778,7 @@ ThrowCompletionOr<GC::Ref<BigInt>> Value::to_bigint(VM& vm) const
         return primitive.as_bigint();
     case STRING_TAG: {
         // 1. Let n be ! StringToBigInt(prim).
-        auto bigint = string_to_bigint(vm, primitive.as_string().byte_string());
+        auto bigint = string_to_bigint(vm, primitive.as_string().utf8_string_view());
 
         // 2. If n is undefined, throw a SyntaxError exception.
         if (!bigint.has_value())
@@ -2226,7 +2226,7 @@ bool same_value_non_number(Value lhs, Value rhs)
     // 5. If x is a String, then
     if (lhs.is_string()) {
         // a. If x and y are exactly the same sequence of code units (same length and same code units at corresponding indices), return true; otherwise, return false.
-        return lhs.as_string().byte_string() == rhs.as_string().byte_string();
+        return lhs.as_string().utf8_string_view() == rhs.as_string().utf8_string_view();
     }
 
     // 3. If x is undefined, return true.
@@ -2307,7 +2307,7 @@ ThrowCompletionOr<bool> is_loosely_equal(VM& vm, Value lhs, Value rhs)
     // 7. If Type(x) is BigInt and Type(y) is String, then
     if (lhs.is_bigint() && rhs.is_string()) {
         // a. Let n be StringToBigInt(y).
-        auto bigint = string_to_bigint(vm, rhs.as_string().byte_string());
+        auto bigint = string_to_bigint(vm, rhs.as_string().utf8_string_view());
 
         // b. If n is undefined, return false.
         if (!bigint.has_value())
@@ -2388,8 +2388,8 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
 
     // 3. If px is a String and py is a String, then
     if (x_primitive.is_string() && y_primitive.is_string()) {
-        auto x_string = x_primitive.as_string().byte_string();
-        auto y_string = y_primitive.as_string().byte_string();
+        auto x_string = x_primitive.as_string().utf8_string_view();
+        auto y_string = y_primitive.as_string().utf8_string_view();
 
         Utf8View x_code_points { x_string };
         Utf8View y_code_points { y_string };
@@ -2424,7 +2424,7 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
     // a. If px is a BigInt and py is a String, then
     if (x_primitive.is_bigint() && y_primitive.is_string()) {
         // i. Let ny be StringToBigInt(py).
-        auto y_bigint = string_to_bigint(vm, y_primitive.as_string().byte_string());
+        auto y_bigint = string_to_bigint(vm, y_primitive.as_string().utf8_string_view());
 
         // ii. If ny is undefined, return undefined.
         if (!y_bigint.has_value())
@@ -2439,7 +2439,7 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
     // b. If px is a String and py is a BigInt, then
     if (x_primitive.is_string() && y_primitive.is_bigint()) {
         // i. Let nx be StringToBigInt(px).
-        auto x_bigint = string_to_bigint(vm, x_primitive.as_string().byte_string());
+        auto x_bigint = string_to_bigint(vm, x_primitive.as_string().utf8_string_view());
 
         // ii. If nx is undefined, return undefined.
         if (!x_bigint.has_value())

--- a/Libraries/LibJS/Runtime/ValueTraits.h
+++ b/Libraries/LibJS/Runtime/ValueTraits.h
@@ -17,10 +17,8 @@ struct ValueTraits : public Traits<Value> {
     static unsigned hash(Value value)
     {
         VERIFY(!value.is_empty());
-        if (value.is_string()) {
-            // FIXME: Propagate this error.
-            return value.as_string().byte_string().hash();
-        }
+        if (value.is_string())
+            return value.as_string().utf8_string().hash();
 
         if (value.is_bigint())
             return value.as_bigint().big_integer().hash();

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -238,7 +238,7 @@ WebIDL::ExceptionOr<Optional<URL::URL>> resolve_imports_match(ByteString const& 
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#resolving-a-url-like-module-specifier
-Optional<URL::URL> resolve_url_like_module_specifier(ByteString const& specifier, URL::URL const& base_url)
+Optional<URL::URL> resolve_url_like_module_specifier(StringView specifier, URL::URL const& base_url)
 {
     // 1. If specifier starts with "/", "./", or "../", then:
     if (specifier.starts_with("/"sv) || specifier.starts_with("./"sv) || specifier.starts_with("../"sv)) {

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -85,7 +85,7 @@ private:
 String module_type_from_module_request(JS::ModuleRequest const&);
 WebIDL::ExceptionOr<URL::URL> resolve_module_specifier(Optional<Script&> referring_script, String const& specifier);
 WebIDL::ExceptionOr<Optional<URL::URL>> resolve_imports_match(ByteString const& normalized_specifier, Optional<URL::URL> as_url, ModuleSpecifierMap const&);
-Optional<URL::URL> resolve_url_like_module_specifier(ByteString const& specifier, URL::URL const& base_url);
+Optional<URL::URL> resolve_url_like_module_specifier(StringView specifier, URL::URL const& base_url);
 ScriptFetchOptions get_descendant_script_fetch_options(ScriptFetchOptions const& original_options, URL::URL const& url, EnvironmentSettingsObject& settings_object);
 String resolve_a_module_integrity_metadata(URL::URL const& url, EnvironmentSettingsObject& settings_object);
 WebIDL::ExceptionOr<void> fetch_classic_script(GC::Ref<HTMLScriptElement>, URL::URL const&, EnvironmentSettingsObject& settings_object, ScriptFetchOptions options, CORSSettingAttribute cors_setting, String character_encoding, OnFetchScriptComplete on_complete);

--- a/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
@@ -147,7 +147,7 @@ WebIDL::ExceptionOr<ModuleSpecifierMap> sort_and_normalise_module_specifier_map(
         }
 
         // 4. Let addressURL be the result of resolving a URL-like module specifier given value and baseURL.
-        auto address_url = resolve_url_like_module_specifier(value.as_string().byte_string(), base_url);
+        auto address_url = resolve_url_like_module_specifier(value.as_string().utf8_string_view(), base_url);
 
         // 5. If addressURL is null, then:
         if (!address_url.has_value()) {

--- a/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
+++ b/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
@@ -71,7 +71,7 @@ JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalEnvironmentExtensions::$_function)
     auto* console_global_object = TRY(get_console(vm));
     auto& window = *console_global_object->m_window_object;
 
-    auto selector = TRY(vm.argument(0).to_byte_string(vm));
+    auto selector = TRY(vm.argument(0).to_string(vm));
 
     if (vm.argument_count() > 1) {
         auto element_value = vm.argument(1);
@@ -95,7 +95,7 @@ JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalEnvironmentExtensions::$$_function)
     auto* console_global_object = TRY(get_console(vm));
     auto& window = *console_global_object->m_window_object;
 
-    auto selector = TRY(vm.argument(0).to_byte_string(vm));
+    auto selector = TRY(vm.argument(0).to_string(vm));
 
     Web::DOM::ParentNode* element = &window.associated_document();
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -69,14 +69,14 @@ TESTJS_GLOBAL_FUNCTION(mark_as_garbage, markAsGarbage)
         return execution_context->lexical_environment != nullptr;
     });
     if (!outer_environment.has_value())
-        return vm.throw_completion<JS::ReferenceError>(JS::ErrorType::UnknownIdentifier, variable_name.byte_string());
+        return vm.throw_completion<JS::ReferenceError>(JS::ErrorType::UnknownIdentifier, variable_name.utf8_string_view());
 
     auto reference = TRY(vm.resolve_binding(variable_name.utf8_string(), outer_environment.value()->lexical_environment));
 
     auto value = TRY(reference.get_value(vm));
 
     if (!can_be_held_weakly(value))
-        return vm.throw_completion<JS::TypeError>(JS::ErrorType::CannotBeHeldWeakly, ByteString::formatted("Variable with name {}", variable_name.byte_string()));
+        return vm.throw_completion<JS::TypeError>(JS::ErrorType::CannotBeHeldWeakly, ByteString::formatted("Variable with name {}", variable_name.utf8_string_view()));
 
     vm.heap().uproot_cell(&value.as_cell());
     TRY(reference.delete_(vm));

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -283,14 +283,14 @@ void WebAssemblyModule::initialize(JS::Realm& realm)
 
 JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::get_export)
 {
-    auto name = TRY(vm.argument(0).to_byte_string(vm));
+    auto name = TRY(vm.argument(0).to_string(vm));
     auto this_value = vm.this_value();
     auto object = TRY(this_value.to_object(vm));
     if (!is<WebAssemblyModule>(*object))
         return vm.throw_completion<JS::TypeError>("Not a WebAssemblyModule"sv);
     auto& instance = static_cast<WebAssemblyModule&>(*object);
     for (auto& entry : instance.module_instance().exports()) {
-        if (entry.name() == name) {
+        if (entry.name() == name.to_byte_string()) {
             auto& value = entry.value();
             if (auto ptr = value.get_pointer<Wasm::FunctionAddress>())
                 return JS::Value(static_cast<unsigned long>(ptr->value()));


### PR DESCRIPTION
PrimitiveString is now internally either UTF-8, UTF-16, or both. We no longer convert them to/from ByteString anywhere, nor does VM have a ByteString cache.