### PR TITLE
LibJS: Do not allow CallExpression LHS on assignment

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1863,9 +1863,9 @@ NonnullRefPtr<RegExpLiteral const> Parser::parse_regexp_literal()
     return create_ast_node<RegExpLiteral>(move(range), move(parsed_regex), move(parsed_pattern), move(parsed_flags), move(pattern), move(flags));
 }
 
-static bool is_simple_assignment_target(Expression const& expression, bool allow_web_reality_call_expression = true)
+static bool is_simple_assignment_target(Expression const& expression)
 {
-    return is<Identifier>(expression) || is<MemberExpression>(expression) || (allow_web_reality_call_expression && is<CallExpression>(expression));
+    return is<Identifier>(expression) || is<MemberExpression>(expression);
 }
 
 NonnullRefPtr<Expression const> Parser::parse_unary_prefixed_expression()
@@ -2617,13 +2617,7 @@ NonnullRefPtr<AssignmentExpression const> Parser::parse_assignment_expression(As
         }
     }
 
-    // Note: The web reality is that all but &&=, ||= and ??= do allow left hand side CallExpresions.
-    //       These are the exception as they are newer.
-    auto has_web_reality_assignment_target_exceptions = assignment_op != AssignmentOp::AndAssignment
-        && assignment_op != AssignmentOp::OrAssignment
-        && assignment_op != AssignmentOp::NullishAssignment;
-
-    if (!is_simple_assignment_target(*lhs, has_web_reality_assignment_target_exceptions)) {
+    if (!is_simple_assignment_target(*lhs)) {
         syntax_error("Invalid left-hand side in assignment"_string);
     } else if (m_state.strict_mode && is<Identifier>(*lhs)) {
         auto const& name = static_cast<Identifier const&>(*lhs).string();

--- a/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
+++ b/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
@@ -1,25 +1,17 @@
-test.xfail("assignment to function call", () => {
-    expect(() => {
-        function foo() {}
-        foo() = "foo";
-    }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
+test("assignment to function call", () => {
+    expect('function foo() {}; foo() = "foo";').not.toEval();
 });
 
-test.xfail("Postfix operator after function call", () => {
-    expect(() => {
-        function foo() {}
-        foo()++;
-    }).toThrow(ReferenceError);
+test("Postfix operator after function call", () => {
+    expect('function foo() {}; foo()++;').not.toEval();
 });
 
 test("assignment to function call in strict mode", () => {
-    expect("'use strict'; foo() = 'foo'").toEval();
+    expect("'use strict'; foo() = 'foo';").not.toEval();
 });
 
-test.xfail("assignment to inline function call", () => {
-    expect(() => {
-        (function () {})() = "foo";
-    }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
+test("assignment to inline function call", () => {
+    expect('(function () {})() = "foo";').not.toEval();
 });
 
 test("assignment to invalid LHS is syntax error", () => {
@@ -41,21 +33,20 @@ test("assignment to invalid LHS is syntax error", () => {
     expect("1 ??= 1").not.toEval();
 });
 
-test("assignment to call LHS is only syntax error for new operators", () => {
-    expect("f() += 1").toEval();
-    expect("f() -= 1").toEval();
-    expect("f() *= 1").toEval();
-    expect("f() /= 1").toEval();
-    expect("f() %= 1").toEval();
-    expect("f() **= 1").toEval();
-    expect("f() &= 1").toEval();
-    expect("f() |= 1").toEval();
-    expect("f() ^= 1").toEval();
-    expect("f() <<= 1").toEval();
-    expect("f() >>= 1").toEval();
-    expect("f() >>>= 1").toEval();
-    expect("f() = 1").toEval();
-
+test("assignment to call LHS is syntax error", () => {
+    expect("f() += 1").not.toEval();
+    expect("f() -= 1").not.toEval();
+    expect("f() *= 1").not.toEval();
+    expect("f() /= 1").not.toEval();
+    expect("f() %= 1").not.toEval();
+    expect("f() **= 1").not.toEval();
+    expect("f() &= 1").not.toEval();
+    expect("f() |= 1").not.toEval();
+    expect("f() ^= 1").not.toEval();
+    expect("f() <<= 1").not.toEval();
+    expect("f() >>= 1").not.toEval();
+    expect("f() >>>= 1").not.toEval();
+    expect("f() = 1").not.toEval();
     expect("f() &&= 1").not.toEval();
     expect("f() ||= 1").not.toEval();
     expect("f() ??= 1").not.toEval();


### PR DESCRIPTION
The claim to support CallExpression on the LHS seems to be bogus (we don't even handle it properly). There are some tests in test262 that we pass by not allowing it:

```
test/language/expressions/assignmenttargettype/direct-callexpression-arguments.js              ❌ -> ✅
test/language/expressions/assignmenttargettype/direct-new-memberexpression-arguments.js        ❌ -> ✅
test/language/expressions/assignmenttargettype/direct-new-newexpression.js                     ❌ -> ✅
test/language/expressions/assignmenttargettype/parenthesized-callexpression-arguments.js       ❌ -> ✅
test/language/expressions/assignmenttargettype/parenthesized-new-memberexpression-arguments.js ❌ -> ✅
test/language/expressions/assignmenttargettype/parenthesized-new-newexpression.js              ❌ -> ✅
```