### PR TITLE
Everywhere: Remove unused private fields

### DIFF
--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -82,7 +82,6 @@ private:
         ConstructTheEmptyStringImpl
     };
     explicit StringImpl(ConstructTheEmptyStringImplTag)
-        : m_fly(true)
     {
         m_inline_buffer[0] = '\0';
     }
@@ -97,7 +96,6 @@ private:
     size_t m_length { 0 };
     mutable unsigned m_hash { 0 };
     mutable bool m_has_hash { false };
-    mutable bool m_fly { false };
     char m_inline_buffer[0];
 };
 

--- a/Libraries/LibIPC/Message.h
+++ b/Libraries/LibIPC/Message.h
@@ -67,7 +67,6 @@ public:
 
 private:
     Vector<u8, 1024> m_data;
-    bool m_fds_taken { false };
     Vector<NonnullRefPtr<AutoCloseFileDescriptor>, 1> m_fds;
 #ifdef AK_OS_WINDOWS
     Vector<size_t> m_handle_offsets;

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -1397,11 +1397,10 @@ private:
 
 class ClassField final : public ClassElement {
 public:
-    ClassField(SourceRange source_range, NonnullRefPtr<Expression const> key, RefPtr<Expression const> init, bool contains_direct_call_to_eval, bool is_static)
+    ClassField(SourceRange source_range, NonnullRefPtr<Expression const> key, RefPtr<Expression const> init, bool is_static)
         : ClassElement(move(source_range), is_static)
         , m_key(move(key))
         , m_initializer(move(init))
-        , m_contains_direct_call_to_eval(contains_direct_call_to_eval)
     {
     }
 
@@ -1418,15 +1417,13 @@ public:
 private:
     NonnullRefPtr<Expression const> m_key;
     RefPtr<Expression const> m_initializer;
-    bool m_contains_direct_call_to_eval { false };
 };
 
 class StaticInitializer final : public ClassElement {
 public:
-    StaticInitializer(SourceRange source_range, NonnullRefPtr<FunctionBody> function_body, bool contains_direct_call_to_eval)
+    StaticInitializer(SourceRange source_range, NonnullRefPtr<FunctionBody> function_body)
         : ClassElement(move(source_range), true)
         , m_function_body(move(function_body))
-        , m_contains_direct_call_to_eval(contains_direct_call_to_eval)
     {
     }
 
@@ -1437,7 +1434,6 @@ public:
 
 private:
     NonnullRefPtr<FunctionBody> m_function_body;
-    bool m_contains_direct_call_to_eval { false };
 };
 
 class SuperExpression final : public Expression {

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1539,7 +1539,7 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
                 parse_statement_list(static_init_block);
 
                 consume(TokenType::CurlyClose);
-                elements.append(create_ast_node<StaticInitializer>({ m_source_code, static_start.position(), position() }, move(static_init_block), static_init_scope.contains_direct_call_to_eval()));
+                elements.append(create_ast_node<StaticInitializer>({ m_source_code, static_start.position(), position() }, move(static_init_block)));
                 continue;
             } else {
                 expected("property key");
@@ -1591,7 +1591,6 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
                 syntax_error("Class cannot have field named 'constructor'"_string);
 
             RefPtr<Expression const> initializer;
-            bool contains_direct_call_to_eval = false;
 
             if (match(TokenType::Equals)) {
                 consume();
@@ -1602,10 +1601,9 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
                 auto class_scope_node = create_ast_node<BlockStatement>({ m_source_code, rule_start.position(), position() });
                 auto class_field_scope = ScopePusher::class_field_scope(*this, *class_scope_node);
                 initializer = parse_expression(2);
-                contains_direct_call_to_eval = class_field_scope.contains_direct_call_to_eval();
             }
 
-            elements.append(create_ast_node<ClassField>({ m_source_code, rule_start.position(), position() }, property_key.release_nonnull(), move(initializer), contains_direct_call_to_eval, is_static));
+            elements.append(create_ast_node<ClassField>({ m_source_code, rule_start.position(), position() }, property_key.release_nonnull(), move(initializer), is_static));
             consume_or_insert_semicolon();
         }
     }

