### PR TITLE
LibWeb/CSS: Use new descriptor parsing for `@property`

### DIFF
--- a/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
@@ -13,18 +13,25 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSPropertyRule);
 
-GC::Ref<CSSPropertyRule> CSSPropertyRule::create(JS::Realm& realm, FlyString name, FlyString syntax, bool inherits, Optional<String> initial_value)
+GC::Ref<CSSPropertyRule> CSSPropertyRule::create(JS::Realm& realm, FlyString name, FlyString syntax, bool inherits, RefPtr<CSSStyleValue> initial_value)
 {
     return realm.create<CSSPropertyRule>(realm, move(name), move(syntax), inherits, move(initial_value));
 }
 
-CSSPropertyRule::CSSPropertyRule(JS::Realm& realm, FlyString name, FlyString syntax, bool inherits, Optional<String> initial_value)
+CSSPropertyRule::CSSPropertyRule(JS::Realm& realm, FlyString name, FlyString syntax, bool inherits, RefPtr<CSSStyleValue> initial_value)
     : CSSRule(realm, Type::Property)
     , m_name(move(name))
     , m_syntax(move(syntax))
     , m_inherits(inherits)
     , m_initial_value(move(initial_value))
 {
+}
+
+Optional<String> CSSPropertyRule::initial_value() const
+{
+    if (m_initial_value)
+        return m_initial_value->to_string(CSSStyleValue::SerializationMode::Normal);
+    return {};
 }
 
 void CSSPropertyRule::initialize(JS::Realm& realm)
@@ -63,8 +70,8 @@ String CSSPropertyRule::serialized() const
     // 8. If the rule’s initial-value is present, follow these substeps:
     if (initial_value().has_value()) {
         // 1. The string "initial-value:".
-        // 2. The result of performing serialize a CSS value in the rule’s initial-value followed by a single SEMICOLON (U+003B), followed by a SPACE (U+0020).
-        // FIXME: Follow the spec for serializing the value whenever we actually have a CSS value here.
+        // 2. The result of performing serialize a CSS value in the rule’s initial-value followed by a single SEMICOLON
+        //    (U+003B), followed by a SPACE (U+0020).
         builder.appendff("initial-value: {}; ", initial_value());
     }
     // 9. A single RIGHT CURLY BRACKET (U+007D).

--- a/Libraries/LibWeb/CSS/CSSPropertyRule.h
+++ b/Libraries/LibWeb/CSS/CSSPropertyRule.h
@@ -21,17 +21,17 @@ class CSSPropertyRule final : public CSSRule {
     GC_DECLARE_ALLOCATOR(CSSPropertyRule);
 
 public:
-    static GC::Ref<CSSPropertyRule> create(JS::Realm&, FlyString name, FlyString syntax, bool inherits, Optional<String> initial_value);
+    static GC::Ref<CSSPropertyRule> create(JS::Realm&, FlyString name, FlyString syntax, bool inherits, RefPtr<CSSStyleValue> initial_value);
 
     virtual ~CSSPropertyRule() = default;
 
     FlyString const& name() const { return m_name; }
     FlyString const& syntax() const { return m_syntax; }
     bool inherits() const { return m_inherits; }
-    Optional<String> initial_value() const { return m_initial_value; }
+    Optional<String> initial_value() const;
 
 private:
-    CSSPropertyRule(JS::Realm&, FlyString name, FlyString syntax, bool inherits, Optional<String> initial_value);
+    CSSPropertyRule(JS::Realm&, FlyString name, FlyString syntax, bool inherits, RefPtr<CSSStyleValue> initial_value);
 
     virtual void initialize(JS::Realm&) override;
     virtual String serialized() const override;
@@ -39,8 +39,7 @@ private:
     FlyString m_name;
     FlyString m_syntax;
     bool m_inherits;
-    // FIXME: This should hold an actual CSS value, matching the syntax
-    Optional<String> m_initial_value;
+    RefPtr<CSSStyleValue> m_initial_value;
 };
 
 template<>

--- a/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
@@ -65,13 +65,11 @@ Parser::ParseErrorOr<NonnullRefPtr<CSSStyleValue>> Parser::parse_descriptor_valu
                     return parse_comma_separated_value_list(tokens, [this](auto& tokens) -> RefPtr<CSSStyleValue> {
                         return parse_font_source_value(tokens);
                     });
-                case DescriptorMetadata::ValueType::OptionalDeclarationValue: {
-                    // FIXME: This is for an @property's initial value. Figure out what this should actually do once we need it.
-                    StringBuilder initial_value_sb;
+                case DescriptorMetadata::ValueType::OptionalDeclarationValue:
+                    // `component_values` already has what we want. Just skip through its tokens so code below knows we consumed them.
                     while (tokens.has_next_token())
-                        initial_value_sb.append(tokens.consume_a_token().to_string());
-                    return StringStyleValue::create(initial_value_sb.to_fly_string_without_validation());
-                }
+                        tokens.discard_a_token();
+                    return UnresolvedStyleValue::create(move(component_values), false, {});
                 case DescriptorMetadata::ValueType::PositivePercentage:
                     if (auto percentage_value = parse_percentage_value(tokens)) {
                         if (percentage_value->is_percentage()) {

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -535,7 +535,7 @@ GC::Ptr<CSSPropertyRule> Parser::convert_to_property_rule(AtRule const& rule)
 
     Optional<FlyString> syntax_maybe;
     Optional<bool> inherits_maybe;
-    Optional<String> initial_value_maybe;
+    RefPtr<CSSStyleValue> initial_value_maybe;
 
     rule.for_each_as_declaration_list([&](auto& declaration) {
         if (auto descriptor = convert_to_descriptor(AtRuleID::Property, declaration); descriptor.has_value()) {
@@ -558,15 +558,16 @@ GC::Ptr<CSSPropertyRule> Parser::convert_to_property_rule(AtRule const& rule)
                 return;
             }
             if (descriptor->descriptor_id == DescriptorID::InitialValue) {
-                if (descriptor->value->is_string())
-                    initial_value_maybe = descriptor->value->as_string().string_value().to_string();
+                initial_value_maybe = *descriptor->value;
                 return;
             }
         }
     });
 
+    // TODO: Parse the initial value using the syntax, if it's provided.
+
     if (syntax_maybe.has_value() && inherits_maybe.has_value()) {
-        return CSSPropertyRule::create(realm(), name, syntax_maybe.value(), inherits_maybe.value(), std::move(initial_value_maybe));
+        return CSSPropertyRule::create(realm(), name, syntax_maybe.value(), inherits_maybe.value(), move(initial_value_maybe));
     }
     return {};
 }


### PR DESCRIPTION
Also, make the `initial-value` descriptor a bit more correct.