### PR TITLE
Reduce amount of dynamic_cast slowness on Speedometer

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2020-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2020-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021-2022, David Tuin <davidot@serenityos.org>
  *
@@ -102,6 +102,11 @@ public:
     virtual bool is_labelled_statement() const { return false; }
     virtual bool is_iteration_statement() const { return false; }
     virtual bool is_class_method() const { return false; }
+    virtual bool is_spread_expression() const { return false; }
+    virtual bool is_function_body() const { return false; }
+    virtual bool is_block_statement() const { return false; }
+    virtual bool is_primitive_literal() const { return false; }
+    virtual bool is_optional_chain() const { return false; }
 
 protected:
     explicit ASTNode(SourceRange);
@@ -573,6 +578,9 @@ public:
         : ScopeNode(move(source_range))
     {
     }
+
+private:
+    virtual bool is_block_statement() const override { return true; }
 };
 
 class FunctionBody final : public ScopeNode {
@@ -587,6 +595,8 @@ public:
     bool in_strict_mode() const { return m_in_strict_mode; }
 
 private:
+    virtual bool is_function_body() const override { return true; }
+
     bool m_in_strict_mode { false };
 };
 
@@ -1191,6 +1201,9 @@ protected:
         : Expression(move(source_range))
     {
     }
+
+private:
+    virtual bool is_primitive_literal() const override { return true; }
 };
 
 class BooleanLiteral final : public PrimitiveLiteral {
@@ -1533,6 +1546,8 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
 private:
+    virtual bool is_spread_expression() const override { return true; }
+
     NonnullRefPtr<Expression const> m_target;
 };
 
@@ -1995,6 +2010,8 @@ public:
     Vector<Reference> const& references() const { return m_references; }
 
 private:
+    virtual bool is_optional_chain() const override { return true; }
+
     NonnullRefPtr<Expression const> m_base;
     Vector<Reference> m_references;
 };
@@ -2287,5 +2304,20 @@ inline bool ASTNode::fast_is<IterationStatement>() const { return is_iteration_s
 
 template<>
 inline bool ASTNode::fast_is<ClassMethod>() const { return is_class_method(); }
+
+template<>
+inline bool ASTNode::fast_is<SpreadExpression>() const { return is_spread_expression(); }
+
+template<>
+inline bool ASTNode::fast_is<FunctionBody>() const { return is_function_body(); }
+
+template<>
+inline bool ASTNode::fast_is<BlockStatement>() const { return is_block_statement(); }
+
+template<>
+inline bool ASTNode::fast_is<PrimitiveLiteral>() const { return is_primitive_literal(); }
+
+template<>
+inline bool ASTNode::fast_is<OptionalChain>() const { return is_optional_chain(); }
 
 }

--- a/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Libraries/LibJS/Runtime/FunctionObject.h
@@ -50,4 +50,7 @@ private:
     virtual bool is_function() const override { return true; }
 };
 
+template<>
+inline bool Object::fast_is<FunctionObject>() const { return is_function(); }
+
 }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -191,6 +191,7 @@ public:
 
     virtual bool is_dom_node() const { return false; }
     virtual bool is_function() const { return false; }
+    virtual bool is_promise() const { return false; }
     virtual bool is_error() const { return false; }
     virtual bool is_date() const { return false; }
     virtual bool is_number_object() const { return false; }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -190,6 +190,11 @@ public:
     void define_native_accessor(Realm&, PropertyKey const&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> getter, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> setter, PropertyAttributes attributes);
 
     virtual bool is_dom_node() const { return false; }
+    virtual bool is_dom_event() const { return false; }
+    virtual bool is_html_window() const { return false; }
+    virtual bool is_html_window_proxy() const { return false; }
+    virtual bool is_html_location() const { return false; }
+
     virtual bool is_function() const { return false; }
     virtual bool is_promise() const { return false; }
     virtual bool is_error() const { return false; }