--- a/Libraries/LibMedia/Color/ColorConverter.cpp
+++ b/Libraries/LibMedia/Color/ColorConverter.cpp
@@ -152,7 +152,7 @@ DecoderErrorOr<ColorConverter> ColorConverter::create(u8 bit_depth, CodingIndepe
     bool should_skip_color_remapping = output_cicp.color_primaries() == input_cicp.color_primaries() && output_cicp.transfer_characteristics() == input_cicp.transfer_characteristics();
     FloatMatrix4x4 input_conversion_matrix = color_conversion_matrix * range_scaling_matrix * integer_scaling_matrix;
 
-    return ColorConverter(bit_depth, input_cicp, should_skip_color_remapping, should_tonemap, input_conversion_matrix, to_linear_lookup_table, color_primaries_matrix_4x4, to_non_linear_lookup_table);
+    return ColorConverter(input_cicp, should_skip_color_remapping, should_tonemap, input_conversion_matrix, to_linear_lookup_table, color_primaries_matrix_4x4, to_non_linear_lookup_table);
 }
 
 }

--- a/Libraries/LibMedia/Color/ColorConverter.h
+++ b/Libraries/LibMedia/Color/ColorConverter.h
@@ -247,9 +247,8 @@ private:
     static constexpr size_t to_linear_size = 64;
     static constexpr size_t to_non_linear_size = 64;
 
-    ColorConverter(u8 bit_depth, CodingIndependentCodePoints cicp, bool should_skip_color_remapping, bool should_tonemap, FloatMatrix4x4 input_conversion_matrix, InterpolatedLookupTable<to_linear_size> to_linear_lookup, FloatMatrix4x4 color_space_conversion_matrix, InterpolatedLookupTable<to_non_linear_size> to_non_linear_lookup)
-        : m_bit_depth(bit_depth)
-        , m_cicp(cicp)
+    ColorConverter(CodingIndependentCodePoints cicp, bool should_skip_color_remapping, bool should_tonemap, FloatMatrix4x4 input_conversion_matrix, InterpolatedLookupTable<to_linear_size> to_linear_lookup, FloatMatrix4x4 color_space_conversion_matrix, InterpolatedLookupTable<to_non_linear_size> to_non_linear_lookup)
+        : m_cicp(cicp)
         , m_should_skip_color_remapping(should_skip_color_remapping)
         , m_should_tonemap(should_tonemap)
         , m_input_conversion_matrix(input_conversion_matrix)
@@ -259,7 +258,6 @@ private:
     {
     }
 
-    u8 m_bit_depth;
     CodingIndependentCodePoints m_cicp;
     bool m_should_skip_color_remapping;
     bool m_should_tonemap;

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -179,7 +179,6 @@ private:
     VideoFrameQueue m_frame_queue;
 
     RefPtr<Core::Timer> m_state_update_timer;
-    unsigned m_decoding_buffer_time_ms = 16;
 
     RefPtr<Threading::Thread> m_decode_thread;
     NonnullOwnPtr<VideoDecoder> m_decoder;

--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -147,10 +147,9 @@ ErrorOr<void> TLSv12::set_close_on_exec(bool enabled)
     return m_socket->set_close_on_exec(enabled);
 }
 
-TLSv12::TLSv12(NonnullOwnPtr<Core::TCPSocket> socket, SSL_CTX* ssl_ctx, SSL* ssl, BIO* bio)
+TLSv12::TLSv12(NonnullOwnPtr<Core::TCPSocket> socket, SSL_CTX* ssl_ctx, SSL* ssl)
     : m_ssl_ctx(ssl_ctx)
     , m_ssl(ssl)
