### PR TITLE
LibWeb: Only create backdrop when originating element is invalidated

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -570,6 +570,9 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                     if (top_layer_element->rendered_in_top_layer()) {
                         // Each element rendered in the top layer has a ::backdrop pseudo-element, for which it is the originating element.
                         [&]() {
+                            if (!should_create_layout_node && !top_layer_element->needs_layout_tree_update())
+                                return;
+
                             if (top_layer_element->has_inclusive_ancestor_with_display_none())
                                 return;
 

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/dialog-backdrop-update.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/dialog-backdrop-update.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      TextNode <#text>
+      TextNode <#text>
+      TextNode <#text>
+  BlockContainer <(anonymous)> at (0,0) content-size 800x600 positioned [BFC] children: not-inline
+  BlockContainer <dialog#dialog> at (395.140625,291.5) content-size 9.703125x17 positioned [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (395.140625,291.5) content-size 9.703125x0 children: inline
+      TextNode <#text>
+    BlockContainer <div#inner> at (395.140625,291.5) content-size 9.703125x17 children: inline
+      frag 0 from TextNode start: 0, length: 1, rect: [395.140625,291.5 9.703125x17] baseline: 13.296875
+          "x"
+      TextNode <#text>
+    BlockContainer <(anonymous)> at (395.140625,308.5) content-size 9.703125x0 children: inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+  PaintableWithLines (BlockContainer(anonymous)) [0,0 800x600]
+  PaintableWithLines (BlockContainer<DIALOG>#dialog) [376.140625,272.5 47.703125x55]
+    PaintableWithLines (BlockContainer(anonymous)) [395.140625,291.5 9.703125x0]
+    PaintableWithLines (BlockContainer<DIV>#inner) [395.140625,291.5 9.703125x17]
+      TextPaintable (TextNode<#text>)
+    PaintableWithLines (BlockContainer(anonymous)) [395.140625,308.5 9.703125x0]

--- a/Tests/LibWeb/Layout/input/layout-tree-update/dialog-backdrop-update.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/dialog-backdrop-update.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<body>
+    <dialog id="dialog">
+        <div id="inner"></div>
+    </dialog>
+</body>
+<script>
+    dialog.showModal();
+    document.body.offsetWidth;
+    inner.prepend("x");
+    document.body.offsetWidth;
+</script>
+    


### PR DESCRIPTION
Fixes #4299