### PR TITLE
CI: Use latest Ubuntu version on merge conflict labeler

### DIFF
--- a/.github/workflows/merge-conflict-labeler.yml
+++ b/.github/workflows/merge-conflict-labeler.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   auto-labeler:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
The example use (https://github.com/eps1lon/actions-label-merge-conflict?tab=readme-ov-file#example-usage) for this action uses Ubuntu-latest, which will keep it running on the latest version if an older version breaks it for some reason.