### PR TITLE
LibWeb/CSP: Implement source expression parsing, URL matching and support for setting CSP by the meta element and prepare stylesheets to work with style-src

### DIFF
--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -199,6 +199,16 @@ public:
         return m_input.substring_view(start, length);
     }
 
+    template<typename TPredicate>
+    constexpr bool consume_specific_with_predicate(TPredicate pred)
+    {
+        if (is_eof() || !pred(peek()))
+            return false;
+
+        ignore();
+        return true;
+    }
+
     // Ignore characters while `pred` returns true
     template<typename TPredicate>
     constexpr void ignore_while(TPredicate pred)

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/KeywordSources.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp
+    ContentSecurityPolicy/Directives/SourceExpression.cpp
     ContentSecurityPolicy/BlockingAlgorithms.cpp
     ContentSecurityPolicy/Policy.cpp
     ContentSecurityPolicy/PolicyList.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/Directive.cpp
     ContentSecurityPolicy/Directives/DirectiveFactory.cpp
     ContentSecurityPolicy/Directives/DirectiveOperations.cpp
+    ContentSecurityPolicy/Directives/KeywordSources.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp
     ContentSecurityPolicy/BlockingAlgorithms.cpp

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
@@ -8,8 +8,13 @@
 #include <AK/HashMap.h>
 #include <AK/Vector.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/SourceExpression.h>
+#include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+#include <LibWeb/Fetch/Infrastructure/URL.h>
+#include <LibWeb/Infra/Strings.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
 
