### PR TITLE
LibWeb: Only apply box offset if the box is not already the ancestor

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -82,7 +82,6 @@ public:
 
     [[nodiscard]] CSSPixelRect absolute_content_rect(Box const&) const;
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
-    [[nodiscard]] CSSPixelRect margin_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect content_box_rect(Box const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect(LayoutState::UsedValues const&) const;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -67,6 +67,8 @@ struct LayoutState {
         void set_content_width(CSSPixels);
         void set_content_height(CSSPixels);
 
+        CSSPixelSize content_size() const { return { content_width(), content_height() }; }
+
         void set_indefinite_content_width();
         void set_indefinite_content_height();
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-inside-margin-auto-container.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-inside-margin-auto-container.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
+      BlockContainer <div.a> at (300,8) content-size 200x300 [BFC] children: inline
+        TextNode <#text>
+        BlockContainer <div.b.g> at (300,8) content-size 150x150 floating [BFC] children: not-inline
+        TextNode <#text>
+        BlockContainer <div.b.r> at (300,158) content-size 150x150 floating [BFC] children: not-inline
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,308) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
+      PaintableWithLines (BlockContainer<DIV>.a) [300,8 200x300]
+        PaintableWithLines (BlockContainer<DIV>.b.g) [300,8 150x150]
+        PaintableWithLines (BlockContainer<DIV>.b.r) [300,158 150x150]
+      PaintableWithLines (BlockContainer(anonymous)) [8,308 784x0]

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-inside-margin-auto-container.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-inside-margin-auto-container.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+.a {
+    margin: auto;
+    overflow: auto;
+    width: 200px;
+}
+.b {
+    height: 150px;
+    float: left;
+    width: 150px;
+}
+.g {
+    background-color: green;
+}
+.r {
+    background-color: red;
+}
+</style>
+<div class="a">
+    <div class="b g"></div>
+    <div class="b r"></div>
+</div>


### PR DESCRIPTION
When determining the content/margin box rects within their ancestor's coordinate space, we were returning early if the passed in values already belonged to the requested ancestor. Unfortunately, we had already applied the used values' offset to the rect, which is the offset to the ancestor's ancestor.

This simplifies the logic to always apply the rect offset after checking if we've reached the ancestor. Fixes determining float intrusions inside block elements with `margin: auto` set.

Fixes #4083.