### PR TITLE
Meta: Update vcpkg to the March 2025 release

### DIFF
--- a/Toolchain/BuildVcpkg.py
+++ b/Toolchain/BuildVcpkg.py
@@ -10,7 +10,7 @@ def main() -> int:
     script_dir = pathlib.Path(__file__).parent.resolve()
 
     git_repo = "https://github.com/microsoft/vcpkg.git"
-    git_rev = "74ec888e385d189b42d6b398d0bbaa6f1b1d3b0e"  # 2025.02.07
+    git_rev = "b02e341c927f16d991edbd915d8ea43eac52096c"  # 2025.03.19
 
     build_dir = script_dir.parent / "Build"
     build_dir.mkdir(parents=True, exist_ok=True)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "74ec888e385d189b42d6b398d0bbaa6f1b1d3b0e",
+  "builtin-baseline": "b02e341c927f16d991edbd915d8ea43eac52096c",
   "dependencies": [
     {
       "name": "angle",


### PR DESCRIPTION
Fixes openh264 compile error on macOS.