### PR TITLE
LibWeb: Fix handling floats with negative margins

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -95,7 +95,7 @@ void BlockFormattingContext::run(AvailableSpace const& available_space)
         // FIXME: this should take writing modes into consideration.
         auto legend_height = legend_state.border_box_height();
         auto new_y = -((legend_height) / 2) - fieldset_state.padding_top;
-        legend_state.set_content_offset({ legend_state.offset.x(), new_y });
+        legend_state.set_content_y(new_y);
 
         // If the computed value of 'inline-size' is 'auto',
         // then the used value is the fit-content inline size.
@@ -955,7 +955,7 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically
 {
     auto& box_state = m_state.get_mutable(child_box);
     y += box_state.border_box_top();
-    box_state.set_content_offset(CSSPixelPoint { box_state.offset.x(), y });
+    box_state.set_content_y(y);
     for (auto const& float_box : m_left_floats.all_boxes)
         float_box->margin_box_rect_in_root_coordinate_space = margin_box_rect_in_ancestor_coordinate_space(float_box->used_values, root());
 
@@ -1004,7 +1004,7 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
         x += box_state.margin_box_left();
     }
 
-    box_state.set_content_offset({ x, box_state.offset.y() });
+    box_state.set_content_x(x);
 }
 
 void BlockFormattingContext::layout_viewport(AvailableSpace const& available_space)

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1089,8 +1089,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
             // Walk all currently tracked floats on the side we're floating towards.
             // We're looking for the innermost preceding float that intersects vertically with `box`.
             for (auto& preceding_float : side_data.current_boxes.in_reverse()) {
-                auto const preceding_float_rect = margin_box_rect_in_ancestor_coordinate_space(preceding_float.used_values, root());
-                if (!preceding_float_rect.contains_vertically(y_in_root))
+                if (!preceding_float.margin_box_rect_in_root_coordinate_space.contains_vertically(y_in_root))
                     continue;
                 // We found a preceding float that intersects vertically with the current float.
                 // Now we need to find out if there's enough inline-axis space to stack them next to each other.

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1828,12 +1828,12 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
 {
     return {
         {
-            -used_values.margin_box_left(),
-            -used_values.margin_box_top(),
+            -max(used_values.margin_box_left(), 0),
+            -max(used_values.margin_box_top(), 0),
         },
         {
-            used_values.margin_box_left() + used_values.content_width() + used_values.margin_box_right(),
-            used_values.margin_box_top() + used_values.content_height() + used_values.margin_box_bottom(),
+            max(used_values.margin_box_left(), 0) + used_values.content_width() + max(used_values.margin_box_right(), 0),
+            max(used_values.margin_box_top(), 0) + used_values.content_height() + max(used_values.margin_box_bottom(), 0),
         },
     };
 }

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-with-negative-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-with-negative-margins.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x48 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      BlockContainer <div.r> at (8,-2) content-size 50x50 floating [BFC] children: not-inline
+      TextNode <#text>
+      BlockContainer <div.g> at (58,-2) content-size 50x50 floating [BFC] children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.r) [8,-2 50x50]
+      PaintableWithLines (BlockContainer<DIV>.g) [58,-2 50x50]

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-with-negative-margins.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-with-negative-margins.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+div {
+    margin-top: -10px;
+    width: 50px;
+    height: 50px;
+    float: left;
+}
+.r { background: red; }
+.g { background: green; }
+</style>
+<div class="r"></div>
+<div class="g"></div>


### PR DESCRIPTION
Negative margins are processed through the `offset` in layout state, and should not contribute to the margin box' rect's size or position.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4249.