### PR TITLE
LibJS: ToInt32 speedups (especially if you have FJCVTZS!)

### DIFF
--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -953,42 +953,6 @@ ThrowCompletionOr<i32> Value::to_i32_slow_case(VM& vm) const
     return static_cast<i32>(int32bit);
 }
 
-// 7.1.6 ToInt32 ( argument ), https://tc39.es/ecma262/#sec-toint32
-ThrowCompletionOr<i32> Value::to_i32(VM& vm) const
-{
-    if (is_int32())
-        return as_i32();
-    return to_i32_slow_case(vm);
-}
-
-// 7.1.7 ToUint32 ( argument ), https://tc39.es/ecma262/#sec-touint32
-ThrowCompletionOr<u32> Value::to_u32(VM& vm) const
-{
-    // OPTIMIZATION: If this value is encoded as a positive i32, return it directly.
-    if (is_int32() && as_i32() >= 0)
-        return as_i32();
-
-    // 1. Let number be ? ToNumber(argument).
-    double number = TRY(to_number(vm)).as_double();
-
-    // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
-    if (!isfinite(number) || number == 0)
-        return 0;
-
-    // 3. Let int be the mathematical value whose sign is the sign of number and whose magnitude is floor(abs(ℝ(number))).
-    auto int_val = floor(fabs(number));
-    if (signbit(number))
-        int_val = -int_val;
-
-    // 4. Let int32bit be int modulo 2^32.
-    auto int32bit = modulo(int_val, NumericLimits<u32>::max() + 1.0);
-
-    // 5. Return 𝔽(int32bit).
-    // Cast to i64 here to ensure that the double --> u32 cast doesn't invoke undefined behavior
-    // Otherwise, negative numbers cause a UBSAN warning.
-    return static_cast<u32>(static_cast<i64>(int32bit));
-}
-
 // 7.1.8 ToInt16 ( argument ), https://tc39.es/ecma262/#sec-toint16
 ThrowCompletionOr<i16> Value::to_i16(VM& vm) const
 {

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -934,6 +934,9 @@ ThrowCompletionOr<i32> Value::to_i32_slow_case(VM& vm) const
     // 1. Let number be ? ToNumber(argument).
     double number = TRY(to_number(vm)).as_double();
 
+#if __has_builtin(__builtin_arm_jcvt)
+    return __builtin_arm_jcvt(number);
+#else
     // 2. If number is not finite or number is either +0𝔽 or -0𝔽, return +0𝔽.
     if (!isfinite(number) || number == 0)
         return 0;
@@ -951,6 +954,7 @@ ThrowCompletionOr<i32> Value::to_i32_slow_case(VM& vm) const
     if (int32bit >= 2147483648.0)
         int32bit -= 4294967296.0;
     return static_cast<i32>(int32bit);
+#endif
 }
 
 // 7.1.8 ToInt16 ( argument ), https://tc39.es/ecma262/#sec-toint16

--- a/Libraries/LibJS/Runtime/ValueInlines.h
+++ b/Libraries/LibJS/Runtime/ValueInlines.h
@@ -54,6 +54,11 @@ inline ThrowCompletionOr<i32> Value::to_i32(VM& vm) const
     if (is_int32())
         return as_i32();
 
+#if __has_builtin(__builtin_arm_jcvt)
+    if (is_double())
+        return __builtin_arm_jcvt(m_value.as_double);
+#endif
+
     return to_i32_slow_case(vm);
 }
 

--- a/Libraries/LibJS/Runtime/ValueInlines.h
+++ b/Libraries/LibJS/Runtime/ValueInlines.h
@@ -48,4 +48,19 @@ inline ThrowCompletionOr<Value> Value::to_primitive(VM& vm, PreferredType prefer
     return to_primitive_slow_case(vm, preferred_type);
 }
 
+// 7.1.6 ToInt32 ( argument ), https://tc39.es/ecma262/#sec-toint32
+inline ThrowCompletionOr<i32> Value::to_i32(VM& vm) const
+{
+    if (is_int32())
+        return as_i32();
+
+    return to_i32_slow_case(vm);
+}
+
+// 7.1.7 ToUint32 ( argument ), https://tc39.es/ecma262/#sec-touint32
+inline ThrowCompletionOr<u32> Value::to_u32(VM& vm) const
+{
+    return static_cast<u32>(TRY(to_i32(vm)));
+}
+
 }

