### PR TITLE
LibWeb/CSS: Start parsing URLs correctly

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -195,6 +195,7 @@ set(SOURCES
     CSS/Time.cpp
     CSS/Transformation.cpp
     CSS/TransitionEvent.cpp
+    CSS/URL.cpp
     CSS/VisualViewport.cpp
     Cookie/Cookie.cpp
     Cookie/ParsedCookie.cpp

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -23,13 +23,13 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSImportRule);
 
-GC::Ref<CSSImportRule> CSSImportRule::create(URL::URL url, DOM::Document& document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
+GC::Ref<CSSImportRule> CSSImportRule::create(::URL::URL url, DOM::Document& document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
 {
     auto& realm = document.realm();
     return realm.create<CSSImportRule>(move(url), document, supports, move(media_query_list));
 }
 
-CSSImportRule::CSSImportRule(URL::URL url, DOM::Document& document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
+CSSImportRule::CSSImportRule(::URL::URL url, DOM::Document& document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
     : CSSRule(document.realm(), Type::Import)
     , m_url(move(url))
     , m_document(document)

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -56,7 +56,10 @@ void CSSImportRule::set_parent_style_sheet(CSSStyleSheet* parent_style_sheet)
     // Crude detection of whether we're already fetching.
     if (m_style_sheet || m_document_load_event_delayer.has_value())
         return;
-    fetch();
+
+    // Only try to fetch if we now have a parent
+    if (parent_style_sheet)
+        fetch();
 }
 
 // https://www.w3.org/TR/cssom/#serialize-a-css-rule

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -23,17 +23,16 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSImportRule);
 
-GC::Ref<CSSImportRule> CSSImportRule::create(::URL::URL url, DOM::Document& document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
+GC::Ref<CSSImportRule> CSSImportRule::create(JS::Realm& realm, ::URL::URL url, GC::Ptr<DOM::Document> document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
 {
-    auto& realm = document.realm();
-    return realm.create<CSSImportRule>(move(url), document, supports, move(media_query_list));
+    return realm.create<CSSImportRule>(realm, move(url), document, move(supports), move(media_query_list));
 }
 
-CSSImportRule::CSSImportRule(::URL::URL url, DOM::Document& document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
-    : CSSRule(document.realm(), Type::Import)
+CSSImportRule::CSSImportRule(JS::Realm& realm, ::URL::URL url, GC::Ptr<DOM::Document> document, RefPtr<Supports> supports, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
+    : CSSRule(realm, Type::Import)
     , m_url(move(url))
     , m_document(document)
-    , m_supports(supports)
+    , m_supports(move(supports))
     , m_media_query_list(move(media_query_list))
 {
 }

--- a/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -21,11 +21,11 @@ class CSSImportRule final
     GC_DECLARE_ALLOCATOR(CSSImportRule);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSImportRule> create(URL::URL, DOM::Document&, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
+    [[nodiscard]] static GC::Ref<CSSImportRule> create(::URL::URL, DOM::Document&, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
 
     virtual ~CSSImportRule() = default;
 
-    URL::URL const& url() const { return m_url; }
+    ::URL::URL const& url() const { return m_url; }
     // FIXME: This should return only the specified part of the url. eg, "stuff/foo.css", not "https://example.com/stuff/foo.css".
     String href() const { return m_url.to_string(); }
 
@@ -37,7 +37,7 @@ public:
     Optional<String> supports_text() const;
 
 private:
-    CSSImportRule(URL::URL, DOM::Document&, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
+    CSSImportRule(::URL::URL, DOM::Document&, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -49,7 +49,7 @@ private:
     void fetch();
     void set_style_sheet(GC::Ref<CSSStyleSheet>);
 
-    URL::URL m_url;
+    ::URL::URL m_url;
     GC::Ptr<DOM::Document> m_document;
     RefPtr<Supports> m_supports;
     Vector<NonnullRefPtr<MediaQuery>> m_media_query_list;

--- a/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -21,7 +21,7 @@ class CSSImportRule final
     GC_DECLARE_ALLOCATOR(CSSImportRule);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSImportRule> create(::URL::URL, DOM::Document&, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
+    [[nodiscard]] static GC::Ref<CSSImportRule> create(JS::Realm&, ::URL::URL, GC::Ptr<DOM::Document>, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
 
     virtual ~CSSImportRule() = default;
 
@@ -37,7 +37,7 @@ public:
     Optional<String> supports_text() const;
 
 private:
-    CSSImportRule(::URL::URL, DOM::Document&, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
+    CSSImportRule(JS::Realm&, ::URL::URL, GC::Ptr<DOM::Document>, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
- * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <LibURL/URL.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
+#include <LibWeb/CSS/URL.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 
 namespace Web::CSS {
@@ -21,13 +21,12 @@ class CSSImportRule final
     GC_DECLARE_ALLOCATOR(CSSImportRule);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSImportRule> create(JS::Realm&, ::URL::URL, GC::Ptr<DOM::Document>, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
+    [[nodiscard]] static GC::Ref<CSSImportRule> create(JS::Realm&, URL, GC::Ptr<DOM::Document>, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
 
     virtual ~CSSImportRule() = default;
 
-    ::URL::URL const& url() const { return m_url; }
-    // FIXME: This should return only the specified part of the url. eg, "stuff/foo.css", not "https://example.com/stuff/foo.css".
-    String href() const { return m_url.to_string(); }
+    URL const& url() const { return m_url; }
+    String href() const { return m_url.url(); }
 
     CSSStyleSheet* loaded_style_sheet() { return m_style_sheet; }
     CSSStyleSheet const* loaded_style_sheet() const { return m_style_sheet; }
@@ -37,7 +36,7 @@ public:
     Optional<String> supports_text() const;
 
 private:
-    CSSImportRule(JS::Realm&, ::URL::URL, GC::Ptr<DOM::Document>, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
+    CSSImportRule(JS::Realm&, URL, GC::Ptr<DOM::Document>, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -49,7 +48,7 @@ private:
     void fetch();
     void set_style_sheet(GC::Ref<CSSStyleSheet>);
 
-    ::URL::URL m_url;
+    URL m_url;
     GC::Ptr<DOM::Document> m_document;
     RefPtr<Supports> m_supports;
     Vector<NonnullRefPtr<MediaQuery>> m_media_query_list;

--- a/Libraries/LibWeb/CSS/CSSImportRule.idl
+++ b/Libraries/LibWeb/CSS/CSSImportRule.idl
@@ -6,7 +6,8 @@
 [Exposed=Window]
 interface CSSImportRule : CSSRule {
     readonly attribute USVString href;
-    [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
+    // AD-HOC: media is null if styleSheet is null. Spec issue: https://github.com/w3c/csswg-drafts/issues/12063
+    [SameObject, PutForwards=mediaText] readonly attribute MediaList? media;
     [SameObject, ImplementedAs=style_sheet_for_bindings] readonly attribute CSSStyleSheet? styleSheet;
     [FIXME] readonly attribute CSSOMString? layerName;
     readonly attribute CSSOMString? supportsText;

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -37,13 +37,13 @@ WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> CSSStyleSheet::construct_impl(JS::Re
 
     // 2. Set sheet’s location to the base URL of the associated Document for the current principal global object.
     auto associated_document = as<HTML::Window>(HTML::current_principal_global_object()).document();
-    sheet->set_location(associated_document->base_url().to_string());
+    sheet->set_location(associated_document->base_url());
 
     // 3. Set sheet’s stylesheet base URL to the baseURL attribute value from options.
     if (options.has_value() && options->base_url.has_value()) {
         Optional<URL::URL> sheet_location_url;
         if (sheet->location().has_value())
-            sheet_location_url = URL::Parser::basic_parse(sheet->location().release_value());
+            sheet_location_url = sheet->location().release_value();
 
         // AD-HOC: This isn't explicitly mentioned in the specification, but multiple modern browsers do this.
         Optional<URL::URL> url = sheet->location().has_value() ? sheet_location_url->complete_url(options->base_url.value()) : URL::Parser::basic_parse(options->base_url.value());
@@ -100,7 +100,7 @@ CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& me
     , m_rules(&rules)
 {
     if (location.has_value())
-        set_location(location->to_string());
+        set_location(move(location));
 
     for (auto& rule : *m_rules)
         rule->set_parent_style_sheet(this);

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -140,8 +140,7 @@ WebIDL::ExceptionOr<unsigned> CSSStyleSheet::insert_rule(StringView rule, unsign
         return WebIDL::NotAllowedError::create(realm(), "Can't call insert_rule() on non-modifiable stylesheets."_string);
 
     // 3. Let parsed rule be the return value of invoking parse a rule with rule.
-    auto context = !m_owning_documents_or_shadow_roots.is_empty() ? Parser::ParsingParams { (*m_owning_documents_or_shadow_roots.begin())->document() } : Parser::ParsingParams { realm() };
-    auto parsed_rule = parse_css_rule(context, rule);
+    auto parsed_rule = parse_css_rule(make_parsing_params(), rule);
 
     // 4. If parsed rule is a syntax error, return parsed rule.
     if (!parsed_rule)
@@ -208,8 +207,7 @@ GC::Ref<WebIDL::Promise> CSSStyleSheet::replace(String text)
         HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         // 1. Let rules be the result of running parse a stylesheet’s contents from text.
-        auto context = !m_owning_documents_or_shadow_roots.is_empty() ? Parser::ParsingParams { (*m_owning_documents_or_shadow_roots.begin())->document() } : CSS::Parser::ParsingParams { realm };
-        auto* parsed_stylesheet = parse_css_stylesheet(context, text);
+        auto* parsed_stylesheet = parse_css_stylesheet(make_parsing_params(), text);
         auto& rules = parsed_stylesheet->rules();
 
         // 2. If rules contains one or more @import rules, remove those rules from rules.
@@ -242,8 +240,7 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::replace_sync(StringView text)
         return WebIDL::NotAllowedError::create(realm(), "Can't call replaceSync() on non-modifiable stylesheets"_string);
 
     // 2. Let rules be the result of running parse a stylesheet’s contents from text.
-    auto context = !m_owning_documents_or_shadow_roots.is_empty() ? Parser::ParsingParams { (*m_owning_documents_or_shadow_roots.begin())->document() } : CSS::Parser::ParsingParams { realm() };
-    auto* parsed_stylesheet = parse_css_stylesheet(context, text);
+    auto* parsed_stylesheet = parse_css_stylesheet(make_parsing_params(), text);
     auto& rules = parsed_stylesheet->rules();
 
     // 3. If rules contains one or more @import rules, remove those rules from rules.
@@ -424,6 +421,13 @@ bool CSSStyleSheet::has_associated_font_loader(FontLoader& font_loader) const
             return true;
     }
     return false;
+}
+
+Parser::ParsingParams CSSStyleSheet::make_parsing_params() const
+{
+    if (!m_owning_documents_or_shadow_roots.is_empty())
+        return Parser::ParsingParams { (*m_owning_documents_or_shadow_roots.begin())->document() };
+    return Parser::ParsingParams { realm() };
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -24,7 +24,7 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSStyleSheet);
 
-GC::Ref<CSSStyleSheet> CSSStyleSheet::create(JS::Realm& realm, CSSRuleList& rules, MediaList& media, Optional<URL::URL> location)
+GC::Ref<CSSStyleSheet> CSSStyleSheet::create(JS::Realm& realm, CSSRuleList& rules, MediaList& media, Optional<::URL::URL> location)
 {
     return realm.create<CSSStyleSheet>(realm, rules, media, move(location));
 }
@@ -41,12 +41,12 @@ WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> CSSStyleSheet::construct_impl(JS::Re
 
     // 3. Set sheet’s stylesheet base URL to the baseURL attribute value from options.
     if (options.has_value() && options->base_url.has_value()) {
-        Optional<URL::URL> sheet_location_url;
+        Optional<::URL::URL> sheet_location_url;
         if (sheet->location().has_value())
             sheet_location_url = sheet->location().release_value();
 
         // AD-HOC: This isn't explicitly mentioned in the specification, but multiple modern browsers do this.
-        Optional<URL::URL> url = sheet->location().has_value() ? sheet_location_url->complete_url(options->base_url.value()) : URL::Parser::basic_parse(options->base_url.value());
+        Optional<::URL::URL> url = sheet->location().has_value() ? sheet_location_url->complete_url(options->base_url.value()) : ::URL::Parser::basic_parse(options->base_url.value());
         if (!url.has_value())
             return WebIDL::NotAllowedError::create(realm, "Constructed style sheets must have a valid base URL"_string);
 
@@ -95,7 +95,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> CSSStyleSheet::construct_impl(JS::Re
     return sheet;
 }
 
-CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& media, Optional<URL::URL> location)
+CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& media, Optional<::URL::URL> location)
     : StyleSheet(realm, media)
     , m_rules(&rules)
 {

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -12,6 +12,7 @@
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSRuleList.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
+#include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleSheet.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/WebIDL/Types.h>
@@ -104,6 +105,8 @@ private:
 
     void set_constructed(bool constructed) { m_constructed = constructed; }
     void set_disallow_modification(bool disallow_modification) { m_disallow_modification = disallow_modification; }
+
+    Parser::ParsingParams make_parsing_params() const;
 
     Optional<String> m_source_text;
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -27,12 +27,13 @@ struct CSSStyleSheetInit {
     bool disabled { false };
 };
 
+// https://drafts.csswg.org/cssom-1/#cssstylesheet
 class CSSStyleSheet final : public StyleSheet {
     WEB_PLATFORM_OBJECT(CSSStyleSheet, StyleSheet);
     GC_DECLARE_ALLOCATOR(CSSStyleSheet);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSStyleSheet> create(JS::Realm&, CSSRuleList&, MediaList&, Optional<URL::URL> location);
+    [[nodiscard]] static GC::Ref<CSSStyleSheet> create(JS::Realm&, CSSRuleList&, MediaList&, Optional<::URL::URL> location);
     static WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> construct_impl(JS::Realm&, Optional<CSSStyleSheetInit> const& options = {});
 
     virtual ~CSSStyleSheet() override = default;
@@ -74,8 +75,8 @@ public:
 
     Vector<GC::Ref<CSSImportRule>> const& import_rules() const { return m_import_rules; }
 
-    Optional<URL::URL> base_url() const { return m_base_url; }
-    void set_base_url(Optional<URL::URL> base_url) { m_base_url = move(base_url); }
+    Optional<::URL::URL> base_url() const { return m_base_url; }
+    void set_base_url(Optional<::URL::URL> base_url) { m_base_url = move(base_url); }
 
     bool constructed() const { return m_constructed; }
 
@@ -94,7 +95,7 @@ public:
     bool has_associated_font_loader(FontLoader& font_loader) const;
 
 private:
-    CSSStyleSheet(JS::Realm&, CSSRuleList&, MediaList&, Optional<URL::URL> location);
+    CSSStyleSheet(JS::Realm&, CSSRuleList&, MediaList&, Optional<::URL::URL> location);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -113,7 +114,7 @@ private:
 
     GC::Ptr<CSSRule> m_owner_css_rule;
 
-    Optional<URL::URL> m_base_url;
+    Optional<::URL::URL> m_base_url;
     GC::Ptr<DOM::Document const> m_constructor_document;
     HashTable<GC::Ptr<DOM::Node>> m_owning_documents_or_shadow_roots;
     bool m_constructed { false };

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -225,40 +225,40 @@ public:
         : m_value(color)
     {
     }
-    SVGPaint(URL::URL const& url)
+    SVGPaint(::URL::URL const& url)
         : m_value(url)
     {
     }
 
     bool is_color() const { return m_value.has<Color>(); }
-    bool is_url() const { return m_value.has<URL::URL>(); }
+    bool is_url() const { return m_value.has<::URL::URL>(); }
     Color as_color() const { return m_value.get<Color>(); }
-    URL::URL const& as_url() const { return m_value.get<URL::URL>(); }
+    ::URL::URL const& as_url() const { return m_value.get<::URL::URL>(); }
 
 private:
-    Variant<URL::URL, Color> m_value;
+    Variant<::URL::URL, Color> m_value;
 };
 
 // https://drafts.fxtf.org/css-masking-1/#typedef-mask-reference
 class MaskReference {
 public:
     // TODO: Support other mask types.
-    MaskReference(URL::URL const& url)
+    MaskReference(::URL::URL const& url)
         : m_url(url)
     {
     }
 
-    URL::URL const& url() const { return m_url; }
+    ::URL::URL const& url() const { return m_url; }
 
 private:
-    URL::URL m_url;
+    ::URL::URL m_url;
 };
 
 // https://drafts.fxtf.org/css-masking/#the-clip-path
 // TODO: Support clip sources.
 class ClipPathReference {
 public:
-    ClipPathReference(URL::URL const& url)
+    ClipPathReference(::URL::URL const& url)
         : m_clip_source(url)
     {
     }
@@ -270,16 +270,16 @@ public:
 
     bool is_basic_shape() const { return m_clip_source.has<BasicShape>(); }
 
-    bool is_url() const { return m_clip_source.has<URL::URL>(); }
+    bool is_url() const { return m_clip_source.has<::URL::URL>(); }
 
-    URL::URL const& url() const { return m_clip_source.get<URL::URL>(); }
+    ::URL::URL const& url() const { return m_clip_source.get<::URL::URL>(); }
 
     BasicShapeStyleValue const& basic_shape() const { return *m_clip_source.get<BasicShape>(); }
 
 private:
     using BasicShape = NonnullRefPtr<BasicShapeStyleValue const>;
 
-    Variant<URL::URL, BasicShape> m_clip_source;
+    Variant<::URL::URL, BasicShape> m_clip_source;
 };
 
 struct BackgroundLayerData {

--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -23,7 +23,7 @@ void fetch_a_style_resource(String const& url_value, CSSStyleSheet const& sheet,
     auto base = sheet.base_url().value_or(environment_settings.api_base_url());
 
     // 3. Let parsedUrl be the result of the URL parser steps with urlValue’s url and base. If the algorithm returns an error, return.
-    auto parsed_url = URL::Parser::basic_parse(url_value, base);
+    auto parsed_url = ::URL::Parser::basic_parse(url_value, base);
     if (!parsed_url.has_value())
         return;
 

--- a/Libraries/LibWeb/CSS/ParsedFontFace.cpp
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.cpp
@@ -38,7 +38,7 @@ Vector<ParsedFontFace::Source> ParsedFontFace::sources_from_style_value(CSSStyle
             [&](FontSourceStyleValue::Local const& local) {
                 sources.empend(extract_font_name(local.name), OptionalNone {});
             },
-            [&](URL::URL const& url) {
+            [&](::URL::URL const& url) {
                 // FIXME: tech()
                 sources.empend(url, font_source.format());
             });

--- a/Libraries/LibWeb/CSS/ParsedFontFace.h
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.h
@@ -19,7 +19,7 @@ namespace Web::CSS {
 class ParsedFontFace {
 public:
     struct Source {
-        Variant<FlyString, URL::URL> local_or_url;
+        Variant<FlyString, ::URL::URL> local_or_url;
         // FIXME: Do we need to keep this around, or is it only needed to discard unwanted formats during parsing?
         Optional<FlyString> format;
     };

--- a/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -42,7 +42,7 @@ GC::Ref<JS::Realm> internal_css_realm()
     return *realm;
 }
 
-CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingParams const& context, StringView css, Optional<URL::URL> location, Vector<NonnullRefPtr<CSS::MediaQuery>> media_query_list)
+CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingParams const& context, StringView css, Optional<::URL::URL> location, Vector<NonnullRefPtr<CSS::MediaQuery>> media_query_list)
 {
     if (css.is_empty()) {
         auto rule_list = CSS::CSSRuleList::create_empty(*context.realm);

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -45,14 +45,14 @@ ParsingParams::ParsingParams(JS::Realm& realm, ParsingMode mode)
 {
 }
 
-ParsingParams::ParsingParams(JS::Realm& realm, URL::URL url, ParsingMode mode)
+ParsingParams::ParsingParams(JS::Realm& realm, ::URL::URL url, ParsingMode mode)
     : realm(realm)
     , url(move(url))
     , mode(mode)
 {
 }
 
-ParsingParams::ParsingParams(DOM::Document const& document, URL::URL url, ParsingMode mode)
+ParsingParams::ParsingParams(DOM::Document const& document, ::URL::URL url, ParsingMode mode)
     : realm(const_cast<JS::Realm&>(document.realm()))
     , document(&document)
     , url(move(url))
@@ -86,7 +86,7 @@ Parser::Parser(ParsingParams const& context, Vector<Token> tokens)
 
 // https://drafts.csswg.org/css-syntax/#parse-stylesheet
 template<typename T>
-Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<T>& input, Optional<URL::URL> location)
+Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<T>& input, Optional<::URL::URL> location)
 {
     // To parse a stylesheet from an input given an optional url location:
 
@@ -119,7 +119,7 @@ Vector<Rule> Parser::parse_a_stylesheets_contents(TokenStream<T>& input)
 }
 
 // https://drafts.csswg.org/css-syntax/#parse-a-css-stylesheet
-CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
+CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<::URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
 {
     // To parse a CSS stylesheet, first parse a stylesheet.
     auto const& style_sheet = parse_a_stylesheet(m_token_stream, {});
@@ -1772,8 +1772,8 @@ Parser::ContextType Parser::context_type_for_at_rule(FlyString const& name)
     return ContextType::Unknown;
 }
 
-template Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<Token>&, Optional<URL::URL>);
-template Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<ComponentValue>&, Optional<URL::URL>);
+template Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<Token>&, Optional<::URL::URL>);
+template Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<ComponentValue>&, Optional<::URL::URL>);
 
 template Vector<Rule> Parser::parse_a_stylesheets_contents(TokenStream<Token>& input);
 template Vector<Rule> Parser::parse_a_stylesheets_contents(TokenStream<ComponentValue>& input);
@@ -1853,10 +1853,10 @@ bool Parser::is_parsing_svg_presentation_attribute() const
 
 // https://www.w3.org/TR/css-values-4/#relative-urls
 // FIXME: URLs shouldn't be completed during parsing, but when used.
-Optional<URL::URL> Parser::complete_url(StringView relative_url) const
+Optional<::URL::URL> Parser::complete_url(StringView relative_url) const
 {
     if (!m_url.is_valid())
-        return URL::Parser::basic_parse(relative_url);
+        return ::URL::Parser::basic_parse(relative_url);
     return m_url.complete_url(relative_url);
 }
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -122,7 +122,7 @@ Vector<Rule> Parser::parse_a_stylesheets_contents(TokenStream<T>& input)
 CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<::URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
 {
     // To parse a CSS stylesheet, first parse a stylesheet.
-    auto const& style_sheet = parse_a_stylesheet(m_token_stream, {});
+    auto const& style_sheet = parse_a_stylesheet(m_token_stream, location);
 
     // Interpret all of the resulting top-level qualified rules as style rules, defined below.
     GC::RootVector<CSSRule*> rules(realm().heap());

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -69,13 +69,13 @@ enum class ParsingMode {
 struct ParsingParams {
     explicit ParsingParams(ParsingMode = ParsingMode::Normal);
     explicit ParsingParams(JS::Realm&, ParsingMode = ParsingMode::Normal);
-    explicit ParsingParams(JS::Realm&, URL::URL, ParsingMode = ParsingMode::Normal);
-    explicit ParsingParams(DOM::Document const&, URL::URL, ParsingMode = ParsingMode::Normal);
+    explicit ParsingParams(JS::Realm&, ::URL::URL, ParsingMode = ParsingMode::Normal);
+    explicit ParsingParams(DOM::Document const&, ::URL::URL, ParsingMode = ParsingMode::Normal);
     explicit ParsingParams(DOM::Document const&, ParsingMode = ParsingMode::Normal);
 
     GC::Ptr<JS::Realm> realm;
     GC::Ptr<DOM::Document const> document;
-    URL::URL url;
+    ::URL::URL url;
     ParsingMode mode { ParsingMode::Normal };
 };
 
@@ -89,7 +89,7 @@ class Parser {
 public:
     static Parser create(ParsingParams const&, StringView input, StringView encoding = "utf-8"sv);
 
-    CSSStyleSheet* parse_as_css_stylesheet(Optional<URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list = {});
+    CSSStyleSheet* parse_as_css_stylesheet(Optional<::URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list = {});
 
     struct PropertiesAndCustomProperties {
         Vector<StyleProperty> properties;
@@ -142,11 +142,11 @@ private:
 
     // "Parse a stylesheet" is intended to be the normal parser entry point, for parsing stylesheets.
     struct ParsedStyleSheet {
-        Optional<URL::URL> location;
+        Optional<::URL::URL> location;
         Vector<Rule> rules;
     };
     template<typename T>
-    ParsedStyleSheet parse_a_stylesheet(TokenStream<T>&, Optional<URL::URL> location);
+    ParsedStyleSheet parse_a_stylesheet(TokenStream<T>&, Optional<::URL::URL> location);
 
     // "Parse a stylesheet’s contents" is intended for use by the CSSStyleSheet replace() method, and similar, which parse text into the contents of an existing stylesheet.
     template<typename T>
@@ -276,7 +276,7 @@ private:
     Optional<GridRepeat> parse_repeat(Vector<ComponentValue> const&);
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
 
-    Optional<URL::URL> parse_url_function(TokenStream<ComponentValue>&);
+    Optional<::URL::URL> parse_url_function(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_url_value(TokenStream<ComponentValue>&);
 
     Optional<ShapeRadius> parse_shape_radius(TokenStream<ComponentValue>&);
@@ -471,11 +471,11 @@ private:
     JS::Realm& realm() const;
     bool in_quirks_mode() const;
     bool is_parsing_svg_presentation_attribute() const;
-    Optional<URL::URL> complete_url(StringView) const;
+    Optional<::URL::URL> complete_url(StringView) const;
 
     GC::Ptr<DOM::Document const> m_document;
     GC::Ptr<JS::Realm> m_realm;
-    URL::URL m_url;
+    ::URL::URL m_url;
     ParsingMode m_parsing_mode { ParsingMode::Normal };
 
     Vector<Token> m_tokens;
@@ -519,7 +519,7 @@ private:
 
 namespace Web {
 
-CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingParams const&, StringView, Optional<URL::URL> location = {}, Vector<NonnullRefPtr<CSS::MediaQuery>> = {});
+CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingParams const&, StringView, Optional<::URL::URL> location = {}, Vector<NonnullRefPtr<CSS::MediaQuery>> = {});
 CSS::Parser::Parser::PropertiesAndCustomProperties parse_css_style_attribute(CSS::Parser::ParsingParams const&, StringView);
 Vector<CSS::Descriptor> parse_css_list_of_descriptors(CSS::Parser::ParsingParams const&, CSS::AtRuleID, StringView);
 RefPtr<CSS::CSSStyleValue> parse_css_value(CSS::Parser::ParsingParams const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -32,6 +32,7 @@
 #include <LibWeb/CSS/StyleValues/BasicShapeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 #include <LibWeb/CSS/Supports.h>
+#include <LibWeb/CSS/URL.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS::Parser {
@@ -276,7 +277,7 @@ private:
     Optional<GridRepeat> parse_repeat(Vector<ComponentValue> const&);
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
 
-    Optional<::URL::URL> parse_url_function(TokenStream<ComponentValue>&);
+    Optional<URL> parse_url_function(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_url_value(TokenStream<ComponentValue>&);
 
     Optional<ShapeRadius> parse_shape_radius(TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -162,13 +162,6 @@ GC::Ptr<CSSImportRule> Parser::convert_to_import_rule(AtRule const& rule)
         return {};
     }
 
-    // FIXME: Stop completing the URL here
-    auto resolved_url = complete_url(url->url());
-    if (!resolved_url.has_value()) {
-        dbgln_if(CSS_PARSER_DEBUG, "Failed to parse @import rule: Unable to complete `{}` as URL.", url->url());
-        return {};
-    }
-
     tokens.discard_whitespace();
     // FIXME: Implement layer support.
     RefPtr<Supports> supports {};
@@ -198,7 +191,7 @@ GC::Ptr<CSSImportRule> Parser::convert_to_import_rule(AtRule const& rule)
         return {};
     }
 
-    return CSSImportRule::create(realm(), resolved_url.release_value(), const_cast<DOM::Document*>(m_document.ptr()), supports, move(media_query_list));
+    return CSSImportRule::create(realm(), url.release_value(), const_cast<DOM::Document*>(m_document.ptr()), supports, move(media_query_list));
 }
 
 Optional<FlyString> Parser::parse_layer_name(TokenStream<ComponentValue>& tokens, AllowBlankLayerName allow_blank_layer_name)

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -153,7 +153,7 @@ GC::Ptr<CSSImportRule> Parser::convert_to_import_rule(AtRule const& rule)
     TokenStream tokens { rule.prelude };
     tokens.discard_whitespace();
 
-    Optional<URL::URL> url = parse_url_function(tokens);
+    Optional<::URL::URL> url = parse_url_function(tokens);
     if (!url.has_value() && tokens.next_token().is(Token::Type::String))
         url = complete_url(tokens.consume_a_token().token().string());
 

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -198,7 +198,7 @@ GC::Ptr<CSSImportRule> Parser::convert_to_import_rule(AtRule const& rule)
         return {};
     }
 
-    return CSSImportRule::create(resolved_url.release_value(), const_cast<DOM::Document&>(*document()), supports, move(media_query_list));
+    return CSSImportRule::create(realm(), resolved_url.release_value(), const_cast<DOM::Document*>(m_document.ptr()), supports, move(media_query_list));
 }
 
 Optional<FlyString> Parser::parse_layer_name(TokenStream<ComponentValue>& tokens, AllowBlankLayerName allow_blank_layer_name)

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2014,7 +2014,7 @@ RefPtr<AbstractImageStyleValue> Parser::parse_image_value(TokenStream<ComponentV
     if (url.has_value()) {
         // If the value is a 'url(..)' parse as image, but if it is just a reference 'url(#xx)', leave it alone,
         // so we can parse as URL further on. These URLs are used as references inside SVG documents for masks.
-        if (!url.value().equals(m_url, URL::ExcludeFragment::Yes)) {
+        if (!url.value().equals(m_url, ::URL::ExcludeFragment::Yes)) {
             tokens.discard_a_mark();
             return ImageStyleValue::create(url.value());
         }
@@ -2562,12 +2562,12 @@ RefPtr<CSSStyleValue> Parser::parse_easing_value(TokenStream<ComponentValue>& to
     return nullptr;
 }
 
-Optional<URL::URL> Parser::parse_url_function(TokenStream<ComponentValue>& tokens)
+Optional<::URL::URL> Parser::parse_url_function(TokenStream<ComponentValue>& tokens)
 {
     auto transaction = tokens.begin_transaction();
     auto& component_value = tokens.consume_a_token();
 
-    auto convert_string_to_url = [&](StringView url_string) -> Optional<URL::URL> {
+    auto convert_string_to_url = [&](StringView url_string) -> Optional<::URL::URL> {
         auto url = complete_url(url_string);
         if (url.has_value()) {
             transaction.commit();

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -185,7 +185,7 @@ StyleComputer::StyleComputer(DOM::Document& document)
 
 StyleComputer::~StyleComputer() = default;
 
-FontLoader::FontLoader(StyleComputer& style_computer, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<URL::URL> urls, Function<void(FontLoader const&)> on_load, Function<void()> on_fail)
+FontLoader::FontLoader(StyleComputer& style_computer, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<::URL::URL> urls, Function<void(FontLoader const&)> on_load, Function<void()> on_fail)
     : m_style_computer(style_computer)
     , m_family_name(move(family_name))
     , m_unicode_ranges(move(unicode_ranges))
@@ -3028,11 +3028,11 @@ Optional<FontLoader&> StyleComputer::load_font_face(ParsedFontFace const& font_f
         .slope = font_face.slope().value_or(0),
     };
 
-    Vector<URL::URL> urls;
+    Vector<::URL::URL> urls;
     for (auto const& source : font_face.sources()) {
         // FIXME: These should be loaded relative to the stylesheet URL instead of the document URL.
-        if (source.local_or_url.has<URL::URL>())
-            urls.append(*m_document->encoding_parse_url(source.local_or_url.get<URL::URL>().to_string()));
+        if (source.local_or_url.has<::URL::URL>())
+            urls.append(*m_document->encoding_parse_url(source.local_or_url.get<::URL::URL>().to_string()));
         // FIXME: Handle local()
     }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -315,7 +315,7 @@ private:
 
 class FontLoader : public ResourceClient {
 public:
-    FontLoader(StyleComputer& style_computer, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<URL::URL> urls, ESCAPING Function<void(FontLoader const&)> on_load = {}, ESCAPING Function<void()> on_fail = {});
+    FontLoader(StyleComputer& style_computer, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<::URL::URL> urls, ESCAPING Function<void(FontLoader const&)> on_load = {}, ESCAPING Function<void()> on_fail = {});
 
     virtual ~FontLoader() override;
 
@@ -340,7 +340,7 @@ private:
     FlyString m_family_name;
     Vector<Gfx::UnicodeRange> m_unicode_ranges;
     RefPtr<Gfx::Typeface> m_vector_font;
-    Vector<URL::URL> m_urls;
+    Vector<::URL::URL> m_urls;
     Function<void(FontLoader const&)> m_on_load;
     Function<void()> m_on_fail;
 };

--- a/Libraries/LibWeb/CSS/StyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheet.cpp
@@ -27,6 +27,13 @@ void StyleSheet::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_media);
 }
 
+Optional<String> StyleSheet::href() const
+{
+    if (m_location.has_value())
+        return m_location->to_string();
+    return {};
+}
+
 void StyleSheet::set_owner_node(DOM::Element* element)
 {
     m_owner_node = element;

--- a/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Libraries/LibWeb/CSS/StyleSheet.h
@@ -13,6 +13,7 @@
 
 namespace Web::CSS {
 
+// https://drafts.csswg.org/cssom-1/#the-stylesheet-interface
 class StyleSheet : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(StyleSheet, Bindings::PlatformObject);
 
@@ -24,10 +25,10 @@ public:
     DOM::Element* owner_node() { return m_owner_node; }
     void set_owner_node(DOM::Element*);
 
-    Optional<String> href() const { return m_location; }
+    Optional<String> href() const;
 
-    Optional<String> location() const { return m_location; }
-    void set_location(Optional<String> location) { m_location = move(location); }
+    Optional<URL::URL> location() const { return m_location; }
+    void set_location(Optional<URL::URL> location) { m_location = move(location); }
 
     String title() const { return m_title; }
     Optional<String> title_for_bindings() const;
@@ -67,7 +68,7 @@ private:
     GC::Ptr<DOM::Element> m_owner_node;
     GC::Ptr<CSSStyleSheet> m_parent_style_sheet;
 
-    Optional<String> m_location;
+    Optional<URL::URL> m_location;
     String m_title;
     String m_type_string;
 

--- a/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Libraries/LibWeb/CSS/StyleSheet.h
@@ -27,8 +27,8 @@ public:
 
     Optional<String> href() const;
 
-    Optional<URL::URL> location() const { return m_location; }
-    void set_location(Optional<URL::URL> location) { m_location = move(location); }
+    Optional<::URL::URL> location() const { return m_location; }
+    void set_location(Optional<::URL::URL> location) { m_location = move(location); }
 
     String title() const { return m_title; }
     Optional<String> title_for_bindings() const;
@@ -68,7 +68,7 @@ private:
     GC::Ptr<DOM::Element> m_owner_node;
     GC::Ptr<CSSStyleSheet> m_parent_style_sheet;
 
-    Optional<URL::URL> m_location;
+    Optional<::URL::URL> m_location;
     String m_title;
     String m_type_string;
 

--- a/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Libraries/LibWeb/CSS/StyleSheet.h
@@ -36,7 +36,7 @@ public:
 
     void set_type(String type) { m_type_string = move(type); }
 
-    MediaList* media() const
+    GC::Ref<MediaList> media() const
     {
         return m_media;
     }

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -60,7 +60,7 @@ void StyleSheetList::add_a_css_style_sheet(CSS::CSSStyleSheet& sheet)
 }
 
 // https://www.w3.org/TR/cssom/#create-a-css-style-sheet
-void StyleSheetList::create_a_css_style_sheet(String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<URL::URL> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
+void StyleSheetList::create_a_css_style_sheet(String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<::URL::URL> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
 {
     // 1. Create a new CSS style sheet object and set its properties as specified.
     // FIXME: We receive `sheet` from the caller already. This is weird.

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -60,7 +60,7 @@ void StyleSheetList::add_a_css_style_sheet(CSS::CSSStyleSheet& sheet)
 }
 
 // https://www.w3.org/TR/cssom/#create-a-css-style-sheet
-void StyleSheetList::create_a_css_style_sheet(String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
+void StyleSheetList::create_a_css_style_sheet(String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<URL::URL> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet& sheet)
 {
     // 1. Create a new CSS style sheet object and set its properties as specified.
     // FIXME: We receive `sheet` from the caller already. This is weird.

--- a/Libraries/LibWeb/CSS/StyleSheetList.h
+++ b/Libraries/LibWeb/CSS/StyleSheetList.h
@@ -21,7 +21,7 @@ public:
 
     void add_a_css_style_sheet(CSS::CSSStyleSheet&);
     void remove_a_css_style_sheet(CSS::CSSStyleSheet&);
-    void create_a_css_style_sheet(String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<String> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet&);
+    void create_a_css_style_sheet(String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<::URL::URL> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet&);
 
     Vector<GC::Ref<CSSStyleSheet>> const& sheets() const { return m_sheets; }
     Vector<GC::Ref<CSSStyleSheet>>& sheets() { return m_sheets; }

--- a/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.cpp
@@ -34,7 +34,7 @@ String FontSourceStyleValue::to_string(SerializationMode) const
             builder.append(')');
             return builder.to_string_without_validation();
         },
-        [this](URL::URL const& url) {
+        [this](::URL::URL const& url) {
             // <url> [ format(<font-format>)]? [ tech( <font-tech>#)]?
             // FIXME: tech()
             StringBuilder builder;
@@ -59,8 +59,8 @@ bool FontSourceStyleValue::properties_equal(FontSourceStyleValue const& other) c
             }
             return false;
         },
-        [&other](URL::URL const& url) {
-            if (auto* other_url = other.m_source.get_pointer<URL::URL>()) {
+        [&other](::URL::URL const& url) {
+            if (auto* other_url = other.m_source.get_pointer<::URL::URL>()) {
                 return url == *other_url;
             }
             return false;

--- a/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.h
@@ -16,7 +16,7 @@ public:
     struct Local {
         NonnullRefPtr<CSSStyleValue> name;
     };
-    using Source = Variant<Local, URL::URL>;
+    using Source = Variant<Local, ::URL::URL>;
 
     static ValueComparingNonnullRefPtr<FontSourceStyleValue> create(Source source, Optional<FlyString> format)
     {

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -20,7 +20,7 @@
 
 namespace Web::CSS {
 
-ImageStyleValue::ImageStyleValue(URL::URL const& url)
+ImageStyleValue::ImageStyleValue(::URL::URL const& url)
     : AbstractImageStyleValue(Type::Image)
     , m_url(url)
 {

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -25,7 +25,7 @@ class ImageStyleValue final
     using Base = AbstractImageStyleValue;
 
 public:
-    static ValueComparingNonnullRefPtr<ImageStyleValue> create(URL::URL const& url)
+    static ValueComparingNonnullRefPtr<ImageStyleValue> create(::URL::URL const& url)
     {
         return adopt_ref(*new (nothrow) ImageStyleValue(url));
     }
@@ -53,14 +53,14 @@ public:
     GC::Ptr<HTML::DecodedImageData> image_data() const;
 
 private:
-    ImageStyleValue(URL::URL const&);
+    ImageStyleValue(::URL::URL const&);
 
     GC::Ptr<HTML::SharedResourceRequest> m_resource_request;
 
     void animate();
     Gfx::ImmutableBitmap const* bitmap(size_t frame_index, Gfx::IntSize = {}) const;
 
-    URL::URL m_url;
+    ::URL::URL m_url;
     WeakPtr<DOM::Document> m_document;
 
     size_t m_current_frame_index { 0 };

--- a/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
@@ -14,14 +14,14 @@ namespace Web::CSS {
 
 class URLStyleValue final : public StyleValueWithDefaultOperators<URLStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<URLStyleValue> create(URL::URL const& url)
+    static ValueComparingNonnullRefPtr<URLStyleValue> create(::URL::URL const& url)
     {
         return adopt_ref(*new (nothrow) URLStyleValue(url));
     }
 
     virtual ~URLStyleValue() override = default;
 
-    URL::URL const& url() const { return m_url; }
+    ::URL::URL const& url() const { return m_url; }
 
     bool properties_equal(URLStyleValue const& other) const { return m_url == other.m_url; }
 
@@ -31,13 +31,13 @@ public:
     }
 
 private:
-    URLStyleValue(URL::URL const& url)
+    URLStyleValue(::URL::URL const& url)
         : StyleValueWithDefaultOperators(Type::URL)
         , m_url(url)
     {
     }
 
-    URL::URL m_url;
+    ::URL::URL m_url;
 };
 
 }

--- a/Libraries/LibWeb/CSS/URL.cpp
+++ b/Libraries/LibWeb/CSS/URL.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/URL.h>
+
+namespace Web::CSS {
+
+URL::URL(String url)
+    : m_url(move(url))
+{
+}
+
+// https://drafts.csswg.org/cssom-1/#serialize-a-url
+String URL::to_string() const
+{
+    // To serialize a URL means to create a string represented by "url(", followed by the serialization of the URL as a string, followed by ")".
+    StringBuilder builder;
+    builder.append("url("sv);
+    serialize_a_string(builder, m_url);
+    builder.append(')');
+
+    return builder.to_string_without_validation();
+}
+
+bool URL::operator==(URL const&) const = default;
+
+}

--- a/Libraries/LibWeb/CSS/URL.h
+++ b/Libraries/LibWeb/CSS/URL.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-values-4/#urls
+class URL {
+public:
+    URL(String url);
+
+    String const& url() const { return m_url; }
+
+    String to_string() const;
+    bool operator==(URL const&) const;
+
+private:
+    String m_url;
+};
+
+}

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5879,7 +5879,7 @@ void Document::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&
 
 static Optional<CSS::CSSStyleSheet&> find_style_sheet_with_url(String const& url, CSS::CSSStyleSheet& style_sheet)
 {
-    if (style_sheet.location() == url)
+    if (style_sheet.href() == url)
         return style_sheet;
 
     for (auto& import_rule : style_sheet.import_rules()) {

--- a/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -54,7 +54,8 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
 
     // FIXME: This is a bit awkward, as the spec doesn't actually tell us when to parse the CSS text,
     //        so we just do it here and pass the parsed sheet to create_a_css_style_sheet().
-    auto* sheet = parse_css_stylesheet(CSS::Parser::ParsingParams(style_element.document()), style_element.text_content().value_or(String {}));
+    // AD-HOC: Are we supposed to use the document's URL for the stylesheet's location? Not doing it breaks things.
+    auto* sheet = parse_css_stylesheet(CSS::Parser::ParsingParams(style_element.document()), style_element.text_content().value_or(String {}), style_element.document().url());
     if (!sheet)
         return;
 

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -790,7 +790,7 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
 void dump_import_rule(StringBuilder& builder, CSS::CSSImportRule const& rule, int indent_levels)
 {
     indent(builder, indent_levels);
-    builder.appendff("  Document URL: {}\n", rule.url());
+    builder.appendff("  Document URL: {}\n", rule.url().to_string());
 }
 
 void dump_layer_block_rule(StringBuilder& builder, CSS::CSSLayerBlockRule const& layer_block, int indent_levels)

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -269,6 +269,7 @@ class TransformationStyleValue;
 class TransitionStyleValue;
 class UnicodeRangeStyleValue;
 class UnresolvedStyleValue;
+class URL;
 class URLStyleValue;
 class VisualViewport;
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -490,7 +490,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
                 m_loaded_style_sheet = parse_css_stylesheet(CSS::Parser::ParsingParams(document(), *response.url()), decoded_string);
 
                 if (m_loaded_style_sheet) {
-                    Optional<String> location;
+                    Optional<::URL::URL> location;
                     if (!response.url_list().is_empty())
                         location = response.url_list().first();
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -492,7 +492,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
                 if (m_loaded_style_sheet) {
                     Optional<String> location;
                     if (!response.url_list().is_empty())
-                        location = response.url_list().first().to_string();
+                        location = response.url_list().first();
 
                     document_or_shadow_root_style_sheets().create_a_css_style_sheet(
                         "text/css"_string,

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -834,8 +834,8 @@ static void gather_style_sheets(Vector<Web::CSS::StyleSheetIdentifier>& results,
     }
 
     if (valid) {
-        if (auto location = sheet.location(); location.has_value())
-            identifier.url = location.release_value();
+        if (auto sheet_url = sheet.href(); sheet_url.has_value())
+            identifier.url = sheet_url.release_value();
 
         identifier.rule_count = sheet.rules().length();
         results.append(move(identifier));

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -848,7 +848,7 @@ static void gather_style_sheets(Vector<Web::CSS::StyleSheetIdentifier>& results,
             // We can gather this anyway, and hope it loads later
             results.append({
                 .type = Web::CSS::StyleSheetIdentifier::Type::ImportRule,
-                .url = import_rule->url().to_string(),
+                .url = import_rule->href(),
             });
         }
     }

--- a/Tests/LibWeb/Text/expected/css/CSSImportRule-supportsText.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSImportRule-supportsText.txt
@@ -1,4 +1,4 @@
-cssText: @import url("https://something.invalid/") supports(foo: bar);
+cssText: @import url("https://something.invalid") supports(foo: bar);
 supportsText: foo: bar
-cssText: @import url("https://something.invalid/") supports((display: block) and (foo: bar));
+cssText: @import url("https://something.invalid") supports((display: block) and (foo: bar));
 supportsText: (display: block) and (foo: bar)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/parsing/supports-import-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/parsing/supports-import-parsing.txt
@@ -1,0 +1,28 @@
+Harness status: OK
+
+Found 22 tests
+
+5 Pass
+17 Fail
+Pass	@import url("nonexist.css") supports(); should be an invalid import rule due to an invalid supports() declaration
+Pass	@import url("nonexist.css") supports(foo: bar); should be an invalid import rule due to an invalid supports() declaration
+Fail	@import url("nonexist.css") supports(display:block); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports((display:flex)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(not (display: flex)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports((display: flex) and (display: block)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports((display: flex) or (display: block)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports((display: flex) or (foo: bar)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(display: block !important); should be a valid supports() import rule
+Pass	@import url("nonexist.css") layer supports(); should be an invalid import rule due to an invalid supports() declaration
+Pass	@import url("nonexist.css") layer supports(foo: bar); should be an invalid import rule due to an invalid supports() declaration
+Fail	@import url("nonexist.css") layer(A) supports((display: flex) or (foo: bar)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") layer(A.B) supports((display: flex) and (foo: bar)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(selector(a)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(selector(p a)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(selector(p > a)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(selector(p + a)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(font-tech(color-colrv1)); should be a valid supports() import rule
+Fail	@import url("nonexist.css") supports(font-format(opentype)); should be a valid supports() import rule
+Fail	@import url(nonexist.css) supports(display:block); should be a valid supports() import rule
+Fail	@import "nonexist.css" supports(display:block); should be a valid supports() import rule
+Pass	@import url("nonexist.css") supports; should still be a valid import rule with an invalid supports() declaration

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/parsing/supports-import-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/parsing/supports-import-parsing.txt
@@ -2,17 +2,17 @@ Harness status: OK
 
 Found 22 tests
 
-5 Pass
-17 Fail
+9 Pass
+13 Fail
 Pass	@import url("nonexist.css") supports(); should be an invalid import rule due to an invalid supports() declaration
 Pass	@import url("nonexist.css") supports(foo: bar); should be an invalid import rule due to an invalid supports() declaration
 Fail	@import url("nonexist.css") supports(display:block); should be a valid supports() import rule
 Fail	@import url("nonexist.css") supports((display:flex)); should be a valid supports() import rule
 Fail	@import url("nonexist.css") supports(not (display: flex)); should be a valid supports() import rule
-Fail	@import url("nonexist.css") supports((display: flex) and (display: block)); should be a valid supports() import rule
-Fail	@import url("nonexist.css") supports((display: flex) or (display: block)); should be a valid supports() import rule
-Fail	@import url("nonexist.css") supports((display: flex) or (foo: bar)); should be a valid supports() import rule
-Fail	@import url("nonexist.css") supports(display: block !important); should be a valid supports() import rule
+Pass	@import url("nonexist.css") supports((display: flex) and (display: block)); should be a valid supports() import rule
+Pass	@import url("nonexist.css") supports((display: flex) or (display: block)); should be a valid supports() import rule
+Pass	@import url("nonexist.css") supports((display: flex) or (foo: bar)); should be a valid supports() import rule
+Pass	@import url("nonexist.css") supports(display: block !important); should be a valid supports() import rule
 Pass	@import url("nonexist.css") layer supports(); should be an invalid import rule due to an invalid supports() declaration
 Pass	@import url("nonexist.css") layer supports(foo: bar); should be an invalid import rule due to an invalid supports() declaration
 Fail	@import url("nonexist.css") layer(A) supports((display: flex) or (foo: bar)); should be a valid supports() import rule

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.txt
@@ -1,0 +1,40 @@
+Harness status: OK
+
+Found 34 tests
+
+30 Pass
+4 Fail
+Pass	@media is CSSGroupingRule
+Pass	@media rule type
+Pass	Empty @media rule length
+Fail	insertRule of @import into @media
+Pass	insertRule into empty @media at bad index
+Pass	insertRule into @media updates length
+Pass	insertRule of valid @media into @media
+Pass	insertRule of valid style rule into @media
+Fail	insertRule of invalid @media into @media
+Pass	insertRule of empty string into @media
+Pass	insertRule of valid @media rule followed by garbage into @media
+Pass	insertRule of valid style rule followed by garbage into @media
+Pass	insertRule of mutiple valid @media into @media
+Pass	insertRule of valid style rulle followed by valid @media into @media
+Pass	insertRule of valid style rule followed by valid @media into @media
+Pass	insertRule of two valid style rules into @media
+Pass	Return value of insertRule into @media
+Pass	@supports is CSSGroupingRule
+Pass	@supports rule type
+Pass	Empty @supports rule length
+Fail	insertRule of @import into @supports
+Pass	insertRule into empty @supports at bad index
+Pass	insertRule into @supports updates length
+Pass	insertRule of valid @media into @supports
+Pass	insertRule of valid style rule into @supports
+Fail	insertRule of invalid @media into @supports
+Pass	insertRule of empty string into @supports
+Pass	insertRule of valid @media rule followed by garbage into @supports
+Pass	insertRule of valid style rule followed by garbage into @supports
+Pass	insertRule of mutiple valid @media into @supports
+Pass	insertRule of valid style rulle followed by valid @media into @supports
+Pass	insertRule of valid style rule followed by valid @media into @supports
+Pass	insertRule of two valid style rules into @supports
+Pass	Return value of insertRule into @supports

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.txt
@@ -2,14 +2,14 @@ Harness status: OK
 
 Found 34 tests
 
-30 Pass
-4 Fail
+26 Pass
+8 Fail
 Pass	@media is CSSGroupingRule
 Pass	@media rule type
 Pass	Empty @media rule length
 Fail	insertRule of @import into @media
-Pass	insertRule into empty @media at bad index
-Pass	insertRule into @media updates length
+Fail	insertRule into empty @media at bad index
+Fail	insertRule into @media updates length
 Pass	insertRule of valid @media into @media
 Pass	insertRule of valid style rule into @media
 Fail	insertRule of invalid @media into @media
@@ -25,8 +25,8 @@ Pass	@supports is CSSGroupingRule
 Pass	@supports rule type
 Pass	Empty @supports rule length
 Fail	insertRule of @import into @supports
-Pass	insertRule into empty @supports at bad index
-Pass	insertRule into @supports updates length
+Fail	insertRule into empty @supports at bad index
+Fail	insertRule into @supports updates length
 Pass	insertRule of valid @media into @supports
 Pass	insertRule of valid style rule into @supports
 Fail	insertRule of invalid @media into @supports

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssimportrule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssimportrule.txt
@@ -2,12 +2,12 @@ Harness status: OK
 
 Found 11 tests
 
-7 Pass
-4 Fail
+8 Pass
+3 Fail
 Pass	CSSRule and CSSImportRule types
 Pass	Type of CSSRule#type and constant values
 Pass	Existence and writability of CSSRule attributes
-Fail	Values of CSSRule attributes
+Pass	Values of CSSRule attributes
 Pass	Existence and writability of CSSImportRule attributes
 Fail	Values of CSSImportRule attributes
 Fail	CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssimportrule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssimportrule.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 11 tests
+
+7 Pass
+4 Fail
+Pass	CSSRule and CSSImportRule types
+Pass	Type of CSSRule#type and constant values
+Pass	Existence and writability of CSSRule attributes
+Fail	Values of CSSRule attributes
+Pass	Existence and writability of CSSImportRule attributes
+Fail	Values of CSSImportRule attributes
+Fail	CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]
+Fail	CSSStyleDeclaration cssText attribute should be updated due to [PutForwards]
+Pass	StyleSheet : MediaList mediaText attribute should be updated due to [PutForwards]
+Pass	Existence and writability of CSSImportRule supportsText attribute
+Pass	Value of CSSImportRule supportsText attribute

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-cascade/parsing/supports-import-parsing.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-cascade/parsing/supports-import-parsing.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>@import rule with supports parsing / serialization</title>
+<link rel="author" href="mailto:oj@oojmed.com">
+<link rel="help" href="https://drafts.csswg.org/css-cascade-4/#at-import">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+  function setupSheet(rule) {
+    const style = document.createElement("style");
+    document.head.append(style);
+    const {sheet} = style;
+    const {cssRules} = sheet;
+
+    assert_equals(cssRules.length, 0, "Sheet should have no rules");
+    sheet.insertRule(rule);
+    assert_equals(cssRules.length, 1, "Sheet should have 1 rule");
+
+    return {sheet, cssRules};
+  }
+
+  function test_valid_supports_import(rule, serialized) {
+    if (serialized === undefined)
+        serialized = rule;
+
+    test(function() {
+      const {sheet, cssRules} = setupSheet(rule);
+
+      const serialization = cssRules[0].cssText;
+      assert_equals(serialization, serialized, 'serialization should be canonical');
+
+      sheet.deleteRule(0);
+      assert_equals(cssRules.length, 0, 'Sheet should have no rule');
+      sheet.insertRule(serialization);
+      assert_equals(cssRules.length, 1, 'Sheet should have 1 rule');
+
+      assert_equals(cssRules[0].cssText, serialization, 'serialization should round-trip');
+    }, rule + ' should be a valid supports() import rule');
+  }
+
+  function test_unsupported_supports_import(rule) {
+    test(function() {
+      const {sheet, cssRules} = setupSheet(rule);
+
+      sheet.deleteRule(0);
+      assert_equals(cssRules.length, 0, 'Sheet should have no rule');
+    }, rule + ' should still be a valid import rule with an invalid supports() declaration');
+  }
+
+  function test_invalid_supports_import(rule) {
+    test(function() {
+      const style = document.createElement("style");
+      document.head.append(style);
+      const {sheet} = style;
+      const {cssRules} = sheet;
+
+      assert_equals(cssRules.length, 0, "Sheet should have no rules");
+    }, rule + ' should be an invalid import rule due to an invalid supports() declaration');
+  }
+
+  test_invalid_supports_import('@import url("nonexist.css") supports();');
+  test_invalid_supports_import('@import url("nonexist.css") supports(foo: bar);');
+  test_valid_supports_import('@import url("nonexist.css") supports(display:block);');
+  test_valid_supports_import('@import url("nonexist.css") supports((display:flex));');
+  test_valid_supports_import('@import url("nonexist.css") supports(not (display: flex));');
+  test_valid_supports_import('@import url("nonexist.css") supports((display: flex) and (display: block));');
+  test_valid_supports_import('@import url("nonexist.css") supports((display: flex) or (display: block));');
+  test_valid_supports_import('@import url("nonexist.css") supports((display: flex) or (foo: bar));');
+  test_valid_supports_import('@import url("nonexist.css") supports(display: block !important);');
+
+  test_invalid_supports_import('@import url("nonexist.css") layer supports();');
+  test_invalid_supports_import('@import url("nonexist.css") layer supports(foo: bar);');
+  test_valid_supports_import('@import url("nonexist.css") layer(A) supports((display: flex) or (foo: bar));');
+  test_valid_supports_import('@import url("nonexist.css") layer(A.B) supports((display: flex) and (foo: bar));');
+
+  test_valid_supports_import('@import url("nonexist.css") supports(selector(a));');
+  test_valid_supports_import('@import url("nonexist.css") supports(selector(p a));');
+  test_valid_supports_import('@import url("nonexist.css") supports(selector(p > a));');
+  test_valid_supports_import('@import url("nonexist.css") supports(selector(p + a));');
+
+  test_valid_supports_import('@import url("nonexist.css") supports(font-tech(color-colrv1));');
+  test_valid_supports_import('@import url("nonexist.css") supports(font-format(opentype));');
+
+  test_valid_supports_import('@import url(nonexist.css) supports(display:block);',
+                             '@import url("nonexist.css") supports(display:block);');
+
+  test_valid_supports_import('@import "nonexist.css" supports(display:block);',
+                             '@import url("nonexist.css") supports(display:block);');
+
+  // “supports” gets parsed as an (unsupported) media query.
+  test_unsupported_supports_import('@import url("nonexist.css") supports;');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.html
@@ -1,0 +1,244 @@
+<!DOCTYPE HTML>
+<html lang=en>
+  <title>CSSGroupingRule Conditional Rules Test</title>
+  <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+  <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+  <link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
+  <link rel="help" href="http://www.w3.org/TR/css3-conditional/#the-cssgroupingrule-interface">
+  <meta name="assert" content="requirements in definition of insertRule">
+  <script src="../../../resources/testharness.js"></script>
+  <script src="../../../resources/testharnessreport.js"></script>
+
+<style id="style">
+  @media unsupported { /* tests need to work even if condition is false */ }
+  @supports (unsupported: value) { }
+</style>
+<div id=log></div>
+<div id="test"></div>
+<script>
+
+  var rules = document.getElementById("style").sheet.cssRules;
+  var rule_names = ["@media", "@supports"];
+  var rule_types = [CSSRule.MEDIA_RULE, CSSRule.SUPPORTS_RULE]
+  var rule_nums  = [4, 12]
+
+  for (let i = 0; i < 2; i++) {
+    var grouping_rule = rules[i];
+    var rule_name = rule_names[i];
+
+    test(function() {
+           assert_true(grouping_rule instanceof CSSGroupingRule,
+                       rule_name + " instanceof CSSGroupingRule");
+         },
+         rule_name + " is CSSGroupingRule");
+
+    test(function() {
+           assert_equals(grouping_rule.type, rule_types[i],
+                         "Rule type of " + rule_name + " rule");
+           assert_equals(grouping_rule.type, rule_nums[i],
+                         "Rule number of " + rule_name + " rule");
+         },
+         rule_name + " rule type");
+
+    test(function() {
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Starting cssRules.length of " + rule_name + " rule");
+         },
+         "Empty " + rule_name + " rule length");
+
+    test(function() {
+           assert_throws_dom("HIERARCHY_REQUEST_ERR",
+                             function() {
+                               grouping_rule.insertRule("@import url(foo.css);", 0);
+                             },
+                             "inserting a disallowed rule should throw HIERARCHY_REQUEST_ERR");
+         },
+         "insertRule of @import into " + rule_name);
+
+    test(function() {
+           assert_throws_dom("INDEX_SIZE_ERR",
+                             function() {
+                               grouping_rule.insertRule("p { color: green }", 1);
+                             },
+                             "inserting at a bad index throws INDEX_SIZE_ERR");
+         },
+         "insertRule into empty " + rule_name + " at bad index");
+
+    test(function() {
+           grouping_rule.insertRule("p { color: green }", 0);
+           assert_equals(grouping_rule.cssRules.length, 1,
+                         "Modified cssRules.length of " + rule_name + " rule");
+           grouping_rule.insertRule("p { color: blue }", 1);
+           assert_equals(grouping_rule.cssRules.length, 2,
+                         "Modified cssRules.length of " + rule_name + " rule");
+           grouping_rule.insertRule("p { color: aqua }", 1);
+           assert_equals(grouping_rule.cssRules.length, 3,
+                         "Modified cssRules.length of " + rule_name + " rule");
+           assert_throws_dom("INDEX_SIZE_ERR",
+                             function() {
+                               grouping_rule.insertRule("p { color: green }", 4);
+                             },
+                             "inserting at a bad index throws INDEX_SIZE_ERR");
+           assert_equals(grouping_rule.cssRules.length, 3,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule into " + rule_name + " updates length");
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           grouping_rule.insertRule("@media print {}", 0);
+           assert_equals(grouping_rule.cssRules.length, 1,
+                         "Modified cssRules.length of " + rule_name + " rule");
+           assert_equals(grouping_rule.cssRules[0].type, CSSRule.MEDIA_RULE,
+                         "inserting syntactically correct media rule succeeds");
+         },
+         "insertRule of valid @media into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           grouping_rule.insertRule("p { color: yellow }", 0);
+           assert_equals(grouping_rule.cssRules.length, 1,
+                         "Modified cssRules.length of " + rule_name + " rule");
+           assert_equals(grouping_rule.cssRules[0].type, CSSRule.STYLE_RULE,
+                         "inserting syntactically correct style rule succeeds");
+         },
+         "insertRule of valid style rule into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("@media bad syntax;", 0);
+                             },
+                             "inserting syntactically invalid rule throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of invalid @media into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("", 0);
+                             },
+                             "inserting empty rule throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of empty string into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("@media print {} foo", 0);
+                             },
+                             "inserting rule with garbage afterwards throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of valid @media rule followed by garbage into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("p { color: yellow } foo", 0);
+                             },
+                             "inserting rule with garbage afterwards throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of valid style rule followed by garbage into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("@media print {} @media print {}", 0);
+                             },
+                             "inserting multiple rules throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of mutiple valid @media into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("p { color: yellow } @media print {}", 0);
+                             },
+                             "inserting multiple rules throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of valid style rulle followed by valid @media into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("@media print {} p { color: yellow }", 0);
+                             },
+                             "inserting multiple rules throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of valid style rule followed by valid @media into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           assert_throws_dom("SYNTAX_ERR",
+                             function() {
+                               grouping_rule.insertRule("p { color: yellow } p { color: yellow }", 0);
+                             },
+                             "inserting multiple rules throws syntax error");
+           assert_equals(grouping_rule.cssRules.length, 0,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "insertRule of two valid style rules into " + rule_name);
+
+    test(function() {
+           while (grouping_rule.cssRules.length > 0) {
+             grouping_rule.deleteRule(0);
+           }
+           var res = grouping_rule.insertRule("p { color: green }", 0);
+           assert_equals(res, 0, "return value should be index");
+           assert_equals(grouping_rule.cssRules.length, 1,
+                         "Modified cssRules.length of " + rule_name + " rule");
+           res = grouping_rule.insertRule("p { color: green }", 0);
+           assert_equals(res, 0, "return value should be index");
+           assert_equals(grouping_rule.cssRules.length, 2,
+                         "Modified cssRules.length of " + rule_name + " rule");
+           res = grouping_rule.insertRule("p { color: green }", 2);
+           assert_equals(res, 2, "return value should be index");
+           assert_equals(grouping_rule.cssRules.length, 3,
+                         "Modified cssRules.length of " + rule_name + " rule");
+         },
+         "Return value of insertRule into " + rule_name);
+  }
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/cssimportrule.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/cssimportrule.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSSOM CSSRule CSSImportRule interface</title>
+    <link rel="author" title="Letitia Lew" href="mailto:lew.letitia@gmail.com">
+    <link rel="help" href="http://www.w3.org/TR/cssom-1/#css-rules">
+    <link rel="help" href="http://www.w3.org/TR/cssom-1/#the-cssrule-interface">
+    <link rel="help" href="http://www.w3.org/TR/cssom-1/#the-cssimportrule-interface">
+    <meta name="flags" content="dom">
+    <meta name="assert" content="All properties for this CSSImportRule instance of CSSRule are initialized correctly">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+
+    <style id="styleElement" type="text/css">
+        @import url("support/a-green.css");
+        @import url("support/a-green.css") screen;
+        @import url("support/a-green.css") all;
+        @import url("support/a-green") supports((display: flex) or (display: block));
+        @import url('quote"quote');
+        @page { background-color: red; }
+    </style>
+</head>
+<body>
+    <div id="log"></div>
+
+    <script type="text/javascript">
+        var styleSheet, ruleList, rule, ruleWithMedia, ruleWithMediaAll, ruleWithSupports, ruleWithQuote;
+        setup(function() {
+            styleSheet = document.getElementById("styleElement").sheet;
+            ruleList = styleSheet.cssRules;
+            rule = ruleList[0];
+            ruleWithMedia = ruleList[1];
+            ruleWithMediaAll = ruleList[2];
+            ruleWithSupports = ruleList[3];
+            ruleWithQuote = ruleList[4];
+        });
+
+        test(function() {
+            assert_true(rule instanceof CSSRule);
+            assert_true(rule instanceof CSSImportRule);
+            assert_true(ruleWithMedia instanceof CSSRule);
+            assert_true(ruleWithMedia instanceof CSSImportRule);
+            assert_true(ruleWithSupports instanceof CSSRule);
+            assert_true(ruleWithSupports instanceof CSSImportRule);
+        }, "CSSRule and CSSImportRule types");
+
+        test(function() {
+            assert_equals(rule.STYLE_RULE, 1);
+            assert_equals(rule.IMPORT_RULE, 3);
+            assert_equals(rule.MEDIA_RULE, 4);
+            assert_equals(rule.FONT_FACE_RULE, 5);
+            assert_equals(rule.PAGE_RULE, 6);
+            assert_equals(rule.NAMESPACE_RULE, 10);
+            assert_idl_attribute(rule, "type");
+            assert_equals(typeof rule.type, "number");
+        }, "Type of CSSRule#type and constant values");
+
+        test(function() {
+            assert_true(rule instanceof CSSRule);
+            assert_idl_attribute(rule, "cssText");
+            assert_idl_attribute(rule, "parentRule");
+            assert_idl_attribute(rule, "parentStyleSheet");
+
+            assert_readonly(rule, "type");
+            assert_readonly(rule, "parentRule");
+            assert_readonly(rule, "parentStyleSheet");
+        }, "Existence and writability of CSSRule attributes");
+
+        test(function() {
+            assert_equals(rule.type, rule.IMPORT_RULE);
+            assert_equals(typeof rule.cssText, "string");
+            assert_equals(rule.cssText, '@import url("support/a-green.css");');
+            assert_equals(ruleWithMedia.cssText, '@import url("support/a-green.css") screen;');
+            assert_equals(ruleWithMediaAll.cssText, '@import url("support/a-green.css") all;');
+            assert_equals(ruleWithSupports.cssText, '@import url("support/a-green") supports((display: flex) or (display: block));');
+            assert_equals(ruleWithQuote.cssText, '@import url("quote\\\"quote");');
+            assert_equals(rule.parentRule, null);
+            assert_true(rule.parentStyleSheet instanceof CSSStyleSheet);
+        }, "Values of CSSRule attributes");
+
+        test(function() {
+            assert_idl_attribute(rule, "href");
+            assert_idl_attribute(rule, "media");
+            assert_idl_attribute(rule, "styleSheet");
+
+            assert_readonly(rule, "href");
+            assert_readonly(rule, "styleSheet");
+        }, "Existence and writability of CSSImportRule attributes");
+
+        test(function() {
+            assert_equals(typeof rule.href, "string");
+            assert_true(rule.media instanceof MediaList);
+            assert_true(rule.styleSheet instanceof CSSStyleSheet);
+            assert_true(ruleWithMedia.media.length > 0);
+            assert_equals(ruleWithMedia.media.mediaText, "screen");
+        }, "Values of CSSImportRule attributes");
+
+        test(function() {
+            ruleWithMedia.media = "print";
+            assert_equals(ruleWithMedia.media.mediaText, "print");
+        }, "CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]");
+
+        test(function() {
+            var ruleWithPage = ruleList[5];
+            ruleWithPage.style = "margin-top: 10px;"
+            assert_equals(ruleWithPage.style.cssText, "margin-top: 10px;");
+        }, "CSSStyleDeclaration cssText attribute should be updated due to [PutForwards]");
+
+        test(function() {
+            styleSheet.media = "screen";
+            assert_equals(styleSheet.media.mediaText, "screen");
+        }, "StyleSheet : MediaList mediaText attribute should be updated due to [PutForwards]");
+
+        test(function() {
+            assert_idl_attribute(ruleWithSupports, "supportsText");
+            assert_readonly(ruleWithSupports, "supportsText");
+        }, "Existence and writability of CSSImportRule supportsText attribute");
+
+        test(function() {
+            assert_equals(ruleWithSupports.supportsText, "(display: flex) or (display: block)");
+        }, "Value of CSSImportRule supportsText attribute");
+    </script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/support/a-green.css
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/support/a-green.css
@@ -1,0 +1,1 @@
+.a { color: green; }


### PR DESCRIPTION
For a long time we've absolutized relative URLs in CSS during parsing. This is bad and wrong and I don't want to go look to see why in case it was my fault. :face_with_peeking_eye:

By *not* returning a parsed URL from the CSS Parser, we get a few benefits: serialization is better, the `href` attribute returns the right thing, and we have a place to put any `<url-modifier>`s once we support those.

URLs are used a lot, so I've tried to tackle this gradually, changing one user at a time. This PR is just as far as I got with it today: Doing the Right Thing :tm: for `@import`. There's more to do, and I'll keep going with it once this is merged.