### PR TITLE
LibWeb/CSS: Parse font sources more correctly

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -3711,6 +3711,12 @@ RefPtr<FontSourceStyleValue> Parser::parse_font_source_value(TokenStream<Compone
             return nullptr;
         }
 
+        format_tokens.discard_whitespace();
+        if (format_tokens.has_next_token()) {
+            dbgln_if(CSS_PARSER_DEBUG, "CSSParser: font source invalid (`format()` has trailing tokens); discarding.");
+            return nullptr;
+        }
+
         format = move(format_name);
     }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-format.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-format.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 35 tests
 
-30 Pass
-5 Fail
+33 Pass
+2 Fail
 Pass	Check that src: url("foo.ttf") is valid
 Pass	Check that src: url("foo.ttf"), url("bar.ttf") is valid
 Pass	Check that src: url("foo.ttf") format() is invalid
@@ -15,14 +15,14 @@ Pass	Check that src: url("foo.ttf") format("opentype") is valid
 Pass	Check that src: url("foo.ttf") format("truetype") is valid
 Pass	Check that src: url("foo.ttf") format("woff") is valid
 Pass	Check that src: url("foo.ttf") format("woff2") is valid
-Fail	Check that src: url("foo.ttf") format("opentype", "truetype") is invalid
+Pass	Check that src: url("foo.ttf") format("opentype", "truetype") is invalid
 Fail	Check that src: url("foo.ttf") format(collection) is valid
 Pass	Check that src: url("foo.ttf") format(opentype) is valid
 Pass	Check that src: url("foo.ttf") format(truetype) is valid
 Pass	Check that src: url("foo.ttf") format(woff) is valid
 Pass	Check that src: url("foo.ttf") format(woff2) is valid
-Fail	Check that src: url("foo.ttf") format(opentype, truetype) is invalid
-Fail	Check that src: url("foo.ttf") format(opentype truetype) is invalid
+Pass	Check that src: url("foo.ttf") format(opentype, truetype) is invalid
+Pass	Check that src: url("foo.ttf") format(opentype truetype) is invalid
 Pass	Check that src: url("foo.ttf") format(auto) is invalid
 Pass	Check that src: url("foo.ttf") format(default) is invalid
 Pass	Check that src: url("foo.ttf") format(inherit) is invalid

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-format.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-format.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 35 tests
 
-21 Pass
-14 Fail
+30 Pass
+5 Fail
 Pass	Check that src: url("foo.ttf") is valid
 Pass	Check that src: url("foo.ttf"), url("bar.ttf") is valid
 Pass	Check that src: url("foo.ttf") format() is invalid
@@ -30,12 +30,12 @@ Pass	Check that src: url("foo.ttf") format(initial) is invalid
 Pass	Check that src: url("foo.ttf") format(none) is invalid
 Pass	Check that src: url("foo.ttf") format(normal) is invalid
 Pass	Check that src: url("foo.ttf") format(xyzzy) is invalid
-Fail	Check that src: url("foo.ttf") format("embedded-opentype"), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") format(embedded-opentype), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") format("svg"), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") format(svg), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") format(xyzz 200px), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") format(xyzz), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") dummy(xyzzy), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") format(), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") format(none), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format("embedded-opentype"), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format(embedded-opentype), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format("svg"), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format(svg), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format(xyzz 200px), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format(xyzz), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") dummy(xyzzy), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format(), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") format(none), url("bar.html") is valid

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-list.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-list.txt
@@ -2,20 +2,19 @@ Harness status: OK
 
 Found 17 tests
 
