### PR TITLE
AK: Allow `Optional<T>` to be used in constant expressions

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -45,6 +45,9 @@ concept OneOf = IsOneOf<U, Ts...>;
 template<typename U, typename... Ts>
 concept OneOfIgnoringCV = IsOneOfIgnoringCV<U, Ts...>;
 
+template<typename U, typename... Ts>
+concept OneOfIgnoringCVReference = IsOneOfIgnoringCVReference<U, Ts...>;
+
 template<typename T, template<typename...> typename S>
 concept SpecializationOf = IsSpecializationOf<T, S>;
 
@@ -185,6 +188,7 @@ using AK::Concepts::IteratorFunction;
 using AK::Concepts::IteratorPairWith;
 using AK::Concepts::OneOf;
 using AK::Concepts::OneOfIgnoringCV;
+using AK::Concepts::OneOfIgnoringCVReference;
 using AK::Concepts::SameAs;
 using AK::Concepts::Signed;
 using AK::Concepts::SpecializationOf;

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -85,19 +85,19 @@ public:
 private:
     friend class Optional<FlyString>;
 
-    explicit FlyString(nullptr_t)
+    explicit constexpr FlyString(nullptr_t)
         : m_data(nullptr)
     {
     }
 
-    explicit FlyString(Detail::StringBase data)
+    explicit constexpr FlyString(Detail::StringBase data)
         : m_data(move(data))
     {
     }
 
     Detail::StringBase m_data;
 
-    bool is_invalid() const { return m_data.raw(Badge<FlyString> {}) == 0; }
+    constexpr bool is_invalid() const { return m_data.raw(Badge<FlyString> {}) == 0; }
 };
 
 void did_destroy_fly_string_data(Badge<Detail::StringData>, Detail::StringData const&);
@@ -110,38 +110,38 @@ class Optional<FlyString> : public OptionalBase<FlyString> {
 public:
     using ValueType = FlyString;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
-    Optional(Optional<FlyString> const& other)
+    constexpr Optional(Optional<FlyString> const& other)
     {
         if (other.has_value())
             m_value = other.m_value;
     }
 
-    Optional(Optional&& other)
-        : m_value(other.m_value)
+    constexpr Optional(Optional&& other)
+        : m_value(move(other.m_value))
     {
     }
 
     template<typename U = FlyString>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    explicit(!IsConvertible<U&&, FlyString>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, FlyString>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<FlyString>> && IsConstructible<FlyString, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             clear();
@@ -150,7 +150,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -159,37 +159,37 @@ public:
         return *this;
     }
 
-    void clear()
+    constexpr void clear()
     {
         m_value = FlyString(nullptr);
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_invalid();
     }
 
-    [[nodiscard]] FlyString& value() &
+    [[nodiscard]] constexpr FlyString& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] FlyString const& value() const&
+    [[nodiscard]] constexpr FlyString const& value() const&
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] FlyString value() &&
+    [[nodiscard]] constexpr FlyString value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] FlyString release_value()
+    [[nodiscard]] constexpr FlyString release_value()
     {
         VERIFY(has_value());
-        FlyString released_value = m_value;
+        FlyString released_value = move(m_value);
         clear();
         return released_value;
     }

--- a/AK/Noncopyable.h
+++ b/AK/Noncopyable.h
@@ -26,14 +26,14 @@ public:                             \
     c(c const&) = default;          \
     c& operator=(c const&) = default
 
-#define AK_MAKE_CONDITIONALLY_NONMOVABLE(c, ...)              \
-public:                                                       \
-    c(c&&)                                                    \
-    requires(!(AK::Detail::IsMoveConstructible __VA_ARGS__))  \
-    = delete;                                                 \
-    c& operator=(c&&)                                         \
-    requires(!(AK::Detail::IsMoveConstructible __VA_ARGS__)   \
-                || !(AK::Detail::IsDestructible __VA_ARGS__)) \
+#define AK_MAKE_CONDITIONALLY_NONMOVABLE(c, ...)                                                            \
+public:                                                                                                     \
+    c(c&&)                                                                                                  \
+    requires(!(AK::Detail::IsMoveConstructible __VA_ARGS__))                                                \
+    = delete;                                                                                               \
+    c& operator=(c&&)                                                                                       \
+    requires(!((AK::Detail::IsMoveConstructible __VA_ARGS__) || (AK::Detail::IsMoveAssignable __VA_ARGS__)) \
+                || !(AK::Detail::IsDestructible __VA_ARGS__))                                               \
     = delete
 
 #define AK_MAKE_CONDITIONALLY_MOVABLE(c, T) \
@@ -41,14 +41,14 @@ public:                                                       \
     c(c&&) = default;                       \
     c& operator=(c&&) = default
 
-#define AK_MAKE_CONDITIONALLY_NONCOPYABLE(c, ...)             \
-public:                                                       \
-    c(c const&)                                               \
-    requires(!(AK::Detail::IsCopyConstructible __VA_ARGS__))  \
-    = delete;                                                 \
-    c& operator=(c const&)                                    \
-    requires(!(AK::Detail::IsCopyConstructible __VA_ARGS__)   \
-                || !(AK::Detail::IsDestructible __VA_ARGS__)) \
+#define AK_MAKE_CONDITIONALLY_NONCOPYABLE(c, ...)                                                           \
+public:                                                                                                     \
+    c(c const&)                                                                                             \
+    requires(!(AK::Detail::IsCopyConstructible __VA_ARGS__))                                                \
+    = delete;                                                                                               \
+    c& operator=(c const&)                                                                                  \
+    requires(!((AK::Detail::IsCopyConstructible __VA_ARGS__) || (AK::Detail::IsCopyAssignable __VA_ARGS__)) \
+                || !(AK::Detail::IsDestructible __VA_ARGS__))                                               \
     = delete
 
 #define AK_MAKE_CONDITIONALLY_COPYABLE(c, ...)         \

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -46,7 +46,7 @@ template<typename>
 class Optional;
 
 struct OptionalNone {
-    explicit OptionalNone() = default;
+    explicit constexpr OptionalNone() = default;
 };
 
 template<typename T, typename Self = Optional<T>>
