### PR TITLE
LibJS: Shrink ThrowCompletionOr<void>

### DIFF
--- a/Libraries/LibJS/CyclicModule.cpp
+++ b/Libraries/LibJS/CyclicModule.cpp
@@ -34,6 +34,8 @@ void CyclicModule::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_async_parent_modules);
     for (auto const& loaded_module : m_loaded_modules)
         visitor.visit(loaded_module.module);
+    if (m_evaluation_error.is_error())
+        visitor.visit(m_evaluation_error.error_value());
 }
 
 void GraphLoadingState::visit_edges(Cell::Visitor& visitor)


### PR DESCRIPTION
By specializing this template and using the special empty JS::Value as a marker for the `void` state, we shrink this very common class from 16 bytes to 8 bytes.
    
This allows bytecode instruction handlers to return their result in a single 64-bit register, allowing tighter code generation.

+ bonus commit adding a missing visit.