### PR TITLE
Make SetCompletionType bytecode instruction actually set type

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -3847,7 +3847,7 @@ void SetCompletionType::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& completion_cell = static_cast<CompletionCell&>(interpreter.get(m_completion).as_cell());
     auto completion = completion_cell.completion();
-    completion_cell.set_completion(Completion { completion.type(), completion.value() });
+    completion_cell.set_completion(Completion { m_type, completion.value() });
 }
 
 ByteString SetCompletionType::to_byte_string_impl(Bytecode::Executable const& executable) const

--- a/Libraries/LibJS/Tests/regress/async-generator-function-set-completion-type.js
+++ b/Libraries/LibJS/Tests/regress/async-generator-function-set-completion-type.js
@@ -1,0 +1,43 @@
+test("test", () => {
+    var obj = {
+        [Symbol.iterator]() {
+            return {
+                next() {
+                    return { value: 1, done: false };
+                },
+            };
+        },
+    };
+
+    async function* asyncg() {
+        yield* obj;
+    }
+
+    let fail = false;
+    let done = false;
+
+    function FAIL() {
+        fail = true;
+    }
+
+    function DONE() {
+        done = true;
+    }
+
+    var iter = asyncg();
+
+    iter.next()
+        .then(function (result) {
+            iter.return()
+                .then(function (result) {
+                    expect(result.done).toBeTrue();
+                    expect(result.value).toBeUndefined();
+                })
+                .catch(FAIL);
+        })
+        .catch(FAIL)
+        .then(DONE);
+    runQueuedPromiseJobs();
+    expect(fail).toBe(false);
+    expect(done).toBe(true);
+});


### PR DESCRIPTION
This recovers 38 tests in test262 that regressed in a0bb31f7a0e.

```
Summary:
    Diff Tests:
        +38 ✅    -38 ❌   

Diff Tests:
    test/built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result-poisoned-done.js               ❌ -> ✅
    test/built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result-poisoned-value.js              ❌ -> ✅
    test/built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result-unwrap-promise.js              ❌ -> ✅
    test/built-ins/AsyncFromSyncIteratorPrototype/return/iterator-result.js                             ❌ -> ✅
    test/built-ins/AsyncFromSyncIteratorPrototype/return/poisoned-get-return.js                         ❌ -> ✅
    test/built-ins/AsyncFromSyncIteratorPrototype/return/poisoned-return.js                             ❌ -> ✅
    test/built-ins/AsyncFromSyncIteratorPrototype/return/result-object-error.js                         ❌ -> ✅
    test/built-ins/AsyncFromSyncIteratorPrototype/return/return-undefined.js                            ❌ -> ✅
    test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-promise.js                      ❌ -> ✅
    test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-try-finally.js                  ❌ -> ✅
    test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield.js                              ❌ -> ✅
    test/language/expressions/async-generator/named-yield-star-async-return.js                          ❌ -> ✅
    test/language/expressions/async-generator/named-yield-star-sync-return.js                           ❌ -> ✅
    test/language/expressions/async-generator/yield-star-async-return.js                                ❌ -> ✅
    test/language/expressions/async-generator/yield-star-getiter-async-return-method-is-null.js         ❌ -> ✅
    test/language/expressions/async-generator/yield-star-sync-return.js                                 ❌ -> ✅
    test/language/expressions/class/async-gen-method-static/yield-star-async-return.js                  ❌ -> ✅
    test/language/expressions/class/async-gen-method-static/yield-star-sync-return.js                   ❌ -> ✅
    test/language/expressions/class/async-gen-method/yield-star-async-return.js                         ❌ -> ✅
    test/language/expressions/class/async-gen-method/yield-star-sync-return.js                          ❌ -> ✅
    test/language/expressions/class/elements/async-gen-private-method-static/yield-star-async-return.js ❌ -> ✅
    test/language/expressions/class/elements/async-gen-private-method-static/yield-star-sync-return.js  ❌ -> ✅
    test/language/expressions/class/elements/async-gen-private-method/yield-star-async-return.js        ❌ -> ✅
    test/language/expressions/class/elements/async-gen-private-method/yield-star-sync-return.js         ❌ -> ✅
    test/language/expressions/object/method-definition/async-gen-yield-star-async-return.js             ❌ -> ✅
    test/language/expressions/object/method-definition/async-gen-yield-star-sync-return.js              ❌ -> ✅
    test/language/statements/async-generator/yield-star-async-return.js                                 ❌ -> ✅
    test/language/statements/async-generator/yield-star-return-missing-value-is-awaited.js              ❌ -> ✅
    test/language/statements/async-generator/yield-star-return-notdone-iter-value-throws.js             ❌ -> ✅
    test/language/statements/async-generator/yield-star-sync-return.js                                  ❌ -> ✅
    test/language/statements/class/async-gen-method-static/yield-star-async-return.js                   ❌ -> ✅
    test/language/statements/class/async-gen-method-static/yield-star-sync-return.js                    ❌ -> ✅
    test/language/statements/class/async-gen-method/yield-star-async-return.js                          ❌ -> ✅
    test/language/statements/class/async-gen-method/yield-star-sync-return.js                           ❌ -> ✅
    test/language/statements/class/elements/async-gen-private-method-static/yield-star-async-return.js  ❌ -> ✅
    test/language/statements/class/elements/async-gen-private-method-static/yield-star-sync-return.js   ❌ -> ✅
    test/language/statements/class/elements/async-gen-private-method/yield-star-async-return.js         ❌ -> ✅
    test/language/statements/class/elements/async-gen-private-method/yield-star-sync-return.js          ❌ -> ✅
```