### PR TITLE
LibWeb/DOM: Actually stub out pointer-capture API

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3796,4 +3796,24 @@ Optional<String> Element::lang() const
         return {};
     return maybe_lang.release_value();
 }
+
+void Element::set_pointer_capture(WebIDL::Long pointer_id)
+{
+    (void)pointer_id;
+    dbgln("FIXME: Implement Element::setPointerCapture()");
+}
+
+void Element::release_pointer_capture(WebIDL::Long pointer_id)
+{
+    (void)pointer_id;
+    dbgln("FIXME: Implement Element::releasePointerCapture()");
+}
+
+bool Element::has_pointer_capture(WebIDL::Long pointer_id)
+{
+    (void)pointer_id;
+    dbgln("FIXME: Implement Element::hasPointerCapture()");
+    return false;
+}
+
 }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -30,6 +30,7 @@
 #include <LibWeb/HTML/TagNames.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::DOM {
 
@@ -465,6 +466,10 @@ public:
     size_t number_of_owned_list_items() const;
     Element const* list_owner() const;
     size_t ordinal_value() const;
+
+    void set_pointer_capture(WebIDL::Long pointer_id);
+    void release_pointer_capture(WebIDL::Long pointer_id);
+    bool has_pointer_capture(WebIDL::Long pointer_id);
 
 protected:
     Element(Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -121,9 +121,9 @@ interface Element : Node {
     [CEReactions] undefined insertAdjacentHTML(DOMString position, DOMString text);
 
     // https://w3c.github.io/pointerevents/#extensions-to-the-element-interface
-    [FIXME] undefined setPointerCapture(long pointerId);
-    [FIXME] undefined releasePointerCapture(long pointerId);
-    [FIXME] boolean hasPointerCapture(long pointerId);
+    undefined setPointerCapture(long pointerId);
+    undefined releasePointerCapture(long pointerId);
+    boolean hasPointerCapture(long pointerId);
 };
 
 dictionary GetHTMLOptions {


### PR DESCRIPTION
For real this time.

This makes panning the KendoReact map widget actually work: https://www.telerik.com/kendo-react-ui/components/map

Fixes #4302 