### PR TITLE
LibWeb: Fulfill `TransformStream` promises with the correct "reason"

### DIFF
--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -5438,7 +5438,7 @@ GC::Ref<WebIDL::Promise> transform_stream_default_sink_abort_algorithm(Transform
     // 7. React to cancelPromise:
     WebIDL::react_to_promise(cancel_promise,
         // 1. If cancelPromise was fulfilled, then:
-        GC::create_function(realm.heap(), [&realm, readable, controller](JS::Value reason) -> WebIDL::ExceptionOr<JS::Value> {
+        GC::create_function(realm.heap(), [&realm, readable, controller, reason](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
             // 1. If readable.[[state]] is "errored", reject controller.[[finishPromise]] with readable.[[storedError]].
             if (readable->state() == ReadableStream::State::Errored) {
                 WebIDL::reject_promise(realm, *controller->finish_promise(), readable->stored_error());

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/errors.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/errors.any.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 21 tests
 
-19 Pass
-2 Fail
+21 Pass
 Pass	TransformStream errors thrown in transform put the writable and readable in an errored state
 Pass	TransformStream errors thrown in flush put the writable and readable in an errored state
 Pass	errored TransformStream should not enqueue new chunks
@@ -23,5 +22,5 @@ Pass	controller.error() should do nothing after readable.cancel() resolves
 Pass	controller.error() should do nothing after writable.abort() has completed
 Pass	controller.error() should do nothing after a transformer method has thrown an exception
 Pass	erroring during write with backpressure should result in the write failing
-Fail	a write() that was waiting for backpressure should reject if the writable is aborted
-Fail	the readable should be errored with the reason passed to the writable abort() method
+Pass	a write() that was waiting for backpressure should reject if the writable is aborted
+Pass	the readable should be errored with the reason passed to the writable abort() method

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/errors.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/errors.any.txt
@@ -1,0 +1,27 @@
+Harness status: OK
+
+Found 21 tests
+
+19 Pass
+2 Fail
+Pass	TransformStream errors thrown in transform put the writable and readable in an errored state
+Pass	TransformStream errors thrown in flush put the writable and readable in an errored state
+Pass	errored TransformStream should not enqueue new chunks
+Pass	TransformStream transformer.start() rejected promise should error the stream
+Pass	when controller.error is followed by a rejection, the error reason should come from controller.error
+Pass	TransformStream constructor should throw when start does
+Pass	when strategy.size throws inside start(), the constructor should throw the same error
+Pass	when strategy.size calls controller.error() then throws, the constructor should throw the first error
+Pass	cancelling the readable side should error the writable
+Pass	it should be possible to error the readable between close requested and complete
+Pass	an exception from transform() should error the stream if terminate has been requested but not completed
+Pass	abort should set the close reason for the writable when it happens before cancel during start, and cancel should reject
+Pass	abort should set the close reason for the writable when it happens before cancel during underlying sink write, but cancel should still succeed
+Pass	controller.error() should do nothing the second time it is called
+Pass	controller.error() should close writable immediately after readable.cancel()
+Pass	controller.error() should do nothing after readable.cancel() resolves
+Pass	controller.error() should do nothing after writable.abort() has completed
+Pass	controller.error() should do nothing after a transformer method has thrown an exception
+Pass	erroring during write with backpressure should result in the write failing
+Fail	a write() that was waiting for backpressure should reject if the writable is aborted
+Fail	the readable should be errored with the reason passed to the writable abort() method

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/reentrant-strategies.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/reentrant-strategies.any.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 11 tests
+
+10 Pass
+1 Fail
+Pass	enqueue() inside size() should work
+Pass	terminate() inside size() should work
+Pass	error() inside size() should work
+Pass	desiredSize inside size() should work
+Pass	readable cancel() inside size() should work
+Pass	pipeTo() inside size() should work
+Pass	read() inside of size() should work
+Pass	writer.write() inside size() should work
+Pass	synchronous writer.write() inside size() should work
+Pass	writer.close() inside size() should work
+Fail	writer.abort() inside size() should work

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/reentrant-strategies.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/transform-streams/reentrant-strategies.any.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 11 tests
 
-10 Pass
-1 Fail
+11 Pass
 Pass	enqueue() inside size() should work
 Pass	terminate() inside size() should work
 Pass	error() inside size() should work
@@ -14,4 +13,4 @@ Pass	read() inside of size() should work
 Pass	writer.write() inside size() should work
 Pass	synchronous writer.write() inside size() should work
 Pass	writer.close() inside size() should work
-Fail	writer.abort() inside size() should work
+Pass	writer.abort() inside size() should work

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/errors.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/errors.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/test-utils.js"></script>
+<div id=log></div>
+<script src="../../streams/transform-streams/errors.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/errors.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/errors.any.js
@@ -1,0 +1,360 @@
+// META: global=window,worker,shadowrealm
+// META: script=../resources/test-utils.js
+'use strict';
+
+const thrownError = new Error('bad things are happening!');
+thrownError.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform() {
+      throw thrownError;
+    },
+    cancel: t.unreached_func('cancel should not be called')
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, writer.write('a'),
+                            'writable\'s write should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.read(),
+                            'readable\'s read should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.closed,
+                            'readable\'s closed should be rejected with the thrown error'),
+    promise_rejects_exactly(t, thrownError, writer.closed,
+                            'writable\'s closed should be rejected with the thrown error')
+  ]);
+}, 'TransformStream errors thrown in transform put the writable and readable in an errored state');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform() {
+    },
+    flush() {
+      throw thrownError;
+    },
+    cancel: t.unreached_func('cancel should not be called')
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+
+  return Promise.all([
+    writer.write('a'),
+    promise_rejects_exactly(t, thrownError, writer.close(),
+                            'writable\'s close should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.read(),
+                            'readable\'s read should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.closed,
+                            'readable\'s closed should be rejected with the thrown error'),
+    promise_rejects_exactly(t, thrownError, writer.closed,
+                            'writable\'s closed should be rejected with the thrown error')
+  ]);
+}, 'TransformStream errors thrown in flush put the writable and readable in an errored state');
+
+test(t => {
+  new TransformStream({
+    start(c) {
+      c.enqueue('a');
+      c.error(new Error('generic error'));
+      assert_throws_js(TypeError, () => c.enqueue('b'), 'enqueue() should throw');
+    },
+    cancel: t.unreached_func('cancel should not be called')
+  });
+}, 'errored TransformStream should not enqueue new chunks');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start() {
+      return flushAsyncEvents().then(() => {
+        throw thrownError;
+      });
+    },
+    transform: t.unreached_func('transform should not be called'),
+    flush: t.unreached_func('flush should not be called'),
+    cancel: t.unreached_func('cancel should not be called')
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, writer.write('a'), 'writer should reject with thrownError'),
+    promise_rejects_exactly(t, thrownError, writer.close(), 'close() should reject with thrownError'),
+    promise_rejects_exactly(t, thrownError, reader.read(), 'reader should reject with thrownError')
+  ]);
+}, 'TransformStream transformer.start() rejected promise should error the stream');
+
+promise_test(t => {
+  const controllerError = new Error('start failure');
+  controllerError.name = 'controllerError';
+  const ts = new TransformStream({
+    start(c) {
+      return flushAsyncEvents()
+        .then(() => {
+          c.error(controllerError);
+          throw new Error('ignored error');
+        });
+    },
+    transform: t.unreached_func('transform should never be called if start() fails'),
+    flush: t.unreached_func('flush should never be called if start() fails'),
+    cancel: t.unreached_func('cancel should never be called if start() fails')
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  return Promise.all([
+    promise_rejects_exactly(t, controllerError, writer.write('a'), 'writer should reject with controllerError'),
+    promise_rejects_exactly(t, controllerError, writer.close(), 'close should reject with same error'),
+    promise_rejects_exactly(t, controllerError, reader.read(), 'reader should reject with same error')
+  ]);
+}, 'when controller.error is followed by a rejection, the error reason should come from controller.error');
+
+test(() => {
+  assert_throws_js(URIError, () => new TransformStream({
+    start() { throw new URIError('start thrown error'); },
+    transform() {}
+  }), 'constructor should throw');
+}, 'TransformStream constructor should throw when start does');
+
+test(() => {
+  const strategy = {
+    size() { throw new URIError('size thrown error'); }
+  };
+
+  assert_throws_js(URIError, () => new TransformStream({
+    start(c) {
+      c.enqueue('a');
+    },
+    transform() {}
+  }, undefined, strategy), 'constructor should throw the same error strategy.size throws');
+}, 'when strategy.size throws inside start(), the constructor should throw the same error');
+
+test(() => {
+  const controllerError = new URIError('controller.error');
+
+  let controller;
+  const strategy = {
+    size() {
+      controller.error(controllerError);
+      throw new Error('redundant error');
+    }
+  };
+
+  assert_throws_js(URIError, () => new TransformStream({
+    start(c) {
+      controller = c;
+      c.enqueue('a');
+    },
+    transform() {}
+  }, undefined, strategy), 'the first error should be thrown');
+}, 'when strategy.size calls controller.error() then throws, the constructor should throw the first error');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  const closedPromise = writer.closed;
+  return Promise.all([
+    ts.readable.cancel(thrownError),
+    promise_rejects_exactly(t, thrownError, closedPromise, 'closed should throw a TypeError')
+  ]);
+}, 'cancelling the readable side should error the writable');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const writePromise = writer.write('a');
+  const closePromise = writer.close();
+  controller.error(thrownError);
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, reader.closed, 'reader.closed should reject'),
+    promise_rejects_exactly(t, thrownError, writePromise, 'writePromise should reject'),
+    promise_rejects_exactly(t, thrownError, closePromise, 'closePromise should reject')]);
+}, 'it should be possible to error the readable between close requested and complete');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      controller.terminate();
+      throw thrownError;
+    }
+  }, undefined, { highWaterMark: 1 });
+  const writePromise = ts.writable.getWriter().write('a');
+  const closedPromise = ts.readable.getReader().closed;
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, writePromise, 'write() should reject'),
+    promise_rejects_exactly(t, thrownError, closedPromise, 'reader.closed should reject')
+  ]);
+}, 'an exception from transform() should error the stream if terminate has been requested but not completed');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  // The microtask following transformer.start() hasn't completed yet, so the abort is queued and not notified to the
+  // TransformStream yet.
+  const abortPromise = writer.abort(thrownError);
+  const cancelPromise = ts.readable.cancel(new Error('cancel reason'));
+  return Promise.all([
+    abortPromise,
+    cancelPromise,
+    promise_rejects_exactly(t, thrownError, writer.closed, 'writer.closed should reject'),
+  ]);
+}, 'abort should set the close reason for the writable when it happens before cancel during start, and cancel should ' +
+             'reject');
+
+promise_test(t => {
+  let resolveTransform;
+  const transformPromise = new Promise(resolve => {
+    resolveTransform = resolve;
+  });
+  const ts = new TransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, { highWaterMark: 2 });
+  const writer = ts.writable.getWriter();
+  return delay(0).then(() => {
+    const writePromise = writer.write();
+    const abortPromise = writer.abort(thrownError);
+    const cancelPromise = ts.readable.cancel(new Error('cancel reason'));
+    resolveTransform();
+    return Promise.all([
+      writePromise,
+      abortPromise,
+      cancelPromise,
+      promise_rejects_exactly(t, thrownError, writer.closed, 'writer.closed should reject with thrownError')]);
+  });
+}, 'abort should set the close reason for the writable when it happens before cancel during underlying sink write, ' +
+             'but cancel should still succeed');
+
+const ignoredError = new Error('ignoredError');
+ignoredError.name = 'ignoredError';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start(controller) {
+      controller.error(thrownError);
+      controller.error(ignoredError);
+    }
+  });
+  return promise_rejects_exactly(t, thrownError, ts.writable.abort(), 'abort() should reject with thrownError');
+}, 'controller.error() should do nothing the second time it is called');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelPromise = ts.readable.cancel(ignoredError);
+  controller.error(thrownError);
+  return Promise.all([
+    cancelPromise,
+    promise_rejects_exactly(t, thrownError, ts.writable.getWriter().closed, 'closed should reject with thrownError')
+  ]);
+}, 'controller.error() should close writable immediately after readable.cancel()');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return ts.readable.cancel(thrownError).then(() => {
+    controller.error(ignoredError);
+    return promise_rejects_exactly(t, thrownError, ts.writable.getWriter().closed, 'closed should reject with thrownError');
+  });
+}, 'controller.error() should do nothing after readable.cancel() resolves');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return ts.writable.abort(thrownError).then(() => {
+    controller.error(ignoredError);
+    return promise_rejects_exactly(t, thrownError, ts.writable.getWriter().closed, 'closed should reject with thrownError');
+  });
+}, 'controller.error() should do nothing after writable.abort() has completed');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    },
+    transform() {
+      throw thrownError;
+    }
+  }, undefined, { highWaterMark: Infinity });
+  const writer = ts.writable.getWriter();
+  return promise_rejects_exactly(t, thrownError, writer.write(), 'write() should reject').then(() => {
+    controller.error();
+    return promise_rejects_exactly(t, thrownError, writer.closed, 'closed should reject with thrownError');
+  });
+}, 'controller.error() should do nothing after a transformer method has thrown an exception');
+
+promise_test(t => {
+  let controller;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    },
+    transform() {
+      ++calls;
+    }
+  }, undefined, { highWaterMark: 1 });
+  return delay(0).then(() => {
+    // Create backpressure.
+    controller.enqueue('a');
+    const writer = ts.writable.getWriter();
+    // transform() will not be called until backpressure is relieved.
+    const writePromise = writer.write('b');
+    assert_equals(calls, 0, 'transform() should not have been called');
+    controller.error(thrownError);
+    // Now backpressure has been relieved and the write can proceed.
+    return promise_rejects_exactly(t, thrownError, writePromise, 'write() should reject').then(() => {
+      assert_equals(calls, 0, 'transform() should not be called');
+    });
+  });
+}, 'erroring during write with backpressure should result in the write failing');
+
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+  return delay(0).then(() => {
+    const writer = ts.writable.getWriter();
+    // write should start synchronously
+    const writePromise = writer.write(0);
+    // The underlying sink's abort() is not called until the write() completes.
+    const abortPromise = writer.abort(thrownError);
+    // Perform a read to relieve backpressure and permit the write() to complete.
+    const readPromise = ts.readable.getReader().read();
+    return Promise.all([
+      promise_rejects_exactly(t, thrownError, readPromise, 'read() should reject'),
+      promise_rejects_exactly(t, thrownError, writePromise, 'write() should reject'),
+      abortPromise
+    ]);
+  });
+}, 'a write() that was waiting for backpressure should reject if the writable is aborted');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  ts.writable.abort(thrownError);
+  const reader = ts.readable.getReader();
+  return promise_rejects_exactly(t, thrownError, reader.read(), 'read() should reject with thrownError');
+}, 'the readable should be errored with the reason passed to the writable abort() method');

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/reentrant-strategies.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/reentrant-strategies.any.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/rs-utils.js"></script>
+<script src="../resources/test-utils.js"></script>
+<div id=log></div>
+<script src="../../streams/transform-streams/reentrant-strategies.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/reentrant-strategies.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transform-streams/reentrant-strategies.any.js
@@ -1,0 +1,323 @@
+// META: global=window,worker,shadowrealm
+// META: script=../resources/recording-streams.js
+// META: script=../resources/rs-utils.js
+// META: script=../resources/test-utils.js
+'use strict';
+
+// The size() function of readableStrategy can re-entrantly call back into the TransformStream implementation. This
+// makes it risky to cache state across the call to ReadableStreamDefaultControllerEnqueue. These tests attempt to catch
+// such errors. They are separated from the other strategy tests because no real user code should ever do anything like
+// this.
+//
+// There is no such issue with writableStrategy size() because it is never called from within TransformStream
+// algorithms.
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(() => {
+  let controller;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        controller.enqueue('b');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([writer.write('a'), writer.close()])
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, ['b', 'a'], 'array should contain two chunks'));
+}, 'enqueue() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      // The readable queue is empty.
+      controller.terminate();
+      // The readable state has gone from "readable" to "closed".
+      return 1;
+      // This chunk will be enqueued, but will be impossible to read because the state is already "closed".
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, [], 'array should contain no chunks'));
+  // The chunk 'a' is still in readable's queue. readable is closed so 'a' cannot be read. writable's queue is empty and
+  // it is still writable.
+}, 'terminate() inside size() should work');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      controller.error(error1);
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => promise_rejects_exactly(t, error1, ts.readable.getReader().read(), 'read() should reject'));
+}, 'error() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      assert_equals(controller.desiredSize, 1, 'desiredSize should be 1');
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([writer.write('a'), writer.close()])
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, ['a'], 'array should contain one chunk'));
+}, 'desiredSize inside size() should work');
+
+promise_test(t => {
+  let cancelPromise;
+  const ts = new TransformStream({}, undefined, {
+    size() {
+      cancelPromise = ts.readable.cancel(error1);
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => {
+        promise_rejects_exactly(t, error1, writer.closed, 'writer.closed should reject');
+        return cancelPromise;
+      });
+}, 'readable cancel() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let pipeToPromise;
+  const ws = recordingWritableStream();
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      if (!pipeToPromise) {
+        pipeToPromise = ts.readable.pipeTo(ws);
+      }
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  // Allow promise returned by start() to resolve so that enqueue() will happen synchronously.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    assert_not_equals(pipeToPromise, undefined);
+
+    // Some pipeTo() implementations need an additional chunk enqueued in order for the first one to be processed. See
+    // https://github.com/whatwg/streams/issues/794 for background.
+    controller.enqueue('a');
+
+    // Give pipeTo() a chance to process the queued chunks.
+    return delay(0);
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'a'], 'ws should contain two chunks');
+    controller.terminate();
+    return pipeToPromise;
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'a', 'close'], 'target should have been closed');
+  });
+}, 'pipeTo() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let readPromise;
+  let calls = 0;
+  let reader;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      // This is triggered by controller.enqueue(). The queue is empty and there are no pending reads. pull() is called
+      // synchronously, allowing transform() to proceed asynchronously. This results in a second call to enqueue(),
+      // which resolves this pending read() without calling size() again.
+      readPromise = reader.read();
+      ++calls;
+      return 1;
+    },
+    highWaterMark: 0
+  });
+  reader = ts.readable.getReader();
+  const writer = ts.writable.getWriter();
+  let writeResolved = false;
+  const writePromise = writer.write('b').then(() => {
+    writeResolved = true;
+  });
+  return flushAsyncEvents().then(() => {
+    assert_false(writeResolved);
+    controller.enqueue('a');
+    assert_equals(calls, 1, 'size() should have been called once');
+    return delay(0);
+  }).then(() => {
+    assert_true(writeResolved);
+    assert_equals(calls, 1, 'size() should only be called once');
+    return readPromise;
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    // See https://github.com/whatwg/streams/issues/794 for why this chunk is not 'a'.
+    assert_equals(value, 'b', 'chunk should have been read');
+    assert_equals(calls, 1, 'calls should still be 1');
+    return writePromise;
+  });
+}, 'read() inside of size() should work');
+
+promise_test(() => {
+  let writer;
+  let writePromise1;
+  let calls = 0;
+  const ts = new TransformStream({}, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        writePromise1 = writer.write('a');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  writer = ts.writable.getWriter();
+  // Give pull() a chance to be called.
+  return delay(0).then(() => {
+    // This write results in a synchronous call to transform(), enqueue(), and size().
+    const writePromise2 = writer.write('b');
+    assert_equals(calls, 1, 'size() should have been called once');
+    return Promise.all([writePromise1, writePromise2, writer.close()]);
+  }).then(() => {
+    assert_equals(calls, 2, 'size() should have been called twice');
+    return readableStreamToArray(ts.readable);
+  }).then(array => {
+    assert_array_equals(array, ['b', 'a'], 'both chunks should have been enqueued');
+    assert_equals(calls, 2, 'calls should still be 2');
+  });
+}, 'writer.write() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let writer;
+  let writePromise;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        writePromise = writer.write('a');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  writer = ts.writable.getWriter();
+  // Give pull() a chance to be called.
+  return delay(0).then(() => {
+    // This enqueue results in synchronous calls to size(), write(), transform() and enqueue().
+    controller.enqueue('b');
+    assert_equals(calls, 2, 'size() should have been called twice');
+    return Promise.all([writePromise, writer.close()]);
+  }).then(() => {
+    return readableStreamToArray(ts.readable);
+  }).then(array => {
+    // Because one call to enqueue() is nested inside the other, they finish in the opposite order that they were
+    // called, so the chunks end up reverse order.
+    assert_array_equals(array, ['a', 'b'], 'both chunks should have been enqueued');
+    assert_equals(calls, 2, 'calls should still be 2');
+  });
+}, 'synchronous writer.write() inside size() should work');
+
+promise_test(() => {
+  let writer;
+  let closePromise;
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      closePromise = writer.close();
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  // Wait for the promise returned by start() to be resolved so that the call to close() will result in a synchronous
+  // call to TransformStreamDefaultSink.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    assert_equals(value, 'a', 'value should be correct');
+    return reader.read();
+  }).then(({ done }) => {
+    assert_true(done, 'done should be true');
+    return closePromise;
+  });
+}, 'writer.close() inside size() should work');
+
+promise_test(t => {
+  let abortPromise;
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      abortPromise = ts.writable.abort(error1);
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  const reader = ts.readable.getReader();
+  // Wait for the promise returned by start() to be resolved so that the call to abort() will result in a synchronous
+  // call to TransformStreamDefaultSink.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    assert_equals(value, 'a', 'value should be correct');
+    return Promise.all([promise_rejects_exactly(t, error1, reader.read(), 'read() should reject'), abortPromise]);
+  });
+}, 'writer.abort() inside size() should work');


### PR DESCRIPTION
We need to use the reason provided to the abort algorithm, not the one from the resolved cancel promise (which will be `undefined`).

We should now be passing all `/streams/transform-streams` tests (ignoring the service worker, etc. variants of course).