### PR TITLE
LibRegex: Some things to go faster!

### DIFF
--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -357,6 +357,12 @@ public:
         return true;
     }
 
+    [[nodiscard]] ReadonlySpan<T> flat_data() const
+    {
+        VERIFY(m_chunks.size() <= 1);
+        return m_chunks.is_empty() ? ReadonlySpan<T> {} : m_chunks.first().span();
+    }
+
     DisjointChunks release_slice(size_t start, size_t length) & { return move(*this).slice(start, length); }
     DisjointChunks release_slice(size_t start) & { return move(*this).slice(start); }
 

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -328,9 +328,9 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
         MUST(array->create_data_property_or_throw(i, captured_value));
 
         // e. If the ith capture of R was defined with a GroupName, then
-        if (capture.capture_group_name.has_value()) {
+        if (capture.capture_group_name >= 0) {
             // i. Let s be the CapturingGroupName of the corresponding RegExpIdentifierName.
-            auto group_name = regex.parser_result.bytecode.get_string(capture.capture_group_name.release_value());
+            auto group_name = regex.parser_result.bytecode.get_string(capture.capture_group_name);
 
             // ii. Perform ! CreateDataPropertyOrThrow(groups, s, capturedValue).
             MUST(groups_object->create_data_property_or_throw(group_name, captured_value));

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -330,7 +330,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
         // e. If the ith capture of R was defined with a GroupName, then
         if (capture.capture_group_name.has_value()) {
             // i. Let s be the CapturingGroupName of the corresponding RegExpIdentifierName.
-            auto group_name = capture.capture_group_name.release_value();
+            auto group_name = regex.parser_result.bytecode.get_string(capture.capture_group_name.release_value());
 
             // ii. Perform ! CreateDataPropertyOrThrow(groups, s, capturedValue).
             MUST(groups_object->create_data_property_or_throw(group_name, captured_value));

--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -409,7 +409,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchIn
 
     auto view = input.view.substring_view(start_position, length);
 
-    match = { view, name(), input.line, start_position, input.global_offset + start_position };
+    match = { view, name_string_table_index(), input.line, start_position, input.global_offset + start_position };
 
     return ExecutionResult::Continue;
 }

--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -540,7 +540,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
                 return ExecutionResult::Failed_ExecuteLowPrioForks;
 
             auto count = m_bytecode->at(offset++);
-            auto range_data = m_bytecode->template spans<4>().slice(offset, count);
+            auto range_data = m_bytecode->flat_data().slice(offset, count);
             offset += count;
 
             auto ch = input.view[state.string_position_in_code_units];

--- a/Libraries/LibRegex/RegexByteCode.h
+++ b/Libraries/LibRegex/RegexByteCode.h
@@ -839,7 +839,8 @@ public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightNamedCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 3; }
-    ALWAYS_INLINE FlyString name() const { return m_bytecode->get_string(argument(0)); }
+    ALWAYS_INLINE FlyString name() const { return m_bytecode->get_string(name_string_table_index()); }
+    ALWAYS_INLINE size_t name_string_table_index() const { return argument(0); }
     ALWAYS_INLINE size_t length() const { return name().bytes_as_string_view().length(); }
     ALWAYS_INLINE size_t id() const { return argument(1); }
     ByteString arguments_string() const override

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -502,7 +502,7 @@ public:
     void reset()
     {
         view = view.typed_null_view();
-        capture_group_name.clear();
+        capture_group_name = -1;
         line = 0;
         column = 0;
         global_offset = 0;
@@ -510,7 +510,10 @@ public:
     }
 
     RegexStringView view {};
-    Optional<size_t> capture_group_name {}; // This is a string table index.
+
+    // This is a string table index. -1 if none. Not using Optional to keep the struct trivially copyable.
+    ssize_t capture_group_name { -1 };
+
     size_t line { 0 };
     size_t column { 0 };
     size_t global_offset { 0 };

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -476,9 +476,6 @@ private:
 };
 
 class Match final {
-private:
-    Optional<FlyString> string;
-
 public:
     Match() = default;
     ~Match() = default;
@@ -489,15 +486,6 @@ public:
         , column(column_)
         , global_offset(global_offset_)
         , left_column(column_)
-    {
-    }
-
-    Match(String string_, size_t const line_, size_t const column_, size_t const global_offset_)
-        : string(move(string_))
-        , view(string.value().bytes_as_string_view())
-        , line(line_)
-        , column(column_)
-        , global_offset(global_offset_)
     {
     }
 

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -489,9 +489,9 @@ public:
     {
     }
 
-    Match(RegexStringView const view_, StringView capture_group_name_, size_t const line_, size_t const column_, size_t const global_offset_)
+    Match(RegexStringView const view_, size_t capture_group_name_, size_t const line_, size_t const column_, size_t const global_offset_)
         : view(view_)
-        , capture_group_name(MUST(FlyString::from_utf8(capture_group_name_)))
+        , capture_group_name(capture_group_name_)
         , line(line_)
         , column(column_)
         , global_offset(global_offset_)
@@ -510,7 +510,7 @@ public:
     }
 
     RegexStringView view {};