--- a/Libraries/LibJS/Runtime/Promise.h
+++ b/Libraries/LibJS/Runtime/Promise.h
@@ -54,6 +54,7 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
+    virtual bool is_promise() const override { return true; }
     bool is_settled() const { return m_state == State::Fulfilled || m_state == State::Rejected; }
 
     void trigger_reactions() const;
@@ -65,5 +66,8 @@ private:
     Vector<GC::Ptr<PromiseReaction>> m_reject_reactions;  // [[PromiseRejectReactions]]
     bool m_is_handled { false };                          // [[PromiseIsHandled]]
 };
+
+template<>
+inline bool Object::fast_is<Promise>() const { return is_promise(); }
 
 }

--- a/Libraries/LibJS/Runtime/Realm.h
+++ b/Libraries/LibJS/Runtime/Realm.h
@@ -30,6 +30,12 @@ public:
         virtual ~HostDefined() = default;
 
         virtual void visit_edges(Cell::Visitor&) { }
+
+        template<typename T>
+        bool fast_is() const = delete;
+
+        virtual bool is_principal_host_defined() const { return false; }
+        virtual bool is_synthetic_host_defined() const { return false; }
     };
 
     template<typename T, typename... Args>

--- a/Libraries/LibJS/Script.h
+++ b/Libraries/LibJS/Script.h
@@ -24,6 +24,14 @@ public:
         virtual ~HostDefined() = default;
 
         virtual void visit_host_defined_self(Cell::Visitor&) = 0;
+
+        template<typename T>
+        bool fast_is() const = delete;
+
+        virtual bool is_script() const { return false; }
+        virtual bool is_classic_script() const { return false; }
+        virtual bool is_module_script() const { return false; }
+        virtual bool is_javascript_module_script() const { return false; }
     };
 
     virtual ~Script() override;

--- a/Libraries/LibWeb/Bindings/Intrinsics.cpp
+++ b/Libraries/LibWeb/Bindings/Intrinsics.cpp
@@ -31,8 +31,8 @@ bool Intrinsics::is_exposed(StringView name) const
 
 Intrinsics& host_defined_intrinsics(JS::Realm& realm)
 {
-    VERIFY(realm.host_defined());
-    return as<Bindings::HostDefined>(*realm.host_defined()).intrinsics;
+    ASSERT(realm.host_defined());
+    return static_cast<Bindings::HostDefined&>(*realm.host_defined()).intrinsics;
 }
 
 }

