### PR TITLE
Everywhere: Make TransportSocket non-movable

### DIFF
--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -35,10 +35,10 @@ public:
     void shutdown();
     virtual void die() { }
 
-    Transport& transport() { return m_transport; }
+    Transport& transport() const { return *m_transport; }
 
 protected:
-    explicit ConnectionBase(IPC::Stub&, Transport, u32 local_endpoint_magic);
+    explicit ConnectionBase(IPC::Stub&, NonnullOwnPtr<Transport>, u32 local_endpoint_magic);
 
     virtual void may_have_become_unresponsive() { }
     virtual void did_become_responsive() { }
@@ -53,7 +53,7 @@ protected:
 
     IPC::Stub& m_local_stub;
 
-    Transport m_transport;
+    NonnullOwnPtr<Transport> m_transport;
 
     RefPtr<Core::Timer> m_responsiveness_timer;
 
@@ -65,7 +65,7 @@ protected:
 template<typename LocalEndpoint, typename PeerEndpoint>
 class Connection : public ConnectionBase {
 public:
-    Connection(IPC::Stub& local_stub, Transport transport)
+    Connection(IPC::Stub& local_stub, NonnullOwnPtr<Transport> transport)
         : ConnectionBase(local_stub, move(transport), LocalEndpoint::static_magic())
     {
     }

--- a/Libraries/LibIPC/ConnectionFromClient.h
+++ b/Libraries/LibIPC/ConnectionFromClient.h
@@ -26,7 +26,7 @@ public:
     using ServerStub = typename ServerEndpoint::Stub;
     using IPCProxy = typename ClientEndpoint::template Proxy<ServerEndpoint>;
 
-    ConnectionFromClient(ServerStub& stub, Transport transport, int client_id)
+    ConnectionFromClient(ServerStub& stub, NonnullOwnPtr<Transport> transport, int client_id)
         : IPC::Connection<ServerEndpoint, ClientEndpoint>(stub, move(transport))
         , ClientEndpoint::template Proxy<ServerEndpoint>(*this, {})
         , m_client_id(client_id)

--- a/Libraries/LibIPC/ConnectionToServer.h
+++ b/Libraries/LibIPC/ConnectionToServer.h
@@ -18,7 +18,7 @@ public:
     using ClientStub = typename ClientEndpoint::Stub;
     using IPCProxy = typename ServerEndpoint::template Proxy<ClientEndpoint>;
 
-    ConnectionToServer(ClientStub& local_endpoint, Transport transport)
+    ConnectionToServer(ClientStub& local_endpoint, NonnullOwnPtr<Transport> transport)
         : Connection<ClientEndpoint, ServerEndpoint>(local_endpoint, move(transport))
         , ServerEndpoint::template Proxy<ClientEndpoint>(*this, {})
     {

--- a/Libraries/LibIPC/MultiServer.h
+++ b/Libraries/LibIPC/MultiServer.h
@@ -30,7 +30,7 @@ private:
         m_server->on_accept = [&](auto client_socket) {
             auto client_id = ++m_next_client_id;
 
-            auto client = IPC::new_client_connection<ConnectionFromClientType>(IPC::Transport(move(client_socket)), client_id);
+            auto client = IPC::new_client_connection<ConnectionFromClientType>(make<IPC::Transport>(move(client_socket)), client_id);
             if (on_new_client)
                 on_new_client(*client);
         };

--- a/Libraries/LibIPC/SingleServer.h
+++ b/Libraries/LibIPC/SingleServer.h
@@ -16,7 +16,7 @@ template<typename ConnectionFromClientType>
 ErrorOr<NonnullRefPtr<ConnectionFromClientType>> take_over_accepted_client_from_system_server()
 {
     auto socket = TRY(Core::take_over_socket_from_system_server());
-    return IPC::new_client_connection<ConnectionFromClientType>(IPC::Transport(move(socket)));
+    return IPC::new_client_connection<ConnectionFromClientType>(make<IPC::Transport>(move(socket)));
 }
 
 }

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -44,7 +44,7 @@ private:
 
 class TransportSocket {
     AK_MAKE_NONCOPYABLE(TransportSocket);
-    AK_MAKE_DEFAULT_MOVABLE(TransportSocket);
+    AK_MAKE_NONMOVABLE(TransportSocket);
 
 public:
     static constexpr socklen_t SOCKET_BUFFER_SIZE = 128 * KiB;
@@ -58,7 +58,7 @@ public:
 
     void wait_until_readable();
 
-    void post_message(Vector<u8> const&, Vector<NonnullRefPtr<AutoCloseFileDescriptor>> const&) const;
+    void post_message(Vector<u8> const&, Vector<NonnullRefPtr<AutoCloseFileDescriptor>> const&);
 
     enum class ShouldShutdown {
         No,
@@ -85,7 +85,7 @@ private:
     // After file descriptor is sent, it is moved to the wait queue until an acknowledgement is received from the peer.
     // This is necessary to handle a specific behavior of the macOS kernel, which may prematurely garbage-collect the file
     // descriptor contained in the message before the peer receives it. https://openradar.me/9477351
-    NonnullOwnPtr<Queue<NonnullRefPtr<AutoCloseFileDescriptor>>> m_fds_retained_until_received_by_peer;
+    Queue<NonnullRefPtr<AutoCloseFileDescriptor>> m_fds_retained_until_received_by_peer;
 
     struct MessageToSend {
         Vector<u8> bytes;

--- a/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Libraries/LibImageDecoderClient/Client.cpp
@@ -9,7 +9,7 @@
 
 namespace ImageDecoderClient {
 
-Client::Client(IPC::Transport transport)
+Client::Client(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(transport))
 {
 }

--- a/Libraries/LibImageDecoderClient/Client.h
+++ b/Libraries/LibImageDecoderClient/Client.h
@@ -36,7 +36,7 @@ class Client final
 public:
     using InitTransport = Messages::ImageDecoderServer::InitTransport;
 
-    Client(IPC::Transport);
+    Client(NonnullOwnPtr<IPC::Transport>);
 
     NonnullRefPtr<Core::Promise<DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});
 

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -10,7 +10,7 @@
 
 namespace Requests {
 
-RequestClient::RequestClient(IPC::Transport transport)
+RequestClient::RequestClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>(*this, move(transport))
 {
 }

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -27,7 +27,7 @@ class RequestClient final
 public:
     using InitTransport = Messages::RequestServer::InitTransport;
 
-    explicit RequestClient(IPC::Transport);
+    explicit RequestClient(NonnullOwnPtr<IPC::Transport>);
     virtual ~RequestClient() override;
 
     RefPtr<Request> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {});

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -86,7 +86,7 @@ private:
     // https://html.spec.whatwg.org/multipage/web-messaging.html#has-been-shipped
     bool m_has_been_shipped { false };
 
-    Optional<IPC::Transport> m_transport;
+    OwnPtr<IPC::Transport> m_transport;
 
     GC::Ptr<DOM::EventTarget> m_worker_event_target;
 };

--- a/Libraries/LibWeb/HTML/WorkerAgent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgent.cpp
@@ -40,7 +40,7 @@ void WorkerAgent::initialize(JS::Realm& realm)
     MUST(worker_socket->set_blocking(true));
 
     // TODO: Mach IPC
-    auto transport = IPC::Transport(move(worker_socket));
+    auto transport = make<IPC::Transport>(move(worker_socket));
 
     m_worker_ipc = make_ref_counted<WebWorkerClient>(move(transport));
 

--- a/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -20,14 +20,14 @@ void WebWorkerClient::did_close_worker()
         on_worker_close();
 }
 
-WebWorkerClient::WebWorkerClient(IPC::Transport transport)
+WebWorkerClient::WebWorkerClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport))
 {
 }
 
 IPC::File WebWorkerClient::clone_transport()
 {
-    return MUST(m_transport.clone_for_transfer());
+    return MUST(m_transport->clone_for_transfer());
 }
 
 }

