### PR TITLE
LibWeb: Add a promise-based alternative to `WebIDL::invoke_callback` and use it in streams

### DIFF
--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -3139,29 +3139,28 @@ WebIDL::ExceptionOr<void> set_up_readable_stream_default_controller_from_underly
         return WebIDL::create_resolved_promise(realm, JS::js_undefined());
     });
 
-    // 5. If underlyingSourceDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["start"] with argument list « controller » and callback this value underlyingSource.
+    // 5. If underlyingSourceDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of
+    //    invoking underlyingSourceDict["start"] with argument list « controller » and callback this value underlyingSource.
     if (underlying_source.start) {
         start_algorithm = GC::create_function(realm.heap(), [controller, underlying_source_value, callback = underlying_source.start]() -> WebIDL::ExceptionOr<JS::Value> {
-            // Note: callback does not return a promise, so invoke_callback may return an abrupt completion
             return TRY(WebIDL::invoke_callback(*callback, underlying_source_value, controller));
         });
     }
 
-    // 6. If underlyingSourceDict["pull"] exists, then set pullAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["pull"] with argument list « controller » and callback this value underlyingSource.
+    // 6. If underlyingSourceDict["pull"] exists, then set pullAlgorithm to an algorithm which returns the result of
+    //    invoking underlyingSourceDict["pull"] with argument list « controller » and callback this value underlyingSource.
     if (underlying_source.pull) {
-        pull_algorithm = GC::create_function(realm.heap(), [&realm, controller, underlying_source_value, callback = underlying_source.pull]() {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, underlying_source_value, controller));
-            return WebIDL::create_resolved_promise(realm, result);
+        pull_algorithm = GC::create_function(realm.heap(), [controller, underlying_source_value, callback = underlying_source.pull]() {
+            return WebIDL::invoke_promise_callback(*callback, underlying_source_value, controller);
         });
     }
 
-    // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and callback this value underlyingSource.
+    // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument
+    //    reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and
+    //    callback this value underlyingSource.
     if (underlying_source.cancel) {
-        cancel_algorithm = GC::create_function(realm.heap(), [&realm, underlying_source_value, callback = underlying_source.cancel](JS::Value reason) {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, underlying_source_value, reason));
-            return WebIDL::create_resolved_promise(realm, result);
+        cancel_algorithm = GC::create_function(realm.heap(), [underlying_source_value, callback = underlying_source.cancel](JS::Value reason) {
+            return WebIDL::invoke_promise_callback(*callback, underlying_source_value, reason);
         });
     }
 
@@ -4843,7 +4842,6 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     //    callback this value underlyingSink.
     if (underlying_sink.start) {
         start_algorithm = GC::create_function(realm.heap(), [controller, underlying_sink_value, callback = underlying_sink.start]() -> WebIDL::ExceptionOr<JS::Value> {
-            // Note: callback does not return a promise, so invoke_callback may return an abrupt completion
             return TRY(WebIDL::invoke_callback(*callback, underlying_sink_value, WebIDL::ExceptionBehavior::Rethrow, controller));
         });
     }
@@ -4852,20 +4850,16 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     //    and returns the result of invoking underlyingSinkDict["write"] with argument list « chunk, controller » and
     //    callback this value underlyingSink.
     if (underlying_sink.write) {
-        write_algorithm = GC::create_function(realm.heap(), [&realm, controller, underlying_sink_value, callback = underlying_sink.write](JS::Value chunk) {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, underlying_sink_value, chunk, controller));
-            return WebIDL::create_resolved_promise(realm, result);
+        write_algorithm = GC::create_function(realm.heap(), [controller, underlying_sink_value, callback = underlying_sink.write](JS::Value chunk) {
+            return WebIDL::invoke_promise_callback(*callback, underlying_sink_value, chunk, controller);
         });
     }
 
     // 8. If underlyingSinkDict["close"] exists, then set closeAlgorithm to an algorithm which returns the result of
     //    invoking underlyingSinkDict["close"] with argument list «» and callback this value underlyingSink.
     if (underlying_sink.close) {
-        close_algorithm = GC::create_function(realm.heap(), [&realm, underlying_sink_value, callback = underlying_sink.close]() {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, underlying_sink_value));
-            return WebIDL::create_resolved_promise(realm, result);
+        close_algorithm = GC::create_function(realm.heap(), [underlying_sink_value, callback = underlying_sink.close]() {
+            return WebIDL::invoke_promise_callback(*callback, underlying_sink_value);
         });
     }
 
