### PR TITLE
LibJS: Elide function wrapper for class field literal initializers

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -94,6 +94,8 @@ public:
     virtual bool is_object_expression() const { return false; }
     virtual bool is_numeric_literal() const { return false; }
     virtual bool is_string_literal() const { return false; }
+    virtual bool is_boolean_literal() const { return false; }
+    virtual bool is_null_literal() const { return false; }
     virtual bool is_update_expression() const { return false; }
     virtual bool is_call_expression() const { return false; }
     virtual bool is_labelled_statement() const { return false; }
@@ -1214,6 +1216,8 @@ public:
     virtual Value value() const override { return Value(m_value); }
 
 private:
+    virtual bool is_boolean_literal() const override { return true; }
+
     bool m_value { false };
 };
 
@@ -1281,6 +1285,9 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
     virtual Value value() const override { return js_null(); }
+
+private:
+    virtual bool is_null_literal() const override { return true; }
 };
 
 class RegExpLiteral final : public Expression {
@@ -2266,6 +2273,15 @@ inline bool ASTNode::fast_is<ObjectExpression>() const { return is_object_expres
 
 template<>
 inline bool ASTNode::fast_is<ImportCall>() const { return is_import_call(); }
+
+template<>
+inline bool ASTNode::fast_is<NumericLiteral>() const { return is_numeric_literal(); }
+
+template<>
+inline bool ASTNode::fast_is<BooleanLiteral>() const { return is_boolean_literal(); }
+
+template<>
+inline bool ASTNode::fast_is<NullLiteral>() const { return is_null_literal(); }
 
 template<>
 inline bool ASTNode::fast_is<StringLiteral>() const { return is_string_literal(); }

--- a/Libraries/LibJS/Runtime/ClassFieldDefinition.h
+++ b/Libraries/LibJS/Runtime/ClassFieldDefinition.h
@@ -17,8 +17,8 @@ using ClassElementName = Variant<PropertyKey, PrivateName>;
 
 // 6.2.10 The ClassFieldDefinition Record Specification Type, https://tc39.es/ecma262/#sec-classfielddefinition-record-specification-type
 struct ClassFieldDefinition {
-    ClassElementName name;                         // [[Name]]
-    GC::Ptr<ECMAScriptFunctionObject> initializer; // [[Initializer]]
+    ClassElementName name;                                                // [[Name]]
+    Variant<GC::Ref<ECMAScriptFunctionObject>, Value, Empty> initializer; // [[Initializer]]
 };
 
 }

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -553,7 +553,14 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
     visitor.visit(m_bytecode_executable);
 
     for (auto& field : m_fields) {
-        visitor.visit(field.initializer);
+        field.initializer.visit(
+            [&visitor](GC::Ref<ECMAScriptFunctionObject>& initializer) {
+                visitor.visit(initializer);
+            },
+            [&visitor](Value initializer) {
+                visitor.visit(initializer);
+            },
+            [](Empty) {});
         if (auto* property_key_ptr = field.name.get_pointer<PropertyKey>(); property_key_ptr && property_key_ptr->is_symbol())
             visitor.visit(property_key_ptr->as_symbol());
     }


### PR DESCRIPTION
If a class field initializer is just a simple literal, we can skip creating (and calling) a wrapper function for it entirely.

1.44x speedup on JetStream3/raytrace-private-class-fields.js
1.53x speedup on JetStream3/raytrace-public-class-fields.js

```
Suite       Test                                Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  --------------------------------  ---------  ---------------------  ---------------------
JetStream3  js-tokens.js                          0.988  9.400 ± 9.300 … 9.500  9.510 ± 9.510 … 9.510
JetStream3  lazy-collections.js                   1.018  1.705 ± 1.700 … 1.710  1.675 ± 1.670 … 1.680
JetStream3  raytrace-private-class-fields.js      1.443  8.860 ± 8.840 … 8.880  6.140 ± 6.140 … 6.140
JetStream3  raytrace-public-class-fields.js       1.533  7.230 ± 7.220 … 7.240  4.715 ± 4.710 … 4.720
JetStream3  sync-file-system.js                   1.006  3.460 ± 3.450 … 3.470  3.440 ± 3.410 … 3.470
JetStream3  Total                                 1.203  30.655                 25.480
```