### PR TITLE
LibGC: Avoid excessive bitfield use in GC::Cell

### DIFF
--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -188,9 +188,9 @@ protected:
     void set_overrides_must_survive_garbage_collection(bool b) { m_overrides_must_survive_garbage_collection = b; }
 
 private:
-    bool m_mark : 1 { false };
-    bool m_overrides_must_survive_garbage_collection : 1 { false };
-    State m_state : 1 { State::Live };
+    bool m_mark { false };
+    bool m_overrides_must_survive_garbage_collection { false };
+    State m_state { State::Live };
 } SWIFT_UNSAFE_REFERENCE;
 
 }


### PR DESCRIPTION
We didn't actually save any space by making the Cell flags bitfields. In fact, it just forced us to do bit twiddling when accessing them.

(This is just re-landing ab5d5d8b50f5f5e8923b6b00cc51765fa3721cae which was oopsed away in a bad merge by 8fd81c3338eec644ae1099d9c46ae62465e085da)