### PR TITLE
LibWeb/CSS: Make `insertRule()` more accurate

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -116,6 +116,7 @@ set(SOURCES
     CSS/Parser/MediaParsing.cpp
     CSS/Parser/Parser.cpp
     CSS/Parser/PropertyParsing.cpp
+    CSS/Parser/RuleContext.cpp
     CSS/Parser/RuleParsing.cpp
     CSS/Parser/SelectorParsing.cpp
     CSS/Parser/Token.cpp

--- a/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
@@ -234,7 +234,7 @@ WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_css_text(StringView value)
 
     // 3. Parse the given value and, if the return value is not the empty list, insert the items in the list into the
     //    declarations, in specified order.
-    auto descriptors = parse_css_list_of_descriptors(Parser::ParsingParams {}, AtRuleID::FontFace, value);
+    auto descriptors = parse_css_descriptor_declaration_block(Parser::ParsingParams {}, AtRuleID::FontFace, value);
     if (!descriptors.is_empty())
         m_descriptors = move(descriptors);
 

--- a/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
@@ -18,6 +18,7 @@ CSSGroupingRule::CSSGroupingRule(JS::Realm& realm, CSSRuleList& rules, Type type
     : CSSRule(realm, type)
     , m_rules(rules)
 {
+    m_rules->set_owner_rule(*this);
     for (auto& rule : *m_rules)
         rule->set_parent_rule(this);
 }

--- a/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
@@ -41,10 +41,14 @@ void CSSGroupingRule::clear_caches()
         rule->clear_caches();
 }
 
+// https://drafts.csswg.org/cssom/#dom-cssgroupingrule-insertrule
 WebIDL::ExceptionOr<u32> CSSGroupingRule::insert_rule(StringView rule, u32 index)
 {
-    TRY(m_rules->insert_a_css_rule(rule, index));
-    // NOTE: The spec doesn't say where to set the parent rule, so we'll do it here.
+    // The insertRule(rule, index) method must return the result of invoking insert a CSS rule rule into the child CSS
+    // rules at index, with the nested flag set.
+    TRY(m_rules->insert_a_css_rule(rule, index, CSSRuleList::Nested::Yes));
+
+    // AD-HOC: The spec doesn't say where to set the parent rule, so we'll do it here.
     m_rules->item(index)->set_parent_rule(this);
     return index;
 }

--- a/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -22,11 +22,11 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSRuleList);
 
-GC::Ref<CSSRuleList> CSSRuleList::create(JS::Realm& realm, GC::RootVector<CSSRule*> const& rules)
+GC::Ref<CSSRuleList> CSSRuleList::create(JS::Realm& realm, ReadonlySpan<GC::Ref<CSSRule>> rules)
 {
     auto rule_list = realm.create<CSSRuleList>(realm);
-    for (auto* rule : rules)
-        rule_list->m_rules.append(*rule);
+    for (auto rule : rules)
+        rule_list->m_rules.append(rule);
     return rule_list;
 }
 
@@ -34,11 +34,6 @@ CSSRuleList::CSSRuleList(JS::Realm& realm)
     : Bindings::PlatformObject(realm)
 {
     m_legacy_platform_object_flags = LegacyPlatformObjectFlags { .supports_indexed_properties = 1 };
-}
-
-GC::Ref<CSSRuleList> CSSRuleList::create_empty(JS::Realm& realm)
-{
-    return realm.create<CSSRuleList>(realm);
 }
 
 void CSSRuleList::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2023, Luke Wilde <lukew@serenityos.org>
  *
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <AK/Function.h>
-#include <AK/Iterator.h>
-#include <AK/RefPtr.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/Forward.h>
@@ -55,7 +53,11 @@ public:
     virtual Optional<JS::Value> item_value(size_t index) const override;
 
     WebIDL::ExceptionOr<void> remove_a_css_rule(u32 index);