@@ -55,24 +55,24 @@ public:
     using ValueType = T;
 
     template<SameAs<OptionalNone> V>
-    Self& operator=(V)
+    ALWAYS_INLINE constexpr Self& operator=(V)
     {
         static_cast<Self&>(*this).clear();
         return static_cast<Self&>(*this);
     }
 
-    [[nodiscard]] ALWAYS_INLINE T* ptr() &
+    [[nodiscard]] ALWAYS_INLINE constexpr T* ptr() &
     {
         return static_cast<Self&>(*this).has_value() ? __builtin_launder(reinterpret_cast<T*>(&static_cast<Self&>(*this).value())) : nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const* ptr() const&
+    [[nodiscard]] ALWAYS_INLINE constexpr T const* ptr() const&
     {
         return static_cast<Self const&>(*this).has_value() ? __builtin_launder(reinterpret_cast<T const*>(&static_cast<Self const&>(*this).value())) : nullptr;
     }
 
     template<typename O = T, typename Fallback = O>
-    [[nodiscard]] ALWAYS_INLINE O value_or(Fallback const& fallback) const&
+    [[nodiscard]] ALWAYS_INLINE constexpr O value_or(Fallback const& fallback) const&
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -81,7 +81,7 @@ public:
 
     template<typename O = T, typename Fallback = O>
     requires(!IsLvalueReference<O> && !IsRvalueReference<O>)
-    [[nodiscard]] ALWAYS_INLINE O value_or(Fallback&& fallback) &&
+    [[nodiscard]] ALWAYS_INLINE constexpr O value_or(Fallback&& fallback) &&
     {
         if (static_cast<Self&>(*this).has_value())
             return move(static_cast<Self&>(*this).value());
@@ -89,7 +89,7 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE O value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr O value_or_lazy_evaluated(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -97,7 +97,7 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE Optional<O> value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr Optional<O> value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -105,7 +105,7 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<O> try_value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<O> try_value_or_lazy_evaluated(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -113,21 +113,21 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<Optional<O>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<Optional<O>> try_value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
         return TRY(callback());
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const& operator*() const { return static_cast<Self const&>(*this).value(); }
-    [[nodiscard]] ALWAYS_INLINE T& operator*() { return static_cast<Self&>(*this).value(); }
+    [[nodiscard]] ALWAYS_INLINE constexpr T const& operator*() const { return static_cast<Self const&>(*this).value(); }
+    [[nodiscard]] ALWAYS_INLINE constexpr T& operator*() { return static_cast<Self&>(*this).value(); }
 
-    ALWAYS_INLINE T const* operator->() const { return &static_cast<Self const&>(*this).value(); }
-    ALWAYS_INLINE T* operator->() { return &static_cast<Self&>(*this).value(); }
+    ALWAYS_INLINE constexpr T const* operator->() const { return &static_cast<Self const&>(*this).value(); }
+    ALWAYS_INLINE constexpr T* operator->() { return &static_cast<Self&>(*this).value(); }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
     {
         if constexpr (IsErrorOr) {
             if (static_cast<Self&>(*this).has_value())
@@ -142,7 +142,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
     {
         if constexpr (IsErrorOr) {
             if (static_cast<Self const&>(*this).has_value())
@@ -167,13 +167,19 @@ requires(!IsLvalueReference<T>) class [[nodiscard]] Optional<T> : public Optiona
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    ALWAYS_INLINE constexpr Optional()
+    {
+        construct_null_if_necessary();
+    }
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    ALWAYS_INLINE constexpr Optional(V)
+    {
+        construct_null_if_necessary();
+    }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    ALWAYS_INLINE constexpr Optional& operator=(V)
     {
         clear();
         return *this;
@@ -183,78 +189,85 @@ public:
     AK_MAKE_CONDITIONALLY_NONMOVABLE(Optional, <T>);
     AK_MAKE_CONDITIONALLY_DESTRUCTIBLE(Optional, <T>);
 
-    ALWAYS_INLINE Optional(Optional const& other)
+    ALWAYS_INLINE constexpr Optional(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T>)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
-            new (&m_storage) T(other.value());
+            construct_at<RemoveConst<T>>(&m_storage, other.value());
+        else
+            construct_null_if_necessary();
     }
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    ALWAYS_INLINE constexpr Optional(Optional&& other)
+    requires(!IsTriviallyMoveConstructible<T>)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
-            new (&m_storage) T(other.release_value());
+            construct_at<RemoveConst<T>>(&m_storage, other.release_value());
+        else
+            construct_null_if_necessary();
     }
 
     template<typename U>
-    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyCopyConstructible<U>)) ALWAYS_INLINE explicit Optional(Optional<U> const& other)
+    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyCopyConstructible<U>)) ALWAYS_INLINE explicit constexpr Optional(Optional<U> const& other)
         : m_has_value(other.has_value())
     {
         if (other.has_value())
-            new (&m_storage) T(other.value());
+            construct_at<RemoveConst<T>>(&m_storage, other.value());
+        else
+            construct_null_if_necessary();
     }
 
     template<typename U>
-    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyMoveConstructible<U>)) ALWAYS_INLINE explicit Optional(Optional<U>&& other)
+    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional> && (!IsLvalueReference<U> || IsTriviallyMoveConstructible<U>)) ALWAYS_INLINE explicit constexpr Optional(Optional<U>&& other)
         : m_has_value(other.has_value())
     {
         if (other.has_value())
-            new (&m_storage) T(other.release_value());
+            construct_at<RemoveConst<T>>(&m_storage, other.release_value());
+        else
+            construct_null_if_necessary();
     }
 
     template<typename U = T>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) Optional(U&& value)
