### PR TITLE
LibJS: Cache length identifier for GetLengthWithThis

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1116,6 +1116,7 @@ void Generator::emit_get_by_id(ScopedOperand dst, ScopedOperand base, Identifier
 void Generator::emit_get_by_id_with_this(ScopedOperand dst, ScopedOperand base, IdentifierTableIndex id, ScopedOperand this_value)
 {
     if (m_identifier_table->get(id) == "length"sv) {
+        m_length_identifier = id;
         emit<Op::GetLengthWithThis>(dst, base, this_value, m_next_property_lookup_cache++);
         return;
     }

--- a/Libraries/LibJS/Tests/regress/super-length-crash.js
+++ b/Libraries/LibJS/Tests/regress/super-length-crash.js
@@ -1,0 +1,22 @@
+test("does not crash when accessing super.length", () => {
+    let result;
+
+    class A {
+        constructor() {}
+
+        get length() {
+            return 2;
+        }
+    }
+
+    class B extends A {
+        constructor() {
+            super();
+            result = super.length;
+        }
+    }
+
+    new B();
+
+    expect(result).toBe(2);
+});


### PR DESCRIPTION
We cached the length identifier for GetLength, but not GetLengthWithThis. This caused an `has_value()` verification failure when accessing super.length. Found by Fuzzilli.