-    , m_bio(bio)
     , m_socket(move(socket))
 {
     m_socket->on_ready_to_read = [this] {
@@ -244,7 +243,7 @@ ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect_internal(NonnullOwnPtr<Core::TCPS
     free_ssl.disarm();
     free_ssl_ctx.disarm();
 
-    return adopt_own(*new TLSv12(move(socket), ssl_ctx, ssl, bio));
+    return adopt_own(*new TLSv12(move(socket), ssl_ctx, ssl));
 }
 
 }

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -65,7 +65,7 @@ public:
     ~TLSv12() override;
 
 private:
-    explicit TLSv12(NonnullOwnPtr<Core::TCPSocket>, SSL_CTX*, SSL*, BIO*);
+    explicit TLSv12(NonnullOwnPtr<Core::TCPSocket>, SSL_CTX*, SSL*);
 
     static ErrorOr<NonnullOwnPtr<TLSv12>> connect_internal(NonnullOwnPtr<Core::TCPSocket>, ByteString const&, Options);
 
@@ -73,7 +73,6 @@ private:
 
     SSL_CTX* m_ssl_ctx { nullptr };
     SSL* m_ssl { nullptr };
-    BIO* m_bio { nullptr };
 
     // Keep this around or the socket will be closed
     NonnullOwnPtr<Core::TCPSocket> m_socket;

--- a/Libraries/LibWeb/IndexedDB/Internal/KeyGenerator.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/KeyGenerator.h
@@ -18,7 +18,8 @@ private:
     // The current number is always a positive integer less than or equal to 2^53 (9007199254740992) + 1.
     // The initial value of a key generator's current number is 1, set when the associated object store is created.
     // The current number is incremented as keys are generated, and may be updated to a specific value by using explicit keys.
-    u64 current_number { 1 };
+    // FIXME: Implement support for KeyGenerator in ObjectStore.
+    [[maybe_unused]] u64 current_number { 1 };
 };
 
 }

--- a/Libraries/LibWeb/ServiceWorker/Registration.h
+++ b/Libraries/LibWeb/ServiceWorker/Registration.h
@@ -68,8 +68,9 @@ private:
     // FIXME: Spec bug: A service worker registration has an associated NavigationPreloadManager object.
     //        This can't possibly be true. The association is the other way around.
 
-    bool m_navigation_preload_enabled = { false }; // https://w3c.github.io/ServiceWorker/#service-worker-registration-navigation-preload-enabled-flag
-    ByteString m_navigation_preload_header_value;  // https://w3c.github.io/ServiceWorker/#service-worker-registration-navigation-preload-header-value
+    // FIXME: Investigate if this is implemented.
+    [[maybe_unused]] bool m_navigation_preload_enabled = { false }; // https://w3c.github.io/ServiceWorker/#service-worker-registration-navigation-preload-enabled-flag
+    ByteString m_navigation_preload_header_value;                   // https://w3c.github.io/ServiceWorker/#service-worker-registration-navigation-preload-header-value
 };
 
 struct RegistrationKey {

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -136,10 +136,6 @@ add_library(GenericClangPlugin INTERFACE)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     add_cxx_compile_options(-Wno-overloaded-virtual)
-    # FIXME: Re-enable this check when the warning stops triggering, or document why we can't stop it from triggering.
-    # For now, there is a lot of unused private fields in LibWeb that trigger this that could be removed.
-    # See issue #14137 for details
-    add_cxx_compile_options(-Wno-unused-private-field)
 
     if (ENABLE_FUZZERS_LIBFUZZER)
         add_cxx_compile_options(-fsanitize=fuzzer)

--- a/Meta/gn/build/BUILD.gn
+++ b/Meta/gn/build/BUILD.gn
@@ -126,7 +126,6 @@ config("compiler_defaults") {
       "-Wstring-conversion",
       "-Wno-user-defined-literals",
       "-fconstexpr-steps=16777216",
-      "-Wno-unused-private-field",
       "-Wno-implicit-const-int-float-conversion",
       "-Wno-vla-cxx-extension",
       "-Wno-unqualified-std-cast-call",


### PR DESCRIPTION
This commit removes the -Wno-unusued-private-field flag, thus reenabling the warning. Unused field were either removed or marked [[maybe_unused]] when unsure.