### PR TITLE
Invalidate less style due to pseudo-class selectors on Speedometer 3

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2023-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -18,6 +18,8 @@
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/LengthBox.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/PseudoClass.h>
+#include <LibWeb/CSS/PseudoClassBitmap.h>
 #include <LibWeb/CSS/StyleProperty.h>
 
 namespace Web::CSS {
@@ -228,8 +230,15 @@ public:
 
     static float resolve_opacity_value(CSSStyleValue const& value);
 
-    bool did_match_any_hover_rules() const { return m_did_match_any_hover_rules; }
-    void set_did_match_any_hover_rules() { m_did_match_any_hover_rules = true; }
+    bool has_attempted_match_against_pseudo_class(PseudoClass pseudo_class) const
+    {
+        return m_attempted_pseudo_class_matches.get(pseudo_class);
+    }
+
+    void set_attempted_pseudo_class_matches(PseudoClassBitmap const& results)
+    {
+        m_attempted_pseudo_class_matches = results;
+    }
 
 private:
     friend class StyleComputer;
@@ -256,7 +265,7 @@ private:
 
     Optional<CSSPixels> m_line_height;
 
-    bool m_did_match_any_hover_rules { false };
+    PseudoClassBitmap m_attempted_pseudo_class_matches;
 };
 
 }

--- a/Libraries/LibWeb/CSS/PseudoClassBitmap.h
+++ b/Libraries/LibWeb/CSS/PseudoClassBitmap.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/PseudoClass.h>
+
+namespace Web::CSS {
+
+class PseudoClassBitmap {
+public:
+    PseudoClassBitmap() = default;
+    ~PseudoClassBitmap() = default;
+
+    void set(PseudoClass pseudo_class, bool bit)
+    {
+        size_t const index = to_underlying(pseudo_class);
+        if (bit)
+            m_bits |= 1LLU << index;
+        else
+            m_bits &= ~(1LLU << index);
+    }
+
+    bool get(PseudoClass pseudo_class) const
+    {
+        size_t const index = to_underlying(pseudo_class);
+        return (m_bits & (1LLU << index)) != 0;
+    }
+
+    void operator|=(PseudoClassBitmap const& other)
+    {
+        m_bits |= other.m_bits;
+    }
+
+private:
+    u64 m_bits { 0 };
+};
+
+// NOTE: If this changes, we'll have to tweak PseudoClassBitmap a little bit :)
+static_assert(to_underlying(PseudoClass::__Count) <= 64);
+
+}

