### PR TITLE
Meta: Update vcpkg to latest master

### DIFF
--- a/Toolchain/BuildVcpkg.py
+++ b/Toolchain/BuildVcpkg.py
@@ -10,7 +10,7 @@ def main() -> int:
     script_dir = pathlib.Path(__file__).parent.resolve()
 
     git_repo = "https://github.com/microsoft/vcpkg.git"
-    git_rev = "533a5fda5c0646d1771345fb572e759283444d5f"  # main on 2025-04-03
+    git_rev = "bc994510d2eb11aac7b43b03f67a7751d5bfe0e4"  # main on 2025-04-12
 
     build_dir = script_dir.parent / "Build"
     build_dir.mkdir(parents=True, exist_ok=True)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "533a5fda5c0646d1771345fb572e759283444d5f",
+  "builtin-baseline": "bc994510d2eb11aac7b43b03f67a7751d5bfe0e4",
   "dependencies": [
     {
       "name": "angle",


### PR DESCRIPTION
Includes a fix for vcpkg git commands not working in git versions below 2.35.
I'm not sure what the minimum version of git for ladybird is, but for vcpkg 2.7.4 should work again. For ladybird I've tested 2.34.1.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4331.
More info in #4333.