### PR TITLE
Tests: Rearrange log order in Messaging-post-channel-over-channel.html

### DIFF
--- a/Tests/LibWeb/Text/expected/Messaging/Messaging-post-channel-over-channel.txt
+++ b/Tests/LibWeb/Text/expected/Messaging/Messaging-post-channel-over-channel.txt
@@ -1,6 +1,6 @@
 Port1: "Hello"
 Port1: {"foo":{}}
-Port2: "Hello"
-Port3: "Hello from the transferred port"
 Port1: "DONE"
+Port2: "Hello"
 Port2: "DONE"
+Port3: "Hello from the transferred port"

--- a/Tests/LibWeb/Text/input/Messaging/Messaging-post-channel-over-channel.html
+++ b/Tests/LibWeb/Text/input/Messaging/Messaging-post-channel-over-channel.html
@@ -4,8 +4,12 @@
     asyncTest(done => {
         let channel = new MessageChannel();
 
+        const port1Logs = [];
+        const port2Logs = [];
+        const port3Logs = [];
+
         channel.port1.onmessage = (event) => {
-            println("Port1: " + JSON.stringify(event.data));
+            port1Logs.push("Port1: " + JSON.stringify(event.data));
             if (event.ports.length > 0) {
                 event.ports[0].postMessage("Hello from the transferred port");
                 return;
@@ -14,8 +18,14 @@
         };
 
         channel.port2.onmessage = (event) => {
-            println("Port2: " + JSON.stringify(event.data));
+            port2Logs.push("Port2: " + JSON.stringify(event.data));
             if (event.data === "DONE") {
+                for (let log of port1Logs)
+                    println(log);
+                for (let log of port2Logs)
+                    println(log);
+                for (let log of port3Logs)
+                    println(log);
                 done();
             }
         };
@@ -23,7 +33,7 @@
         let channel2 = new MessageChannel();
 
         channel2.port2.onmessage = (event) => {
-            println("Port3: " + JSON.stringify(event.data));
+            port3Logs.push("Port3: " + JSON.stringify(event.data));
             channel.port2.postMessage("DONE");
         }
 


### PR DESCRIPTION
When a message is posted to multiple ports at once, the order in which the callbacks for these messages are invoked is non-deterministic. To account for this, the test has been rewritten to accumulate logs for each port separately, and then print them grouped by port.