--- a/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLImageElementPrototype.h>
 #include <LibWeb/Bindings/ImageConstructor.h>

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -30,6 +30,7 @@
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DataView.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Crypto/CryptoAlgorithms.h>
 #include <LibWeb/Crypto/KeyAlgorithms.h>

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -11,6 +11,7 @@
 #include <LibCrypto/Hash/HashManager.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/JSONObject.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SubtleCryptoPrototype.h>

--- a/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/NodeIteratorPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Node.h>

--- a/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/TreeWalkerPrototype.h>
 #include <LibWeb/DOM/Node.h>

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -16,6 +16,7 @@
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWasm/AbstractMachine/Validator.h>
 #include <LibWeb/Bindings/ResponsePrototype.h>
 #include <LibWeb/Fetch/Response.h>

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/MemoryStream.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibTest/JavaScriptTestRunner.h>
 #include <LibWasm/AbstractMachine/BytecodeInterpreter.h>
 #include <LibWasm/Types.h>


### PR DESCRIPTION
See individual commits.

Nice benchmark results from my M3 MacBook Pro:

```
Suite       Test                                   Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------  ---------------------------
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                           1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                   1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    1      0.125 ± 0.120 … 0.130        0.125 ± 0.120 … 0.130
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-partial-sums.js                     1      0.050 ± 0.050 … 0.050        0.050 ± 0.050 … 0.050
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            0.984  0.305 ± 0.300 … 0.310        0.310 ± 0.310 … 0.310
SunSpider   string-base64.js                         1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   string-fasta.js                          1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-tagcloud.js                       1      0.150 ± 0.150 … 0.150        0.150 ± 0.150 … 0.150
SunSpider   string-unpack-code.js                    1      0.110 ± 0.110 … 0.110        0.110 ± 0.110 … 0.110
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
Kraken      ai-astar.js                              0.986  1.025 ± 1.010 … 1.040        1.040 ± 1.020 … 1.060
Kraken      audio-beat-detection.js                  0.994  0.855 ± 0.850 … 0.860        0.860 ± 0.860 … 0.860
Kraken      audio-dft.js                             0.991  0.580 ± 0.580 … 0.580        0.585 ± 0.580 … 0.590
Kraken      audio-fft.js                             0.98   0.725 ± 0.720 … 0.730        0.740 ± 0.740 … 0.740
Kraken      audio-oscillator.js                      1.006  0.850 ± 0.850 … 0.850        0.845 ± 0.840 … 0.850
Kraken      imaging-darkroom.js                      0.996  1.230 ± 1.230 … 1.230        1.235 ± 1.230 … 1.240
Kraken      imaging-desaturate.js                    1.005  1.020 ± 1.020 … 1.020        1.015 ± 1.010 … 1.020
Kraken      imaging-gaussian-blur.js                 1.001  4.335 ± 4.330 … 4.340        4.330 ± 4.310 … 4.350
Kraken      json-parse-financial.js                  0.923  0.060 ± 0.060 … 0.060        0.065 ± 0.060 … 0.070
Kraken      json-stringify-tinderbox.js              1      0.090 ± 0.090 … 0.090        0.090 ± 0.090 … 0.090
Kraken      stanford-crypto-aes.js                   1.027  0.380 ± 0.380 … 0.380        0.370 ± 0.370 … 0.370
Kraken      stanford-crypto-ccm.js                   1      0.330 ± 0.330 … 0.330        0.330 ± 0.330 … 0.330
Kraken      stanford-crypto-pbkdf2.js                1.063  0.670 ± 0.670 … 0.670        0.630 ± 0.630 … 0.630
Kraken      stanford-crypto-sha256-iterative.js      1.04   0.260 ± 0.260 … 0.260        0.250 ± 0.250 … 0.250
Octane      box2d.js                                 0.998  2.070 ± 2.070 … 2.070        2.075 ± 2.070 … 2.080
Octane      code-load.js                             0.998  2.015 ± 2.010 … 2.020        2.020 ± 2.020 … 2.020
Octane      crypto.js                                1.002  5.090 ± 5.080 … 5.100        5.080 ± 5.030 … 5.130
Octane      deltablue.js                             0.995  2.005 ± 2.000 … 2.010        2.015 ± 2.010 … 2.020
Octane      earley-boyer.js                          0.996  11.040 ± 11.030 … 11.050     11.080 ± 11.060 … 11.100
Octane      gbemu.js                                 1.143  2.435 ± 2.430 … 2.440        2.130 ± 2.130 … 2.130
Octane      mandreel.js                              0.993  7.475 ± 7.470 … 7.480        7.525 ± 7.470 … 7.580
Octane      navier-stokes.js                         0.998  2.045 ± 2.030 … 2.060        2.050 ± 2.050 … 2.050
Octane      pdfjs.js                                 1      1.320 ± 1.320 … 1.320        1.320 ± 1.310 … 1.330
Octane      raytrace.js                              0.999  4.130 ± 4.120 … 4.140        4.135 ± 4.120 … 4.150
Octane      regexp.js                                1.006  16.940 ± 16.880 … 17.000     16.840 ± 16.760 … 16.920
Octane      richards.js                              0.998  2.005 ± 2.000 … 2.010        2.010 ± 2.010 … 2.010
Octane      splay.js                                 0.998  2.320 ± 2.310 … 2.330        2.325 ± 2.320 … 2.330
Octane      typescript.js                            0.999  14.370 ± 14.360 … 14.380     14.380 ± 14.320 … 14.440
Octane      zlib.js                                  0.996  43.710 ± 43.600 … 43.820     43.885 ± 43.760 … 44.010
JetStream   bigfib.cpp.js                            1.038  7.865 ± 7.850 … 7.880        7.575 ± 7.510 … 7.640
JetStream   cdjs.js                                  0.997  6.365 ± 6.300 … 6.430        6.385 ± 6.360 … 6.410
JetStream   container.cpp.js                         1.003  33.515 ± 33.470 … 33.560     33.420 ± 33.320 … 33.520
JetStream   dry.c.js                                 1.022  19.015 ± 18.780 … 19.250     18.605 ± 18.570 … 18.640
JetStream   float-mm.c.js                            0.991  20.510 ± 20.450 … 20.570     20.695 ± 20.570 … 20.820
JetStream   gcc-loops.cpp.js                         1.018  111.900 ± 111.340 … 112.460  109.950 ± 109.010 … 110.890
JetStream   hash-map.js                              1.03   3.475 ± 3.380 … 3.570        3.375 ± 3.360 … 3.390
JetStream   n-body.c.js                              1.027  28.635 ± 28.580 … 28.690     27.875 ± 27.660 … 28.090
JetStream   quicksort.c.js                           1.027  4.445 ± 4.430 … 4.460        4.330 ± 4.320 … 4.340
JetStream   towers.c.js                              1.001  7.365 ± 7.340 … 7.390        7.355 ± 7.300 … 7.410
JetStream3  js-tokens.js                             1.01   9.565 ± 9.560 … 9.570        9.470 ± 9.470 … 9.470
JetStream3  lazy-collections.js                      1.018  1.675 ± 1.670 … 1.680        1.645 ± 1.640 … 1.650
JetStream3  raytrace-private-class-fields.js         1.027  6.260 ± 6.240 … 6.280        6.095 ± 6.060 … 6.130
JetStream3  raytrace-public-class-fields.js          1.012  4.670 ± 4.660 … 4.680        4.615 ± 4.580 … 4.650
JetStream3  sync-file-system.js                      1.131  2.890 ± 2.870 … 2.910        2.555 ± 2.550 … 2.560
SunSpider   Total                                    0.996  1.260                        1.265
Kraken      Total                                    1.002  12.410                       12.385
Octane      Total                                    1.001  118.970                      118.870
JetStream   Total                                    1.015  243.090                      239.565
JetStream3  Total                                    1.028  25.060                       24.380
All Suites  Total                                    1.011  400.790                      396.465
```