### PR TITLE
AK+Everywhere: Recognise that surrogates in utf16 aren't all that common

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -37,35 +37,40 @@ static constexpr u16 host_code_unit(u16 code_unit, Endianness endianness)
 }
 
 template<OneOf<Utf8View, Utf32View> UtfViewType>
-static ErrorOr<Utf16Data> to_utf16_slow(UtfViewType const& view, Endianness endianness)
+static ErrorOr<Utf16ConversionResult> to_utf16_slow(UtfViewType const& view, Endianness endianness)
 {
     Utf16Data utf16_data;
     TRY(utf16_data.try_ensure_capacity(view.length()));
 
-    for (auto code_point : view)
+    size_t code_point_count = 0;
+    for (auto code_point : view) {
         TRY(code_point_to_utf16(utf16_data, code_point, endianness));
+        code_point_count++;
+    }
 
-    return utf16_data;
+    return Utf16ConversionResult { move(utf16_data), code_point_count };
 }
 
-ErrorOr<Utf16Data> utf8_to_utf16(StringView utf8_view, Endianness endianness)
+ErrorOr<Utf16ConversionResult> utf8_to_utf16(StringView utf8_view, Endianness endianness)
 {
     return utf8_to_utf16(Utf8View { utf8_view }, endianness);
 }
 