--- a/Libraries/LibWeb/Bindings/PrincipalHostDefined.h
+++ b/Libraries/LibWeb/Bindings/PrincipalHostDefined.h
@@ -14,7 +14,7 @@
 
 namespace Web::Bindings {
 
-struct PrincipalHostDefined : public HostDefined {
+struct PrincipalHostDefined final : public HostDefined {
     PrincipalHostDefined(GC::Ref<HTML::EnvironmentSettingsObject> eso, GC::Ref<Intrinsics> intrinsics, GC::Ref<Page> page)
         : HostDefined(intrinsics)
         , environment_settings_object(eso)
@@ -23,6 +23,7 @@ struct PrincipalHostDefined : public HostDefined {
     }
     virtual ~PrincipalHostDefined() override = default;
     virtual void visit_edges(JS::Cell::Visitor& visitor) override;
+    virtual bool is_principal_host_defined() const override { return true; }
 
     GC::Ref<HTML::EnvironmentSettingsObject> environment_settings_object;
     GC::Ref<Page> page;
@@ -44,3 +45,6 @@ struct PrincipalHostDefined : public HostDefined {
 }
 
 }
+
+template<>
+inline bool JS::Realm::HostDefined::fast_is<Web::Bindings::PrincipalHostDefined>() const { return is_principal_host_defined(); }

--- a/Libraries/LibWeb/Bindings/SyntheticHostDefined.h
+++ b/Libraries/LibWeb/Bindings/SyntheticHostDefined.h
@@ -13,7 +13,7 @@
 
 namespace Web::Bindings {
 
-struct SyntheticHostDefined : public HostDefined {
+struct SyntheticHostDefined final : public HostDefined {
     SyntheticHostDefined(HTML::SyntheticRealmSettings synthetic_realm_settings, GC::Ref<Intrinsics> intrinsics)
         : HostDefined(intrinsics)
         , synthetic_realm_settings(move(synthetic_realm_settings))
@@ -22,8 +22,12 @@ struct SyntheticHostDefined : public HostDefined {
 
     virtual ~SyntheticHostDefined() override = default;
     virtual void visit_edges(JS::Cell::Visitor& visitor) override;
+    virtual bool is_synthetic_host_defined() const override { return true; }
 
     HTML::SyntheticRealmSettings synthetic_realm_settings;
 };
 
 }
+
+template<>
+inline bool JS::Realm::HostDefined::fast_is<Web::Bindings::SyntheticHostDefined>() const { return is_synthetic_host_defined(); }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -67,7 +67,7 @@ bool CSSRGB::equals(CSSStyleValue const& other) const
     auto const& other_color = other.as_color();
     if (color_type() != other_color.color_type())
         return false;
-    auto const& other_rgb = as<CSSRGB>(other_color);
+    auto const& other_rgb = static_cast<CSSRGB const&>(other_color);
     return m_properties == other_rgb.m_properties;
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6029,7 +6029,7 @@ void Document::for_each_shadow_root(Function<void(DOM::ShadowRoot&)>&& callback)
 
 bool Document::is_decoded_svg() const
 {
-    return is<Web::SVG::SVGDecodedImageData::SVGPageClient>(page().client());
+    return page().client().is_svg_page_client();
 }
 
 // https://drafts.csswg.org/css-position-4/#add-an-element-to-the-top-layer

--- a/Libraries/LibWeb/DOM/Event.h
+++ b/Libraries/LibWeb/DOM/Event.h
@@ -159,6 +159,8 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
+    virtual bool is_dom_event() const final { return true; }
+
     FlyString m_type;
     GC::Ptr<EventTarget> m_target;
     GC::Ptr<EventTarget> m_related_target;
@@ -188,3 +190,6 @@ private:
 };
 
 }
+
+template<>
+inline bool JS::Object::fast_is<Web::DOM::Event>() const { return is_dom_event(); }

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -67,7 +67,7 @@ void EventTarget::initialize(JS::Realm& realm)
 
     // FIXME: We can't do this for HTML::Window or HTML::WorkerGlobalScope, as this will run when creating the initial global object.
     //        During this time, the ESO is not setup, so it will cause a nullptr dereference in host_defined_intrinsics.
-    if (!is<HTML::WindowOrWorkerGlobalScopeMixin>(this))
+    if (!is_window_or_worker_global_scope_mixin())
         WEB_SET_PROTOTYPE_FOR_INTERFACE(EventTarget);
 }
 

--- a/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Libraries/LibWeb/DOM/EventTarget.h
@@ -59,6 +59,8 @@ public:
     bool has_event_listener(FlyString const& type) const;
     bool has_event_listeners() const;
 
+    virtual bool is_window_or_worker_global_scope_mixin() const { return false; }
+
 protected:
     explicit EventTarget(JS::Realm&, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -144,6 +144,8 @@ public:
     virtual bool is_svg_style_element() const { return false; }
     virtual bool is_svg_svg_element() const { return false; }
     virtual bool is_svg_use_element() const { return false; }
+    virtual bool is_svg_a_element() const { return false; }
+    virtual bool is_svg_foreign_object_element() const { return false; }
 
     bool in_a_document_tree() const;
 
@@ -158,10 +160,13 @@ public:
     virtual bool is_html_element() const { return false; }
     virtual bool is_html_html_element() const { return false; }
     virtual bool is_html_anchor_element() const { return false; }
+    virtual bool is_html_area_element() const { return false; }
     virtual bool is_html_base_element() const { return false; }
     virtual bool is_html_body_element() const { return false; }
+    virtual bool is_html_head_element() const { return false; }
     virtual bool is_html_input_element() const { return false; }
     virtual bool is_html_link_element() const { return false; }
+    virtual bool is_html_media_element() const { return false; }
     virtual bool is_html_progress_element() const { return false; }
     virtual bool is_html_script_element() const { return false; }
     virtual bool is_html_style_element() const { return false; }
@@ -170,6 +175,7 @@ public:
     virtual bool is_html_table_section_element() const { return false; }
     virtual bool is_html_table_row_element() const { return false; }
     virtual bool is_html_table_cell_element() const { return false; }
+    virtual bool is_html_title_element() const { return false; }
     virtual bool is_html_br_element() const { return false; }
     virtual bool is_html_button_element() const { return false; }
     virtual bool is_html_slot_element() const { return false; }
@@ -178,6 +184,8 @@ public:
     virtual bool is_html_form_element() const { return false; }
     virtual bool is_html_image_element() const { return false; }
     virtual bool is_html_iframe_element() const { return false; }
+    virtual bool is_html_frameset_element() const { return false; }
+    virtual bool is_html_fieldset_element() const { return false; }
     virtual bool is_navigable_container() const { return false; }
     virtual bool is_lazy_loading() const { return false; }
 

--- a/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -25,6 +25,8 @@ public:
 private:
     HTMLAreaElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_area_element() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -58,4 +60,9 @@ private:
     GC::Ptr<DOM::DOMTokenList> m_rel_list;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLAreaElement>() const { return is_html_area_element(); }
 }

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -54,7 +54,14 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual bool is_html_fieldset_element() const override { return true; }
+
     GC::Ptr<DOM::HTMLCollection> m_elements;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLFieldSetElement>() const { return is_html_fieldset_element(); }
 }

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -24,6 +24,8 @@ public:
 private:
     HTMLFrameSetElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_frameset_element() const override { return true; }
