### PR TITLE
LibIPC+Meta: Keep message buffer alive until acknowledged by peer

### DIFF
--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -12,6 +12,7 @@
 #include <LibCore/EventReceiver.h>
 #include <LibIPC/File.h>
 #include <LibIPC/Forward.h>
+#include <LibIPC/Message.h>
 #include <LibIPC/Transport.h>
 #include <LibIPC/UnprocessedFileDescriptors.h>
 #include <LibThreading/ConditionVariable.h>
@@ -26,9 +27,14 @@ class ConnectionBase : public Core::EventReceiver {
 public:
     virtual ~ConnectionBase() override;
 
+    enum class MessageNeedsAcknowledgement {
+        No,
+        Yes,
+    };
+
     [[nodiscard]] bool is_open() const;
     ErrorOr<void> post_message(Message const&);
-    ErrorOr<void> post_message(u32 endpoint_magic, MessageBuffer);
+    ErrorOr<void> post_message(u32 endpoint_magic, MessageBuffer, MessageNeedsAcknowledgement = MessageNeedsAcknowledgement::Yes);
 
     void shutdown();
     virtual void die() { }
@@ -36,7 +42,7 @@ public:
     Transport& transport() { return m_transport; }
 
 protected:
-    explicit ConnectionBase(IPC::Stub&, Transport, u32 local_endpoint_magic);
+    explicit ConnectionBase(IPC::Stub&, Transport, u32 local_endpoint_magic, u32 peer_endpoint_magic);
 
     virtual void may_have_become_unresponsive() { }
     virtual void did_become_responsive() { }
@@ -62,23 +68,38 @@ protected:
     ByteBuffer m_unprocessed_bytes;
 
     u32 m_local_endpoint_magic { 0 };
+    u32 m_peer_endpoint_magic { 0 };
+
+    struct MessageToSend {
+        MessageBuffer buffer;
+        MessageNeedsAcknowledgement needs_acknowledgement { MessageNeedsAcknowledgement::Yes };
+    };
 
     struct SendQueue : public AtomicRefCounted<SendQueue> {
-        AK::SinglyLinkedList<MessageBuffer> messages;
+        AK::SinglyLinkedList<MessageToSend> messages;
         Threading::Mutex mutex;
         Threading::ConditionVariable condition { mutex };
         bool running { true };
     };
 
+    // After a message is sent, it is moved to the acknowledgement wait queue until an acknowledgement is received from the peer.
+    // This is necessary to handle a specific behavior of the macOS kernel, which may prematurely garbage-collect the file
+    // descriptor contained in the message before the peer receives it. https://openradar.me/9477351
+    struct AcknowledgementWaitQueue : public AtomicRefCounted<AcknowledgementWaitQueue> {
+        AK::SinglyLinkedList<MessageBuffer> messages;
+        Threading::Mutex mutex;
+    };
+
     RefPtr<Threading::Thread> m_send_thread;
     RefPtr<SendQueue> m_send_queue;
+    RefPtr<AcknowledgementWaitQueue> m_acknowledgement_wait_queue;
 };
 
 template<typename LocalEndpoint, typename PeerEndpoint>
 class Connection : public ConnectionBase {
 public:
     Connection(IPC::Stub& local_stub, Transport transport)
-        : ConnectionBase(local_stub, move(transport), LocalEndpoint::static_magic())
+        : ConnectionBase(local_stub, move(transport), LocalEndpoint::static_magic(), PeerEndpoint::static_magic())
     {
     }
 

--- a/Libraries/LibIPC/Message.cpp
+++ b/Libraries/LibIPC/Message.cpp
@@ -111,4 +111,32 @@ ErrorOr<NonnullOwnPtr<LargeMessageWrapper>> LargeMessageWrapper::decode(u32 endp
     return make<LargeMessageWrapper>(endpoint_magic, wrapped_message_data, move(wrapped_fds));
 }
 
+Acknowledgement::Acknowledgement(u32 endpoint_magic, u32 ack_count)
+    : m_endpoint_magic(endpoint_magic)
+    , m_ack_count(ack_count)
+{
+}
+
+NonnullOwnPtr<Acknowledgement> Acknowledgement::create(u32 endpoint_magic, u32 ack_count)
+{
+    return make<Acknowledgement>(endpoint_magic, ack_count);
+}
+
+ErrorOr<MessageBuffer> Acknowledgement::encode() const
+{
+    MessageBuffer buffer;
+    Encoder stream { buffer };
+    TRY(stream.encode(m_endpoint_magic));
+    TRY(stream.encode(MESSAGE_ID));
+    TRY(stream.encode(m_ack_count));
+    return buffer;
+}
+
+ErrorOr<NonnullOwnPtr<Acknowledgement>> Acknowledgement::decode(u32 endpoint_magic, Stream& stream, UnprocessedFileDescriptors& files)
+{
+    Decoder decoder { stream, files };
+    auto ack_count = TRY(decoder.decode<u32>());
+    return make<Acknowledgement>(endpoint_magic, ack_count);
+}
+
 }

--- a/Libraries/LibIPC/Message.h
+++ b/Libraries/LibIPC/Message.h
@@ -119,4 +119,28 @@ private:
     Vector<File> m_wrapped_fds;
 };
 
+class Acknowledgement : public Message {
+public:
+    ~Acknowledgement() override = default;
+
+    static constexpr int MESSAGE_ID = 0xFFFFFFFF;
+
+    static NonnullOwnPtr<Acknowledgement> create(u32 endpoint_magic, u32 ack_count);
+
+    u32 endpoint_magic() const override { return m_endpoint_magic; }
+    int message_id() const override { return MESSAGE_ID; }
+    char const* message_name() const override { return "Acknowledgement"; }
+    ErrorOr<MessageBuffer> encode() const override;
+
+    static ErrorOr<NonnullOwnPtr<Acknowledgement>> decode(u32 endpoint_magic, Stream& stream, UnprocessedFileDescriptors& files);
+
+    u32 ack_count() const { return m_ack_count; }
+
+    Acknowledgement(u32 endpoint_magic, u32 number_of_acknowledged_messages);
+
+private:
+    u32 m_endpoint_magic { 0 };
+    u32 m_ack_count { 0 };
+};
+
 }

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -760,6 +760,8 @@ public:
     generator.append(R"~~~(
         case (int)IPC::LargeMessageWrapper::MESSAGE_ID:
             return TRY(IPC::LargeMessageWrapper::decode(message_endpoint_magic, stream, files));
+        case (int)IPC::Acknowledgement::MESSAGE_ID:
+            return TRY(IPC::Acknowledgement::decode(message_endpoint_magic, stream, files));
 )~~~");
 
     generator.append(R"~~~(


### PR DESCRIPTION
This change ensures that instead of immediately deallocating the message buffer after sending, we retain it in an acknowledgement wait queue until an acknowledgement is received from the peer. This is necessary to handle a behavior of the macOS kernel, which may prematurely garbage-collect file descriptors contained within the message buffer before the peer receives them.

The acknowledgement mechanism assumes messages are received in the same order they were sent so, each acknowledgement message simply indicates the count of successfully received messages, specifying how many entries can safely be removed from the acknowledgement wait queue.