### PR TITLE
LibWeb/CSS: Fetch ImageStyleValues closer to spec

### DIFF
--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -116,7 +116,7 @@ void CSSImportRule::fetch()
     m_document_load_event_delayer.emplace(*m_document);
 
     // 4. Fetch a style resource from parsedUrl, with stylesheet parentStylesheet, destination "style", CORS mode "no-cors", and processResponse being the following steps given response response and byte stream, null or failure byteStream:
-    fetch_a_style_resource(parsed_url.value(), parent_style_sheet, Fetch::Infrastructure::Request::Destination::Style, CorsMode::NoCors,
+    fetch_a_style_resource(parsed_url.value(), { parent_style_sheet }, Fetch::Infrastructure::Request::Destination::Style, CorsMode::NoCors,
         [strong_this = GC::Ref { *this }, parent_style_sheet = GC::Ref { parent_style_sheet }, parsed_url = parsed_url.value()](auto response, auto maybe_byte_stream) {
             // AD-HOC: Stop delaying the load event.
             ScopeGuard guard = [strong_this] {

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -116,7 +116,7 @@ void CSSImportRule::fetch()
     m_document_load_event_delayer.emplace(*m_document);
 
     // 4. Fetch a style resource from parsedUrl, with stylesheet parentStylesheet, destination "style", CORS mode "no-cors", and processResponse being the following steps given response response and byte stream, null or failure byteStream:
-    fetch_a_style_resource(parsed_url->to_string(), parent_style_sheet, Fetch::Infrastructure::Request::Destination::Style, CorsMode::NoCors,
+    fetch_a_style_resource(parsed_url.value(), parent_style_sheet, Fetch::Infrastructure::Request::Destination::Style, CorsMode::NoCors,
         [strong_this = GC::Ref { *this }, parent_style_sheet = GC::Ref { parent_style_sheet }, parsed_url = parsed_url.value()](auto response, auto maybe_byte_stream) {
             // AD-HOC: Stop delaying the load event.
             ScopeGuard guard = [strong_this] {

--- a/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -205,6 +205,16 @@ void CSSStyleRule::clear_caches()
     m_cached_absolutized_selectors.clear();
 }
 
+void CSSStyleRule::set_parent_style_sheet(CSSStyleSheet* parent_style_sheet)
+{
+    Base::set_parent_style_sheet(parent_style_sheet);
+
+    // This is annoying: Style values that request resources need to know their CSSStyleSheet in order to fetch them.
+    for (auto const& property : m_declaration->properties()) {
+        const_cast<CSSStyleValue&>(*property.value).set_style_sheet(parent_style_sheet);
+    }
+}
+
 CSSStyleRule const* CSSStyleRule::parent_style_rule() const
 {
     for (auto* parent = parent_rule(); parent; parent = parent->parent_rule()) {

--- a/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -42,6 +42,8 @@ private:
     virtual void clear_caches() override;
     virtual String serialized() const override;
 
+    virtual void set_parent_style_sheet(CSSStyleSheet*) override;
+
     CSSStyleRule const* parent_style_rule() const;
 
     SelectorList m_selectors;

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -68,6 +68,7 @@ public:
     void add_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root);
     void remove_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root);
     void invalidate_owners(DOM::StyleInvalidationReason);
+    GC::Ptr<DOM::Document> owning_document() const;
 
     Optional<FlyString> default_namespace() const;
     GC::Ptr<CSSNamespaceRule> default_namespace_rule() const { return m_default_namespace_rule; }

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -381,6 +381,7 @@ public:
     [[nodiscard]] int to_font_slope() const;
     [[nodiscard]] int to_font_width() const;
 
+    virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) { }
     virtual void visit_edges(JS::Cell::Visitor&) const { }
 
     virtual bool equals(CSSStyleValue const& other) const = 0;
@@ -400,6 +401,7 @@ private:
 template<typename T>
 struct StyleValueWithDefaultOperators : public CSSStyleValue {
     using CSSStyleValue::CSSStyleValue;
+    using Base = CSSStyleValue;
 
     virtual bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -9,11 +9,12 @@
 #include <LibWeb/CSS/Fetch.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
+#include <LibWeb/HTML/SharedResourceRequest.h>
 
 namespace Web::CSS {
 
 // https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
-void fetch_a_style_resource(StyleResourceURL const& url_value, StyleSheetOrDocument sheet_or_document, Fetch::Infrastructure::Request::Destination destination, CorsMode cors_mode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response)
+static GC::Ptr<Fetch::Infrastructure::Request> fetch_a_style_resource_impl(StyleResourceURL const& url_value, StyleSheetOrDocument sheet_or_document, Fetch::Infrastructure::Request::Destination destination, CorsMode cors_mode)
 {
     // AD-HOC: Not every caller has a CSSStyleSheet, so allow passing a Document in instead for URL completion.
     //         Spec issue: https://github.com/w3c/csswg-drafts/issues/12065
@@ -39,7 +40,7 @@ void fetch_a_style_resource(StyleResourceURL const& url_value, StyleSheetOrDocum
         [](CSS::URL const& url) { return url.url(); });
     auto parsed_url = ::URL::Parser::basic_parse(url_string, base);
     if (!parsed_url.has_value())
-        return;
+        return {};
 
     // 4. Let req be a new request whose url is parsedUrl, whose destination is destination, mode is corsMode,
     //    origin is environmentSettings’s origin, credentials mode is "same-origin", use-url-credentials flag is set,
@@ -70,10 +71,65 @@ void fetch_a_style_resource(StyleResourceURL const& url_value, StyleSheetOrDocum
         request->set_initiator_type(Fetch::Infrastructure::Request::InitiatorType::CSS);
 
     // 8. Fetch req, with processresponseconsumebody set to processResponse.
-    Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
-    fetch_algorithms_input.process_response_consume_body = move(process_response);
+    // NB: Implemented by caller.
+    return request;
+}
 
-    (void)Fetch::Fetching::fetch(environment_settings.realm(), request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
+// https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
+void fetch_a_style_resource(StyleResourceURL const& url_value, StyleSheetOrDocument sheet_or_document, Fetch::Infrastructure::Request::Destination destination, CorsMode cors_mode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response)
+{
+    if (auto request = fetch_a_style_resource_impl(url_value, sheet_or_document, destination, cors_mode)) {
+        auto& environment_settings = HTML::relevant_settings_object(sheet_or_document.visit([](auto& it) -> JS::Object& { return it; }));
+        auto& vm = environment_settings.vm();
+
+        Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
+        fetch_algorithms_input.process_response_consume_body = move(process_response);
+
+        (void)Fetch::Fetching::fetch(environment_settings.realm(), *request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
+    }
+}
+
+// https://drafts.csswg.org/css-images-4/#fetch-an-external-image-for-a-stylesheet
+GC::Ptr<HTML::SharedResourceRequest> fetch_an_external_image_for_a_stylesheet(StyleResourceURL const& url_value, StyleSheetOrDocument sheet_or_document)
+{
+    // To fetch an external image for a stylesheet, given a <url> url and CSSStyleSheet sheet, fetch a style resource
+    // given url, with stylesheet CSSStyleSheet, destination "image", CORS mode "no-cors", and processResponse being
+    // the following steps given response res and null, failure or a byte stream byteStream: If byteStream is a byte
+    // stream, load the image from the byte stream.
+
+    // NB: We can't directly call fetch_a_style_resource() because we want to make use of SharedResourceRequest to
+    //     deduplicate image requests.
+
+    if (auto request = fetch_a_style_resource_impl(url_value, sheet_or_document, Fetch::Infrastructure::Request::Destination::Image, CorsMode::NoCors)) {
+
+        auto document = sheet_or_document.visit(
+            [&](GC::Ref<CSSStyleSheet> const& sheet) -> GC::Ref<DOM::Document> { return *sheet->owning_document(); },
+            [](GC::Ref<DOM::Document> const& document) -> GC::Ref<DOM::Document> { return document; });
+        auto& realm = document->realm();
+
+        auto shared_resource_request = HTML::SharedResourceRequest::get_or_create(realm, document->page(), request->url());
+        shared_resource_request->add_callbacks(
+            [document, weak_document = document->make_weak_ptr<DOM::Document>()] {
+                if (!weak_document)
+                    return;
+
+                if (auto navigable = document->navigable()) {
+                    // Once the image has loaded, we need to re-resolve CSS properties that depend on the image's dimensions.
+                    document->set_needs_to_resolve_paint_only_properties();
+
+                    // FIXME: Do less than a full repaint if possible?
+                    document->set_needs_display();
+                }
+            },
+            nullptr);
+
+        if (shared_resource_request->needs_fetching())
+            shared_resource_request->fetch_resource(realm, *request);
+
+        return shared_resource_request;
+    }
+
+    return nullptr;
 }
 
 }

--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -44,9 +44,8 @@ void fetch_a_style_resource(String const& url_value, CSSStyleSheet const& sheet,
     // FIXME: No specs seem to define these yet. When they do, implement them.
 
     // 6. If req’s mode is "cors", set req’s referrer to sheet’s location. [CSSOM]
-    if (request->mode() == Fetch::Infrastructure::Request::Mode::CORS) {
-        // FIXME: sheet's location is an optional string, what do we do here?
-    }
+    if (request->mode() == Fetch::Infrastructure::Request::Mode::CORS)
+        request->set_referrer(sheet.location().value());
 
     // 7. If sheet’s origin-clean flag is set, set req’s initiator type to "css". [CSSOM]
     if (sheet.is_origin_clean())

--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2024-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,7 +12,7 @@
 namespace Web::CSS {
 
 // https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
-void fetch_a_style_resource(String const& url_value, CSSStyleSheet const& sheet, Fetch::Infrastructure::Request::Destination destination, CorsMode cors_mode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response)
+void fetch_a_style_resource(StyleResourceURL const& url_value, CSSStyleSheet const& sheet, Fetch::Infrastructure::Request::Destination destination, CorsMode cors_mode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response)
 {
     auto& vm = sheet.vm();
 
@@ -23,7 +23,10 @@ void fetch_a_style_resource(String const& url_value, CSSStyleSheet const& sheet,
     auto base = sheet.base_url().value_or(environment_settings.api_base_url());
 
     // 3. Let parsedUrl be the result of the URL parser steps with urlValue’s url and base. If the algorithm returns an error, return.
-    auto parsed_url = ::URL::Parser::basic_parse(url_value, base);
+    auto url_string = url_value.visit(
+        [](::URL::URL const& url) { return url.to_string(); },
+        [](CSS::URL const& url) { return url.url(); });
+    auto parsed_url = ::URL::Parser::basic_parse(url_string, base);
     if (!parsed_url.has_value())
         return;
 

--- a/Libraries/LibWeb/CSS/Fetch.h
+++ b/Libraries/LibWeb/CSS/Fetch.h
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/URL.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
@@ -25,5 +26,8 @@ using StyleSheetOrDocument = Variant<GC::Ref<CSSStyleSheet>, GC::Ref<DOM::Docume
 
 // https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
 void fetch_a_style_resource(StyleResourceURL const& url, StyleSheetOrDocument, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
+
+// https://drafts.csswg.org/css-images-4/#fetch-an-external-image-for-a-stylesheet
+GC::Ptr<HTML::SharedResourceRequest> fetch_an_external_image_for_a_stylesheet(StyleResourceURL const&, StyleSheetOrDocument);
 
 }

--- a/Libraries/LibWeb/CSS/Fetch.h
+++ b/Libraries/LibWeb/CSS/Fetch.h
@@ -20,7 +20,10 @@ enum class CorsMode {
 
 using StyleResourceURL = Variant<::URL::URL, CSS::URL>;
 
+// AD-HOC: See comment inside fetch_a_style_resource() implementation.
+using StyleSheetOrDocument = Variant<GC::Ref<CSSStyleSheet>, GC::Ref<DOM::Document>>;
+
 // https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
-void fetch_a_style_resource(StyleResourceURL const& url, CSSStyleSheet const&, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
+void fetch_a_style_resource(StyleResourceURL const& url, StyleSheetOrDocument, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
 
 }

--- a/Libraries/LibWeb/CSS/Fetch.h
+++ b/Libraries/LibWeb/CSS/Fetch.h
@@ -1,12 +1,13 @@
 /*
- * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2024-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/String.h>
+#include <LibURL/URL.h>
+#include <LibWeb/CSS/URL.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 
@@ -17,7 +18,9 @@ enum class CorsMode {
     Cors,
 };
 
+using StyleResourceURL = Variant<::URL::URL, CSS::URL>;
+
 // https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
-void fetch_a_style_resource(String const& url, CSSStyleSheet const&, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
+void fetch_a_style_resource(StyleResourceURL const& url, CSSStyleSheet const&, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
 
 }

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2013,13 +2013,10 @@ RefPtr<AbstractImageStyleValue> Parser::parse_image_value(TokenStream<ComponentV
     if (url.has_value()) {
         // If the value is a 'url(..)' parse as image, but if it is just a reference 'url(#xx)', leave it alone,
         // so we can parse as URL further on. These URLs are used as references inside SVG documents for masks.
+        // FIXME: Remove this special case once mask-image accepts `<image>`.
         if (!url->url().starts_with('#')) {
-            // FIXME: Stop completing the URL here
-            auto completed_url = complete_url(url->url());
-            if (completed_url.has_value()) {
-                tokens.discard_a_mark();
-                return ImageStyleValue::create(completed_url.release_value());
-            }
+            tokens.discard_a_mark();
+            return ImageStyleValue::create(url.release_value());
         }
         tokens.restore_a_mark();
         return nullptr;

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/ImageRequest.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
+#include <LibWeb/HTML/SharedResourceRequest.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/Platform/Timer.h>

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -1,18 +1,17 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "ImageStyleValue.h"
 #include <LibWeb/CSS/ComputedValues.h>
-#include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/Fetch.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/DecodedImageData.h>
-#include <LibWeb/HTML/ImageRequest.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/SharedResourceRequest.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
@@ -21,7 +20,17 @@
 
 namespace Web::CSS {
 
-ImageStyleValue::ImageStyleValue(::URL::URL const& url)
+ValueComparingNonnullRefPtr<ImageStyleValue> ImageStyleValue::create(URL const& url)
+{
+    return adopt_ref(*new (nothrow) ImageStyleValue(url));
+}
+
+ValueComparingNonnullRefPtr<ImageStyleValue> ImageStyleValue::create(::URL::URL const& url)
+{
+    return adopt_ref(*new (nothrow) ImageStyleValue(URL { url.to_string() }));
+}
+
+ImageStyleValue::ImageStyleValue(URL const& url)
     : AbstractImageStyleValue(Type::Image)
     , m_url(url)
 {
@@ -35,6 +44,7 @@ void ImageStyleValue::visit_edges(JS::Cell::Visitor& visitor) const
     // FIXME: visit_edges in non-GC allocated classes is confusing pattern.
     //        Consider making CSSStyleValue to be GC allocated instead.
     visitor.visit(m_resource_request);
+    visitor.visit(m_style_sheet);
     visitor.visit(m_timer);
 }
 
@@ -44,37 +54,26 @@ void ImageStyleValue::load_any_resources(DOM::Document& document)
         return;
     m_document = &document;
 
-    m_resource_request = HTML::SharedResourceRequest::get_or_create(document.realm(), document.page(), m_url);
-    m_resource_request->add_callbacks(
-        [this, weak_this = make_weak_ptr()] {
-            if (!weak_this)
-                return;
+    if (m_style_sheet) {
+        m_resource_request = fetch_an_external_image_for_a_stylesheet(m_url, { *m_style_sheet });
+    } else {
+        m_resource_request = fetch_an_external_image_for_a_stylesheet(m_url, { document });
+    }
+    if (m_resource_request) {
+        m_resource_request->add_callbacks(
+            [this, weak_this = make_weak_ptr()] {
+                if (!weak_this || !m_document)
+                    return;
 
-            if (!m_document)
-                return;
-
-            if (auto navigable = m_document->navigable()) {
-                // Once the image has loaded, we need to re-resolve CSS properties that depend on the image's dimensions.
-                m_document->set_needs_to_resolve_paint_only_properties();
-
-                // FIXME: Do less than a full repaint if possible?
-                m_document->set_needs_display();
-            }
-
-            auto image_data = m_resource_request->image_data();
-            if (image_data->is_animated() && image_data->frame_count() > 1) {
-                m_timer = Platform::Timer::create(m_document->heap());
-                m_timer->set_interval(image_data->frame_duration(0));
-                m_timer->on_timeout = GC::create_function(m_document->heap(), [this] { animate(); });
-                m_timer->start();
-            }
-        },
-        nullptr);
-
-    if (m_resource_request->needs_fetching()) {
-        auto request = HTML::create_potential_CORS_request(document.vm(), m_url, Fetch::Infrastructure::Request::Destination::Image, HTML::CORSSettingAttribute::NoCORS);
-        request->set_client(&document.relevant_settings_object());
-        m_resource_request->fetch_resource(document.realm(), request);
+                auto image_data = m_resource_request->image_data();
+                if (image_data->is_animated() && image_data->frame_count() > 1) {
+                    m_timer = Platform::Timer::create(m_document->heap());
+                    m_timer->set_interval(image_data->frame_duration(0));
+                    m_timer->on_timeout = GC::create_function(m_document->heap(), [this] { animate(); });
+                    m_timer->start();
+                }
+            },
+            nullptr);
     }
 }
 
@@ -116,7 +115,7 @@ Gfx::ImmutableBitmap const* ImageStyleValue::bitmap(size_t frame_index, Gfx::Int
 
 String ImageStyleValue::to_string(SerializationMode) const
 {
-    return serialize_a_url(m_url.to_string());
+    return m_url.to_string();
 }
 
 bool ImageStyleValue::equals(CSSStyleValue const& other) const
@@ -175,6 +174,12 @@ Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap() const
             return b->get_pixel(0, 0);
     }
     return {};
+}
+
+void ImageStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
+{
+    Base::set_style_sheet(style_sheet);
+    m_style_sheet = style_sheet;
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -9,11 +9,10 @@
 
 #pragma once
 
-#include <LibGC/Root.h>
 #include <LibJS/Heap/Cell.h>
-#include <LibURL/URL.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
+#include <LibWeb/CSS/URL.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -25,10 +24,9 @@ class ImageStyleValue final
     using Base = AbstractImageStyleValue;
 
 public:
-    static ValueComparingNonnullRefPtr<ImageStyleValue> create(::URL::URL const& url)
-    {
-        return adopt_ref(*new (nothrow) ImageStyleValue(url));
-    }
+    static ValueComparingNonnullRefPtr<ImageStyleValue> create(URL const&);
+    static ValueComparingNonnullRefPtr<ImageStyleValue> create(::URL::URL const&);
+
     virtual ~ImageStyleValue() override;
 
     virtual void visit_edges(JS::Cell::Visitor& visitor) const override;
@@ -53,14 +51,17 @@ public:
     GC::Ptr<HTML::DecodedImageData> image_data() const;
 
 private:
-    ImageStyleValue(::URL::URL const&);
+    ImageStyleValue(URL const&);
 
-    GC::Ptr<HTML::SharedResourceRequest> m_resource_request;
+    virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
 
     void animate();
     Gfx::ImmutableBitmap const* bitmap(size_t frame_index, Gfx::IntSize = {}) const;
 
-    ::URL::URL m_url;
+    GC::Ptr<HTML::SharedResourceRequest> m_resource_request;
+    GC::Ptr<CSSStyleSheet> m_style_sheet;
+
+    URL m_url;
     WeakPtr<DOM::Document> m_document;
 
     size_t m_current_frame_index { 0 };

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -14,7 +14,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
-#include <LibWeb/HTML/SharedResourceRequest.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -433,4 +433,11 @@ String ShorthandStyleValue::to_string(SerializationMode mode) const
     }
 }
 
+void ShorthandStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
+{
+    Base::set_style_sheet(style_sheet);
+    for (auto& value : m_properties.values)
+        const_cast<CSSStyleValue&>(*value).set_style_sheet(style_sheet);
+}
+
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.h
@@ -30,6 +30,8 @@ public:
 private:
     ShorthandStyleValue(PropertyID shorthand, Vector<PropertyID> sub_properties, Vector<ValueComparingNonnullRefPtr<CSSStyleValue const>> values);
 
+    virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
+
     struct Properties {
         PropertyID shorthand_property;
         Vector<PropertyID> sub_properties;

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -37,6 +37,13 @@ String StyleValueList::to_string(SerializationMode mode) const
             builder.append(separator);
     }
     return MUST(builder.to_string());
+}
+
+void StyleValueList::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
+{
+    Base::set_style_sheet(style_sheet);
+    for (auto& value : m_properties.values)
+        const_cast<CSSStyleValue&>(*value).set_style_sheet(style_sheet);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -45,6 +45,8 @@ private:
         , m_properties { .separator = separator, .values = move(values) }
     {
     }
+
+    virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
 
     struct Properties {
         Separator separator;

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/SharedResourceRequest.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Painting/PaintableBox.h>

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -26,6 +26,7 @@
 #include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
+#include <LibWeb/HTML/SharedResourceRequest.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/NavigableContainerViewport.h>
 #include <LibWeb/Loader/ResourceLoader.h>

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
+#include <LibWeb/HTML/SharedResourceRequest.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/SVGGraphicsBox.h>
 #include <LibWeb/Namespace.h>

--- a/Tests/LibWeb/Ref/data/checkerboard-background.css
+++ b/Tests/LibWeb/Ref/data/checkerboard-background.css
@@ -1,0 +1,3 @@
+#checkerboard {
+    background: url("2x2checkerboard.png");
+}

--- a/Tests/LibWeb/Ref/expected/css/images-load-relative-to-style-sheet-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/images-load-relative-to-style-sheet-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+     #checkerboard {
+          width: 20px;
+          height: 20px;
+          background: url("../../data/2x2checkerboard.png");
+          background-size: cover;
+     }
+</style>
+<!-- FIXME: Workaround to ensure CSS background-image is loaded before taking screenshot: https://github.com/LadybirdBrowser/ladybird/issues/3448 -->
+<img style="display:none" src="../../data/2x2checkerboard.png">
+<div id="checkerboard"></div>

--- a/Tests/LibWeb/Ref/input/css/images-load-relative-to-imported-style-sheet.html
+++ b/Tests/LibWeb/Ref/input/css/images-load-relative-to-imported-style-sheet.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/images-load-relative-to-style-sheet-ref.html" />
+<style>
+     @import url("../../data/checkerboard-background.css");
+     #checkerboard {
+          width: 20px;
+          height: 20px;
+          background-size: cover;
+     }
+</style>
+<!-- FIXME: Workaround to ensure CSS background-image is loaded before taking screenshot: https://github.com/LadybirdBrowser/ladybird/issues/3448 -->
+<img style="display:none" src="../../data/2x2checkerboard.png">
+<div id="checkerboard"></div>

--- a/Tests/LibWeb/Ref/input/css/images-load-relative-to-linked-style-sheet.html
+++ b/Tests/LibWeb/Ref/input/css/images-load-relative-to-linked-style-sheet.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/images-load-relative-to-style-sheet-ref.html" />
+<link rel="stylesheet" href="../../data/checkerboard-background.css" />
+<style>
+     #checkerboard {
+          width: 20px;
+          height: 20px;
+          background-size: cover;
+     }
+</style>
+<!-- FIXME: Workaround to ensure CSS background-image is loaded before taking screenshot: https://github.com/LadybirdBrowser/ladybird/issues/3448 -->
+<img style="display:none" src="../../data/2x2checkerboard.png">
+<div id="checkerboard"></div>


### PR DESCRIPTION
Part 2 of the CSS `<url>` saga.

We stop absolutizing the URLs for ImageStyleValue during parsing, and instead make use of CSS::URL and the spec's "fetch an external image for a stylesheet" algorithm. I've come across (and reported) a couple of issues in the spec involving these fetch algorithms, and so the implementation is a bit ad-hoc, but I've tried to keep it as close as possible.

I'm not seeing any regressions, but I added a test for one hole in our coverage so there could be others.