### PR TITLE
LibWeb: Make RopeString subclass so PrimitiveString can be smaller

### DIFF
--- a/Libraries/LibJS/Runtime/Utf16String.cpp
+++ b/Libraries/LibJS/Runtime/Utf16String.cpp
@@ -84,6 +84,12 @@ Utf16String Utf16String::create(Utf16View const& string)
     return Utf16String { Detail::Utf16StringImpl::create(string) };
 }
 
+Utf16String Utf16String::invalid()
+{
+    static auto invalid = Utf16String {};
+    return invalid;
+}
+
 Utf16String::Utf16String(NonnullRefPtr<Detail::Utf16StringImpl> string)
     : m_string(move(string))
 {

--- a/Libraries/LibJS/Runtime/Utf16String.h
+++ b/Libraries/LibJS/Runtime/Utf16String.h
@@ -58,6 +58,7 @@ public:
     [[nodiscard]] static Utf16String create(Utf16Data);
     [[nodiscard]] static Utf16String create(StringView);
     [[nodiscard]] static Utf16String create(Utf16View const&);
+    [[nodiscard]] static Utf16String invalid();
 
     Utf16Data const& string() const;
     Utf16View view() const;
@@ -70,6 +71,7 @@ public:
 
     size_t length_in_code_units() const;
     bool is_empty() const;
+    bool is_valid() const { return m_string; }
 
     [[nodiscard]] u32 hash() const { return m_string->hash(); }
     [[nodiscard]] bool operator==(Utf16String const& other) const
@@ -80,9 +82,10 @@ public:
     }
 
 private:
+    Utf16String() = default;
     explicit Utf16String(NonnullRefPtr<Detail::Utf16StringImpl>);
 
-    NonnullRefPtr<Detail::Utf16StringImpl> m_string;
+    RefPtr<Detail::Utf16StringImpl> m_string;
 };
 
 }
@@ -92,6 +95,102 @@ namespace AK {
 template<>
 struct Traits<JS::Utf16String> : public DefaultTraits<JS::Utf16String> {
     static unsigned hash(JS::Utf16String const& s) { return s.hash(); }
+};
+
+template<>
+class Optional<JS::Utf16String> : public OptionalBase<JS::Utf16String> {
+    template<typename U>
+    friend class Optional;
+
+public:
+    using ValueType = JS::Utf16String;
+
+    Optional() = default;
+
+    template<SameAs<OptionalNone> V>
+    Optional(V) { }
+
+    Optional(Optional<JS::Utf16String> const& other)
+    {
+        if (other.has_value())
+            m_value = other.m_value;
+    }
+
+    Optional(Optional&& other)
+        : m_value(other.m_value)
+    {
+    }
+
+    template<typename U = JS::Utf16String>
+    requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
+    explicit(!IsConvertible<U&&, JS::Utf16String>) Optional(U&& value)
+    requires(!IsSame<RemoveCVReference<U>, Optional<JS::Utf16String>> && IsConstructible<JS::Utf16String, U &&>)
+        : m_value(forward<U>(value))
+    {
+    }
+
+    template<SameAs<OptionalNone> V>
+    Optional& operator=(V)
+    {
+        clear();
+        return *this;
+    }
+
+    Optional& operator=(Optional const& other)
+    {
+        if (this != &other) {
+            clear();
+            m_value = other.m_value;
+        }
+        return *this;
+    }
+
+    Optional& operator=(Optional&& other)
+    {
+        if (this != &other) {
+            clear();
+            m_value = other.m_value;
+        }
+        return *this;
+    }
+
+    void clear()
+    {
+        m_value = JS::Utf16String::invalid();
+    }
+
+    [[nodiscard]] bool has_value() const
+    {
+        return m_value.is_valid();
+    }
+
+    [[nodiscard]] JS::Utf16String& value() &
+    {
+        VERIFY(has_value());
+        return m_value;
+    }
+
+    [[nodiscard]] JS::Utf16String const& value() const&
+    {
+        VERIFY(has_value());
+        return m_value;
+    }
+
+    [[nodiscard]] JS::Utf16String value() &&
+    {
+        return release_value();
+    }
+
+    [[nodiscard]] JS::Utf16String release_value()
+    {
+        VERIFY(has_value());
+        JS::Utf16String released_value = m_value;
+        clear();
+        return released_value;
+    }
+
+private:
+    JS::Utf16String m_value { JS::Utf16String::invalid() };
 };
 
 }


### PR DESCRIPTION
By moving the LHS and RHS pointers used by rope strings into a RopeString subclass, we shrink PrimitiveString by 16 bytes. Most strings are not rope strings, so this ends up saving quite a bit of memory.

cc @tcl3 