### PR TITLE
LibWeb: Allow working on N+1 frame while N is rasterizing

### DIFF
--- a/Services/WebContent/BackingStoreManager.h
+++ b/Services/WebContent/BackingStoreManager.h
@@ -25,14 +25,25 @@ public:
     void reallocate_backing_stores(Gfx::IntSize);
     void restart_resize_timer();
 
-    Web::Painting::BackingStore* back_store() { return m_back_store.ptr(); }
-    i32 front_id() const { return m_front_bitmap_id; }
+    struct BackingStore {
+        i32 bitmap_id { -1 };
+        Web::Painting::BackingStore* store { nullptr };
+    };
 
-    void swap_back_and_front();
+    BackingStore acquire_store_for_next_frame()
+    {
+        BackingStore backing_store;
+        backing_store.bitmap_id = m_back_bitmap_id;
+        backing_store.store = m_back_store.ptr();
+        swap_back_and_front();
+        return backing_store;
+    }
 
     BackingStoreManager(PageClient&);
 
 private:
+    void swap_back_and_front();
+
     // FIXME: We should come up with an ownership model for this class that makes the GC-checker happy
     IGNORE_GC PageClient& m_page_client;
 

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -190,12 +190,7 @@ private:
     bool m_should_show_line_box_borders { false };
     bool m_has_focus { false };
 
-    enum class PaintState {
-        Ready,
-        WaitingForClient,
-    };
-
-    PaintState m_paint_state { PaintState::Ready };
+    i32 m_number_of_queued_rasterization_tasks { 0 };
 
     struct ScreenshotTask {
         Optional<Web::UniqueNodeID> node_id;

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,6 +20,7 @@ Text/input/css/transition-basics.html
 ; Flaky on CI, see #19
 Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/WebAnimations/animation-properties/currentTime.html
+Text/input/WebAnimations/animation-methods/updatePlaybackRate.html
 
 ; Worker tests are flaky on CI
 Text/input/Worker/Worker-blob.html


### PR DESCRIPTION
This change allows us to overlap rasterization and rendering work across threads: while the rasterization thread processes frame N, the main thread can simultaneously work on producing the display list for frame N+1.