### PR TITLE
LibTLS: Call `close()` when we receive `SSL_ERROR_ZERO_RETURN`

### DIFF
--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -58,6 +58,9 @@ ErrorOr<Bytes> TLSv12::read_some(Bytes bytes)
     if (ret <= 0) {
         switch (SSL_get_error(m_ssl, ret)) {
         case SSL_ERROR_ZERO_RETURN:
+            if (auto const pending = TRY(pending_bytes()); pending > 0)
+                return Error::from_errno(EAGAIN);
+            close();
             return Bytes { bytes.data(), 0 };
         case SSL_ERROR_WANT_READ:
         case SSL_ERROR_WANT_WRITE:


### PR DESCRIPTION
If we don't do this, then we endlessly spin trying to read data which ends up in a deadlock.

The description for SSL_ERROR_ZERO_RETURN states:
> The TLS/SSL connection has been closed. If the protocol version is SSL
> 3.0 or TLS 1.0, this result code is returned only if a closure alert
> has occurred in the protocol, i.e., if the connection has been closed
> cleanly. Note that in this case SSL_ERROR_ZERO_RETURN does not
> necessarily indicate that the underlying transport has been closed.