### PR TITLE
AK/LibJS/LibCrypto: implement random for Windows

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -73,4 +73,5 @@ endif()
 if (WIN32)
     # FIXME: Windows on ARM
     target_link_libraries(AK PRIVATE clang_rt.builtins-x86_64.lib)
+    target_link_libraries(AK PRIVATE Bcrypt.lib)
 endif()

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -18,38 +18,7 @@
 
 namespace AK {
 
-inline void fill_with_random([[maybe_unused]] Bytes bytes)
-{
-#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_HAIKU) || AK_LIBC_GLIBC_PREREQ(2, 36)
-    arc4random_buf(bytes.data(), bytes.size());
-#elif defined(OSS_FUZZ)
-#else
-    auto fill_with_random_fallback = [&]() {
-        for (auto& byte : bytes)
-            byte = rand();
-    };
-
-#    if defined(__unix__)
-    // The maximum permitted value for the getentropy length argument.
-    static constexpr size_t getentropy_length_limit = 256;
-    auto iterations = bytes.size() / getentropy_length_limit;
-
-    for (size_t i = 0; i < iterations; ++i) {
-        if (getentropy(bytes.data(), getentropy_length_limit) != 0) {
-            fill_with_random_fallback();
-            return;
-        }
-
-        bytes = bytes.slice(getentropy_length_limit);
-    }
-
-    if (bytes.is_empty() || getentropy(bytes.data(), bytes.size()) == 0)
-        return;
-#    endif
-
-    fill_with_random_fallback();
-#endif
-}
+void fill_with_random([[maybe_unused]] Bytes bytes);
 
 template<typename T>
 inline T get_random()

--- a/Libraries/LibCrypto/SecureRandom.h
+++ b/Libraries/LibCrypto/SecureRandom.h
@@ -12,4 +12,12 @@ namespace Crypto {
 
 void fill_with_secure_random(Bytes);
 
+template<typename T>
+inline T get_secure_random()
+{
+    T t;
+    fill_with_secure_random({ &t, sizeof(T) });
+    return t;
+}
+
 }

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -10,6 +10,7 @@
 #include <AK/BuiltinWrappers.h>
 #include <AK/Function.h>
 #include <AK/Random.h>
+#include <LibCrypto/SecureRandom.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Iterator.h>
@@ -799,12 +800,15 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::pow)
     return pow_impl(vm, vm.argument(0), vm.argument(1));
 }
 
-class XorShift128PlusPlusRNG {
+// http://vigna.di.unimi.it/ftp/papers/xorshiftplus.pdf
+class XorShift128PlusRNG {
 public:
-    XorShift128PlusPlusRNG()
+    XorShift128PlusRNG()
     {
-        u64 seed = get_random<u32>();
+        // Splitmix64 is used as xorshift is sensitive to being seeded with all 0s
+        u64 seed = Crypto::get_secure_random<u64>();
         m_low = splitmix64(seed);
+        seed = Crypto::get_secure_random<u64>();
         m_high = splitmix64(seed);
     }
 
@@ -823,6 +827,7 @@ private:
         return z ^ (z >> 31);
     }
 
+    // Apparently this set of constants is better: https://stackoverflow.com/a/34432126
     u64 advance()
     {
         u64 s1 = m_low;
@@ -830,8 +835,8 @@ private:
         u64 const result = s0 + s1;
         m_low = s0;
         s1 ^= s1 << 23;
-        s1 ^= s1 >> 17;
-        s1 ^= s0 ^ (s0 >> 26);
+        s1 ^= s1 >> 18;
+        s1 ^= s0 ^ (s0 >> 5);
         m_high = s1;
         return result + s1;
     }
@@ -845,7 +850,7 @@ Value MathObject::random_impl()
     // This function returns a Number value with positive sign, greater than or equal to +0𝔽 but strictly less than 1𝔽,
     // chosen randomly or pseudo randomly with approximately uniform distribution over that range, using an
     // implementation-defined algorithm or strategy.
-    static XorShift128PlusPlusRNG rng;
+    static XorShift128PlusRNG rng;
     return Value(rng.get());
 }
 


### PR DESCRIPTION
This commit implements a high quality randomness source for AK/Random. This avoids the fallback to rand(). The LibJS math xoshiro128+ prng is now seeded with SecureRandom. A convenience get_secure_random method was added to SecureRandom to directly construct the requested type.