+    ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<T>> && IsConstructible<T, U &&>)
         : m_has_value(true)
     {
-        new (&m_storage) T(forward<U>(value));
+        construct_at<RemoveConst<T>>(&m_storage, forward<U>(value));
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T> || !IsTriviallyDestructible<T>)
     {
         if (this != &other) {
             clear();
             m_has_value = other.m_has_value;
-            if (other.has_value()) {
-                new (&m_storage) T(other.value());
-            }
+            if (other.has_value())
+                construct_at<RemoveConst<T>>(&m_storage, other.value());
         }
         return *this;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
             m_has_value = other.m_has_value;
-            if (other.has_value()) {
-                new (&m_storage) T(other.release_value());
-            }
+            if (other.has_value())
+                construct_at<RemoveConst<T>>(&m_storage, other.release_value());
         }
         return *this;
     }
 
-    ALWAYS_INLINE ~Optional()
+    ALWAYS_INLINE constexpr ~Optional()
     requires(!IsTriviallyDestructible<T> && IsDestructible<T>)
     {
         clear();
     }
 
-    ALWAYS_INLINE void clear()
+    ALWAYS_INLINE constexpr void clear()
     {
         if (m_has_value) {
             value().~T();
@@ -263,41 +276,41 @@ public:
     }
 
     template<typename... Parameters>
-    ALWAYS_INLINE void emplace(Parameters&&... parameters)
+    ALWAYS_INLINE constexpr void emplace(Parameters&&... parameters)
     {
         clear();
         m_has_value = true;
-        new (&m_storage) T(forward<Parameters>(parameters)...);
+        construct_at<RemoveConst<T>>(&m_storage, forward<Parameters>(parameters)...);
     }
 
     template<typename Callable>
-    ALWAYS_INLINE void lazy_emplace(Callable callable)
+    ALWAYS_INLINE constexpr void lazy_emplace(Callable callable)
     {
         clear();
         m_has_value = true;
-        new (&m_storage) T { callable() };
+        construct_at<RemoveConst<T>>(&m_storage, callable());
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_has_value; }
+    [[nodiscard]] ALWAYS_INLINE constexpr bool has_value() const { return m_has_value; }
 
-    [[nodiscard]] ALWAYS_INLINE T& value() &
+    [[nodiscard]] ALWAYS_INLINE constexpr T& value() &
     {
         VERIFY(m_has_value);
-        return *__builtin_launder(reinterpret_cast<T*>(&m_storage));
+        return m_storage;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const& value() const&
+    [[nodiscard]] ALWAYS_INLINE constexpr T const& value() const&
     {
         VERIFY(m_has_value);
-        return *__builtin_launder(reinterpret_cast<T const*>(&m_storage));
+        return m_storage;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value() &&
+    [[nodiscard]] ALWAYS_INLINE constexpr T value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] ALWAYS_INLINE constexpr T release_value()
     {
         VERIFY(m_has_value);
         T released_value = move(value());
@@ -307,7 +320,27 @@ public:
     }
 
 private:
-    alignas(T) u8 m_storage[sizeof(T)];
+    ALWAYS_INLINE constexpr void construct_null_if_necessary(bool should_construct = is_constant_evaluated())
+    {
+        // OPTIMIZATION: Only construct the `m_null` member when we are constant-evaluating.
+        // Otherwise, this generates an unnecessary zero-fill.
+#if defined(AK_COMPILER_GCC)
+        // NOTE: GCCs -Wuninitialized warning ends up checking this as well.
+        should_construct = true;
+#endif
+        if (should_construct)
+            construct_at(&m_null);
+    }
+
+    union {
+        // FIXME: GCC seems to have an issue with uninitialized unions and non trivial types,
+        //        which forces us to have an equally sized trivial null member in the union
+        //        to pseudo-initialize the union.
+        struct {
+            u8 _[sizeof(T)];
+        } m_null;
+        RemoveConst<T> m_storage;
+    };
     bool m_has_value { false };
 };
 
@@ -325,46 +358,46 @@ requires(IsLvalueReference<T>) class [[nodiscard]] Optional<T> {
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    ALWAYS_INLINE constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    ALWAYS_INLINE constexpr Optional(V) { }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    ALWAYS_INLINE constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
     template<typename U = T>
-    ALWAYS_INLINE Optional(U& value)
+    ALWAYS_INLINE constexpr Optional(U& value)
     requires(CanBePlacedInOptional<U&>)
         : m_pointer(&value)
     {
     }
 
-    ALWAYS_INLINE Optional(RemoveReference<T>& value)
+    ALWAYS_INLINE constexpr Optional(RemoveReference<T>& value)
         : m_pointer(&value)
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U>& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U>& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.ptr())
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U> const& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U> const& other)
     requires(CanBePlacedInOptional<U const>)
         : m_pointer(other.ptr())
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U>&& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U>&& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.ptr())
     {
@@ -372,7 +405,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U>& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U>& other)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = other.ptr();
@@ -380,7 +413,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U> const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U> const& other)
     requires(CanBePlacedInOptional<U const>)
     {
         m_pointer = other.ptr();
@@ -388,7 +421,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U>&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U>&& other)
     requires(CanBePlacedInOptional<U> && IsLvalueReference<U>)
     {
         m_pointer = other.m_pointer;
@@ -398,7 +431,7 @@ public:
 
     template<typename U>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE Optional& operator=(U& value)
+    ALWAYS_INLINE constexpr Optional& operator=(U& value)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = &value;
@@ -412,12 +445,12 @@ public:
     requires(CanBePlacedInOptional<U>)
     = delete;
 
-    ALWAYS_INLINE void clear()
+    ALWAYS_INLINE constexpr void clear()
     {
         m_pointer = nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_pointer != nullptr; }
+    [[nodiscard]] ALWAYS_INLINE constexpr bool has_value() const { return m_pointer != nullptr; }
 
     [[nodiscard]] ALWAYS_INLINE RemoveReference<T>* ptr()
     {
@@ -429,20 +462,20 @@ public:
         return m_pointer;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value()
+    [[nodiscard]] ALWAYS_INLINE constexpr T value()
     {
         VERIFY(m_pointer);
         return *m_pointer;
     }
 
-    [[nodiscard]] ALWAYS_INLINE AddConstToReferencedType<T> value() const
+    [[nodiscard]] ALWAYS_INLINE constexpr AddConstToReferencedType<T> value() const
     {
         VERIFY(m_pointer);
         return *m_pointer;
     }
 
     template<typename U>
-    requires(IsBaseOf<RemoveCVReference<T>, U>) [[nodiscard]] ALWAYS_INLINE AddConstToReferencedType<T> value_or(U& fallback) const
+    requires(IsBaseOf<RemoveCVReference<T>, U>) [[nodiscard]] ALWAYS_INLINE constexpr AddConstToReferencedType<T> value_or(U& fallback) const
     {
         if (m_pointer)
             return value();
@@ -450,26 +483,26 @@ public:
     }
 
     // Note that this ends up copying the value.
-    [[nodiscard]] ALWAYS_INLINE RemoveCVReference<T> value_or(RemoveCVReference<T> fallback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr RemoveCVReference<T> value_or(RemoveCVReference<T> fallback) const
     {
         if (m_pointer)
             return value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] ALWAYS_INLINE constexpr T release_value()
     {
         return *exchange(m_pointer, nullptr);
     }
 
-    ALWAYS_INLINE AddConstToReferencedType<T> operator*() const { return value(); }
-    ALWAYS_INLINE T operator*() { return value(); }
+    ALWAYS_INLINE constexpr AddConstToReferencedType<T> operator*() const { return value(); }
+    ALWAYS_INLINE constexpr T operator*() { return value(); }
 
     ALWAYS_INLINE RawPtr<AddConst<RemoveReference<T>>> operator->() const { return &value(); }
     ALWAYS_INLINE RawPtr<RemoveReference<T>> operator->() { return &value(); }
 
     // Conversion operators from Optional<T&> -> Optional<T>, implicit when T is trivially copyable.
-    ALWAYS_INLINE operator Optional<RemoveCVReference<T>>() const
+    ALWAYS_INLINE constexpr operator Optional<RemoveCVReference<T>>() const
     requires(IsTriviallyCopyable<RemoveCVReference<T>>)
     {
         if (has_value())
@@ -478,7 +511,7 @@ public:
     }
 
     // Conversion operators from Optional<T&> -> Optional<T>, explicit when T is not trivially copyable, since this is usually a mistake.
-    ALWAYS_INLINE explicit operator Optional<RemoveCVReference<T>>() const
+    ALWAYS_INLINE explicit constexpr operator Optional<RemoveCVReference<T>>() const
     requires(!IsTriviallyCopyable<RemoveCVReference<T>>)
     {
         if (has_value())
@@ -492,7 +525,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE T value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr T value_or_lazy_evaluated(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -500,7 +533,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -508,7 +541,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -516,7 +549,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -524,7 +557,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
     {
         if constexpr (IsErrorOr) {
             if (m_pointer != nullptr)
@@ -539,7 +572,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
     {
         if constexpr (IsErrorOr) {
             if (m_pointer != nullptr)
@@ -558,20 +591,20 @@ private:
 };
 
 template<typename T1, typename T2>
-ALWAYS_INLINE bool operator==(Optional<T1> const& first, Optional<T2> const& second)
+ALWAYS_INLINE constexpr bool operator==(Optional<T1> const& first, Optional<T2> const& second)
 {
     return first.has_value() == second.has_value()
         && (!first.has_value() || first.value() == second.value());
 }
 
 template<typename T1, typename T2>
-ALWAYS_INLINE bool operator==(Optional<T1> const& first, T2 const& second)
+ALWAYS_INLINE constexpr bool operator==(Optional<T1> const& first, T2 const& second)
 {
     return first.has_value() && first.value() == second;
 }
 
 template<typename T>
-ALWAYS_INLINE bool operator==(Optional<T> const& first, OptionalNone)
+ALWAYS_INLINE constexpr bool operator==(Optional<T> const& first, OptionalNone)
 {
     return !first.has_value();
 }

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -584,6 +584,12 @@ inline constexpr bool IsSameIgnoringCV = IsSame<RemoveCV<T>, RemoveCV<U>>;
 template<typename T, typename... Ts>
 inline constexpr bool IsOneOfIgnoringCV = (IsSameIgnoringCV<T, Ts> || ...);
 
+template<typename T, typename U>
+inline constexpr bool IsSameIgnoringCVReference = IsSame<RemoveCVReference<T>, RemoveCVReference<U>>;
+
+template<typename T, typename... Ts>
+inline constexpr bool IsOneOfIgnoringCVReference = (IsSameIgnoringCVReference<T, Ts> || ...);
+
 template<typename...>
 struct __InvokeResult { };
 
@@ -682,11 +688,13 @@ using AK::Detail::IsMoveConstructible;
 using AK::Detail::IsNullPointer;
 using AK::Detail::IsOneOf;
 using AK::Detail::IsOneOfIgnoringCV;
+using AK::Detail::IsOneOfIgnoringCVReference;
 using AK::Detail::IsPOD;
 using AK::Detail::IsPointer;
 using AK::Detail::IsRvalueReference;
 using AK::Detail::IsSame;
 using AK::Detail::IsSameIgnoringCV;
+using AK::Detail::IsSameIgnoringCVReference;
 using AK::Detail::IsSigned;
 using AK::Detail::IsSpecializationOf;
 using AK::Detail::IsTemplateBaseOf;

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -91,6 +91,15 @@ inline constexpr bool __IsPointerHelper<T*> = true;
 template<class T>
 inline constexpr bool IsPointer = __IsPointerHelper<RemoveCV<T>>;
 
+template<class T>
+inline constexpr bool __IsMemberPointer = false;
+
+template<class T, class C>
+inline constexpr bool __IsMemberPointer<T C::*> = true;
+
+template<class T>
+inline constexpr bool IsMemberPointer = __IsMemberPointer<RemoveCV<T>>;
+
 template<class>
 inline constexpr bool IsFunction = false;
 template<class Ret, class... Args>
@@ -683,6 +692,7 @@ using AK::Detail::IsFundamental;
 using AK::Detail::IsHashCompatible;
 using AK::Detail::IsIntegral;
 using AK::Detail::IsLvalueReference;
+using AK::Detail::IsMemberPointer;
 using AK::Detail::IsMoveAssignable;
 using AK::Detail::IsMoveConstructible;
 using AK::Detail::IsNullPointer;

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -407,6 +407,9 @@ inline constexpr bool IsArithmetic = IsIntegral<T> || IsFloatingPoint<T>;
 template<typename T>
 inline constexpr bool IsFundamental = IsArithmetic<T> || IsVoid<T> || IsNullPointer<T>;
 
+template<typename T>
+inline constexpr bool IsScalar = IsArithmetic<T> || IsEnum<T> || IsPointer<T> || IsNullPointer<T> || IsMemberPointer<T>;
+
 template<typename T, T... Ts>
 struct IntegerSequence {
     using Type = T;
@@ -705,6 +708,7 @@ using AK::Detail::IsRvalueReference;
 using AK::Detail::IsSame;
 using AK::Detail::IsSameIgnoringCV;
 using AK::Detail::IsSameIgnoringCVReference;
+using AK::Detail::IsScalar;
 using AK::Detail::IsSigned;
 using AK::Detail::IsSpecializationOf;
 using AK::Detail::IsTemplateBaseOf;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -10,6 +10,7 @@
 #include <AK/Platform.h>
 #include <AK/StdLibExtraDetails.h>
 
+#include <memory>
 #include <utility>
 
 namespace AK {
@@ -31,6 +32,7 @@ requires(AK::Detail::IsIntegral<T>)
 template<typename... Args>
 void compiletime_fail(Args...);
 
+using std::construct_at;
 using std::forward;
 using std::move;
 }

--- a/AK/String.h
+++ b/AK/String.h
@@ -225,7 +225,7 @@ private:
 
     using ShortString = Detail::ShortString;
 
-    bool is_invalid() const
+    constexpr bool is_invalid() const
     {
         return raw(Badge<String> {}) == 0;
     }
@@ -249,38 +249,38 @@ class Optional<String> : public OptionalBase<String> {
 public:
     using ValueType = String;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
-    Optional(Optional<String> const& other)
+    constexpr Optional(Optional<String> const& other)
     {
         if (other.has_value())
             m_value = other.m_value;
     }
 
-    Optional(Optional&& other)
+    constexpr Optional(Optional&& other)
         : m_value(move(other.m_value))
     {
     }
 
     template<typename U = String>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    explicit(!IsConvertible<U&&, String>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, String>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<String>> && IsConstructible<String, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             m_value = other.m_value;
@@ -288,7 +288,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             m_value = move(other.m_value);
@@ -296,37 +296,37 @@ public:
         return *this;
     }
 
-    void clear()
+    constexpr void clear()
     {
         m_value = String(nullptr);
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_invalid();
     }
 
-    [[nodiscard]] String& value() &
+    [[nodiscard]] constexpr String& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] String const& value() const&
+    [[nodiscard]] constexpr String const& value() const&
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] String value() &&
+    [[nodiscard]] constexpr String value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] String release_value()
+    [[nodiscard]] constexpr String release_value()
     {
         VERIFY(has_value());
-        String released_value = m_value;
+        String released_value = move(m_value);
         clear();
         return released_value;
     }

--- a/AK/StringBase.h
+++ b/AK/StringBase.h
@@ -70,8 +70,8 @@ public:
 
     [[nodiscard]] bool operator==(StringBase const&) const;
 
-    [[nodiscard]] ALWAYS_INLINE FlatPtr raw(Badge<FlyString>) const { return bit_cast<FlatPtr>(m_impl); }
-    [[nodiscard]] ALWAYS_INLINE FlatPtr raw(Badge<String>) const { return bit_cast<FlatPtr>(m_impl); }
+    [[nodiscard]] ALWAYS_INLINE constexpr FlatPtr raw(Badge<FlyString>) const { return bit_cast<FlatPtr>(m_impl); }
+    [[nodiscard]] ALWAYS_INLINE constexpr FlatPtr raw(Badge<String>) const { return bit_cast<FlatPtr>(m_impl); }
 
     template<typename Func>
     ALWAYS_INLINE ErrorOr<void> replace_with_new_string(Badge<StringView>, size_t byte_count, Func&& callback)

--- a/Libraries/LibJS/Runtime/Completion.h
+++ b/Libraries/LibJS/Runtime/Completion.h
@@ -60,7 +60,7 @@ public:
         Throw,
     };
 
-    ALWAYS_INLINE Completion(Type type, Value value)
+    ALWAYS_INLINE constexpr Completion(Type type, Value value)
         : m_type(type)
         , m_value(value)
     {
@@ -72,12 +72,12 @@ public:
 
     // 5.2.3.1 Implicit Completion Values, https://tc39.es/ecma262/#sec-implicit-completion-values
     // Not `explicit` on purpose.
-    ALWAYS_INLINE Completion(Value value)
+    ALWAYS_INLINE constexpr Completion(Value value)
         : Completion(Type::Normal, value)
     {
     }
 
-    ALWAYS_INLINE Completion()
+    ALWAYS_INLINE constexpr Completion()
         : Completion(js_undefined())
     {
     }
@@ -87,21 +87,21 @@ public:
     Completion(Completion&&) = default;
     Completion& operator=(Completion&&) = default;
 
-    [[nodiscard]] Type type() const
+    [[nodiscard]] constexpr Type type() const
     {
         VERIFY(m_type != Type::Empty);
         return m_type;
     }
-    [[nodiscard]] Value& value() { return m_value; }
-    [[nodiscard]] Value const& value() const { return m_value; }
+    [[nodiscard]] constexpr Value& value() { return m_value; }
+    [[nodiscard]] constexpr Value const& value() const { return m_value; }
 
     // "abrupt completion refers to any completion with a [[Type]] value other than normal"
-    [[nodiscard]] bool is_abrupt() const { return m_type != Type::Normal; }
+    [[nodiscard]] constexpr bool is_abrupt() const { return m_type != Type::Normal; }
 
     // These are for compatibility with the TRY() macro in AK.
-    [[nodiscard]] bool is_error() const { return m_type == Type::Throw; }
-    [[nodiscard]] Value release_value() { return m_value; }
-    Completion release_error()
+    [[nodiscard]] constexpr bool is_error() const { return m_type == Type::Throw; }
+    [[nodiscard]] constexpr Value release_value() { return m_value; }
+    constexpr Completion release_error()
     {
         VERIFY(is_error());
         return { m_type, release_value() };
@@ -112,12 +112,12 @@ private:
     };
     friend AK::Optional<Completion>;
 
-    Completion(EmptyTag)
+    constexpr Completion(EmptyTag)
         : m_type(Type::Empty)
     {
     }
 
-    bool is_empty() const
+    constexpr bool is_empty() const
     {
         return m_type == Type::Empty;
     }
@@ -139,27 +139,27 @@ class Optional<JS::Completion> : public OptionalBase<JS::Completion> {
 public:
     using ValueType = JS::Completion;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
-    Optional(Optional<JS::Completion> const& other)
+    constexpr Optional(Optional<JS::Completion> const& other)
     {
         if (other.has_value())
             m_value = other.m_value;
     }
 
-    Optional(Optional&& other)
+    constexpr Optional(Optional&& other)
         : m_value(move(other.m_value))
     {
     }
 
     template<typename U = JS::Completion>
-    explicit(!IsConvertible<U&&, JS::Completion>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, JS::Completion>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<JS::Completion>> && IsConstructible<JS::Completion, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             clear();
@@ -168,7 +168,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -177,34 +177,34 @@ public:
         return *this;
     }
 
-    void clear()
+    constexpr void clear()
     {
         m_value = JS::Completion(JS::Completion::EmptyTag {});
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_empty();
     }
 
-    [[nodiscard]] JS::Completion& value() &
+    [[nodiscard]] constexpr JS::Completion& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] JS::Completion const& value() const&
+    [[nodiscard]] constexpr JS::Completion const& value() const&
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] JS::Completion value() &&
+    [[nodiscard]] constexpr JS::Completion value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] JS::Completion release_value()
+    [[nodiscard]] constexpr JS::Completion release_value()
     {
         VERIFY(has_value());
         JS::Completion released_value = m_value;

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -154,7 +154,7 @@ public:
         return !is_nan() && !is_infinity();
     }
 
-    Value()
+    constexpr Value()
         : Value(UNDEFINED_TAG << GC::TAG_SHIFT, (u64)0)
     {
     }
@@ -428,12 +428,12 @@ private:
 
     enum class EmptyTag { Empty };
 
-    Value(EmptyTag)
+    constexpr Value(EmptyTag)
         : Value(EMPTY_TAG << GC::TAG_SHIFT, (u64)0)
     {
     }
 
-    Value(u64 tag, u64 val)
+    constexpr Value(u64 tag, u64 val)
     {
         ASSERT(!(tag & val));
         m_value.encoded = tag | val;
@@ -467,9 +467,9 @@ private:
 
     ThrowCompletionOr<i32> to_i32_slow_case(VM&) const;
 
-    friend Value js_undefined();
-    friend Value js_null();
-    friend Value js_special_empty_value();
+    friend constexpr Value js_undefined();
+    friend constexpr Value js_null();
+    friend constexpr Value js_special_empty_value();
     friend ThrowCompletionOr<Value> greater_than(VM&, Value lhs, Value rhs);
     friend ThrowCompletionOr<Value> greater_than_equals(VM&, Value lhs, Value rhs);
     friend ThrowCompletionOr<Value> less_than(VM&, Value lhs, Value rhs);
@@ -478,17 +478,17 @@ private:
     friend bool same_value_non_number(Value lhs, Value rhs);
 };
 
-inline Value js_undefined()
+inline constexpr Value js_undefined()
 {
     return Value(UNDEFINED_TAG << GC::TAG_SHIFT, (u64)0);
 }
 
-inline Value js_null()
+inline constexpr Value js_null()
 {
     return Value(NULL_TAG << GC::TAG_SHIFT, (u64)0);
 }
 
-inline Value js_special_empty_value()
+inline constexpr Value js_special_empty_value()
 {
     return Value(Value::EmptyTag::Empty);
 }
@@ -564,38 +564,38 @@ class Optional<JS::Value> : public OptionalBase<JS::Value> {
 public:
     using ValueType = JS::Value;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
-    Optional(Optional<JS::Value> const& other)
+    constexpr Optional(Optional<JS::Value> const& other)
     {
         if (other.has_value())
             m_value = other.m_value;
     }
 
-    Optional(Optional&& other)
+    constexpr Optional(Optional&& other)
         : m_value(other.m_value)
     {
     }
 
     template<typename U = JS::Value>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    explicit(!IsConvertible<U&&, JS::Value>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, JS::Value>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<JS::Value>> && IsConstructible<JS::Value, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             clear();
@@ -604,7 +604,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -613,34 +613,34 @@ public:
         return *this;
     }
 
-    void clear()
+    constexpr void clear()
     {
         m_value = JS::js_special_empty_value();
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_special_empty_value();
     }
 
-    [[nodiscard]] JS::Value& value() &
+    [[nodiscard]] constexpr JS::Value& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] JS::Value const& value() const&
+    [[nodiscard]] constexpr JS::Value const& value() const&
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] JS::Value value() &&
+    [[nodiscard]] constexpr JS::Value value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] JS::Value release_value()
+    [[nodiscard]] constexpr JS::Value release_value()
     {
         VERIFY(has_value());
         JS::Value released_value = m_value;

--- a/Libraries/LibTest/Macros.h
+++ b/Libraries/LibTest/Macros.h
@@ -130,6 +130,9 @@ bool assume(T const& expression, StringView expression_string, SourceLocation lo
     return true;
 }
 
+template<typename T>
+consteval void expect_consteval(T) { }
+
 }
 
 #define EXPECT(...)                                    \
@@ -178,6 +181,8 @@ bool assume(T const& expression, StringView expression_string, SourceLocation lo
             ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: {}", __FILE__, __LINE__, message); \
         ::Test::set_current_test_result(::Test::TestResult::Failed);                       \
     } while (false)
+
+#define EXPECT_CONSTEVAL(...) ::Test::expect_consteval(__VA_ARGS__)
 
 // To use, specify the lambda to execute in a sub process and verify it exits:
 //  EXPECT_CRASH("This should fail", []{

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -841,7 +841,6 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     bool should_clip_overflow = computed_values().overflow_x() != CSS::Overflow::Visible && computed_values().overflow_y() != CSS::Overflow::Visible;
-    Optional<u32> corner_clip_id;
 
     auto clip_box = absolute_padding_box_rect();
     if (get_clip_rect().has_value()) {

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -18,7 +18,7 @@ class NonCopyable {
     AK_MAKE_DEFAULT_MOVABLE(NonCopyable);
 
 public:
-    NonCopyable() { }
+    constexpr NonCopyable() { }
     ~NonCopyable() = default;
 
     int x { 13 };
@@ -29,7 +29,7 @@ class NonTriviallyCopyable {
     AK_MAKE_DEFAULT_MOVABLE(NonTriviallyCopyable);
 
 public:
-    NonTriviallyCopyable() = default;
+    constexpr NonTriviallyCopyable() = default;
     ~NonTriviallyCopyable() = default;
 
     ByteString x { "13" };
@@ -40,7 +40,7 @@ class TriviallyCopyable {
     AK_MAKE_DEFAULT_MOVABLE(TriviallyCopyable);
 
 public:
-    TriviallyCopyable() = default;
+    constexpr TriviallyCopyable() = default;
     ~TriviallyCopyable() = default;
 
     int x { 13 };
@@ -142,6 +142,56 @@ TEST_CASE(comparison_with_numeric_types)
     EXPECT_EQ(opt1, 7.0);
     EXPECT_EQ(opt1, 7u);
     EXPECT_NE(opt1, -2);
+}
+
+TEST_CASE(test_constexpr)
+{
+    int i = 13;
+    NonCopyable dcm {};
+
+    EXPECT_CONSTEVAL(Optional<int> {});
+    EXPECT_CONSTEVAL(Optional<NonCopyable> {});
+    EXPECT_CONSTEVAL(Optional<int const> {});
+    EXPECT_CONSTEVAL(Optional<NonCopyable const> {});
+    EXPECT_CONSTEVAL(Optional<int&> {});
+    EXPECT_CONSTEVAL(Optional<NonCopyable&> {});
+    EXPECT_CONSTEVAL(Optional<int const&> {});
+    EXPECT_CONSTEVAL(Optional<NonCopyable const&> {});
+
+    EXPECT_CONSTEVAL(Optional<int> { 13 });
+    EXPECT_CONSTEVAL(Optional<NonCopyable> { NonCopyable {} });
+    EXPECT_CONSTEVAL(Optional<int const> { 13 });
+    EXPECT_CONSTEVAL(Optional<NonCopyable const> { NonCopyable {} });
+    EXPECT_CONSTEVAL(Optional<int&> { i });
+    EXPECT_CONSTEVAL(Optional<NonCopyable&> { dcm });
+    EXPECT_CONSTEVAL(Optional<int const&> { 13 });
+    EXPECT_CONSTEVAL(Optional<NonCopyable const&> { NonCopyable {} });
+
+    static_assert(!Optional<int> {}.has_value());
+    static_assert(!Optional<NonCopyable> {}.has_value());
+    static_assert(!Optional<int const> {}.has_value());
+    static_assert(!Optional<NonCopyable const> {}.has_value());
+    static_assert(!Optional<int&> {}.has_value());
+    static_assert(!Optional<NonCopyable&> {}.has_value());
+    static_assert(!Optional<int const&> {}.has_value());
+    static_assert(!Optional<NonCopyable const&> {}.has_value());
+
+    static_assert(Optional<int> { 13 }.has_value());
+    static_assert(Optional<NonCopyable> { NonCopyable {} }.has_value());
+    static_assert(Optional<int const> { 13 }.has_value());
+    static_assert(Optional<NonCopyable const> { NonCopyable {} }.has_value());
+    static_assert(Optional<int&> { i }.has_value());
+    static_assert(Optional<NonCopyable&> { dcm }.has_value());
+    static_assert(Optional<int const&> { 13 }.has_value());
+    static_assert(Optional<NonCopyable const&> { NonCopyable {} }.has_value());
+
+    static_assert(Optional<int> { 13 }.value() == 13);
+    static_assert(Optional<NonCopyable> { NonCopyable {} }.value().x == 13);
+    static_assert(Optional<int const> { 13 }.value() == 13);
+    static_assert(Optional<int const&> { 13 }.value() == 13);
+    static_assert(Optional<NonCopyable const&> { NonCopyable {} }.value().x == 13);
+
+    static_assert(!(Optional<int> { 1 } = {}).has_value(), "Assigning a `{}` should clear the Optional, even for scalar types^^");
 }
 
 TEST_CASE(test_copy_ctor_and_dtor_called)
@@ -292,6 +342,63 @@ TEST_CASE(comparison_reference)
     EXPECT_EQ(opt1, opt2);
     EXPECT_NE(opt1, opt3);
 }
+
+TEST_CASE(uninitialized_constructor)
+{
+    static bool was_constructed = false;
+    struct Internal {
+        Internal() { was_constructed = true; }
+    };
+
+    struct ShouldNotBeDefaultConstructed {
+        bool m_default_constructed { true };
+        Internal m_internal;
+        ShouldNotBeDefaultConstructed() = default;
+        ShouldNotBeDefaultConstructed(bool)
+            : m_default_constructed(false)
+        {
+        }
+    };
+    static_assert(IsConstructible<ShouldNotBeDefaultConstructed>);
+
+    Optional<ShouldNotBeDefaultConstructed> opt;
+    EXPECT(!was_constructed);
+    EXPECT(!opt.has_value());
+
+    opt = ShouldNotBeDefaultConstructed { true };
+    EXPECT(was_constructed);
+    EXPECT(opt.has_value());
+    EXPECT(!opt.value().m_default_constructed);
+}
+
+consteval bool test_constexpr()
+{
+    Optional<int> none;
+    if (none.has_value())
+        return false;
+
+    Optional<int> x;
+    x = 3;
+    if (!x.has_value())
+        return false;
+
+    if (x.value() != 3)
+        return false;
+
+    Optional<int> y;
+    y = x.release_value();
+    if (!y.has_value())
+        return false;
+
+    if (y.value() != 3)
+        return false;
+
+    if (x.has_value())
+        return false;
+
+    return true;
+}
+static_assert(test_constexpr());
 
 template<typename To, typename From>
 struct CheckAssignments;

--- a/Tests/ClangPlugins/CMakeLists.txt
+++ b/Tests/ClangPlugins/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND CLANG_PLUGINS_COMPILE_OPTIONS_FOR_TESTS
     -Wno-literal-range
     -Wno-unknown-warning-option
     -Wno-unqualified-std-cast-call
+    -fgnuc-version=4.2.1 # NOTE: Clang default as of 10.0.0
 )
 
 # Ensure we always check for invalid function field types regardless of the value of ENABLE_CLANG_PLUGINS_INVALID_FUNCTION_MEMBERS


### PR DESCRIPTION
Attempt 1: https://github.com/LadybirdBrowser/ladybird/pull/2455
Related SerenityOS PR: https://github.com/SerenityOS/serenity/pull/25740