### PR TITLE
LibJS: Fix memory corruption when using class static initializers

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1537,6 +1537,8 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
 
                 {
                     ScopePusher static_init_scope = ScopePusher::static_init_block_scope(*this, *static_init_block);
+                    static_init_scope.set_function_parameters(FunctionParameters::empty());
+
                     parse_statement_list(static_init_block);
                 }
 

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1535,8 +1535,10 @@ NonnullRefPtr<ClassExpression const> Parser::parse_class_expression(bool expect_
                 TemporaryChange class_static_init_block_rollback(m_state.in_class_static_init_block, true);
                 TemporaryChange super_property_access_rollback(m_state.allow_super_property_lookup, true);
 
-                ScopePusher static_init_scope = ScopePusher::static_init_block_scope(*this, *static_init_block);
-                parse_statement_list(static_init_block);
+                {
+                    ScopePusher static_init_scope = ScopePusher::static_init_block_scope(*this, *static_init_block);
+                    parse_statement_list(static_init_block);
+                }
 
                 consume(TokenType::CurlyClose);
                 elements.append(create_ast_node<StaticInitializer>({ m_source_code, static_start.position(), position() }, move(static_init_block)));

--- a/Libraries/LibJS/Tests/classes/class-static-initializers.js
+++ b/Libraries/LibJS/Tests/classes/class-static-initializers.js
@@ -72,3 +72,20 @@ describe("class like constructs can be used inside", () => {
         expect(hit).toBeTrue();
     });
 });
+
+// https://github.com/LadybirdBrowser/ladybird/pull/4226
+test("declaring variables", () => {
+    class A {
+        static {
+            const a = 1;
+            let b = 2;
+            var c = 3;
+            function d() {}
+
+            expect(a).toBe(1);
+            expect(b).toBe(2);
+            expect(c).toBe(3);
+            expect(typeof d).toBe("function");
+        }
+    }
+});


### PR DESCRIPTION
The following code causes a memory corruption:

```js
function main() {
  class C0 {
    static {
      let a0;
    }
  }
}
main()
```

This is because the variable `a0` is added to the `last_function_scope` here:
https://github.com/LadybirdBrowser/ladybird/blob/28d5d982ce1e53b78131b8c502333971af891fe7/Libraries/LibJS/Parser.cpp#L357-L373

However, since `last_function_scope` uses `m_function_parameters` to find a valid function scope, it misses the static class initializer and goes all the way up to `main`.

