### PR TITLE
LibWeb: Don't double-dispatch click events on a label's child input

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -555,7 +555,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPix
             }
 
             if (auto* input_control = input_control_associated_with_ancestor_label_element(*paintable)) {
-                if (button == UIEvents::MouseButton::Primary) {
+                if (button == UIEvents::MouseButton::Primary && input_control != node) {
                     input_control->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, screen_position, page_offset, viewport_position, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors());
                 }
             }

--- a/Tests/LibWeb/Text/expected/UIEvents/click-event-on-checkbox-inside-label-element-not-duplicated.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/click-event-on-checkbox-inside-label-element-not-duplicated.txt
@@ -1,0 +1,2 @@
+click event on input#radio1
+click event on input#radio2

--- a/Tests/LibWeb/Text/input/UIEvents/click-event-on-checkbox-inside-label-element-not-duplicated.html
+++ b/Tests/LibWeb/Text/input/UIEvents/click-event-on-checkbox-inside-label-element-not-duplicated.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<style>
+    * {
+        margin: 0;
+    }
+
+    .box {
+        display: inline-block;
+        width: 100px;
+        height: 100px;
+        background-color: purple;
+    }
+
+    label {
+        display: block;
+        width: 200px;
+        height: 200px;
+        border: 1px solid black;
+    }
+</style>
+<script src="../include.js"></script>
+<body>
+    <form>
+        <label>
+            <input type="checkbox" id="radio1" class="target">
+        </label>
+        <label>
+            <input type="checkbox" id="radio2" class="target">
+        </label>
+        <input type="checkbox" id="done">
+    </form>
+</body>
+<script>
+    asyncTest(done => {
+        document.querySelectorAll('.target').forEach(function (element) {
+            element.addEventListener('click', function (event) {
+                println(`click event on input#${event.target.id}`);
+            });
+        });
+
+        document.getElementById('done').addEventListener('click', function (event) {
+            done();
+        });
+
+        internals.click(5, 10);
+        internals.click(5, 210);
+        internals.click(5, 410);
+    });
+</script>
+</html>


### PR DESCRIPTION
If the user clicked directly on the input inside a label, then it already received a click event. Dispatching a second one via the label is redundant, and means that if the input is a checkbox, it gets its value toggled twice.

It kept bothering me that the checkboxes on WPT pages (to filter the passing/failing subtests) had this issue, so: a fix! :tada: 