+
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
     virtual void initialize(JS::Realm&) override;
@@ -36,4 +38,9 @@ private:
     virtual GC::Ptr<EventTarget> window_event_handlers_to_event_target() override;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLFrameSetElement>() const { return is_html_frameset_element(); }
 }

--- a/Libraries/LibWeb/HTML/HTMLHeadElement.h
+++ b/Libraries/LibWeb/HTML/HTMLHeadElement.h
@@ -20,7 +20,13 @@ public:
 private:
     HTMLHeadElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_head_element() const final { return true; }
     virtual void initialize(JS::Realm&) override;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLHeadElement>() const { return is_html_head_element(); }
 }

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -69,3 +69,8 @@ private:
 void run_iframe_load_event_steps(HTML::HTMLIFrameElement&);
 
 }
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLIFrameElement>() const { return is_html_iframe_element(); }
+}

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -182,6 +182,8 @@ protected:
 private:
     friend SourceElementSelector;
 
+    virtual bool is_html_media_element() const final { return true; }
+
     struct EntireResource { };
     using ByteRange = Variant<EntireResource>; // FIXME: This will need to include "until end" and an actual byte range.
 
@@ -323,4 +325,9 @@ private:
     mutable CachedLayoutBoxes m_layout_boxes;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLMediaElement>() const { return is_html_media_element(); }
 }

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.h
@@ -23,8 +23,14 @@ public:
 private:
     HTMLTitleElement(DOM::Document&, DOM::QualifiedName);
 
+    virtual bool is_html_title_element() const override { return true; }
     virtual void initialize(JS::Realm&) override;
     virtual void children_changed(ChildrenChangedMetadata const*) override;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLTitleElement>() const { return is_html_title_element(); }
 }

