### PR TITLE
AK: Add macro for NO_UNIQUE_ADDRESS and add an escape hatch for current Swift issues

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -789,7 +789,7 @@ private:
 
     BucketType* m_buckets { nullptr };
 
-    [[no_unique_address]] CollectionDataType m_collection_data;
+    NO_UNIQUE_ADDRESS CollectionDataType m_collection_data;
     size_t m_size { 0 };
     size_t m_capacity { 0 };
 };

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -169,7 +169,7 @@ private:
     IntrusiveListStorage<T, Container>* m_storage = nullptr;
     SubstitutedIntrusiveListNode<T, Container>* m_next = nullptr;
     SubstitutedIntrusiveListNode<T, Container>* m_prev = nullptr;
-    [[no_unique_address]] SelfReferenceIfNeeded<Container, IsRaw> m_self;
+    NO_UNIQUE_ADDRESS SelfReferenceIfNeeded<Container, IsRaw> m_self;
 };
 
 template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -212,7 +212,7 @@ private:
 #endif
 
     bool m_in_tree { false };
-    [[no_unique_address]] SelfReferenceIfNeeded<Container, IsRaw> m_self;
+    NO_UNIQUE_ADDRESS SelfReferenceIfNeeded<Container, IsRaw> m_self;
 };
 
 // Specialise IntrusiveRedBlackTree for NonnullRefPtr

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -247,6 +247,19 @@
 #    define DISALLOW(message) __attribute__((error(message)))
 #endif
 
+#ifdef NO_UNIQUE_ADDRESS
+#    undef NO_UNIQUE_ADDRESS
+#endif
+#if defined(AK_DISABLE_NO_UNIQUE_ADDRESS)
+#    define NO_UNIQUE_ADDRESS
+#else
+#    if defined(AK_OS_WINDOWS)
+#        define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#    else
+#        define NO_UNIQUE_ADDRESS [[no_unique_address]]
+#    endif
+#endif
+
 // GCC doesn't have __has_feature but clang does
 #ifndef __has_feature
 #    define __has_feature(...) 0

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -138,7 +138,7 @@ private:
     size_t calculate_length_in_code_points() const;
 
     ReadonlySpan<u16> m_code_units;
-    [[no_unique_address]] mutable Optional<size_t> m_length_in_code_points;
+    NO_UNIQUE_ADDRESS mutable Optional<size_t> m_length_in_code_points;
     Endianness m_endianness { Endianness::Host };
 };
 

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -139,3 +139,8 @@ endif()
 if (NOT MSVC)
     add_cxx_compile_options(-fstrict-flex-arrays=2)
 endif()
+
+# FIXME: https://github.com/swiftlang/swift/issues/80764
+if (CMAKE_Swift_COMPILER_LOADED)
+    add_cxx_compile_definitions(AK_DISABLE_NO_UNIQUE_ADDRESS)
+endif()

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -49,7 +49,6 @@ endmacro()
 
 # FIXME: Rework these flags to remove the suspicious ones.
 if (WIN32)
-  add_compile_options(-Wno-unknown-attributes) # [[no_unique_address]] is broken in MSVC ABI until next ABI break
   add_compile_options(-Wno-reinterpret-base-class)
   add_compile_options(-Wno-microsoft-unqualified-friend) # MSVC doesn't support unqualified friends
   add_compile_definitions(_CRT_SECURE_NO_WARNINGS) # _s replacements not desired (or implemented on any other platform other than VxWorks)


### PR DESCRIPTION
We only use this annotation in AK as it is, since it's such a low-level library tool. These patches make it so the annotation works as expected on MSVC ABIs, and should unbreak the Swift nightlies.