### PR TITLE
LibIPC: Use AllocatingMemoryStream in TransportSocket send queue

### DIFF
--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -86,6 +86,8 @@ class AllocatingMemoryStream final : public Stream {
 public:
     static constexpr size_t CHUNK_SIZE = 4096;
 
+    void peek_some(Bytes) const;
+
     virtual ErrorOr<Bytes> read_some(Bytes) override;
     virtual ErrorOr<size_t> write_some(ReadonlyBytes) override;
     virtual ErrorOr<void> discard(size_t) override;
@@ -101,7 +103,7 @@ private:
     // Note: We set the inline buffer capacity to zero to make moving chunks as efficient as possible.
     using Chunk = AK::Detail::ByteBuffer<0>;
 
-    ErrorOr<ReadonlyBytes> next_read_range();
+    ErrorOr<ReadonlyBytes> next_read_range(size_t read_offset) const;
     ErrorOr<Bytes> next_write_range();
     void cleanup_unused_chunks();
 

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/MemoryStream.h>
 #include <AK/Queue.h>
 #include <LibCore/Socket.h>
 #include <LibThreading/ConditionVariable.h>
@@ -56,11 +57,11 @@ public:
         Vector<u8> bytes;
         Vector<int> fds;
     };
-    BytesAndFds dequeue(size_t max_bytes);
-    void return_unsent_data_to_front_of_queue(ReadonlyBytes const& bytes, Vector<int> const& fds);
+    BytesAndFds peek(size_t max_bytes);
+    void discard(size_t bytes_count, size_t fds_count);
 
 private:
-    Vector<u8> m_bytes;
+    AllocatingMemoryStream m_stream;
     Vector<int> m_fds;
     Threading::Mutex m_mutex;
     Threading::ConditionVariable m_condition { m_mutex };


### PR DESCRIPTION
Memory stream is a more suitable container for the socket send queue, as using it results in fewer allocations than trying to emulate a stream using a Vector.