### PR TITLE
LibRegex: One more optimization for the performance gods

### DIFF
--- a/AK/COWVector.h
+++ b/AK/COWVector.h
@@ -127,6 +127,13 @@ public:
         return m_detail->m_members[index];
     }
 
+    Span<T const> span() const { return m_detail->m_members; }
+    Span<T> mutable_span()
+    {
+        copy();
+        return m_detail->m_members;
+    }
+
     size_t capacity() const
     {
         return m_detail->m_members.capacity();

--- a/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Libraries/LibJS/Runtime/RegExpObject.h
@@ -35,7 +35,6 @@ public:
     static constexpr regex::RegexOptions<ECMAScriptFlags> default_flags {
         (regex::ECMAScriptFlags)regex::AllFlags::SingleMatch
         | (regex::ECMAScriptFlags)regex::AllFlags::Global
-        | (regex::ECMAScriptFlags)regex::AllFlags::SkipTrimEmptyMatches
         | regex::ECMAScriptFlags::BrowserExtended
     };
 

--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -294,7 +294,7 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(VM& vm, RegExpObject& regexp
     // 33. For each integer i such that i ≥ 1 and i ≤ n, in ascending order, do
     for (size_t i = 1; i <= result.n_capture_groups; ++i) {
         // a. Let captureI be ith element of r's captures List.
-        auto& capture = result.capture_group_matches[0][i];
+        auto& capture = result.capture_group_matches[0][i - 1];
 
         Value captured_value;
 

--- a/Libraries/LibRegex/RegexDebug.h
+++ b/Libraries/LibRegex/RegexDebug.h
@@ -39,7 +39,7 @@ public:
 
     void print_bytecode(ByteCode const& bytecode) const
     {
-        MatchState state;
+        auto state = MatchState::only_for_enumeration();
         for (;;) {
             auto& opcode = bytecode.get_opcode(state);
             print_opcode("PrintBytecode", opcode, state);

--- a/Libraries/LibRegex/RegexDefs.h
+++ b/Libraries/LibRegex/RegexDefs.h
@@ -43,12 +43,11 @@ enum __RegexAllFlags {
     __Regex_SingleLine = __Regex_Global << 10,                   // Dot matches newline characters
     __Regex_Sticky = __Regex_Global << 11,                       // Force the pattern to only match consecutive matches from where the previous match ended.
     __Regex_Multiline = __Regex_Global << 12,                    // Handle newline characters. Match each line, one by one.
-    __Regex_SkipTrimEmptyMatches = __Regex_Global << 13,         // Do not remove empty capture group results.
-    __Regex_SingleMatch = __Regex_Global << 14,                  // Stop after acquiring a single match.
-    __Regex_UnicodeSets = __Regex_Global << 15,                  // ECMA262 Parser specific: Allow set operations in char classes.
-    __Regex_Internal_Stateful = __Regex_Global << 16,            // Internal flag; enables stateful matches.
-    __Regex_Internal_BrowserExtended = __Regex_Global << 17,     // Internal flag; enable browser-specific ECMA262 extensions.
-    __Regex_Internal_ConsiderNewline = __Regex_Global << 18,     // Internal flag; allow matchers to consider newlines as line separators.
-    __Regex_Internal_ECMA262DotSemantics = __Regex_Global << 19, // Internal flag; use ECMA262 semantics for dot ('.') - disallow CR/LF/LS/PS instead of just CR.
+    __Regex_SingleMatch = __Regex_Global << 13,                  // Stop after acquiring a single match.
+    __Regex_UnicodeSets = __Regex_Global << 14,                  // ECMA262 Parser specific: Allow set operations in char classes.
+    __Regex_Internal_Stateful = __Regex_Global << 15,            // Internal flag; enables stateful matches.
+    __Regex_Internal_BrowserExtended = __Regex_Global << 16,     // Internal flag; enable browser-specific ECMA262 extensions.
+    __Regex_Internal_ConsiderNewline = __Regex_Global << 17,     // Internal flag; allow matchers to consider newlines as line separators.
+    __Regex_Internal_ECMA262DotSemantics = __Regex_Global << 18, // Internal flag; use ECMA262 semantics for dot ('.') - disallow CR/LF/LS/PS instead of just CR.
     __Regex_Last = __Regex_Internal_ECMA262DotSemantics,
 };

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -418,7 +418,8 @@ struct MatchState {
         auto combine = [&hash](auto value) {
             hash ^= value + 0x9e3779b97f4a7c15 + (hash << 6) + (hash >> 2);
         };
-        auto combine_vector = [&hash](auto const& vector) {
+        auto combine_vector = [&hash](auto const& vector, auto tag) {
+            hash ^= tag * (vector.size() + 1);
             for (auto& value : vector) {
                 hash ^= value;
                 hash *= 0x100000001b3;
@@ -431,8 +432,8 @@ struct MatchState {
         combine(instruction_position);
         combine(fork_at_position);
         combine(initiating_fork.value_or(0) + initiating_fork.has_value());
-        combine_vector(repetition_marks);
-        combine_vector(checkpoints);
+        combine_vector(repetition_marks, 0xbeefbeefbeefbeef);
+        combine_vector(checkpoints, 0xfacefacefaceface);
 
         return hash;
     }

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -467,11 +467,18 @@ private:
     Node* m_last { nullptr };
 };
 
+struct SufficientlyUniformValueTraits : DefaultTraits<u64> {
+    static constexpr unsigned hash(u64 value)
+    {
+        return (value >> 32) ^ value;
+    }
+};
+
 template<class Parser>
 bool Matcher<Parser>::execute(MatchInput const& input, MatchState& state, size_t& operations) const
 {
     BumpAllocatedLinkedList<MatchState> states_to_try_next;
-    HashTable<u64> seen_state_hashes;
+    HashTable<u64, SufficientlyUniformValueTraits> seen_state_hashes;
 #if REGEX_DEBUG
     size_t recursion_level = 0;
 #endif

--- a/Libraries/LibRegex/RegexMatcher.h
+++ b/Libraries/LibRegex/RegexMatcher.h
@@ -230,6 +230,7 @@ private:
     void run_optimization_passes();
     void attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&);
     bool attempt_rewrite_entire_match_as_substring_search(BasicBlockList const&);
+    void fill_optimization_data(BasicBlockList const&);
 };
 
 // free standing functions for match, search and has_match

--- a/Libraries/LibRegex/RegexMatcher.h
+++ b/Libraries/LibRegex/RegexMatcher.h
@@ -31,13 +31,13 @@ struct Block {
 }
 
 static constexpr size_t const c_max_recursion = 5000;
-static constexpr size_t const c_match_preallocation_count = 0;
 
 struct RegexResult final {
     bool success { false };
     size_t count { 0 };
     Vector<Match> matches;
-    Vector<Vector<Match>> capture_group_matches;
+    Vector<Match> flat_capture_group_matches;
+    Vector<Span<Match>> capture_group_matches;
     size_t n_operations { 0 };
     size_t n_capture_groups { 0 };
     size_t n_named_capture_groups { 0 };

--- a/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Libraries/LibRegex/RegexOptimizer.cpp
@@ -37,7 +37,7 @@ void Regex<Parser>::run_optimization_passes()
     attempt_rewrite_loops_as_atomic_groups(blocks);
 
     // FIXME: "There are a few more conditions this can be true in (e.g. within an arbitrarily nested capture group)"
-    MatchState state;
+    auto state = MatchState::only_for_enumeration();
     auto& opcode = parser_result.bytecode.get_opcode(state);
     if (opcode.opcode_id() == OpCodeId::CheckBegin)
         parser_result.optimization_data.only_start_of_line = true;
@@ -53,7 +53,7 @@ typename Regex<Parser>::BasicBlockList Regex<Parser>::split_basic_blocks(ByteCod
 
     auto bytecode_size = bytecode.size();
 
-    MatchState state;
+    auto state = MatchState::only_for_enumeration();
     state.instruction_position = 0;
     auto check_jump = [&]<typename T>(OpCode const& opcode) {
         auto& op = static_cast<T const&>(opcode);
@@ -512,7 +512,7 @@ enum class AtomicRewritePreconditionResult {
 static AtomicRewritePreconditionResult block_satisfies_atomic_rewrite_precondition(ByteCode const& bytecode, Block repeated_block, Block following_block, auto const& all_blocks)
 {
     Vector<Vector<CompareTypeAndValuePair>> repeated_values;
-    MatchState state;
+    auto state = MatchState::only_for_enumeration();
     auto has_seen_actionable_opcode = false;
     for (state.instruction_position = repeated_block.start; state.instruction_position < repeated_block.end;) {
         auto& opcode = bytecode.get_opcode(state);
@@ -680,7 +680,7 @@ bool Regex<Parser>::attempt_rewrite_entire_match_as_substring_search(BasicBlockL
 
     // We have a single basic block, let's see if it's a series of character or string compares.
     StringBuilder final_string;
-    MatchState state;
+    auto state = MatchState::only_for_enumeration();
     while (state.instruction_position < bytecode.size()) {
         auto& opcode = bytecode.get_opcode(state);
         switch (opcode.opcode_id()) {
@@ -796,7 +796,7 @@ void Regex<Parser>::attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&
         Optional<Block> fork_fallback_block;
         if (i + 1 < basic_blocks.size())
             fork_fallback_block = basic_blocks[i + 1];
-        MatchState state;
+        auto state = MatchState::only_for_enumeration();
         // Check if the last instruction in this block is a jump to the block itself:
         {
             state.instruction_position = forking_block.end;
@@ -913,7 +913,7 @@ void Regex<Parser>::attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&
     }
 
     if (!needed_patches.is_empty()) {
-        MatchState state;
+        auto state = MatchState::only_for_enumeration();
         auto bytecode_size = bytecode.size();
         state.instruction_position = 0;
         struct Patch {
@@ -1039,7 +1039,7 @@ void Optimizer::append_alternation(ByteCode& target, Span<ByteCode> alternatives
 
     auto has_any_backwards_jump = false;
 
-    MatchState state;
+    auto state = MatchState::only_for_enumeration();
 
     for (size_t i = 0; i < alternatives.size(); ++i) {
         auto& alternative = alternatives[i];
@@ -1144,7 +1144,7 @@ void Optimizer::append_alternation(ByteCode& target, Span<ByteCode> alternatives
                     node.metadata_value().size(),
                     node.metadata_value().size() == 1 ? "" : "s");
 
-                MatchState state;
+                auto state = MatchState::only_for_enumeration();
                 state.instruction_position = node.metadata_value().first().instruction_position;
                 auto& opcode = alternatives[node.metadata_value().first().alternative_index].get_opcode(state);
                 insn = ByteString::formatted("{} {}", opcode.to_byte_string(), opcode.arguments_string());

--- a/Libraries/LibRegex/RegexOptions.h
+++ b/Libraries/LibRegex/RegexOptions.h
@@ -28,7 +28,6 @@ enum class AllFlags {
     SingleLine = __Regex_SingleLine,                                     // Dot matches newline characters
     Sticky = __Regex_Sticky,                                             // Force the pattern to only match consecutive matches from where the previous match ended.
     Multiline = __Regex_Multiline,                                       // Handle newline characters. Match each line, one by one.
-    SkipTrimEmptyMatches = __Regex_SkipTrimEmptyMatches,                 // Do not remove empty capture group results.
     SingleMatch = __Regex_SingleMatch,                                   // Stop after acquiring a single match.
     UnicodeSets = __Regex_UnicodeSets,                                   // Only for ECMA262, Allow set operations in character classes.
     Internal_Stateful = __Regex_Internal_Stateful,                       // Make global matches match one result at a time, and further match() calls on the same instance continue where the previous one left off.
@@ -49,7 +48,6 @@ enum class PosixFlags : FlagsUnderlyingType {
     MatchNotBeginOfLine = (FlagsUnderlyingType)AllFlags::MatchNotBeginOfLine,
     MatchNotEndOfLine = (FlagsUnderlyingType)AllFlags::MatchNotEndOfLine,
     SkipSubExprResults = (FlagsUnderlyingType)AllFlags::SkipSubExprResults,
-    SkipTrimEmptyMatches = (FlagsUnderlyingType)AllFlags::SkipTrimEmptyMatches,
     Multiline = (FlagsUnderlyingType)AllFlags::Multiline,
     SingleMatch = (FlagsUnderlyingType)AllFlags::SingleMatch,
 };

--- a/Libraries/LibRegex/RegexParser.cpp
+++ b/Libraries/LibRegex/RegexParser.cpp
@@ -857,7 +857,7 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_sub_expression(ByteCode& stack, si
 
             auto current_capture_group = m_parser_state.capture_groups_count;
             if (!(m_parser_state.regex_options & AllFlags::SkipSubExprResults || prevent_capture_group)) {
-                bytecode.insert_bytecode_group_capture_left(current_capture_group);
+                bytecode.insert_bytecode_group_capture_left(current_capture_group + 1);
                 m_parser_state.capture_groups_count++;
             }
 
@@ -888,9 +888,9 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_sub_expression(ByteCode& stack, si
 
             if (!(m_parser_state.regex_options & AllFlags::SkipSubExprResults || prevent_capture_group)) {
                 if (capture_group_name.has_value())
-                    bytecode.insert_bytecode_group_capture_right(current_capture_group, capture_group_name.value());
+                    bytecode.insert_bytecode_group_capture_right(current_capture_group + 1, capture_group_name.value());
                 else
-                    bytecode.insert_bytecode_group_capture_right(current_capture_group);
+                    bytecode.insert_bytecode_group_capture_right(current_capture_group + 1);
             }
             should_parse_repetition_symbol = true;
             break;

--- a/Libraries/LibRegex/RegexParser.h
+++ b/Libraries/LibRegex/RegexParser.h
@@ -64,6 +64,8 @@ public:
 
         struct {
             Optional<ByteString> pure_substring_search;
+            // If populated, the pattern only accepts strings that start with a character in these ranges.
+            Vector<CharRange> starting_ranges;
             bool only_start_of_line = false;
         } optimization_data {};
     };

--- a/Libraries/LibURL/Pattern/Component.cpp
+++ b/Libraries/LibURL/Pattern/Component.cpp
@@ -228,7 +228,6 @@ PatternErrorOr<Component> Component::compile(Utf8View const& input, PatternParse
     auto flags = regex::RegexOptions<ECMAScriptFlags> {
         (regex::ECMAScriptFlags)regex::AllFlags::SingleMatch
         | (regex::ECMAScriptFlags)regex::AllFlags::Global
-        | (regex::ECMAScriptFlags)regex::AllFlags::SkipTrimEmptyMatches
         | regex::ECMAScriptFlags::BrowserExtended
     };
 
@@ -288,7 +287,7 @@ Component::Result Component::create_match_result(String const& input, regex::Reg
     // 4. Let index be 1.
     // 5. While index is less than Get(execResult, "length"):
     for (size_t index = 1; index <= exec_result.n_capture_groups; ++index) {
-        auto const& capture = exec_result.capture_group_matches[0][index];
+        auto const& capture = exec_result.capture_group_matches[0][index - 1];
 
         // 1. Let name be component’s group name list[index − 1].
         auto name = group_name_list[index - 1];

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -373,7 +373,7 @@ TEST_CASE(ini_file_entries)
     }
 
     EXPECT_EQ(result.matches.at(0).view, "[Window]");
-    EXPECT_EQ(result.capture_group_matches.at(0).at(0).view, "Window");
+    EXPECT_EQ(result.capture_group_matches.at(0).at(1).view, "Window");
     EXPECT_EQ(result.matches.at(1).view, "Opacity=255");
     EXPECT_EQ(result.matches.at(1).line, 1u);
     EXPECT_EQ(result.matches.at(1).column, 0u);


### PR DESCRIPTION
The main workhorse of this nice PR is pulling out the first compare to apply outside the VM, this avoid setting up a bunch of state and allows the matcher to (relatively) quickly seek to a point where the pattern would at least have a chance of succeeding; this leads to a ~20% perf improvement on that one bad regex Andreas has been complaining about (but not in general, that's not measured here)
(p.s. my first PR from inside ladybird, be nice:)