--- a/Libraries/LibWeb/Worker/WebWorkerClient.h
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.h
@@ -18,7 +18,7 @@ class WebWorkerClient final
     C_OBJECT_ABSTRACT(WebWorkerClient);
 
 public:
-    explicit WebWorkerClient(IPC::Transport);
+    explicit WebWorkerClient(NonnullOwnPtr<IPC::Transport>);
 
     virtual void did_close_worker() override;
 

--- a/Libraries/LibWebView/BrowserProcess.h
+++ b/Libraries/LibWebView/BrowserProcess.h
@@ -32,7 +32,7 @@ public:
     Function<void(Vector<URL::URL> const&)> on_new_window;
 
 private:
-    UIProcessConnectionFromClient(IPC::Transport, int client_id);
+    UIProcessConnectionFromClient(NonnullOwnPtr<IPC::Transport>, int client_id);
 
     virtual void create_new_tab(Vector<ByteString> urls) override;
     virtual void create_new_window(Vector<ByteString> urls) override;

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -47,7 +47,7 @@ ErrorOr<Process::ProcessAndIPCTransport> Process::spawn_and_connect_to_process(C
     guard_fd_0.disarm();
     TRY(ipc_socket->set_blocking(true));
 
-    return ProcessAndIPCTransport { move(process), IPC::Transport(move(ipc_socket)) };
+    return ProcessAndIPCTransport { move(process), make<IPC::Transport>(move(ipc_socket)) };
 }
 
 #ifdef AK_OS_WINDOWS