--- a/Libraries/LibWeb/HTML/Location.h
+++ b/Libraries/LibWeb/HTML/Location.h
@@ -71,6 +71,8 @@ public:
 private:
     explicit Location(JS::Realm&);
 
+    virtual bool is_html_location() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -86,3 +88,6 @@ private:
 };
 
 }
+
+template<>
+inline bool JS::Object::fast_is<Web::HTML::Location>() const { return is_html_location(); }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -99,11 +99,6 @@ Vector<GC::Root<Navigable>> Navigable::child_navigables() const
     return results;
 }
 
-bool Navigable::is_traversable() const
-{
-    return is<TraversableNavigable>(*this);
-}
-
 bool Navigable::is_ancestor_of(GC::Ref<Navigable> other) const
 {
     for (auto ancestor = other->parent(); ancestor; ancestor = ancestor->parent()) {

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -52,7 +52,7 @@ public:
 
     Vector<GC::Root<Navigable>> child_navigables() const;
 
-    bool is_traversable() const;
+    virtual bool is_traversable() const { return false; }
 
     String const& id() const { return m_id; }
     GC::Ptr<Navigable> parent() const { return m_parent; }
@@ -187,6 +187,9 @@ public:
     void set_has_session_history_entry_and_ready_for_navigation();
 
     bool has_pending_navigations() const { return !m_pending_navigations.is_empty(); }
+
+    template<typename T>
+    bool fast_is() const = delete;
 
 protected:
     explicit Navigable(GC::Ref<Page>);

--- a/Libraries/LibWeb/HTML/Scripting/Agent.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Agent.cpp
@@ -15,7 +15,7 @@ Agent& relevant_agent(JS::Object const& object)
 {
     // The relevant agent for a platform object platformObject is platformObject's relevant Realm's agent.
     // Spec Note: This pointer is not yet defined in the JavaScript specification; see tc39/ecma262#1357.
-    return as<Bindings::WebEngineCustomData>(relevant_realm(object).vm().custom_data())->agent;
+    return static_cast<Bindings::WebEngineCustomData*>(relevant_realm(object).vm().custom_data())->agent;
 }
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -40,6 +40,8 @@ public:
 private:
     ClassicScript(URL::URL base_url, ByteString filename, JS::Realm&);
 
+    virtual bool is_classic_script() const final { return true; }
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     GC::Ptr<JS::Script> m_script_record;
@@ -47,3 +49,6 @@ private:
 };
 
 }
+
+template<>
+inline bool JS::Script::HostDefined::fast_is<Web::HTML::ClassicScript>() const { return is_classic_script(); }

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
@@ -20,6 +20,9 @@ public:
 
 protected:
     ModuleScript(URL::URL base_url, ByteString filename, JS::Realm&);
+
+private:
+    virtual bool is_module_script() const final { return true; }
 };
 
 class JavaScriptModuleScript final : public ModuleScript {
@@ -45,6 +48,7 @@ protected:
     JavaScriptModuleScript(URL::URL base_url, ByteString filename, JS::Realm&);
 
 private:
+    virtual bool is_javascript_module_script() const final { return true; }
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     GC::Ptr<JS::SourceTextModule> m_record;
@@ -56,3 +60,9 @@ private:
 };
 
 }
+
+template<>
+inline bool JS::Script::HostDefined::fast_is<Web::HTML::ModuleScript>() const { return is_module_script(); }
+
+template<>
+inline bool JS::Script::HostDefined::fast_is<Web::HTML::JavaScriptModuleScript>() const { return is_javascript_module_script(); }

--- a/Libraries/LibWeb/HTML/Scripting/Script.h
+++ b/Libraries/LibWeb/HTML/Scripting/Script.h
@@ -42,6 +42,7 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
+    virtual bool is_script() const final { return true; }
     virtual void visit_host_defined_self(JS::Cell::Visitor&) override;
 
     Optional<URL::URL> m_base_url;
