### PR TITLE
LibWeb: Ignore boxes without layout node in intersection observer steps

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4663,8 +4663,8 @@ void Document::run_the_update_intersection_observations_steps(HighResolutionTime
             auto intersection_root_document = intersection_root.visit([](auto& node) -> GC::Ref<Document> {
                 return node->document();
             });
-            if (!(observer->root().has<Empty>() && &target->document() == intersection_root_document.ptr())
-                || !(intersection_root.has<GC::Root<DOM::Element>>() && !target->is_descendant_of(*intersection_root.get<GC::Root<DOM::Element>>()))) {
+            // NOTE: Check if target has a layout node is not in the spec but required to match other browsers.
+            if (target->layout_node() && (!(observer->root().has<Empty>() && &target->document() == intersection_root_document.ptr()) || !(intersection_root.has<GC::Root<DOM::Element>>() && !target->is_descendant_of(*intersection_root.get<GC::Root<DOM::Element>>())))) {
                 // 4. Set targetRect to the DOMRectReadOnly obtained by getting the bounding box for target.
                 target_rect = target->get_bounding_client_rect();
 

--- a/Tests/LibWeb/Text/expected/IntersectionObserver/box-without-layout-node-should-not-intersect.txt
+++ b/Tests/LibWeb/Text/expected/IntersectionObserver/box-without-layout-node-should-not-intersect.txt
@@ -1,0 +1,2 @@
+flip #container to visible
+#nested is visible

--- a/Tests/LibWeb/Text/input/IntersectionObserver/box-without-layout-node-should-not-intersect.html
+++ b/Tests/LibWeb/Text/input/IntersectionObserver/box-without-layout-node-should-not-intersect.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="container" style="height:200px; display:none">
+    <div id="nested"></div>
+</div>
+<script>
+    asyncTest(done => {
+        let observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    println('#nested is visible');
+                    done();
+                }
+            });
+        });
+        observer.observe(document.getElementById('nested'));
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                println('flip #container to visible');
+                document.getElementById('container').style.display = 'block';
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
Check if box has associated layout node is not mentioned in the spec, but it is required to match behavior of other browsers that do not invoke intersection observer steps for boxes without layout node.