### PR TITLE
LibWeb: Always store ComputedProperties, even if no invalidations

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -539,8 +539,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
     auto old_display_is_none = m_computed_properties ? m_computed_properties->display().is_none() : true;
     auto new_display_is_none = new_computed_properties->display().is_none();
 
-    if (!invalidation.is_none())
-        set_computed_properties(move(new_computed_properties));
+    set_computed_properties(move(new_computed_properties));
 
     if (old_display_is_none != new_display_is_none) {
         play_or_cancel_animations_after_display_property_change();

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-box/inheritance.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-box/inheritance.txt
@@ -1,0 +1,30 @@
+Harness status: OK
+
+Found 24 tests
+
+22 Pass
+2 Fail
+Pass	Property clear has initial value none
+Pass	Property clear does not inherit
+Pass	Property float has initial value none
+Pass	Property float does not inherit
+Pass	Property margin-bottom has initial value 0px
+Pass	Property margin-bottom does not inherit
+Pass	Property margin-left has initial value 0px
+Pass	Property margin-left does not inherit
+Pass	Property margin-right has initial value 0px
+Pass	Property margin-right does not inherit
+Pass	Property margin-top has initial value 0px
+Pass	Property margin-top does not inherit
+Fail	Property margin-trim has initial value none
+Fail	Property margin-trim does not inherit
+Pass	Property padding-bottom has initial value 0px
+Pass	Property padding-bottom does not inherit
+Pass	Property padding-left has initial value 0px
+Pass	Property padding-left does not inherit
+Pass	Property padding-right has initial value 0px
+Pass	Property padding-right does not inherit
+Pass	Property padding-top has initial value 0px
+Pass	Property padding-top does not inherit
+Pass	Property visibility has initial value visible
+Pass	Property visibility inherits

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-box/inheritance.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-box/inheritance.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSS Box Model properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#property-index">
+<link rel="help" href="https://www.w3.org/TR/CSS2/">
+<meta name="assert" content="Properties do not inherit.">
+<meta name="assert" content="length-percentage properties have initial value 0.">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+assert_not_inherited('clear', 'none', 'right');
+assert_not_inherited('float', 'none', 'right');
+
+assert_not_inherited('margin-bottom', '0px', '10px');
+assert_not_inherited('margin-left', '0px', '10px');
+assert_not_inherited('margin-right', '0px', '10px');
+assert_not_inherited('margin-top', '0px', '10px');
+assert_not_inherited('margin-trim', 'none', 'block');
+assert_not_inherited('padding-bottom', '0px', '10px');
+assert_not_inherited('padding-left', '0px', '10px');
+assert_not_inherited('padding-right', '0px', '10px');
+assert_not_inherited('padding-top', '0px', '10px');
+
+assert_inherited('visibility', 'visible', 'collapse');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Before this change, we'd skip storing the new ComputedProperties in Element::recompute_style() if there was no invalidation needed.

This caused us to lose the information about which properties are inherited and/or important (which is also carried by ComputedProperties, but doesn't affect invalidation).

Consequently, we'd then fail to recompute inherited styles, since that mechanism depends on this data.

The fix is simply to always store the new ComputedProperties.