-ErrorOr<Utf16Data> utf8_to_utf16(Utf8View const& utf8_view, Endianness endianness)
+ErrorOr<Utf16ConversionResult> utf8_to_utf16(Utf8View const& utf8_view, Endianness endianness)
 {
     // All callers want to allow lonely surrogates, which simdutf does not permit.
     if (!utf8_view.validate(Utf8View::AllowSurrogates::No)) [[unlikely]]
         return to_utf16_slow(utf8_view, endianness);
     if (utf8_view.is_empty())
-        return Utf16Data {};
+        return Utf16ConversionResult { Utf16Data {}, 0 };
 
     auto const* data = reinterpret_cast<char const*>(utf8_view.bytes());
     auto length = utf8_view.byte_length();
 
     Utf16Data utf16_data;
     TRY(utf16_data.try_resize(simdutf::utf16_length_from_utf8(data, length)));
+    // FIXME: simdutf _could_ be telling us about this, but it doesn't -- so we have to compute it again.
+    auto code_point_length = simdutf::count_utf8(data, length);
 
     [[maybe_unused]] auto result = [&]() {
         switch (endianness) {
@@ -80,13 +85,13 @@ ErrorOr<Utf16Data> utf8_to_utf16(Utf8View const& utf8_view, Endianness endiannes
     }();
     ASSERT(result == utf16_data.size());
 
-    return utf16_data;
+    return Utf16ConversionResult { utf16_data, code_point_length };
 }
 
-ErrorOr<Utf16Data> utf32_to_utf16(Utf32View const& utf32_view, Endianness endianness)
+ErrorOr<Utf16ConversionResult> utf32_to_utf16(Utf32View const& utf32_view, Endianness endianness)
 {
     if (utf32_view.is_empty())
-        return Utf16Data {};
+        return Utf16ConversionResult { Utf16Data {}, 0 };
 
     auto const* data = reinterpret_cast<char32_t const*>(utf32_view.code_points());
     auto length = utf32_view.length();
@@ -107,7 +112,7 @@ ErrorOr<Utf16Data> utf32_to_utf16(Utf32View const& utf32_view, Endianness endian
     }();
     ASSERT(result == utf16_data.size());
 
-    return utf16_data;
+    return Utf16ConversionResult { utf16_data, length };
 }
 
 ErrorOr<void> code_point_to_utf16(Utf16Data& string, u32 code_point, Endianness endianness)
@@ -207,6 +212,9 @@ u32 Utf16View::code_point_at(size_t index) const
 
 size_t Utf16View::code_point_offset_of(size_t code_unit_offset) const
 {
+    if (m_length_in_code_points == m_code_units.size()) // Fast path: all code points are one code unit.
+        return code_unit_offset;
+
     size_t code_point_offset = 0;
 
     for (auto it = begin(); it != end(); ++it) {
@@ -222,6 +230,9 @@ size_t Utf16View::code_point_offset_of(size_t code_unit_offset) const
 
 size_t Utf16View::code_unit_offset_of(size_t code_point_offset) const
 {
+    if (m_length_in_code_points == m_code_units.size()) // Fast path: all code points are one code unit.
+        return code_point_offset;
+
     size_t code_unit_offset = 0;
 
     for (auto it = begin(); it != end(); ++it) {
@@ -255,6 +266,9 @@ Utf16View Utf16View::unicode_substring_view(size_t code_point_offset, size_t cod
 {
     if (code_point_length == 0)
         return {};
+
+    if (m_length_in_code_points == m_code_units.size()) // Fast path: all code points are one code unit.
+        return substring_view(code_point_offset, code_point_length);
 
     auto code_unit_offset_of = [&](Utf16CodePointIterator const& it) { return it.m_ptr - begin_ptr(); };
     size_t code_point_index = 0;

--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -572,7 +572,8 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::escape)
     // 2. Let length be the length of string.
     // 5. Let k be 0.
     // 6. Repeat, while k < length,
-    for (auto code_point : TRY_OR_THROW_OOM(vm, utf8_to_utf16(string))) {
+    auto utf16_conversion = TRY_OR_THROW_OOM(vm, utf8_to_utf16(string));
+    for (auto code_point : utf16_conversion.data) {
         // a. Let char be the code unit at index k within string.
 
         // b. If unescapedSet contains char, then

--- a/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -97,8 +97,8 @@ ErrorOr<String, ParseRegexPatternError> parse_regex_pattern(StringView pattern, 
     if (utf16_pattern_result.is_error())
         return ParseRegexPatternError { "Out of memory"_string };
 
-    auto utf16_pattern = utf16_pattern_result.release_value();
-    Utf16View utf16_pattern_view { utf16_pattern };
+    auto utf16_result = utf16_pattern_result.release_value();
+    Utf16View utf16_pattern_view { utf16_result };
     StringBuilder builder;
 
     // If the Unicode flag is set, append each code point to the pattern. Otherwise, append each

--- a/Libraries/LibJS/Runtime/Utf16String.h
+++ b/Libraries/LibJS/Runtime/Utf16String.h
@@ -48,6 +48,7 @@ private:
     mutable bool m_has_hash { false };
     mutable u32 m_hash { 0 };
     Utf16Data m_string;
+    Utf16View m_cached_view { m_string.span() };
 };
 
 }

--- a/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -327,8 +327,8 @@ void URLSearchParams::sort()
     // 1. Sort all name-value pairs, if any, by their names. Sorting must be done by comparison of code units. The relative order between name-value pairs with equal names must be preserved.
     insertion_sort(m_list, [](auto& a, auto& b) {
         // FIXME: There should be a way to do this without converting to utf16
-        auto a_utf16 = MUST(utf8_to_utf16(a.name));
-        auto b_utf16 = MUST(utf8_to_utf16(b.name));
+        auto a_utf16 = MUST(utf8_to_utf16(a.name)).data;
+        auto b_utf16 = MUST(utf8_to_utf16(b.name)).data;
 
         auto common_length = min(a_utf16.size(), b_utf16.size());
 

--- a/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextContentElement.cpp
@@ -54,7 +54,7 @@ ByteString SVGTextContentElement::text_contents() const
 // https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getNumberOfChars
 WebIDL::ExceptionOr<WebIDL::Long> SVGTextContentElement::get_number_of_chars() const
 {
-    auto chars = TRY_OR_THROW_OOM(vm(), utf8_to_utf16(text_contents()));
+    auto chars = TRY_OR_THROW_OOM(vm(), utf8_to_utf16(text_contents())).data;
     return static_cast<WebIDL::Long>(chars.size());
 }
 

--- a/Tests/LibUnicode/TestSegmenter.cpp
+++ b/Tests/LibUnicode/TestSegmenter.cpp
@@ -160,16 +160,16 @@ TEST_CASE(out_of_bounds)
         auto segmenter = Unicode::Segmenter::create(Unicode::SegmenterGranularity::Word);
         segmenter->set_segmented_text(Utf16View { text });
 
-        auto result = segmenter->previous_boundary(text.size() + 1);
+        auto result = segmenter->previous_boundary(text.data.size() + 1);
         EXPECT(result.has_value());
 
-        result = segmenter->next_boundary(text.size() + 1);
+        result = segmenter->next_boundary(text.data.size() + 1);
         EXPECT(!result.has_value());
 
-        result = segmenter->previous_boundary(text.size());
+        result = segmenter->previous_boundary(text.data.size());
         EXPECT(result.has_value());
 
-        result = segmenter->next_boundary(text.size());
+        result = segmenter->next_boundary(text.data.size());
         EXPECT(!result.has_value());
 
         result = segmenter->next_boundary(0);


### PR DESCRIPTION
For the slight cost of counting code points when converting between encodings and a teeny bit of memory, this commit adds a fast path for all-happy utf-16 substrings and code point operations.

This seems to be a significant chunk of time spent in many regex benchmarks.

js benchmarks for fun:
```
SunSpider   Total                0.982  2.190           2.230
Kraken      Total                0.953  34.653          36.347
Octane      Total                1.003  222.273         221.690
JetStream   Total                0.998  275.303         275.777
JetStream3  Total                0.638  29.243          45.803
All Suites  Total                0.969  563.663         581.847
```