### PR TITLE
Some LibJS optimizations for JetStream and Octane

### DIFF
--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1349,7 +1349,7 @@ static Bytecode::CodeGenerationErrorOr<void> generate_object_binding_pattern_byt
                 excluded_property_names.append(excluded_name);
             }
 
-            generator.emit<Bytecode::Op::GetByValue>(value, object, property_name);
+            generator.emit_get_by_value(value, object, property_name);
         }
 
         if (initializer) {
@@ -1683,7 +1683,7 @@ static Bytecode::CodeGenerationErrorOr<BaseAndValue> get_base_and_value_from_mem
         if (computed_property.has_value()) {
             // 5. Let propertyKey be ? ToPropertyKey(propertyNameValue).
             // FIXME: This does ToPropertyKey out of order, which is observable by Symbol.toPrimitive!
-            generator.emit<Bytecode::Op::GetByValueWithThis>(value, super_base, *computed_property, this_value);
+            generator.emit_get_by_value_with_this(value, super_base, *computed_property, this_value);
         } else {
             // 3. Let propertyKey be StringValue of IdentifierName.
             auto identifier_table_ref = generator.intern_identifier(as<Identifier>(member_expression.property()).string());
@@ -1697,7 +1697,7 @@ static Bytecode::CodeGenerationErrorOr<BaseAndValue> get_base_and_value_from_mem
     auto value = generator.allocate_register();
     if (member_expression.is_computed()) {
         auto property = TRY(member_expression.property().generate_bytecode(generator)).value();
-        generator.emit<Bytecode::Op::GetByValue>(value, base, property);
+        generator.emit_get_by_value(value, base, property);
     } else if (is<PrivateIdentifier>(member_expression.property())) {
         generator.emit<Bytecode::Op::GetPrivateById>(
             value,
@@ -3482,7 +3482,7 @@ static Bytecode::CodeGenerationErrorOr<void> generate_optional_chain(Bytecode::G
             [&](OptionalChain::ComputedReference const& ref) -> Bytecode::CodeGenerationErrorOr<void> {
                 generator.emit_mov(current_base, current_value);
                 auto property = TRY(ref.expression->generate_bytecode(generator)).value();
-                generator.emit<Bytecode::Op::GetByValue>(current_value, current_value, property);
+                generator.emit_get_by_value(current_value, current_value, property);
                 return {};
             },
             [&](OptionalChain::MemberReference const& ref) -> Bytecode::CodeGenerationErrorOr<void> {

--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -625,9 +625,9 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> AssignmentExpression::g
 
                     if (expression.is_computed()) {
                         if (!lhs_is_super_expression)
-                            generator.emit<Bytecode::Op::PutByValue>(*base, *computed_property, rval, Bytecode::Op::PropertyKind::KeyValue, move(base_identifier));
+                            generator.emit_put_by_value(*base, *computed_property, rval, Bytecode::Op::PropertyKind::KeyValue, move(base_identifier));
                         else
-                            generator.emit<Bytecode::Op::PutByValueWithThis>(*base, *computed_property, *this_value, rval);
+                            generator.emit_put_by_value_with_this(*base, *computed_property, *this_value, rval, Op::PropertyKind::KeyValue);
                     } else if (expression.property().is_identifier()) {
                         auto identifier_table_ref = generator.intern_identifier(as<Identifier>(expression.property()).string());
                         if (!lhs_is_super_expression)
@@ -1180,7 +1180,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> ObjectExpression::gener
             auto property_name = TRY(property->key().generate_bytecode(generator)).value();
             auto value = TRY(property->value().generate_bytecode(generator)).value();
 
-            generator.emit<Bytecode::Op::PutByValue>(object, property_name, value, property_kind);
+            generator.emit_put_by_value(object, property_name, value, property_kind, {});
         }
     }
 

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -324,6 +324,9 @@ public:
 
     void emit_get_by_id_with_this(ScopedOperand dst, ScopedOperand base, IdentifierTableIndex, ScopedOperand this_value);
 
+    void emit_get_by_value(ScopedOperand dst, ScopedOperand base, ScopedOperand property, Optional<IdentifierTableIndex> base_identifier = {});
+    void emit_get_by_value_with_this(ScopedOperand dst, ScopedOperand base, ScopedOperand property, ScopedOperand this_value);
+
     void emit_iterator_value(ScopedOperand dst, ScopedOperand result);
     void emit_iterator_complete(ScopedOperand dst, ScopedOperand result);
 

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -327,6 +327,9 @@ public:
     void emit_get_by_value(ScopedOperand dst, ScopedOperand base, ScopedOperand property, Optional<IdentifierTableIndex> base_identifier = {});
     void emit_get_by_value_with_this(ScopedOperand dst, ScopedOperand base, ScopedOperand property, ScopedOperand this_value);
 
+    void emit_put_by_value(ScopedOperand base, ScopedOperand property, ScopedOperand src, Bytecode::Op::PropertyKind, Optional<IdentifierTableIndex> base_identifier);
+    void emit_put_by_value_with_this(ScopedOperand base, ScopedOperand property, ScopedOperand this_value, ScopedOperand src, Bytecode::Op::PropertyKind);
+
     void emit_iterator_value(ScopedOperand dst, ScopedOperand result);
     void emit_iterator_complete(ScopedOperand dst, ScopedOperand result);
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -602,6 +602,17 @@ ThrowCompletionOr<GC::Ref<Object>> Value::to_object(VM& vm) const
 // 7.1.3 ToNumeric ( value ), https://tc39.es/ecma262/#sec-tonumeric
 FLATTEN ThrowCompletionOr<Value> Value::to_numeric_slow_case(VM& vm) const
 {
+    // OPTIMIZATION: Fast paths for some trivial common cases.
+    if (is_boolean()) {
+        return Value(as_bool() ? 1 : 0);
+    }
+    if (is_null()) {
+        return Value(0);
+    }
+    if (is_undefined()) {
+        return js_nan();
+    }
+
     // 1. Let primValue be ? ToPrimitive(value, number).
     auto primitive_value = TRY(to_primitive(vm, Value::PreferredType::Number));
 

--- a/Libraries/LibJS/Runtime/ValueInlines.h
+++ b/Libraries/LibJS/Runtime/ValueInlines.h
@@ -17,6 +17,9 @@ inline bool Value::to_boolean() const
     if (is_boolean())
         return as_bool();
 
+    if (is_int32())
+        return as_i32() != 0;
+
     return to_boolean_slow_case();
 }
 


### PR DESCRIPTION
Some easy changes for 1% improvement on JetStream and Octane. The rest look neutral.

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                           1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                   1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    1      0.130 ± 0.130 … 0.130        0.130 ± 0.130 … 0.130
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   math-partial-sums.js                     1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            0.984  0.310 ± 0.310 … 0.310        0.315 ± 0.310 … 0.320
SunSpider   string-base64.js                         1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   string-fasta.js                          1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-tagcloud.js                       1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-unpack-code.js                    1      0.110 ± 0.110 … 0.110        0.110 ± 0.110 … 0.110
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
Kraken      ai-astar.js                              0.983  1.125 ± 1.110 … 1.140        1.145 ± 1.130 … 1.160
Kraken      audio-beat-detection.js                  1.022  0.950 ± 0.950 … 0.950        0.930 ± 0.930 … 0.930
Kraken      audio-dft.js                             1      0.650 ± 0.650 … 0.650        0.650 ± 0.650 … 0.650
Kraken      audio-fft.js                             1.019  0.820 ± 0.820 … 0.820        0.805 ± 0.800 … 0.810
Kraken      audio-oscillator.js                      0.994  0.900 ± 0.900 … 0.900        0.905 ± 0.900 … 0.910
Kraken      imaging-darkroom.js                      0.996  1.365 ± 1.360 … 1.370        1.370 ± 1.370 … 1.370
Kraken      imaging-desaturate.js                    1.008  1.210 ± 1.200 … 1.220        1.200 ± 1.200 … 1.200
Kraken      imaging-gaussian-blur.js                 1.008  4.595 ± 4.590 … 4.600        4.560 ± 4.550 … 4.570
Kraken      json-parse-financial.js                  0.923  0.060 ± 0.060 … 0.060        0.065 ± 0.060 … 0.070
Kraken      json-stringify-tinderbox.js              1      0.090 ± 0.090 … 0.090        0.090 ± 0.090 … 0.090
Kraken      stanford-crypto-aes.js                   1      0.410 ± 0.410 … 0.410        0.410 ± 0.410 … 0.410
Kraken      stanford-crypto-ccm.js                   1.014  0.355 ± 0.350 … 0.360        0.350 ± 0.350 … 0.350
Kraken      stanford-crypto-pbkdf2.js                0.993  0.740 ± 0.730 … 0.750        0.745 ± 0.740 … 0.750
Kraken      stanford-crypto-sha256-iterative.js      1      0.285 ± 0.280 … 0.290        0.285 ± 0.280 … 0.290
Octane      box2d.js                                 1.002  2.220 ± 2.210 … 2.230        2.215 ± 2.210 … 2.220
Octane      code-load.js                             1      2.020 ± 2.020 … 2.020        2.020 ± 2.020 … 2.020
Octane      crypto.js                                1.001  5.120 ± 5.110 … 5.130        5.115 ± 5.080 … 5.150
Octane      deltablue.js                             0.998  2.010 ± 2.010 … 2.010        2.015 ± 2.010 … 2.020
Octane      earley-boyer.js                          0.993  11.220 ± 11.210 … 11.230     11.300 ± 11.280 … 11.320
Octane      gbemu.js                                 0.993  2.195 ± 2.190 … 2.200        2.210 ± 2.210 … 2.210
Octane      mandreel.js                              0.999  8.040 ± 8.030 … 8.050        8.050 ± 8.040 … 8.060
Octane      navier-stokes.js                         0.805  2.100 ± 2.100 … 2.100        2.610 ± 2.140 … 3.080
Octane      pdfjs.js                                 1.004  1.420 ± 1.420 … 1.420        1.415 ± 1.410 … 1.420
Octane      raytrace.js                              0.996  4.270 ± 4.260 … 4.280        4.285 ± 4.280 … 4.290
Octane      regexp.js                                1.006  17.695 ± 17.620 … 17.770     17.595 ± 17.540 … 17.650
Octane      richards.js                              1      2.005 ± 2.000 … 2.010        2.005 ± 2.000 … 2.010
Octane      splay.js                                 1      2.310 ± 2.310 … 2.310        2.310 ± 2.310 … 2.310
Octane      typescript.js                            1.004  14.820 ± 14.780 … 14.860     14.760 ± 14.740 … 14.780
Octane      zlib.js                                  1.04   53.260 ± 52.960 … 53.560     51.215 ± 51.100 … 51.330
JetStream   bigfib.cpp.js                            1.066  10.120 ± 9.920 … 10.320      9.495 ± 9.280 … 9.710
JetStream   cdjs.js                                  1.005  6.815 ± 6.790 … 6.840        6.780 ± 6.780 … 6.780
JetStream   container.cpp.js                         1.026  38.725 ± 38.470 … 38.980     37.730 ± 37.360 … 38.100
JetStream   dry.c.js                                 0.961  20.475 ± 20.420 … 20.530     21.300 ± 20.560 … 22.040
JetStream   float-mm.c.js                            0.976  23.225 ± 23.100 … 23.350     23.805 ± 23.630 … 23.980
JetStream   gcc-loops.cpp.js                         1.018  128.900 ± 127.860 … 129.940  126.560 ± 126.180 … 126.940
JetStream   hash-map.js                              1.001  3.475 ± 3.470 … 3.480        3.470 ± 3.410 … 3.530
JetStream   n-body.c.js                              1.01   34.680 ± 34.210 … 35.150     34.350 ± 34.100 … 34.600
JetStream   quicksort.c.js                           1.019  5.125 ± 5.040 … 5.210        5.030 ± 4.920 … 5.140
JetStream   towers.c.js                              1.034  8.205 ± 8.180 … 8.230        7.935 ± 7.900 … 7.970
JetStream3  js-tokens.js                             1.001  9.510 ± 9.510 … 9.510        9.500 ± 9.490 … 9.510
JetStream3  lazy-collections.js                      1.018  1.720 ± 1.710 … 1.730        1.690 ± 1.670 … 1.710
JetStream3  raytrace-private-class-fields.js         1.005  6.255 ± 6.230 … 6.280        6.225 ± 6.190 … 6.260
JetStream3  raytrace-public-class-fields.js          1.006  4.750 ± 4.740 … 4.760        4.720 ± 4.710 … 4.730
JetStream3  sync-file-system.js                      1.003  3.020 ± 3.000 … 3.040        3.010 ± 2.990 … 3.030
SunSpider   Total                                    0.996  1.300                        1.305
Kraken      Total                                    1.003  13.555                       13.510
Octane      Total                                    1.012  130.705                      129.120
JetStream   Total                                    1.012  279.745                      276.455
JetStream3  Total                                    1.004  25.255                       25.145
All Suites  Total                                    1.011  450.560                      445.535
```