### PR TITLE
LibWeb: Perform writes during ReadableStreamPipeTo asynchronously

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/streams/piping/general-addition.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/piping/general-addition.any.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	enqueue() must not synchronously call write algorithm
+1 Pass
+Pass	enqueue() must not synchronously call write algorithm

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/piping/general-addition.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/piping/general-addition.any.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	enqueue() must not synchronously call write algorithm

--- a/Tests/LibWeb/Text/input/wpt-import/streams/piping/general-addition.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/piping/general-addition.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../streams/piping/general-addition.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/piping/general-addition.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/piping/general-addition.any.js
@@ -1,0 +1,15 @@
+// META: global=window,worker,shadowrealm
+'use strict';
+
+promise_test(async t => {
+  /** @type {ReadableStreamDefaultController} */
+  var con;
+  let synchronous = false;
+  new ReadableStream({ start(c) { con = c }}, { highWaterMark: 0 }).pipeTo(
+    new WritableStream({ write() { synchronous = true; } })
+  )
+  // wait until start algorithm finishes
+  await Promise.resolve();
+  con.enqueue();
+  assert_false(synchronous, 'write algorithm must not run synchronously');
+}, "enqueue() must not synchronously call write algorithm");


### PR DESCRIPTION
I don't quite see what spec text requires this, but it is explicitly checked by WPT. We used to pass this test, but that regressed after commit https://github.com/LadybirdBrowser/ladybird/commit/3c6010c663dddb78aa84b85e7a27307c4841a9dd.