### PR TITLE
LibURL/Pattern: Do not trim whitespace interpreting port

### DIFF
--- a/Libraries/LibURL/Parser.cpp
+++ b/Libraries/LibURL/Parser.cpp
@@ -140,11 +140,11 @@ static Optional<ParsedIPv4Number> parse_ipv4_number(StringView input)
     // 8. Let output be the mathematical integer value that is represented by input in radix-R notation, using ASCII hex digits for digits with values 0 through 15.
     Optional<u32> maybe_output;
     if (radix == 8)
-        maybe_output = AK::StringUtils::convert_to_uint_from_octal(input);
+        maybe_output = AK::StringUtils::convert_to_uint_from_octal(input, TrimWhitespace::No);
     else if (radix == 10)
-        maybe_output = input.to_number<u32>();
+        maybe_output = input.to_number<u32>(TrimWhitespace::No);
     else if (radix == 16)
-        maybe_output = AK::StringUtils::convert_to_uint_from_hex(input);
+        maybe_output = AK::StringUtils::convert_to_uint_from_hex(input, TrimWhitespace::No);
     else
         VERIFY_NOT_REACHED();
 
@@ -1250,7 +1250,7 @@ Optional<URL> Parser::basic_parse(StringView raw_input, Optional<URL const&> bas
                 // 1. If buffer is not the empty string:
                 if (!buffer.is_empty()) {
                     // 1. Let port be the mathematical integer value that is represented by buffer in radix-10 using ASCII digits for digits with values 0 through 9.
-                    auto port = buffer.string_view().to_number<u16>();
+                    auto port = buffer.string_view().to_number<u16>(TrimWhitespace::No);
 
                     // 2. If port is greater than 2^16 − 1, port-out-of-range validation error, return failure.
                     // NOTE: This is done by to_number.

--- a/Libraries/LibURL/Pattern/Pattern.cpp
+++ b/Libraries/LibURL/Pattern/Pattern.cpp
@@ -95,7 +95,7 @@ PatternErrorOr<Pattern> Pattern::create(Input const& input, Optional<String> con
     // 6. If processedInit["protocol"] is a special scheme and processedInit["port"] is a string which represents its
     //    corresponding default port in radix-10 using ASCII digits then set processedInit["port"] to the empty string.
     if (is_special_scheme(processed_init.protocol.value())) {
-        auto maybe_port = processed_init.port->to_number<u16>();
+        auto maybe_port = processed_init.port->to_number<u16>(TrimWhitespace::No);
         if (maybe_port.has_value() && *maybe_port == default_port_for_scheme(*processed_init.protocol).value())
             processed_init.port = String {};
     }

--- a/Libraries/LibURL/Pattern/PatternParser.cpp
+++ b/Libraries/LibURL/Pattern/PatternParser.cpp
@@ -311,7 +311,7 @@ PatternErrorOr<Vector<Part>> PatternParser::parse(Utf8View const& input, Options
                 prefix = char_token->value;
 
             // 3. If prefix is not the empty string and not options’s prefix code point:
-            if (!prefix.is_empty() && options.prefix_code_point.has_value() && prefix != String::from_code_point(*options.prefix_code_point)) {
+            if (!prefix.is_empty() && (!options.prefix_code_point.has_value() || prefix != String::from_code_point(*options.prefix_code_point))) {
                 // 1. Append prefix to the end of parser’s pending fixed value.
                 parser.m_pending_fixed_value.append(prefix);
 

--- a/Tests/LibWeb/Text/expected/wpt-import/urlpattern/urlpattern.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/urlpattern/urlpattern.any.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 354 tests
 
-352 Pass
-2 Fail
+353 Pass
+1 Fail
 Pass	Loading data...
 Pass	Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 Pass	Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
@@ -282,7 +282,7 @@ Pass	Pattern: [{"hostname":"[*\\:1]"}] Inputs: [{"hostname":"[::ab:1]"}]
 Pass	Pattern: [{"hostname":"*\\:1]"}] Inputs: undefined
 Pass	Pattern: ["https://foo{{@}}example.com"] Inputs: ["https://foo@example.com"]
 Pass	Pattern: ["https://foo{@example.com"] Inputs: ["https://foo@example.com"]
-Fail	Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"]
+Pass	Pattern: ["data\\:text/javascript,let x = 100/:tens?5;"] Inputs: ["data:text/javascript,let x = 100/5;"]
 Pass	Pattern: [{"pathname":"/:id/:id"}] Inputs: undefined
 Pass	Pattern: [{"pathname":"/foo","baseURL":""}] Inputs: undefined
 Pass	Pattern: ["/foo",""] Inputs: undefined

--- a/Tests/LibWeb/Text/expected/wpt-import/urlpattern/urlpattern.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/urlpattern/urlpattern.any.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 354 tests
 
-351 Pass
-3 Fail
+352 Pass
+2 Fail
 Pass	Loading data...
 Pass	Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}]
 Pass	Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}]
@@ -170,7 +170,7 @@ Pass	Pattern: [{"pathname":":í ½U+deb2"}] Inputs: undefined
 Pass	Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 Pass	Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 Pass	Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
-Fail	Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+Pass	Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
 Pass	Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 Pass	Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 Pass	Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]


### PR DESCRIPTION
The remaining test failure is some weird issue with how LibRegexp is being invoked when performing a match, which results in an empty string being used for the regular expression group instead of undefined.