### PR TITLE
Revert "LibIPC: Change TransportSocket to write large messages in…"

### DIFF
--- a/Libraries/LibIPC/Connection.cpp
+++ b/Libraries/LibIPC/Connection.cpp
@@ -12,6 +12,7 @@
 #include <LibIPC/Connection.h>
 #include <LibIPC/Message.h>
 #include <LibIPC/Stub.h>
+#include <LibIPC/UnprocessedFileDescriptors.h>
 
 namespace IPC {
 
@@ -39,15 +40,20 @@ bool ConnectionBase::is_open() const
 
 ErrorOr<void> ConnectionBase::post_message(Message const& message)
 {
-    return post_message(TRY(message.encode()));
+    return post_message(message.endpoint_magic(), TRY(message.encode()));
 }
 
-ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
+ErrorOr<void> ConnectionBase::post_message(u32 endpoint_magic, MessageBuffer buffer)
 {
     // NOTE: If this connection is being shut down, but has not yet been destroyed,
     //       the socket will be closed. Don't try to send more messages.
     if (!m_transport->is_open())
         return Error::from_string_literal("Trying to post_message during IPC shutdown");
+
+    if (buffer.data().size() > TransportSocket::SOCKET_BUFFER_SIZE) {
+        auto wrapper = LargeMessageWrapper::create(endpoint_magic, buffer);
+        buffer = MUST(wrapper->encode());
+    }
 
     MUST(buffer.transfer_message(*m_transport));
 
@@ -79,7 +85,7 @@ void ConnectionBase::handle_messages()
             }
 
             if (auto response = handler_result.release_value()) {
-                if (auto post_result = post_message(*response); post_result.is_error()) {
+                if (auto post_result = post_message(m_local_endpoint_magic, *response); post_result.is_error()) {
                     dbgln("IPC::ConnectionBase::handle_messages: {}", post_result.error());
                 }
             }
@@ -94,11 +100,24 @@ void ConnectionBase::wait_for_transport_to_become_readable()
 
 ErrorOr<void> ConnectionBase::drain_messages_from_peer()
 {
-    auto schedule_shutdown = m_transport->read_as_many_messages_as_possible_without_blocking([&](auto&& raw_message) {
-        if (auto message = try_parse_message(raw_message.bytes, raw_message.fds)) {
+    auto schedule_shutdown = m_transport->read_as_many_messages_as_possible_without_blocking([&](auto&& unparsed_message) {
+        auto const& bytes = unparsed_message.bytes;
+        UnprocessedFileDescriptors unprocessed_fds;
+        unprocessed_fds.return_fds_to_front_of_queue(move(unparsed_message.fds));
+        if (auto message = try_parse_message(bytes, unprocessed_fds)) {
+            if (message->message_id() == LargeMessageWrapper::MESSAGE_ID) {
+                LargeMessageWrapper* wrapper = static_cast<LargeMessageWrapper*>(message.ptr());
+                auto wrapped_message = wrapper->wrapped_message_data();
+                unprocessed_fds.return_fds_to_front_of_queue(wrapper->take_fds());
+                auto parsed_message = try_parse_message(wrapped_message, unprocessed_fds);
+                VERIFY(parsed_message);
+                m_unprocessed_messages.append(parsed_message.release_nonnull());
+                return;
+            }
+
             m_unprocessed_messages.append(message.release_nonnull());
         } else {
-            dbgln("Failed to parse IPC message {:hex-dump}", raw_message.bytes);
+            dbgln("Failed to parse IPC message {:hex-dump}", bytes);
             VERIFY_NOT_REACHED();
         }
     });

--- a/Libraries/LibIPC/Decoder.h
+++ b/Libraries/LibIPC/Decoder.h
@@ -23,6 +23,7 @@
 #include <LibIPC/File.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/Message.h>
+#include <LibIPC/UnprocessedFileDescriptors.h>
 #include <LibURL/Origin.h>
 #include <LibURL/URL.h>
 
@@ -37,7 +38,7 @@ inline ErrorOr<T> decode(Decoder&)
 
 class Decoder {
 public:
-    Decoder(Stream& stream, Queue<File>& files)
+    Decoder(Stream& stream, UnprocessedFileDescriptors& files)
         : m_stream(stream)
         , m_files(files)
     {
@@ -62,11 +63,11 @@ public:
     ErrorOr<size_t> decode_size();
 
     Stream& stream() { return m_stream; }
-    Queue<File>& files() { return m_files; }
+    UnprocessedFileDescriptors& files() { return m_files; }
 
 private:
     Stream& m_stream;
-    Queue<File>& m_files;
+    UnprocessedFileDescriptors& m_files;
 };
 
 template<Arithmetic T>

--- a/Libraries/LibIPC/Message.cpp
+++ b/Libraries/LibIPC/Message.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Checked.h>
 #include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
 #include <LibIPC/Message.h>
 
 namespace IPC {
@@ -44,6 +45,55 @@ ErrorOr<void> MessageBuffer::transfer_message(Transport& transport)
 
     transport.post_message(m_data, m_fds);
     return {};
+}
+
+NonnullOwnPtr<LargeMessageWrapper> LargeMessageWrapper::create(u32 endpoint_magic, MessageBuffer& buffer_to_wrap)
+{
+    auto size = buffer_to_wrap.data().size();
+    auto wrapped_message_data = MUST(Core::AnonymousBuffer::create_with_size(size));
+    memcpy(wrapped_message_data.data<void>(), buffer_to_wrap.data().data(), size);
+    Vector<File> files;
+    for (auto& owned_fd : buffer_to_wrap.take_fds()) {
+        files.append(File::adopt_fd(owned_fd->take_fd()));
+    }
+    return make<LargeMessageWrapper>(endpoint_magic, move(wrapped_message_data), move(files));
+}
+
+LargeMessageWrapper::LargeMessageWrapper(u32 endpoint_magic, Core::AnonymousBuffer wrapped_message_data, Vector<File>&& wrapped_fds)
+    : m_endpoint_magic(endpoint_magic)
+    , m_wrapped_message_data(move(wrapped_message_data))
+    , m_wrapped_fds(move(wrapped_fds))
+{
+}
+
+ErrorOr<MessageBuffer> LargeMessageWrapper::encode() const
+{
+    MessageBuffer buffer;
+    Encoder stream { buffer };
+    TRY(stream.encode(m_endpoint_magic));
+    TRY(stream.encode(MESSAGE_ID));
+    TRY(stream.encode(m_wrapped_message_data));
+    TRY(stream.encode(m_wrapped_fds.size()));
+    for (auto const& wrapped_fd : m_wrapped_fds) {
+        TRY(stream.append_file_descriptor(wrapped_fd.take_fd()));
+    }
+
+    return buffer;
+}
+
+ErrorOr<NonnullOwnPtr<LargeMessageWrapper>> LargeMessageWrapper::decode(u32 endpoint_magic, Stream& stream, UnprocessedFileDescriptors& files)
+{
+    Decoder decoder { stream, files };
+    auto wrapped_message_data = TRY(decoder.decode<Core::AnonymousBuffer>());
+
+    Vector<File> wrapped_fds;
+    auto num_fds = TRY(decoder.decode<u32>());
+    for (u32 i = 0; i < num_fds; ++i) {
+        auto fd = TRY(decoder.decode<IPC::File>());
+        wrapped_fds.append(move(fd));
+    }
+
+    return make<LargeMessageWrapper>(endpoint_magic, wrapped_message_data, move(wrapped_fds));
 }
 
 }

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -173,7 +173,7 @@ ErrorOr<void> TransportSocket::send_message(Core::LocalSocket& socket, ReadonlyB
     return {};
 }
 
-TransportSocket::ShouldShutdown TransportSocket::read_as_many_messages_as_possible_without_blocking(Function<void(Message&&)>&& callback)
+TransportSocket::ShouldShutdown TransportSocket::read_as_many_messages_as_possible_without_blocking(Function<void(Message)>&& callback)
 {
     bool should_shutdown = false;
     while (is_open()) {
@@ -222,7 +222,7 @@ TransportSocket::ShouldShutdown TransportSocket::read_as_many_messages_as_possib
             Message message;
             received_fd_count += header.fd_count;
             for (size_t i = 0; i < header.fd_count; ++i)
-                message.fds.enqueue(m_unprocessed_fds.dequeue());
+                message.fds.append(m_unprocessed_fds.dequeue());
             message.bytes.append(m_unprocessed_bytes.data() + index + sizeof(MessageHeader), header.payload_size);
             callback(move(message));
         } else if (header.type == MessageHeader::Type::FileDescriptorAcknowledgement) {

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -41,31 +41,6 @@ private:
     int m_fd;
 };
 
-class SendQueue : public AtomicRefCounted<SendQueue> {
-public:
-    enum class Running {
-        No,
-        Yes,
-    };
-    Running block_until_message_enqueued();
-    void stop();
-
-    void enqueue_message(Vector<u8>&& bytes, Vector<int>&& fds);
-    struct BytesAndFds {
-        Vector<u8> bytes;
-        Vector<int> fds;
-    };
-    BytesAndFds dequeue(size_t max_bytes);
-    void return_unsent_data_to_front_of_queue(ReadonlyBytes const& bytes, Vector<int> const& fds);
-
-private:
-    Vector<u8> m_bytes;
-    Vector<int> m_fds;
-    Threading::Mutex m_mutex;
-    Threading::ConditionVariable m_condition { m_mutex };
-    bool m_running { true };
-};
-
 class TransportSocket {
     AK_MAKE_NONCOPYABLE(TransportSocket);
     AK_MAKE_NONMOVABLE(TransportSocket);
@@ -100,7 +75,7 @@ public:
     ErrorOr<IPC::File> clone_for_transfer();
 
 private:
-    static ErrorOr<void> send_message(Core::LocalSocket&, ReadonlyBytes& bytes, Vector<int>& unowned_fds);
+    static ErrorOr<void> send_message(Core::LocalSocket&, ReadonlyBytes&&, Vector<int, 1> const& unowned_fds);
 
     NonnullOwnPtr<Core::LocalSocket> m_socket;
     ByteBuffer m_unprocessed_bytes;
@@ -111,8 +86,19 @@ private:
     // descriptor contained in the message before the peer receives it. https://openradar.me/9477351
     Queue<NonnullRefPtr<AutoCloseFileDescriptor>> m_fds_retained_until_received_by_peer;
 
+    struct MessageToSend {
+        Vector<u8> bytes;
+        Vector<int, 1> fds;
+    };
+    struct SendQueue : public AtomicRefCounted<SendQueue> {
+        AK::SinglyLinkedList<MessageToSend> messages;
+        Threading::Mutex mutex;
+        Threading::ConditionVariable condition { mutex };
+        bool running { true };
+    };
     RefPtr<Threading::Thread> m_send_thread;
     RefPtr<SendQueue> m_send_queue;
+    void queue_message_on_send_thread(MessageToSend&&) const;
 };
 
 }

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -9,6 +9,7 @@
 
 #include <AK/Queue.h>
 #include <LibCore/Socket.h>
+#include <LibIPC/UnprocessedFileDescriptors.h>
 #include <LibThreading/ConditionVariable.h>
 #include <LibThreading/MutexProtected.h>
 #include <LibThreading/Thread.h>
@@ -65,9 +66,9 @@ public:
     };
     struct Message {
         Vector<u8> bytes;
-        Queue<File> fds;
+        Vector<File> fds;
     };
-    ShouldShutdown read_as_many_messages_as_possible_without_blocking(Function<void(Message&&)>&& schedule_shutdown);
+    ShouldShutdown read_as_many_messages_as_possible_without_blocking(Function<void(Message)>&& schedule_shutdown);
 
     // Obnoxious name to make it clear that this is a dangerous operation.
     ErrorOr<int> release_underlying_transport_for_transfer();
@@ -79,7 +80,7 @@ private:
 
     NonnullOwnPtr<Core::LocalSocket> m_socket;
     ByteBuffer m_unprocessed_bytes;
-    Queue<File> m_unprocessed_fds;
+    UnprocessedFileDescriptors m_unprocessed_fds;
 
     // After file descriptor is sent, it is moved to the wait queue until an acknowledgement is received from the peer.
     // This is necessary to handle a specific behavior of the macOS kernel, which may prematurely garbage-collect the file

--- a/Libraries/LibIPC/UnprocessedFileDescriptors.h
+++ b/Libraries/LibIPC/UnprocessedFileDescriptors.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibIPC/File.h>
+
+namespace IPC {
+
+class UnprocessedFileDescriptors {
+public:
+    void enqueue(File&& fd)
+    {
+        m_fds.append(move(fd));
+    }
+
+    File dequeue()
+    {
+        return m_fds.take_first();
+    }
+
+    void return_fds_to_front_of_queue(Vector<File>&& fds)
+    {
+        m_fds.prepend(move(fds));
+    }
+
+    size_t size() const { return m_fds.size(); }
+
+private:
+    Vector<File> m_fds;
+};
+
+}

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -13,6 +13,7 @@
 #include <LibCore/Socket.h>
 #include <LibIPC/File.h>
 #include <LibIPC/Transport.h>
+#include <LibIPC/UnprocessedFileDescriptors.h>
 #include <LibWeb/Bindings/Transferable.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>


### PR DESCRIPTION
…small chunks"

This reverts PR #4304 

This change caused a regression in [this WPT run](<https://wpt.fyi/results/?diff&filter=ADC&run_id=5159713182580736&run_id=5104108925353984>), particularly in the encoding tests.