### PR TITLE
CI: Run js-benchmarks on macOS

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -58,7 +58,7 @@ runs:
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 16.2
+        xcode-version: 16.3
 
     - name: 'Install Swift toolchain'
       if: ${{ inputs.toolchain == 'Swift' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -110,7 +110,7 @@ runs:
       run: |
         set -e
         brew update
-        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@19 nasm ninja qt unzip wabt
+        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@19 nasm ninja pkg-config qt unzip wabt
 
     - name: 'Set required environment variables'
       if: ${{ inputs.os == 'Linux' && inputs.arch == 'arm64' }}

--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -18,15 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         os_name: ['Linux']
-        os: [ubuntu-24.04]
+        os: ['ubuntu-24.04']
         arch: ['x86_64']
-        package_type: [Linux-x86_64]
+        package_type: ['Linux-x86_64']
 
         include:
           - os_name: 'macOS'
-            os: macos-15
+            os: 'macos-15'
             arch: 'arm64'
-            package_type: macOS-universal2
+            package_type: 'macOS-universal2'
 
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.os_name }}

--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -9,11 +9,24 @@ on:
 
 jobs:
   js-benchmarks:
-    runs-on: js-benchmarks-runner
+    runs-on: ['js-benchmarks', 'self-hosted', '${{ matrix.os }}']
     if: ${{ github.repository == 'LadybirdBrowser/ladybird' && github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os_name: ['Linux']
+        os: ['ubuntu-24.04-internal']
+        arch: ['x86_64']
+        package_type: ['Linux-x86_64']
+
+        include:
+          - os_name: 'macOS'
+            os: 'macos-15'
+            arch: 'arm64'
+            package_type: 'macOS-universal2'
 
     concurrency:
-      group: js-benchmarks
+      group: ${{ github.workflow }}-${{ matrix.os_name }}
 
     steps:
       - name: 'Checkout LadybirdBrowser/js-benchmarks'
@@ -23,6 +36,7 @@ jobs:
           path: js-benchmarks
 
       - name: 'Install dependencies'
+        if: ${{ matrix.os_name == 'Linux' }}
         shell: bash
         run: |
           sudo apt-get update
@@ -36,14 +50,14 @@ jobs:
         with:
           workflow: js-artifacts.yml
           commit: ${{ github.sha }}
-          name: ladybird-js-Linux-x86_64
+          name: ladybird-js-${{ matrix.package_type }}
           path: js-repl
 
       - name: 'Extract JS repl'
         shell: bash
         run: |
           cd js-repl
-          tar -xvzf ladybird-js-Linux-x86_64.tar.gz
+          tar -xvzf ladybird-js-${{ matrix.os_name }}-${{ matrix.arch }}.tar.gz
 
       - name: 'Run the JS benchmarks'
         shell: bash
@@ -57,7 +71,7 @@ jobs:
       - name: 'Save results as an artifact'
         uses: actions/upload-artifact@v4
         with:
-          name: js-benchmarks-results
+          name: js-benchmarks-results-${{ matrix.os_name }}-${{ matrix.arch }}
           path: js-benchmarks/results.json
           retention-days: 90
 
@@ -66,6 +80,8 @@ jobs:
         run: |
           echo -n '{                                                                       \
               "commit": "${{ github.sha }}",                                               \
+              "os_name": "${{ matrix.os_name }}",                                          \
+              "artifact": "js-benchmarks-results-${{ matrix.os_name }}-${{ matrix.arch }}" \
           }' > request.json
           curl \
               --fail \

--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -1,4 +1,4 @@
-name: 'Run the JS benchmarks'
+name: 'JS benchmarks'
 
 on:
   workflow_run:

--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -62,7 +62,16 @@ jobs:
           retention-days: 90
 
       - name: 'Call webhook'
-        uses: distributhor/workflow-webhook@v3
-        with:
-          webhook_url: ${{ secrets.JS_BENCHMARKS_WEBHOOK_URL }}
-          webhook_secret: ${{ secrets.JS_BENCHMARKS_WEBHOOK_SECRET }}
+        shell: bash
+        run: |
+          echo -n '{                                                                       \
+              "commit": "${{ github.sha }}",                                               \
+          }' > request.json
+          curl \
+              --fail \
+              --silent \
+              --show-error \
+              --header 'Content-Type: application/json' \
+              --header "X-Hub-Signature-256: sha256=$(openssl dgst -sha256 -hmac '${{ secrets.JS_BENCHMARKS_WEBHOOK_SECRET }}' request.json)" \
+              --data-binary '@request.json' \
+              '${{ secrets.JS_BENCHMARKS_WEBHOOK_URL }}'


### PR DESCRIPTION
We are running a self-hosted Mac mini runner that can pick up the macOS arm64 build of our JS repl and run that against [js-benchmarks](https://github.com/LadybirdBrowser/js-benchmarks/). This changes our CI so the `js-benchmarks.yml` workflow now also creates jobs based on a matrix, and adds macOS as a target.