--- a/Libraries/LibWebView/Process.h
+++ b/Libraries/LibWebView/Process.h
@@ -54,7 +54,7 @@ public:
 private:
     struct ProcessAndIPCTransport {
         Core::Process process;
-        IPC::Transport transport;
+        NonnullOwnPtr<IPC::Transport> transport;
     };
     static ErrorOr<ProcessAndIPCTransport> spawn_and_connect_to_process(Core::ProcessSpawnOptions const& options);
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -25,14 +25,14 @@ Optional<ViewImplementation&> WebContentClient::view_for_pid_and_page_id(pid_t p
     return {};
 }
 
-WebContentClient::WebContentClient(IPC::Transport transport, ViewImplementation& view)
+WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, ViewImplementation& view)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
 {
     s_clients.set(this);
     m_views.set(0, &view);
 }
 
-WebContentClient::WebContentClient(IPC::Transport transport)
+WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
 {
     s_clients.set(this);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -39,8 +39,8 @@ public:
 
     static size_t client_count() { return s_clients.size(); }
 
-    explicit WebContentClient(IPC::Transport);
-    WebContentClient(IPC::Transport, ViewImplementation&);
+    explicit WebContentClient(NonnullOwnPtr<IPC::Transport>);
+    WebContentClient(NonnullOwnPtr<IPC::Transport>, ViewImplementation&);
     ~WebContentClient();
 
     void assign_view(Badge<Application>, ViewImplementation&);

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -27,7 +27,7 @@ static ErrorOr<NonnullRefPtr<WebUIType>> create_web_ui(WebContentClient& client,
         return client_socket.release_error();
     }
 
-    auto web_ui = WebUIType::create(client, IPC::Transport { client_socket.release_value() }, move(host));
+    auto web_ui = WebUIType::create(client, make<IPC::Transport>(client_socket.release_value()), move(host));
     client.async_connect_to_web_ui(0, IPC::File::adopt_fd(socket_fds[1]));
 
     return web_ui;
@@ -48,7 +48,7 @@ ErrorOr<RefPtr<WebUI>> WebUI::create(WebContentClient& client, String host)
     return web_ui;
 }
 