@@ -222,6 +227,355 @@ FlyString get_the_effective_directive_for_inline_checks(Directive::InlineType ty
     // FIXME: File spec issue that this should be invalid, as the result of this algorithm ends up being piped into
     //        Violation's effective directive, which is defined to be a non-empty string.
     VERIFY_NOT_REACHED();
+}
+
+// https://w3c.github.io/webappsec-csp/#scheme-part-match
+// An ASCII string scheme-part matches another ASCII string if a CSP source expression that contained the first as a
+// scheme-part could potentially match a URL containing the latter as a scheme. For example, we say that "http"
+// scheme-part matches "https".
+// More formally, two ASCII strings A and B are said to scheme-part match if the following algorithm returns "Matches":
+// Spec Note: The matching relation is asymmetric. For example, the source expressions https: and https://example.com/
+//            do not match the URL http://example.com/. We always allow a secure upgrade from an explicitly insecure
+//            expression. script-src http: is treated as equivalent to script-src http: https:,
+//            script-src http://example.com to script-src http://example.com https://example.com,
+//            and connect-src ws: to connect-src ws: wss:.
+[[nodiscard]] static MatchResult scheme_part_matches(StringView a, StringView b)
+{
+    // 1. If one of the following is true, return "Matches":
+    //    1. A is an ASCII case-insensitive match for B.
+    if (Infra::is_ascii_case_insensitive_match(a, b))
+        return MatchResult::Matches;
+
+    //    2. A is an ASCII case-insensitive match for "http", and B is an ASCII case-insensitive match for "https".
+    if (Infra::is_ascii_case_insensitive_match(a, "http"sv) && Infra::is_ascii_case_insensitive_match(b, "https"sv))
+        return MatchResult::Matches;
+
+    //    3. A is an ASCII case-insensitive match for "ws", and B is an ASCII case-insensitive match for "wss", "http", or "https".
+    if (Infra::is_ascii_case_insensitive_match(a, "ws"sv)
+        && (Infra::is_ascii_case_insensitive_match(b, "wss"sv)
+            || Infra::is_ascii_case_insensitive_match(b, "http"sv)
+            || Infra::is_ascii_case_insensitive_match(b, "https"sv))) {
+        return MatchResult::Matches;
+    }
+
+    //    4. A is an ASCII case-insensitive match for "wss", and B is an ASCII case-insensitive match for "https".
+    if (Infra::is_ascii_case_insensitive_match(a, "wss"sv) && Infra::is_ascii_case_insensitive_match(b, "https"sv))
+        return MatchResult::Matches;
+
+    // 2. Return "Does Not Match".
+    return MatchResult::DoesNotMatch;
+}
+
+// https://w3c.github.io/webappsec-csp/#host-part-match
+// An ASCII string host-part matches a host if a CSP source expression that contained the first as a host-part could
+// potentially match the latter. For example, we say that "www.example.com" host-part matches "www.example.com".
+// More formally, ASCII string pattern and host host are said to host-part match if the following algorithm returns "Matches":
+// Spec Note: The matching relation is asymmetric. That is, pattern matching host does not mean that host will match pattern.
+//            For example, *.example.com host-part matches www.example.com, but www.example.com does not host-part match *.example.com.
+[[nodiscard]] static MatchResult host_part_matches(StringView pattern, Optional<URL::Host> const& maybe_host)
+{
+    // 1. If host is not a domain, return "Does Not Match".
+    // Spec Note: A future version of this specification may allow literal IPv6 and IPv4 addresses, depending on usage and demand.
+    //            Given the weak security properties of IP addresses in relation to named hosts, however, authors are encouraged
+    //            to prefer the latter whenever possible.
+    if (!maybe_host.has_value())
+        return MatchResult::DoesNotMatch;
+
+    auto const& host = maybe_host.value();
+
+    if (!host.is_domain())
+        return MatchResult::DoesNotMatch;
+
+    // 2. If pattern is "*", return "Matches".
+    if (pattern == "*"sv)
+        return MatchResult::Matches;
+
+    VERIFY(host.has<String>());
+    auto host_string = host.get<String>();
+
+    // 3. If pattern starts with "*.":
+    if (pattern.starts_with("*."sv)) {
+        // 1. Let remaining be pattern with the leading U+002A (*) removed and ASCII lowercased.
+        auto remaining = MUST(Infra::to_ascii_lowercase(pattern.substring_view(1)));
+
+        // 2. If host to ASCII lowercase ends with remaining, then return "Matches".
+        auto lowercase_host = MUST(Infra::to_ascii_lowercase(host_string));
+        if (lowercase_host.ends_with_bytes(remaining))
+            return MatchResult::Matches;
+
+        // 3. Return "Does Not Match".
+        return MatchResult::DoesNotMatch;
+    }
+
+    // 4. If pattern is not an ASCII case-insensitive match for host, return "Does Not Match".
+    if (!Infra::is_ascii_case_insensitive_match(pattern, host_string))
+        return MatchResult::DoesNotMatch;
+
+    // 5. Return "Matches".
+    return MatchResult::Matches;
+}
+
+// https://w3c.github.io/webappsec-csp/#port-part-matches
+// An ASCII string input port-part matches URL url if a CSP source expression that contained the first as a port-part
+// could potentially match a URL containing the latter’s port and scheme. For example, "80" port-part matches
+// matches http://example.com.
+[[nodiscard]] static MatchResult port_part_matches(Optional<StringView> input, URL::URL const& url)
+{
+    // FIXME: 1. Assert: input is the empty string, "*", or a sequence of ASCII digits.
+
+    // 2. If input is equal to "*", return "Matches".
+    if (input == "*"sv)
+        return MatchResult::Matches;
+
+    // 3. Let normalizedInput be null if input is the empty string; otherwise input interpreted as decimal number.
+    Optional<u16> normalized_input;
+    if (input.has_value()) {
+        VERIFY(!input.value().is_empty());
+        auto maybe_port = input.value().to_number<u16>(TrimWhitespace::No);
+
+        // If the port is empty here, then it's because the input overflowed the u16. Since this means it's bigger than
+        // a u16, it can never match the URL's port, which is only within the u16 range.
+        if (!maybe_port.has_value())
+            return MatchResult::DoesNotMatch;
+
+        normalized_input = maybe_port.value();
+    }
+
+    // 4. If normalizedInput equals url’s port, return "Matches".
+    if (normalized_input == url.port())
+        return MatchResult::Matches;
+
+    // 5. If url’s port is null:
+    if (!url.port().has_value()) {
+        // 1. Let defaultPort be the default port for url’s scheme.
+        auto default_port = URL::default_port_for_scheme(url.scheme());
+
+        // 2. If normalizedInput equals defaultPort, return "Matches".
+        if (normalized_input == default_port)
+            return MatchResult::Matches;
+    }
+
+    // 6. Return "Does Not Match".
+    return MatchResult::DoesNotMatch;
+}
+
+// https://w3c.github.io/webappsec-csp/#path-part-match
+// An ASCII string path A path-part matches another ASCII string path B if a CSP source expression that contained the
+// first as a path-part could potentially match a URL containing the latter as a path. For example, we say that
+// "/subdirectory/" path-part matches "/subdirectory/file".
+// Spec Note: The matching relation is asymmetric. That is, path A matching path B does not mean that path B will
+//            match path A.
+[[nodiscard]] static MatchResult path_part_matches(StringView a, StringView b)
+{
+    // 1. If path A is the empty string, return "Matches".
+    if (a.is_empty())
+        return MatchResult::Matches;
+
+    // 2. If path A consists of one character that is equal to the U+002F SOLIDUS character (/) and path B is the empty
+    //    string, return "Matches".
+    if (a == "/"sv && b.is_empty())
+        return MatchResult::Matches;
+
+    // 3. Let exact match be false if the final character of path A is the U+002F SOLIDUS character (/), and true
+    //    otherwise.
+    auto exact_match = !a.ends_with('/');
+
+    // 4. Let path list A and path list B be the result of strictly splitting path A and path B respectively on the
+    //    U+002F SOLIDUS character (/).
+    auto path_list_a = a.split_view('/', SplitBehavior::KeepEmpty);
+    auto path_list_b = b.split_view('/', SplitBehavior::KeepEmpty);
+
+    // 5. If path list A has more items than path list B, return "Does Not Match".
+    if (path_list_a.size() > path_list_b.size())
+        return MatchResult::DoesNotMatch;
+
+    // 6. If exact match is true, and path list A does not have the same number of items as path list B,
+    //    return "Does Not Match".
+    if (exact_match && path_list_a.size() != path_list_b.size())
+        return MatchResult::DoesNotMatch;
+
+    // 7. If exact match is false:
+    if (!exact_match) {
+        // 1. Assert: the final item in path list A is the empty string.
+        VERIFY(path_list_a.last().is_empty());
+
+        // 2. Remove the final item from path list A.
+        (void)path_list_a.take_last();
+    }
+
+    // 8. For each piece A of path list A:
+    for (size_t path_set_a_index = 0; path_set_a_index < path_list_a.size(); ++path_set_a_index) {
+        auto piece_a = path_list_a[path_set_a_index];
+
+        // 1. Let piece B be the next item in path list B.
+        auto piece_b = path_list_b[path_set_a_index];
+
+        // 2. Let decoded piece A be the percent-decoding of piece A.
+        auto decoded_piece_a = URL::percent_decode(piece_a);
+
+        // 3. Let decoded piece B be the percent-decoding of piece B.
+        auto decoded_piece_b = URL::percent_decode(piece_b);
+
+        // 4. If decoded piece A is not decoded piece B, return "Does Not Match".
+        if (decoded_piece_a != decoded_piece_b)
+            return MatchResult::DoesNotMatch;
+    }
+
+    // 9. Return "Matches".
+    return MatchResult::Matches;
+}
+
+// https://w3c.github.io/webappsec-csp/#match-url-to-source-expression
+MatchResult does_url_match_expression_in_origin_with_redirect_count(URL::URL const& url, String const& expression, URL::Origin const& origin, u8 redirect_count)
+{
+    // Spec Note: origin is the origin of the resource relative to which the expression should be resolved.
+    //            "'self'", for instance, will have distinct meaning depending on that bit of context.
+
+    // 1. If expression is the string "*", return "Matches" if one or more of the following conditions is met:
+    //    1. url’s scheme is an HTTP(S) scheme.
+    //    2. url’s scheme is the same as origin’s scheme.
+    // Spec Note: This logic means that in order to allow a resource from a non-HTTP(S) scheme, it has to be either
+    //            explicitly specified (e.g. default-src * data: custom-scheme-1: custom-scheme-2:), or the protected
+    //            resource must be loaded from the same scheme.
+    StringView origin_scheme {};
+    if (!origin.is_opaque() && origin.scheme().has_value())
+        origin_scheme = origin.scheme()->bytes_as_string_view();
+
+    if (expression == "*"sv && (Fetch::Infrastructure::is_http_or_https_scheme(url.scheme()) || url.scheme() == origin_scheme))
+        return MatchResult::Matches;
+
+    // 2. If expression matches the scheme-source or host-source grammar:
+    auto scheme_source_parse_result = parse_source_expression(Production::SchemeSource, expression);
+    auto host_source_parse_result = parse_source_expression(Production::HostSource, expression);
+    if (scheme_source_parse_result.has_value() || host_source_parse_result.has_value()) {
+        // 1. If expression has a scheme-part, and it does not scheme-part match url’s scheme, return "Does Not Match".
+        auto maybe_scheme_part = scheme_source_parse_result.has_value()
+            ? scheme_source_parse_result->scheme_part
+            : host_source_parse_result->scheme_part;
+
+        if (maybe_scheme_part.has_value()) {
+            if (scheme_part_matches(maybe_scheme_part.value(), url.scheme()) == MatchResult::DoesNotMatch)
+                return MatchResult::DoesNotMatch;
+        }
+
+        // 2. If expression matches the scheme-source grammar, return "Matches".
+        if (scheme_source_parse_result.has_value())
+            return MatchResult::Matches;
+    }
+
+    // 3. If expression matches the host-source grammar:
+    if (host_source_parse_result.has_value()) {
+        // 1. If url’s host is null, return "Does Not Match".
+        if (!url.host().has_value())
+            return MatchResult::DoesNotMatch;
+
+        // 2. If expression does not have a scheme-part, and origin’s scheme does not scheme-part match url’s scheme,
+        //    return "Does Not Match".
+        // Spec Note: As with scheme-part above, we allow schemeless host-source expressions to be upgraded from
+        //            insecure schemes to secure schemes.
+        if (!host_source_parse_result->scheme_part.has_value() && scheme_part_matches(origin_scheme, url.scheme()) == MatchResult::DoesNotMatch)
+            return MatchResult::DoesNotMatch;
+
+        // 3. If expression’s host-part does not host-part match url’s host, return "Does Not Match".
+        VERIFY(host_source_parse_result->host_part.has_value());
+        if (host_part_matches(host_source_parse_result->host_part.value(), url.host()) == MatchResult::DoesNotMatch)
+            return MatchResult::DoesNotMatch;
+
+        // 4. Let port-part be expression’s port-part if present, and null otherwise.
+        auto port_part = host_source_parse_result->port_part;
+
+        // 5. If port-part does not port-part match url, return "Does Not Match".
+        if (port_part_matches(port_part, url) == MatchResult::DoesNotMatch)
+            return MatchResult::DoesNotMatch;
+
+        // 6. If expression contains a non-empty path-part, and redirect count is 0, then:
+        if (host_source_parse_result->path_part.has_value() && !host_source_parse_result->path_part->is_empty() && redirect_count == 0) {
+            // 1. Let path be the resulting of joining url’s path on the U+002F SOLIDUS character (/).
+            // FIXME: File spec issue that if path_part is only '/', then plainly joining will always fail to match.
+            //        It should likely use the URL path serializer instead.
+            StringBuilder builder;
+            builder.append('/');
+            builder.join('/', url.paths());
+            auto path = MUST(builder.to_string());
+
+            // 2. If expression’s path-part does not path-part match path, return "Does Not Match".
+            if (path_part_matches(host_source_parse_result->path_part.value(), path) == MatchResult::DoesNotMatch)
+                return MatchResult::DoesNotMatch;
+        }
+
+        // 7. Return "Matches".
+        return MatchResult::Matches;
+    }
+
+    // 4. If expression is an ASCII case-insensitive match for "'self'", return "Matches" if one or more of the
+    //    following conditions is met:
+    // Spec Note: Like the scheme-part logic above, the "'self'" matching algorithm allows upgrades to secure schemes
+    //            when it is safe to do so. We limit these upgrades to endpoints running on the default port for a
+    //            particular scheme or a port that matches the origin of the protected resource, as this seems
+    //            sufficient to deal with upgrades that can be reasonably expected to succeed.
+    if (Infra::is_ascii_case_insensitive_match(expression, KeywordSources::Self)) {
+        // 1. origin is the same as url’s origin
+        if (origin.is_same_origin(url.origin()))
+            return MatchResult::Matches;
+
+        // 2. origin’s host is the same as url’s host, origin’s port and url’s port are either the same or the default
+        //    ports for their respective schemes, and one or more of the following conditions is met:
+        auto origin_default_port = URL::default_port_for_scheme(origin_scheme);
+        auto url_default_port = URL::default_port_for_scheme(url.scheme());
+
+        Optional<URL::Host> origin_host;
+        Optional<u16> origin_port;
+
+        if (!origin.is_opaque()) {
+            origin_host = origin.host();
+            origin_port = origin.port();
+        }
+
+        if (origin_host == url.host() && (origin.port() == url.port() || (origin_port == origin_default_port && url.port() == url_default_port))) {
+            // 1. url’s scheme is "https" or "wss"
+            if (url.scheme() == "https"sv || url.scheme() == "wss"sv)
+                return MatchResult::Matches;
+
+            // 2. origin’s scheme is "http" and url’s scheme is "http" or "ws"
+            if (origin_scheme == "http"sv && (url.scheme() == "http"sv || url.scheme() == "ws"sv))
+                return MatchResult::Matches;
+        }
+    }
+
+    // 5. Return "Does Not Match".
+    return MatchResult::DoesNotMatch;
+}
+
+// https://w3c.github.io/webappsec-csp/#match-url-to-source-list
+MatchResult does_url_match_source_list_in_origin_with_redirect_count(URL::URL const& url, Vector<String> const& source_list, URL::Origin const& origin, u8 redirect_count)
+{
+    // 1. Assert: source list is not null.
+    // NOTE: Already done by source_list being passed by reference.
+
+    // 2. If source list is empty, return "Does Not Match".
+    // Spec Note: An empty source list (that is, a directive without a value: script-src, as opposed to script-src host1)
+    //            is equivalent to a source list containing 'none', and will not match any URL.
+    if (source_list.is_empty())
+        return MatchResult::DoesNotMatch;
+
+    // 3. If source list’s size is 1, and source list[0] is an ASCII case-insensitive match for the string "'none'",
+    //    return "Does Not Match".
+    // Spec Note: The 'none' keyword has no effect when other source expressions are present. That is, the list « 'none' »
+    //            does not match any URL. A list consisting of « 'none', https://example.com », on the other hand, would
+    //            match https://example.com/.
+    if (source_list.size() == 1 && Infra::is_ascii_case_insensitive_match(source_list.first(), "'none'"sv))
+        return MatchResult::DoesNotMatch;
+
+    // 4. For each expression of source list:
+    for (auto const& expression : source_list) {
+        // 1. If § 6.7.2.8 Does url match expression in origin with redirect count? returns "Matches" when executed
+        //    upon url, expression, origin, and redirect count, return "Matches".
+        if (does_url_match_expression_in_origin_with_redirect_count(url, expression, origin, redirect_count) == MatchResult::Matches)
+            return MatchResult::Matches;
+    }
+
+    // 5. Return "Does Not Match".
+    return MatchResult::DoesNotMatch;
 }
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h
@@ -8,6 +8,7 @@
 
 #include <AK/StringView.h>
 #include <LibGC/Ptr.h>