@@ -56,3 +57,6 @@ private:
 };
 
 }
+
+template<>
+inline bool JS::Script::HostDefined::fast_is<Web::HTML::Script>() const { return is_script(); }

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -120,6 +120,8 @@ public:
 private:
     TraversableNavigable(GC::Ref<Page>);
 
+    virtual bool is_traversable() const override { return true; }
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     // FIXME: Fix spec typo cancelation --> cancellation
@@ -174,5 +176,8 @@ struct BrowsingContextAndDocument {
 
 WebIDL::ExceptionOr<BrowsingContextAndDocument> create_a_new_top_level_browsing_context_and_document(GC::Ref<Page> page);
 void finalize_a_same_document_navigation(GC::Ref<TraversableNavigable> traversable, GC::Ref<Navigable> target_navigable, GC::Ref<SessionHistoryEntry> target_entry, GC::Ptr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
+
+template<>
+inline bool Navigable::fast_is<TraversableNavigable>() const { return is_traversable(); }
 
 }

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -269,6 +269,8 @@ public:
 private:
     explicit Window(JS::Realm&);
 
+    virtual bool is_window_or_worker_global_scope_mixin() const final { return true; }
+
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
 

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -274,6 +274,8 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
 
+    virtual bool is_html_window() const override { return true; }
+
     // ^HTML::GlobalEventHandlers
     virtual GC::Ptr<DOM::EventTarget> global_event_handlers_to_event_target(FlyString const&) override { return *this; }
 
@@ -356,3 +358,6 @@ private:
 void run_animation_frame_callbacks(DOM::Document&, double now);
 
 }
+
+template<>
+inline bool JS::Object::fast_is<Web::HTML::Window>() const { return is_html_window(); }

--- a/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Libraries/LibWeb/HTML/WindowProxy.h
@@ -40,6 +40,7 @@ public:
 private:
     explicit WindowProxy(JS::Realm&);
 
+    virtual bool is_html_window_proxy() const override { return true; }
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     // [[Window]], https://html.spec.whatwg.org/multipage/window-object.html#concept-windowproxy-window
@@ -47,3 +48,6 @@ private:
 };
 
 }
+
+template<>
+inline bool JS::Object::fast_is<Web::HTML::WindowProxy>() const { return is_html_window_proxy(); }

--- a/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -112,6 +112,8 @@ protected:
     GC::Ptr<MessagePort> m_internal_port;
 
 private:
+    virtual bool is_window_or_worker_global_scope_mixin() const final { return true; }
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     GC::Ptr<WorkerLocation> m_location;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -101,6 +101,7 @@ public:
     virtual bool is_svg_geometry_box() const { return false; }
     virtual bool is_svg_mask_box() const { return false; }
     virtual bool is_svg_svg_box() const { return false; }
+    virtual bool is_svg_graphics_box() const { return false; }
     virtual bool is_label() const { return false; }
     virtual bool is_replaced_box() const { return false; }
     virtual bool is_list_item_box() const { return false; }
@@ -108,6 +109,7 @@ public:
     virtual bool is_fieldset_box() const { return false; }
     virtual bool is_legend_box() const { return false; }
     virtual bool is_table_wrapper() const { return false; }
+    virtual bool is_node_with_style() const { return false; }
     virtual bool is_node_with_style_and_box_model_metrics() const { return false; }
 
     template<typename T>
@@ -245,12 +247,17 @@ protected:
     NodeWithStyle(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
 
 private:
+    virtual bool is_node_with_style() const final { return true; }
+
     void reset_table_box_computed_values_used_by_wrapper_to_init_values();
     void propagate_style_to_anonymous_wrappers();
 
     NonnullOwnPtr<CSS::ComputedValues> m_computed_values;
     RefPtr<CSS::AbstractImageStyleValue const> m_list_style_image;
 };
