### PR TITLE
LibWeb: Use relative coordinates for `available_space_for_line()` to determine float intrusions

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -58,12 +58,11 @@ CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels y) const
 
 AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels y) const
 {
-    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, y);
-    if (m_available_space->width.is_definite()) {
-        return AvailableSize::make_definite(m_available_space->width.to_px_or_zero() - (intrusions.left + intrusions.right));
-    } else {
+    if (!m_available_space->width.is_definite())
         return m_available_space->width;
-    }
+
+    auto intrusions = parent().intrusion_by_floats_into_box(m_containing_block_used_values, y);
+    return AvailableSize::make_definite(m_available_space->width.to_px_or_zero() - intrusions.left - intrusions.right);
 }
 
 CSSPixels InlineFormattingContext::automatic_content_width() const

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-intrusions-relative-coordinates.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-intrusions-relative-coordinates.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x158 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
+      BlockContainer <div.a> at (8,8) content-size 784x50 children: not-inline
+      BlockContainer <(anonymous)> at (8,58) content-size 784x0 children: inline
+        TextNode <#text>
+        BlockContainer <div.b.bug> at (8,58) content-size 784x50 floating [BFC] children: not-inline
+        TextNode <#text>
+        BlockContainer <div.c.bug> at (8,108) content-size 784x50 floating [BFC] children: not-inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x158]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableWithLines (BlockContainer<DIV>.a) [8,8 784x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,58 784x0]
+        PaintableWithLines (BlockContainer<DIV>.b.bug) [8,58 784x50]
+        PaintableWithLines (BlockContainer<DIV>.c.bug) [8,108 784x50]

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-intrusions-relative-coordinates.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-intrusions-relative-coordinates.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+.a {
+    background: red;
+    height: 50px;
+}
+.b {
+    background: green;
+}
+.c {
+    background: blue;
+}
+.bug {
+    float: left;
+    height: 50px;
+    width: 100%;
+}
+</style>
+<div class="a"></div>
+<div class="b bug"></div>
+<div class="c bug"></div>


### PR DESCRIPTION
We were accidentally providing it with absolute Y-coordinates, messing up stacked floating boxes that would otherwise intrude on each other.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4160.