### PR TITLE
LibWeb/CSS: Use "pending-substitution value" for cascading unresolved shorthands

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -863,9 +863,10 @@ WebIDL::ExceptionOr<void> KeyframeEffect::set_keyframes(Optional<GC::Root<JS::Ob
         for (auto [property_id, property_value] : keyframe.parsed_properties()) {
             if (property_value->is_unresolved() && target)
                 property_value = CSS::Parser::Parser::resolve_unresolved_style_value(CSS::Parser::ParsingParams { target->document() }, *target, pseudo_element_type(), property_id, property_value->as_unresolved());
-            CSS::StyleComputer::for_each_property_expanding_shorthands(property_id, property_value, CSS::StyleComputer::AllowUnresolved::Yes, [&](CSS::PropertyID shorthand_id, CSS::CSSStyleValue const& shorthand_value) {
-                m_target_properties.set(shorthand_id);
-                resolved_keyframe.properties.set(shorthand_id, NonnullRefPtr<CSS::CSSStyleValue const> { shorthand_value });
+
+            CSS::StyleComputer::for_each_property_expanding_shorthands(property_id, property_value, CSS::StyleComputer::AllowUnresolved::Yes, [&](CSS::PropertyID longhand_id, CSS::CSSStyleValue const& longhand_value) {
+                m_target_properties.set(longhand_id);
+                resolved_keyframe.properties.set(longhand_id, NonnullRefPtr<CSS::CSSStyleValue const> { longhand_value });
             });
         }
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -864,7 +864,7 @@ WebIDL::ExceptionOr<void> KeyframeEffect::set_keyframes(Optional<GC::Root<JS::Ob
             if (property_value->is_unresolved() && target)
                 property_value = CSS::Parser::Parser::resolve_unresolved_style_value(CSS::Parser::ParsingParams { target->document() }, *target, pseudo_element_type(), property_id, property_value->as_unresolved());
 
-            CSS::StyleComputer::for_each_property_expanding_shorthands(property_id, property_value, CSS::StyleComputer::AllowUnresolved::Yes, [&](CSS::PropertyID longhand_id, CSS::CSSStyleValue const& longhand_value) {
+            CSS::StyleComputer::for_each_property_expanding_shorthands(property_id, property_value, [&](CSS::PropertyID longhand_id, CSS::CSSStyleValue const& longhand_value) {
                 m_target_properties.set(longhand_id);
                 resolved_keyframe.properties.set(longhand_id, NonnullRefPtr<CSS::CSSStyleValue const> { longhand_value });
             });

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -242,7 +242,7 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(StringView property_n
     // 8. If property is a shorthand property,
     if (property_is_shorthand(property_id)) {
         // then for each longhand property longhand that property maps to, in canonical order, follow these substeps:
-        StyleComputer::for_each_property_expanding_shorthands(property_id, *component_value_list, StyleComputer::AllowUnresolved::Yes, [this, &updated, priority](PropertyID longhand_property_id, CSSStyleValue const& longhand_value) {
+        StyleComputer::for_each_property_expanding_shorthands(property_id, *component_value_list, [this, &updated, priority](PropertyID longhand_property_id, CSSStyleValue const& longhand_value) {
             // 1. Let longhand result be the result of set the CSS declaration longhand with the appropriate value(s) from component value list,
             //    with the important flag set if priority is not the empty string, and unset otherwise, and with the list of declarations being the declarations.
             // 2. If longhand result is true, let updated be true.

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -40,6 +40,7 @@
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
@@ -238,6 +239,12 @@ GridTrackSizeListStyleValue const& CSSStyleValue::as_grid_track_size_list() cons
 {
     VERIFY(is_grid_track_size_list());
     return static_cast<GridTrackSizeListStyleValue const&>(*this);
+}
+
+GuaranteedInvalidStyleValue const& CSSStyleValue::as_guaranteed_invalid() const
+{
+    VERIFY(is_guaranteed_invalid());
+    return static_cast<GuaranteedInvalidStyleValue const&>(*this);
 }
 
 CSSKeywordValue const& CSSStyleValue::as_keyword() const

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -48,6 +48,7 @@
 #include <LibWeb/CSS/StyleValues/MathDepthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PendingSubstitutionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/CSS/StyleValues/RadialGradientStyleValue.h>
@@ -293,6 +294,12 @@ OpenTypeTaggedStyleValue const& CSSStyleValue::as_open_type_tagged() const
 {
     VERIFY(is_open_type_tagged());
     return static_cast<OpenTypeTaggedStyleValue const&>(*this);
+}
+
+PendingSubstitutionStyleValue const& CSSStyleValue::as_pending_substitution() const
+{
+    VERIFY(is_pending_substitution());
+    return static_cast<PendingSubstitutionStyleValue const&>(*this);
 }
 
 PercentageStyleValue const& CSSStyleValue::as_percentage() const

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -108,7 +108,6 @@ public:
         Flex,
         FontSource,
         FontStyle,
-        FontVariant,
         Frequency,
         GridAutoFlow,
         GridTemplateArea,

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -113,6 +113,7 @@ public:
         GridTemplateArea,
         GridTrackPlacement,
         GridTrackSizeList,
+        GuaranteedInvalid,
         Image,
         Integer,
         Keyword,
@@ -257,6 +258,10 @@ public:
     bool is_grid_track_size_list() const { return type() == Type::GridTrackSizeList; }
     GridTrackSizeListStyleValue const& as_grid_track_size_list() const;
     GridTrackSizeListStyleValue& as_grid_track_size_list() { return const_cast<GridTrackSizeListStyleValue&>(const_cast<CSSStyleValue const&>(*this).as_grid_track_size_list()); }
+
+    bool is_guaranteed_invalid() const { return type() == Type::GuaranteedInvalid; }
+    GuaranteedInvalidStyleValue const& as_guaranteed_invalid() const;
+    GuaranteedInvalidStyleValue& as_guaranteed_invalid() { return const_cast<GuaranteedInvalidStyleValue&>(const_cast<CSSStyleValue const&>(*this).as_guaranteed_invalid()); }
 
     bool is_image() const { return type() == Type::Image; }
     ImageStyleValue const& as_image() const;

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -122,6 +122,7 @@ public:
         MathDepth,
         Number,
         OpenTypeTagged,
+        PendingSubstitution,
         Percentage,
         Position,
         RadialGradient,
@@ -294,6 +295,10 @@ public:
     bool is_open_type_tagged() const { return type() == Type::OpenTypeTagged; }
     OpenTypeTaggedStyleValue const& as_open_type_tagged() const;
     OpenTypeTaggedStyleValue& as_open_type_tagged() { return const_cast<OpenTypeTaggedStyleValue&>(const_cast<CSSStyleValue const&>(*this).as_open_type_tagged()); }
+
+    bool is_pending_substitution() const { return type() == Type::PendingSubstitution; }
+    PendingSubstitutionStyleValue const& as_pending_substitution() const;
+    PendingSubstitutionStyleValue& as_pending_substitution() { return const_cast<PendingSubstitutionStyleValue&>(const_cast<CSSStyleValue const&>(*this).as_pending_substitution()); }
 
     bool is_percentage() const { return type() == Type::Percentage; }
     PercentageStyleValue const& as_percentage() const;

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -45,14 +45,20 @@ static T interpolate_raw(T from, T to, float delta)
 
 static NonnullRefPtr<CSSStyleValue const> with_keyword_values_resolved(DOM::Element& element, PropertyID property_id, CSSStyleValue const& value)
 {
+    if (value.is_guaranteed_invalid()) {
+        // At the moment, we're only dealing with "real" properties, so this behaves the same as `unset`.
+        // https://drafts.csswg.org/css-values-5/#invalid-at-computed-value-time
+        return property_initial_value(property_id);
+    }
+
     if (!value.is_keyword())
         return value;
     switch (value.as_keyword().keyword()) {
-    case CSS::Keyword::Initial:
-    case CSS::Keyword::Unset:
+    case Keyword::Initial:
+    case Keyword::Unset:
         return property_initial_value(property_id);
-    case CSS::Keyword::Inherit:
-        return CSS::StyleComputer::get_inherit_value(property_id, &element);
+    case Keyword::Inherit:
+        return StyleComputer::get_inherit_value(property_id, &element);
     default:
         break;
     }

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1328,7 +1328,7 @@ Parser::PropertiesAndCustomProperties Parser::parse_as_property_declaration_bloc
         Vector<StyleProperty> expanded_properties;
         for (auto& property : properties) {
             if (property_is_shorthand(property.property_id)) {
-                StyleComputer::for_each_property_expanding_shorthands(property.property_id, *property.value, StyleComputer::AllowUnresolved::Yes, [&](PropertyID longhand_property_id, CSSStyleValue const& longhand_value) {
+                StyleComputer::for_each_property_expanding_shorthands(property.property_id, *property.value, [&](PropertyID longhand_property_id, CSSStyleValue const& longhand_value) {
                     expanded_properties.append(CSS::StyleProperty {
                         .important = property.important,
                         .property_id = longhand_property_id,

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1708,8 +1708,6 @@ NonnullRefPtr<CSSStyleValue const> StyleComputer::get_inherit_value(CSS::Propert
 
 void StyleComputer::compute_defaulted_property_value(ComputedProperties& style, DOM::Element const* element, CSS::PropertyID property_id, Optional<CSS::PseudoElement> pseudo_element) const
 {
-    // FIXME: If we don't know the correct initial value for a property, we fall back to `initial`.
-
     auto& value_slot = style.m_property_values[to_underlying(property_id)];
     if (!value_slot) {
         if (is_inherited_property(property_id)) {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1041,8 +1041,8 @@ void StyleComputer::cascade_declarations(
     Important important,
     Optional<FlyString> layer_name) const
 {
-    for (auto const& match : matching_rules) {
-        for (auto const& property : match->declaration().properties()) {
+    auto cascade_style_declaration = [&](CSSStyleProperties const& declaration) {
+        for (auto const& property : declaration.properties()) {
             if (important != property.important)
                 continue;
 
@@ -1050,7 +1050,7 @@ void StyleComputer::cascade_declarations(
                 continue;
 
             if (property.property_id == CSS::PropertyID::All) {
-                set_all_properties(cascaded_properties, element, pseudo_element, property.value, m_document, &match->declaration(), cascade_origin, important, layer_name);
+                set_all_properties(cascaded_properties, element, pseudo_element, property.value, m_document, &declaration, cascade_origin, important, layer_name);
                 continue;
             }
 
@@ -1058,27 +1058,17 @@ void StyleComputer::cascade_declarations(
             if (property.value->is_unresolved())
                 property_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { document() }, element, pseudo_element, property.property_id, property.value->as_unresolved());
             if (!property_value->is_unresolved())
-                set_property_expanding_shorthands(cascaded_properties, property.property_id, property_value, &match->declaration(), cascade_origin, important, layer_name);
+                set_property_expanding_shorthands(cascaded_properties, property.property_id, property_value, &declaration, cascade_origin, important, layer_name);
         }
+    };
+
+    for (auto const& match : matching_rules) {
+        cascade_style_declaration(match->declaration());
     }
 
     if (cascade_origin == CascadeOrigin::Author && !pseudo_element.has_value()) {
         if (auto const inline_style = element.inline_style()) {
-            for (auto const& property : inline_style->properties()) {
-                if (important != property.important)
-                    continue;
-
-                if (property.property_id == CSS::PropertyID::All) {
-                    set_all_properties(cascaded_properties, element, pseudo_element, property.value, m_document, inline_style, cascade_origin, important, layer_name);
-                    continue;
-                }
-
-                auto property_value = property.value;
-                if (property.value->is_unresolved())
-                    property_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { document() }, element, pseudo_element, property.property_id, property.value->as_unresolved());
-                if (!property_value->is_unresolved())
-                    set_property_expanding_shorthands(cascaded_properties, property.property_id, property_value, inline_style, cascade_origin, important, layer_name);
-            }
+            cascade_style_declaration(*inline_style);
         }
     }
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1028,10 +1028,7 @@ void StyleComputer::set_all_properties(
         NonnullRefPtr<CSSStyleValue const> property_value = value;
         if (property_value->is_unresolved())
             property_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { document }, element, pseudo_element, property_id, property_value->as_unresolved());
-        if (!property_value->is_unresolved())
-            set_property_expanding_shorthands(cascaded_properties, property_id, property_value, declaration, cascade_origin, important, layer_name);
-
-        set_property_expanding_shorthands(cascaded_properties, property_id, value, declaration, cascade_origin, important, layer_name);
+        set_property_expanding_shorthands(cascaded_properties, property_id, property_value, declaration, cascade_origin, important, layer_name);
     }
 }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -128,11 +128,7 @@ class FontLoader;
 
 class StyleComputer {
 public:
-    enum class AllowUnresolved {
-        Yes,
-        No,
-    };
-    static void for_each_property_expanding_shorthands(PropertyID, CSSStyleValue const&, AllowUnresolved, Function<void(PropertyID, CSSStyleValue const&)> const& set_longhand_property);
+    static void for_each_property_expanding_shorthands(PropertyID, CSSStyleValue const&, Function<void(PropertyID, CSSStyleValue const&)> const& set_longhand_property);
     static void set_property_expanding_shorthands(
         CascadedProperties&,
         PropertyID,

--- a/Libraries/LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/GuaranteedInvalidStyleValue.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/CSSStyleValue.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-variables/#guaranteed-invalid-value
+class GuaranteedInvalidStyleValue final : public StyleValueWithDefaultOperators<GuaranteedInvalidStyleValue> {
+public:
+    static ValueComparingNonnullRefPtr<GuaranteedInvalidStyleValue> create()
+    {
+        static ValueComparingNonnullRefPtr<GuaranteedInvalidStyleValue> instance = adopt_ref(*new (nothrow) GuaranteedInvalidStyleValue());
+        return instance;
+    }
+    virtual ~GuaranteedInvalidStyleValue() override = default;
+    virtual String to_string(SerializationMode) const override { return {}; }
+
+    bool properties_equal(GuaranteedInvalidStyleValue const&) const { return true; }
+
+private:
+    GuaranteedInvalidStyleValue()
+        : StyleValueWithDefaultOperators(Type::GuaranteedInvalid)
+    {
+    }
+};
+
+}

--- a/Libraries/LibWeb/CSS/StyleValues/PendingSubstitutionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/PendingSubstitutionStyleValue.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/CSSStyleValue.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-values-5/#pending-substitution-value
+class PendingSubstitutionStyleValue final : public StyleValueWithDefaultOperators<PendingSubstitutionStyleValue> {
+public:
+    static ValueComparingNonnullRefPtr<PendingSubstitutionStyleValue> create()
+    {
+        static ValueComparingNonnullRefPtr<PendingSubstitutionStyleValue> instance = adopt_ref(*new (nothrow) PendingSubstitutionStyleValue());
+        return instance;
+    }
+    virtual ~PendingSubstitutionStyleValue() override = default;
+    virtual String to_string(SerializationMode) const override { return {}; }
+
+    // We shouldn't need to compare these, but in case we do: The nature of them is that their value is unknown, so
+    // consider them all to be unique.
+    bool properties_equal(PendingSubstitutionStyleValue const&) const { return false; }
+
+private:
+    PendingSubstitutionStyleValue()
+        : StyleValueWithDefaultOperators(Type::PendingSubstitution)
+    {
+    }
+};
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -240,6 +240,7 @@ class NumberOrCalculated;
 class NumberStyleValue;
 class OpenTypeTaggedStyleValue;
 class ParsedFontFace;
+class PendingSubstitutionStyleValue;
 class Percentage;
 class PercentageOrCalculated;
 class PercentageStyleValue;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -219,6 +219,7 @@ class GridTrackPlacement;
 class GridTrackPlacementStyleValue;
 class GridTrackSizeList;
 class GridTrackSizeListStyleValue;
+class GuaranteedInvalidStyleValue;
 class ImageStyleValue;
 class IntegerOrCalculated;
 class IntegerStyleValue;

--- a/Tests/LibWeb/Text/expected/css/var-in-margin-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/css/var-in-margin-shorthand.txt
@@ -1,0 +1,24 @@
+margins for #just-margin:
+marginTop: 5px
+marginRight: 10px
+marginBottom: 5px
+marginLeft: 10px
+
+margins for #margin-before:
+marginTop: 20px
+marginRight: 10px
+marginBottom: 5px
+marginLeft: 10px
+
+margins for #margin-after:
+marginTop: 5px
+marginRight: 10px
+marginBottom: 5px
+marginLeft: 10px
+
+margins for #margin-repeated:
+marginTop: 7px
+marginRight: 5px
+marginBottom: 10px
+marginLeft: 5px
+

--- a/Tests/LibWeb/Text/input/css/var-in-margin-shorthand.html
+++ b/Tests/LibWeb/Text/input/css/var-in-margin-shorthand.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="just-margin" style="--a: 5px; margin: var(--a) 10px"></div>
+<div id="margin-before" style="--a: 5px; margin: var(--a) 10px; margin-top: 20px"></div>
+<div id="margin-after" style="--a: 5px; margin-top: 20px; margin: var(--a) 10px"></div>
+<div id="margin-repeated" style="--a: 5px; margin-top: 20px; margin: var(--a) 10px; margin-top: 50px; margin: 10px var(--a); margin-top: 7px"></div>
+<script>
+    test(() => {
+        function printMargins(id) {
+            const target = document.getElementById(id);
+            const targetStyle = getComputedStyle(target);
+            println(`margins for #${id}:`);
+            println(`marginTop: ${targetStyle.marginTop}`);
+            println(`marginRight: ${targetStyle.marginRight}`);
+            println(`marginBottom: ${targetStyle.marginBottom}`);
+            println(`marginLeft: ${targetStyle.marginLeft}`);
+            println("");
+        }
+
+        printMargins("just-margin");
+        printMargins("margin-before");
+        printMargins("margin-after");
+        printMargins("margin-repeated");
+    });
+</script>


### PR DESCRIPTION
Description from the main commit. The rest are prep/tangential fixes.

---

Previously, we would just assign the UnresolvedStyleValue to each
longhand, which was completely wrong but happened to work if it was a
ShorthandStyleValue (because that's basically a list of "set property X
to Y", and doesn't care which property it's the value of).

For example, the included `var-in-margin-shorthand.html` test would:
1. Set `margin-top` to `var(--a) 10px`
2. Resolve it to `margin-top: 5px 10px`
3. Reject that as invalid

What now happens is:
1. Set `margin-top` to a PendingSubstitutionValue
2. Resolve `margin` to `5px 10px`
3. Expand that out into its longhands
4. `margin-top` is `5px` 🎉

In order to support this, `for_each_property_expanding_shorthands()` now
runs the callback for the shorthand too if it's an unresolved or
pending-substitution value. This is so that we can store those in the
CascadedProperties until they can be resolved - otherwise, by the time
we want to resolve them, we don't have them any more.

`cascade_declarations()` has an unfortunate hack: it tracks, for each
declaration, which properties have already been given values, so that
it can avoid overwriting an actual value with a pending one. This is
necessary because of the unfortunate way that CSSStyleProperties holds
expanded longhands, and not just the original declarations. The spec
disagrees with itself about this, but we do need to do that expansion
for `element.style` to work correctly. This HashTable is unfortunate
but it does solve the problem until a better solution can be found.