@@ -4873,10 +4867,8 @@ WebIDL::ExceptionOr<void> set_up_writable_stream_default_controller_from_underly
     //    and returns the result of invoking underlyingSinkDict["abort"] with argument list « reason » and callback this
     //    value underlyingSink.
     if (underlying_sink.abort) {
-        abort_algorithm = GC::create_function(realm.heap(), [&realm, underlying_sink_value, callback = underlying_sink.abort](JS::Value reason) {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, underlying_sink_value, reason));
-            return WebIDL::create_resolved_promise(realm, result);
+        abort_algorithm = GC::create_function(realm.heap(), [underlying_sink_value, callback = underlying_sink.abort](JS::Value reason) {
+            return WebIDL::invoke_promise_callback(*callback, underlying_sink_value, reason);
         });
     }
 
@@ -5278,30 +5270,24 @@ void set_up_transform_stream_default_controller_from_transformer(TransformStream
     //    and returns the result of invoking transformerDict["transform"] with argument list « chunk, controller » and
     //    callback this value transformer.
     if (transformer_dict.transform) {
-        transform_algorithm = GC::create_function(realm.heap(), [controller, &realm, transformer, callback = transformer_dict.transform](JS::Value chunk) {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, transformer, chunk, controller));
-            return WebIDL::create_resolved_promise(realm, result);
+        transform_algorithm = GC::create_function(realm.heap(), [controller, transformer, callback = transformer_dict.transform](JS::Value chunk) {
+            return WebIDL::invoke_promise_callback(*callback, transformer, chunk, controller);
         });
     }
 
     // 6. If transformerDict["flush"] exists, set flushAlgorithm to an algorithm which returns the result of invoking
     //    transformerDict["flush"] with argument list « controller » and callback this value transformer.
     if (transformer_dict.flush) {
-        flush_algorithm = GC::create_function(realm.heap(), [&realm, transformer, callback = transformer_dict.flush, controller]() {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, transformer, controller));
-            return WebIDL::create_resolved_promise(realm, result);
+        flush_algorithm = GC::create_function(realm.heap(), [transformer, callback = transformer_dict.flush, controller]() {
+            return WebIDL::invoke_promise_callback(*callback, transformer, controller);
         });
     }
 
     // 7. If transformerDict["cancel"] exists, set cancelAlgorithm to an algorithm which takes an argument reason and returns
     // the result of invoking transformerDict["cancel"] with argument list « reason » and callback this value transformer.
     if (transformer_dict.cancel) {
-        cancel_algorithm = GC::create_function(realm.heap(), [&realm, transformer, callback = transformer_dict.cancel](JS::Value reason) {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, transformer, reason));
-            return WebIDL::create_resolved_promise(realm, result);
+        cancel_algorithm = GC::create_function(realm.heap(), [transformer, callback = transformer_dict.cancel](JS::Value reason) {
+            return WebIDL::invoke_promise_callback(*callback, transformer, reason);
         });
     }
 
@@ -5822,29 +5808,28 @@ WebIDL::ExceptionOr<void> set_up_readable_byte_stream_controller_from_underlying
         return WebIDL::create_resolved_promise(realm, JS::js_undefined());
     });
 
-    // 5. If underlyingSourceDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["start"] with argument list « controller » and callback this value underlyingSource.
+    // 5. If underlyingSourceDict["start"] exists, then set startAlgorithm to an algorithm which returns the result of
+    //    invoking underlyingSourceDict["start"] with argument list « controller » and callback this value underlyingSource.
     if (underlying_source_dict.start) {
         start_algorithm = GC::create_function(realm.heap(), [controller, underlying_source, callback = underlying_source_dict.start]() -> WebIDL::ExceptionOr<JS::Value> {
-            // Note: callback does not return a promise, so invoke_callback may return an abrupt completion
             return TRY(WebIDL::invoke_callback(*callback, underlying_source, controller));
         });
     }
 
-    // 6. If underlyingSourceDict["pull"] exists, then set pullAlgorithm to an algorithm which returns the result of invoking underlyingSourceDict["pull"] with argument list « controller » and callback this value underlyingSource.
+    // 6. If underlyingSourceDict["pull"] exists, then set pullAlgorithm to an algorithm which returns the result of
+    //    invoking underlyingSourceDict["pull"] with argument list « controller » and callback this value underlyingSource.
     if (underlying_source_dict.pull) {
-        pull_algorithm = GC::create_function(realm.heap(), [&realm, controller, underlying_source, callback = underlying_source_dict.pull]() {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, underlying_source, controller));
-            return WebIDL::create_resolved_promise(realm, result);
+        pull_algorithm = GC::create_function(realm.heap(), [controller, underlying_source, callback = underlying_source_dict.pull]() {
+            return WebIDL::invoke_promise_callback(*callback, underlying_source, controller);
         });
     }
 
