### PR TITLE
LibWebView: Respect autocomplete response Content-Encoding headers

### DIFF
--- a/Libraries/LibWebView/Autocomplete.h
+++ b/Libraries/LibWebView/Autocomplete.h
@@ -34,7 +34,7 @@ public:
     void query_autocomplete_engine(String);
 
 private:
-    static ErrorOr<Vector<String>> received_autocomplete_respsonse(AutocompleteEngine const&, StringView response);
+    static ErrorOr<Vector<String>> received_autocomplete_respsonse(AutocompleteEngine const&, Optional<ByteString const&> content_type, StringView response);
     void invoke_autocomplete_query_complete(Vector<String> suggestions) const;
 
     String m_query;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -81,7 +81,7 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibWebView webview)
-target_link_libraries(LibWebView PRIVATE LibCore LibDevTools LibFileSystem LibGfx LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSyntax)
+target_link_libraries(LibWebView PRIVATE LibCore LibDevTools LibFileSystem LibGfx LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSyntax LibTextCodec)
 
 if (APPLE)
     target_link_libraries(LibWebView PRIVATE LibThreading)


### PR DESCRIPTION
For example, Google uses ISO-8859-1 encoding. This patch allows us to decode such responses, falling back to UTF-8 if a Content-Type was not specified or could not be parsed. We should also now handle if decoding fails, rather than crashing inside `JsonParser`.

Fixes #4380.

<img width="255" alt="Screenshot 2025-04-16 at 5 42 34 PM" src="https://github.com/user-attachments/assets/10e9d26a-26b9-4f8a-9098-75c9e3895760" />
