### PR TITLE
LibWeb/HTML: Correctly parse milliseconds in time inputs

### DIFF
--- a/Libraries/LibWeb/HTML/Dates.h
+++ b/Libraries/LibWeb/HTML/Dates.h
@@ -43,7 +43,7 @@ struct YearMonthDay {
 struct HourMinuteSecond {
     i32 hour;
     i32 minute;
-    i32 second;
+    f32 second;
 };
 
 struct DateAndTime {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2209,7 +2209,7 @@ static Optional<double> convert_local_date_and_time_string_to_number(StringView 
     auto date = date_and_time.date;
     auto time = date_and_time.time;
 
-    auto date_time = UnixDateTime::from_unix_time_parts(date.year, date.month, date.day, time.hour, time.minute, time.second, 0);
+    auto date_time = UnixDateTime::from_unix_time_parts(date.year, date.month, date.day, time.hour, time.minute, time.second, static_cast<i32>(time.second * 1000) % 1000);
     return date_time.milliseconds_since_epoch();
 }
 

--- a/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-invalid-time-digits.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-invalid-time-digits.txt
@@ -1,1 +1,6 @@
+Parsed invalid as NaN
+Parsed xx:34:56 as NaN
+Parsed 12:xx:56 as NaN
+Parsed 12:34:xx as NaN
+Parsed 12:34:60 as NaN
 PASS (didn't crash)

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeOverflow.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeOverflow.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 49 tests
 
-43 Pass
-6 Fail
+49 Pass
 Pass	[INPUT in DATETIME-LOCAL status] The max attribute is not set
 Pass	[INPUT in DATETIME-LOCAL status] Value is empty string
 Pass	[INPUT in DATETIME-LOCAL status] The max attribute is an invalid local date time string
@@ -11,9 +10,9 @@ Pass	[INPUT in DATETIME-LOCAL status] The max attribute is greater than the valu
 Pass	[INPUT in DATETIME-LOCAL status] The value is an invalid local date time string(hour is greater than 23)
 Pass	[INPUT in DATETIME-LOCAL status] The value if an invalid local date time string(year is two digits)
 Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max
-Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 1 digit)
-Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 2 digits)
-Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 3 digits)
+Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 1 digit)
+Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 2 digits)
+Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 3 digits)
 Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max(Year is 10000 should be valid)
 Pass	[INPUT in DATE status] The max attribute is not set
 Pass	[INPUT in DATE status] Value is empty string
@@ -35,9 +34,9 @@ Pass	[INPUT in TIME status] The value attribute is an invalid time string(second
 Pass	[INPUT in TIME status] The max attribute is greater than value attribute
 Pass	[INPUT in TIME status] The time missing second and minute parts is invalid
 Pass	[INPUT in TIME status] The value attribute is greater than max attribute
-Fail	[INPUT in TIME status] The value is greater than max(with millisecond in 1 digit)
-Fail	[INPUT in TIME status] The value is greater than max(with millisecond in 2 digit)
-Fail	[INPUT in TIME status] The value is greater than max(with millisecond in 3 digit)
+Pass	[INPUT in TIME status] The value is greater than max(with millisecond in 1 digit)
+Pass	[INPUT in TIME status] The value is greater than max(with millisecond in 2 digit)
+Pass	[INPUT in TIME status] The value is greater than max(with millisecond in 3 digit)
 Pass	[INPUT in TIME status] The time missing second part is valid
 Pass	[INPUT in TIME status] The time is max for reversed range
 Pass	[INPUT in TIME status] The time is outside the accepted range for reversed range

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeUnderflow.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeUnderflow.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 47 tests
 
-41 Pass
-6 Fail
+47 Pass
 Pass	[INPUT in DATETIME-LOCAL status] The min attribute is not set
 Pass	[INPUT in DATETIME-LOCAL status] Value is empty string
 Pass	[INPUT in DATETIME-LOCAL status] The min attribute is an invalid local date time string
@@ -11,9 +10,9 @@ Pass	[INPUT in DATETIME-LOCAL status] The min attribute is less than the value a
 Pass	[INPUT in DATETIME-LOCAL status] The value is an invalid local date time string(hour is greater than 23)
 Pass	[INPUT in DATETIME-LOCAL status] The value is an invalid local date time string(year is two digits)
 Pass	[INPUT in DATETIME-LOCAL status] The value is less than min
-Fail	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 1 digit)
-Fail	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 2 digits)
-Fail	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 3 digits)
+Pass	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 1 digit)
+Pass	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 2 digits)
+Pass	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 3 digits)
 Pass	[INPUT in DATETIME-LOCAL status] The value is less than min(Year is 10000 should be valid)
 Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max
 Pass	[INPUT in DATE status] The min attribute is not set
@@ -33,9 +32,9 @@ Pass	[INPUT in TIME status] The value attribute is an invalid time string
 Pass	[INPUT in TIME status] The min attribute is less than value attribute
 Pass	[INPUT in TIME status] The time missing second and minute parts is invalid
 Pass	[INPUT in TIME status] The value attribute is less than min attribute