Crash for e73438e82c14c062bf6a8e725305a0fdfc02d336: 
```
=================================================================
==177126==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5060000026f8 at pc 0x7fd3e8092532 bp 0x7ffefdee43e0 sp 0x7ffefdee43d8
WRITE of size 8 at 0x5060000026f8 thread T0
    #0 0x7fd3e8092531 in JS::Bytecode::Interpreter::set(JS::Bytecode::Operand, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:192
    #1 0x7fd3e8092531 in JS::Bytecode::Interpreter::run_bytecode(unsigned long) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:415
    #2 0x7fd3e809862f in JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:758
    #3 0x7fd3e8e22849 in JS::ECMAScriptFunctionObject::ordinary_call_evaluate_body() /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:833
    #4 0x7fd3e8e34526 in JS::ECMAScriptFunctionObject::internal_call(JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:432
    #5 0x7fd3e79cd15b in JS::ThrowCompletionOr<JS::Value> JS::call<>(JS::VM&, JS::FunctionObject&, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/AbstractOperations.h:131
    #6 0x7fd3e79cd15b in operator() /home/devgianlu/Projects/ladybird/Libraries/LibJS/AST.cpp:443
    #7 0x7fd3e79cd15b in visit<AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >, AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >::Visitor<JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(JS::ClassFieldDefinition&)>, JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(GC::Root<JS::ECMAScriptFunctionObject>)> >, 1> /home/devgianlu/Projects/ladybird/AK/Variant.h:113
    #8 0x7fd3e79cd15b in visit<AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >, AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >::Visitor<JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(JS::ClassFieldDefinition&)>, JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(GC::Root<JS::ECMAScriptFunctionObject>)> > > /home/devgianlu/Projects/ladybird/AK/Variant.h:119
    #9 0x7fd3e79cd15b in visit<JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(JS::ClassFieldDefinition&)>, JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(GC::Root<JS::ECMAScriptFunctionObject>)> > /home/devgianlu/Projects/ladybird/AK/Variant.h:403
    #10 0x7fd3e79cd15b in JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::Span<JS::Value const>, AK::Optional<AK::FlyString> const&, AK::FlyString const&) const /home/devgianlu/Projects/ladybird/Libraries/LibJS/AST.cpp:443
    #11 0x7fd3e80bfe3e in JS::Bytecode::new_class(JS::VM&, JS::Value, JS::ClassExpression const&, AK::Optional<JS::Bytecode::IdentifierTableIndex> const&, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:1555
    #12 0x7fd3e7fc08fc in JS::Bytecode::Op::NewClass::execute_impl(JS::Bytecode::Interpreter&) const /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2982
    #13 0x7fd3e8075bb7 in JS::Bytecode::Interpreter::run_bytecode(unsigned long) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:658
    #14 0x7fd3e809862f in JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:758
    #15 0x7fd3e8e22849 in JS::ECMAScriptFunctionObject::ordinary_call_evaluate_body() /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:833
    #16 0x7fd3e8e34526 in JS::ECMAScriptFunctionObject::internal_call(JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:432
    #17 0x7fd3e80ecb42 in JS::call(JS::VM&, JS::FunctionObject&, JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/AbstractOperations.h:114
    #18 0x7fd3e80ecb42 in JS::Bytecode::perform_call(JS::Bytecode::Interpreter&, JS::Value, JS::Bytecode::Op::CallType, JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:1271
    #19 0x7fd3e8023a3b in JS::Bytecode::Op::Call::execute_impl(JS::Bytecode::Interpreter&) const /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2623
    #20 0x7fd3e8068ecc in JS::Bytecode::Interpreter::run_bytecode(unsigned long) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:592
    #21 0x7fd3e809862f in JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:758
    #22 0x7fd3e809f397 in JS::Bytecode::Interpreter::run(JS::Script&, GC::Ptr<JS::Environment>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:268
    #23 0x432812 in operator()<GC::Ref<JS::Script> > /home/devgianlu/Projects/ladybird/Utilities/js.cpp:221
    #24 0x432812 in parse_and_run /home/devgianlu/Projects/ladybird/Utilities/js.cpp:236
    #25 0x4407c0 in serenity_main(Main::Arguments) /home/devgianlu/Projects/ladybird/Utilities/js.cpp:858
    #26 0x4030ff in main /home/devgianlu/Projects/ladybird/Libraries/LibMain/Main.cpp:43
    #27 0x7fd3e1210247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: f83d43b9b4b0ed5c2bd0a1613bf33e08ee054c93)
    #28 0x7fd3e121030a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x330a) (BuildId: f83d43b9b4b0ed5c2bd0a1613bf33e08ee054c93)
    #29 0x4037f4 in _start (/home/devgianlu/Projects/ladybird/Build/sanitizers/bin/js+0x4037f4) (BuildId: 9e3365ee2da9001113b80b9b9600f6de29ed9460)

0x5060000026f8 is located 0 bytes after 56-byte region [0x5060000026c0,0x5060000026f8)
allocated by thread T0 here:
    #0 0x7fd3f52c2897 in malloc (/lib64/libasan.so.8+0xc2897) (BuildId: 0505b45e5a5d9a6c8ecb1d529aaaf13cd21fbe4e)
    #1 0x7fd3e7c27cdd in kmalloc_array(AK::Checked<unsigned long>, AK::Checked<unsigned long>) /home/devgianlu/Projects/ladybird/AK/kmalloc.h:42
    #2 0x7fd3e7c27cdd in AK::Vector<JS::Value, 0ul>::try_ensure_capacity(unsigned long) /home/devgianlu/Projects/ladybird/AK/Vector.h:654
    #3 0x7fd3e7c294a6 in _ZN2AK6VectorIN2JS5ValueELm0EE10try_resizeEmbQntL_ZNS0_IT_XT0_EE18contains_referenceEE /home/devgianlu/Projects/ladybird/AK/Vector.h:681
    #4 0x7fd3e8e22662 in _ZN2AK6VectorIN2JS5ValueELm0EE6resizeEmbQntL_ZNS0_IT_XT0_EE18contains_referenceEE /home/devgianlu/Projects/ladybird/AK/Vector.h:727
    #5 0x7fd3e8e22662 in JS::ECMAScriptFunctionObject::ordinary_call_evaluate_body() /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:831
    #6 0x7fd3e8e34526 in JS::ECMAScriptFunctionObject::internal_call(JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:432
    #7 0x7fd3e79cd15b in JS::ThrowCompletionOr<JS::Value> JS::call<>(JS::VM&, JS::FunctionObject&, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/AbstractOperations.h:131
    #8 0x7fd3e79cd15b in operator() /home/devgianlu/Projects/ladybird/Libraries/LibJS/AST.cpp:443
    #9 0x7fd3e79cd15b in visit<AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >, AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >::Visitor<JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(JS::ClassFieldDefinition&)>, JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(GC::Root<JS::ECMAScriptFunctionObject>)> >, 1> /home/devgianlu/Projects/ladybird/AK/Variant.h:113
    #10 0x7fd3e79cd15b in visit<AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >, AK::Variant<JS::ClassFieldDefinition, GC::Ref<JS::ECMAScriptFunctionObject> >::Visitor<JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(JS::ClassFieldDefinition&)>, JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(GC::Root<JS::ECMAScriptFunctionObject>)> > > /home/devgianlu/Projects/ladybird/AK/Variant.h:119
    #11 0x7fd3e79cd15b in visit<JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(JS::ClassFieldDefinition&)>, JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::ReadonlySpan<JS::Value>, const AK::Optional<AK::FlyString>&, const AK::FlyString&) const::<lambda(GC::Root<JS::ECMAScriptFunctionObject>)> > /home/devgianlu/Projects/ladybird/AK/Variant.h:403
    #12 0x7fd3e79cd15b in JS::ClassExpression::create_class_constructor(JS::VM&, JS::Environment*, JS::Environment*, JS::Value, AK::Span<JS::Value const>, AK::Optional<AK::FlyString> const&, AK::FlyString const&) const /home/devgianlu/Projects/ladybird/Libraries/LibJS/AST.cpp:443
    #13 0x7fd3e80bfe3e in JS::Bytecode::new_class(JS::VM&, JS::Value, JS::ClassExpression const&, AK::Optional<JS::Bytecode::IdentifierTableIndex> const&, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:1555
    #14 0x7fd3e7fc08fc in JS::Bytecode::Op::NewClass::execute_impl(JS::Bytecode::Interpreter&) const /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2982
    #15 0x7fd3e8075bb7 in JS::Bytecode::Interpreter::run_bytecode(unsigned long) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:658
    #16 0x7fd3e809862f in JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:758
    #17 0x7fd3e8e22849 in JS::ECMAScriptFunctionObject::ordinary_call_evaluate_body() /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:833
    #18 0x7fd3e8e34526 in JS::ECMAScriptFunctionObject::internal_call(JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:432
    #19 0x7fd3e80ecb42 in JS::call(JS::VM&, JS::FunctionObject&, JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Runtime/AbstractOperations.h:114
    #20 0x7fd3e80ecb42 in JS::Bytecode::perform_call(JS::Bytecode::Interpreter&, JS::Value, JS::Bytecode::Op::CallType, JS::Value, AK::Span<JS::Value const>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:1271
    #21 0x7fd3e8023a3b in JS::Bytecode::Op::Call::execute_impl(JS::Bytecode::Interpreter&) const /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2623
    #22 0x7fd3e8068ecc in JS::Bytecode::Interpreter::run_bytecode(unsigned long) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:592
    #23 0x7fd3e809862f in JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:758
    #24 0x7fd3e809f397 in JS::Bytecode::Interpreter::run(JS::Script&, GC::Ptr<JS::Environment>) /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:268
    #25 0x432812 in operator()<GC::Ref<JS::Script> > /home/devgianlu/Projects/ladybird/Utilities/js.cpp:221
    #26 0x432812 in parse_and_run /home/devgianlu/Projects/ladybird/Utilities/js.cpp:236
    #27 0x4407c0 in serenity_main(Main::Arguments) /home/devgianlu/Projects/ladybird/Utilities/js.cpp:858
    #28 0x4030ff in main /home/devgianlu/Projects/ladybird/Libraries/LibMain/Main.cpp:43
    #29 0x7fd3e1210247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: f83d43b9b4b0ed5c2bd0a1613bf33e08ee054c93)
    #30 0x7fd3e121030a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x330a) (BuildId: f83d43b9b4b0ed5c2bd0a1613bf33e08ee054c93)
    #31 0x4037f4 in _start (/home/devgianlu/Projects/ladybird/Build/sanitizers/bin/js+0x4037f4) (BuildId: 9e3365ee2da9001113b80b9b9600f6de29ed9460)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/devgianlu/Projects/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:192 in JS::Bytecode::Interpreter::set(JS::Bytecode::Operand, JS::Value)
Shadow bytes around the buggy address:
  0x506000002400: fa fa fa fa 00 00 00 00 00 00 00 fa fa fa fa fa
  0x506000002480: 00 00 00 00 00 00 00 00 fa fa fa fa 00 00 00 00
  0x506000002500: 00 00 00 00 fa fa fa fa 00 00 00 00 00 00 00 00
  0x506000002580: fa fa fa fa fd fd fd fd fd fd fd fd fa fa fa fa
  0x506000002600: 00 00 00 00 00 00 06 fa fa fa fa fa 00 00 00 00
=>0x506000002680: 00 00 00 00 fa fa fa fa 00 00 00 00 00 00 00[fa]
  0x506000002700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x506000002780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x506000002800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x506000002880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x506000002900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==177126==ABORTING
```




I feel like this needs a test, but I am not sure where to put it.