-WebUI::WebUI(WebContentClient& client, IPC::Transport transport, String host)
+WebUI::WebUI(WebContentClient& client, NonnullOwnPtr<IPC::Transport> transport, String host)
     : IPC::ConnectionToServer<WebUIClientEndpoint, WebUIServerEndpoint>(*this, move(transport))
     , m_client(client)
     , m_host(move(host))

--- a/Libraries/LibWebView/WebUI.h
+++ b/Libraries/LibWebView/WebUI.h
@@ -30,7 +30,7 @@ public:
     String const& host() const { return m_host; }
 
 protected:
-    WebUI(WebContentClient&, IPC::Transport, String host);
+    WebUI(WebContentClient&, NonnullOwnPtr<IPC::Transport>, String host);
 
     using Interface = Function<void(JsonValue)>;
 
@@ -47,17 +47,17 @@ private:
     HashMap<StringView, Interface> m_interfaces;
 };
 
-#define WEB_UI(WebUIType)                                                                                   \
-public:                                                                                                     \
-    static NonnullRefPtr<WebUIType> create(WebContentClient& client, IPC::Transport transport, String host) \
-    {                                                                                                       \
-        return adopt_ref(*new WebUIType(client, move(transport), move(host)));                              \
-    }                                                                                                       \
-                                                                                                            \
-private:                                                                                                    \
-    WebUIType(WebContentClient& client, IPC::Transport transport, String host)                              \
-        : WebView::WebUI(client, move(transport), move(host))                                               \
-    {                                                                                                       \
+#define WEB_UI(WebUIType)                                                                                                  \
+public:                                                                                                                    \
+    static NonnullRefPtr<WebUIType> create(WebContentClient& client, NonnullOwnPtr<IPC::Transport> transport, String host) \
+    {                                                                                                                      \
+        return adopt_ref(*new WebUIType(client, move(transport), move(host)));                                             \
+    }                                                                                                                      \
+                                                                                                                           \
+private:                                                                                                                   \
+    WebUIType(WebContentClient& client, NonnullOwnPtr<IPC::Transport> transport, String host)                              \
+        : WebView::WebUI(client, move(transport), move(host))                                                              \
+    {                                                                                                                      \
     }
 
 }

--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -17,7 +17,7 @@ namespace ImageDecoder {
 static HashMap<int, RefPtr<ConnectionFromClient>> s_connections;
 static IDAllocator s_client_ids;
 
-ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionFromClient<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(transport), s_client_ids.allocate())
 {
     s_connections.set(client_id(), *this);
@@ -64,7 +64,7 @@ ErrorOr<IPC::File> ConnectionFromClient::connect_new_client()
 
     auto client_socket = client_socket_or_error.release_value();
     // Note: A ref is stored in the static s_connections map
-    auto client = adopt_ref(*new ConnectionFromClient(IPC::Transport(move(client_socket))));
+    auto client = adopt_ref(*new ConnectionFromClient(make<IPC::Transport>(move(client_socket))));
 
     return IPC::File::adopt_fd(socket_fds[1]);
 }

--- a/Services/ImageDecoder/ConnectionFromClient.h
+++ b/Services/ImageDecoder/ConnectionFromClient.h
@@ -38,7 +38,7 @@ public:
 private:
     using Job = Threading::BackgroundAction<DecodeResult>;
 
-    explicit ConnectionFromClient(IPC::Transport);
+    explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
 
     virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) override;
     virtual void cancel_decoding(i64 image_id) override;

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -264,7 +264,7 @@ int ConnectionFromClient::on_timeout_callback(void*, long timeout_ms, void* user
     return 0;
 }
 
-ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionFromClient<RequestClientEndpoint, RequestServerEndpoint>(*this, move(transport), s_client_ids.allocate())
     , m_resolver(default_resolver())
 {
@@ -335,7 +335,7 @@ Messages::RequestServer::ConnectNewClientResponse ConnectionFromClient::connect_
     }
     auto client_socket = client_socket_or_error.release_value();
     // Note: A ref is stored in the static s_connections map