-Fail	[INPUT in TIME status] The value is less than min(with millisecond in 1 digit)
-Fail	[INPUT in TIME status] The value is less than min(with millisecond in 2 digit)
-Fail	[INPUT in TIME status] The value is less than min(with millisecond in 3 digit)
+Pass	[INPUT in TIME status] The value is less than min(with millisecond in 1 digit)
+Pass	[INPUT in TIME status] The value is less than min(with millisecond in 2 digit)
+Pass	[INPUT in TIME status] The value is less than min(with millisecond in 3 digit)
 Pass	[INPUT in TIME status] The time missing second part is valid
 Pass	[INPUT in TIME status] The time is max for reversed range
 Pass	[INPUT in TIME status] The time is outside the accepted range for reversed range

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/input-seconds-leading-zeroes.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/input-seconds-leading-zeroes.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 12 tests
+
+12 Pass
+Pass	Expected valueAsNumber=946729801000 from 2000-01-01T12:30:01
+Pass	Expected digits unchanged in round-trip of 2000-01-01T12:30:01
+Pass	Expected valueAsNumber=946729800500 from 2000-01-01T12:30:00.5
+Pass	Expected digits unchanged in round-trip of 2000-01-01T12:30:00.5
+Pass	Expected valueAsNumber=946729800040 from 2000-01-01T12:30:00.04
+Pass	Expected digits unchanged in round-trip of 2000-01-01T12:30:00.04
+Pass	Expected valueAsNumber=946729800003 from 2000-01-01T12:30:00.003
+Pass	Expected digits unchanged in round-trip of 2000-01-01T12:30:00.003
+Pass	Expected valueAsNumber=45001000 from 12:30:01
+Pass	Expected valueAsNumber=45000500 from 12:30:00.5
+Pass	Expected valueAsNumber=45000040 from 12:30:00.04
+Pass	Expected valueAsNumber=45000003 from 12:30:00.003

--- a/Tests/LibWeb/Text/input/HTML/HTMLInputElement-invalid-time-digits.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLInputElement-invalid-time-digits.html
@@ -4,10 +4,10 @@
     test(() => {
         const inputElement = document.createElement("input");
         inputElement.type = "time";
-        inputElement.value = "invalid";
-        inputElement.value = "xx:34:56";
-        inputElement.value = "12:xx:56";
-        inputElement.value = "12:34:xx";
+        ["invalid", "xx:34:56", "12:xx:56", "12:34:xx", "12:34:60"].forEach(value => {
+            inputElement.value = value;
+            println(`Parsed ${value} as ${inputElement.valueAsNumber}`);
+        });
         println("PASS (didn't crash)");
     });
 </script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/input-seconds-leading-zeroes.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/input-seconds-leading-zeroes.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<html>
+ <head>
+  <title>HTMLInputElement leading zeroes in seconds/millis</title>
+  <script src="../../../../resources/testharness.js"></script>
+  <script src="../../../../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <h3>input times and datetimes with leading zeroes in seconds/millis</h3>
+  <!-- This test ensures that seconds and milliseconds are being
+       output with the appropriate field widths when sanitizing
+       datetime-locals and times, e.g. that we don't see "12:30:1".
+       The spec is not specific about how much precision to use
+       in a sanitized time string, but an invalid string would
+       fail at .valueAsNumber -->
+  <hr>
+  <div id="log"></div>
+
+  <input id="inp">
+  <script>
+    var inp=document.getElementById("inp");
+    var cases = [
+      ["datetime-local", "2000-01-01T12:30:01",     946729801000],
+      ["datetime-local", "2000-01-01T12:30:00.5",   946729800500],
+      ["datetime-local", "2000-01-01T12:30:00.04",  946729800040],
+      ["datetime-local", "2000-01-01T12:30:00.003", 946729800003],
+
+      ["time", "12:30:01",     45001000],
+      ["time", "12:30:00.5",   45000500],
+      ["time", "12:30:00.04",  45000040],
+      ["time", "12:30:00.003", 45000003],
+    ];
+
+    for (var i in cases) {
+      var c = cases[i];
+      test(function() {
+        inp.setAttribute("type", c[0]);
+        inp.value = c[1];
+        assert_equals(inp.valueAsNumber, c[2]);
+      },"Expected valueAsNumber=" +c[2] + " from " + c[1]);
+      if (c[0] == "datetime-local") {
+        test(function() {
+          inp.setAttribute("type", c[0]);
+          inp.value = c[1];
+          assert_in_array(inp.value, [c[1], c[1].replace("T", " ")]);
+        },"Expected digits unchanged in round-trip of " + c[1])
+      }
+    }
+  </script>
+ </body>
+</html>


### PR DESCRIPTION
This brings the way we parse time inputs closer to the spec by no longer ignoring milliseconds in time strings.