### PR TITLE
CI: Remove concurrency configuration for JS artifacts and benchmarks

### DIFF
--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -28,9 +28,6 @@ jobs:
             arch: 'arm64'
             package_type: 'macOS-universal2'
 
-    concurrency:
-      group: ${{ github.workflow }}-${{ matrix.os_name }}
-
     steps:
       - name: Checkout LadybirdBrowser/ladybird
         uses: actions/checkout@v4

--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -25,9 +25,6 @@ jobs:
             arch: 'arm64'
             package_type: 'macOS-universal2'
 
-    concurrency:
-      group: ${{ github.workflow }}-${{ matrix.os_name }}
-
     steps:
       - name: 'Checkout LadybirdBrowser/js-benchmarks'
         uses: actions/checkout@v4


### PR DESCRIPTION
We had concurrency set on the JS artifacts and JS benchmarks workflows causing them to not run in parallel for the same combination of (workflow, OS name). You'd expect that this causes a FIFO queue to exist of the jobs to run sequentially, but in reality GitHub maintains a single job to prioritize and cancels all others. We don't want that for our artifacts and benchmarks: we want them to run on each push.

For example, a new push could have workflows getting cancelled because someone restarted a previously failed workflow, resulting in the following message:

  "Canceling since a higher priority waiting request for [..] exists"

By removing the concurrency setting from these workflows, we make use of all available runners to execute the jobs and potentially run some of them in parallel. For the benchmarks however, we currently only have one matching self-hosted runner per job, and as such they are still not run in parallel.