### PR TITLE
LibIPC: Move early fd deallocation workaround to the transport layer

### DIFF
--- a/Libraries/LibIPC/Connection.cpp
+++ b/Libraries/LibIPC/Connection.cpp
@@ -16,11 +16,10 @@
 
 namespace IPC {
 
-ConnectionBase::ConnectionBase(IPC::Stub& local_stub, Transport transport, u32 local_endpoint_magic, u32 peer_endpoint_magic)
+ConnectionBase::ConnectionBase(IPC::Stub& local_stub, Transport transport, u32 local_endpoint_magic)
     : m_local_stub(local_stub)
     , m_transport(move(transport))
     , m_local_endpoint_magic(local_endpoint_magic)
-    , m_peer_endpoint_magic(peer_endpoint_magic)
 {
     m_responsiveness_timer = Core::Timer::create_single_shot(3000, [this] { may_have_become_unresponsive(); });
 
@@ -32,8 +31,7 @@ ConnectionBase::ConnectionBase(IPC::Stub& local_stub, Transport transport, u32 l
     });
 
     m_send_queue = adopt_ref(*new SendQueue);
-    m_acknowledgement_wait_queue = adopt_ref(*new AcknowledgementWaitQueue);
-    m_send_thread = Threading::Thread::construct([this, send_queue = m_send_queue, acknowledgement_wait_queue = m_acknowledgement_wait_queue]() -> intptr_t {
+    m_send_thread = Threading::Thread::construct([this, send_queue = m_send_queue]() -> intptr_t {
         for (;;) {
             send_queue->mutex.lock();
             while (send_queue->messages.is_empty() && send_queue->running)
@@ -44,13 +42,8 @@ ConnectionBase::ConnectionBase(IPC::Stub& local_stub, Transport transport, u32 l
                 break;
             }
 
-            auto [message_buffer, needs_acknowledgement] = send_queue->messages.take_first();
+            auto message_buffer = send_queue->messages.take_first();
             send_queue->mutex.unlock();
-
-            if (needs_acknowledgement == MessageNeedsAcknowledgement::Yes) {
-                Threading::MutexLocker lock(acknowledgement_wait_queue->mutex);
-                acknowledgement_wait_queue->messages.append(message_buffer);
-            }
 
             if (auto result = message_buffer.transfer_message(m_transport); result.is_error()) {
                 dbgln("ConnectionBase::send_thread: {}", result.error());
@@ -82,7 +75,7 @@ ErrorOr<void> ConnectionBase::post_message(Message const& message)
     return post_message(message.endpoint_magic(), TRY(message.encode()));
 }
 
-ErrorOr<void> ConnectionBase::post_message(u32 endpoint_magic, MessageBuffer buffer, MessageNeedsAcknowledgement needs_acknowledgement)
+ErrorOr<void> ConnectionBase::post_message(u32 endpoint_magic, MessageBuffer buffer)
 {
     // NOTE: If this connection is being shut down, but has not yet been destroyed,
     //       the socket will be closed. Don't try to send more messages.
@@ -96,7 +89,7 @@ ErrorOr<void> ConnectionBase::post_message(u32 endpoint_magic, MessageBuffer buf
 
     {
         Threading::MutexLocker locker(m_send_queue->mutex);
-        m_send_queue->messages.append({ move(buffer), needs_acknowledgement });
+        m_send_queue->messages.append(move(buffer));
         m_send_queue->condition.signal();
     }
 
@@ -143,8 +136,6 @@ void ConnectionBase::wait_for_transport_to_become_readable()
 
 ErrorOr<void> ConnectionBase::drain_messages_from_peer()
 {
-    u32 pending_ack_count = 0;
-    u32 received_ack_count = 0;
     auto schedule_shutdown = m_transport.read_as_many_messages_as_possible_without_blocking([&](auto&& unparsed_message) {
         auto const& bytes = unparsed_message.bytes;
         UnprocessedFileDescriptors unprocessed_fds;
@@ -156,36 +147,16 @@ ErrorOr<void> ConnectionBase::drain_messages_from_peer()
                 unprocessed_fds.return_fds_to_front_of_queue(wrapper->take_fds());
                 auto parsed_message = try_parse_message(wrapped_message, unprocessed_fds);
                 VERIFY(parsed_message);
-                VERIFY(parsed_message->message_id() != Acknowledgement::MESSAGE_ID);
-                pending_ack_count++;
                 m_unprocessed_messages.append(parsed_message.release_nonnull());
                 return;
             }
 
-            if (message->message_id() == Acknowledgement::MESSAGE_ID) {
-                VERIFY(message->endpoint_magic() == m_local_endpoint_magic);
-                received_ack_count += static_cast<Acknowledgement*>(message.ptr())->ack_count();
-                return;
-            }
-
-            pending_ack_count++;
             m_unprocessed_messages.append(message.release_nonnull());
         } else {
             dbgln("Failed to parse IPC message {:hex-dump}", bytes);
             VERIFY_NOT_REACHED();
         }
     });
-
-    if (received_ack_count > 0) {
-        Threading::MutexLocker lock(m_acknowledgement_wait_queue->mutex);
-        for (size_t i = 0; i < received_ack_count; ++i)
-            m_acknowledgement_wait_queue->messages.take_first();
-    }
-
-    if (is_open() && pending_ack_count > 0) {
-        auto acknowledgement = Acknowledgement::create(m_peer_endpoint_magic, pending_ack_count);
-        MUST(post_message(m_peer_endpoint_magic, MUST(acknowledgement->encode()), MessageNeedsAcknowledgement::No));
-    }
 
     if (!m_unprocessed_messages.is_empty()) {
         m_responsiveness_timer->stop();

--- a/Libraries/LibIPC/Connection.cpp
+++ b/Libraries/LibIPC/Connection.cpp
@@ -69,7 +69,7 @@ ConnectionBase::~ConnectionBase()
         m_send_queue->running = false;
         m_send_queue->condition.signal();
     }
-    m_send_thread->detach();
+    (void)m_send_thread->join();
 }
 
 bool ConnectionBase::is_open() const

--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -60,16 +60,6 @@ protected:
     Vector<NonnullOwnPtr<Message>> m_unprocessed_messages;
 
     u32 m_local_endpoint_magic { 0 };
-
-    struct SendQueue : public AtomicRefCounted<SendQueue> {
-        AK::SinglyLinkedList<MessageBuffer> messages;
-        Threading::Mutex mutex;
-        Threading::ConditionVariable condition { mutex };
-        bool running { true };
-    };
-
-    RefPtr<Threading::Thread> m_send_thread;
-    RefPtr<SendQueue> m_send_queue;
 };
 
 template<typename LocalEndpoint, typename PeerEndpoint>

--- a/Libraries/LibIPC/Message.cpp
+++ b/Libraries/LibIPC/Message.cpp
@@ -43,16 +43,7 @@ ErrorOr<void> MessageBuffer::transfer_message(Transport& transport)
         return Error::from_string_literal("Message is too large for IPC encoding");
     }
 
-    auto raw_fds = Vector<int, 1> {};
-    auto num_fds_to_transfer = m_fds.size();
-    if (num_fds_to_transfer > 0) {
-        raw_fds.ensure_capacity(num_fds_to_transfer);
-        for (auto& owned_fd : m_fds) {
-            raw_fds.unchecked_append(owned_fd->value());
-        }
-    }
-
-    TRY(transport.transfer_message(m_data.span(), raw_fds));
+    transport.post_message(m_data, m_fds);
     return {};
 }
 

--- a/Libraries/LibIPC/Message.cpp
+++ b/Libraries/LibIPC/Message.cpp
@@ -105,32 +105,4 @@ ErrorOr<NonnullOwnPtr<LargeMessageWrapper>> LargeMessageWrapper::decode(u32 endp
     return make<LargeMessageWrapper>(endpoint_magic, wrapped_message_data, move(wrapped_fds));
 }
 
-Acknowledgement::Acknowledgement(u32 endpoint_magic, u32 ack_count)
-    : m_endpoint_magic(endpoint_magic)
-    , m_ack_count(ack_count)
-{
-}
-
-NonnullOwnPtr<Acknowledgement> Acknowledgement::create(u32 endpoint_magic, u32 ack_count)
-{
-    return make<Acknowledgement>(endpoint_magic, ack_count);
-}
-
-ErrorOr<MessageBuffer> Acknowledgement::encode() const
-{
-    MessageBuffer buffer;
-    Encoder stream { buffer };
-    TRY(stream.encode(m_endpoint_magic));
-    TRY(stream.encode(MESSAGE_ID));
-    TRY(stream.encode(m_ack_count));
-    return buffer;
-}
-
-ErrorOr<NonnullOwnPtr<Acknowledgement>> Acknowledgement::decode(u32 endpoint_magic, Stream& stream, UnprocessedFileDescriptors& files)
-{
-    Decoder decoder { stream, files };
-    auto ack_count = TRY(decoder.decode<u32>());
-    return make<Acknowledgement>(endpoint_magic, ack_count);
-}
-
 }

--- a/Libraries/LibIPC/Message.h
+++ b/Libraries/LibIPC/Message.h
@@ -19,32 +19,6 @@
 
 namespace IPC {
 
-class AutoCloseFileDescriptor : public RefCounted<AutoCloseFileDescriptor> {
-public:
-    AutoCloseFileDescriptor(int fd)
-        : m_fd(fd)
-    {
-    }
-
-    ~AutoCloseFileDescriptor()
-    {
-        if (m_fd != -1)
-            (void)Core::System::close(m_fd);
-    }
-
-    int value() const { return m_fd; }
-
-    int take_fd()
-    {
-        int fd = m_fd;
-        m_fd = -1;
-        return fd;
-    }
-
-private:
-    int m_fd;
-};
-
 class MessageBuffer {
 public:
     MessageBuffer();

--- a/Libraries/LibIPC/Message.h
+++ b/Libraries/LibIPC/Message.h
@@ -119,28 +119,4 @@ private:
     Vector<File> m_wrapped_fds;
 };
 
-class Acknowledgement : public Message {
-public:
-    ~Acknowledgement() override = default;
-
-    static constexpr int MESSAGE_ID = 0xFFFFFFFF;
-
-    static NonnullOwnPtr<Acknowledgement> create(u32 endpoint_magic, u32 ack_count);
-
-    u32 endpoint_magic() const override { return m_endpoint_magic; }
-    int message_id() const override { return MESSAGE_ID; }
-    char const* message_name() const override { return "Acknowledgement"; }
-    ErrorOr<MessageBuffer> encode() const override;
-
-    static ErrorOr<NonnullOwnPtr<Acknowledgement>> decode(u32 endpoint_magic, Stream& stream, UnprocessedFileDescriptors& files);
-
-    u32 ack_count() const { return m_ack_count; }
-
-    Acknowledgement(u32 endpoint_magic, u32 number_of_acknowledged_messages);
-
-private:
-    u32 m_endpoint_magic { 0 };
-    u32 m_ack_count { 0 };
-};
-
 }

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -8,10 +8,39 @@
 #pragma once
 
 #include <AK/Queue.h>
+#include <LibCore/Socket.h>
 #include <LibIPC/UnprocessedFileDescriptors.h>
+#include <LibThreading/ConditionVariable.h>
 #include <LibThreading/MutexProtected.h>
+#include <LibThreading/Thread.h>
 
 namespace IPC {
+
+class AutoCloseFileDescriptor : public RefCounted<AutoCloseFileDescriptor> {
+public:
+    AutoCloseFileDescriptor(int fd)
+        : m_fd(fd)
+    {
+    }
+
+    ~AutoCloseFileDescriptor()
+    {
+        if (m_fd != -1)
+            (void)Core::System::close(m_fd);
+    }
+
+    int value() const { return m_fd; }
+
+    int take_fd()
+    {
+        int fd = m_fd;
+        m_fd = -1;
+        return fd;
+    }
+
+private:
+    int m_fd;
+};
 
 class TransportSocket {
     AK_MAKE_NONCOPYABLE(TransportSocket);
@@ -29,7 +58,7 @@ public:
 
     void wait_until_readable();
 
-    ErrorOr<void> transfer_message(ReadonlyBytes, Vector<int, 1> const& unowned_fds);
+    void post_message(Vector<u8> const&, Vector<NonnullRefPtr<AutoCloseFileDescriptor>> const&) const;
 
     enum class ShouldShutdown {
         No,
@@ -47,17 +76,30 @@ public:
     ErrorOr<IPC::File> clone_for_transfer();
 
 private:
-    ErrorOr<void> transfer(ReadonlyBytes, Vector<int, 1> const& unowned_fds);
+    static ErrorOr<void> send_message(Core::LocalSocket&, ReadonlyBytes&&, Vector<int, 1> const& unowned_fds);
 
     NonnullOwnPtr<Core::LocalSocket> m_socket;
-    NonnullOwnPtr<Threading::Mutex> m_socket_write_mutex;
     ByteBuffer m_unprocessed_bytes;
     UnprocessedFileDescriptors m_unprocessed_fds;
 
     // After file descriptor is sent, it is moved to the wait queue until an acknowledgement is received from the peer.
     // This is necessary to handle a specific behavior of the macOS kernel, which may prematurely garbage-collect the file
     // descriptor contained in the message before the peer receives it. https://openradar.me/9477351
-    NonnullOwnPtr<Threading::MutexProtected<Queue<File>>> m_fds_retained_until_received_by_peer;
+    NonnullOwnPtr<Queue<NonnullRefPtr<AutoCloseFileDescriptor>>> m_fds_retained_until_received_by_peer;
+
+    struct MessageToSend {
+        Vector<u8> bytes;
+        Vector<int, 1> fds;
+    };
+    struct SendQueue : public AtomicRefCounted<SendQueue> {
+        AK::SinglyLinkedList<MessageToSend> messages;
+        Threading::Mutex mutex;
+        Threading::ConditionVariable condition { mutex };
+        bool running { true };
+    };
+    RefPtr<Threading::Thread> m_send_thread;
+    RefPtr<SendQueue> m_send_queue;
+    void queue_message_on_send_thread(MessageToSend&&) const;
 };
 
 }

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -760,8 +760,6 @@ public:
     generator.append(R"~~~(
         case (int)IPC::LargeMessageWrapper::MESSAGE_ID:
             return TRY(IPC::LargeMessageWrapper::decode(message_endpoint_magic, stream, files));
-        case (int)IPC::Acknowledgement::MESSAGE_ID:
-            return TRY(IPC::Acknowledgement::decode(message_endpoint_magic, stream, files));
 )~~~");
 
     generator.append(R"~~~(

--- a/Tests/LibWeb/Text/expected/Messaging/Messaging-post-channel-over-channel.txt
+++ b/Tests/LibWeb/Text/expected/Messaging/Messaging-post-channel-over-channel.txt
@@ -1,6 +1,6 @@
 Port1: "Hello"
 Port1: {"foo":{}}
-Port1: "DONE"
 Port2: "Hello"
 Port3: "Hello from the transferred port"
+Port1: "DONE"
 Port2: "DONE"

--- a/Tests/LibWeb/Text/input/Messaging/Messaging-post-channel-over-channel.html
+++ b/Tests/LibWeb/Text/input/Messaging/Messaging-post-channel-over-channel.html
@@ -23,11 +23,11 @@
         let channel2 = new MessageChannel();
 
         channel2.port2.onmessage = (event) => {
-            println("Port3: " + JSON.stringify(event.data))
+            println("Port3: " + JSON.stringify(event.data));
+            channel.port2.postMessage("DONE");
         }
 
         channel.port2.postMessage("Hello");
         channel.port2.postMessage({ foo: channel2.port1 }, { transfer: [channel2.port1] });
-        channel.port2.postMessage("DONE");
     });
 </script>


### PR DESCRIPTION
Reimplements c3121c9d at the transport layer, allowing us to solve the same problem once, in a single place, for both the LibIPC connection and MessagePort. This avoids exposing a workaround for a macOS specific Unix domain socket issue to higher abstraction layers.