### PR TITLE
Use dbgln for "Trying to post_message during IPC shutdown" error

### DIFF
--- a/Libraries/LibIPC/Connection.cpp
+++ b/Libraries/LibIPC/Connection.cpp
@@ -47,8 +47,10 @@ ErrorOr<void> ConnectionBase::post_message(u32 endpoint_magic, MessageBuffer buf
 {
     // NOTE: If this connection is being shut down, but has not yet been destroyed,
     //       the socket will be closed. Don't try to send more messages.
-    if (!m_transport->is_open())
-        return Error::from_string_literal("Trying to post_message during IPC shutdown");
+    if (!m_transport->is_open()) {
+        dbgln("Trying to post_message during IPC shutdown");
+        return {};
+    }
 
     if (buffer.data().size() > TransportSocket::SOCKET_BUFFER_SIZE) {
         auto wrapper = LargeMessageWrapper::create(endpoint_magic, buffer);


### PR DESCRIPTION
Before this change, we were getting a stack trace for this error on
Linux whenever the headless-browser tests successfully completed, which
was annoying. Let's switch to only printing a log message instead,
because there is nothing meaningful we can do if a message is sent
during shutdown.