### PR TITLE
More work on making LibJS bytecode smaller

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1280,7 +1280,7 @@ static inline Completion throw_type_error_for_callee(Bytecode::Interpreter& inte
     auto& vm = interpreter.vm();
 
     if (expression_string.has_value())
-        return vm.throw_completion<TypeError>(ErrorType::IsNotAEvaluatedFrom, callee.to_string_without_side_effects(), callee_type, interpreter.current_executable().get_string(expression_string->value()));
+        return vm.throw_completion<TypeError>(ErrorType::IsNotAEvaluatedFrom, callee.to_string_without_side_effects(), callee_type, interpreter.current_executable().get_string(*expression_string));
 
     return vm.throw_completion<TypeError>(ErrorType::IsNotA, callee.to_string_without_side_effects(), callee_type);
 }
@@ -3078,9 +3078,10 @@ ByteString NewObject::to_byte_string_impl(Bytecode::Executable const& executable
 
 ByteString NewRegExp::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
-    return ByteString::formatted("NewRegExp {}, source:{} (\"{}\") flags:{} (\"{}\")",
+    return ByteString::formatted("NewRegExp {}, source:\"{}\" flags:\"{}\"",
         format_operand("dst"sv, dst(), executable),
-        m_source_index, executable.get_string(m_source_index), m_flags_index, executable.get_string(m_flags_index));
+        executable.get_string(m_source_index),
+        executable.get_string(m_flags_index));
 }
 
 ByteString CopyObjectExcludingProperties::to_byte_string_impl(Bytecode::Executable const& executable) const

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -322,7 +322,7 @@ public:
 private:
     Operand m_dst;
     Operand m_from_object;
-    size_t m_excluded_names_count { 0 };
+    u32 m_excluded_names_count { 0 };
     Operand m_excluded_names[];
 };
 
@@ -367,7 +367,7 @@ public:
 
 private:
     Operand m_dst;
-    size_t m_element_count { 0 };
+    u32 m_element_count { 0 };
     Operand m_elements[];
 };
 
@@ -401,7 +401,7 @@ public:
 
 private:
     Operand m_dst;
-    size_t m_element_count { 0 };
+    u32 m_element_count { 0 };
     Value m_elements[];
 };
 
@@ -2105,7 +2105,7 @@ private:
     Optional<Operand> m_super_class;
     ClassExpression const& m_class_expression;
     Optional<IdentifierTableIndex> m_lhs_name;
-    size_t m_element_keys_count { 0 };
+    u32 m_element_keys_count { 0 };
     Optional<Operand> m_element_keys[];
 };
 

