### PR TITLE
More LibJS interpreter optimizations

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -323,7 +323,7 @@ ThrowCompletionOr<Value> Interpreter::run(SourceTextModule& module)
     return js_undefined();
 }
 
-Interpreter::HandleExceptionResponse Interpreter::handle_exception(size_t& program_counter, Value exception)
+NEVER_INLINE Interpreter::HandleExceptionResponse Interpreter::handle_exception(size_t& program_counter, Value exception)
 {
     reg(Register::exception()) = exception;
     m_scheduled_jump = {};

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -481,7 +481,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             goto start;                                                                                                 \
         }                                                                                                               \
         auto result = op_snake_case(vm(), get(instruction.lhs()), get(instruction.rhs()));                              \
-        if (result.is_error()) {                                                                                        \
+        if (result.is_error()) [[unlikely]] {                                                                           \
             if (handle_exception(program_counter, result.error_value()) == HandleExceptionResponse::ExitFromExecutable) \
                 return;                                                                                                 \
             goto start;                                                                                                 \
@@ -563,7 +563,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
         auto& instruction = *reinterpret_cast<Op::name const*>(&bytecode[program_counter]);                                 \
         {                                                                                                                   \
             auto result = instruction.execute_impl(*this);                                                                  \
-            if (result.is_error()) {                                                                                        \
+            if (result.is_error()) [[unlikely]] {                                                                           \
                 if (handle_exception(program_counter, result.error_value()) == HandleExceptionResponse::ExitFromExecutable) \
                     return;                                                                                                 \
                 goto start;                                                                                                 \

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -95,9 +95,9 @@ public:
 
     [[nodiscard]] u16 tag() const { return m_value.tag; }
 
-    bool is_special_empty_value() const { return m_value.tag == EMPTY_TAG; }
-    bool is_undefined() const { return m_value.tag == UNDEFINED_TAG; }
-    bool is_null() const { return m_value.tag == NULL_TAG; }
+    bool is_special_empty_value() const { return m_value.encoded == (EMPTY_TAG << GC::TAG_SHIFT); }
+    bool is_undefined() const { return m_value.encoded == (UNDEFINED_TAG << GC::TAG_SHIFT); }
+    bool is_null() const { return m_value.encoded == (NULL_TAG << GC::TAG_SHIFT); }
     bool is_number() const { return is_double() || is_int32(); }
     bool is_string() const { return m_value.tag == STRING_TAG; }
     bool is_object() const { return m_value.tag == OBJECT_TAG; }


### PR DESCRIPTION
See individual commits. Strong results on my M3 MacBook Pro:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                           1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                   1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    1.04   0.130 ± 0.130 … 0.130        0.125 ± 0.120 … 0.130
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-partial-sums.js                     1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            1      0.310 ± 0.310 … 0.310        0.310 ± 0.310 … 0.310
SunSpider   string-base64.js                         1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   string-fasta.js                          1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-tagcloud.js                       1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-unpack-code.js                    1      0.110 ± 0.110 … 0.110        0.110 ± 0.110 … 0.110
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
Kraken      ai-astar.js                              0.971  1.020 ± 1.020 … 1.020        1.050 ± 1.040 … 1.060
Kraken      audio-beat-detection.js                  1.006  0.845 ± 0.840 … 0.850        0.840 ± 0.840 … 0.840
Kraken      audio-dft.js                             1.009  0.575 ± 0.570 … 0.580        0.570 ± 0.570 … 0.570
Kraken      audio-fft.js                             1.014  0.730 ± 0.730 … 0.730        0.720 ± 0.720 … 0.720
Kraken      audio-oscillator.js                      1      0.845 ± 0.840 … 0.850        0.845 ± 0.840 … 0.850
Kraken      imaging-darkroom.js                      1.008  1.225 ± 1.220 … 1.230        1.215 ± 1.210 … 1.220
Kraken      imaging-desaturate.js                    1.005  1.015 ± 1.010 … 1.020        1.010 ± 1.010 … 1.010
Kraken      imaging-gaussian-blur.js                 0.994  4.335 ± 4.270 … 4.400        4.360 ± 4.340 … 4.380
Kraken      json-parse-financial.js                  1      0.065 ± 0.060 … 0.070        0.065 ± 0.060 … 0.070
Kraken      json-stringify-tinderbox.js              1      0.090 ± 0.090 … 0.090        0.090 ± 0.090 … 0.090
Kraken      stanford-crypto-aes.js                   1      0.370 ± 0.370 … 0.370        0.370 ± 0.370 … 0.370
Kraken      stanford-crypto-ccm.js                   1      0.330 ± 0.330 … 0.330        0.330 ± 0.330 … 0.330
Kraken      stanford-crypto-pbkdf2.js                1      0.660 ± 0.660 … 0.660        0.660 ± 0.660 … 0.660
Kraken      stanford-crypto-sha256-iterative.js      1      0.260 ± 0.260 … 0.260        0.260 ± 0.260 … 0.260
Octane      box2d.js                                 0.993  2.065 ± 2.060 … 2.070        2.080 ± 2.080 … 2.080
Octane      code-load.js                             1      2.010 ± 2.010 … 2.010        2.010 ± 2.010 … 2.010
Octane      crypto.js                                1.011  5.100 ± 5.070 … 5.130        5.045 ± 5.030 … 5.060
Octane      deltablue.js                             1      2.010 ± 2.010 … 2.010        2.010 ± 2.010 … 2.010
Octane      earley-boyer.js                          0.998  11.085 ± 11.030 … 11.140     11.110 ± 11.040 … 11.180
Octane      gbemu.js                                 1.005  2.180 ± 2.180 … 2.180        2.170 ± 2.140 … 2.200
Octane      mandreel.js                              1.018  7.505 ± 7.480 … 7.530        7.370 ± 7.350 … 7.390
Octane      navier-stokes.js                         1.007  2.060 ± 2.020 … 2.100        2.045 ± 2.030 … 2.060
Octane      pdfjs.js                                 1.011  1.395 ± 1.390 … 1.400        1.380 ± 1.380 … 1.380
Octane      raytrace.js                              1.011  4.130 ± 4.110 … 4.150        4.085 ± 4.070 … 4.100
Octane      regexp.js                                1.001  17.600 ± 17.590 … 17.610     17.585 ± 17.500 … 17.670
Octane      richards.js                              1      2.010 ± 2.010 … 2.010        2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.004  2.325 ± 2.310 … 2.340        2.315 ± 2.310 … 2.320
Octane      typescript.js                            0.995  14.340 ± 14.300 … 14.380     14.405 ± 14.400 … 14.410
Octane      zlib.js                                  1.064  44.285 ± 44.260 … 44.310     41.620 ± 41.280 … 41.960
JetStream   bigfib.cpp.js                            1.045  8.190 ± 8.130 … 8.250        7.835 ± 7.830 … 7.840
JetStream   cdjs.js                                  0.999  6.630 ± 6.630 … 6.630        6.635 ± 6.590 … 6.680
JetStream   container.cpp.js                         1.026  33.885 ± 33.810 … 33.960     33.025 ± 32.830 … 33.220
JetStream   dry.c.js                                 1.026  18.780 ± 18.160 … 19.400     18.310 ± 18.190 … 18.430
JetStream   float-mm.c.js                            1.015  20.540 ± 20.460 … 20.620     20.245 ± 20.180 … 20.310
JetStream   gcc-loops.cpp.js                         1.044  112.525 ± 112.060 … 112.990  107.815 ± 107.810 … 107.820
JetStream   hash-map.js                              1      3.340 ± 3.310 … 3.370        3.340 ± 3.340 … 3.340
JetStream   n-body.c.js                              1.024  29.000 ± 28.790 … 29.210     28.310 ± 28.140 … 28.480
JetStream   quicksort.c.js                           1.043  4.450 ± 4.390 … 4.510        4.265 ± 4.260 … 4.270
JetStream   towers.c.js                              1.032  7.435 ± 7.430 … 7.440        7.205 ± 7.170 … 7.240
JetStream3  js-tokens.js                             1.003  9.520 ± 9.510 … 9.530        9.495 ± 9.490 … 9.500
JetStream3  lazy-collections.js                      1.009  1.665 ± 1.650 … 1.680        1.650 ± 1.600 … 1.700
JetStream3  raytrace-private-class-fields.js         1.002  6.000 ± 5.970 … 6.030        5.990 ± 5.980 … 6.000
JetStream3  raytrace-public-class-fields.js          0.986  4.495 ± 4.490 … 4.500        4.560 ± 4.550 … 4.570
JetStream3  sync-file-system.js                      1.012  2.835 ± 2.820 … 2.850        2.800 ± 2.780 … 2.820
SunSpider   Total                                    1.004  1.280                        1.275
Kraken      Total                                    0.998  12.365                       12.385
Octane      Total                                    1.024  120.100                      117.240
JetStream   Total                                    1.033  244.775                      236.985
JetStream3  Total                                    1.001  24.515                       24.495
All Suites  Total                                    1.027  403.035                      392.380
```