--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -101,16 +101,12 @@ Selector::Selector(Vector<CompoundSelector>&& compound_selectors)
                 break;
             }
             if (simple_selector.type == SimpleSelector::Type::PseudoClass) {
-                if (simple_selector.pseudo_class().type == PseudoClass::Hover) {
-                    m_contains_hover_pseudo_class = true;
-                }
+                m_contained_pseudo_classes.set(simple_selector.pseudo_class().type, true);
                 for (auto const& child_selector : simple_selector.pseudo_class().argument_selector_list) {
                     if (child_selector->contains_the_nesting_selector()) {
                         m_contains_the_nesting_selector = true;
                     }
-                    if (child_selector->contains_hover_pseudo_class()) {
-                        m_contains_hover_pseudo_class = true;
-                    }
+                    m_contained_pseudo_classes |= child_selector->m_contained_pseudo_classes;
                 }
                 if (m_contains_the_nesting_selector)
                     break;

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/Keyword.h>
 #include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/PseudoClass.h>
+#include <LibWeb/CSS/PseudoClassBitmap.h>
 #include <LibWeb/CSS/PseudoElement.h>
 
 namespace Web::CSS {
@@ -236,7 +237,7 @@ public:
     Optional<PseudoElementSelector> const& pseudo_element() const { return m_pseudo_element; }
     NonnullRefPtr<Selector> relative_to(SimpleSelector const&) const;
     bool contains_the_nesting_selector() const { return m_contains_the_nesting_selector; }
-    bool contains_hover_pseudo_class() const { return m_contains_hover_pseudo_class; }
+    bool contains_pseudo_class(PseudoClass pseudo_class) const { return m_contained_pseudo_classes.get(pseudo_class); }
     bool contains_unknown_webkit_pseudo_element() const;
     RefPtr<Selector> absolutized(SimpleSelector const& selector_for_nesting) const;
     u32 specificity() const;
@@ -259,7 +260,8 @@ private:
     bool m_can_use_fast_matches { false };
     bool m_can_use_ancestor_filter { false };
     bool m_contains_the_nesting_selector { false };
-    bool m_contains_hover_pseudo_class { false };
+
+    PseudoClassBitmap m_contained_pseudo_classes;
 
     void collect_ancestor_hashes();
 

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -433,7 +433,10 @@ static bool matches_optimal_value_pseudo_class(DOM::Element const& element, HTML
 
 static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClassSelector const& pseudo_class, DOM::Element const& element, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, GC::Ptr<DOM::ParentNode const> scope, SelectorKind selector_kind)
 {
+    context.attempted_pseudo_class_matches.set(pseudo_class.type, true);
     switch (pseudo_class.type) {
+    case CSS::PseudoClass::__Count:
+        VERIFY_NOT_REACHED();
     case CSS::PseudoClass::Link:
     case CSS::PseudoClass::AnyLink:
         // NOTE: AnyLink should match whether the link is visited or not, so if we ever start matching
@@ -448,7 +451,6 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     case CSS::PseudoClass::Active:
         return element.is_active();
     case CSS::PseudoClass::Hover:
-        context.did_match_any_hover_rules = true;
         return matches_hover_pseudo_class(element);
     case CSS::PseudoClass::Focus:
         return element.is_focused();
@@ -586,6 +588,8 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
 
         int index = 1;
         switch (pseudo_class.type) {
+        case CSS::PseudoClass::__Count:
+            VERIFY_NOT_REACHED();
         case CSS::PseudoClass::NthChild: {
             if (!matches_selector_list(pseudo_class.argument_selector_list, element))
                 return false;

--- a/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -20,7 +20,7 @@ struct MatchContext {
     GC::Ptr<CSS::CSSStyleSheet const> style_sheet_for_rule {};
     GC::Ptr<DOM::Element const> subject {};
     bool collect_per_element_selector_involvement_metadata { false };
-    bool did_match_any_hover_rules { false };
+    CSS::PseudoClassBitmap attempted_pseudo_class_matches {};
 };
 
 bool matches(CSS::Selector const&, DOM::Element const&, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, Optional<CSS::PseudoElement> = {}, GC::Ptr<DOM::ParentNode const> scope = {}, SelectorKind selector_kind = SelectorKind::Normal, GC::Ptr<DOM::Element const> anchor = nullptr);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2809,7 +2809,6 @@ void StyleComputer::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_ori
                     selector.specificity(),
                     cascade_origin,
                     false,
-                    false,
                 };
 
                 auto const& qualified_layer_name = matching_rule.qualified_layer_name();
@@ -2831,25 +2830,6 @@ void StyleComputer::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_ori
                         if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass
                             && simple_selector.pseudo_class().type == CSS::PseudoClass::Root) {
                             contains_root_pseudo_class = true;
-                        }
-                    }
-
-                    if (!matching_rule.must_be_hovered) {
-                        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass && simple_selector.pseudo_class().type == CSS::PseudoClass::Hover) {
-                            matching_rule.must_be_hovered = true;
-                        }
-                        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass
-                            && (simple_selector.pseudo_class().type == CSS::PseudoClass::Is
-                                || simple_selector.pseudo_class().type == CSS::PseudoClass::Where)) {
-                            auto const& argument_selectors = simple_selector.pseudo_class().argument_selector_list;
-
-                            if (argument_selectors.size() == 1) {
-                                auto const& simple_argument_selector = argument_selectors.first()->compound_selectors().last().simple_selectors.last();
-                                if (simple_argument_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass
-                                    && simple_argument_selector.pseudo_class().type == CSS::PseudoClass::Hover) {
-                                    matching_rule.must_be_hovered = true;
-                                }
-                            }
                         }
                     }
                 }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -160,8 +160,9 @@ public:
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style(DOM::Element&, Optional<CSS::PseudoElement> = {}) const;
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::PseudoElement>) const;
 
-    RuleCache const& get_hover_rules() const;
-    [[nodiscard]] Vector<MatchingRule const*> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::PseudoElement>, bool& did_match_any_hover_rules, FlyString const& qualified_layer_name = {}) const;
+    [[nodiscard]] RuleCache const& get_pseudo_class_rule_cache(PseudoClass) const;
+
+    [[nodiscard]] Vector<MatchingRule const*> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::PseudoElement>, PseudoClassBitmap& attempted_psuedo_class_matches, FlyString const& qualified_layer_name = {}) const;
 
     InvalidationSet invalidation_set_for_properties(Vector<InvalidationSet::Property> const&) const;
     bool invalidation_property_used_in_has_selector(InvalidationSet::Property const&) const;
