### PR TITLE
LibRegex: Fix crash when parse result exceeds max cache size

### DIFF
--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
@@ -77,3 +77,7 @@ test("v flag should enable unicode mode", () => {
     const re = new RegExp("a\\u{10FFFF}", "v");
     expect(re.test("a\u{10FFFF}")).toBe(true);
 });
+
+test("parsing a large bytestring shouldn't crash", () => {
+    RegExp(new Uint8Array(0x40000));
+});


### PR DESCRIPTION
Before, If the cache was empty we would try and evict non-existant entries and crash. So we should make sure that we don't saturate the cache with a single parse result.

Heres a way of triggering it from javascript:
```js
RegExp(new Uint8Array(0x40000));
```