-    WebIDL::ExceptionOr<unsigned> insert_a_css_rule(Variant<StringView, CSSRule*>, u32 index);
+    enum class Nested {
+        No,
+        Yes,
+    };
+    WebIDL::ExceptionOr<unsigned> insert_a_css_rule(Variant<StringView, CSSRule*>, u32 index, Nested = Nested::No);
 
     void for_each_effective_rule(TraversalOrder, Function<void(CSSRule const&)> const& callback) const;
     // Returns whether the match state of any media queries changed after evaluation.

--- a/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -23,8 +23,7 @@ class CSSRuleList : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(CSSRuleList);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSRuleList> create(JS::Realm&, GC::RootVector<CSSRule*> const&);
-    [[nodiscard]] static GC::Ref<CSSRuleList> create_empty(JS::Realm&);
+    [[nodiscard]] static GC::Ref<CSSRuleList> create(JS::Realm&, ReadonlySpan<GC::Ref<CSSRule>> = {});
 
     ~CSSRuleList() = default;
 

--- a/Libraries/LibWeb/CSS/CSSRuleList.h
+++ b/Libraries/LibWeb/CSS/CSSRuleList.h
@@ -11,6 +11,7 @@
 #include <AK/Function.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/CSSRule.h>
+#include <LibWeb/CSS/Parser/RuleContext.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/TraversalOrder.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -62,6 +63,7 @@ public:
     // Returns whether the match state of any media queries changed after evaluation.
     bool evaluate_media_queries(HTML::Window const&);
 
+    void set_owner_rule(GC::Ref<CSSRule> owner_rule) { m_owner_rule = owner_rule; }
     void set_rules(Badge<CSSStyleSheet>, Vector<GC::Ref<CSSRule>> rules) { m_rules = move(rules); }
 
     Function<void()> on_change;
@@ -72,7 +74,10 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
+    Vector<Parser::RuleContext> rule_context() const;
+
     Vector<GC::Ref<CSSRule>> m_rules;
+    GC::Ptr<CSSRule> m_owner_rule;
 };
 
 }

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1216,7 +1216,7 @@ void CSSStyleProperties::set_declarations_from_text(StringView css_text)
     auto parsing_params = owner_node().has_value()
         ? Parser::ParsingParams(owner_node()->element().document())
         : Parser::ParsingParams();
-    auto style = parse_css_style_attribute(parsing_params, css_text);
+    auto style = parse_css_property_declaration_block(parsing_params, css_text);
     set_the_declarations(style.properties, style.custom_properties);
 }
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1216,6 +1216,8 @@ void CSSStyleProperties::set_declarations_from_text(StringView css_text)
     auto parsing_params = owner_node().has_value()
         ? Parser::ParsingParams(owner_node()->element().document())
         : Parser::ParsingParams();