-    auto client = adopt_ref(*new ConnectionFromClient(IPC::Transport(move(client_socket))));
+    auto client = adopt_ref(*new ConnectionFromClient(make<IPC::Transport>(move(client_socket))));
 
     return IPC::File::adopt_fd(socket_fds[1]);
 }

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -35,7 +35,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ConnectionFromClient(IPC::Transport);
+    explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
 
     virtual Messages::RequestServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client() override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -56,7 +56,7 @@
 
 namespace WebContent {
 
-ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionFromClient<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport), 1)
     , m_page_host(PageHost::create(*this))
 {

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -51,7 +51,7 @@ public:
     Queue<Web::QueuedInputEvent>& input_event_queue() { return m_input_event_queue; }
 
 private:
-    explicit ConnectionFromClient(IPC::Transport);
+    explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
 
     Optional<PageClient&> page(u64 index, SourceLocation = SourceLocation::current());
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -197,10 +197,10 @@ ErrorOr<NonnullRefPtr<WebDriverConnection>> WebDriverConnection::connect(Web::Pa
     page_client.page().set_should_block_pop_ups(false);
 
     dbgln_if(WEBDRIVER_DEBUG, "Connected to WebDriver");
-    return adopt_nonnull_ref_or_enomem(new (nothrow) WebDriverConnection(IPC::Transport(move(socket)), page_client));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) WebDriverConnection(make<IPC::Transport>(move(socket)), page_client));
 }
 