+
+template<>
+inline bool Node::fast_is<NodeWithStyle>() const { return is_node_with_style(); }
 
 class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {
     GC_CELL(NodeWithStyleAndBoxModelMetrics, NodeWithStyle);

--- a/Libraries/LibWeb/Layout/SVGGraphicsBox.h
+++ b/Libraries/LibWeb/Layout/SVGGraphicsBox.h
@@ -23,6 +23,12 @@ public:
     SVG::SVGGraphicsElement const& dom_node() const { return as<SVG::SVGGraphicsElement>(SVGBox::dom_node()); }
 
     virtual GC::Ptr<Painting::Paintable> create_paintable() const override;
+
+private:
+    virtual bool is_svg_graphics_box() const override { return true; }
 };
+
+template<>
+inline bool Node::fast_is<SVGGraphicsBox>() const { return is_svg_graphics_box(); }
 
 }

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -74,7 +74,8 @@ static bool parent_element_for_event_dispatch(Painting::Paintable& paintable, GC
 
     auto* current_ancestor_node = node.ptr();
     do {
-        if (is<HTML::FormAssociatedElement>(current_ancestor_node) && !dynamic_cast<HTML::FormAssociatedElement*>(current_ancestor_node)->enabled()) {
+        auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(current_ancestor_node);
+        if (form_associated_element && !form_associated_element->enabled()) {
             return false;
         }
     } while ((current_ancestor_node = current_ancestor_node->parent()));

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -408,6 +408,8 @@ public:
 
     virtual bool is_headless() const = 0;
 
+    virtual bool is_svg_page_client() const { return false; }
+
 protected:
     virtual ~PageClient() = default;
 };

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -125,6 +125,7 @@ public:
     [[nodiscard]] virtual bool is_paintable_box() const { return false; }
     [[nodiscard]] virtual bool is_paintable_with_lines() const { return false; }
     [[nodiscard]] virtual bool is_svg_paintable() const { return false; }
+    [[nodiscard]] virtual bool is_svg_svg_paintable() const { return false; }
     [[nodiscard]] virtual bool is_text_paintable() const { return false; }
 
     DOM::Document const& document() const;

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.h
@@ -28,6 +28,12 @@ public:
 
 protected:
     SVGSVGPaintable(Layout::SVGSVGBox const&);
+
+private:
+    virtual bool is_svg_svg_paintable() const final { return true; }
 };
+
+template<>
+inline bool Paintable::fast_is<SVGSVGPaintable>() const { return is_svg_svg_paintable(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGAElement.h
+++ b/Libraries/LibWeb/SVG/SVGAElement.h
@@ -31,6 +31,8 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual bool is_svg_a_element() const override { return true; }
+
     // ^DOM::Element
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
@@ -38,4 +40,9 @@ private:
     GC::Ptr<DOM::DOMTokenList> m_rel_list;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<SVG::SVGAElement>() const { return is_svg_a_element(); }
 }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -92,6 +92,8 @@ private:
     {
     }
 
+    virtual bool is_svg_page_client() const override { return true; }
+
     virtual void visit_edges(Visitor&) override;
 };
 

--- a/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
+++ b/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
@@ -28,6 +28,8 @@ public:
 private:
     SVGForeignObjectElement(DOM::Document& document, DOM::QualifiedName qualified_name);
 
+    virtual bool is_svg_foreign_object_element() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -40,4 +42,9 @@ private:
     GC::Ptr<SVG::SVGAnimatedLength> m_height;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<SVG::SVGForeignObjectElement>() const { return is_svg_foreign_object_element(); }
 }


### PR DESCRIPTION
For this set of changes, I set debugger breakpoints on our uses of `dynamic_cast` and took steps to avoid the most common ones hit by the Speedometer 3 benchmark.

This saves just over 1% of CPU time that we were spending on `dynamic_cast` according to Instruments.