+    parsing_params.rule_context.append(Parser::RuleContext::Style);
+
     auto style = parse_css_property_declaration_block(parsing_params, css_text);
     set_the_declarations(style.properties, style.custom_properties);
 }

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -33,7 +33,7 @@ GC::Ref<CSSStyleSheet> CSSStyleSheet::create(JS::Realm& realm, CSSRuleList& rule
 WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> CSSStyleSheet::construct_impl(JS::Realm& realm, Optional<CSSStyleSheetInit> const& options)
 {
     // 1. Construct a new CSSStyleSheet object sheet.
-    auto sheet = create(realm, CSSRuleList::create_empty(realm), CSS::MediaList::create(realm, {}), {});
+    auto sheet = create(realm, CSSRuleList::create(realm), CSS::MediaList::create(realm, {}), {});
 
     // 2. Set sheet’s location to the base URL of the associated Document for the current principal global object.
     auto associated_document = as<HTML::Window>(HTML::current_principal_global_object()).document();

--- a/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -45,7 +45,7 @@ GC::Ref<JS::Realm> internal_css_realm()
 GC::Ref<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::Parser::ParsingParams const& context, StringView css, Optional<::URL::URL> location, Vector<NonnullRefPtr<CSS::MediaQuery>> media_query_list)
 {
     if (css.is_empty()) {
-        auto rule_list = CSS::CSSRuleList::create_empty(*context.realm);
+        auto rule_list = CSS::CSSRuleList::create(*context.realm);
         auto media_list = CSS::MediaList::create(*context.realm, {});
         auto style_sheet = CSS::CSSStyleSheet::create(*context.realm, rule_list, media_list, location);
         style_sheet->set_source_text({});

--- a/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -57,18 +57,18 @@ GC::Ref<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::Parser::ParsingParams cons
     return style_sheet;
 }
 
-CSS::Parser::Parser::PropertiesAndCustomProperties parse_css_style_attribute(CSS::Parser::ParsingParams const& context, StringView css)
+CSS::Parser::Parser::PropertiesAndCustomProperties parse_css_property_declaration_block(CSS::Parser::ParsingParams const& context, StringView css)
 {
     if (css.is_empty())
         return {};
-    return CSS::Parser::Parser::create(context, css).parse_as_style_attribute();
+    return CSS::Parser::Parser::create(context, css).parse_as_property_declaration_block();
 }
 
-Vector<CSS::Descriptor> parse_css_list_of_descriptors(CSS::Parser::ParsingParams const& parsing_params, CSS::AtRuleID at_rule_id, StringView css)
+Vector<CSS::Descriptor> parse_css_descriptor_declaration_block(CSS::Parser::ParsingParams const& parsing_params, CSS::AtRuleID at_rule_id, StringView css)
 {
     if (css.is_empty())
         return {};
-    return CSS::Parser::Parser::create(parsing_params, css).parse_as_list_of_descriptors(at_rule_id);
+    return CSS::Parser::Parser::create(parsing_params, css).parse_as_descriptor_declaration_block(at_rule_id);
 }
 
 RefPtr<CSS::CSSStyleValue const> parse_css_value(CSS::Parser::ParsingParams const& context, StringView string, CSS::PropertyID property_id)

--- a/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -497,12 +497,12 @@ GC::Ptr<CSSMediaRule> Parser::convert_to_media_rule(AtRule const& rule, Nested n
     auto media_query_list = parse_a_media_query_list(media_query_tokens);
     auto media_list = MediaList::create(realm(), move(media_query_list));
 
-    GC::RootVector<CSSRule*> child_rules { realm().heap() };
+    GC::RootVector<GC::Ref<CSSRule>> child_rules { realm().heap() };
     for (auto const& child : rule.child_rules_and_lists_of_declarations) {
         child.visit(
             [&](Rule const& rule) {
                 if (auto child_rule = convert_to_rule(rule, nested))
-                    child_rules.append(child_rule);
+                    child_rules.append(*child_rule);
             },
             [&](Vector<Declaration> const& declarations) {
                 child_rules.append(CSSNestedDeclarations::create(realm(), *convert_to_style_declaration(declarations)));

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -141,7 +141,7 @@ GC::Ref<CSS::CSSStyleSheet> Parser::parse_as_css_stylesheet(Optional<::URL::URL>
     auto const& style_sheet = parse_a_stylesheet(m_token_stream, location);
 
     // Interpret all of the resulting top-level qualified rules as style rules, defined below.
-    GC::RootVector<CSSRule*> rules(realm().heap());
+    GC::RootVector<GC::Ref<CSSRule>> rules(realm().heap());
     for (auto const& raw_rule : style_sheet.rules) {
         auto rule = convert_to_rule(raw_rule, Nested::No);
         // If any style rule is invalid, or any at-rule is not recognized or is invalid according to its grammar or context, it’s a parse error.
@@ -150,7 +150,7 @@ GC::Ref<CSS::CSSStyleSheet> Parser::parse_as_css_stylesheet(Optional<::URL::URL>
             log_parse_error();
             continue;
         }
-        rules.append(rule);
+        rules.append(*rule);
     }
 
     auto rule_list = CSSRuleList::create(realm(), rules);

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1360,9 +1360,7 @@ Parser::PropertiesAndCustomProperties Parser::parse_as_property_declaration_bloc
     };
 
     // 1. Let declarations be the returned declarations from invoking parse a block’s contents with string.
-    m_rule_context.append(RuleContext::Style);
     auto declarations_and_at_rules = parse_a_blocks_contents(m_token_stream);
-    m_rule_context.take_last();
 
     // 2. Let parsed declarations be a new empty list.
     PropertiesAndCustomProperties parsed_declarations;

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -81,6 +81,7 @@ Parser::Parser(ParsingParams const& context, Vector<Token> tokens)
     , m_parsing_mode(context.mode)
     , m_tokens(move(tokens))
     , m_token_stream(m_tokens)
+    , m_rule_context(move(context.rule_context))
 {
 }
 
@@ -168,7 +169,7 @@ RefPtr<Supports> Parser::parse_a_supports(TokenStream<T>& tokens)
 {
     auto component_values = parse_a_list_of_component_values(tokens);
     TokenStream<ComponentValue> token_stream { component_values };
-    m_rule_context.append(ContextType::SupportsCondition);
+    m_rule_context.append(RuleContext::SupportsCondition);
     auto maybe_condition = parse_boolean_expression(token_stream, MatchResult::False, [this](auto& tokens) { return parse_supports_feature(tokens); });
     m_rule_context.take_last();
     token_stream.discard_whitespace();
@@ -492,7 +493,7 @@ Optional<AtRule> Parser::consume_an_at_rule(TokenStream<T>& input, Nested nested
         // <{-token>
         if (token.is(Token::Type::OpenCurly)) {
             // Consume a block from input, and assign the result to rule’s child rules.
-            m_rule_context.append(context_type_for_at_rule(rule.name));
+            m_rule_context.append(rule_context_type_for_at_rule(rule.name));
             rule.child_rules_and_lists_of_declarations = consume_a_block(input);
             m_rule_context.take_last();
 
@@ -525,9 +526,9 @@ Variant<Empty, QualifiedRule, Parser::InvalidRuleError> Parser::consume_a_qualif
 
     // NOTE: Qualified rules inside @keyframes are a keyframe rule.
     //       We'll assume all others are style rules.
-    auto type_of_qualified_rule = (!m_rule_context.is_empty() && m_rule_context.last() == ContextType::AtKeyframes)
-        ? ContextType::Keyframe
-        : ContextType::Style;
+    auto type_of_qualified_rule = (!m_rule_context.is_empty() && m_rule_context.last() == RuleContext::AtKeyframes)
+        ? RuleContext::Keyframe
+        : RuleContext::Style;
 
     // Process input:
     for (;;) {
@@ -1236,7 +1237,7 @@ Vector<RuleOrListOfDeclarations> Parser::parse_a_blocks_contents(TokenStream<T>&
 
 Optional<StyleProperty> Parser::parse_as_supports_condition()
 {
-    m_rule_context.append(ContextType::SupportsCondition);
+    m_rule_context.append(RuleContext::SupportsCondition);
     auto maybe_declaration = parse_a_declaration(m_token_stream);
     m_rule_context.take_last();
     if (maybe_declaration.has_value())
@@ -1359,7 +1360,7 @@ Parser::PropertiesAndCustomProperties Parser::parse_as_property_declaration_bloc
     };
 
     // 1. Let declarations be the returned declarations from invoking parse a block’s contents with string.
-    m_rule_context.append(ContextType::Style);
+    m_rule_context.append(RuleContext::Style);
     auto declarations_and_at_rules = parse_a_blocks_contents(m_token_stream);
     m_rule_context.take_last();
 
@@ -1392,9 +1393,9 @@ Vector<Descriptor> Parser::parse_as_descriptor_declaration_block(AtRuleID at_rul
     auto context_type = [at_rule_id] {
         switch (at_rule_id) {
         case AtRuleID::FontFace:
-            return ContextType::AtFontFace;
+            return RuleContext::AtFontFace;
         case AtRuleID::Property:
-            return ContextType::AtProperty;
+            return RuleContext::AtProperty;
         }
         VERIFY_NOT_REACHED();
     }();
@@ -1436,31 +1437,31 @@ bool Parser::is_valid_in_the_current_context(Declaration const&) const
         return false;
 
     switch (m_rule_context.last()) {
-    case ContextType::Unknown:
+    case RuleContext::Unknown:
         // If the context is an unknown type, we don't accept anything.
         return false;
 
-    case ContextType::Style:
-    case ContextType::Keyframe:
+    case RuleContext::Style:
+    case RuleContext::Keyframe:
         // Style and keyframe rules contain property declarations
         return true;
 
-    case ContextType::AtLayer:
-    case ContextType::AtMedia:
-    case ContextType::AtSupports:
+    case RuleContext::AtLayer:
+    case RuleContext::AtMedia:
+    case RuleContext::AtSupports:
         // Grouping rules can contain declarations if they are themselves inside a style rule
-        return m_rule_context.contains_slow(ContextType::Style);
+        return m_rule_context.contains_slow(RuleContext::Style);
 
-    case ContextType::AtFontFace:
-    case ContextType::AtProperty:
+    case RuleContext::AtFontFace:
+    case RuleContext::AtProperty:
         // @font-face and @property have descriptor declarations
         return true;
 
-    case ContextType::AtKeyframes:
+    case RuleContext::AtKeyframes:
         // @keyframes can only contain keyframe rules
         return false;
 
-    case ContextType::SupportsCondition:
+    case RuleContext::SupportsCondition:
         // @supports conditions accept all declarations
         return true;
     }
@@ -1475,32 +1476,32 @@ bool Parser::is_valid_in_the_current_context(AtRule const& at_rule) const
         return true;
 
     // Only grouping rules can be nested within style rules
-    if (m_rule_context.contains_slow(ContextType::Style))
+    if (m_rule_context.contains_slow(RuleContext::Style))
         return first_is_one_of(at_rule.name, "layer", "media", "supports");
 
     switch (m_rule_context.last()) {
-    case ContextType::Unknown:
+    case RuleContext::Unknown:
         // If the context is an unknown type, we don't accept anything.
         return false;
 
-    case ContextType::Style:
+    case RuleContext::Style:
         // Already handled above
         VERIFY_NOT_REACHED();
 
-    case ContextType::AtLayer:
-    case ContextType::AtMedia:
-    case ContextType::AtSupports:
+    case RuleContext::AtLayer:
+    case RuleContext::AtMedia:
+    case RuleContext::AtSupports:
         // Grouping rules can contain anything except @import or @namespace
         return !first_is_one_of(at_rule.name, "import", "namespace");
 
-    case ContextType::SupportsCondition:
+    case RuleContext::SupportsCondition:
         // @supports cannot check for at-rules
         return false;
 
-    case ContextType::AtFontFace:
-    case ContextType::AtKeyframes:
-    case ContextType::Keyframe:
-    case ContextType::AtProperty:
+    case RuleContext::AtFontFace:
+    case RuleContext::AtKeyframes:
+    case RuleContext::Keyframe:
+    case RuleContext::AtProperty:
         // These can't contain any at-rules
         return false;
     }
@@ -1517,31 +1518,31 @@ bool Parser::is_valid_in_the_current_context(QualifiedRule const&) const
         return true;
 
     switch (m_rule_context.last()) {
-    case ContextType::Unknown:
+    case RuleContext::Unknown:
         // If the context is an unknown type, we don't accept anything.
         return false;
 
-    case ContextType::Style:
+    case RuleContext::Style:
         // Style rules can contain style rules
         return true;
 
-    case ContextType::AtLayer:
-    case ContextType::AtMedia:
-    case ContextType::AtSupports:
+    case RuleContext::AtLayer:
+    case RuleContext::AtMedia:
+    case RuleContext::AtSupports:
         // Grouping rules can contain style rules
         return true;
 
-    case ContextType::AtKeyframes:
+    case RuleContext::AtKeyframes:
         // @keyframes can contain keyframe rules
         return true;
 
-    case ContextType::SupportsCondition:
+    case RuleContext::SupportsCondition:
         // @supports cannot check qualified rules
         return false;
 
-    case ContextType::AtFontFace:
-    case ContextType::AtProperty:
-    case ContextType::Keyframe:
+    case RuleContext::AtFontFace:
+    case RuleContext::AtProperty:
+    case RuleContext::Keyframe:
         // These can't contain qualified rules
         return false;
     }
@@ -1784,23 +1785,6 @@ bool Parser::has_ignored_vendor_prefix(StringView string)
     if (string.starts_with("-libweb-"sv))
         return false;
     return true;
-}
-
-Parser::ContextType Parser::context_type_for_at_rule(FlyString const& name)
-{
-    if (name == "media")
-        return ContextType::AtMedia;
-    if (name == "font-face")
-        return ContextType::AtFontFace;
-    if (name == "keyframes")
-        return ContextType::AtKeyframes;
-    if (name == "supports")
-        return ContextType::AtSupports;
-    if (name == "layer")
-        return ContextType::AtLayer;
-    if (name == "property")
-        return ContextType::AtProperty;
-    return ContextType::Unknown;
 }
 
 template Parser::ParsedStyleSheet Parser::parse_a_stylesheet(TokenStream<Token>&, Optional<::URL::URL>);

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -22,6 +22,7 @@
 #include <LibWeb/CSS/ParsedFontFace.h>
 #include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/Dimension.h>
+#include <LibWeb/CSS/Parser/RuleContext.h>
 #include <LibWeb/CSS/Parser/TokenStream.h>
 #include <LibWeb/CSS/Parser/Tokenizer.h>
 #include <LibWeb/CSS/Parser/Types.h>
@@ -78,6 +79,8 @@ struct ParsingParams {
     GC::Ptr<DOM::Document const> document;
     ::URL::URL url;
     ParsingMode mode { ParsingMode::Normal };
+
+    Vector<RuleContext> rule_context;
 };
 
 // The very large CSS Parser implementation code is broken up among several .cpp files:
@@ -499,20 +502,7 @@ private:
     }
     bool context_allows_quirky_length() const;
 
-    enum class ContextType {
-        Unknown,
-        Style,
-        AtMedia,
-        AtFontFace,
-        AtKeyframes,
-        Keyframe,
-        AtSupports,
-        SupportsCondition,
-        AtLayer,
-        AtProperty,
-    };
-    static ContextType context_type_for_at_rule(FlyString const&);
-    Vector<ContextType> m_rule_context;
+    Vector<RuleContext> m_rule_context;
 
     Vector<PseudoClass> m_pseudo_class_context; // Stack of pseudo-class functions we're currently inside
 };

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -96,8 +96,8 @@ public:
         Vector<StyleProperty> properties;
         HashMap<FlyString, StyleProperty> custom_properties;
     };
-    PropertiesAndCustomProperties parse_as_style_attribute();
-    Vector<Descriptor> parse_as_list_of_descriptors(AtRuleID);
+    PropertiesAndCustomProperties parse_as_property_declaration_block();
+    Vector<Descriptor> parse_as_descriptor_declaration_block(AtRuleID);
     CSSRule* parse_as_css_rule();
     Optional<StyleProperty> parse_as_supports_condition();
     GC::RootVector<GC::Ref<CSSRule>> parse_as_stylesheet_contents();
@@ -466,7 +466,6 @@ private:
 
     static bool has_ignored_vendor_prefix(StringView);
 
-    PropertiesAndCustomProperties extract_properties(Vector<RuleOrListOfDeclarations> const&);
     void extract_property(Declaration const&, Parser::PropertiesAndCustomProperties&);
 
     DOM::Document const* document() const;
@@ -523,8 +522,8 @@ private:
 namespace Web {
 
 GC::Ref<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::Parser::ParsingParams const&, StringView, Optional<::URL::URL> location = {}, Vector<NonnullRefPtr<CSS::MediaQuery>> = {});
-CSS::Parser::Parser::PropertiesAndCustomProperties parse_css_style_attribute(CSS::Parser::ParsingParams const&, StringView);
-Vector<CSS::Descriptor> parse_css_list_of_descriptors(CSS::Parser::ParsingParams const&, CSS::AtRuleID, StringView);
+CSS::Parser::Parser::PropertiesAndCustomProperties parse_css_property_declaration_block(CSS::Parser::ParsingParams const&, StringView);
+Vector<CSS::Descriptor> parse_css_descriptor_declaration_block(CSS::Parser::ParsingParams const&, CSS::AtRuleID, StringView);
 RefPtr<CSS::CSSStyleValue const> parse_css_value(CSS::Parser::ParsingParams const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
 RefPtr<CSS::CSSStyleValue const> parse_css_descriptor(CSS::Parser::ParsingParams const&, CSS::AtRuleID, CSS::DescriptorID, StringView);
 Optional<CSS::SelectorList> parse_selector(CSS::Parser::ParsingParams const&, StringView);

--- a/Libraries/LibWeb/CSS/Parser/RuleContext.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleContext.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/Parser/RuleContext.h>
+
+namespace Web::CSS::Parser {
+
+RuleContext rule_context_type_for_rule(CSSRule::Type rule_type)
+{
+    switch (rule_type) {
+    case CSSRule::Type::Style:
+        return RuleContext::Style;
+    case CSSRule::Type::Media:
+        return RuleContext::AtMedia;
+    case CSSRule::Type::FontFace:
+        return RuleContext::AtFontFace;
+    case CSSRule::Type::Keyframes:
+        return RuleContext::AtKeyframes;
+    case CSSRule::Type::Keyframe:
+        return RuleContext::Keyframe;
+    case CSSRule::Type::Supports:
+        return RuleContext::AtSupports;
+    case CSSRule::Type::LayerBlock:
+        return RuleContext::AtLayer;
+    case CSSRule::Type::NestedDeclarations:
+        return RuleContext::Style;
+    case CSSRule::Type::Property:
+        return RuleContext::AtProperty;
+        // Other types shouldn't be trying to create a context.
+    case CSSRule::Type::Import:
+    case CSSRule::Type::LayerStatement:
+    case CSSRule::Type::Namespace:
+        break;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+RuleContext rule_context_type_for_at_rule(FlyString const& name)
+{
+    if (name == "media")
+        return RuleContext::AtMedia;
+    if (name == "font-face")
+        return RuleContext::AtFontFace;
+    if (name == "keyframes")
+        return RuleContext::AtKeyframes;
+    if (name == "supports")
+        return RuleContext::AtSupports;
+    if (name == "layer")
+        return RuleContext::AtLayer;
+    if (name == "property")
+        return RuleContext::AtProperty;
+    return RuleContext::Unknown;
+}
+
+}

--- a/Libraries/LibWeb/CSS/Parser/RuleContext.h
+++ b/Libraries/LibWeb/CSS/Parser/RuleContext.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <LibWeb/CSS/CSSRule.h>
+
+namespace Web::CSS::Parser {
+
+enum class RuleContext : u8 {
+    Unknown,
+    Style,
+    AtMedia,
+    AtFontFace,
+    AtKeyframes,
+    Keyframe,
+    AtSupports,
+    SupportsCondition,
+    AtLayer,
+    AtProperty,
+};
+RuleContext rule_context_type_for_rule(CSSRule::Type);
+RuleContext rule_context_type_for_at_rule(FlyString const&);
+
+}

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -171,7 +171,7 @@ GC::Ptr<CSSImportRule> Parser::convert_to_import_rule(AtRule const& rule)
         if (supports_tokens.next_token().is_block()) {
             supports = parse_a_supports(supports_tokens);
         } else {
-            m_rule_context.append(ContextType::SupportsCondition);
+            m_rule_context.append(RuleContext::SupportsCondition);
             auto declaration = consume_a_declaration(supports_tokens);
             m_rule_context.take_last();
             if (declaration.has_value()) {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/js/conditional-CSSGroupingRule.txt
@@ -2,14 +2,14 @@ Harness status: OK
 
 Found 34 tests
 
-26 Pass
-8 Fail
+30 Pass
+4 Fail
 Pass	@media is CSSGroupingRule
 Pass	@media rule type
 Pass	Empty @media rule length
 Fail	insertRule of @import into @media
-Fail	insertRule into empty @media at bad index
-Fail	insertRule into @media updates length
+Pass	insertRule into empty @media at bad index
+Pass	insertRule into @media updates length
 Pass	insertRule of valid @media into @media
 Pass	insertRule of valid style rule into @media
 Fail	insertRule of invalid @media into @media
@@ -25,8 +25,8 @@ Pass	@supports is CSSGroupingRule
 Pass	@supports rule type
 Pass	Empty @supports rule length
 Fail	insertRule of @import into @supports
-Fail	insertRule into empty @supports at bad index
-Fail	insertRule into @supports updates length
+Pass	insertRule into empty @supports at bad index
+Pass	insertRule into @supports updates length
 Pass	insertRule of valid @media into @supports
 Pass	insertRule of valid style rule into @supports
 Fail	insertRule of invalid @media into @supports

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/nested-declarations-cssom.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/nested-declarations-cssom.txt
@@ -2,17 +2,17 @@ Harness status: OK
 
 Found 12 tests
 
-6 Pass
-6 Fail
+7 Pass
+5 Fail
 Fail	Trailing declarations
 Fail	Mixed declarations
 Fail	CSSNestedDeclarations.style
 Pass	Nested group rule
 Pass	Nested @scope rule
 Fail	Inner rule starting with an ident
-Fail	Inserting a CSSNestedDeclaration rule into style rule
-Fail	Inserting a CSSNestedDeclaration rule into nested group rule
-Pass	Attempting to insert a CSSNestedDeclaration rule into top-level @media rule
+Pass	Inserting a CSSNestedDeclaration rule into style rule
+Pass	Inserting a CSSNestedDeclaration rule into nested group rule
+Fail	Attempting to insert a CSSNestedDeclaration rule into top-level @media rule
 Pass	Attempting to insert a CSSNestedDeclaration rule into a stylesheet
 Pass	Attempting to insert a CSSNestedDeclaration rule, empty block
 Pass	Attempting to insert a CSSNestedDeclaration rule, all invalid declarations

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/nested-declarations-cssom.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/nested-declarations-cssom.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 12 tests
 
-7 Pass
-5 Fail
+8 Pass
+4 Fail
 Fail	Trailing declarations
 Fail	Mixed declarations
 Fail	CSSNestedDeclarations.style
@@ -12,7 +12,7 @@ Pass	Nested @scope rule
 Fail	Inner rule starting with an ident
 Pass	Inserting a CSSNestedDeclaration rule into style rule
 Pass	Inserting a CSSNestedDeclaration rule into nested group rule
-Fail	Attempting to insert a CSSNestedDeclaration rule into top-level @media rule
+Pass	Attempting to insert a CSSNestedDeclaration rule into top-level @media rule
 Pass	Attempting to insert a CSSNestedDeclaration rule into a stylesheet
 Pass	Attempting to insert a CSSNestedDeclaration rule, empty block
 Pass	Attempting to insert a CSSNestedDeclaration rule, all invalid declarations


### PR DESCRIPTION
The main part of this is updating our implementation to support nested declarations. But also, we now track the rule context (aka, the tree of CSSRules we're in) when parsing CSS set by JS. This definitely needs doing in more places, but for now, it fixes a few WPT subtests.