### PR TITLE
LibWeb: Set location for linked stylesheets during parsing

### DIFF
--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -156,7 +156,7 @@ void CSSImportRule::fetch()
             }
             auto decoded = decoded_or_error.release_value();
 
-            auto* imported_style_sheet = parse_css_stylesheet(Parser::ParsingParams(*strong_this->m_document, parsed_url), decoded, parsed_url, strong_this->m_media_query_list);
+            auto imported_style_sheet = parse_css_stylesheet(Parser::ParsingParams(*strong_this->m_document, parsed_url), decoded, parsed_url, strong_this->m_media_query_list);
 
             // 5. Set importedStylesheet’s origin-clean flag to parentStylesheet’s origin-clean flag.
             imported_style_sheet->set_origin_clean(parent_style_sheet->is_origin_clean());
@@ -166,7 +166,7 @@ void CSSImportRule::fetch()
                 imported_style_sheet->set_origin_clean(false);
 
             // 7. Set rule’s styleSheet to importedStylesheet.
-            strong_this->set_style_sheet(*imported_style_sheet);
+            strong_this->set_style_sheet(imported_style_sheet);
         });
 }
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -207,7 +207,7 @@ GC::Ref<WebIDL::Promise> CSSStyleSheet::replace(String text)
         HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         // 1. Let rules be the result of running parse a stylesheet’s contents from text.
-        auto* parsed_stylesheet = parse_css_stylesheet(make_parsing_params(), text);
+        auto parsed_stylesheet = parse_css_stylesheet(make_parsing_params(), text);
         auto& rules = parsed_stylesheet->rules();
 
         // 2. If rules contains one or more @import rules, remove those rules from rules.
@@ -240,7 +240,7 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::replace_sync(StringView text)
         return WebIDL::NotAllowedError::create(realm(), "Can't call replaceSync() on non-modifiable stylesheets"_string);
 
     // 2. Let rules be the result of running parse a stylesheet’s contents from text.
-    auto* parsed_stylesheet = parse_css_stylesheet(make_parsing_params(), text);
+    auto parsed_stylesheet = parse_css_stylesheet(make_parsing_params(), text);
     auto& rules = parsed_stylesheet->rules();
 
     // 3. If rules contains one or more @import rules, remove those rules from rules.

--- a/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -42,7 +42,7 @@ GC::Ref<JS::Realm> internal_css_realm()
     return *realm;
 }
 
-CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingParams const& context, StringView css, Optional<::URL::URL> location, Vector<NonnullRefPtr<CSS::MediaQuery>> media_query_list)
+GC::Ref<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::Parser::ParsingParams const& context, StringView css, Optional<::URL::URL> location, Vector<NonnullRefPtr<CSS::MediaQuery>> media_query_list)
 {
     if (css.is_empty()) {
         auto rule_list = CSS::CSSRuleList::create_empty(*context.realm);
@@ -51,7 +51,7 @@ CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingParams const& conte
         style_sheet->set_source_text({});
         return style_sheet;
     }
-    auto* style_sheet = CSS::Parser::Parser::create(context, css).parse_as_css_stylesheet(location, move(media_query_list));
+    auto style_sheet = CSS::Parser::Parser::create(context, css).parse_as_css_stylesheet(location, move(media_query_list));
     // FIXME: Avoid this copy
     style_sheet->set_source_text(MUST(String::from_utf8(css)));
     return style_sheet;

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -119,7 +119,7 @@ Vector<Rule> Parser::parse_a_stylesheets_contents(TokenStream<T>& input)
 }
 
 // https://drafts.csswg.org/css-syntax/#parse-a-css-stylesheet
-CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<::URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
+GC::Ref<CSS::CSSStyleSheet> Parser::parse_as_css_stylesheet(Optional<::URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list)
 {
     // To parse a CSS stylesheet, first parse a stylesheet.
     auto const& style_sheet = parse_a_stylesheet(m_token_stream, location);

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -90,7 +90,7 @@ class Parser {
 public:
     static Parser create(ParsingParams const&, StringView input, StringView encoding = "utf-8"sv);
 
-    CSSStyleSheet* parse_as_css_stylesheet(Optional<::URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list = {});
+    GC::Ref<CSS::CSSStyleSheet> parse_as_css_stylesheet(Optional<::URL::URL> location, Vector<NonnullRefPtr<MediaQuery>> media_query_list = {});
 
     struct PropertiesAndCustomProperties {
         Vector<StyleProperty> properties;
@@ -520,7 +520,7 @@ private:
 
 namespace Web {
 
-CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingParams const&, StringView, Optional<::URL::URL> location = {}, Vector<NonnullRefPtr<CSS::MediaQuery>> = {});
+GC::Ref<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::Parser::ParsingParams const&, StringView, Optional<::URL::URL> location = {}, Vector<NonnullRefPtr<CSS::MediaQuery>> = {});
 CSS::Parser::Parser::PropertiesAndCustomProperties parse_css_style_attribute(CSS::Parser::ParsingParams const&, StringView);
 Vector<CSS::Descriptor> parse_css_list_of_descriptors(CSS::Parser::ParsingParams const&, CSS::AtRuleID, StringView);
 RefPtr<CSS::CSSStyleValue> parse_css_value(CSS::Parser::ParsingParams const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -61,20 +61,13 @@ void StyleSheetList::add_a_css_style_sheet(CSS::CSSStyleSheet& sheet)
 }
 
 // https://www.w3.org/TR/cssom/#create-a-css-style-sheet
-GC::Ptr<CSSStyleSheet> StyleSheetList::create_a_css_style_sheet(String const& css_text, String type, DOM::Element* owner_node, String media, String title, Alternate alternate, OriginClean origin_clean, Optional<::URL::URL> location, CSSStyleSheet* parent_style_sheet, CSSRule* owner_rule)
+GC::Ref<CSSStyleSheet> StyleSheetList::create_a_css_style_sheet(String const& css_text, String type, DOM::Element* owner_node, String media, String title, Alternate alternate, OriginClean origin_clean, Optional<::URL::URL> location, CSSStyleSheet* parent_style_sheet, CSSRule* owner_rule)
 {
     // 1. Create a new CSS style sheet object and set its properties as specified.
     // AD-HOC: The spec never tells us when to parse this style sheet, but the most logical place is here.
     // AD-HOC: Are we supposed to use the document's URL for the stylesheet's location during parsing? Not doing it breaks things.
     auto location_url = location.value_or(document().url());
-    auto* sheet = parse_css_stylesheet(Parser::ParsingParams { document(), location_url }, css_text, location_url);
-
-    // AD-HOC: Exit out if parsing failed.
-    // FIXME: What should we actually do here?
-    if (!sheet) {
-        dbgln_if(CSS_LOADER_DEBUG, "StyleSheetList::create_a_css_style_sheet(): Failed to parse stylesheet at {}", location_url);
-        return nullptr;
-    }
+    auto sheet = parse_css_stylesheet(Parser::ParsingParams { document(), location_url }, css_text, location_url);
 
     sheet->set_parent_css_style_sheet(parent_style_sheet);
     sheet->set_owner_css_rule(owner_rule);

--- a/Libraries/LibWeb/CSS/StyleSheetList.h
+++ b/Libraries/LibWeb/CSS/StyleSheetList.h
@@ -30,7 +30,7 @@ public:
         No,
         Yes,
     };
-    GC::Ptr<CSSStyleSheet> create_a_css_style_sheet(String const& css_text, String type, DOM::Element* owner_node, String media, String title, Alternate, OriginClean, Optional<::URL::URL> location, CSSStyleSheet* parent_style_sheet, CSSRule* owner_rule);
+    GC::Ref<CSSStyleSheet> create_a_css_style_sheet(String const& css_text, String type, DOM::Element* owner_node, String media, String title, Alternate, OriginClean, Optional<::URL::URL> location, CSSStyleSheet* parent_style_sheet, CSSRule* owner_rule);
 
     Vector<GC::Ref<CSSStyleSheet>> const& sheets() const { return m_sheets; }
     Vector<GC::Ref<CSSStyleSheet>>& sheets() { return m_sheets; }

--- a/Libraries/LibWeb/CSS/StyleSheetList.h
+++ b/Libraries/LibWeb/CSS/StyleSheetList.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2024, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2023, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,9 +20,17 @@ class StyleSheetList final : public Bindings::PlatformObject {
 public:
     [[nodiscard]] static GC::Ref<StyleSheetList> create(GC::Ref<DOM::Node> document_or_shadow_root);
 
-    void add_a_css_style_sheet(CSS::CSSStyleSheet&);
-    void remove_a_css_style_sheet(CSS::CSSStyleSheet&);
-    void create_a_css_style_sheet(String type, DOM::Element* owner_node, String media, String title, bool alternate, bool origin_clean, Optional<::URL::URL> location, CSS::CSSStyleSheet* parent_style_sheet, CSS::CSSRule* owner_rule, CSS::CSSStyleSheet&);
+    void add_a_css_style_sheet(CSSStyleSheet&);
+    void remove_a_css_style_sheet(CSSStyleSheet&);
+    enum class Alternate : u8 {
+        No,
+        Yes,
+    };
+    enum class OriginClean : u8 {
+        No,
+        Yes,
+    };
+    GC::Ptr<CSSStyleSheet> create_a_css_style_sheet(String const& css_text, String type, DOM::Element* owner_node, String media, String title, Alternate, OriginClean, Optional<::URL::URL> location, CSSStyleSheet* parent_style_sheet, CSSRule* owner_rule);
 
     Vector<GC::Ref<CSSStyleSheet>> const& sheets() const { return m_sheets; }
     Vector<GC::Ref<CSSStyleSheet>>& sheets() { return m_sheets; }

--- a/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -52,31 +52,41 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
 
     // FIXME: 5. If the Should element's inline behavior be blocked by Content Security Policy? algorithm returns "Blocked" when executed upon the style element, "style", and the style element's child text content, then return. [CSP]
 
-    // FIXME: This is a bit awkward, as the spec doesn't actually tell us when to parse the CSS text,
-    //        so we just do it here and pass the parsed sheet to create_a_css_style_sheet().
-    // AD-HOC: Are we supposed to use the document's URL for the stylesheet's location? Not doing it breaks things.
-    auto* sheet = parse_css_stylesheet(CSS::Parser::ParsingParams(style_element.document()), style_element.text_content().value_or(String {}), style_element.document().url());
-    if (!sheet)
-        return;
-
-    // FIXME: This should probably be handled by StyleSheet::set_owner_node().
-    m_associated_css_style_sheet = sheet;
-
-    // 6. Create a CSS style sheet with the following properties...
+    // 6. Create a CSS style sheet with the following properties:
+    //        type
+    //            text/css
+    //        owner node
+    //            element
+    //        media
+    //            The media attribute of element.
+    //        title
+    //            The title attribute of element, if element is in a document tree, or the empty string otherwise.
+    //        alternate flag
+    //            Unset.
+    //        origin-clean flag
+    //            Set.
+    //        location
+    //        parent CSS style sheet
+    //        owner CSS rule
+    //            null
+    //        disabled flag
+    //            Left at its default value.
+    //        CSS rules
+    //          Left uninitialized.
     m_style_sheet_list = style_element.document_or_shadow_root_style_sheets();
-    m_style_sheet_list->create_a_css_style_sheet(
+    m_associated_css_style_sheet = m_style_sheet_list->create_a_css_style_sheet(
+        style_element.text_content().value_or(String {}),
         "text/css"_string,
         &style_element,
         style_element.attribute(HTML::AttributeNames::media).value_or({}),
         style_element.in_a_document_tree()
             ? style_element.attribute(HTML::AttributeNames::title).value_or({})
             : String {},
-        false,
-        true,
+        CSS::StyleSheetList::Alternate::No,
+        CSS::StyleSheetList::OriginClean::Yes,
         {},
         nullptr,
-        nullptr,
-        *sheet);
+        nullptr);
 }
 
 void StyleElementUtils::visit_edges(JS::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -487,13 +487,11 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
                 dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::error));
             } else {
                 auto const decoded_string = maybe_decoded_string.release_value();
-                m_loaded_style_sheet = parse_css_stylesheet(CSS::Parser::ParsingParams(document(), *response.url()), decoded_string);
+                VERIFY(!response.url_list().is_empty());
+                auto location = response.url_list().first();
+                m_loaded_style_sheet = parse_css_stylesheet(CSS::Parser::ParsingParams(document(), location), decoded_string, location);
 
                 if (m_loaded_style_sheet) {
-                    Optional<::URL::URL> location;
-                    if (!response.url_list().is_empty())
-                        location = response.url_list().first();
-
                     document_or_shadow_root_style_sheets().create_a_css_style_sheet(
                         "text/css"_string,
                         this,

--- a/Tests/LibWeb/Layout/data/import-a.css
+++ b/Tests/LibWeb/Layout/data/import-a.css
@@ -1,0 +1,5 @@
+@import "import-b.css";
+
+#target {
+    width: 50px;
+}

--- a/Tests/LibWeb/Layout/data/import-b.css
+++ b/Tests/LibWeb/Layout/data/import-b.css
@@ -1,0 +1,3 @@
+#target {
+    width: 200px !important;
+}

--- a/Tests/LibWeb/Layout/expected/import-from-linked-style-sheet.txt
+++ b/Tests/LibWeb/Layout/expected/import-from-linked-style-sheet.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
+      BlockContainer <div#target> at (8,8) content-size 200x17 children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 39.78125x17] baseline: 13.296875
+            "Hello"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer<DIV>#target) [8,8 200x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]

--- a/Tests/LibWeb/Layout/input/import-from-linked-style-sheet.html
+++ b/Tests/LibWeb/Layout/input/import-from-linked-style-sheet.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<link rel="stylesheet" href="../data/import-a.css">
+<div id="target">Hello</div>


### PR DESCRIPTION
Fixes #4334.

The bug was caused by not passing the URL to `parse_css_stylesheet()`. But I've then gone on to make that mistake harder to make by moving style sheet parsing into `StyleSheetList::create_a_css_style_sheet()`. The spec isn't clear but I think this is more correct too.