### PR TITLE
CI: Use workflow run's event commit SHA for JS benchmarks

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -46,7 +46,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v9
         with:
           workflow: js-artifacts.yml
-          commit: ${{ github.sha }}
+          commit: ${{ github.event.head_sha }}
           name: ladybird-js-${{ matrix.package_type }}
           path: js-repl
 
@@ -76,7 +76,7 @@ jobs:
         shell: bash
         run: |
           echo '{
-              "commit": "${{ github.sha }}",
+              "commit": "${{ github.event.head_sha }}",
               "os": "${{ matrix.os_name }}",
               "arch": "${{ matrix.arch }}",
               "artifact": "js-benchmarks-results-${{ matrix.os_name }}-${{ matrix.arch }}"


### PR DESCRIPTION
Chaining workflows does not cause the subsequently spawned workflow runs to use the same event, but rather it uses the latest head SHA based on the branch it runs on. This would cause the JS benchmarks jobs to not be able to find artifacts (if a new JS repl workflow was started before the previous one could finish) and/or assign the wrong commit SHA to the benchmark results.

Since `github.event` contains information about the original workflow run that spawned the JS benchmarks jobs, we can take the commit SHA from there and use it to download the correct artifact.