+#include <LibURL/Forward.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
 #include <LibWeb/Forward.h>
 
@@ -18,10 +19,18 @@ enum class ShouldExecute {
     Yes,
 };
 
+enum class MatchResult {
+    DoesNotMatch,
+    Matches,
+};
+
 [[nodiscard]] Optional<FlyString> get_the_effective_directive_for_request(GC::Ref<Fetch::Infrastructure::Request const> request);
 [[nodiscard]] Vector<StringView> get_fetch_directive_fallback_list(Optional<FlyString> directive_name);
 [[nodiscard]] ShouldExecute should_fetch_directive_execute(Optional<FlyString> effective_directive_name, FlyString const& directive_name, GC::Ref<Policy const> policy);
 
 [[nodiscard]] FlyString get_the_effective_directive_for_inline_checks(Directive::InlineType type);
+
+[[nodiscard]] MatchResult does_url_match_expression_in_origin_with_redirect_count(URL::URL const& url, String const& expression, URL::Origin const& origin, u8 redirect_count);
+[[nodiscard]] MatchResult does_url_match_source_list_in_origin_with_redirect_count(URL::URL const& url, Vector<String> const& source_list, URL::Origin const& origin, u8 redirect_count);
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/KeywordSources.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/KeywordSources.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h>
+
+namespace Web::ContentSecurityPolicy::Directives::KeywordSources {
+
+#define __ENUMERATE_KEYWORD_SOURCE(name, value) \
+    FlyString name = value##_fly_string;
+ENUMERATE_KEYWORD_SOURCES
+#undef __ENUMERATE_KEYWORD_SOURCE
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+
+namespace Web::ContentSecurityPolicy::Directives::KeywordSources {
+
+// https://w3c.github.io/webappsec-csp/#grammardef-keyword-source
+#define ENUMERATE_KEYWORD_SOURCES                                                \
+    __ENUMERATE_KEYWORD_SOURCE(Self, "'self'")                                   \
+    __ENUMERATE_KEYWORD_SOURCE(UnsafeInline, "'unsafe-inline'")                  \
+    __ENUMERATE_KEYWORD_SOURCE(UnsafeEval, "'unsafe-eval'")                      \
+    __ENUMERATE_KEYWORD_SOURCE(StrictDynamic, "'strict-dynamic'")                \
+    __ENUMERATE_KEYWORD_SOURCE(UnsafeHashes, "'unsafe-hashes'")                  \
+    __ENUMERATE_KEYWORD_SOURCE(ReportSample, "'report-sample'")                  \
+    __ENUMERATE_KEYWORD_SOURCE(UnsafeAllowRedirects, "'unsafe-allow-redirects'") \
+    __ENUMERATE_KEYWORD_SOURCE(WasmUnsafeEval, "'wasm-unsafe-eval'")
+
+#define __ENUMERATE_KEYWORD_SOURCE(name, value) extern FlyString name;
+ENUMERATE_KEYWORD_SOURCES
+#undef __ENUMERATE_KEYWORD_SOURCE
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/Names.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/Names.h
@@ -39,6 +39,4 @@ namespace Web::ContentSecurityPolicy::Directives::Names {
 ENUMERATE_DIRECTIVE_NAMES
 #undef __ENUMERATE_DIRECTIVE_NAME
 
-void initialize_strings();
-
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/SourceExpression.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/SourceExpression.cpp
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) 2025, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/GenericLexer.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/SourceExpression.h>
+#include <LibWeb/Infra/Strings.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#source-expression
+class SourceExpressionParser {
+public:
+    explicit SourceExpressionParser(StringView input)
+        : m_input(input)
+        , m_state({
+              .lexer = GenericLexer { input },
+              .parse_result = {},
+          })
+    {
+    }
+
+    [[nodiscard]] GenericLexer const& lexer() const { return m_state.lexer; }
+    [[nodiscard]] SourceExpressionParseResult const& parse_result() const { return m_state.parse_result; }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-scheme-source
+    [[nodiscard]] bool parse_scheme_source()
+    {
+        // ; Schemes: "https:" / "custom-scheme:" / "another.custom-scheme:"
+        // scheme-source = scheme-part ":"
+        if (!parse_scheme_part())
+            return false;
+
+        return m_state.lexer.consume_specific(':');
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
+    [[nodiscard]] bool parse_scheme_part()
+    {
+        // scheme-part = scheme
+        // ; scheme is defined in section 3.1 of RFC 3986.
+        StateTransaction transaction { *this };
+
+        if (!parse_scheme())
+            return false;
+
+        m_state.parse_result.scheme_part = transaction.parsed_string_view();
+        transaction.commit();
+        return true;
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
+    [[nodiscard]] bool parse_scheme()
+    {
+        // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+        if (!m_state.lexer.consume_specific_with_predicate(is_ascii_alpha))
+            return false;
+
+        (void)m_state.lexer.consume_while([](char ch) {
+            return is_ascii_alpha(ch) || is_ascii_digit(ch) || ch == '+' || ch == '-' || ch == '.';
+        });
+        return true;
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-host-source
+    [[nodiscard]] bool parse_host_source()
+    {
+        // ; Hosts: "example.com" / "*.example.com" / "https://*.example.com:12/path/to/file.js"
+        // host-source = [ scheme-part "://" ] host-part [ ":" port-part ] [ path-part ]
+        auto parse_scheme = [&] {
+            StateTransaction transaction { *this };
+
+            if (!parse_scheme_part())
+                return;
+
+            if (!m_state.lexer.consume_specific("://"sv)) {
+                m_state.parse_result.scheme_part = OptionalNone {};
+                return;
+            }
+
+            transaction.commit();
+        };
+
+        parse_scheme();
+
+        if (!parse_host_part())
+            return false;
+
+        if (m_state.lexer.consume_specific(':')) {
+            if (!parse_port_part())
+                return false;
+        }
+
+        (void)parse_path_part();
+
+        return true;
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-host-part
+    [[nodiscard]] bool parse_host_part()
+    {
+        // host-part = "*" / [ "*." ] 1*host-char *( "." 1*host-char ) [ "." ]
+        StateTransaction transaction { *this };
+
+        if (m_state.lexer.consume_specific('*') && !m_state.lexer.consume_specific('.')) {
+            m_state.parse_result.host_part = transaction.parsed_string_view();
+            transaction.commit();
+            return true;
+        }
+
+        if (!parse_host_char())
+            return false;
+
+        while (parse_host_char())
+            ;
+
+        while (m_state.lexer.consume_specific('.')) {
+            if (parse_host_char()) {
+                while (parse_host_char())
+                    ;
+            } else {
+                break;
+            }
+        }
+
+        m_state.parse_result.host_part = transaction.parsed_string_view();
+        transaction.commit();
+        return true;
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-host-char
+    [[nodiscard]] bool parse_host_char()
+    {
+        // host-char = ALPHA / DIGIT / "-"
+        return m_state.lexer.consume_specific_with_predicate(is_ascii_alpha)
+            || m_state.lexer.consume_specific_with_predicate(is_ascii_digit)
+            || m_state.lexer.consume_specific('-');
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-port-part
+    [[nodiscard]] bool parse_port_part()
+    {
+        // port-part = 1*DIGIT / "*"
+        StateTransaction transaction { *this };
+
+        if (m_state.lexer.consume_specific('*')) {
+            m_state.parse_result.port_part = transaction.parsed_string_view();
+            transaction.commit();
+            return true;
+        }
+
+        if (!m_state.lexer.consume_specific_with_predicate(is_ascii_digit))
+            return false;
+
+        (void)m_state.lexer.consume_while(is_ascii_digit);
+
+        m_state.parse_result.port_part = transaction.parsed_string_view();
+        transaction.commit();
+        return true;
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-path-part
+    [[nodiscard]] bool parse_path_part()
+    {
+        // path-part = path-absolute (but not including ";" or ",")
+        // ; path-absolute is defined in section 3.3 of RFC 3986.
+        StateTransaction transaction { *this };
+
+        if (!parse_path_absolute())
+            return false;
+
+        m_state.parse_result.path_part = transaction.parsed_string_view();
+        transaction.commit();
+        return true;
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+    [[nodiscard]] bool parse_path_absolute()
+    {
+        // path-absolute = "/" [ segment-nz *( "/" segment ) ]
+        if (!m_state.lexer.consume_specific('/'))
+            return false;
+
+        if (parse_segment_non_zero()) {
+            while (m_state.lexer.consume_specific('/')) {
+                parse_segment();
+            }
+        }
+
+        return true;
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+    void parse_segment()
+    {
+        // segment = *pchar
+        while (parse_path_character())
+            ;
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+    [[nodiscard]] bool parse_segment_non_zero()
+    {
+        // segment-nz = 1*pchar
+        if (!parse_path_character())
+            return false;
+
+        while (parse_path_character())
+            ;
+
+        return true;
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
+    [[nodiscard]] bool parse_path_character()
+    {
+        // pchar = unreserved / pct-encoded / sub-delims / ":" / "@"
+        return parse_unreserved()
+            || parse_percent_encoded()
+            || parse_sub_delims()
+            || m_state.lexer.consume_specific_with_predicate(is_any_of(":@"sv));
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
+    [[nodiscard]] bool parse_unreserved()
+    {
+        // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+        return m_state.lexer.consume_specific_with_predicate(is_ascii_alpha)
+            || m_state.lexer.consume_specific_with_predicate(is_ascii_digit)
+            || m_state.lexer.consume_specific_with_predicate(is_any_of("-._~"sv));
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
+    [[nodiscard]] bool parse_percent_encoded()
+    {
+        // pct-encoded = "%" HEXDIG HEXDIG
+        // "The uppercase hexadecimal digits 'A' through 'F' are equivalent to
+        //  the lowercase digits 'a' through 'f', respectively.  If two URIs
+        //  differ only in the case of hexadecimal digits used in percent-encoded
+        //  octets, they are equivalent.  For consistency, URI producers and
+        //  normalizers should use uppercase hexadecimal digits for all percent-
+        //  encodings."
+        return m_state.lexer.consume_specific('%')
+            && m_state.lexer.consume_specific_with_predicate(is_ascii_hex_digit)
+            && m_state.lexer.consume_specific_with_predicate(is_ascii_hex_digit);
+    }
+
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
+    [[nodiscard]] bool parse_sub_delims()
+    {
+        // sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
+        //             / "*" / "+" / "," / ";" / "="
+        // NOTE: This does not contain ';' and ',' as per the requirement specified in parse_path_part.
+        return m_state.lexer.consume_specific_with_predicate(is_any_of("!$&'()*+="sv));
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-keyword-source
+    [[nodiscard]] bool parse_keyword_source()
+    {
+        // ; Keywords:
+        // keyword-source = "'self'" / "'unsafe-inline'" / "'unsafe-eval'"
+        //                  / "'strict-dynamic'" / "'unsafe-hashes'" /
+        //                  / "'report-sample'" / "'unsafe-allow-redirects'"
+        //                  / "'wasm-unsafe-eval'"
+        StateTransaction transaction { *this };
+
+#define __ENUMERATE_KEYWORD_SOURCE(_, value)                                    \
+    if (m_state.lexer.consume_specific(value##sv)) {                            \
+        m_state.parse_result.keyword_source = transaction.parsed_string_view(); \
+        transaction.commit();                                                   \
+        return true;                                                            \
+    }
+        ENUMERATE_KEYWORD_SOURCES
+#undef __ENUMERATE_KEYWORD_SOURCE
+
+        return false;
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-nonce-source
+    [[nodiscard]] bool parse_nonce_source()
+    {
+        // ; Nonces: 'nonce-[nonce goes here]'
+        // nonce-source = "'nonce-" base64-value "'"
+        auto prefix = m_state.lexer.consume(7);
+        if (prefix.length() != 7)
+            return false;
+
+        if (!Infra::is_ascii_case_insensitive_match(prefix, "'nonce-"sv))
+            return false;
+
+        if (!parse_base64_value())
+            return false;
+
+        return m_state.lexer.consume_specific('\'');
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-base64-value
+    [[nodiscard]] bool parse_base64_value()
+    {
+        // base64-value = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
+        StateTransaction transaction { *this };
+
+        auto is_main_part = [](char ch) {
+            return is_ascii_alpha(ch) || is_ascii_digit(ch) || ch == '+' || ch == '/' || ch == '-' || ch == '_';
+        };
+
+        if (!m_state.lexer.consume_specific_with_predicate(is_main_part))
+            return false;
+
+        (void)m_state.lexer.consume_while(is_main_part);
+        (void)m_state.lexer.consume_specific('=');
+        (void)m_state.lexer.consume_specific('=');
+
+        m_state.parse_result.base64_value = transaction.parsed_string_view();
+        transaction.commit();
+        return true;
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-hash-source
+    [[nodiscard]] bool parse_hash_source()
+    {
+        // ; Digests: 'sha256-[digest goes here]'
+        // hash-source = "'" hash-algorithm "-" base64-value "'"
+        if (!m_state.lexer.consume_specific('\''))
+            return false;
+
+        if (!parse_hash_algorithm())
+            return false;
+
+        if (!m_state.lexer.consume_specific('-'))
+            return false;
+
+        if (!parse_base64_value())
+            return false;
+
+        return m_state.lexer.consume_specific('\'');
+    }
+
+    // https://w3c.github.io/webappsec-csp/#grammardef-hash-algorithm
+    [[nodiscard]] bool parse_hash_algorithm()
+    {
+        // hash-algorithm = "sha256" / "sha384" / "sha512"
+        StateTransaction transaction { *this };
+
+        auto hash_algorithm = m_state.lexer.consume(6);
+        if (hash_algorithm.length() != 6)
+            return false;
+
+        if (Infra::is_ascii_case_insensitive_match(hash_algorithm, "sha256"sv)) {
+            m_state.parse_result.hash_algorithm = transaction.parsed_string_view();
+            transaction.commit();
+            return true;
+        }
+
+        if (Infra::is_ascii_case_insensitive_match(hash_algorithm, "sha384"sv)) {
+            m_state.parse_result.hash_algorithm = transaction.parsed_string_view();
+            transaction.commit();
+            return true;
+        }
+
+        if (Infra::is_ascii_case_insensitive_match(hash_algorithm, "sha512"sv)) {
+            m_state.parse_result.hash_algorithm = transaction.parsed_string_view();
+            transaction.commit();
+            return true;
+        }
+
+        return false;
+    }
+
+private:
+    struct State {
+        GenericLexer lexer;
+        SourceExpressionParseResult parse_result;
+    };
+
+    struct StateTransaction {
+        explicit StateTransaction(SourceExpressionParser& parser)
+            : m_parser(parser)
+            , m_saved_state(parser.m_state)
+            , m_start_index(parser.m_state.lexer.tell())
+        {
+        }
+
+        ~StateTransaction()
+        {
+            if (!m_commit)
+                m_parser.m_state = move(m_saved_state);
+        }
+
+        void commit() { m_commit = true; }
+        StringView parsed_string_view() const
+        {
+            return m_parser.m_input.substring_view(m_start_index, m_parser.m_state.lexer.tell() - m_start_index);
+        }
+
+    private:
+        SourceExpressionParser& m_parser;
+        State m_saved_state;
+        size_t m_start_index { 0 };
+        bool m_commit { false };
+    };
+
+    StringView m_input;
+    State m_state;
+};
+
+#define ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSERS                                   \
+    __ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSER(SchemeSource, parse_scheme_source)   \
+    __ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSER(HostSource, parse_host_source)       \
+    __ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSER(KeywordSource, parse_keyword_source) \
+    __ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSER(NonceSource, parse_nonce_source)     \
+    __ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSER(HashSource, parse_hash_source)
+
+Optional<SourceExpressionParseResult> parse_source_expression(Production production, StringView input)
+{
+    SourceExpressionParser parser { input };
+
+    switch (production) {
+#define __ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSER(ProductionName, parse_production) \
+    case Production::ProductionName:                                                      \
+        if (!parser.parse_production())                                                   \
+            return {};                                                                    \
+        break;
+        ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSERS
+#undef __ENUMERATE_SOURCE_EXPRESSION_PRODUCTION_PARSER
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    // If we parsed successfully but didn't reach the end, the string doesn't match the given production.
+    if (!parser.lexer().is_eof())
+        return {};
+
+    return parser.parse_result();
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/SourceExpression.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/SourceExpression.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+struct SourceExpressionParseResult {
+    Optional<StringView> scheme_part;
+    Optional<StringView> host_part;
+    Optional<StringView> port_part;
+    Optional<StringView> path_part;
+    Optional<StringView> keyword_source;
+    Optional<StringView> base64_value;
+    Optional<StringView> hash_algorithm;
+};
+
+enum class Production {
+    SchemeSource,
+    HostSource,
+    KeywordSource,
+    NonceSource,
+    HashSource,
+};
+
+Optional<SourceExpressionParseResult> parse_source_expression(Production, StringView);
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Policy.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Policy.cpp
@@ -206,6 +206,18 @@ SerializedPolicy Policy::serialize() const
     };
 }
 
+void Policy::remove_directive(Badge<HTML::HTMLMetaElement>, FlyString const& name)
+{
+    m_directives.remove_all_matching([&name](auto const& directive) {
+        return directive->name() == name;
+    });
+}
+
+void Policy::set_self_origin(Badge<HTML::HTMLMetaElement>, URL::Origin const& origin)
+{
+    m_self_origin = origin;
+}
+
 void Policy::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Libraries/LibWeb/ContentSecurityPolicy/Policy.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Policy.h
@@ -54,6 +54,9 @@ public:
     [[nodiscard]] GC::Ref<Policy> clone(JS::Realm&) const;
     [[nodiscard]] SerializedPolicy serialize() const;
 
+    void remove_directive(Badge<HTML::HTMLMetaElement>, FlyString const& name);
+    void set_self_origin(Badge<HTML::HTMLMetaElement>, URL::Origin const& origin);
+
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.cpp
@@ -79,6 +79,13 @@ HTML::SandboxingFlagSet PolicyList::csp_derived_sandboxing_flags() const
     return HTML::SandboxingFlagSet {};
 }
 
+// https://w3c.github.io/webappsec-csp/#enforced
+void PolicyList::enforce_policy(GC::Ref<Policy> policy)
+{
+    // A policy is enforced or monitored for a global object by inserting it into the global object’s CSP list.
+    m_policies.append(policy);
+}
+
 GC::Ref<PolicyList> PolicyList::clone(JS::Realm& realm) const
 {
     auto policy_list = realm.create<PolicyList>();

--- a/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.h
@@ -29,6 +29,8 @@ public:
 
     [[nodiscard]] HTML::SandboxingFlagSet csp_derived_sandboxing_flags() const;
 
+    void enforce_policy(GC::Ref<Policy>);
+
     [[nodiscard]] GC::Ref<PolicyList> clone(JS::Realm&) const;
     [[nodiscard]] Vector<SerializedPolicy> serialize() const;
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -554,6 +554,10 @@ bool HTMLLinkElement::stylesheet_linked_resource_fetch_setup_steps(Fetch::Infras
     if (document().is_render_blocking_element(*this))
         request.set_render_blocking(true);
 
+    // FIXME: We currently don't set the destination for stylesheets, so we do it here.
+    //        File a spec issue that the destination for stylesheets is not actually set if the `as` attribute is missing.
+    request.set_destination(Fetch::Infrastructure::Request::Destination::Style);
+
     // 5. Return true.
     return true;
 }

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -12,7 +12,10 @@
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/StyleValues/CSSColorValue.h>
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/ContentSecurityPolicy/PolicyList.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/HTMLHeadElement.h>
 #include <LibWeb/HTML/HTMLMetaElement.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Page/Page.h>
@@ -141,6 +144,38 @@ void HTMLMetaElement::inserted()
             // 9. Set the pragma-set default language to candidate.
             auto language = String::from_utf8_without_validation(candidate.bytes());
             document().set_pragma_set_default_language(language);
+            break;
+        }
+        case HttpEquivAttributeState::ContentSecurityPolicy: {
+            // https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-security-policy
+            // This pragma enforces a Content Security Policy on a Document. [CSP]
+            // 1. If the meta element is not a child of a head element, return.
+            if (!is<HTMLHeadElement>(parent()))
+                break;
+
+            // 2. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
+            auto input = get_attribute(AttributeNames::content);
+            if (!input.has_value() || input.value().is_empty())
+                break;
+
+            // 3. Let policy be the result of executing Content Security Policy's parse a serialized Content Security
+            //    Policy algorithm on the meta element's content attribute's value, with a source of "meta", and a
+            //    disposition of "enforce".
+            auto& realm = this->realm();
+            auto policy = ContentSecurityPolicy::Policy::parse_a_serialized_csp(realm, input.value(), ContentSecurityPolicy::Policy::Source::Meta, ContentSecurityPolicy::Policy::Disposition::Enforce);
+
+            // 4. Remove all occurrences of the report-uri, frame-ancestors, and sandbox directives from policy.
+            policy->remove_directive({}, ContentSecurityPolicy::Directives::Names::ReportUri);
+            policy->remove_directive({}, ContentSecurityPolicy::Directives::Names::FrameAncestors);
+            policy->remove_directive({}, ContentSecurityPolicy::Directives::Names::Sandbox);
+
+            // FIXME: File spec issue stating the policy's self origin isn't set here.
+            policy->set_self_origin({}, document().origin());
+
+            // 5. Enforce the policy policy.
+            auto policy_list = ContentSecurityPolicy::PolicyList::from_object(realm.global_object());
+            VERIFY(policy_list);
+            policy_list->enforce_policy(policy);
             break;
         }
         default:

--- a/Tests/AK/TestGenericLexer.cpp
+++ b/Tests/AK/TestGenericLexer.cpp
@@ -100,6 +100,20 @@ TEST_CASE(should_constexpr_consume_specific_cstring)
     static_assert(sut.peek() == 'e');
 }
 
+TEST_CASE(should_constexpr_consume_specific_with_predicate)
+{
+    constexpr auto sut = [] {
+        GenericLexer sut("h e l l o !"sv);
+        for (size_t i = 0; i < 100; ++i) {
+            sut.consume_specific_with_predicate([](auto c) {
+                return is_ascii_alpha(c) || is_ascii_space(c);
+            });
+        }
+        return sut;
+    }();
+    static_assert(sut.peek() == '!');
+}
+
 TEST_CASE(should_constexpr_ignore_until)
 {
     constexpr auto sut = [] {


### PR DESCRIPTION
Part 7 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854

Final bit of prep work before implementing the directives. See individual commits.