### PR TITLE
LibWeb: Use (de)serialization with transfer AOs for structured cloning

### DIFF
--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -324,11 +324,11 @@ void MessagePort::post_message_task_steps(SerializedTransferRecord& serialize_wi
 
     // 2. Let targetRealm be finalTargetPort's relevant realm.
     auto& target_realm = relevant_realm(*final_target_port);
-    auto& target_vm = target_realm.vm();
+
+    TemporaryExecutionContext context { target_realm };
 
     // 3. Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
-    TemporaryExecutionContext context { relevant_realm(*final_target_port) };
-    auto deserialize_record_or_error = structured_deserialize_with_transfer(target_vm, serialize_with_transfer_result);
+    auto deserialize_record_or_error = structured_deserialize_with_transfer(serialize_with_transfer_result, target_realm);
     if (deserialize_record_or_error.is_error()) {
         // If this throws an exception, catch it, fire an event named messageerror at finalTargetPort, using MessageEvent, and then return.
         auto exception = deserialize_record_or_error.release_error();

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -1319,9 +1319,9 @@ static WebIDL::ExceptionOr<GC::Ref<Bindings::PlatformObject>> create_transferred
 }
 
 // https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer
-WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_transfer(JS::VM& vm, SerializedTransferRecord& serialize_with_transfer_result)
+WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_transfer(SerializedTransferRecord& serialize_with_transfer_result, JS::Realm& target_realm)
 {
-    auto& target_realm = *vm.current_realm();
+    auto& vm = target_realm.vm();
 
     // 1. Let memory be an empty map.
     auto memory = DeserializationMemory(vm.heap());

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -124,7 +124,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::PrimitiveString>> deserialize_string_primitive(J
 WebIDL::ExceptionOr<GC::Ref<JS::BigInt>> deserialize_big_int_primitive(JS::VM& vm, ReadonlySpan<u32> vector, size_t& position);
 
 WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer(JS::VM& vm, JS::Value value, Vector<GC::Root<JS::Object>> const& transfer_list);
-WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_transfer(JS::VM& vm, SerializedTransferRecord&);
+WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_transfer(SerializedTransferRecord&, JS::Realm& target_realm);
 
 }
 

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
@@ -93,19 +93,16 @@ void UniversalGlobalScopeMixin::queue_microtask(WebIDL::CallbackType& callback)
 // https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone
 WebIDL::ExceptionOr<JS::Value> UniversalGlobalScopeMixin::structured_clone(JS::Value value, StructuredSerializeOptions const& options) const
 {
-    auto& vm = this_impl().vm();
-    (void)options;
+    auto& realm = HTML::relevant_realm(this_impl());
 
     // 1. Let serialized be ? StructuredSerializeWithTransfer(value, options["transfer"]).
-    // FIXME: Use WithTransfer variant of the AO
-    auto serialized = TRY(structured_serialize(vm, value));
+    auto serialized = TRY(structured_serialize_with_transfer(realm.vm(), value, options.transfer));
 
     // 2. Let deserializeRecord be ? StructuredDeserializeWithTransfer(serialized, this's relevant realm).
-    // FIXME: Use WithTransfer variant of the AO
-    auto deserialized = TRY(structured_deserialize(vm, serialized, relevant_realm(this_impl())));
+    auto deserialized = TRY(structured_deserialize_with_transfer(serialized, realm));
 
     // 3. Return deserializeRecord.[[Deserialized]].
-    return deserialized;
+    return deserialized.deserialized;
 }
 
 // https://streams.spec.whatwg.org/#count-queuing-strategy-size-function

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1190,9 +1190,10 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
         // 3. Let source be the WindowProxy object corresponding to incumbentSettings's global object (a Window object).
         auto& source = as<WindowProxy>(incumbent_settings.realm().global_environment().global_this_value());
 
+        TemporaryExecutionContext temporary_execution_context { target_realm, TemporaryExecutionContext::CallbacksEnabled::Yes };
+
         // 4. Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
-        auto temporary_execution_context = TemporaryExecutionContext { target_realm, TemporaryExecutionContext::CallbacksEnabled::Yes };
-        auto deserialize_record_or_error = structured_deserialize_with_transfer(vm(), serialize_with_transfer_result);
+        auto deserialize_record_or_error = structured_deserialize_with_transfer(serialize_with_transfer_result, target_realm);
 
         // If this throws an exception, catch it, fire an event named messageerror at targetWindow, using MessageEvent,
         // with the origin attribute initialized to origin and the source attribute initialized to source, and then return.

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	enqueue after detaching byobRequest.view.buffer should throw
+1 Pass
+Pass	enqueue after detaching byobRequest.view.buffer should throw

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	enqueue after detaching byobRequest.view.buffer should throw

--- a/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../streams/readable-byte-streams/enqueue-with-detached-buffer.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/enqueue-with-detached-buffer.any.js
@@ -1,0 +1,21 @@
+// META: global=window,worker,shadowrealm
+
+promise_test(async t => {
+  const error = new Error('cannot proceed');
+  const rs = new ReadableStream({
+    type: 'bytes',
+    pull: t.step_func((controller) => {
+      const buffer = controller.byobRequest.view.buffer;
+      // Detach the buffer.
+      structuredClone(buffer, { transfer: [buffer] });
+
+      // Try to enqueue with a new buffer.
+      assert_throws_js(TypeError, () => controller.enqueue(new Uint8Array([42])));
+
+      // If we got here the test passed.
+      controller.error(error);
+    })
+  });
+  const reader = rs.getReader({ mode: 'byob' });
+  await promise_rejects_exactly(t, error, reader.read(new Uint8Array(1)));
+}, 'enqueue after detaching byobRequest.view.buffer should throw');


### PR DESCRIPTION
This is important, for example, to detach transferred array buffers.

~~Draft for now because I can't import an affected WPT test while wpt.live is down~~
