### PR TITLE
LibWeb/DOM: Stub out Element pointerevents methods

### DIFF
--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -120,6 +120,10 @@ interface Element : Node {
     // FIXME: [CEReactions] undefined insertAdjacentHTML(DOMString position, (TrustedHTML or DOMString) string);
     [CEReactions] undefined insertAdjacentHTML(DOMString position, DOMString text);
 
+    // https://w3c.github.io/pointerevents/#extensions-to-the-element-interface
+    [FIXME] undefined setPointerCapture(long pointerId);
+    [FIXME] undefined releasePointerCapture(long pointerId);
+    [FIXME] boolean hasPointerCapture(long pointerId);
 };
 
 dictionary GetHTMLOptions {


### PR DESCRIPTION
Partly addresses #4302 - it removes the spam, but doesn't make panning actually work.