-    // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and callback this value underlyingSource.
+    // 7. If underlyingSourceDict["cancel"] exists, then set cancelAlgorithm to an algorithm which takes an argument
+    //    reason and returns the result of invoking underlyingSourceDict["cancel"] with argument list « reason » and
+    //    callback this value underlyingSource.
     if (underlying_source_dict.cancel) {
-        cancel_algorithm = GC::create_function(realm.heap(), [&realm, underlying_source, callback = underlying_source_dict.cancel](JS::Value reason) {
-            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
-            auto result = MUST(WebIDL::invoke_callback(*callback, underlying_source, reason));
-            return WebIDL::create_resolved_promise(realm, result);
+        cancel_algorithm = GC::create_function(realm.heap(), [underlying_source, callback = underlying_source_dict.cancel](JS::Value reason) {
+            return WebIDL::invoke_promise_callback(*callback, underlying_source, reason);
         });
     }
 

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -243,18 +243,10 @@ JS::ThrowCompletionOr<String> to_usv_string(JS::VM& vm, JS::Value value)
 
 // https://webidl.spec.whatwg.org/#invoke-a-callback-function
 // https://whatpr.org/webidl/1437.html#invoke-a-callback-function
-JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, ExceptionBehavior exception_behavior, GC::RootVector<JS::Value> args)
+template<typename ReturnSteps>
+static auto invoke_callback_impl(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, GC::RootVector<JS::Value> args, ReturnSteps&& return_steps)
 {
-    // https://webidl.spec.whatwg.org/#js-invoking-callback-functions
-    // The exceptionBehavior argument must be supplied if, and only if, callable’s return type is not a promise type. If callable’s return type is neither undefined nor any, it must be "rethrow".
-    // NOTE: Until call sites are updated to respect this, specifications which fail to provide a value here when it would be mandatory should be understood as supplying "rethrow".
-    if (exception_behavior == ExceptionBehavior::NotSpecified && callback.operation_returns_promise == OperationReturnsPromise::No)
-        exception_behavior = ExceptionBehavior::Rethrow;
-
-    VERIFY(exception_behavior == ExceptionBehavior::NotSpecified || callback.operation_returns_promise == OperationReturnsPromise::No);
-
     // 1. Let completion be an uninitialized variable.
-    JS::Completion completion;
 
     // 2. If thisArg was not given, let thisArg be undefined.
     if (!this_argument.has_value())
@@ -263,17 +255,16 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     // 3. Let F be the ECMAScript object corresponding to callable.
     auto& function_object = callback.callback;
 
+    // 5. Let relevant realm be F’s associated realm.
+    auto& relevant_realm = function_object->shape().realm();
+
     // 4. If ! IsCallable(F) is false:
     if (!function_object->is_function()) {
         // 1. Note: This is only possible when the callback function came from an attribute marked with [LegacyTreatNonObjectAsNull].
 
         // 2. Return the result of converting undefined to the callback function’s return type.
-        // FIXME: This does no conversion.
-        return { JS::js_undefined() };
+        return return_steps(relevant_realm, JS::js_undefined());
     }
-
-    // 5. Let relevant realm be F’s associated realm.
-    auto& relevant_realm = function_object->shape().realm();
 
     // 6. Let stored realm be callable’s callback context.
     auto& stored_realm = callback.callback_context;
@@ -291,7 +282,11 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     auto& vm = function_object->vm();
     auto call_result = JS::call(vm, as<JS::FunctionObject>(*function_object), this_argument.value(), args.span());
 
-    auto return_steps = [&](JS::Completion completion) -> JS::Completion {
+    // 11. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
+    // 12. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as callable’s
+    //     return type. If this throws an exception, set completion to the completion value representing the thrown exception.
+    // 13. Return: at this point completion will be set to an IDL value or an abrupt completion.
+    {
         // 1. Clean up after running a callback with stored realm.
         HTML::clean_up_after_running_callback(stored_realm);
 
@@ -299,6 +294,21 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
         // FIXME: This method follows an older version of the spec, which takes a realm, so we use F's associated realm instead.
         HTML::clean_up_after_running_script(relevant_realm);
 
+        return return_steps(relevant_realm, move(call_result));
+    }
+}
+
+JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, ExceptionBehavior exception_behavior, GC::RootVector<JS::Value> args)
+{
+    // https://webidl.spec.whatwg.org/#js-invoking-callback-functions
+    // The exceptionBehavior argument must be supplied if, and only if, callable’s return type is not a promise type. If callable’s return type is neither undefined nor any, it must be "rethrow".
+    // NOTE: Until call sites are updated to respect this, specifications which fail to provide a value here when it would be mandatory should be understood as supplying "rethrow".
+    if (exception_behavior == ExceptionBehavior::NotSpecified && callback.operation_returns_promise == OperationReturnsPromise::No)
+        exception_behavior = ExceptionBehavior::Rethrow;
+
+    VERIFY(exception_behavior == ExceptionBehavior::NotSpecified || callback.operation_returns_promise == OperationReturnsPromise::No);
+
+    return invoke_callback_impl(callback, move(this_argument), move(args), [&](JS::Realm& relevant_realm, JS::Completion completion) -> JS::Completion {
         // 3. If completion is an IDL value, return completion.
         if (!completion.is_abrupt())
             return completion;
@@ -308,10 +318,11 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
 
         // 5. If exceptionBehavior is "rethrow", throw completion.[[Value]].
         if (exception_behavior == ExceptionBehavior::Rethrow) {
-            TRY(JS::throw_completion(completion.release_value()));
+            return JS::throw_completion(completion.release_value());
         }
+
         // 6. Otherwise, if exceptionBehavior is "report":
-        else if (exception_behavior == ExceptionBehavior::Report) {
+        if (exception_behavior == ExceptionBehavior::Report) {
             // FIXME: 1. Assert: callable’s return type is undefined or any.
 
             // 2. Report an exception completion.[[Value]] for relevant realm’s global object.
@@ -330,25 +341,34 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
 
         // 9. Return the result of converting rejectedPromise to the callback function’s return type.
         return JS::Value { rejected_promise->promise() };
-    };
-
-    // 11. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
-    if (call_result.is_throw_completion()) {
-        completion = call_result.throw_completion();
-        return return_steps(completion);
-    }
-
-    // 12. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as callable’s return type.
-    //     If this throws an exception, set completion to the completion value representing the thrown exception.
-    // FIXME: This does no conversion.
-    completion = call_result.value();
-
-    return return_steps(completion);
+    });
 }
 
 JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, GC::RootVector<JS::Value> args)
 {
     return invoke_callback(callback, move(this_argument), ExceptionBehavior::NotSpecified, move(args));
+}
+
+// AD-HOC: This may be used as an alternative to WebIDL::invoke_callback when you know the callback returns a promise,
+//         and the caller needs a WebIDL::Promise rather than a JS::Promise.
+GC::Ref<WebIDL::Promise> invoke_promise_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, GC::RootVector<JS::Value> args)
+{
+    VERIFY(callback.operation_returns_promise == OperationReturnsPromise::Yes);
+
+    return invoke_callback_impl(callback, move(this_argument), move(args), [&](JS::Realm& relevant_realm, JS::Completion completion) -> GC::Ref<WebIDL::Promise> {
+        // 3. If completion is an IDL value, return completion.
+        if (!completion.is_abrupt())
+            return WebIDL::create_resolved_promise(relevant_realm, completion.release_value());
+
+        // 4. Assert: completion is an abrupt completion.
+        VERIFY(completion.is_abrupt());
+
+        // NOTE: The intermediate steps to handle exception behavior are not relevant for promise-returning callbacks.
+
+        // 8. Let rejectedPromise be ! Call(%Promise.reject%, %Promise%, «completion.[[Value]]»).
+        // 9. Return the result of converting rejectedPromise to the callback function’s return type.
+        return create_rejected_promise(relevant_realm, completion.release_value());
+    });
 }
 
 JS::Completion construct(WebIDL::CallbackType& callback, GC::RootVector<JS::Value> args)

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -66,6 +66,19 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     return invoke_callback(callback, move(this_argument), ExceptionBehavior::NotSpecified, forward<Args>(args)...);
 }
 
