### PR TITLE
LibWeb/XML: Allow attributes with known namespaces

### DIFF
--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -116,7 +116,7 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
         m_namespace_stack.last().depth += 1;
     }
 
-    auto namespace_ = namespace_for_element(name);
+    auto namespace_ = namespace_for_name(name);
 
     auto qualified_name_or_error = DOM::validate_and_extract(m_document->realm(), namespace_, FlyString(MUST(String::from_byte_string(name))));
 
@@ -358,10 +358,17 @@ void XMLDocumentBuilder::document_end()
     m_document->set_ready_for_post_load_tasks(true);
 }
 
-Optional<FlyString> XMLDocumentBuilder::namespace_for_element(XML::Name const& element_name)
+Optional<FlyString> XMLDocumentBuilder::namespace_for_name(XML::Name const& name)
 {
-    Optional<ByteString> prefix;
-    if (auto parts = element_name.split_limit(':', 2); parts.size() == 2) {
+    Optional<StringView> prefix;
+
+    auto parts = name.split_limit(':', 3);
+    if (parts.size() > 2)
+        return {};
+
+    if (parts.size() == 2) {
+        if (parts[0].is_empty() || parts[1].is_empty())
+            return {};
         prefix = parts[0];
     }
 

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -38,7 +38,7 @@ private:
     virtual void comment(StringView data) override;
     virtual void document_end() override;
 
-    Optional<FlyString> namespace_for_element(XML::Name const& element_name);
+    Optional<FlyString> namespace_for_name(XML::Name const&);
 
     GC::Ref<DOM::Document> m_document;
     GC::Ptr<DOM::Node> m_current_node;

--- a/Tests/LibWeb/Ref/expected/svg/custom-namespaced-attributes-ref.svg
+++ b/Tests/LibWeb/Ref/expected/svg/custom-namespaced-attributes-ref.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg:svg
+    width="200"
+    height="200"
+    xmlns:svg="http://www.w3.org/2000/svg"
+>
+     <svg:circle cx="100" cy="100" r="50" fill="#ff0000"/>
+</svg:svg>

--- a/Tests/LibWeb/Ref/input/svg/custom-namespaced-attributes.svg
+++ b/Tests/LibWeb/Ref/input/svg/custom-namespaced-attributes.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg:svg
+    width="200"
+    height="200"
+    xmlns:svg="http://www.w3.org/2000/svg"
+    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+    inkscape:test="test"
+>
+     <link rel="match" href="../../expected/svg/custom-namespaced-attributes-ref.svg" />
+     <svg:circle cx="100" cy="100" r="50" fill="#ff0000"/>
+</svg:svg>


### PR DESCRIPTION
Fixes #2290.

I am far from an expert on XML but it seems a lot more correct to set `m_has_error = true` if setting the attribute fails, instead of `MUST()`-ing it.