### PR TITLE
Everywhere: Mark `GC::Cell` derived classes as Weakable explicitly

### DIFF
--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -36,7 +36,7 @@ public:                                            \
     }                                              \
     friend class GC::Heap;
 
-class Cell : public Weakable<Cell> {
+class Cell {
     AK_MAKE_NONCOPYABLE(Cell);
     AK_MAKE_NONMOVABLE(Cell);
 

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -51,7 +51,8 @@ struct CacheablePropertyMetadata {
     GC::Ptr<Object const> prototype;
 };
 
-class Object : public Cell {
+class Object : public Cell
+    , public Weakable<Object> {
     GC_CELL(Object, Cell);
     GC_DECLARE_ALLOCATOR(Object);
 

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -34,7 +34,8 @@ struct TransitionKey {
     }
 };
 
-class PrototypeChainValidity final : public Cell {
+class PrototypeChainValidity final : public Cell
+    , public Weakable<PrototypeChainValidity> {
     GC_CELL(PrototypeChainValidity, Cell);
     GC_DECLARE_ALLOCATOR(PrototypeChainValidity);
 
@@ -47,7 +48,8 @@ private:
     size_t padding { 0 };
 };
 
-class Shape final : public Cell {
+class Shape final : public Cell
+    , public Weakable<Shape> {
     GC_CELL(Shape, Cell);
     GC_DECLARE_ALLOCATOR(Shape);
 

--- a/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -16,7 +16,8 @@
 
 namespace Web::HTML {
 
-class BrowsingContext final : public JS::Cell {
+class BrowsingContext final : public JS::Cell
+    , public Weakable<BrowsingContext> {
     GC_CELL(BrowsingContext, JS::Cell);
     GC_DECLARE_ALLOCATOR(BrowsingContext);
 

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -34,7 +34,8 @@ struct TargetSnapshotParams {
 };
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#navigable
-class Navigable : public JS::Cell {
+class Navigable : public JS::Cell
+    , public Weakable<Navigable> {
     GC_CELL(Navigable, JS::Cell);
     GC_DECLARE_ALLOCATOR(Navigable);
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -27,6 +27,7 @@ namespace Web::Painting {
 extern bool g_paint_viewport_scrollbars;
 
 class PaintableBox : public Paintable
+    , public Weakable<PaintableBox>
     , public ClippableAndScrollable {
     GC_CELL(PaintableBox, Paintable);
 

--- a/Services/WebContent/WebContentConsoleClient.h
+++ b/Services/WebContent/WebContentConsoleClient.h
@@ -16,7 +16,8 @@
 
 namespace WebContent {
 
-class WebContentConsoleClient : public JS::ConsoleClient {
+class WebContentConsoleClient : public JS::ConsoleClient
+    , public Weakable<WebContentConsoleClient> {
     GC_CELL(WebContentConsoleClient, JS::ConsoleClient);
     GC_DECLARE_ALLOCATOR(WebContentConsoleClient);
 


### PR DESCRIPTION
Previously, all `GC::Cell` derived classes were Weakable. Marking only those classes that require this functionality as Weakable allows us to reduce the memory footprint of some frequently used classes.