+GC::Ref<WebIDL::Promise> invoke_promise_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, GC::RootVector<JS::Value> args);
+
+template<typename... Args>
+GC::Ref<WebIDL::Promise> invoke_promise_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, Args&&... args)
+{
+    auto& function_object = callback.callback;
+
+    GC::RootVector<JS::Value> arguments_list { function_object->heap() };
+    (arguments_list.append(forward<Args>(args)), ...);
+
+    return invoke_promise_callback(callback, move(this_argument), move(arguments_list));
+}
+
 JS::Completion construct(WebIDL::CallbackType& callback, GC::RootVector<JS::Value> args);
 
 // https://webidl.spec.whatwg.org/#construct-a-callback-function

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/readable-streams/tee.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/readable-streams/tee.any.txt
@@ -1,0 +1,32 @@
+Harness status: OK
+
+Found 26 tests
+
+25 Pass
+1 Fail
+Pass	ReadableStream teeing: rs.tee() returns an array of two ReadableStreams
+Pass	ReadableStream teeing: should be able to read one branch to the end without affecting the other
+Pass	ReadableStream teeing: values should be equal across each branch
+Fail	ReadableStream teeing: errors in the source should propagate to both branches
+Pass	ReadableStream teeing: canceling branch1 should not impact branch2
+Pass	ReadableStream teeing: canceling branch2 should not impact branch1
+Pass	Running templatedRSTeeCancel with ReadableStream teeing
+Pass	ReadableStream teeing: canceling both branches should aggregate the cancel reasons into an array
+Pass	ReadableStream teeing: canceling both branches in reverse order should aggregate the cancel reasons into an array
+Pass	ReadableStream teeing: failing to cancel the original stream should cause cancel() to reject on branches
+Pass	ReadableStream teeing: erroring a teed stream should properly handle canceled branches
+Pass	ReadableStream teeing: erroring a teed stream should error both branches
+Pass	ReadableStream teeing: closing the original should immediately close the branches
+Pass	ReadableStream teeing: erroring the original should immediately error the branches
+Pass	ReadableStream teeing: canceling branch1 should finish when branch2 reads until end of stream
+Pass	ReadableStream teeing: canceling branch1 should finish when original stream errors
+Pass	ReadableStream teeing: canceling both branches in sequence with delay
+Pass	ReadableStream teeing: failing to cancel when canceling both branches in sequence with delay
+Pass	ReadableStreamTee should not use a modified ReadableStream constructor from the global object
+Pass	ReadableStreamTee should not pull more chunks than can fit in the branch queue
+Pass	ReadableStreamTee should only pull enough to fill the emptiest queue
+Pass	ReadableStreamTee should not pull when original is already errored
+Pass	ReadableStreamTee stops pulling when original stream errors while branch 1 is reading
+Pass	ReadableStreamTee stops pulling when original stream errors while branch 2 is reading
+Pass	ReadableStreamTee stops pulling when original stream errors while both branches are reading
+Pass	ReadableStream teeing: enqueue() and close() while both branches are pulling

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/readable-streams/tee.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/readable-streams/tee.any.txt
@@ -2,12 +2,11 @@ Harness status: OK
 
 Found 26 tests
 
