### PR TITLE
Meta+Docs: Enforce and document minimum Git version

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -4,7 +4,7 @@
 
 Qt6 development packages, nasm, additional build tools, and a C++23 capable compiler like g++-13 or clang-17 are required.
 
-CMake 3.25 or newer must be available in $PATH.
+CMake 3.25 and Git 2.36 or newer versions of each must be available in $PATH.
 
 > [!NOTE]
 > In all of the below lists of packages, the Qt6 multimedia package is not needed if your Linux system supports PulseAudio.

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -85,6 +85,7 @@ fi
 
 create_build_dir() {
     check_program_version_at_least CMake cmake 3.25 || exit 1
+    check_program_version_at_least Git git 2.36 || exit 1 # Required by vcpkg
     cmake --preset "$BUILD_PRESET" "${CMAKE_ARGS[@]}" -S "$LADYBIRD_SOURCE_DIR" -B "$BUILD_DIR"
 }
 


### PR DESCRIPTION
vcpkg calls `git checkout-index` with the option `--ignore-skip-worktree-bits`. This option was [added in version 2.36](https://lore.kernel.org/git/xmqqh76qz791.fsf@gitster.g/).

It seems some Linux distros ship Git versions older than that, leading to a bunch of error spam as well as a red herring error message. To avoid this and improve the error message, check for the required Git version explicitly and mention it in the corresponding documentation.

Fixes #4331