### PR TITLE
LibJS: Close the iterator on an abrupt completion in for/of loops

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -981,7 +981,7 @@ void Generator::generate_scoped_jump(JumpType type)
             emit<Bytecode::Op::LeaveLexicalEnvironment>();
             break;
         case ReturnToFinally: {
-            VERIFY(m_current_unwind_context->finalizer().has_value());
+            VERIFY(m_current_unwind_context && m_current_unwind_context->finalizer().has_value());
             m_current_unwind_context = m_current_unwind_context->previous();
             auto jump_type_name = type == JumpType::Break ? "break"sv : "continue"sv;
             auto block_name = MUST(String::formatted("{}.{}", current_block().name(), jump_type_name));
@@ -1020,7 +1020,7 @@ void Generator::generate_labelled_jump(JumpType type, FlyString const& label)
             } else if (boundary == BlockBoundaryType::LeaveLexicalEnvironment) {
                 emit<Bytecode::Op::LeaveLexicalEnvironment>();
             } else if (boundary == BlockBoundaryType::ReturnToFinally) {
-                VERIFY(m_current_unwind_context->finalizer().has_value());
+                VERIFY(m_current_unwind_context && m_current_unwind_context->finalizer().has_value());
                 m_current_unwind_context = m_current_unwind_context->previous();
                 auto jump_type_name = type == JumpType::Break ? "break"sv : "continue"sv;
                 auto block_name = MUST(String::formatted("{}.{}", current_block().name(), jump_type_name));

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -2682,11 +2682,9 @@ private:
 
 class IteratorClose final : public Instruction {
 public:
-    IteratorClose(Operand iterator_record, Completion::Type completion_type, Optional<Value> completion_value)
+    IteratorClose(Operand iterator_record)
         : Instruction(Type::IteratorClose)
         , m_iterator_record(iterator_record)
-        , m_completion_type(completion_type)
-        , m_completion_value(completion_value)
     {
     }
 
@@ -2698,22 +2696,16 @@ public:
     }
 
     Operand iterator_record() const { return m_iterator_record; }
-    Completion::Type completion_type() const { return m_completion_type; }
-    Optional<Value> const& completion_value() const { return m_completion_value; }
 
 private:
     Operand m_iterator_record;
-    Completion::Type m_completion_type { Completion::Type::Normal };
-    Optional<Value> m_completion_value;
 };
 
 class AsyncIteratorClose final : public Instruction {
 public:
-    AsyncIteratorClose(Operand iterator_record, Completion::Type completion_type, Optional<Value> completion_value)
+    AsyncIteratorClose(Operand iterator_record)
         : Instruction(Type::AsyncIteratorClose)
         , m_iterator_record(iterator_record)
-        , m_completion_type(completion_type)
-        , m_completion_value(completion_value)
     {
     }
 
@@ -2725,13 +2717,9 @@ public:
     }
 
     Operand iterator_record() const { return m_iterator_record; }
-    Completion::Type completion_type() const { return m_completion_type; }
-    Optional<Value> const& completion_value() const { return m_completion_value; }
 
 private:
     Operand m_iterator_record;
