### PR TITLE
LibJS: Make async functions & generators faster with helper types

### DIFF
--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -57,6 +57,7 @@
     O(GetByValue)                      \
     O(GetByValueWithThis)              \
     O(GetCalleeAndThisFromEnvironment) \
+    O(GetCompletionFields)             \
     O(GetGlobal)                       \
     O(GetImportMeta)                   \
     O(GetIterator)                     \
@@ -131,6 +132,7 @@
     O(RightShift)                      \
     O(ScheduleJump)                    \
     O(SetArgument)                     \
+    O(SetCompletionType)               \
     O(SetLexicalBinding)               \
     O(SetVariableBinding)              \
     O(StrictlyEquals)                  \

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -962,6 +962,58 @@ private:
     u32 m_cache_index { 0 };
 };
 
+class GetCompletionFields final : public Instruction {
+public:
+    GetCompletionFields(Operand type_dst, Operand value_dst, Operand completion)
+        : Instruction(Type::GetCompletionFields)
+        , m_type_dst(type_dst)
+        , m_value_dst(value_dst)
+        , m_completion(completion)
+    {
+    }
+
+    void execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_type_dst);
+        visitor(m_value_dst);
+        visitor(m_completion);
+    }
+
+    Operand type_dst() const { return m_type_dst; }
+    Operand value_dst() const { return m_value_dst; }
+    Operand completion() const { return m_completion; }
+
+private:
+    Operand m_type_dst;
+    Operand m_value_dst;
+    Operand m_completion;
+};
+
+class SetCompletionType final : public Instruction {
+public:
+    SetCompletionType(Operand completion, Completion::Type type)
+        : Instruction(Type::SetCompletionType)
+        , m_completion(completion)
+        , m_type(type)
+    {
+    }
+
+    void execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_completion);
+    }
+
+    Operand completion() const { return m_completion; }
+
+private:
+    Operand m_completion;
+    Completion::Type m_type;
+};
+
 class GetByIdWithThis final : public Instruction {
 public:
     GetByIdWithThis(Operand dst, Operand base, IdentifierTableIndex property, Operand this_value, u32 cache_index)

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SOURCES
     Runtime/BooleanPrototype.cpp
     Runtime/BoundFunction.cpp
     Runtime/Completion.cpp
+    Runtime/CompletionCell.cpp
     Runtime/ConsoleObjectPrototype.cpp
     Runtime/ConsoleObject.cpp
     Runtime/DataView.cpp
@@ -94,6 +95,7 @@ set(SOURCES
     Runtime/GeneratorFunctionPrototype.cpp
     Runtime/GeneratorObject.cpp
     Runtime/GeneratorPrototype.cpp
+    Runtime/GeneratorResult.cpp
     Runtime/GlobalEnvironment.cpp
     Runtime/GlobalObject.cpp
     Runtime/IndexedProperties.cpp

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -91,7 +91,6 @@ namespace JS {
     P(construct)                             \
     P(constructor)                           \
     P(containing)                            \
-    P(continuation)                          \
     P(copyWithin)                            \
     P(cos)                                   \
     P(cosh)                                  \
@@ -277,7 +276,6 @@ namespace JS {
     P(Intl)                                  \
     P(is)                                    \
     P(isArray)                               \
-    P(isAwait)                               \
     P(isDisjointFrom)                        \
     P(isError)                               \
     P(isExtensible)                          \
@@ -409,7 +407,6 @@ namespace JS {
     P(reason)                                \
     P(reduce)                                \
     P(reduceRight)                           \
-    P(result)                                \
     P(Reflect)                               \
     P(RegExp)                                \
     P(region)                                \

--- a/Libraries/LibJS/Runtime/CompletionCell.cpp
+++ b/Libraries/LibJS/Runtime/CompletionCell.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/CompletionCell.h>
+
+namespace JS {
+
+GC_DEFINE_ALLOCATOR(CompletionCell);
+
+CompletionCell::~CompletionCell() = default;
+
+void CompletionCell::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    if (m_completion.value().has_value())
+        visitor.visit(m_completion.value().value());
+}
+
+}

--- a/Libraries/LibJS/Runtime/CompletionCell.h
+++ b/Libraries/LibJS/Runtime/CompletionCell.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGC/CellAllocator.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/Completion.h>
+
+namespace JS {
+
+class CompletionCell final : public Cell {
+    GC_CELL(CompletionCell, Cell);
+    GC_DECLARE_ALLOCATOR(CompletionCell);
+
+public:
+    CompletionCell(Completion completion)
+        : m_completion(move(completion))
+    {
+    }
+
+    virtual ~CompletionCell() override;
+
+    [[nodiscard]] Completion const& completion() const { return m_completion; }
+    void set_completion(Completion completion) { m_completion = move(completion); }
+
+private:
+    virtual void visit_edges(Cell::Visitor& visitor) override;
+
+    Completion m_completion;
+};
+
+}

--- a/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -7,8 +7,10 @@
 #include <AK/TemporaryChange.h>
 #include <LibJS/Bytecode/Generator.h>
 #include <LibJS/Bytecode/Interpreter.h>
+#include <LibJS/Runtime/CompletionCell.h>
 #include <LibJS/Runtime/GeneratorObject.h>
 #include <LibJS/Runtime/GeneratorPrototype.h>
+#include <LibJS/Runtime/GeneratorResult.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Iterator.h>
 
@@ -82,15 +84,15 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
 
     VERIFY(completion.value().has_value());
 
-    auto generated_value = [&vm](Value value) -> Value {
-        if (value.is_object())
-            return value.as_object().get_without_side_effects(vm.names.result);
+    auto generated_value = [](Value value) -> Value {
+        if (value.is_cell())
+            return static_cast<GeneratorResult const&>(value.as_cell()).result();
         return value.is_empty() ? js_undefined() : value;
     };
 
     auto generated_continuation = [&](Value value) -> Optional<size_t> {
-        if (value.is_object()) {
-            auto number_value = value.as_object().get_without_side_effects(vm.names.continuation);
+        if (value.is_cell()) {
+            auto number_value = static_cast<GeneratorResult const&>(value.as_cell()).continuation();
             if (number_value.is_null())
                 return {};
             return static_cast<u64>(number_value.as_double());
@@ -98,10 +100,7 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
         return {};
     };
 
-    auto& realm = *vm.current_realm();
-    auto completion_object = Object::create(realm, nullptr);
-    completion_object->define_direct_property(vm.names.type, Value(to_underlying(completion.type())), default_attributes);
-    completion_object->define_direct_property(vm.names.value, completion.value().value(), default_attributes);
+    auto compleion_cell = heap().allocate<CompletionCell>(completion);
 
     auto& bytecode_interpreter = vm.bytecode_interpreter();
 
@@ -110,7 +109,7 @@ ThrowCompletionOr<Value> GeneratorObject::execute(VM& vm, Completion const& comp
     // We should never enter `execute` again after the generator is complete.
     VERIFY(next_block.has_value());
 
-    auto next_result = bytecode_interpreter.run_executable(*m_generating_function->bytecode_executable(), next_block, completion_object);
+    auto next_result = bytecode_interpreter.run_executable(*m_generating_function->bytecode_executable(), next_block, compleion_cell);
 
     vm.pop_execution_context();
 

--- a/Libraries/LibJS/Runtime/GeneratorResult.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorResult.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GeneratorResult.h>
+
+namespace JS {
+
+GC_DEFINE_ALLOCATOR(GeneratorResult);
+
+GeneratorResult::~GeneratorResult() = default;
+
+void GeneratorResult::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_result);
+    visitor.visit(m_continuation);
+}
+
+}

--- a/Libraries/LibJS/Runtime/GeneratorResult.h
+++ b/Libraries/LibJS/Runtime/GeneratorResult.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGC/CellAllocator.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS {
+
+class GeneratorResult final : public Cell {
+    GC_CELL(GeneratorResult, Cell);
+    GC_DECLARE_ALLOCATOR(GeneratorResult);
+
+public:
+    GeneratorResult(Value result, Value continuation, bool is_await)
+        : m_is_await(is_await)
+        , m_result(result)
+        , m_continuation(continuation)
+    {
+    }
+
+    virtual ~GeneratorResult() override;
+
+    [[nodiscard]] Value result() const { return m_result; }
+    [[nodiscard]] Value continuation() const { return m_continuation; }
+    [[nodiscard]] bool is_await() const { return m_is_await; }
+
+private:
+    virtual void visit_edges(Cell::Visitor& visitor) override;
+
+    bool m_is_await { false };
+    Value m_result;
+    Value m_continuation;
+};
+
+}


### PR DESCRIPTION
Instead of returning internal generator results as ordinary JS::Objects with properties, we now use GeneratorResult and CompletionCell which both inherit from Cell directly and allow efficient access to state.

1.59x speedup on JetStream3/lazy-collections.js :^)

```
Suite       Test                                Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  --------------------------------  ---------  ------------------------  ------------------------
JetStream3  js-tokens.js                          1.004  25.770 ± 25.670 … 25.870  25.655 ± 25.640 … 25.670
JetStream3  lazy-collections.js                   1.592  2.810 ± 2.790 … 2.830     1.765 ± 1.760 … 1.770
JetStream3  raytrace-private-class-fields.js      1.012  9.750 ± 9.740 … 9.760     9.635 ± 9.390 … 9.880
JetStream3  raytrace-public-class-fields.js       1.02   7.840 ± 7.580 … 8.100     7.685 ± 7.600 … 7.770
JetStream3  sync-file-system.js                   0.979  4.640 ± 4.600 … 4.680     4.740 ± 4.660 … 4.820
JetStream3  Total                                 1.027  50.810                    49.480
```