### PR TITLE
LibIPC: Break from message parsing if whole message payload is not ready

### DIFF
--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -152,9 +152,13 @@ TransportSocket::ShouldShutdown TransportSocket::read_as_many_messages_as_possib
     }
 
     size_t index = 0;
-    while (index + sizeof(MessageHeader) < m_unprocessed_bytes.size()) {
+    while (index + sizeof(MessageHeader) <= m_unprocessed_bytes.size()) {
         MessageHeader header;
         memcpy(&header, m_unprocessed_bytes.data() + index, sizeof(MessageHeader));
+        if (header.size + sizeof(MessageHeader) > m_unprocessed_bytes.size() - index)
+            break;
+        if (header.fd_count > m_unprocessed_fds.size())
+            break;
         Message message;
         for (size_t i = 0; i < header.fd_count; ++i)
             message.fds.append(m_unprocessed_fds.dequeue());

--- a/Libraries/LibIPC/UnprocessedFileDescriptors.h
+++ b/Libraries/LibIPC/UnprocessedFileDescriptors.h
@@ -27,6 +27,8 @@ public:
         m_fds.prepend(move(fds));
     }
 
+    size_t size() const { return m_fds.size(); }
+
 private:
     Vector<File> m_fds;
 };


### PR DESCRIPTION
Fixes the bug when we try to read message payload without checking if we received enough bytes or file descriptors.