@@ -213,7 +214,7 @@ private:
     struct MatchingFontCandidate;
 
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_style_impl(DOM::Element&, Optional<CSS::PseudoElement>, ComputeStyleMode) const;
-    [[nodiscard]] GC::Ref<CascadedProperties> compute_cascaded_values(DOM::Element&, Optional<CSS::PseudoElement>, bool& did_match_any_pseudo_element_rules, bool& did_match_any_hover_rules, ComputeStyleMode) const;
+    [[nodiscard]] GC::Ref<CascadedProperties> compute_cascaded_values(DOM::Element&, Optional<CSS::PseudoElement>, bool& did_match_any_pseudo_element_rules, PseudoClassBitmap& attempted_pseudo_class_matches, ComputeStyleMode) const;
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     RefPtr<Gfx::FontCascadeList const> font_matching_algorithm(FlyString const& family_name, int weight, int slope, float font_size_in_pt) const;
@@ -292,7 +293,7 @@ private:
     static void collect_selector_insights(Selector const&, SelectorInsights&);
 
     OwnPtr<SelectorInsights> m_selector_insights;
-    OwnPtr<RuleCache> m_hover_rule_cache;
+    Array<OwnPtr<RuleCache>, to_underlying(PseudoClass::__Count)> m_pseudo_class_rule_cache;
     OwnPtr<StyleInvalidationData> m_style_invalidation_data;
     OwnPtr<RuleCachesForDocumentAndShadowRoots> m_author_rule_cache;
     OwnPtr<RuleCachesForDocumentAndShadowRoots> m_user_rule_cache;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -86,7 +86,6 @@ struct MatchingRule {
     u32 specificity { 0 };
     CascadeOrigin cascade_origin;
     bool contains_pseudo_element { false };
-    bool must_be_hovered { false };
 
     // Helpers to deal with the fact that `rule` might be a CSSStyleRule or a CSSNestedDeclarations
     CSSStyleProperties const& declaration() const;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -435,7 +435,7 @@ public:
     void set_active_element(Element*);
 
     Element const* target_element() const { return m_target_element.ptr(); }
-    void set_target_element(Element*);
+    void set_target_element(GC::Ptr<Element>);
 
     void try_to_scroll_to_the_fragment();
     void scroll_to_the_fragment();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -431,8 +431,7 @@ public:
     void set_focused_element(GC::Ptr<Element>);
 
     Element const* active_element() const { return m_active_element.ptr(); }
-
-    void set_active_element(Element*);
+    void set_active_element(GC::Ptr<Element>);
 
     Element const* target_element() const { return m_target_element.ptr(); }
     void set_target_element(GC::Ptr<Element>);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -253,8 +253,9 @@ public:
 
     virtual FlyString node_name() const override { return "#document"_fly_string; }
 
-    void invalidate_style_for_elements_affected_by_hover_change(Node& old_new_hovered_common_ancestor, GC::Ptr<Node> hovered_node);
-    void set_hovered_node(Node*);
+    void invalidate_style_for_elements_affected_by_pseudo_class_change(CSS::PseudoClass, auto& element_slot, Node& old_new_common_ancestor, auto node);
+
+    void set_hovered_node(GC::Ptr<Node>);
     Node* hovered_node() { return m_hovered_node.ptr(); }
     Node const* hovered_node() const { return m_hovered_node.ptr(); }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -428,7 +428,7 @@ public:
     Element* focused_element() { return m_focused_element.ptr(); }
     Element const* focused_element() const { return m_focused_element.ptr(); }
 
-    void set_focused_element(Element*);
+    void set_focused_element(GC::Ptr<Element>);
 
     Element const* active_element() const { return m_active_element.ptr(); }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1207,16 +1207,16 @@ GC::Ptr<Layout::NodeWithStyle> Element::get_pseudo_element_node(CSS::PseudoEleme
     return nullptr;
 }
 
-bool Element::affected_by_hover() const
+bool Element::affected_by_pseudo_class(CSS::PseudoClass pseudo_class) const
 {
-    if (m_computed_properties && m_computed_properties->did_match_any_hover_rules()) {
+    if (m_computed_properties && m_computed_properties->has_attempted_match_against_pseudo_class(pseudo_class)) {
         return true;
     }
     if (m_pseudo_element_data) {
         for (auto& pseudo_element : *m_pseudo_element_data) {
             if (!pseudo_element.computed_properties)
                 continue;
-            if (pseudo_element.computed_properties->did_match_any_hover_rules())
+            if (pseudo_element.computed_properties->has_attempted_match_against_pseudo_class(pseudo_class))
                 return true;
         }
     }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -271,7 +271,7 @@ public:
 
     static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, GC::Ref<CSS::ComputedProperties>, Element*);
 
-    bool affected_by_hover() const;
+    [[nodiscard]] bool affected_by_pseudo_class(CSS::PseudoClass) const;
     bool includes_properties_from_invalidation_set(CSS::InvalidationSet const&) const;
 
     void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::PseudoElement, GC::Ptr<Layout::NodeWithStyle>);

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -49,7 +49,6 @@ enum class ShouldComputeRole {
 };
 
 #define ENUMERATE_STYLE_INVALIDATION_REASONS(X)     \
-    X(ActiveElementChange)                          \
     X(AdoptedStyleSheetsList)                       \
     X(CSSFontLoaded)                                \
     X(CSSImportRule)                                \
@@ -60,7 +59,6 @@ enum class ShouldComputeRole {
     X(EditingInsertion)                             \
     X(ElementAttributeChange)                       \
     X(ElementSetShadowRoot)                         \
-    X(FocusedElementChange)                         \
     X(HTMLHyperlinkElementHrefChange)               \
     X(HTMLIFrameElementGeometryChange)              \
     X(HTMLInputElementSetChecked)                   \
@@ -68,7 +66,6 @@ enum class ShouldComputeRole {
     X(HTMLObjectElementUpdateLayoutAndChildObjects) \
     X(HTMLOptionElementSelectedChange)              \
     X(HTMLSelectElementSetIsOpen)                   \
-    X(Hover)                                        \
     X(MediaListSetMediaText)                        \
     X(MediaListAppendMedium)                        \
     X(MediaListDeleteMedium)                        \
@@ -83,8 +80,7 @@ enum class ShouldComputeRole {
     X(StyleSheetDeleteRule)                         \
     X(StyleSheetInsertRule)                         \
     X(StyleSheetListAddSheet)                       \
-    X(StyleSheetListRemoveSheet)                    \
-    X(TargetElementChange)
+    X(StyleSheetListRemoveSheet)
 
 enum class StyleInvalidationReason {
 #define __ENUMERATE_STYLE_INVALIDATION_REASON(reason) reason,

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -223,7 +223,7 @@ WebIDL::ExceptionOr<void> HTMLDialogElement::show_a_modal_dialog(HTMLDialogEleme
     TRY(subject.set_attribute(AttributeNames::open, {}));
 
     // 12. Set is modal of subject to true.
-    subject.m_is_modal = true;
+    subject.set_is_modal(true);
 
     // FIXME: 13. Assert: subject's node document's open dialogs list does not contain subject.
     // FIXME: 14. Add subject to subject's node document's open dialogs list.
@@ -338,7 +338,7 @@ void HTMLDialogElement::close_the_dialog(Optional<String> result)
     // FIXME: 7. Let wasModal be the value of subject's is modal flag.
 
     // 8. Set the is modal flag of subject to false.
-    m_is_modal = false;
+    set_is_modal(false);
 
     // FIXME: 9. Remove subject from subject's node document's open dialogs list.
 
@@ -433,6 +433,14 @@ void HTMLDialogElement::run_dialog_focusing_steps()
 
     // FIXME: 9. Empty topDocument's autofocus candidates.
     // FIXME: 10. Set topDocument's autofocus processed flag to true.
+}
+
+void HTMLDialogElement::set_is_modal(bool is_modal)
+{
+    if (m_is_modal == is_modal)
+        return;
+    m_is_modal = is_modal;
+    invalidate_style(DOM::StyleInvalidationReason::NodeRemove);
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -37,6 +37,7 @@ public:
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::dialog; }
 
     bool is_modal() const { return m_is_modal; }
+    void set_is_modal(bool);
 
 private:
     HTMLDialogElement(DOM::Document&, DOM::QualifiedName);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -60,6 +60,7 @@ enum class PseudoClass {
         member_generator.appendln("    @name:titlecase@,");
     });
     generator.append(R"~~~(
+    __Count,
 };
 
 Optional<PseudoClass> pseudo_class_from_string(StringView);
@@ -123,6 +124,8 @@ Optional<PseudoClass> pseudo_class_from_string(StringView string)
 StringView pseudo_class_name(PseudoClass pseudo_class)
 {
     switch (pseudo_class) {
+    case PseudoClass::__Count:
+        VERIFY_NOT_REACHED();
 )~~~");
 
     pseudo_classes_data.for_each_member([&](auto& name, auto&) {
@@ -144,6 +147,8 @@ StringView pseudo_class_name(PseudoClass pseudo_class)
 PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
 {
     switch (pseudo_class) {
+    case PseudoClass::__Count:
+        VERIFY_NOT_REACHED();
 )~~~");
 
     pseudo_classes_data.for_each_member([&](auto& name, JsonValue const& value) {


### PR DESCRIPTION
The main theme here is taking the clever tricks we did for `:hover` and generalizing them for `:active`, `:focus`, `:focus-within`, `:focus-visible`, `:target`, and `:target-within` as well.

This gives us roughly a 5% speed-up on Speedometer 3.

It also exposed some under-invalidation in `HTMLDialogElement`, which we take care of.