### PR TITLE
LibWeb: Make BackingStore atomic ref-counted

### DIFF
--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1414,7 +1414,7 @@ NonnullRefPtr<Gfx::PaintingSurface> TraversableNavigable::painting_surface_for_b
 #ifdef USE_VULKAN
         // Vulkan: Try to create an accelerated surface.
         new_surface = Gfx::PaintingSurface::create_with_size(m_skia_backend_context, backing_store.size(), Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
-        new_surface->on_flush = [&bitmap = bitmap](auto& surface) { surface.read_into_bitmap(bitmap); };
+        new_surface->on_flush = [backing_store = static_cast<NonnullRefPtr<Painting::BackingStore>>(backing_store)](auto& surface) { surface.read_into_bitmap(backing_store->bitmap()); };
 #endif
 #ifdef AK_OS_MACOS
         // macOS: Wrap an IOSurface if available.

--- a/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -56,7 +56,7 @@ ErrorOr<GC::Ref<HTML::HTMLCanvasElement>, WebDriver::Error> draw_bounding_box_fr
     Gfx::IntRect paint_rect { rect.x(), rect.y(), paint_width, paint_height };
 
     auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, canvas.surface()->size()));
-    auto backing_store = Web::Painting::BitmapBackingStore(bitmap);
+    auto backing_store = Painting::BitmapBackingStore::create(bitmap);
     IGNORE_USE_IN_ESCAPING_LAMBDA bool did_paint = false;
     browsing_context.page().client().start_display_list_rendering(paint_rect.to_type<Web::DevicePixels>(), backing_store, {}, [&did_paint] {
         did_paint = true;

--- a/Services/WebContent/BackingStoreManager.cpp
+++ b/Services/WebContent/BackingStoreManager.cpp
@@ -83,8 +83,8 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
             VERIFY_NOT_REACHED();
         }
 
-        m_front_store = make<Web::Painting::IOSurfaceBackingStore>(move(front_iosurface));
-        m_back_store = make<Web::Painting::IOSurfaceBackingStore>(move(back_iosurface));
+        m_front_store = Web::Painting::IOSurfaceBackingStore::create(move(front_iosurface));
+        m_back_store = Web::Painting::IOSurfaceBackingStore::create(move(back_iosurface));
 
         return;
     }
@@ -96,8 +96,8 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
     auto front_bitmap = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, size).release_value();
     auto back_bitmap = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, size).release_value();
 
-    m_front_store = make<Web::Painting::BitmapBackingStore>(front_bitmap);
-    m_back_store = make<Web::Painting::BitmapBackingStore>(back_bitmap);
+    m_front_store = Web::Painting::BitmapBackingStore::create(front_bitmap);
+    m_back_store = Web::Painting::BitmapBackingStore::create(back_bitmap);
 
     m_page_client.page_did_allocate_backing_stores(m_front_bitmap_id, front_bitmap->to_shareable_bitmap(), m_back_bitmap_id, back_bitmap->to_shareable_bitmap());
 }

--- a/Services/WebContent/BackingStoreManager.h
+++ b/Services/WebContent/BackingStoreManager.h
@@ -38,8 +38,8 @@ private:
 
     i32 m_front_bitmap_id { -1 };
     i32 m_back_bitmap_id { -1 };
-    OwnPtr<Web::Painting::BackingStore> m_front_store;
-    OwnPtr<Web::Painting::BackingStore> m_back_store;
+    RefPtr<Web::Painting::BackingStore> m_front_store;
+    RefPtr<Web::Painting::BackingStore> m_back_store;
     int m_next_bitmap_id { 0 };
 
     RefPtr<Core::Timer> m_backing_store_shrink_timer;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -205,16 +205,16 @@ void PageClient::process_screenshot_requests()
             }
             auto rect = page().enclosing_device_rect(dom_node->paintable_box()->absolute_border_box_rect());
             auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>()).release_value_but_fixme_should_propagate_errors();
-            auto backing_store = Web::Painting::BitmapBackingStore(*bitmap);
-            start_display_list_rendering(rect, backing_store, { .paint_overlay = Web::PaintOptions::PaintOverlay::No }, [this, bitmap] {
-                client().async_did_take_screenshot(m_id, bitmap->to_shareable_bitmap());
+            auto backing_store = Web::Painting::BitmapBackingStore::create(*bitmap);
+            start_display_list_rendering(rect, backing_store, { .paint_overlay = Web::PaintOptions::PaintOverlay::No }, [this, backing_store] {
+                client().async_did_take_screenshot(m_id, backing_store->bitmap().to_shareable_bitmap());
             });
         } else {
             Web::DevicePixelRect rect { { 0, 0 }, content_size() };
             auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>()).release_value_but_fixme_should_propagate_errors();
-            auto backing_store = Web::Painting::BitmapBackingStore(*bitmap);
-            start_display_list_rendering(rect, backing_store, {}, [this, bitmap] {
-                client().async_did_take_screenshot(m_id, bitmap->to_shareable_bitmap());
+            auto backing_store = Web::Painting::BitmapBackingStore::create(*bitmap);
+            start_display_list_rendering(rect, backing_store, {}, [this, backing_store] {
+                client().async_did_take_screenshot(m_id, backing_store->bitmap().to_shareable_bitmap());
             });
         }
     }


### PR DESCRIPTION
This is required to make sure rendering thread will keep backing stores alive in case backing stores reallocation happens during rasterization.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4164