### PR TITLE
LibWeb: Reserve zero for not supported transfer type

### DIFF
--- a/Libraries/LibWeb/HTML/ImageBitmap.cpp
+++ b/Libraries/LibWeb/HTML/ImageBitmap.cpp
@@ -65,7 +65,7 @@ HTML::TransferType ImageBitmap::primary_interface() const
 {
     // FIXME: Implement this
     dbgln("(STUBBED) ImageBitmap::primary_interface()");
-    return {};
+    return TransferType::Unknown;
 }
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-width

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -1291,9 +1291,11 @@ static bool is_interface_exposed_on_target_realm(TransferType name, JS::Realm& r
     case TransferType::MessagePort:
         return intrinsics.is_exposed("MessagePort"sv);
         break;
-    default:
+    case TransferType::Unknown:
         dbgln("Unknown interface type for transfer: {}", to_underlying(name));
         break;
+    default:
+        VERIFY_NOT_REACHED();
     }
     return false;
 }
@@ -1309,6 +1311,8 @@ static WebIDL::ExceptionOr<GC::Ref<Bindings::PlatformObject>> create_transferred
     case TransferType::ArrayBuffer:
     case TransferType::ResizableArrayBuffer:
         dbgln("ArrayBuffer ({}) is not a platform object.", to_underlying(name));
+        break;
+    case TransferType::Unknown:
         break;
     }
     VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -45,9 +45,10 @@ struct DeserializedRecord {
 };
 
 enum class TransferType : u8 {
-    MessagePort,
-    ArrayBuffer,
-    ResizableArrayBuffer,
+    Unknown = 0,
+    MessagePort = 1,
+    ArrayBuffer = 2,
+    ResizableArrayBuffer = 3,
 };
 
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Value);


### PR DESCRIPTION
Previously we were using 0 for both unsupported type and MessagePort, which led to crashing on attempt to decode unsupported transfer type as MessagePort.

Fixes crashing on
https://docs.mapbox.com/mapbox-gl-js/clip-layer-building-demo.html