### PR TITLE
LibWeb/WebDriver: A few promise-related fixes

### DIFF
--- a/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -34,6 +34,8 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingCo
     auto& realm = environment_settings.realm();
     auto& global_scope = realm.global_environment();
 
+    // FIXME: This does not handle scripts which contain `await` statements. It is not as as simple as declaring this
+    //        function async, unfortunately. See: https://github.com/w3c/webdriver/issues/1436
     auto source_text = ByteString::formatted(
         R"~~~(function() {{
             {}


### PR DESCRIPTION
This resolves the remaining FIXMEs surrounding our use of promises in our WebDriver script executor. We don't quite pass everything related to promises yet, due to WPT using `await` in a couple of tests, which isn't handled by the spec yet.

`/webdriver/tests/classic/execute_script`
Before:
```
web-platform-test
~~~~~~~~~~~~~~~~~
Ran 134 checks (124 subtests, 10 tests)
Expected results: 121
Unexpected results: 13
  test: 1 (1 timeout)
  subtest: 12 (12 fail)
```
After:
```
web-platform-test
~~~~~~~~~~~~~~~~~
Ran 144 checks (134 subtests, 10 tests)
Expected results: 130
Unexpected results: 14
  subtest: 14 (14 fail)
```