### PR TITLE
LibWeb+WebContent: Move display list rasterization off the main thread

### DIFF
--- a/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Libraries/LibGfx/ImmutableBitmap.h
@@ -1,14 +1,14 @@
 /*
- * Copyright (c) 2023-2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2023-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/AtomicRefCounted.h>
 #include <AK/Forward.h>
 #include <AK/NonnullOwnPtr.h>
-#include <AK/RefCounted.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ColorSpace.h>
 #include <LibGfx/Forward.h>
@@ -20,7 +20,7 @@ namespace Gfx {
 
 struct ImmutableBitmapImpl;
 
-class ImmutableBitmap final : public RefCounted<ImmutableBitmap> {
+class ImmutableBitmap final : public AtomicRefCounted<ImmutableBitmap> {
 public:
     static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> bitmap, ColorSpace color_space = {});
     static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> bitmap, AlphaType, ColorSpace color_space = {});

--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -1,14 +1,14 @@
 /*
- * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2024-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/AtomicRefCounted.h>
 #include <AK/Function.h>
 #include <AK/NonnullOwnPtr.h>
-#include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Size.h>
@@ -23,7 +23,7 @@ class SkSurface;
 
 namespace Gfx {
 
-class PaintingSurface : public RefCounted<PaintingSurface> {
+class PaintingSurface : public AtomicRefCounted<PaintingSurface> {
 public:
     enum class Origin {
         TopLeft,

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/AtomicRefCounted.h>
 #include <AK/Forward.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
@@ -33,7 +34,7 @@ typedef struct ShapeFeature {
 
 using ShapeFeatures = Vector<ShapeFeature, 4>;
 
-class GlyphRun : public RefCounted<GlyphRun> {
+class GlyphRun : public AtomicRefCounted<GlyphRun> {
 public:
     enum class TextType {
         Common,

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -484,6 +484,7 @@ set(SOURCES
     HTML/PotentialCORSRequest.cpp
     HTML/PromiseRejectionEvent.cpp
     HTML/RadioNodeList.cpp
+    HTML/RenderingThread.cpp
     HTML/Scripting/Agent.cpp
     HTML/Scripting/ClassicScript.cpp
     HTML/Scripting/Environments.cpp
@@ -973,7 +974,7 @@ set(GENERATED_SOURCES
 
 serenity_lib(LibWeb web)
 
-target_link_libraries(LibWeb PRIVATE LibCore LibCompress LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests LibGC skia)
+target_link_libraries(LibWeb PRIVATE LibCore LibCompress LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests LibGC LibThreading skia)
 
 if (APPLE)
     target_link_libraries(LibWeb PRIVATE unofficial::angle::libEGL unofficial::angle::libGLESv2)

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/EventLoop.h>
+#include <LibWeb/HTML/RenderingThread.h>
+
+namespace Web::HTML {
+
+RenderingThread::RenderingThread()
+    : m_main_thread_event_loop(Core::EventLoop::current())
+{
+}
+
+RenderingThread::~RenderingThread()
+{
+    m_exit = true;
+    m_rendering_task_ready_wake_condition.signal();
+    (void)m_thread->join();
+}
+
+void RenderingThread::start()
+{
+    VERIFY(m_skia_player);
+    m_thread = Threading::Thread::construct([this] {
+        rendering_thread_loop();
+        return static_cast<intptr_t>(0);
+    });
+    m_thread->start();
+}
+
+void RenderingThread::rendering_thread_loop()
+{
+    while (true) {
+        auto task = [this]() -> Optional<Task> {
+            Threading::MutexLocker const locker { m_rendering_task_mutex };
+            while (m_rendering_tasks.is_empty() && !m_exit) {
+                m_rendering_task_ready_wake_condition.wait();
+            }
+            if (m_exit)
+                return {};
+            return m_rendering_tasks.dequeue();
+        }();
+
+        if (!task.has_value()) {
+            VERIFY(m_exit);
+            break;
+        }
+
+        m_skia_player->set_surface(task->painting_surface);
+        m_skia_player->execute(*task->display_list);
+        m_main_thread_event_loop.deferred_invoke([callback = move(task->callback)] {
+            callback();
+        });
+    }
+}
+
+void RenderingThread::enqueue_rendering_task(RefPtr<Painting::DisplayList> display_list, NonnullRefPtr<Gfx::PaintingSurface> painting_surface, Function<void()>&& callback)
+{
+    Threading::MutexLocker const locker { m_rendering_task_mutex };
+    m_rendering_tasks.enqueue(Task { move(display_list), move(painting_surface), move(callback) });
+    m_rendering_task_ready_wake_condition.signal();
+}
+
+}

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/Queue.h>
+#include <LibThreading/ConditionVariable.h>
+#include <LibThreading/Mutex.h>
+#include <LibThreading/Thread.h>
+#include <LibWeb/Painting/DisplayListPlayerSkia.h>
+
+namespace Web::HTML {
+
+class RenderingThread {
+    AK_MAKE_NONCOPYABLE(RenderingThread);
+    AK_MAKE_NONMOVABLE(RenderingThread);
+
+public:
+    RenderingThread();
+    ~RenderingThread();
+
+    void start();
+    void set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player) { m_skia_player = move(player); }
+    void enqueue_rendering_task(RefPtr<Painting::DisplayList>, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
+
+private:
+    void rendering_thread_loop();
+
+    Core::EventLoop& m_main_thread_event_loop;
+
+    OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
+
+    RefPtr<Threading::Thread> m_thread;
+    Atomic<bool> m_exit { false };
+
+    struct Task {
+        RefPtr<Painting::DisplayList> display_list;
+        NonnullRefPtr<Gfx::PaintingSurface> painting_surface;
+        Function<void()> callback;
+    };
+    // NOTE: Queue will only contain multiple items in case tasks were scheduled by screenshot requests.
+    //       Otherwise, it will contain only one item at a time.
+    Queue<Task> m_rendering_tasks;
+    Threading::Mutex m_rendering_task_mutex;
+    Threading::ConditionVariable m_rendering_task_ready_wake_condition { m_rendering_task_mutex };
+};
+
+}

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -324,7 +324,7 @@ public:
     virtual CSS::PreferredMotion preferred_motion() const = 0;
     virtual void paint_next_frame() = 0;
     virtual void process_screenshot_requests() = 0;
-    virtual void paint(DevicePixelRect const&, Painting::BackingStore&, PaintOptions = {}) = 0;
+    virtual void start_display_list_rendering(DevicePixelRect const&, Painting::BackingStore&, PaintOptions, Function<void()>&& callback) = 0;
     virtual Queue<QueuedInputEvent>& input_event_queue() = 0;
     virtual void report_finished_handling_input_event(u64 page_id, EventResult event_was_handled) = 0;
     virtual void page_did_change_title(ByteString const&) { }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -76,7 +76,7 @@ private:
     RefPtr<Gfx::PaintingSurface> m_surface;
 };
 
-class DisplayList : public RefCounted<DisplayList> {
+class DisplayList : public AtomicRefCounted<DisplayList> {
 public:
     static NonnullRefPtr<DisplayList> create()
     {

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -78,7 +78,7 @@ public:
     virtual void request_file(FileRequest) override { }
     virtual void paint_next_frame() override { }
     virtual void process_screenshot_requests() override { }
-    virtual void paint(DevicePixelRect const&, Painting::BackingStore&, Web::PaintOptions = {}) override { }
+    virtual void start_display_list_rendering(DevicePixelRect const&, Painting::BackingStore&, PaintOptions, Function<void()>&&) override { }
     virtual bool is_ready_to_paint() const override { return true; }
     virtual Queue<QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] EventResult event_was_handled) override { }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -48,7 +48,7 @@ public:
 
     virtual void paint_next_frame() override;
     virtual void process_screenshot_requests() override;
-    virtual void paint(Web::DevicePixelRect const& content_rect, Web::Painting::BackingStore&, Web::PaintOptions = {}) override;
+    virtual void start_display_list_rendering(Web::DevicePixelRect const& content_rect, Web::Painting::BackingStore&, Web::PaintOptions, Function<void()>&& callback) override;
 
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override;
     virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;

--- a/Services/WebWorker/PageHost.cpp
+++ b/Services/WebWorker/PageHost.cpp
@@ -77,7 +77,7 @@ Web::CSS::PreferredMotion PageHost::preferred_motion() const
     return Web::CSS::PreferredMotion::Auto;
 }
 
-void PageHost::paint(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions)
+void PageHost::start_display_list_rendering(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions, Function<void()>&&)
 {
 }
 

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -33,7 +33,7 @@ public:
     virtual Web::CSS::PreferredMotion preferred_motion() const override;
     virtual void paint_next_frame() override { }
     virtual void process_screenshot_requests() override { }
-    virtual void paint(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions = {}) override;
+    virtual void start_display_list_rendering(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions, Function<void()>&& callback) override;
     virtual void request_file(Web::FileRequest) override;
     virtual bool is_ready_to_paint() const override { return true; }
     virtual Web::DisplayListPlayerType display_list_player_type() const override { VERIFY_NOT_REACHED(); }


### PR DESCRIPTION
Reopen https://github.com/LadybirdBrowser/ladybird/pull/3688

initially I underestimated impact of the change, but profiling using Instruments with "Record Waiting Threads" turned on revealed that we spend up to 25%, depending on a website, in `DisplayListPlayerSkia::flush()`, waiting for a GPU to process submitted work. I tried to solve this by making flush asynchronous, but Skia's Ganesh backend doesn't seem to provide a reliable  API for finished painting callback. likely offloading rendering onto separate thread is the most straightforward way to solve this.