-    Optional<FlyString> capture_group_name {};
+    Optional<size_t> capture_group_name {}; // This is a string table index.
     size_t line { 0 };
     size_t column { 0 };
     size_t global_offset { 0 };

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -594,3 +594,8 @@ struct AK::Formatter<regex::RegexStringView> : Formatter<StringView> {
         return Formatter<StringView>::format(builder, string);
     }
 };
+
+template<>
+struct AK::Traits<regex::Match> : public AK::DefaultTraits<regex::Match> {
+    constexpr static bool is_trivial() { return true; }
+};

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -426,10 +426,10 @@ TEST_CASE(named_capture_group)
     EXPECT_EQ(result.count, 2u);
     EXPECT_EQ(result.matches.at(0).view, "Opacity=255");
     EXPECT_EQ(result.capture_group_matches.at(0).at(0).view, "255");
-    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(0).at(0).capture_group_name.value()), "Test");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(0).at(0).capture_group_name), "Test");
     EXPECT_EQ(result.matches.at(1).view, "AudibleBeep=0");
     EXPECT_EQ(result.capture_group_matches.at(1).at(0).view, "0");
-    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(1).at(0).capture_group_name.value()), "Test");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(1).at(0).capture_group_name), "Test");
 }
 
 TEST_CASE(ecma262_named_capture_group_with_dollar_sign)
@@ -449,10 +449,10 @@ TEST_CASE(ecma262_named_capture_group_with_dollar_sign)
     EXPECT_EQ(result.count, 2u);
     EXPECT_EQ(result.matches.at(0).view, "Opacity=255");
     EXPECT_EQ(result.capture_group_matches.at(0).at(0).view, "255");
-    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(0).at(0).capture_group_name.value()), "$Test$");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(0).at(0).capture_group_name), "$Test$");
     EXPECT_EQ(result.matches.at(1).view, "AudibleBeep=0");
     EXPECT_EQ(result.capture_group_matches.at(1).at(0).view, "0");
-    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(1).at(0).capture_group_name.value()), "$Test$");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(1).at(0).capture_group_name), "$Test$");
 }
 
 TEST_CASE(a_star)

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -426,10 +426,10 @@ TEST_CASE(named_capture_group)
     EXPECT_EQ(result.count, 2u);
     EXPECT_EQ(result.matches.at(0).view, "Opacity=255");
     EXPECT_EQ(result.capture_group_matches.at(0).at(0).view, "255");
-    EXPECT_EQ(result.capture_group_matches.at(0).at(0).capture_group_name, "Test");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(0).at(0).capture_group_name.value()), "Test");
     EXPECT_EQ(result.matches.at(1).view, "AudibleBeep=0");
     EXPECT_EQ(result.capture_group_matches.at(1).at(0).view, "0");
-    EXPECT_EQ(result.capture_group_matches.at(1).at(0).capture_group_name, "Test");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(1).at(0).capture_group_name.value()), "Test");
 }
 
 TEST_CASE(ecma262_named_capture_group_with_dollar_sign)
@@ -449,10 +449,10 @@ TEST_CASE(ecma262_named_capture_group_with_dollar_sign)
     EXPECT_EQ(result.count, 2u);
     EXPECT_EQ(result.matches.at(0).view, "Opacity=255");
     EXPECT_EQ(result.capture_group_matches.at(0).at(0).view, "255");
-    EXPECT_EQ(result.capture_group_matches.at(0).at(0).capture_group_name, "$Test$");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(0).at(0).capture_group_name.value()), "$Test$");
     EXPECT_EQ(result.matches.at(1).view, "AudibleBeep=0");
     EXPECT_EQ(result.capture_group_matches.at(1).at(0).view, "0");
-    EXPECT_EQ(result.capture_group_matches.at(1).at(0).capture_group_name, "$Test$");
+    EXPECT_EQ(re.parser_result.bytecode.get_string(result.capture_group_matches.at(1).at(0).capture_group_name.value()), "$Test$");
 }
 
 TEST_CASE(a_star)


### PR DESCRIPTION
Two main things here:
- First, get rid of non-trivial members in `regex::Match` so we can move it around with `memcpy()`
- Then, take advantage of the fact that bytecode is flattened by the time we're executing it, and don't create expensive `DisjointSpans` in `Opcode_Compare` execution.

Solid progression on RegExp-using benchmarks:

```
Suite       Test                              Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  ------------------------------  ---------  ---------------------  ---------------------
Octane      regexp.js                           1.075  17.085 ± 17.070 … 17.100  15.900 ± 15.840 … 15.960
RegExp      speedometer-jquery-regexp-1.js      1.094  2.795 ± 2.780 … 2.810     2.555 ± 2.550 … 2.560
```