-WebDriverConnection::WebDriverConnection(IPC::Transport transport, Web::PageClient& page_client)
+WebDriverConnection::WebDriverConnection(NonnullOwnPtr<IPC::Transport> transport, Web::PageClient& page_client)
     : IPC::ConnectionToServer<WebDriverClientEndpoint, WebDriverServerEndpoint>(*this, move(transport))
 {
     set_current_top_level_browsing_context(page_client.page().top_level_browsing_context());

--- a/Services/WebContent/WebDriverConnection.h
+++ b/Services/WebContent/WebDriverConnection.h
@@ -42,7 +42,7 @@ public:
     void page_did_open_dialog(Badge<PageClient>);
 
 private:
-    WebDriverConnection(IPC::Transport transport, Web::PageClient& page_client);
+    WebDriverConnection(NonnullOwnPtr<IPC::Transport> transport, Web::PageClient& page_client);
 
     virtual void die() override { }
 

--- a/Services/WebContent/WebUIConnection.cpp
+++ b/Services/WebContent/WebUIConnection.cpp
@@ -26,10 +26,10 @@ ErrorOr<NonnullRefPtr<WebUIConnection>> WebUIConnection::connect(IPC::File web_u
     auto socket = TRY(Core::LocalSocket::adopt_fd(web_ui_socket.take_fd()));
     TRY(socket->set_blocking(true));
 
-    return adopt_ref(*new WebUIConnection(IPC::Transport { move(socket) }, document));
+    return adopt_ref(*new WebUIConnection(make<IPC::Transport>(move(socket)), document));
 }
 
-WebUIConnection::WebUIConnection(IPC::Transport transport, Web::DOM::Document& document)
+WebUIConnection::WebUIConnection(NonnullOwnPtr<IPC::Transport> transport, Web::DOM::Document& document)
     : IPC::ConnectionFromClient<WebUIClientEndpoint, WebUIServerEndpoint>(*this, move(transport), 1)
     , m_document(document)
 {

--- a/Services/WebContent/WebUIConnection.h
+++ b/Services/WebContent/WebUIConnection.h
@@ -28,7 +28,7 @@ public:
     void received_message_from_web_ui(String const& name, JS::Value data);
 
 private:
-    WebUIConnection(IPC::Transport, Web::DOM::Document&);
+    WebUIConnection(NonnullOwnPtr<IPC::Transport>, Web::DOM::Document&);
 
     virtual void die() override { }
     virtual void send_message(String name, JsonValue data) override;

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -206,7 +206,7 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(NonnullRefPtr<S
     server->listen(*m_web_content_socket_path);
 
     server->on_accept = [this, promise](auto client_socket) {
-        auto maybe_connection = adopt_nonnull_ref_or_enomem(new (nothrow) WebContentConnection(IPC::Transport(move(client_socket))));
+        auto maybe_connection = adopt_nonnull_ref_or_enomem(new (nothrow) WebContentConnection(make<IPC::Transport>(move(client_socket))));
         if (maybe_connection.is_error()) {
             promise->resolve(maybe_connection.release_error());
             return;

--- a/Services/WebDriver/WebContentConnection.cpp
+++ b/Services/WebDriver/WebContentConnection.cpp
@@ -9,7 +9,7 @@
 
 namespace WebDriver {
 
-WebContentConnection::WebContentConnection(IPC::Transport transport)
+WebContentConnection::WebContentConnection(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionFromClient<WebDriverClientEndpoint, WebDriverServerEndpoint>(*this, move(transport), 1)
 {
 }

--- a/Services/WebDriver/WebContentConnection.h
+++ b/Services/WebDriver/WebContentConnection.h
@@ -19,7 +19,7 @@ class WebContentConnection
     : public IPC::ConnectionFromClient<WebDriverClientEndpoint, WebDriverServerEndpoint> {
     C_OBJECT_ABSTRACT(WebContentConnection)
 public:
-    explicit WebContentConnection(IPC::Transport transport);
+    explicit WebContentConnection(NonnullOwnPtr<IPC::Transport> transport);
 
     Function<void()> on_close;
     Function<void(Web::WebDriver::Response)> on_driver_execution_complete;

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -45,7 +45,7 @@ void ConnectionFromClient::request_file(Web::FileRequest request)
         handle_file_return(0, IPC::File::adopt_file(file.release_value()), request_id);
 }
 
-ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
+ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionFromClient<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport), 1)
     , m_page_host(PageHost::create(Web::Bindings::main_thread_vm(), *this))
 {

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -36,7 +36,7 @@ public:
     PageHost const& page_host() const { return *m_page_host; }
 
 private:
-    explicit ConnectionFromClient(IPC::Transport);
+    explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
 
     Web::Page& page();
     Web::Page const& page() const;

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -83,7 +83,7 @@ static ErrorOr<void> initialize_image_decoder(int image_decoder_socket)
     auto socket = TRY(Core::LocalSocket::adopt_fd(image_decoder_socket));
     TRY(socket->set_blocking(true));
 
-    auto new_client = TRY(try_make_ref_counted<ImageDecoderClient::Client>(IPC::Transport(move(socket))));
+    auto new_client = TRY(try_make_ref_counted<ImageDecoderClient::Client>(make<IPC::Transport>(move(socket))));
 #ifdef AK_OS_WINDOWS
     auto response = new_client->send_sync<Messages::ImageDecoderServer::InitTransport>(Core::System::getpid());
     new_client->transport().set_peer_pid(response->peer_pid());
@@ -101,7 +101,7 @@ static ErrorOr<void> initialize_resource_loader(GC::Heap& heap, int request_serv
     auto socket = TRY(Core::LocalSocket::adopt_fd(request_server_socket));
     TRY(socket->set_blocking(true));
 
-    auto request_client = TRY(try_make_ref_counted<Requests::RequestClient>(IPC::Transport(move(socket))));
+    auto request_client = TRY(try_make_ref_counted<Requests::RequestClient>(make<IPC::Transport>(move(socket))));
 #ifdef AK_OS_WINDOWS
     auto response = request_client->send_sync<Messages::RequestServer::InitTransport>(Core::System::getpid());
     request_client->transport().set_peer_pid(response->peer_pid());


### PR DESCRIPTION
Instead of wrapping all non-movable members of TransportSocket in OwnPtr to keep it movable, make TransportSocket itself non-movable and wrap it in OwnPtr.