### PR TITLE
LibWeb: Store a SpeculativeHTMLParser on the HTML Parser

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -101,7 +101,7 @@ runs:
 
         echo "swiftly version: $(swiftly --version)" >&2
 
-        swiftly install --use main-snapshot-2025-04-02
+        swiftly install --use main-snapshot-2025-04-12
         swiftly list
 
     - name: 'Install Dependencies'

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -14,6 +14,14 @@
 #include <LibWeb/HTML/Parser/StackOfOpenElements.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 
+#ifdef LIBWEB_USE_SWIFT
+#    include <LibGC/ForeignCell.h>
+
+namespace Web {
+class SpeculativeHTMLParser;
+}
+#endif
+
 namespace Web::HTML {
 
 #define ENUMERATE_INSERTION_MODES               \
@@ -96,6 +104,7 @@ private:
     HTMLParser(DOM::Document&);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void initialize(JS::Realm&) override;
 
     char const* insertion_mode_name() const;
 
@@ -209,6 +218,10 @@ private:
     GC::Ptr<HTMLHeadElement> m_head_element;
     GC::Ptr<HTMLFormElement> m_form_element;
     GC::Ptr<DOM::Element> m_context_element;
+
+#ifdef LIBWEB_USE_SWIFT
+    GC::ForeignPtr<Web::SpeculativeHTMLParser> m_speculative_parser;
+#endif
 
     Vector<HTMLToken> m_pending_table_character_tokens;
 

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.swift
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.swift
@@ -57,4 +57,8 @@ public final class SpeculativeHTMLParser: HeapAllocatable {
     public func visitEdges(_ visitor: GC.Cell.Visitor) {
         visitor.visit(parser)
     }
+
+    public func poke() {
+        print("Hello from SpeculativeHTMLParser")
+    }
 }


### PR DESCRIPTION
The parser was previously added, but unused. Actually attaching one to
the HTML Parser will let us test the limits of Swift interop.