-    Completion::Type m_completion_type { Completion::Type::Normal };
-    Optional<Value> m_completion_value;
 };
 
 class IteratorNext final : public Instruction {


### PR DESCRIPTION
Opened for early feedback before I write tests (and to make sure no one starts on the same work before I opened this PR)

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4337

Currently crashes in the original ReadableStream async-iterator test that the issue was opened for, due to the weird `await` implementation that does it own thing instead of how `await` actually works with our interpreter:
```
VERIFICATION FAILED: vm().execution_context_stack().is_empty() at /Users/lukewilde/Repositories/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:57
0   liblagom-ak.0.0.0.dylib             0x0000000104d7d668 ak_trap + 56
1   liblagom-ak.0.0.0.dylib             0x0000000104d7d970 ak_assertion_failed + 0
2   liblagom-web.0.0.0.dylib            0x0000000108755944 Web::HTML::EventLoop::perform_a_microtask_checkpoint() (.cold.3) + 0
3   liblagom-web.0.0.0.dylib            0x0000000107b0df5c Web::HTML::EventLoop::spin_processing_tasks_with_source_until(Web::HTML::Task::Source, GC::Ref<GC::Function<bool ()>>) + 0
4   liblagom-web.0.0.0.dylib            0x00000001079eaa34 Web::DOM::Document::update_animations_and_send_events(AK::Optional<double> const&) + 124
5   liblagom-web.0.0.0.dylib            0x0000000107b0efc4 Web::HTML::EventLoop::update_the_rendering() + 432
6   liblagom-web.0.0.0.dylib            0x0000000107b10a80 Web::HTML::Task::execute() + 92
7   liblagom-web.0.0.0.dylib            0x0000000107b0e1bc Web::HTML::EventLoop::process() + 84
8   liblagom-web.0.0.0.dylib            0x0000000107d44c50 AK::Function<void ()>::CallableWrapper<Web::Platform::TimerSerenity::TimerSerenity()::$_0>::call() + 100
9   liblagom-core.0.0.0.dylib           0x0000000104b5959c Core::Timer::timer_event(Core::TimerEvent&) + 208
10  liblagom-core.0.0.0.dylib           0x0000000104b4ac70 Core::EventReceiver::dispatch_event(Core::Event&, Core::EventReceiver*) + 228
11  liblagom-core.0.0.0.dylib           0x0000000104b58584 Core::ThreadEventQueue::process() + 432
12  liblagom-core.0.0.0.dylib           0x0000000104b49164 Core::EventLoop::spin_until(AK::Function<bool ()>) + 220
13  liblagom-web.0.0.0.dylib            0x0000000107d440cc Web::Platform::EventLoopPluginSerenity::spin_until(GC::Root<GC::Function<bool ()>>) + 116
14  liblagom-web.0.0.0.dylib            0x00000001077f4174 Web::Bindings::WebEngineCustomData::spin_event_loop_until(GC::Root<GC::Function<bool ()>>) + 68
15  liblagom-js.0.0.0.dylib             0x0000000105224a50 JS::await(JS::VM&, JS::Value) + 1068
16  liblagom-js.0.0.0.dylib             0x00000001052a3c10 JS::iterator_close_impl(JS::VM&, JS::IteratorRecord const&, JS::Completion, JS::IteratorHint) + 204
17  liblagom-js.0.0.0.dylib             0x0000000105153d88 JS::Bytecode::Interpreter::run_bytecode(unsigned long) + 14212
18  liblagom-js.0.0.0.dylib             0x0000000105150458 JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) + 424
19  liblagom-js.0.0.0.dylib             0x00000001052556bc JS::GeneratorObject::execute(JS::VM&, JS::Completion const&) + 292
20  liblagom-js.0.0.0.dylib             0x00000001052558c4 JS::GeneratorObject::resume(JS::VM&, JS::Value, AK::Optional<AK::StringView> const&) + 216
21  liblagom-js.0.0.0.dylib             0x000000010520ad44 JS::AsyncFunctionDriverWrapper::continue_async_execution(JS::VM&, JS::Value, bool) + 84
22  liblagom-js.0.0.0.dylib             0x00000001053c01c0 AK::Function<JS::ThrowCompletionOr<JS::Value> (JS::VM&)>::CallableWrapper<JS::AsyncFunctionDriverWrapper::await(JS::Value)::$_0>::call(JS::VM&) (.cold.1) + 84
23  liblagom-js.0.0.0.dylib             0x000000010520b538 AK::Function<JS::ThrowCompletionOr<JS::Value> (JS::VM&)>::CallableWrapper<JS::AsyncFunctionDriverWrapper::await(JS::Value)::$_0>::call(JS::VM&) + 64
24  liblagom-js.0.0.0.dylib             0x00000001052bb674 JS::NativeFunction::call() + 124
25  liblagom-js.0.0.0.dylib             0x00000001052bb3b4 JS::NativeFunction::internal_call(JS::Value, AK::Span<JS::Value const>) + 280
26  liblagom-web.0.0.0.dylib            0x00000001077f5074 AK::Function<JS::ThrowCompletionOr<JS::Value> (JS::JobCallback&, JS::Value, AK::Span<JS::Value const>)>::CallableWrapper<Web::Bindings::initialize_main_thread_vm(Web::HTML::EventLoop::Type)::$_3>::call(JS::JobCallback&, JS::Value, AK::Span<JS::Value const>) + 144
27  liblagom-js.0.0.0.dylib             0x00000001052d91b0 AK::Function<JS::ThrowCompletionOr<JS::Value> ()>::CallableWrapper<JS::create_promise_reaction_job(JS::VM&, JS::PromiseReaction&, JS::Value)::$_0>::call() + 168
28  liblagom-web.0.0.0.dylib            0x00000001077f567c AK::Function<void ()>::CallableWrapper<Web::Bindings::initialize_main_thread_vm(Web::HTML::EventLoop::Type)::$_5::operator()(GC::Ref<GC::Function<JS::ThrowCompletionOr<JS::Value> ()>>, JS::Realm*) const::'lambda'()>::call() + 240
29  liblagom-web.0.0.0.dylib            0x0000000107b10a80 Web::HTML::Task::execute() + 92
30  liblagom-web.0.0.0.dylib            0x0000000107b0de78 Web::HTML::EventLoop::perform_a_microtask_checkpoint() + 100
31  liblagom-web.0.0.0.dylib            0x0000000107c0c600 Web::HTML::TemporaryExecutionContext::~TemporaryExecutionContext() + 24
32  liblagom-web.0.0.0.dylib            0x0000000107c49704 AK::Function<void ()>::CallableWrapper<Web::HTML::WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(AK::Variant<GC::Ref<Web::WebIDL::CallbackType>, AK::String>, int, GC::RootVector<JS::Value, 0ul>, Web::HTML::WindowOrWorkerGlobalScopeMixin::Repeat, AK::Optional<int>)::$_1::operator()()::'lambda'()>::call() + 200
33  liblagom-web.0.0.0.dylib            0x0000000107b10a80 Web::HTML::Task::execute() + 92
34  liblagom-web.0.0.0.dylib            0x0000000107b0e1bc Web::HTML::EventLoop::process() + 84
35  liblagom-web.0.0.0.dylib            0x0000000107d44c50 AK::Function<void ()>::CallableWrapper<Web::Platform::TimerSerenity::TimerSerenity()::$_0>::call() + 100
36  liblagom-core.0.0.0.dylib           0x0000000104b5959c Core::Timer::timer_event(Core::TimerEvent&) + 208
37  liblagom-core.0.0.0.dylib           0x0000000104b4ac70 Core::EventReceiver::dispatch_event(Core::Event&, Core::EventReceiver*) + 228
38  liblagom-core.0.0.0.dylib           0x0000000104b58584 Core::ThreadEventQueue::process() + 432
39  liblagom-core.0.0.0.dylib           0x0000000104b5d924 Core::EventLoopImplementationUnix::exec() + 44
40  liblagom-core.0.0.0.dylib           0x0000000104b48fec Core::EventLoop::exec() + 68
41  WebContent                          0x00000001041404d4 serenity_main(Main::Arguments) + 3932
42  WebContent                          0x00000001041e3afc main + 196
43  dyld                                0x0000000186edab4c start + 600
```