### PR TITLE
Documentation: Remove now-obsolete patch from Servo's DevTools parser

### DIFF
--- a/Documentation/DevTools.md
+++ b/Documentation/DevTools.md
@@ -456,23 +456,32 @@ WebContent process:
 ## Inspecting the protocol with Firefox
 
 When developing a DevTools feature, it's invaluable to see how the DevTools protocol is used by Firefox itself. First,
-enable remote debugging in your Firefox profile's `about:config` page. You may wish to create a new profile for this:
+enable remote debugging in your Firefox profile's `about:config` page:
 
 ```
 devtools.chrome.enabled = true
 devtools.debugger.remote-enabled = true
 ```
 
-Then close all Firefox windows. Restart Firefox via the command line, specifying the DevTools server port:
+You may wish to create a new profile for this, rather than modifying your default profile. To create a new profile from
+the command line:
+
+```bash
+firefox -CreateProfile YOUR_PROFILE_NAME
+```
+
+If you are using your default profile, then close all Firefox windows. Restart Firefox via the command line, specifying
+the DevTools server port:
 
 ```bash
 firefox --start-debugger-server 6000
 ```
 
-If you created a new profile, specify its path with the `--profile` flag:
+Or if you created a new profile, you do not need to close all Firefox windows. Instead, launch a new instance with the
+`--new-instance` flag, and specify your new profile's path with the `--profile` flag:
 
 ```bash
-firefox --start-debugger-server 6000 --profile ~/snap/firefox/common/.mozilla/firefox/z20dtqwq.TEST
+firefox --start-debugger-server 6000 --new-instance --profile ~/snap/firefox/common/.mozilla/firefox/z20dtqwq.YOUR_PROFILE_NAME
 ```
 
 After Firefox is running, we can now snoop the specified port. The Servo team has written a nice script using `tshark`

--- a/Documentation/DevTools.md
+++ b/Documentation/DevTools.md
@@ -489,27 +489,9 @@ to listen on this port and pretty-print the JSON packets. You will have to insta
 
 https://github.com/servo/servo/blob/main/etc/devtools_parser.py
 
-You may run into issues with the latest version of Firefox using this script directly, such as exceptions being thrown
-while decoding packets. The following patch helps with this:
-
-```diff
-diff --git a/etc/devtools_parser.py b/etc/devtools_parser.py
-index d33a4ee330..3d5dc74a32 100755
---- a/etc/devtools_parser.py
-+++ b/etc/devtools_parser.py
-@@ -118,7 +118,7 @@ def process_data(out, port):
-             continue
-         try:
-             dec = bytearray.fromhex(curr_data).decode()
--        except UnicodeError:
-+        except:
-             continue
-
-         indices = [m.span() for m in re.finditer(pattern, dec)]
-```
-
-Since such exceptions are hit fairly regularly, it is recommended to run this script in two phases. First, use the script
-to snoop on the DevTools port and write out a packet capture. You may need to run this script with `sudo`.
+You may run into cases where the script does not log all captured packets. Since this occurs fairly regularly, it is
+recommended to run this script in two phases. First, use the script to snoop on the DevTools port and write out a packet
+capture. You may need to run this script with `sudo`.
 
 ```bash
 ./etc/devtools_parser.py -s /tmp/devtools.pcap -p 6000
@@ -522,8 +504,8 @@ Now, use `about:debugging` to connect to the Firefox DevTools server and inspect
 exercise the feature you wish to implement.
 
 Once complete, use `ctrl+c` on Servo's snooping script to complete the capture. The script will try to print all packets
-at this point, but due to the aforementioned exceptions, it is likely that this will not print everything. So we can use
-the script again to inspect the now-existing .pcap, and it seems to have better luck printing everything this way:
+at this point, but due to the aforementioned incomplete logging, it is likely that this will not print everything. So we
+can use the script again to inspect the now-existing .pcap, and it should be able to print everything this way:
 
 ```bash
 ./etc/devtools_parser.py --use /tmp/devtools.pcap -p 6000


### PR DESCRIPTION
They have fixed the exception mentioned here, but the script still has trouble displaying all live-captured packets.