### PR TITLE
WebContent: Remove unused private member

### DIFF
--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -56,9 +56,8 @@
 
 namespace WebContent {
 
-ConnectionFromClient::ConnectionFromClient(GC::Heap& heap, IPC::Transport transport)
+ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
     : IPC::ConnectionFromClient<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport), 1)
-    , m_heap(heap)
     , m_page_host(PageHost::create(*this))
 {
 }

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -51,7 +51,7 @@ public:
     Queue<Web::QueuedInputEvent>& input_event_queue() { return m_input_event_queue; }
 
 private:
-    explicit ConnectionFromClient(GC::Heap&, IPC::Transport);
+    explicit ConnectionFromClient(IPC::Transport);
 
     Optional<PageClient&> page(u64 index, SourceLocation = SourceLocation::current());
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;
@@ -157,7 +157,6 @@ private:
 
     virtual void system_time_zone_changed() override;
 
-    GC::Heap& m_heap;
     NonnullOwnPtr<PageHost> m_page_host;
 
     HashMap<int, Web::FileRequest> m_requested_files {};

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -213,7 +213,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     static_assert(IsSame<IPC::Transport, IPC::TransportSocket>, "Need to handle other IPC transports here");
 
     auto webcontent_socket = TRY(Core::take_over_socket_from_system_server("WebContent"sv));
-    auto webcontent_client = TRY(WebContent::ConnectionFromClient::try_create(Web::Bindings::main_thread_vm().heap(), IPC::Transport(move(webcontent_socket))));
+    auto webcontent_client = TRY(WebContent::ConnectionFromClient::try_create(IPC::Transport(move(webcontent_socket))));
 
     webcontent_client->on_image_decoder_connection = [&](auto& socket_file) {
         auto maybe_error = reinitialize_image_decoder(socket_file);


### PR DESCRIPTION
This commit removes the unused m_heap member from ConnectionFromClient. This also works around an issue where some cmake version doesn't apply compiler options from within a subdirectory globally.