--- a/Libraries/LibJS/Bytecode/Operand.h
+++ b/Libraries/LibJS/Bytecode/Operand.h
@@ -13,7 +13,7 @@ namespace JS::Bytecode {
 
 class Operand {
 public:
-    enum class Type {
+    enum class Type : u8 {
         Invalid,
         Register,
         Local,
@@ -26,6 +26,7 @@ public:
         : m_type(type)
         , m_index(index)
     {
+        VERIFY((index & 0x3fffffff) == index);
     }
 
     explicit Operand(Register);
@@ -42,9 +43,11 @@ public:
     void offset_index_by(u32 offset) { m_index += offset; }
 
 private:
-    Type m_type {};
-    u32 m_index { 0 };
+    Type m_type : 2 {};
+    u32 m_index : 30 { 0 };
 };
+
+static_assert(sizeof(Operand) == 4);
 
 }
 

--- a/Libraries/LibJS/Bytecode/RegexTable.h
+++ b/Libraries/LibJS/Bytecode/RegexTable.h
@@ -13,7 +13,7 @@
 
 namespace JS::Bytecode {
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(size_t, RegexTableIndex, Comparison);
+AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u32, RegexTableIndex, Comparison);
 
 struct ParsedRegex {
     regex::Parser::Result regex;

--- a/Libraries/LibJS/Bytecode/StringTable.cpp
+++ b/Libraries/LibJS/Bytecode/StringTable.cpp
@@ -11,12 +11,12 @@ namespace JS::Bytecode {
 StringTableIndex StringTable::insert(String string)
 {
     m_strings.append(move(string));
-    return m_strings.size() - 1;
+    return { static_cast<u32>(m_strings.size() - 1) };
 }
 
 String const& StringTable::get(StringTableIndex index) const
 {
-    return m_strings[index.value()];
+    return m_strings[index.value];
 }
 
 void StringTable::dump() const

--- a/Libraries/LibJS/Bytecode/StringTable.h
+++ b/Libraries/LibJS/Bytecode/StringTable.h
@@ -12,7 +12,11 @@
 
 namespace JS::Bytecode {
 
-AK_TYPEDEF_DISTINCT_NUMERIC_GENERAL(u32, StringTableIndex, Comparison);
+struct StringTableIndex {
+    static constexpr u32 invalid = 0xffffffffu;
+    bool is_valid() const { return value != invalid; }
+    u32 value { 0 };
+};
 
 class StringTable {
     AK_MAKE_NONMOVABLE(StringTable);
@@ -28,6 +32,105 @@ public:
 
 private:
     Vector<String> m_strings;
+};
+
+}
+
+namespace AK {
+template<>
+class Optional<JS::Bytecode::StringTableIndex> : public OptionalBase<JS::Bytecode::StringTableIndex> {
+    template<typename U>
+    friend class Optional;
+
+public:
+    using ValueType = JS::Bytecode::StringTableIndex;
+
+    Optional() = default;
+
+    template<SameAs<OptionalNone> V>
+    Optional(V) { }
+
+    Optional(Optional<JS::Bytecode::StringTableIndex> const& other)
+    {
+        if (other.has_value())
+            m_value = other.m_value;
+    }
+
+    Optional(Optional&& other)
+        : m_value(other.m_value)
+    {
+    }
+
+    template<typename U = JS::Bytecode::StringTableIndex>
+    requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
+    explicit(!IsConvertible<U&&, JS::Bytecode::StringTableIndex>) Optional(U&& value)
+    requires(!IsSame<RemoveCVReference<U>, Optional<JS::Bytecode::StringTableIndex>> && IsConstructible<JS::Bytecode::StringTableIndex, U &&>)
+        : m_value(forward<U>(value))
+    {
+    }
+
+    template<SameAs<OptionalNone> V>
+    Optional& operator=(V)
+    {
+        clear();
+        return *this;
+    }
+
+    Optional& operator=(Optional const& other)
+    {
+        if (this != &other) {
+            clear();
+            m_value = other.m_value;
+        }
+        return *this;
+    }
+
+    Optional& operator=(Optional&& other)
+    {
+        if (this != &other) {
+            clear();
+            m_value = other.m_value;
+        }
+        return *this;
+    }
+
+    void clear()
+    {
+        m_value.value = JS::Bytecode::StringTableIndex::invalid;
+    }
+
+    [[nodiscard]] bool has_value() const
+    {
+        return m_value.is_valid();
+    }
+
+    [[nodiscard]] JS::Bytecode::StringTableIndex& value() &
+    {
+        VERIFY(has_value());
+        return m_value;
+    }
+
+    [[nodiscard]] JS::Bytecode::StringTableIndex const& value() const&
+    {
+        VERIFY(has_value());
+        return m_value;
+    }
+
+    [[nodiscard]] JS::Bytecode::StringTableIndex value() &&
+    {
+        return release_value();
+    }
+
+    [[nodiscard]] JS::Bytecode::StringTableIndex release_value()
+    {
+        VERIFY(has_value());
+        JS::Bytecode::StringTableIndex released_value = m_value;
+        clear();
+        return released_value;
+    }
+
+private:
+    JS::Bytecode::StringTableIndex m_value { JS::Bytecode::StringTableIndex::invalid };
 };
 
 }


### PR DESCRIPTION
See individual commits. Solid progress on all benchmark as measured by my M3 MacBook Pro:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                           1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                   1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    0.962  0.125 ± 0.120 … 0.130        0.130 ± 0.130 … 0.130
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-partial-sums.js                     1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            1      0.315 ± 0.310 … 0.320        0.315 ± 0.310 … 0.320
SunSpider   string-base64.js                         1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   string-fasta.js                          1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-tagcloud.js                       1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-unpack-code.js                    1      0.110 ± 0.110 … 0.110        0.110 ± 0.110 … 0.110
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
Kraken      ai-astar.js                              1.054  1.075 ± 1.050 … 1.100        1.020 ± 1.020 … 1.020
Kraken      audio-beat-detection.js                  1.079  0.890 ± 0.890 … 0.890        0.825 ± 0.820 … 0.830
Kraken      audio-dft.js                             1.017  0.585 ± 0.580 … 0.590        0.575 ± 0.570 … 0.580
Kraken      audio-fft.js                             1.042  0.750 ± 0.750 … 0.750        0.720 ± 0.720 … 0.720
Kraken      audio-oscillator.js                      1.03   0.865 ± 0.860 … 0.870        0.840 ± 0.840 … 0.840
Kraken      imaging-darkroom.js                      1.017  1.230 ± 1.230 … 1.230        1.210 ± 1.200 … 1.220
Kraken      imaging-desaturate.js                    1.059  1.075 ± 1.070 … 1.080        1.015 ± 1.000 … 1.030
Kraken      imaging-gaussian-blur.js                 1.059  4.470 ± 4.440 … 4.500        4.220 ± 4.200 … 4.240
Kraken      json-parse-financial.js                  1      0.065 ± 0.060 … 0.070        0.065 ± 0.060 … 0.070
Kraken      json-stringify-tinderbox.js              1      0.090 ± 0.090 … 0.090        0.090 ± 0.090 … 0.090
Kraken      stanford-crypto-aes.js                   1.069  0.385 ± 0.380 … 0.390        0.360 ± 0.360 … 0.360
Kraken      stanford-crypto-ccm.js                   1.015  0.330 ± 0.330 … 0.330        0.325 ± 0.320 … 0.330
Kraken      stanford-crypto-pbkdf2.js                1.038  0.680 ± 0.680 … 0.680        0.655 ± 0.650 … 0.660
Kraken      stanford-crypto-sha256-iterative.js      1.02   0.260 ± 0.260 … 0.260        0.255 ± 0.250 … 0.260
Octane      box2d.js                                 1.012  2.105 ± 2.100 … 2.110        2.080 ± 2.080 … 2.080
Octane      code-load.js                             1      2.010 ± 2.010 … 2.010        2.010 ± 2.010 … 2.010
Octane      crypto.js                                0.983  5.030 ± 5.030 … 5.030        5.115 ± 5.100 … 5.130
Octane      deltablue.js                             1      2.015 ± 2.010 … 2.020        2.015 ± 2.010 … 2.020
Octane      earley-boyer.js                          0.996  11.095 ± 11.090 … 11.100     11.135 ± 11.070 … 11.200
Octane      gbemu.js                                 0.941  2.155 ± 2.150 … 2.160        2.290 ± 2.140 … 2.440
Octane      mandreel.js                              1.021  7.630 ± 7.600 … 7.660        7.475 ± 7.460 … 7.490
Octane      navier-stokes.js                         0.988  2.070 ± 2.070 … 2.070        2.095 ± 2.090 … 2.100
Octane      pdfjs.js                                 0.996  1.390 ± 1.390 … 1.390        1.395 ± 1.390 … 1.400
Octane      raytrace.js                              1.022  4.200 ± 4.160 … 4.240        4.110 ± 4.110 … 4.110
Octane      regexp.js                                1.001  17.715 ± 17.710 … 17.720     17.705 ± 17.660 … 17.750
Octane      richards.js                              1      2.010 ± 2.010 … 2.010        2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.002  2.310 ± 2.310 … 2.310        2.305 ± 2.300 … 2.310
Octane      typescript.js                            1.007  14.470 ± 14.460 … 14.480     14.375 ± 14.330 … 14.420
Octane      zlib.js                                  1.061  46.330 ± 46.320 … 46.340     43.660 ± 43.660 … 43.660
JetStream   bigfib.cpp.js                            1.057  8.670 ± 8.650 … 8.690        8.205 ± 8.200 … 8.210
JetStream   cdjs.js                                  0.995  6.550 ± 6.550 … 6.550        6.585 ± 6.580 … 6.590
JetStream   container.cpp.js                         1.041  34.815 ± 34.750 … 34.880     33.430 ± 33.370 … 33.490
JetStream   dry.c.js                                 1.034  18.650 ± 18.470 … 18.830     18.035 ± 17.580 … 18.490
JetStream   float-mm.c.js                            0.997  20.270 ± 19.910 … 20.630     20.330 ± 20.040 … 20.620
JetStream   gcc-loops.cpp.js                         1.031  115.090 ± 113.710 … 116.470  111.655 ± 110.560 … 112.750
JetStream   hash-map.js                              1.003  3.370 ± 3.370 … 3.370        3.360 ± 3.360 … 3.360
JetStream   n-body.c.js                              1.006  28.755 ± 28.580 … 28.930     28.590 ± 28.290 … 28.890
JetStream   quicksort.c.js                           1.077  4.570 ± 4.540 … 4.600        4.245 ± 4.230 … 4.260
JetStream   towers.c.js                              1.04   7.600 ± 7.590 … 7.610        7.310 ± 7.280 … 7.340
JetStream3  js-tokens.js                             1.001  9.520 ± 9.510 … 9.530        9.510 ± 9.510 … 9.510
JetStream3  lazy-collections.js                      0.973  1.620 ± 1.610 … 1.630        1.665 ± 1.660 … 1.670
JetStream3  raytrace-private-class-fields.js         0.989  5.965 ± 5.950 … 5.980        6.030 ± 6.020 … 6.040
JetStream3  raytrace-public-class-fields.js          0.999  4.535 ± 4.530 … 4.540        4.540 ± 4.520 … 4.560
JetStream3  sync-file-system.js                      1.014  2.845 ± 2.840 … 2.850        2.805 ± 2.800 … 2.810
SunSpider   Total                                    0.996  1.280                        1.285
Kraken      Total                                    1.047  12.750                       12.175
Octane      Total                                    1.023  122.535                      119.775
JetStream   Total                                    1.027  248.340                      241.745
JetStream3  Total                                    0.997  24.485                       24.550
All Suites  Total                                    1.025  409.390                      399.530
```