-25 Pass
-1 Fail
+26 Pass
 Pass	ReadableStream teeing: rs.tee() returns an array of two ReadableStreams
 Pass	ReadableStream teeing: should be able to read one branch to the end without affecting the other
 Pass	ReadableStream teeing: values should be equal across each branch
-Fail	ReadableStream teeing: errors in the source should propagate to both branches
+Pass	ReadableStream teeing: errors in the source should propagate to both branches
 Pass	ReadableStream teeing: canceling branch1 should not impact branch2
 Pass	ReadableStream teeing: canceling branch2 should not impact branch1
 Pass	Running templatedRSTeeCancel with ReadableStream teeing

--- a/Tests/LibWeb/Text/input/wpt-import/streams/readable-streams/tee.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/readable-streams/tee.any.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/rs-utils.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/rs-test-templates.js"></script>
+<div id=log></div>
+<script src="../../streams/readable-streams/tee.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/readable-streams/tee.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/readable-streams/tee.any.js
@@ -1,0 +1,479 @@
+// META: global=window,worker,shadowrealm
+// META: script=../resources/rs-utils.js
+// META: script=../resources/test-utils.js
+// META: script=../resources/recording-streams.js
+// META: script=../resources/rs-test-templates.js
+'use strict';
+
+test(() => {
+
+  const rs = new ReadableStream();
+  const result = rs.tee();
+
+  assert_true(Array.isArray(result), 'return value should be an array');
+  assert_equals(result.length, 2, 'array should have length 2');
+  assert_equals(result[0].constructor, ReadableStream, '0th element should be a ReadableStream');
+  assert_equals(result[1].constructor, ReadableStream, '1st element should be a ReadableStream');
+
+}, 'ReadableStream teeing: rs.tee() returns an array of two ReadableStreams');
+
+promise_test(t => {
+
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+      c.close();
+    }
+  });
+
+  const branch = rs.tee();
+  const branch1 = branch[0];
+  const branch2 = branch[1];
+  const reader1 = branch1.getReader();
+  const reader2 = branch2.getReader();
+
+  reader2.closed.then(t.unreached_func('branch2 should not be closed'));
+
+  return Promise.all([
+    reader1.closed,
+    reader1.read().then(r => {
+      assert_object_equals(r, { value: 'a', done: false }, 'first chunk from branch1 should be correct');
+    }),
+    reader1.read().then(r => {
+      assert_object_equals(r, { value: 'b', done: false }, 'second chunk from branch1 should be correct');
+    }),
+    reader1.read().then(r => {
+      assert_object_equals(r, { value: undefined, done: true }, 'third read() from branch1 should be done');
+    }),
+    reader2.read().then(r => {
+      assert_object_equals(r, { value: 'a', done: false }, 'first chunk from branch2 should be correct');
+    })
+  ]);
+
+}, 'ReadableStream teeing: should be able to read one branch to the end without affecting the other');
+
+promise_test(() => {
+
+  const theObject = { the: 'test object' };
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue(theObject);
+    }
+  });
+
+  const branch = rs.tee();
+  const branch1 = branch[0];
+  const branch2 = branch[1];
+  const reader1 = branch1.getReader();
+  const reader2 = branch2.getReader();
+
+  return Promise.all([reader1.read(), reader2.read()]).then(values => {
+    assert_object_equals(values[0], values[1], 'the values should be equal');
+  });
+
+}, 'ReadableStream teeing: values should be equal across each branch');
+
+promise_test(t => {
+
+  const theError = { name: 'boo!' };
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+    },
+    pull() {
+      throw theError;
+    }
+  });
+
+  const branches = rs.tee();
+  const reader1 = branches[0].getReader();
+  const reader2 = branches[1].getReader();
+
+  reader1.label = 'reader1';
+  reader2.label = 'reader2';
+
+  return Promise.all([
+    promise_rejects_exactly(t, theError, reader1.closed),
+    promise_rejects_exactly(t, theError, reader2.closed),
+    reader1.read().then(r => {
+      assert_object_equals(r, { value: 'a', done: false }, 'should be able to read the first chunk in branch1');
+    }),
+    reader1.read().then(r => {
+      assert_object_equals(r, { value: 'b', done: false }, 'should be able to read the second chunk in branch1');
+
+      return promise_rejects_exactly(t, theError, reader2.read());
+    })
+    .then(() => promise_rejects_exactly(t, theError, reader1.read()))
+  ]);
+
+}, 'ReadableStream teeing: errors in the source should propagate to both branches');
+
+promise_test(() => {
+
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+      c.close();
+    }
+  });
+
+  const branches = rs.tee();
+  const branch1 = branches[0];
+  const branch2 = branches[1];
+  branch1.cancel();
+
+  return Promise.all([
+    readableStreamToArray(branch1).then(chunks => {
+      assert_array_equals(chunks, [], 'branch1 should have no chunks');
+    }),
+    readableStreamToArray(branch2).then(chunks => {
+      assert_array_equals(chunks, ['a', 'b'], 'branch2 should have two chunks');
+    })
+  ]);
+
+}, 'ReadableStream teeing: canceling branch1 should not impact branch2');
+
+promise_test(() => {
+
+  const rs = new ReadableStream({
+    start(c) {
+      c.enqueue('a');
+      c.enqueue('b');
+      c.close();
+    }
+  });
+
+  const branches = rs.tee();
+  const branch1 = branches[0];
+  const branch2 = branches[1];
+  branch2.cancel();
+
+  return Promise.all([
+    readableStreamToArray(branch1).then(chunks => {
+      assert_array_equals(chunks, ['a', 'b'], 'branch1 should have two chunks');
+    }),
+    readableStreamToArray(branch2).then(chunks => {
+      assert_array_equals(chunks, [], 'branch2 should have no chunks');
+    })
+  ]);
+
+}, 'ReadableStream teeing: canceling branch2 should not impact branch1');
+
+templatedRSTeeCancel('ReadableStream teeing', (extras) => {
+  return new ReadableStream({ ...extras });
+});
+
+promise_test(t => {
+
+  let controller;
+  const stream = new ReadableStream({ start(c) { controller = c; } });
+  const [branch1, branch2] = stream.tee();
+
+  const error = new Error();
+  error.name = 'distinctive';
+
+  // Ensure neither branch is waiting in ReadableStreamDefaultReaderRead().
+  controller.enqueue();
+  controller.enqueue();
+
+  return delay(0).then(() => {
+    // This error will have to be detected via [[closedPromise]].
+    controller.error(error);
+
+    const reader1 = branch1.getReader();
+    const reader2 = branch2.getReader();
+
+    return Promise.all([
+      promise_rejects_exactly(t, error, reader1.closed, 'reader1.closed should reject'),
+      promise_rejects_exactly(t, error, reader2.closed, 'reader2.closed should reject')
+    ]);
+  });
+
+}, 'ReadableStream teeing: erroring a teed stream should error both branches');
+
+promise_test(() => {
+
+  let controller;
+  const rs = new ReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+
+  const branches = rs.tee();
+  const reader1 = branches[0].getReader();
+  const reader2 = branches[1].getReader();
+
+  const promise = Promise.all([reader1.closed, reader2.closed]);
+
+  controller.close();
+  return promise;
+
+}, 'ReadableStream teeing: closing the original should immediately close the branches');
+
+promise_test(t => {
+
+  let controller;
+  const rs = new ReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+
+  const branches = rs.tee();
+  const reader1 = branches[0].getReader();
+  const reader2 = branches[1].getReader();
+
+  const theError = { name: 'boo!' };
+  const promise = Promise.all([
+    promise_rejects_exactly(t, theError, reader1.closed),
+    promise_rejects_exactly(t, theError, reader2.closed)
+  ]);
+
+  controller.error(theError);
+  return promise;
+
+}, 'ReadableStream teeing: erroring the original should immediately error the branches');
+
+promise_test(async t => {
+
+  let controller;
+  const rs = new ReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+  const cancelPromise = reader2.cancel();
+
+  controller.enqueue('a');
+
+  const read1 = await reader1.read();
+  assert_object_equals(read1, { value: 'a', done: false }, 'first read() from branch1 should fulfill with the chunk');
+
+  controller.close();
+
+  const read2 = await reader1.read();
+  assert_object_equals(read2, { value: undefined, done: true }, 'second read() from branch1 should be done');
+
+  await Promise.all([
+    reader1.closed,
+    cancelPromise
+  ]);
+
+}, 'ReadableStream teeing: canceling branch1 should finish when branch2 reads until end of stream');
+
+promise_test(async t => {
+
+  let controller;
+  const theError = { name: 'boo!' };
+  const rs = new ReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+  const cancelPromise = reader2.cancel();
+
+  controller.error(theError);
+
+  await Promise.all([
+    promise_rejects_exactly(t, theError, reader1.read()),
+    cancelPromise
+  ]);
+
+}, 'ReadableStream teeing: canceling branch1 should finish when original stream errors');
+
+promise_test(async () => {
+
+  const rs = new ReadableStream({});
+
+  const [branch1, branch2] = rs.tee();
+
+  const cancel1 = branch1.cancel();
+  await flushAsyncEvents();
+  const cancel2 = branch2.cancel();
+
+  await Promise.all([cancel1, cancel2]);
+
+}, 'ReadableStream teeing: canceling both branches in sequence with delay');
+
+promise_test(async t => {
+
+  const theError = { name: 'boo!' };
+  const rs = new ReadableStream({
+    cancel() {
+      throw theError;
+    }
+  });
+
+  const [branch1, branch2] = rs.tee();
+
+  const cancel1 = branch1.cancel();
+  await flushAsyncEvents();
+  const cancel2 = branch2.cancel();
+
+  await Promise.all([
+    promise_rejects_exactly(t, theError, cancel1),
+    promise_rejects_exactly(t, theError, cancel2)
+  ]);
+
+}, 'ReadableStream teeing: failing to cancel when canceling both branches in sequence with delay');
+
+test(t => {
+
+  // Copy original global.
+  const oldReadableStream = ReadableStream;
+  const getReader = ReadableStream.prototype.getReader;
+
+  const origRS = new ReadableStream();
+
+  // Replace the global ReadableStream constructor with one that doesn't work.
+  ReadableStream = function() {
+    throw new Error('global ReadableStream constructor called');
+  };
+  t.add_cleanup(() => {
+    ReadableStream = oldReadableStream;
+  });
+
+  // This will probably fail if the global ReadableStream constructor was used.
+  const [rs1, rs2] = origRS.tee();
+
+  // These will definitely fail if the global ReadableStream constructor was used.
+  assert_not_equals(getReader.call(rs1), undefined, 'getReader should work on rs1');
+  assert_not_equals(getReader.call(rs2), undefined, 'getReader should work on rs2');
+
+}, 'ReadableStreamTee should not use a modified ReadableStream constructor from the global object');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+
+  // Create two branches, each with a HWM of 1. This should result in one
+  // chunk being pulled, not two.
+  rs.tee();
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(rs.events, ['pull'], 'pull should only be called once');
+  });
+
+}, 'ReadableStreamTee should not pull more chunks than can fit in the branch queue');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({
+    pull(controller) {
+      controller.enqueue('a');
+    }
+  }, { highWaterMark: 0 });
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+  return Promise.all([reader1.read(), reader2.read()])
+      .then(() => {
+    assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+  });
+
+}, 'ReadableStreamTee should only pull enough to fill the emptiest queue');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+  const theError = { name: 'boo!' };
+
+  rs.controller.error(theError);
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(rs.events, [], 'pull should not be called');
+
+    return Promise.all([
+      promise_rejects_exactly(t, theError, reader1.closed),
+      promise_rejects_exactly(t, theError, reader2.closed)
+    ]);
+  });
+
+}, 'ReadableStreamTee should not pull when original is already errored');
+
+for (const branch of [1, 2]) {
+  promise_test(t => {
+
+    const rs = recordingReadableStream({}, { highWaterMark: 0 });
+    const theError = { name: 'boo!' };
+
+    const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+
+    return flushAsyncEvents().then(() => {
+      assert_array_equals(rs.events, ['pull'], 'pull should be called once');
+
+      rs.controller.enqueue('a');
+
+      const reader = (branch === 1) ? reader1 : reader2;
+      return reader.read();
+    }).then(() => flushAsyncEvents()).then(() => {
+      assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+
+      rs.controller.error(theError);
+
+      return Promise.all([
+        promise_rejects_exactly(t, theError, reader1.closed),
+        promise_rejects_exactly(t, theError, reader2.closed)
+      ]);
+    }).then(() => flushAsyncEvents()).then(() => {
+      assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+    });
+
+  }, `ReadableStreamTee stops pulling when original stream errors while branch ${branch} is reading`);
+}
+
+promise_test(t => {
+
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+  const theError = { name: 'boo!' };
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(rs.events, ['pull'], 'pull should be called once');
+
+    rs.controller.enqueue('a');
+
+    return Promise.all([reader1.read(), reader2.read()]);
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+
+    rs.controller.error(theError);
+
+    return Promise.all([
+      promise_rejects_exactly(t, theError, reader1.closed),
+      promise_rejects_exactly(t, theError, reader2.closed)
+    ]);
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(rs.events, ['pull', 'pull'], 'pull should be called twice');
+  });
+
+}, 'ReadableStreamTee stops pulling when original stream errors while both branches are reading');
+
+promise_test(async () => {
+
+  const rs = recordingReadableStream();
+
+  const [reader1, reader2] = rs.tee().map(branch => branch.getReader());
+  const branch1Reads = [reader1.read(), reader1.read()];
+  const branch2Reads = [reader2.read(), reader2.read()];
+
+  await flushAsyncEvents();
+  rs.controller.enqueue('a');
+  rs.controller.close();
+
+  assert_object_equals(await branch1Reads[0], { value: 'a', done: false }, 'first chunk from branch1 should be correct');
+  assert_object_equals(await branch2Reads[0], { value: 'a', done: false }, 'first chunk from branch2 should be correct');
+
+  assert_object_equals(await branch1Reads[1], { value: undefined, done: true }, 'second read() from branch1 should be done');
+  assert_object_equals(await branch2Reads[1], { value: undefined, done: true }, 'second read() from branch2 should be done');
+
+}, 'ReadableStream teeing: enqueue() and close() while both branches are pulling');


### PR DESCRIPTION
In Streams, we were invoking callbacks that return a `JS::Promise` and turning them into a `WebIDL::Promise` resolved with the `JS::Promise` as its value. The problem here is when the `JS::Promise` was actually rejected - we are meant to have a rejected `WebIDL::Promise` as a result.

As it turns out, we can simply add an alternative `WebIDL::invoke_promise_callback` to handle this nuance. It will return a promise to us in the correct state so that Streams doesn't have to worry about it.