### PR TITLE
LibJS: Batch of Intl editorial updates

### DIFF
--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -274,11 +274,14 @@ JS_ENUMERATE_INTL_OBJECTS
 #undef __JS_ENUMERATE
 
 class Intl;
+class IntlObject;
 class MathematicalValue;
 
 // Not included in JS_ENUMERATE_INTL_OBJECTS due to missing distinct constructor
 class Segments;
 class SegmentsPrototype;
+
+struct ResolutionOptionDescriptor;
 };
 
 namespace Temporal {

--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -13,6 +13,7 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibJS/Runtime/Intl/Locale.h>
 #include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
 #include <LibJS/Runtime/VM.h>
@@ -610,7 +611,75 @@ ResolvedLocale resolve_locale(ReadonlySpan<String> requested_locales, LocaleOpti
     return result;
 }
 
-// 9.2.8 FilterLocales ( availableLocales, requestedLocales, options ), https://tc39.es/ecma402/#sec-lookupsupportedlocales
+// 9.2.8 ResolveOptions ( constructor, localeData, locales, options [ , specialBehaviours [ , modifyResolutionOptions ] ] ), https://tc39.es/ecma402/#sec-resolveoptions
+ThrowCompletionOr<ResolvedOptions> resolve_options(VM& vm, IntlObject& object, Value locales, Value options_value, SpecialBehaviors special_behaviours, Function<void(LocaleOptions&)> modify_resolution_options)
+{
+    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
+
+    // 2. If specialBehaviours is present and contains REQUIRE-OPTIONS and options is undefined, throw a TypeError exception.
+    if (has_flag(special_behaviours, SpecialBehaviors::RequireOptions) && options_value.is_undefined())
+        return vm.throw_completion<TypeError>(ErrorType::IsUndefined, "options"sv);
+
+    // 3. If specialBehaviours is present and contains COERCE-OPTIONS, set options to ? CoerceOptionsToObject(options).
+    //    Otherwise, set options to ? GetOptionsObject(options).
+    GC::Ref<Object> options = has_flag(special_behaviours, SpecialBehaviors::CoerceOptions)
+        ? *TRY(coerce_options_to_object(vm, options_value))
+        : *TRY(get_options_object(vm, options_value));
+
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", STRING, « "lookup", "best fit" », "best fit").
+    auto matcher = TRY(get_option(vm, options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
+
+    // 5. Let opt be the Record { [[localeMatcher]]: matcher }.
+    LocaleOptions opt {};
+    opt.locale_matcher = matcher;
+
+    // 6. For each Resolution Option Descriptor desc of constructor.[[ResolutionOptionDescriptors]], do
+    for (auto const& descriptor : object.resolution_option_descriptors(vm)) {
+        // a. If desc has a [[Type]] field, let type be desc.[[Type]]. Otherwise, let type be STRING.
+        auto type = descriptor.type;
+
+        // b. If desc has a [[Values]] field, let values be desc.[[Values]]. Otherwise, let values be EMPTY.
+        auto values = descriptor.values;
+
+        // c. Let value be ? GetOption(options, desc.[[Property]], type, values, undefined).
+        auto value = TRY(get_option(vm, options, descriptor.property, type, values, Empty {}));
+        Optional<LocaleKey> locale_key;
+
+        // d. If value is not undefined, then
+        if (!value.is_undefined()) {
+            // i. Set value to ! ToString(value).
+            auto value_string = MUST(value.to_string(vm));
+
+            // ii. If value cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
+            if (!Unicode::is_type_identifier(value_string))
+                return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, value_string, descriptor.property);
+
+            locale_key = move(value_string);
+        }
+
+        // e. Let key be desc.[[Key]].
+        auto key = descriptor.key;
+
+        // f. Set opt.[[<key>]] to value.
+        if (descriptor.property == vm.names.hour12)
+            opt.hour12 = value;
+        else
+            find_key_in_value(opt, key) = move(locale_key);
+    }
+
+    // 7. If modifyResolutionOptions is present, perform ! modifyResolutionOptions(opt).
+    if (modify_resolution_options)
+        modify_resolution_options(opt);
+
+    // 8. Let resolution be ResolveLocale(constructor.[[AvailableLocales]], requestedLocales, opt, constructor.[[RelevantExtensionKeys]], localeData).
+    auto resolution = resolve_locale(requested_locales, opt, object.relevant_extension_keys());
+
+    // 9. Return the Record { [[Options]]: options, [[ResolvedLocale]]: resolution, [[ResolutionOptions]]: opt }.
+    return ResolvedOptions { .options = options, .resolved_locale = move(resolution), .resolution_options = move(opt) };
+}
+
+// 9.2.9 FilterLocales ( availableLocales, requestedLocales, options ), https://tc39.es/ecma402/#sec-lookupsupportedlocales
 ThrowCompletionOr<Array*> filter_locales(VM& vm, ReadonlySpan<String> requested_locales, Value options)
 {
     auto& realm = *vm.current_realm();
@@ -648,7 +717,7 @@ ThrowCompletionOr<Array*> filter_locales(VM& vm, ReadonlySpan<String> requested_
     return Array::create_from<String>(realm, subset, [&vm](auto& locale) { return PrimitiveString::create(vm, move(locale)); }).ptr();
 }
 
-// 9.2.10 CoerceOptionsToObject ( options ), https://tc39.es/ecma402/#sec-coerceoptionstoobject
+// 9.2.11 CoerceOptionsToObject ( options ), https://tc39.es/ecma402/#sec-coerceoptionstoobject
 ThrowCompletionOr<Object*> coerce_options_to_object(VM& vm, Value options)
 {
     auto& realm = *vm.current_realm();
@@ -663,9 +732,9 @@ ThrowCompletionOr<Object*> coerce_options_to_object(VM& vm, Value options)
     return TRY(options.to_object(vm)).ptr();
 }
 
-// NOTE: 9.2.11 GetOption has been removed and is being pulled in from ECMA-262 in the Temporal proposal.
+// NOTE: 9.2.12 GetOption has been removed and is being pulled in from ECMA-262 in the Temporal proposal.
 
-// 9.2.12 GetBooleanOrStringNumberFormatOption ( options, property, stringValues, fallback ), https://tc39.es/ecma402/#sec-getbooleanorstringnumberformatoption
+// 9.2.13 GetBooleanOrStringNumberFormatOption ( options, property, stringValues, fallback ), https://tc39.es/ecma402/#sec-getbooleanorstringnumberformatoption
 ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, ReadonlySpan<StringView> string_values, StringOrBoolean fallback)
 {
     // 1. Let value be ? Get(options, property).
@@ -695,7 +764,7 @@ ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM
     return StringOrBoolean { *it };
 }
 
-// 9.2.13 DefaultNumberOption ( value, minimum, maximum, fallback ), https://tc39.es/ecma402/#sec-defaultnumberoption
+// 9.2.14 DefaultNumberOption ( value, minimum, maximum, fallback ), https://tc39.es/ecma402/#sec-defaultnumberoption
 ThrowCompletionOr<Optional<int>> default_number_option(VM& vm, Value value, int minimum, int maximum, Optional<int> fallback)
 {
     // 1. If value is undefined, return fallback.
@@ -713,7 +782,7 @@ ThrowCompletionOr<Optional<int>> default_number_option(VM& vm, Value value, int 
     return floor(value.as_double());
 }
 
-// 9.2.14 GetNumberOption ( options, property, minimum, maximum, fallback ), https://tc39.es/ecma402/#sec-getnumberoption
+// 9.2.15 GetNumberOption ( options, property, minimum, maximum, fallback ), https://tc39.es/ecma402/#sec-getnumberoption
 ThrowCompletionOr<Optional<int>> get_number_option(VM& vm, Object const& options, PropertyKey const& property, int minimum, int maximum, Optional<int> fallback)
 {
     // 1. Assert: Type(options) is Object.

--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -23,17 +23,6 @@
 
 namespace JS::Intl {
 
-Optional<LocaleKey> locale_key_from_value(Value value)
-{
-    if (value.is_undefined())
-        return OptionalNone {};
-    if (value.is_null())
-        return Empty {};
-    if (value.is_string())
-        return value.as_string().utf8_string();
-    VERIFY_NOT_REACHED();
-}
-
 // 6.2.1 IsStructurallyValidLanguageTag ( locale ), https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag
 bool is_structurally_valid_language_tag(StringView locale)
 {

--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -20,7 +20,6 @@
 namespace JS::Intl {
 
 using LocaleKey = Variant<Empty, String>;
-Optional<LocaleKey> locale_key_from_value(Value);
 
 struct LocaleOptions {
     Value locale_matcher;

--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -75,8 +75,8 @@ Optional<MatchedLocale> lookup_matching_locale_by_best_fit(ReadonlySpan<String> 
 String insert_unicode_extension_and_canonicalize(Unicode::LocaleID locale_id, Vector<String> attributes, Vector<Unicode::Keyword> keywords);
 ResolvedLocale resolve_locale(ReadonlySpan<String> requested_locales, LocaleOptions const& options, ReadonlySpan<StringView> relevant_extension_keys);
 ThrowCompletionOr<ResolvedOptions> resolve_options(VM& vm, IntlObject& object, Value locales, Value options_value, SpecialBehaviors special_behaviours = SpecialBehaviors::None, Function<void(LocaleOptions&)> modify_resolution_options = {});
-ThrowCompletionOr<Array*> filter_locales(VM& vm, ReadonlySpan<String> requested_locales, Value options);
-ThrowCompletionOr<Object*> coerce_options_to_object(VM&, Value options);
+ThrowCompletionOr<GC::Ref<Array>> filter_locales(VM& vm, ReadonlySpan<String> requested_locales, Value options);
+ThrowCompletionOr<GC::Ref<Object>> coerce_options_to_object(VM&, Value options);
 ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, ReadonlySpan<StringView> string_values, StringOrBoolean fallback);
 ThrowCompletionOr<Optional<int>> default_number_option(VM&, Value value, int minimum, int maximum, Optional<int> fallback);
 ThrowCompletionOr<Optional<int>> get_number_option(VM&, Object const& options, PropertyKey const& property, int minimum, int maximum, Optional<int> fallback);

--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/EnumBits.h>
 #include <AK/Span.h>
 #include <AK/String.h>
 #include <AK/Variant.h>
@@ -29,6 +30,7 @@ struct LocaleOptions {
     Optional<LocaleKey> kf; // [[CaseFirst]]
     Optional<LocaleKey> kn; // [[Numeric]]
     Optional<LocaleKey> nu; // [[NumberingSystem]]
+    Value hour12;
 };
 
 struct MatchedLocale {
@@ -47,6 +49,19 @@ struct ResolvedLocale {
     LocaleKey nu; // [[NumberingSystem]]
 };
 
+struct ResolvedOptions {
+    GC::Ref<Object> options;
+    ResolvedLocale resolved_locale;
+    LocaleOptions resolution_options;
+};
+
+enum class SpecialBehaviors : u8 {
+    None = 0,
+    RequireOptions = 1 << 1,
+    CoerceOptions = 1 << 2,
+};
+AK_ENUM_BITWISE_OPERATORS(SpecialBehaviors);
+
 using StringOrBoolean = Variant<StringView, bool>;
 
 bool is_structurally_valid_language_tag(StringView locale);
@@ -60,6 +75,7 @@ Optional<MatchedLocale> lookup_matching_locale_by_prefix(ReadonlySpan<String> re
 Optional<MatchedLocale> lookup_matching_locale_by_best_fit(ReadonlySpan<String> requested_locales);
 String insert_unicode_extension_and_canonicalize(Unicode::LocaleID locale_id, Vector<String> attributes, Vector<Unicode::Keyword> keywords);
 ResolvedLocale resolve_locale(ReadonlySpan<String> requested_locales, LocaleOptions const& options, ReadonlySpan<StringView> relevant_extension_keys);
+ThrowCompletionOr<ResolvedOptions> resolve_options(VM& vm, IntlObject& object, Value locales, Value options_value, SpecialBehaviors special_behaviours = SpecialBehaviors::None, Function<void(LocaleOptions&)> modify_resolution_options = {});
 ThrowCompletionOr<Array*> filter_locales(VM& vm, ReadonlySpan<String> requested_locales, Value options);
 ThrowCompletionOr<Object*> coerce_options_to_object(VM&, Value options);
 ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, ReadonlySpan<StringView> string_values, StringOrBoolean fallback);

--- a/Libraries/LibJS/Runtime/Intl/Collator.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Collator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,7 +12,7 @@ GC_DEFINE_ALLOCATOR(Collator);
 
 // 10 Collator Objects, https://tc39.es/ecma402/#collator-objects
 Collator::Collator(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
 }
 
@@ -20,6 +20,29 @@ void Collator::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_bound_compare);
+}
+
+// 10.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl-collator-internal-slots
+ReadonlySpan<StringView> Collator::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is a List that must include the element "co", may include any or all of the elements "kf" and "kn", and must not include any other elements.
+    static constexpr AK::Array keys { "co"sv, "kf"sv, "kn"sv };
+    return keys;
+}
+
+// 10.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl-collator-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> Collator::resolution_option_descriptors(VM& vm) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « { [[Key]]: "co", [[Property]]: "collation" }, { [[Key]]: "kn", [[Property]]: "numeric", [[Type]]: boolean }, { [[Key]]: "kf", [[Property]]: "caseFirst", [[Values]]: « "upper", "lower", "false" » } ».
+    static constexpr AK::Array case_first_values { "upper"sv, "lower"sv, "false"sv };
+
+    static auto descriptors = to_array<ResolutionOptionDescriptor>({
+        { .key = "co"sv, .property = vm.names.collation },
+        { .key = "kn"sv, .property = vm.names.numeric, .type = OptionType::Boolean },
+        { .key = "kf"sv, .property = vm.names.caseFirst, .values = case_first_values },
+    });
+
+    return descriptors;
 }
 
 }

--- a/Libraries/LibJS/Runtime/Intl/Collator.h
+++ b/Libraries/LibJS/Runtime/Intl/Collator.h
@@ -1,33 +1,28 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibJS/Runtime/Intl/CollatorCompareFunction.h>
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibUnicode/Collator.h>
 
 namespace JS::Intl {
 
-class Collator final : public Object {
-    JS_OBJECT(Collator, Object);
+class Collator final : public IntlObject {
+    JS_OBJECT(Collator, IntlObject);
     GC_DECLARE_ALLOCATOR(Collator);
 
 public:
-    static constexpr auto relevant_extension_keys()
-    {
-        // 10.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl-collator-internal-slots
-        // The value of the [[RelevantExtensionKeys]] internal slot is a List that must include the element "co", may include any or all of the elements "kf" and "kn", and must not include any other elements.
-        return AK::Array { "co"sv, "kf"sv, "kn"sv };
-    }
-
     virtual ~Collator() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }

--- a/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -113,7 +113,7 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     opt.kf = locale_key_from_value(case_first);
 
     // 21. Let r be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], requestedLocales, opt, %Intl.Collator%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, Collator::relevant_extension_keys());
+    auto result = resolve_locale(requested_locales, opt, collator->relevant_extension_keys());
 
     // 22. Set collator.[[Locale]] to r.[[Locale]].
     collator->set_locale(move(result.locale));

--- a/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -63,10 +63,10 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales_value));
 
     // 6. Set options to ? CoerceOptionsToObject(options).
-    auto* options = TRY(coerce_options_to_object(vm, options_value));
+    auto options = TRY(coerce_options_to_object(vm, options_value));
 
     // 7. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
-    auto usage = TRY(get_option(vm, *options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
+    auto usage = TRY(get_option(vm, options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
 
     // 8. Set collator.[[Usage]] to usage.
     collator->set_usage(usage.as_string().utf8_string_view());
@@ -109,7 +109,7 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     auto default_sensitivity = collator->usage() == Unicode::Usage::Sort ? "variant"sv : OptionDefault {};
 
     // 20. Set collator.[[Sensitivity]] to ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », defaultSensitivity).
-    auto sensitivity_value = TRY(get_option(vm, *options, vm.names.sensitivity, OptionType::String, { "base"sv, "accent"sv, "case"sv, "variant"sv }, default_sensitivity));
+    auto sensitivity_value = TRY(get_option(vm, options, vm.names.sensitivity, OptionType::String, { "base"sv, "accent"sv, "case"sv, "variant"sv }, default_sensitivity));
 
     Optional<Unicode::Sensitivity> sensitivity;
     if (!sensitivity_value.is_undefined())
@@ -120,7 +120,7 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     //       default value if an override was not provided here.
 
     // 22. Set collator.[[IgnorePunctuation]] to ? GetOption(options, "ignorePunctuation", boolean, empty, defaultIgnorePunctuation).
-    auto ignore_punctuation_value = TRY(get_option(vm, *options, vm.names.ignorePunctuation, OptionType::Boolean, {}, Empty {}));
+    auto ignore_punctuation_value = TRY(get_option(vm, options, vm.names.ignorePunctuation, OptionType::Boolean, {}, Empty {}));
 
     Optional<bool> ignore_punctuation;
     if (!ignore_punctuation_value.is_undefined())

--- a/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -47,6 +47,7 @@ ThrowCompletionOr<Value> CollatorConstructor::call()
 ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
+    auto& realm = *vm.current_realm();
 
     auto locales_value = vm.argument(0);
     auto options_value = vm.argument(1);
@@ -55,105 +56,70 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     // 3. Let collator be ? OrdinaryCreateFromConstructor(newTarget, "%Intl.Collator.prototype%", internalSlotsList).
     auto collator = TRY(ordinary_create_from_constructor<Collator>(vm, new_target, &Intrinsics::intl_collator_prototype));
 
-    // 4. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    // 4. NOTE: The source of locale data for ResolveOptions depends upon the "usage" property of options, but the following
+    //    two steps must observably precede that lookup (and must not observably repeat inside ResolveOptions).
+
+    // 5. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales_value));
 
-    // 5. Set options to ? CoerceOptionsToObject(options).
+    // 6. Set options to ? CoerceOptionsToObject(options).
     auto* options = TRY(coerce_options_to_object(vm, options_value));
 
-    // 6. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
+    // 7. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
     auto usage = TRY(get_option(vm, *options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
 
-    // 7. Set collator.[[Usage]] to usage.
+    // 8. Set collator.[[Usage]] to usage.
     collator->set_usage(usage.as_string().utf8_string_view());
 
-    // 8. If usage is "sort", then
+    // 9. If usage is "sort", then
     //     a. Let localeData be %Intl.Collator%.[[SortLocaleData]].
-    // 9. Else,
+    // 10. Else,
     //     a. Let localeData be %Intl.Collator%.[[SearchLocaleData]].
 
-    // 10. Let opt be a new Record.
-    LocaleOptions opt {};
+    // 11. Let optionsResolution be ? ResolveOptions(%Intl.Collator%, localeData, CreateArrayFromList(requestedLocales), options).
+    auto requested_locales_array = Array::create_from<String>(realm, requested_locales, [&](auto& locale) { return PrimitiveString::create(vm, move(locale)); });
+    auto options_resolution = TRY(resolve_options(vm, collator, requested_locales_array, options_value));
 
-    // 11. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
-    auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
+    // 12. Let r be optionsResolution.[[ResolvedLocale]].
+    auto result = move(options_resolution.resolved_locale);
 
-    // 12. Set opt.[[localeMatcher]] to matcher.
-    opt.locale_matcher = matcher;
-
-    // 13. Let collation be ? GetOption(options, "collation", string, empty, undefined).
-    auto collation = TRY(get_option(vm, *options, vm.names.collation, OptionType::String, {}, Empty {}));
-
-    // 14. If collation is not undefined, then
-    if (!collation.is_undefined()) {
-        // a. If collation cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
-        if (!Unicode::is_type_identifier(collation.as_string().utf8_string_view()))
-            return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, collation, "collation"sv);
-    }
-
-    // 15. Set opt.[[co]] to collation.
-    opt.co = locale_key_from_value(collation);
-
-    // 16. Let numeric be ? GetOption(options, "numeric", boolean, empty, undefined).
-    auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
-
-    // 17. If numeric is not undefined, then
-    if (!numeric.is_undefined()) {
-        // a. Set numeric to ! ToString(numeric).
-        numeric = PrimitiveString::create(vm, MUST(numeric.to_string(vm)));
-    }
-
-    // 18. Set opt.[[kn]] to numeric.
-    opt.kn = locale_key_from_value(numeric);
-
-    // 19. Let caseFirst be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
-    auto case_first = TRY(get_option(vm, *options, vm.names.caseFirst, OptionType::String, { "upper"sv, "lower"sv, "false"sv }, Empty {}));
-
-    // 20. Set opt.[[kf]] to caseFirst.
-    opt.kf = locale_key_from_value(case_first);
-
-    // 21. Let r be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], requestedLocales, opt, %Intl.Collator%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, collator->relevant_extension_keys());
-
-    // 22. Set collator.[[Locale]] to r.[[Locale]].
+    // 13. Set collator.[[Locale]] to r.[[Locale]].
     collator->set_locale(move(result.locale));
 
-    // 23. Set collation to r.[[co]].
-    auto collation_value = move(result.co);
+    // 14. If r.[[co]] is null, let collation be "default". Otherwise, let collation be r.[[co]].
+    auto collation = result.co.has<Empty>()
+        ? "default"_string
+        : move(result.co.get<String>());
 
-    // 24. If collation is null, set collation to "default".
-    if (collation_value.has<Empty>())
-        collation_value = "default"_string;
+    // 15. Set collator.[[Collation]] to collation.
+    collator->set_collation(move(collation));
 
-    // 25. Set collator.[[Collation]] to collation.
-    collator->set_collation(move(collation_value.get<String>()));
-
-    // 26. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
+    // 16. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
     collator->set_numeric(result.kn == "true"_string);
 
-    // 27. Set collator.[[CaseFirst]] to r.[[kf]].
+    // 17. Set collator.[[CaseFirst]] to r.[[kf]].
     if (auto const* resolved_case_first = result.kf.get_pointer<String>())
         collator->set_case_first(*resolved_case_first);
 
-    // 28. Let resolvedLocaleData be r.[[LocaleData]].
+    // 18. Let resolvedLocaleData be r.[[LocaleData]].
 
-    // 29. If usage is "sort", let defaultSensitivity be "variant". Otherwise, let defaultSensitivity be resolvedLocaleData.[[sensitivity]].
+    // 19. If usage is "sort", let defaultSensitivity be "variant". Otherwise, let defaultSensitivity be resolvedLocaleData.[[sensitivity]].
     // NOTE: We do not acquire resolvedLocaleData.[[sensitivity]] here. Instead, we let LibUnicode fill in the
     //       default value if an override was not provided here.
     auto default_sensitivity = collator->usage() == Unicode::Usage::Sort ? "variant"sv : OptionDefault {};
 
-    // 30. Set collator.[[Sensitivity]] to ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », defaultSensitivity).
+    // 20. Set collator.[[Sensitivity]] to ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », defaultSensitivity).
     auto sensitivity_value = TRY(get_option(vm, *options, vm.names.sensitivity, OptionType::String, { "base"sv, "accent"sv, "case"sv, "variant"sv }, default_sensitivity));
 
     Optional<Unicode::Sensitivity> sensitivity;
     if (!sensitivity_value.is_undefined())
         sensitivity = Unicode::sensitivity_from_string(sensitivity_value.as_string().utf8_string_view());
 
-    // 31. Let defaultIgnorePunctuation be resolvedLocaleData.[[ignorePunctuation]].
+    // 21. Let defaultIgnorePunctuation be resolvedLocaleData.[[ignorePunctuation]].
     // NOTE: We do not acquire resolvedLocaleData.[[ignorePunctuation]] here. Instead, we let LibUnicode fill in the
     //       default value if an override was not provided here.
 
-    // 32. Set collator.[[IgnorePunctuation]] to ? GetOption(options, "ignorePunctuation", boolean, empty, defaultIgnorePunctuation).
+    // 22. Set collator.[[IgnorePunctuation]] to ? GetOption(options, "ignorePunctuation", boolean, empty, defaultIgnorePunctuation).
     auto ignore_punctuation_value = TRY(get_option(vm, *options, vm.names.ignorePunctuation, OptionType::Boolean, {}, Empty {}));
 
     Optional<bool> ignore_punctuation;
@@ -174,7 +140,7 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     collator->set_sensitivity(collator->collator().sensitivity());
     collator->set_ignore_punctuation(collator->collator().ignore_punctuation());
 
-    // 33. Return collator.
+    // 23. Return collator.
     return collator;
 }
 

--- a/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -51,110 +51,96 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     auto locales_value = vm.argument(0);
     auto options_value = vm.argument(1);
 
-    // 2. Let internalSlotsList be « [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] ».
-    // 3. If %Intl.Collator%.[[RelevantExtensionKeys]] contains "kn", then
-    //     a. Append [[Numeric]] to internalSlotsList.
-    // 4. If %Intl.Collator%.[[RelevantExtensionKeys]] contains "kf", then
-    //     a. Append [[CaseFirst]] to internalSlotsList.
-
-    // 5. Let collator be ? OrdinaryCreateFromConstructor(newTarget, "%Intl.Collator.prototype%", internalSlotsList).
+    // 2. Let internalSlotsList be « [[InitializedCollator]], [[Locale]], [[Usage]], [[Collation]], [[Numeric]], [[CaseFirst]], [[Sensitivity]], [[IgnorePunctuation]], [[BoundCompare]] ».
+    // 3. Let collator be ? OrdinaryCreateFromConstructor(newTarget, "%Intl.Collator.prototype%", internalSlotsList).
     auto collator = TRY(ordinary_create_from_constructor<Collator>(vm, new_target, &Intrinsics::intl_collator_prototype));
 
-    // 6. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    // 4. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales_value));
 
-    // 7. Set options to ? CoerceOptionsToObject(options).
+    // 5. Set options to ? CoerceOptionsToObject(options).
     auto* options = TRY(coerce_options_to_object(vm, options_value));
 
-    // 8. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
+    // 6. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
     auto usage = TRY(get_option(vm, *options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
 
-    // 9. Set collator.[[Usage]] to usage.
+    // 7. Set collator.[[Usage]] to usage.
     collator->set_usage(usage.as_string().utf8_string_view());
 
-    // 10. If usage is "sort", then
+    // 8. If usage is "sort", then
     //     a. Let localeData be %Intl.Collator%.[[SortLocaleData]].
-    // 11. Else,
+    // 9. Else,
     //     a. Let localeData be %Intl.Collator%.[[SearchLocaleData]].
 
-    // 12. Let opt be a new Record.
+    // 10. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 13. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
+    // 11. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
-    // 14. Set opt.[[localeMatcher]] to matcher.
+    // 12. Set opt.[[localeMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 15. Let collation be ? GetOption(options, "collation", string, empty, undefined).
+    // 13. Let collation be ? GetOption(options, "collation", string, empty, undefined).
     auto collation = TRY(get_option(vm, *options, vm.names.collation, OptionType::String, {}, Empty {}));
 
-    // 16. If collation is not undefined, then
+    // 14. If collation is not undefined, then
     if (!collation.is_undefined()) {
         // a. If collation cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
         if (!Unicode::is_type_identifier(collation.as_string().utf8_string_view()))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, collation, "collation"sv);
     }
 
-    // 17. Set opt.[[co]] to collation.
+    // 15. Set opt.[[co]] to collation.
     opt.co = locale_key_from_value(collation);
 
-    // 18. Let numeric be ? GetOption(options, "numeric", boolean, empty, undefined).
+    // 16. Let numeric be ? GetOption(options, "numeric", boolean, empty, undefined).
     auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
 
-    // 19. If numeric is not undefined, then
+    // 17. If numeric is not undefined, then
     if (!numeric.is_undefined()) {
         // a. Set numeric to ! ToString(numeric).
         numeric = PrimitiveString::create(vm, MUST(numeric.to_string(vm)));
     }
 
-    // 20. Set opt.[[kn]] to numeric.
+    // 18. Set opt.[[kn]] to numeric.
     opt.kn = locale_key_from_value(numeric);
 
-    // 21. Let caseFirst be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
+    // 19. Let caseFirst be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
     auto case_first = TRY(get_option(vm, *options, vm.names.caseFirst, OptionType::String, { "upper"sv, "lower"sv, "false"sv }, Empty {}));
 
-    // 22. Set opt.[[kf]] to caseFirst.
+    // 20. Set opt.[[kf]] to caseFirst.
     opt.kf = locale_key_from_value(case_first);
 
-    // 23. Let relevantExtensionKeys be %Intl.Collator%.[[RelevantExtensionKeys]].
-    auto relevant_extension_keys = Collator::relevant_extension_keys();
+    // 21. Let r be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], requestedLocales, opt, %Intl.Collator%.[[RelevantExtensionKeys]], localeData).
+    auto result = resolve_locale(requested_locales, opt, Collator::relevant_extension_keys());
 
-    // 24. Let r be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], requestedLocales, opt, relevantExtensionKeys, localeData).
-    auto result = resolve_locale(requested_locales, opt, relevant_extension_keys);
-
-    // 25. Set collator.[[Locale]] to r.[[Locale]].
+    // 22. Set collator.[[Locale]] to r.[[Locale]].
     collator->set_locale(move(result.locale));
 
-    // 26. Set collation to r.[[co]].
+    // 23. Set collation to r.[[co]].
     auto collation_value = move(result.co);
 
-    // 27. If collation is null, set collation to "default".
+    // 24. If collation is null, set collation to "default".
     if (collation_value.has<Empty>())
         collation_value = "default"_string;
 
-    // 28. Set collator.[[Collation]] to collation.
+    // 25. Set collator.[[Collation]] to collation.
     collator->set_collation(move(collation_value.get<String>()));
 
-    // 29. If relevantExtensionKeys contains "kn", then
-    if (relevant_extension_keys.span().contains_slow("kn"sv)) {
-        // a. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
-        collator->set_numeric(result.kn == "true"_string);
-    }
+    // 26. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
+    collator->set_numeric(result.kn == "true"_string);
 
-    // 30. If relevantExtensionKeys contains "kf", then
-    if (relevant_extension_keys.span().contains_slow("kf"sv)) {
-        // a. Set collator.[[CaseFirst]] to r.[[kf]].
-        if (auto* resolved_case_first = result.kf.get_pointer<String>())
-            collator->set_case_first(*resolved_case_first);
-    }
+    // 27. Set collator.[[CaseFirst]] to r.[[kf]].
+    if (auto const* resolved_case_first = result.kf.get_pointer<String>())
+        collator->set_case_first(*resolved_case_first);
 
-    // 31. Let resolvedLocaleData be r.[[LocaleData]].
+    // 28. Let resolvedLocaleData be r.[[LocaleData]].
 
-    // 32. Let sensitivity be ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », undefined).
+    // 29. Let sensitivity be ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », undefined).
     auto sensitivity_value = TRY(get_option(vm, *options, vm.names.sensitivity, OptionType::String, { "base"sv, "accent"sv, "case"sv, "variant"sv }, Empty {}));
 
-    // 33. If sensitivity is undefined, then
+    // 30. If sensitivity is undefined, then
     if (sensitivity_value.is_undefined()) {
         // a. If usage is "sort", then
         if (collator->usage() == Unicode::Usage::Sort) {
@@ -173,11 +159,11 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
     if (!sensitivity_value.is_undefined())
         sensitivity = Unicode::sensitivity_from_string(sensitivity_value.as_string().utf8_string_view());
 
-    // 35. Let defaultIgnorePunctuation be resolvedLocaleData.[[ignorePunctuation]].
+    // 32. Let defaultIgnorePunctuation be resolvedLocaleData.[[ignorePunctuation]].
     // NOTE: We do not acquire the default [[ignorePunctuation]] here. Instead, we default the option to null,
     //       and let LibUnicode fill in the default value if an override was not provided here.
 
-    // 36. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation", boolean, empty, defaultIgnorePunctuation).
+    // 33. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation", boolean, empty, defaultIgnorePunctuation).
     auto ignore_punctuation_value = TRY(get_option(vm, *options, vm.names.ignorePunctuation, OptionType::Boolean, {}, Empty {}));
 
     Optional<bool> ignore_punctuation;
@@ -195,13 +181,13 @@ ThrowCompletionOr<GC::Ref<Object>> CollatorConstructor::construct(FunctionObject
         ignore_punctuation);
     collator->set_collator(move(icu_collator));
 
-    // 34. Set collator.[[Sensitivity]] to sensitivity.
+    // 31. Set collator.[[Sensitivity]] to sensitivity.
     collator->set_sensitivity(collator->collator().sensitivity());
 
-    // 37. Set collator.[[IgnorePunctuation]] to ignorePunctuation.
+    // 34. Set collator.[[IgnorePunctuation]] to ignorePunctuation.
     collator->set_ignore_punctuation(collator->collator().ignore_punctuation());
 
-    // 38. Return collator.
+    // 35. Return collator.
     return collator;
 }
 

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -24,7 +24,7 @@ GC_DEFINE_ALLOCATOR(DateTimeFormat);
 
 // 11 DateTimeFormat Objects, https://tc39.es/ecma402/#datetimeformat-objects
 DateTimeFormat::DateTimeFormat(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
 }
 
@@ -32,6 +32,30 @@ void DateTimeFormat::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_bound_format);
+}
+
+// 11.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
+ReadonlySpan<StringView> DateTimeFormat::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "hc", "nu" ».
+    static constexpr AK::Array keys { "ca"sv, "hc"sv, "nu"sv };
+    return keys;
+}
+
+// 11.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> DateTimeFormat::resolution_option_descriptors(VM& vm) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « { [[Key]]: "ca", [[Property]]: "calendar" }, { [[Key]]: "nu", [[Property]]: "numberingSystem" }, { [[Key]]: "hour12", [[Property]]: "hour12", [[Type]]: boolean }, { [[Key]]: "hc", [[Property]]: "hourCycle", [[Values]]: « "h11", "h12", "h23", "h24" » } ».
+    static constexpr AK::Array hour_cycle_values { "h11"sv, "h12"sv, "h23"sv, "h24"sv };
+
+    static auto descriptors = to_array<ResolutionOptionDescriptor>({
+        { .key = "ca"sv, .property = vm.names.calendar },
+        { .key = "nu"sv, .property = vm.names.numberingSystem },
+        { .key = "hour12"sv, .property = vm.names.hour12, .type = OptionType::Boolean },
+        { .key = "hc"sv, .property = vm.names.hourCycle, .values = hour_cycle_values },
+    });
+
+    return descriptors;
 }
 
 static Optional<Unicode::DateTimeFormat const&> get_or_create_formatter(StringView locale, StringView time_zone, OwnPtr<Unicode::DateTimeFormat>& formatter, Optional<Unicode::CalendarPattern> const& format)

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -13,27 +13,23 @@
 #include <AK/Vector.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Intl/DateTimeFormatConstructor.h>
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibUnicode/DateTimeFormat.h>
 
 namespace JS::Intl {
 
-class DateTimeFormat final : public Object {
-    JS_OBJECT(DateTimeFormat, Object);
+class DateTimeFormat final : public IntlObject {
+    JS_OBJECT(DateTimeFormat, IntlObject);
     GC_DECLARE_ALLOCATOR(DateTimeFormat);
 
     using Patterns = Unicode::CalendarPattern;
 
 public:
-    static constexpr auto relevant_extension_keys()
-    {
-        // 11.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
-        // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "hc", "nu" ».
-        return AK::Array { "ca"sv, "hc"sv, "nu"sv };
-    }
-
     virtual ~DateTimeFormat() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
@@ -90,7 +86,7 @@ public:
     void set_temporal_time_zone(String temporal_time_zone) { m_temporal_time_zone = move(temporal_time_zone); }
 
 private:
-    DateTimeFormat(Object& prototype);
+    explicit DateTimeFormat(Object& prototype);
 
     virtual void visit_edges(Visitor&) override;
 

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -145,7 +145,7 @@ ThrowCompletionOr<GC::Ref<DateTimeFormat>> create_date_time_format(VM& vm, Funct
     opt.hc = locale_key_from_value(hour_cycle);
 
     // 17. Let r be ResolveLocale(%Intl.DateTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %Intl.DateTimeFormat%.[[RelevantExtensionKeys]], %Intl.DateTimeFormat%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, DateTimeFormat::relevant_extension_keys());
+    auto result = resolve_locale(requested_locales, opt, date_time_format->relevant_extension_keys());
 
     // 18. Set dateTimeFormat.[[Locale]] to r.[[Locale]].
     date_time_format->set_locale(move(result.locale));

--- a/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
+#include <LibJS/Runtime/VM.h>
 
 namespace JS::Intl {
 
@@ -14,8 +14,22 @@ GC_DEFINE_ALLOCATOR(DisplayNames);
 
 // 12 DisplayNames Objects, https://tc39.es/ecma402/#intl-displaynames-objects
 DisplayNames::DisplayNames(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
+}
+
+// 12.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.DisplayNames-internal-slots
+ReadonlySpan<StringView> DisplayNames::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « ».
+    return {};
+}
+
+// 12.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.DisplayNames-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> DisplayNames::resolution_option_descriptors(VM&) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « ».
+    return {};
 }
 
 void DisplayNames::set_type(StringView type)

--- a/Libraries/LibJS/Runtime/Intl/DisplayNames.h
+++ b/Libraries/LibJS/Runtime/Intl/DisplayNames.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,14 +9,14 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibUnicode/DisplayNames.h>
 #include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
-class DisplayNames final : public Object {
-    JS_OBJECT(DisplayNames, Object);
+class DisplayNames final : public IntlObject {
+    JS_OBJECT(DisplayNames, IntlObject);
     GC_DECLARE_ALLOCATOR(DisplayNames);
 
     enum class Type {
@@ -37,6 +37,9 @@ class DisplayNames final : public Object {
 
 public:
     virtual ~DisplayNames() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
@@ -59,7 +62,7 @@ public:
     StringView language_display_string() const { return Unicode::language_display_to_string(*m_language_display); }
 
 private:
-    DisplayNames(Object& prototype);
+    explicit DisplayNames(Object& prototype);
 
     String m_locale;                                       // [[Locale]]
     Unicode::Style m_style { Unicode::Style::Long };       // [[Style]]

--- a/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -49,70 +49,53 @@ ThrowCompletionOr<GC::Ref<Object>> DisplayNamesConstructor::construct(FunctionOb
 {
     auto& vm = this->vm();
 
-    auto locale_value = vm.argument(0);
+    auto locales_value = vm.argument(0);
     auto options_value = vm.argument(1);
 
     // 2. Let displayNames be ? OrdinaryCreateFromConstructor(NewTarget, "%Intl.DisplayNames.prototype%", « [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], [[LanguageDisplay]], [[Fields]] »).
     auto display_names = TRY(ordinary_create_from_constructor<DisplayNames>(vm, new_target, &Intrinsics::intl_display_names_prototype));
 
-    // 3. Let requestedLocales be ? CanonicalizeLocaleList(locales).
-    auto requested_locales = TRY(canonicalize_locale_list(vm, locale_value));
+    // 3. Let optionsResolution be ? ResolveOptions(%Intl.DisplayNames%, %Intl.DisplayNames%.[[LocaleData]], locales, options, « REQUIRE-OPTIONS »).
+    // 4. Set options to optionsResolution.[[Options]].
+    // 5. Let r be optionsResolution.[[ResolvedLocale]].
+    auto [options, result, _] = TRY(resolve_options(vm, display_names, locales_value, options_value, SpecialBehaviors::RequireOptions));
 
-    // 4. If options is undefined, throw a TypeError exception.
-    if (options_value.is_undefined())
-        return vm.throw_completion<TypeError>(ErrorType::IsUndefined, "options"sv);
-
-    // 5. Set options to ? GetOptionsObject(options).
-    auto options = TRY(get_options_object(vm, options_value));
-
-    // 6. Let opt be a new Record.
-    LocaleOptions opt {};
-
-    // 7. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
-    auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
-
-    // 8. Set opt.[[localeMatcher]] to matcher.
-    opt.locale_matcher = matcher;
-
-    // 9. Let r be ResolveLocale(%Intl.DisplayNames%.[[AvailableLocales]], requestedLocales, opt, %Intl.DisplayNames%.[[RelevantExtensionKeys]], %Intl.DisplayNames%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, display_names->relevant_extension_keys());
-
-    // 10. Let style be ? GetOption(options, "style", string, « "narrow", "short", "long" », "long").
+    // 6. Let style be ? GetOption(options, "style", string, « "narrow", "short", "long" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "narrow"sv, "short"sv, "long"sv }, "long"sv));
 
-    // 11. Set displayNames.[[Style]] to style.
+    // 7. Set displayNames.[[Style]] to style.
     display_names->set_style(style.as_string().utf8_string_view());
 
-    // 12. Let type be ? GetOption(options, "type", string, « "language", "region", "script", "currency", "calendar", "dateTimeField" », undefined).
+    // 8. Let type be ? GetOption(options, "type", string, « "language", "region", "script", "currency", "calendar", "dateTimeField" », undefined).
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, { "language"sv, "region"sv, "script"sv, "currency"sv, "calendar"sv, "dateTimeField"sv }, Empty {}));
 
-    // 13. If type is undefined, throw a TypeError exception.
+    // 9. If type is undefined, throw a TypeError exception.
     if (type.is_undefined())
         return vm.throw_completion<TypeError>(ErrorType::IsUndefined, "options.type"sv);
 
-    // 14. Set displayNames.[[Type]] to type.
+    // 10. Set displayNames.[[Type]] to type.
     display_names->set_type(type.as_string().utf8_string_view());
 
-    // 15. Let fallback be ? GetOption(options, "fallback", string, « "code", "none" », "code").
+    // 11. Let fallback be ? GetOption(options, "fallback", string, « "code", "none" », "code").
     auto fallback = TRY(get_option(vm, *options, vm.names.fallback, OptionType::String, { "code"sv, "none"sv }, "code"sv));
 
-    // 16. Set displayNames.[[Fallback]] to fallback.
+    // 12. Set displayNames.[[Fallback]] to fallback.
     display_names->set_fallback(fallback.as_string().utf8_string_view());
 
-    // 17. Set displayNames.[[Locale]] to r.[[Locale]].
+    // 13. Set displayNames.[[Locale]] to r.[[Locale]].
     display_names->set_locale(move(result.locale));
 
-    // 18. Let resolvedLocaleData be r.[[LocaleData]].
-    // 19. Let types be resolvedLocaleData.[[types]].
-    // 20. Assert: types is a Record (see 12.2.3).
+    // 14. Let resolvedLocaleData be r.[[LocaleData]].
+    // 15. Let types be resolvedLocaleData.[[types]].
+    // 16. Assert: types is a Record (see 12.2.3).
 
-    // 21. Let languageDisplay be ? GetOption(options, "languageDisplay", string, « "dialect", "standard" », "dialect").
+    // 17. Let languageDisplay be ? GetOption(options, "languageDisplay", string, « "dialect", "standard" », "dialect").
     auto language_display = TRY(get_option(vm, *options, vm.names.languageDisplay, OptionType::String, { "dialect"sv, "standard"sv }, "dialect"sv));
 
-    // 22. Let typeFields be types.[[<type>]].
-    // 23. Assert: typeFields is a Record (see 12.2.3).
+    // 18. Let typeFields be types.[[<type>]].
+    // 19. Assert: typeFields is a Record (see 12.2.3).
 
-    // 24. If type is "language", then
+    // 20. If type is "language", then
     if (display_names->type() == DisplayNames::Type::Language) {
         // a. Set displayNames.[[LanguageDisplay]] to languageDisplay.
         display_names->set_language_display(language_display.as_string().utf8_string_view());
@@ -121,11 +104,11 @@ ThrowCompletionOr<GC::Ref<Object>> DisplayNamesConstructor::construct(FunctionOb
         // c. Assert: typeFields is a Record (see 12.2.3).
     }
 
-    // 25. Let styleFields be typeFields.[[<style>]].
-    // 26. Assert: styleFields is a Record (see 12.2.3).
-    // 27. Set displayNames.[[Fields]] to styleFields.
+    // 21. Let styleFields be typeFields.[[<style>]].
+    // 22. Assert: styleFields is a Record (see 12.2.3).
+    // 23. Set displayNames.[[Fields]] to styleFields.
 
-    // 28. Return displayNames.
+    // 24. Return displayNames.
     return display_names;
 }
 

--- a/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -75,7 +75,7 @@ ThrowCompletionOr<GC::Ref<Object>> DisplayNamesConstructor::construct(FunctionOb
     opt.locale_matcher = matcher;
 
     // 9. Let r be ResolveLocale(%Intl.DisplayNames%.[[AvailableLocales]], requestedLocales, opt, %Intl.DisplayNames%.[[RelevantExtensionKeys]], %Intl.DisplayNames%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = resolve_locale(requested_locales, opt, display_names->relevant_extension_keys());
 
     // 10. Let style be ? GetOption(options, "style", string, « "narrow", "short", "long" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "narrow"sv, "short"sv, "long"sv }, "long"sv));

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -8,15 +8,12 @@
 #include <AK/GenericShorthands.h>
 #include <AK/StringBuilder.h>
 #include <LibJS/Runtime/AbstractOperations.h>
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/DurationFormat.h>
 #include <LibJS/Runtime/Intl/ListFormat.h>
 #include <LibJS/Runtime/Intl/ListFormatConstructor.h>
 #include <LibJS/Runtime/Intl/MathematicalValue.h>
 #include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
-#include <LibJS/Runtime/Intl/PluralRules.h>
-#include <LibJS/Runtime/Intl/PluralRulesConstructor.h>
-#include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS::Intl {
@@ -25,8 +22,27 @@ GC_DEFINE_ALLOCATOR(DurationFormat);
 
 // 13 DurationFormat Objects, https://tc39.es/ecma402/#durationformat-objects
 DurationFormat::DurationFormat(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
+}
+
+// 13.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.DurationFormat-internal-slots
+ReadonlySpan<StringView> DurationFormat::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
+    static constexpr AK::Array keys { "nu"sv };
+    return keys;
+}
+
+// 13.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.DurationFormat-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> DurationFormat::resolution_option_descriptors(VM& vm) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « { [[Key]]: "nu", [[Property]]: "numberingSystem" } ».
+    static auto descriptors = to_array<ResolutionOptionDescriptor>({
+        { .key = "nu"sv, .property = vm.names.numberingSystem },
+    });
+
+    return descriptors;
 }
 
 DurationFormat::Style DurationFormat::style_from_string(StringView style)

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -10,15 +10,14 @@
 #include <AK/Array.h>
 #include <AK/String.h>
 #include <LibCrypto/BigFraction/BigFraction.h>
-#include <LibJS/Runtime/Intl/AbstractOperations.h>
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibJS/Runtime/Temporal/Duration.h>
 #include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
-class DurationFormat final : public Object {
-    JS_OBJECT(DurationFormat, Object);
+class DurationFormat final : public IntlObject {
+    JS_OBJECT(DurationFormat, IntlObject);
     GC_DECLARE_ALLOCATOR(DurationFormat);
 
 public:
@@ -72,14 +71,10 @@ public:
         Display display { Display::Auto };
     };
 
-    static constexpr auto relevant_extension_keys()
-    {
-        // 13.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.DurationFormat-internal-slots
-        // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
-        return AK::Array { "nu"sv };
-    }
-
     virtual ~DurationFormat() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     void set_locale(String locale) { m_locale = move(locale); }
     String const& locale() const { return m_locale; }

--- a/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -81,7 +81,7 @@ ThrowCompletionOr<GC::Ref<Object>> DurationFormatConstructor::construct(Function
     opt.nu = locale_key_from_value(numbering_system);
 
     // 9. Let r be ResolveLocale(%Intl.DurationFormat%.[[AvailableLocales]], requestedLocales, opt, %Intl.DurationFormat%.[[RelevantExtensionKeys]], %Intl.DurationFormat%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, DurationFormat::relevant_extension_keys());
+    auto result = resolve_locale(requested_locales, opt, duration_format->relevant_extension_keys());
 
     // 10. Set durationFormat.[[Locale]] to r.[[Locale]].
     duration_format->set_locale(move(result.locale));

--- a/Libraries/LibJS/Runtime/Intl/IntlObject.h
+++ b/Libraries/LibJS/Runtime/Intl/IntlObject.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Span.h>
+#include <AK/StringView.h>
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/PropertyKey.h>
+
+namespace JS::Intl {
+
+// https://tc39.es/ecma402/#resolution-option-descriptor
+struct ResolutionOptionDescriptor {
+    StringView key;
+    PropertyKey property;
+    OptionType type { OptionType::String };
+    ReadonlySpan<StringView> values {};
+};
+
+class IntlObject : public Object {
+    JS_OBJECT(IntlObject, Object);
+
+public:
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const = 0;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const = 0;
+
+protected:
+    using Object::Object;
+};
+
+}

--- a/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringBuilder.h>
 #include <LibJS/Runtime/Array.h>
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/ListFormat.h>
 #include <LibJS/Runtime/Iterator.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibUnicode/ListFormat.h>
 
 namespace JS::Intl {
@@ -17,8 +16,22 @@ GC_DEFINE_ALLOCATOR(ListFormat);
 
 // 14 ListFormat Objects, https://tc39.es/ecma402/#listformat-objects
 ListFormat::ListFormat(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
+}
+
+// 14.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.ListFormat-internal-slots
+ReadonlySpan<StringView> ListFormat::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « ».
+    return {};
+}
+
+// 14.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.ListFormat-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> ListFormat::resolution_option_descriptors(VM&) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « ».
+    return {};
 }
 
 // 14.5.2 CreatePartsFromList ( listFormat, list ), https://tc39.es/ecma402/#sec-createpartsfromlist

--- a/Libraries/LibJS/Runtime/Intl/ListFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/ListFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,15 +9,14 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
-#include <LibJS/Runtime/Intl/AbstractOperations.h>
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibUnicode/ListFormat.h>
 #include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
-class ListFormat final : public Object {
-    JS_OBJECT(ListFormat, Object);
+class ListFormat final : public IntlObject {
+    JS_OBJECT(ListFormat, IntlObject);
     GC_DECLARE_ALLOCATOR(ListFormat);
 
 public:
@@ -29,6 +28,9 @@ public:
     };
 
     virtual ~ListFormat() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }

--- a/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -70,7 +70,7 @@ ThrowCompletionOr<GC::Ref<Object>> ListFormatConstructor::construct(FunctionObje
     opt.locale_matcher = matcher;
 
     // 8. Let r be ResolveLocale(%Intl.ListFormat%.[[AvailableLocales]], requestedLocales, opt, %Intl.ListFormat%.[[RelevantExtensionKeys]], %Intl.ListFormat%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = resolve_locale(requested_locales, opt, list_format->relevant_extension_keys());
 
     // 9. Set listFormat.[[Locale]] to r.[[Locale]].
     list_format->set_locale(move(result.locale));

--- a/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -29,9 +29,9 @@ public:
     {
         // 15.2.2 Internal slots, https://tc39.es/ecma402/#sec-intl.locale-internal-slots
         // 1.3.2 Internal slots, https://tc39.es/proposal-intl-locale-info/#sec-intl.locale-internal-slots
-        // The value of the [[LocaleExtensionKeys]] internal slot is « "ca", "co", "fw", "hc", "kf", "kn", "nu" ».
-        // If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain "kf", then remove "kf" from %Intl.Locale%.[[LocaleExtensionKeys]].
-        // If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain "kn", then remove "kn" from %Intl.Locale%.[[LocaleExtensionKeys]].
+        // The value of the [[LocaleExtensionKeys]] internal slot is a List that must include all elements of
+        // « "ca", "co", "fw"sv, "hc", "nu" », must additionally include any element of « "kf", "kn" » that is also an
+        // element of %Intl.Collator%.[[RelevantExtensionKeys]], and must not include any other elements.
         return AK::Array { "ca"sv, "co"sv, "fw"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
     }
 

--- a/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -25,15 +25,13 @@ class Locale final : public Object {
 public:
     static GC::Ref<Locale> create(Realm&, GC::Ref<Locale> source_locale, String);
 
-    static constexpr auto relevant_extension_keys()
+    static constexpr auto locale_extension_keys()
     {
         // 15.2.2 Internal slots, https://tc39.es/ecma402/#sec-intl.locale-internal-slots
         // 1.3.2 Internal slots, https://tc39.es/proposal-intl-locale-info/#sec-intl.locale-internal-slots
-        // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "co", "fw", "hc", "kf", "kn", "nu" ».
-        // If %Collator%.[[RelevantExtensionKeys]] does not contain "kf", then remove "kf" from %Locale%.[[RelevantExtensionKeys]].
-        // If %Collator%.[[RelevantExtensionKeys]] does not contain "kn", then remove "kn" from %Locale%.[[RelevantExtensionKeys]].
-
-        // FIXME: We do not yet have an Intl.Collator object. For now, we behave as if "kf" and "kn" exist, as test262 depends on it.
+        // The value of the [[LocaleExtensionKeys]] internal slot is « "ca", "co", "fw", "hc", "kf", "kn", "nu" ».
+        // If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain "kf", then remove "kf" from %Intl.Locale%.[[LocaleExtensionKeys]].
+        // If %Intl.Collator%.[[RelevantExtensionKeys]] does not contain "kn", then remove "kn" from %Intl.Locale%.[[LocaleExtensionKeys]].
         return AK::Array { "ca"sv, "co"sv, "fw"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
     }
 

--- a/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -282,10 +282,10 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
     }
 
     // 10. Set options to ? CoerceOptionsToObject(options).
-    auto* options = TRY(coerce_options_to_object(vm, options_value));
+    auto options = TRY(coerce_options_to_object(vm, options_value));
 
     // 11. Set tag to ? ApplyOptionsToTag(tag, options).
-    tag = TRY(apply_options_to_tag(vm, tag, *options));
+    tag = TRY(apply_options_to_tag(vm, tag, options));
 
     // 12. Let opt be a new Record.
     LocaleAndKeys opt {};
@@ -294,16 +294,16 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
     // 14. If calendar is not undefined, then
     //     a. If calendar does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
     // 15. Set opt.[[ca]] to calendar.
-    opt.ca = TRY(get_string_option(vm, *options, vm.names.calendar, Unicode::is_type_identifier));
+    opt.ca = TRY(get_string_option(vm, options, vm.names.calendar, Unicode::is_type_identifier));
 
     // 16. Let collation be ? GetOption(options, "collation", string, empty, undefined).
     // 17. If collation is not undefined, then
     //     a. If collation does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
     // 18. Set opt.[[co]] to collation.
-    opt.co = TRY(get_string_option(vm, *options, vm.names.collation, Unicode::is_type_identifier));
+    opt.co = TRY(get_string_option(vm, options, vm.names.collation, Unicode::is_type_identifier));
 
     // 19. Let fw be ? Let fw be ? GetOption(options, "firstDayOfWeek", "string", undefined, undefined).
-    auto first_day_of_week = TRY(get_string_option(vm, *options, vm.names.firstDayOfWeek, nullptr));
+    auto first_day_of_week = TRY(get_string_option(vm, options, vm.names.firstDayOfWeek, nullptr));
 
     // 20. If fw is not undefined, then
     if (first_day_of_week.has_value()) {
@@ -320,14 +320,14 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
 
     // 22. Let hc be ? GetOption(options, "hourCycle", string, « "h11", "h12", "h23", "h24" », undefined).
     // 23. Set opt.[[hc]] to hc.
-    opt.hc = TRY(get_string_option(vm, *options, vm.names.hourCycle, nullptr, AK::Array { "h11"sv, "h12"sv, "h23"sv, "h24"sv }));
+    opt.hc = TRY(get_string_option(vm, options, vm.names.hourCycle, nullptr, AK::Array { "h11"sv, "h12"sv, "h23"sv, "h24"sv }));
 
     // 24. Let kf be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
     // 25. Set opt.[[kf]] to kf.
-    opt.kf = TRY(get_string_option(vm, *options, vm.names.caseFirst, nullptr, AK::Array { "upper"sv, "lower"sv, "false"sv }));
+    opt.kf = TRY(get_string_option(vm, options, vm.names.caseFirst, nullptr, AK::Array { "upper"sv, "lower"sv, "false"sv }));
 
     // 26. Let kn be ? GetOption(options, "numeric", boolean, empty, undefined).
-    auto kn = TRY(get_option(vm, *options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
+    auto kn = TRY(get_option(vm, options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
 
     // 27. If kn is not undefined, set kn to ! ToString(kn).
     // 28. Set opt.[[kn]] to kn.
@@ -338,7 +338,7 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
     // 30. If numberingSystem is not undefined, then
     //     a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
     // 31. Set opt.[[nu]] to numberingSystem.
-    opt.nu = TRY(get_string_option(vm, *options, vm.names.numberingSystem, Unicode::is_type_identifier));
+    opt.nu = TRY(get_string_option(vm, options, vm.names.numberingSystem, Unicode::is_type_identifier));
 
     // 32. Let r be ! ApplyUnicodeExtensionToTag(tag, opt, localeExtensionKeys).
     auto result = apply_unicode_extension_to_tag(tag, move(opt), locale_extension_keys);

--- a/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -251,14 +251,14 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
     auto tag_value = vm.argument(0);
     auto options_value = vm.argument(1);
 
-    // 2. Let relevantExtensionKeys be %Locale%.[[RelevantExtensionKeys]].
-    auto relevant_extension_keys = Locale::relevant_extension_keys();
+    // 2. Let localeExtensionKeys be %Intl.Locale%.[[LocaleExtensionKeys]].
+    auto locale_extension_keys = Locale::locale_extension_keys();
 
     // 3. Let internalSlotsList be « [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[FirstDayOfWeek]], [[HourCycle]], [[NumberingSystem]] ».
-    // 4. If relevantExtensionKeys contains "kf", then
-    //     a. Append [[CaseFirst]] as the last element of internalSlotsList.
-    // 5. If relevantExtensionKeys contains "kn", then
-    //     a. Append [[Numeric]] as the last element of internalSlotsList.
+    // 4. If localeExtensionKeys contains "kf", then
+    //     a. Append [[CaseFirst]] to internalSlotsList.
+    // 5. If localeExtensionKeys contains "kn", then
+    //     a. Append [[Numeric]] to internalSlotsList.
 
     // 6. Let locale be ? OrdinaryCreateFromConstructor(NewTarget, "%Intl.Locale.prototype%", internalSlotsList).
     auto locale = TRY(ordinary_create_from_constructor<Locale>(vm, new_target, &Intrinsics::intl_locale_prototype));
@@ -340,8 +340,8 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
     // 31. Set opt.[[nu]] to numberingSystem.
     opt.nu = TRY(get_string_option(vm, *options, vm.names.numberingSystem, Unicode::is_type_identifier));
 
-    // 32. Let r be ! ApplyUnicodeExtensionToTag(tag, opt, relevantExtensionKeys).
-    auto result = apply_unicode_extension_to_tag(tag, move(opt), relevant_extension_keys);
+    // 32. Let r be ! ApplyUnicodeExtensionToTag(tag, opt, localeExtensionKeys).
+    auto result = apply_unicode_extension_to_tag(tag, move(opt), locale_extension_keys);
 
     // 33. Set locale.[[Locale]] to r.[[locale]].
     locale->set_locale(move(result.locale));
@@ -362,15 +362,15 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
     if (result.hc.has_value())
         locale->set_hour_cycle(result.hc.release_value());
 
-    // 38. If relevantExtensionKeys contains "kf", then
-    if (relevant_extension_keys.span().contains_slow("kf"sv)) {
+    // 38. If localeExtensionKeys contains "kf", then
+    if (locale_extension_keys.span().contains_slow("kf"sv)) {
         // a. Set locale.[[CaseFirst]] to r.[[kf]].
         if (result.kf.has_value())
             locale->set_case_first(result.kf.release_value());
     }
 
-    // 39. If relevantExtensionKeys contains "kn", then
-    if (relevant_extension_keys.span().contains_slow("kn"sv)) {
+    // 39. If localeExtensionKeys contains "kn", then
+    if (locale_extension_keys.span().contains_slow("kn"sv)) {
         // a. If SameValue(r.[[kn]], "true") is true or r.[[kn]] is the empty String, then
         if (result.kn.has_value() && (result.kn == "true"sv || result.kn->is_empty())) {
             // i. Set locale.[[Numeric]] to true.

--- a/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -125,7 +125,7 @@ int currency_digits(StringView currency)
     return 2;
 }
 
-// 16.5.3 FormatNumericToString ( intlObject, x ), https://tc39.es/ecma402/#sec-formatnumberstring
+// 16.5.3 FormatNumericToString ( intlObject, x ), https://tc39.es/ecma402/#sec-formatnumerictostring
 String format_numeric_to_string(NumberFormatBase const& intl_object, MathematicalValue const& number)
 {
     return intl_object.formatter().format_to_decimal(number.to_value());

--- a/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -4,22 +4,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Checked.h>
-#include <AK/StringBuilder.h>
-#include <AK/Utf8View.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
-#include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/BigInt.h>
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/NumberFormat.h>
-#include <LibJS/Runtime/Intl/NumberFormatFunction.h>
-#include <LibJS/Runtime/Intl/PluralRules.h>
+#include <LibJS/Runtime/NativeFunction.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibUnicode/CurrencyCode.h>
-#include <LibUnicode/DisplayNames.h>
 #include <math.h>
-#include <stdlib.h>
 
 namespace JS::Intl {
 
@@ -27,7 +20,7 @@ GC_DEFINE_ALLOCATOR(NumberFormatBase);
 GC_DEFINE_ALLOCATOR(NumberFormat);
 
 NumberFormatBase::NumberFormatBase(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
 }
 
@@ -42,6 +35,25 @@ void NumberFormat::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     if (m_bound_format)
         visitor.visit(m_bound_format);
+}
+
+// 16.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
+ReadonlySpan<StringView> NumberFormat::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
+    static constexpr AK::Array keys { "nu"sv };
+    return keys;
+}
+
+// 16.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> NumberFormat::resolution_option_descriptors(VM& vm) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « { [[Key]]: "nu", [[Property]]: "numberingSystem" } ».
+    static auto descriptors = to_array<ResolutionOptionDescriptor>({
+        { .key = "nu"sv, .property = vm.names.numberingSystem },
+    });
+
+    return descriptors;
 }
 
 StringView NumberFormatBase::computed_rounding_priority_string() const

--- a/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -6,19 +6,18 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibJS/Runtime/Intl/MathematicalValue.h>
-#include <LibJS/Runtime/Object.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/NumberFormat.h>
 
 namespace JS::Intl {
 
-class NumberFormatBase : public Object {
-    JS_OBJECT(NumberFormatBase, Object);
+class NumberFormatBase : public IntlObject {
+    JS_OBJECT(NumberFormatBase, IntlObject);
     GC_DECLARE_ALLOCATOR(NumberFormatBase);
 
 public:
@@ -102,14 +101,10 @@ class NumberFormat final : public NumberFormatBase {
     GC_DECLARE_ALLOCATOR(NumberFormat);
 
 public:
-    static constexpr auto relevant_extension_keys()
-    {
-        // 16.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
-        // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
-        return AK::Array { "nu"sv };
-    }
-
     virtual ~NumberFormat() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     String const& numbering_system() const { return m_numbering_system; }
     void set_numbering_system(String numbering_system) { m_numbering_system = move(numbering_system); }

--- a/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -83,7 +83,7 @@ ThrowCompletionOr<GC::Ref<Object>> NumberFormatConstructor::construct(FunctionOb
     opt.nu = locale_key_from_value(numbering_system);
 
     // 11. Let r be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], requestedLocales, opt, %Intl.NumberFormat%.[[RelevantExtensionKeys]], %Intl.NumberFormat%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, NumberFormat::relevant_extension_keys());
+    auto result = resolve_locale(requested_locales, opt, number_format->relevant_extension_keys());
 
     // 12. Set numberFormat.[[Locale]] to r.[[Locale]].
     number_format->set_locale(move(result.locale));

--- a/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -17,6 +17,20 @@ PluralRules::PluralRules(Object& prototype)
 {
 }
 
+// 17.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.pluralrules-internal-slots
+ReadonlySpan<StringView> PluralRules::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « ».
+    return {};
+}
+
+// 17.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.pluralrules-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> PluralRules::resolution_option_descriptors(VM&) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « ».
+    return {};
+}
+
 // 17.5.2 ResolvePlural ( pluralRules, n ), https://tc39.es/ecma402/#sec-resolveplural
 Unicode::PluralCategory resolve_plural(PluralRules const& plural_rules, Value number)
 {

--- a/Libraries/LibJS/Runtime/Intl/PluralRules.h
+++ b/Libraries/LibJS/Runtime/Intl/PluralRules.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,6 +20,9 @@ class PluralRules final : public NumberFormatBase {
 
 public:
     virtual ~PluralRules() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     Unicode::PluralForm type() const { return m_type; }
     StringView type_string() const { return Unicode::plural_form_to_string(m_type); }

--- a/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -71,7 +71,7 @@ ThrowCompletionOr<GC::Ref<Object>> PluralRulesConstructor::construct(FunctionObj
     opt.locale_matcher = matcher;
 
     // 8. Let r be ResolveLocale(%Intl.PluralRules%.[[AvailableLocales]], requestedLocales, opt, %Intl.PluralRules%.[[RelevantExtensionKeys]], %Intl.PluralRules%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = resolve_locale(requested_locales, opt, plural_rules->relevant_extension_keys());
 
     // 9. Set pluralRules.[[Locale]] to r.[[locale]].
     plural_rules->set_locale(move(result.locale));

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -5,14 +5,9 @@
  */
 
 #include <AK/Enumerate.h>
-#include <AK/StringBuilder.h>
-#include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
-#include <LibJS/Runtime/GlobalObject.h>
-#include <LibJS/Runtime/Intl/NumberFormat.h>
-#include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
-#include <LibJS/Runtime/Intl/PluralRules.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
+#include <LibJS/Runtime/VM.h>
 
 namespace JS::Intl {
 
@@ -20,8 +15,27 @@ GC_DEFINE_ALLOCATOR(RelativeTimeFormat);
 
 // 18 RelativeTimeFormat Objects, https://tc39.es/ecma402/#relativetimeformat-objects
 RelativeTimeFormat::RelativeTimeFormat(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
+}
+
+// 18.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat-internal-slots
+ReadonlySpan<StringView> RelativeTimeFormat::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
+    static constexpr AK::Array keys { "nu"sv };
+    return keys;
+}
+
+// 18.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> RelativeTimeFormat::resolution_option_descriptors(VM& vm) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « { [[Key]]: "nu", [[Property]]: "numberingSystem" } ».
+    static auto descriptors = to_array<ResolutionOptionDescriptor>({
+        { .key = "nu"sv, .property = vm.names.numberingSystem },
+    });
+
+    return descriptors;
 }
 
 // 18.5.1 SingularRelativeTimeUnit ( unit ), https://tc39.es/ecma402/#sec-singularrelativetimeunit

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -6,31 +6,24 @@
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibJS/Runtime/Completion.h>
-#include <LibJS/Runtime/Intl/AbstractOperations.h>
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibUnicode/Locale.h>
-#include <LibUnicode/NumberFormat.h>
 #include <LibUnicode/RelativeTimeFormat.h>
 
 namespace JS::Intl {
 
-class RelativeTimeFormat final : public Object {
-    JS_OBJECT(RelativeTimeFormat, Object);
+class RelativeTimeFormat final : public IntlObject {
+    JS_OBJECT(RelativeTimeFormat, IntlObject);
     GC_DECLARE_ALLOCATOR(RelativeTimeFormat);
 
 public:
-    static constexpr auto relevant_extension_keys()
-    {
-        // 18.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat-internal-slots
-        // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
-        return AK::Array { "nu"sv };
-    }
-
     virtual ~RelativeTimeFormat() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -83,7 +83,7 @@ ThrowCompletionOr<GC::Ref<Object>> RelativeTimeFormatConstructor::construct(Func
     opt.nu = locale_key_from_value(numbering_system);
 
     // 11. Let r be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], %Intl.RelativeTimeFormat%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, RelativeTimeFormat::relevant_extension_keys());
+    auto result = resolve_locale(requested_locales, opt, relative_time_format->relevant_extension_keys());
 
     // 12. Let locale be r.[[Locale]].
     auto locale = move(result.locale);

--- a/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Segmenter.cpp
@@ -6,8 +6,8 @@
  */
 
 #include <AK/Utf16View.h>
-#include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/Segmenter.h>
+#include <LibJS/Runtime/VM.h>
 
 namespace JS::Intl {
 
@@ -15,8 +15,22 @@ GC_DEFINE_ALLOCATOR(Segmenter);
 
 // 19 Segmenter Objects, https://tc39.es/ecma402/#segmenter-objects
 Segmenter::Segmenter(Object& prototype)
-    : Object(ConstructWithPrototypeTag::Tag, prototype)
+    : IntlObject(ConstructWithPrototypeTag::Tag, prototype)
 {
+}
+
+// 19.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.segmenter-internal-slots
+ReadonlySpan<StringView> Segmenter::relevant_extension_keys() const
+{
+    // The value of the [[RelevantExtensionKeys]] internal slot is « ».
+    return {};
+}
+
+// 19.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.segmenter-internal-slots
+ReadonlySpan<ResolutionOptionDescriptor> Segmenter::resolution_option_descriptors(VM&) const
+{
+    // The value of the [[ResolutionOptionDescriptors]] internal slot is « ».
+    return {};
 }
 
 // 19.7.1 CreateSegmentDataObject ( segmenter, string, startIndex, endIndex ), https://tc39.es/ecma402/#sec-createsegmentdataobject

--- a/Libraries/LibJS/Runtime/Intl/Segmenter.h
+++ b/Libraries/LibJS/Runtime/Intl/Segmenter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,17 +8,20 @@
 #pragma once
 
 #include <AK/String.h>
-#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Intl/IntlObject.h>
 #include <LibUnicode/Segmenter.h>
 
 namespace JS::Intl {
 
-class Segmenter final : public Object {
-    JS_OBJECT(Segmenter, Object);
+class Segmenter final : public IntlObject {
+    JS_OBJECT(Segmenter, IntlObject);
     GC_DECLARE_ALLOCATOR(Segmenter);
 
 public:
     virtual ~Segmenter() override = default;
+
+    virtual ReadonlySpan<StringView> relevant_extension_keys() const override;
+    virtual ReadonlySpan<ResolutionOptionDescriptor> resolution_option_descriptors(VM&) const override;
 
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }

--- a/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
@@ -71,7 +71,7 @@ ThrowCompletionOr<GC::Ref<Object>> SegmenterConstructor::construct(FunctionObjec
     opt.locale_matcher = matcher;
 
     // 9. Let r be ResolveLocale(%Intl.Segmenter%.[[AvailableLocales]], requestedLocales, opt, %Intl.Segmenter%.[[RelevantExtensionKeys]], %Intl.Segmenter%.[[LocaleData]]).
-    auto result = resolve_locale(requested_locales, opt, {});
+    auto result = resolve_locale(requested_locales, opt, segmenter->relevant_extension_keys());
 
     // 10. Set segmenter.[[Locale]] to r.[[locale]].
     segmenter->set_locale(move(result.locale));


### PR DESCRIPTION
The gist of these changes is that the spec steps for the Intl constructors were highly repetitive, in terms of getting constructor options and resolving locales. These repeated steps have been extracted into a new AO, `ResolveOptions`.