-5 Pass
-12 Fail
-Fail	Check that src: local(inherit), url(foo.ttf) is valid
-Fail	Check that src: local("myfont"), local(unset) is valid
-Fail	Check that src: local(), url(foo.ttf) is valid
-Fail	Check that src: local(12px monospace), url(foo.ttf) is valid
-Fail	Check that src: local("myfont") format(opentype), url(foo.ttf) is valid
-Fail	Check that src: url(not a valid url/bar.ttf), url(foo.ttf) is valid
-Fail	Check that src: url(foo.ttf) format(bad), url(foo.ttf) is valid
-Fail	Check that src: url(foo.ttf) tech(unknown), url(foo.ttf) is valid
-Fail	Check that src: url(foo.ttf) tech(color-COLRv0) otherfunc(othervalue), url(foo.ttf) is valid
-Fail	Check that src: url(foo.ttf), url(something.ttf) format(broken) is valid
-Fail	Check that src: /* an empty component */, url(foo.ttf) is valid
-Fail	Check that src: local(""), url(foo.ttf), unparseable-garbage, local("another font name") is valid
+17 Pass
+Pass	Check that src: local(inherit), url(foo.ttf) is valid
+Pass	Check that src: local("myfont"), local(unset) is valid
+Pass	Check that src: local(), url(foo.ttf) is valid
+Pass	Check that src: local(12px monospace), url(foo.ttf) is valid
+Pass	Check that src: local("myfont") format(opentype), url(foo.ttf) is valid
+Pass	Check that src: url(not a valid url/bar.ttf), url(foo.ttf) is valid
+Pass	Check that src: url(foo.ttf) format(bad), url(foo.ttf) is valid
+Pass	Check that src: url(foo.ttf) tech(unknown), url(foo.ttf) is valid
+Pass	Check that src: url(foo.ttf) tech(color-COLRv0) otherfunc(othervalue), url(foo.ttf) is valid
+Pass	Check that src: url(foo.ttf), url(something.ttf) format(broken) is valid
+Pass	Check that src: /* an empty component */, url(foo.ttf) is valid
+Pass	Check that src: local(""), url(foo.ttf), unparseable-garbage, local("another font name") is valid
 Pass	Check that src: local(), local(initial) is invalid
 Pass	Check that src: local("textfont") format(opentype), local("emoji") tech(color-COLRv0) is invalid
 Pass	Check that src: local(), /*empty*/, url(should be quoted.ttf), junk is invalid

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-tech.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-tech.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 39 tests
 
-22 Pass
-17 Fail
+28 Pass
+11 Fail
 Pass	Check that src: url("foo.ttf") is valid
 Pass	Check that src: url("foo.ttf") tech() is invalid
 Fail	Check that src: url("foo.ttf") tech(features-opentype) is valid
@@ -33,13 +33,13 @@ Pass	Check that src: url("foo.ttf") tech(xyzzy, features-opentype) is invalid
 Pass	Check that src: url("foo.ttf") tech(features-opentype, xyzzy) is invalid
 Fail	Check that src: url("foo.ttf") format(opentype) tech(features-opentype) is valid
 Pass	Check that src: url("foo.ttf") tech(features-opentype) format(opentype) is invalid
-Fail	Check that src: url("foo.ttf") tech(incremental), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") tech(incremental, color-SVG, features-graphite, features-aat), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") tech(color-SVG, features-graphite), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") tech(color-SVG), url("bar.html") is valid
-Fail	Check that src: url("foo.ttf") tech(features-graphite), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") tech(incremental), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") tech(incremental, color-SVG, features-graphite, features-aat), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") tech(color-SVG, features-graphite), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") tech(color-SVG), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") tech(features-graphite), url("bar.html") is valid
 Pass	Check that src: url("foo.ttf") dummy("opentype") tech(variations) is invalid
 Pass	Check that src: url("foo.ttf") dummy("opentype") dummy(variations) is invalid
 Pass	Check that src: url("foo.ttf") format(opentype) tech(features-opentype) dummy(something) is invalid
 Fail	Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid
-Fail	Check that src: url("foo.ttf") tech(color), url("bar.html") is valid
+Pass	Check that src: url("foo.ttf") tech(color), url("bar.html") is valid


### PR DESCRIPTION
Details in commits. This gets us 30 WPT subtests for our in-tree tests, and fixes the menubar icons on https://mdn-bcd-collector.gooborg.com/