### PR TITLE
LibWeb: Append style sheet to ShadowRoot's list if link el is in one

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLLinkElement-appends-and-removes-from-ShadowRoot-styleSheets.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLLinkElement-appends-and-removes-from-ShadowRoot-styleSheets.txt
@@ -1,0 +1,13 @@
+== before appending
+is linkEl.sheet null? true
+- document stylesheets (length = 0)
+- shadow root stylesheets (length = 0)
+== link loaded
+is linkEl.sheet null? false
+- document stylesheets (length = 0)
+- shadow root stylesheets (length = 1)
+-- shadow root linkEl.sheet === sheet: true
+== link removed
+is linkEl.sheet null? true
+- document stylesheets (length = 0)
+- shadow root stylesheets (length = 0)

--- a/Tests/LibWeb/Text/input/HTML/HTMLLinkElement-appends-and-removes-from-ShadowRoot-styleSheets.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLLinkElement-appends-and-removes-from-ShadowRoot-styleSheets.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<div id="shadowhost"></div>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        const shadowHost = document.getElementById("shadowhost");
+        const shadowRoot = shadowHost.attachShadow({ mode: "closed" });
+
+        const linkEl = document.createElement("link");
+        linkEl.href = "../valid.css";
+        linkEl.rel = "stylesheet";
+
+        const printSheets = () => {
+            println(`is linkEl.sheet null? ${linkEl.sheet === null}`)
+            println(`- document stylesheets (length = ${document.styleSheets.length})`);
+            for (const sheet of document.styleSheets) {
+                println(`-- document stylesheet linkEl.sheet === sheet: ${linkEl.sheet === sheet}`);
+            }
+            println(`- shadow root stylesheets (length = ${shadowRoot.styleSheets.length})`);
+            for (const sheet of shadowRoot.styleSheets) {
+                println(`-- shadow root linkEl.sheet === sheet: ${linkEl.sheet === sheet}`);
+            }
+        };
+
+        println("== before appending");
+        printSheets();
+
+        linkEl.addEventListener("load", () => {
+            println("== link loaded");
+            printSheets();
+
+            linkEl.remove();
+            println("== link removed");
+            printSheets();
+            done();
+        }, { once: true });
+
+        shadowRoot.appendChild(linkEl);
+    });
+</script>


### PR DESCRIPTION
We were handling removing the style sheet from the shadow root, but not appending to it. Fixing this also revealed a bug that a removed link element would always try to remove from the document's list, as the root is no longer the shadow root it's in. The fix is to use the passed in old root to remove the style sheet from.

Fixes the cookie banner on https://nos.nl/

Before:
<img width="1624" alt="Screenshot 2025-04-02 at 17 04 49" src="https://github.com/user-attachments/assets/9fa74358-d190-459a-be29-a6c5e663ff2c" />

After:
<img width="1624" alt="Screenshot 2025-04-02 at 17 02 41" src="https://github.com/user-attachments/assets/b9f08545-a938-403b-939e-bdbe4faf2b58" />

