### PR TITLE
LibWeb: Implement `ReadableStreamPipeTo` reads with less observability

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/streams/piping/then-interception.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/piping/then-interception.any.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Fail
+Fail	piping should not be observable
+Fail	tee should not be observable

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/piping/then-interception.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/piping/then-interception.any.txt
@@ -2,6 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	piping should not be observable
-Fail	tee should not be observable
+2 Pass
+Pass	piping should not be observable
+Pass	tee should not be observable

--- a/Tests/LibWeb/Text/input/wpt-import/streams/piping/then-interception.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/piping/then-interception.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
+<div id=log></div>
+<script src="../../streams/piping/then-interception.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/piping/then-interception.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/piping/then-interception.any.js
@@ -1,0 +1,68 @@
+// META: global=window,worker,shadowrealm
+// META: script=../resources/test-utils.js
+// META: script=../resources/recording-streams.js
+'use strict';
+
+function interceptThen() {
+  const intercepted = [];
+  let callCount = 0;
+  Object.prototype.then = function(resolver) {
+    if (!this.done) {
+      intercepted.push(this.value);
+    }
+    const retval = Object.create(null);
+    retval.done = ++callCount === 3;
+    retval.value = callCount;
+    resolver(retval);
+    if (retval.done) {
+      delete Object.prototype.then;
+    }
+  }
+  return intercepted;
+}
+
+promise_test(async t => {
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.close();
+    }
+  });
+  const ws = recordingWritableStream();
+
+  const intercepted = interceptThen();
+  t.add_cleanup(() => {
+    delete Object.prototype.then;
+  });
+
+  await rs.pipeTo(ws);
+  delete Object.prototype.then;
+
+
+  assert_array_equals(intercepted, [], 'nothing should have been intercepted');
+  assert_array_equals(ws.events, ['write', 'a', 'close'], 'written chunk should be "a"');
+}, 'piping should not be observable');
+
+promise_test(async t => {
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.close();
+    }
+  });
+  const ws = recordingWritableStream();
+
+  const [ branch1, branch2 ] = rs.tee();
+
+  const intercepted = interceptThen();
+  t.add_cleanup(() => {
+    delete Object.prototype.then;
+  });
+
+  await branch1.pipeTo(ws);
+  delete Object.prototype.then;
+  branch2.cancel();
+
+  assert_array_equals(intercepted, [], 'nothing should have been intercepted');
+  assert_array_equals(ws.events, ['write', 'a', 'close'], 'written chunk should be "a"');
+}, 'tee should not be observable');


### PR DESCRIPTION
The spec states:

    Public API must not be used: while reading or writing, or performing
    any of the operations below, the JavaScript-modifiable reader,
    writer, and stream APIs (i.e. methods on the appropriate prototypes)
    must not be used. Instead, the streams must be manipulated directly.

This migrates the default request request we were using to a custom read
request which does not involve extra promises.

I'm not sure about an analogous change with the way we write chunks to
the receiving end. There isn't a "WriteRequest" utility to be used here,
and no matter what AO we use, promises will be involved. Our current
implementation at least does not seem to affect any tests.