### PR TITLE
LibURL: Remove URL's valid state 

### DIFF
--- a/Libraries/LibCore/Proxy.h
+++ b/Libraries/LibCore/Proxy.h
@@ -27,9 +27,6 @@ struct ProxyData {
 
     static ErrorOr<ProxyData> parse_url(URL::URL const& url)
     {
-        if (!url.is_valid())
-            return Error::from_string_literal("Invalid proxy URL");
-
         ProxyData proxy_data;
         if (url.scheme() != "socks5")
             return Error::from_string_literal("Unsupported proxy type");

--- a/Libraries/LibURL/Parser.cpp
+++ b/Libraries/LibURL/Parser.cpp
@@ -1663,7 +1663,6 @@ Optional<URL> Parser::basic_parse(StringView raw_input, Optional<URL const&> bas
         ++iterator;
     }
 
-    url->m_data->valid = true;
     dbgln_if(URL_PARSER_DEBUG, "URL::Parser::basic_parse: Parsed URL to be '{}'.", url->serialize());
 
     // 10. Return url.

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -169,15 +169,19 @@ URL create_with_file_scheme(ByteString const& path, ByteString const& fragment, 
     if (!lexical_path.is_absolute())
         return {};
 
-    URL url;
-    url.set_scheme("file"_string);
-    url.set_host(hostname == "localhost" ? String {} : String::from_byte_string(hostname).release_value_but_fixme_should_propagate_errors());
-    url.set_paths(lexical_path.parts());
+    StringBuilder url_builder;
+    url_builder.append("file://"sv);
+    url_builder.append(hostname);
+    url_builder.append(lexical_path.string());
     if (path.ends_with('/'))
-        url.append_slash();
-    if (!fragment.is_empty())
-        url.set_fragment(String::from_byte_string(fragment).release_value_but_fixme_should_propagate_errors());
-    return url;
+        url_builder.append('/');
+    if (!fragment.is_empty()) {
+        url_builder.append('#');
+        url_builder.append(fragment);
+    }
+
+    auto url = Parser::basic_parse(url_builder.string_view());
+    return url.has_value() ? url.release_value() : URL {};
 }
 
 URL create_with_url_or_path(ByteString const& url_or_path)

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -24,9 +24,6 @@ namespace URL {
 
 Optional<URL> URL::complete_url(StringView relative_url) const
 {
-    if (!is_valid())
-        return {};
-
     return Parser::basic_parse(relative_url, *this);
 }
 
@@ -38,8 +35,6 @@ ByteString URL::path_segment_at_index(size_t index) const
 
 ByteString URL::basename() const
 {
-    if (!m_data->valid)
-        return {};
     if (m_data->paths.is_empty())
         return {};
     auto& last_segment = m_data->paths.last();
@@ -49,7 +44,6 @@ ByteString URL::basename() const
 void URL::set_scheme(String scheme)
 {
     m_data->scheme = move(scheme);
-    m_data->valid = compute_validity();
 }
 
 // https://url.spec.whatwg.org/#set-the-username
@@ -57,7 +51,6 @@ void URL::set_username(StringView username)
 {
     // To set the username given a url and username, set url’s username to the result of running UTF-8 percent-encode on username using the userinfo percent-encode set.
     m_data->username = percent_encode(username, PercentEncodeSet::Userinfo);
-    m_data->valid = compute_validity();
 }
 
 // https://url.spec.whatwg.org/#set-the-password
@@ -65,13 +58,11 @@ void URL::set_password(StringView password)
 {
     // To set the password given a url and password, set url’s password to the result of running UTF-8 percent-encode on password using the userinfo percent-encode set.
     m_data->password = percent_encode(password, PercentEncodeSet::Userinfo);
-    m_data->valid = compute_validity();
 }
 
 void URL::set_host(Host host)
 {
     m_data->host = move(host);
-    m_data->valid = compute_validity();
 }
 
 // https://url.spec.whatwg.org/#concept-host-serializer
@@ -87,7 +78,6 @@ void URL::set_port(Optional<u16> port)
         return;
     }
     m_data->port = move(port);
-    m_data->valid = compute_validity();
 }
 
 void URL::set_paths(Vector<ByteString> const& paths)
@@ -96,7 +86,6 @@ void URL::set_paths(Vector<ByteString> const& paths)
     m_data->paths.ensure_capacity(paths.size());
     for (auto const& segment : paths)
         m_data->paths.unchecked_append(percent_encode(segment, PercentEncodeSet::Path));
-    m_data->valid = compute_validity();
 }
 
 void URL::append_path(StringView path)
@@ -110,33 +99,6 @@ bool URL::cannot_have_a_username_or_password_or_port() const
     // A URL cannot have a username/password/port if its host is null or the empty string, or its scheme is "file".
 
     return !m_data->host.has_value() || m_data->host->is_empty_host() || m_data->scheme == "file"sv;
-}
-
-// FIXME: This is by no means complete.
-// NOTE: This relies on some assumptions about how the spec-defined URL parser works that may turn out to be wrong.
-bool URL::compute_validity() const
-{
-    if (m_data->scheme.is_empty())
-        return false;
-
-    if (m_data->has_an_opaque_path) {
-        if (m_data->paths.size() != 1)
-            return false;
-        if (m_data->paths[0].is_empty())
-            return false;
-    } else {
-        if (m_data->scheme.is_one_of("about", "mailto"))
-            return false;
-        // NOTE: Maybe it is allowed to have a zero-segment path.
-        if (m_data->paths.size() == 0)
-            return false;
-    }
-
-    // FIXME: A file URL's host should be the empty string for localhost, not null.
-    if (m_data->scheme == "file" && !m_data->host.has_value())
-        return false;
-
-    return true;
 }
 
 // https://url.spec.whatwg.org/#default-port
@@ -333,8 +295,6 @@ String URL::serialize(ExcludeFragment exclude_fragment) const
 //        resulting from percent-decoding those sequences converted to bytes, unless that renders those sequences invisible.
 ByteString URL::serialize_for_display() const
 {
-    VERIFY(m_data->valid);
-
     StringBuilder builder;
     builder.append(m_data->scheme);
     builder.append(':');
@@ -422,8 +382,6 @@ bool URL::equals(URL const& other, ExcludeFragment exclude_fragments) const
 {
     if (this == &other)
         return true;
-    if (!m_data->valid || !other.m_data->valid)
-        return false;
     return serialize(exclude_fragments) == other.serialize(exclude_fragments);
 }
 
@@ -495,7 +453,6 @@ String percent_encode(StringView input, PercentEncodeSet set, SpaceAsPlus space_
 URL URL::about(String path)
 {
     URL url;
-    url.m_data->valid = true;
     url.m_data->scheme = "about"_string;
     url.m_data->paths = { move(path) };
     url.m_data->has_an_opaque_path = true;

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -163,7 +163,7 @@ Optional<u16> default_port_for_scheme(StringView scheme)
     return {};
 }
 
-URL create_with_file_scheme(ByteString const& path, ByteString const& fragment, ByteString const& hostname)
+Optional<URL> create_with_file_scheme(ByteString const& path, ByteString const& fragment, ByteString const& hostname)
 {
     LexicalPath lexical_path(path);
     if (!lexical_path.is_absolute())
@@ -180,11 +180,10 @@ URL create_with_file_scheme(ByteString const& path, ByteString const& fragment, 
         url_builder.append(fragment);
     }
 
-    auto url = Parser::basic_parse(url_builder.string_view());
-    return url.has_value() ? url.release_value() : URL {};
+    return Parser::basic_parse(url_builder.string_view());
 }
 
-URL create_with_url_or_path(ByteString const& url_or_path)
+Optional<URL> create_with_url_or_path(ByteString const& url_or_path)
 {
     auto url = Parser::basic_parse(url_or_path);
     if (url.has_value())

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -77,9 +77,8 @@ class URL {
     friend class Parser;
 
 public:
+    // FIXME: We should get rid of the default constructor, all URLs should be constructed through the Parser.
     URL() = default;
-
-    bool is_valid() const { return m_data->valid; }
 
     String const& scheme() const { return m_data->scheme; }
     String const& username() const { return m_data->username; }
@@ -147,13 +146,10 @@ public:
     static URL about(String path);
 
 private:
-    bool compute_validity() const;
-
     struct Data : public RefCounted<Data> {
-        NonnullRefPtr<Data> clone()
+        NonnullRefPtr<Data> clone() const
         {
             auto clone = adopt_ref(*new Data);
-            clone->valid = valid;
             clone->scheme = scheme;
             clone->username = username;
             clone->password = password;
@@ -166,8 +162,6 @@ private:
             clone->blob_url_entry = blob_url_entry;
             return clone;
         }
-
-        bool valid { false };
 
         // A URL’s scheme is an ASCII string that identifies the type of URL and can be used to dispatch a URL for further processing after parsing. It is initially the empty string.
         String scheme;

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -203,8 +203,8 @@ private:
     AK::CopyOnWrite<Data> m_data;
 };
 
-URL create_with_url_or_path(ByteString const&);
-URL create_with_file_scheme(ByteString const& path, ByteString const& fragment = {}, ByteString const& hostname = {});
+Optional<URL> create_with_url_or_path(ByteString const&);
+Optional<URL> create_with_file_scheme(ByteString const& path, ByteString const& fragment = {}, ByteString const& hostname = {});
 URL create_with_data(StringView mime_type, StringView payload, bool is_base64 = false);
 
 bool is_public_suffix(StringView host);

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1871,9 +1871,9 @@ bool Parser::is_parsing_svg_presentation_attribute() const
 // FIXME: URLs shouldn't be completed during parsing, but when used.
 Optional<::URL::URL> Parser::complete_url(StringView relative_url) const
 {
-    if (!m_url.is_valid())
+    if (!m_url.has_value())
         return ::URL::Parser::basic_parse(relative_url);
-    return m_url.complete_url(relative_url);
+    return m_url->complete_url(relative_url);
 }
 
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -477,7 +477,7 @@ private:
 
     GC::Ptr<DOM::Document const> m_document;
     GC::Ptr<JS::Realm> m_realm;
-    ::URL::URL m_url;
+    Optional<::URL::URL> m_url;
     ParsingMode m_parsing_mode { ParsingMode::Normal };
 
     Vector<Token> m_tokens;

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -610,7 +610,7 @@ bool HTMLLinkElement::load_favicon_and_use_if_window_is_active()
         return false;
 
     // FIXME: Refactor the caller(s) to handle the async nature of image loading
-    auto promise = decode_favicon(resource()->encoded_data(), resource()->url(), document());
+    auto promise = decode_favicon(resource()->encoded_data(), *resource()->url(), document());
     auto result = promise->await();
     return !result.is_error();
 }

--- a/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Libraries/LibWeb/Loader/LoadRequest.h
@@ -27,12 +27,12 @@ public:
     bool is_main_resource() const { return m_main_resource; }
     void set_main_resource(bool b) { m_main_resource = b; }
 
-    bool is_valid() const { return m_url.is_valid(); }
+    bool is_valid() const { return m_url.has_value(); }
 
     int id() const { return m_id; }
 
-    const URL::URL& url() const { return m_url; }
-    void set_url(const URL::URL& url) { m_url = url; }
+    Optional<URL::URL> const& url() const { return m_url; }
+    void set_url(Optional<URL::URL> url) { m_url = move(url); }
 
     ByteString const& method() const { return m_method; }
     void set_method(ByteString const& method) { m_method = method; }
@@ -50,7 +50,8 @@ public:
     {
         auto body_hash = string_hash((char const*)m_body.data(), m_body.size());
         auto body_and_headers_hash = pair_int_hash(body_hash, m_headers.hash());
-        auto url_and_method_hash = pair_int_hash(m_url.to_byte_string().hash(), m_method.hash());
+        auto url_hash = m_url.has_value() ? m_url->to_byte_string().hash() : 0;
+        auto url_and_method_hash = pair_int_hash(url_hash, m_method.hash());
         return pair_int_hash(body_and_headers_hash, url_and_method_hash);
     }
 
@@ -75,7 +76,7 @@ public:
 
 private:
     int m_id { 0 };
-    URL::URL m_url;
+    Optional<URL::URL> m_url;
     ByteString m_method { "GET" };
     HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> m_headers;
     ByteBuffer m_body;

--- a/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Libraries/LibWeb/Loader/Resource.cpp
@@ -102,7 +102,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HTTP::HeaderM
         if (content_type_options.value_or("").equals_ignoring_ascii_case("nosniff"sv)) {
             m_mime_type = "text/plain";
         } else {
-            m_mime_type = Core::guess_mime_type_based_on_filename(url().file_path());
+            m_mime_type = Core::guess_mime_type_based_on_filename(url()->file_path());
         }
     }
 

--- a/Libraries/LibWeb/Loader/Resource.h
+++ b/Libraries/LibWeb/Loader/Resource.h
@@ -50,7 +50,7 @@ public:
 
     bool has_encoded_data() const { return !m_encoded_data.is_empty(); }
 
-    const URL::URL& url() const { return m_request.url(); }
+    Optional<URL::URL> const& url() const { return m_request.url(); }
     ByteBuffer const& encoded_data() const { return m_encoded_data; }
 
     [[nodiscard]] HTTP::HeaderMap const& response_headers() const { return m_response_headers; }

--- a/Libraries/LibWebView/CookieJar.cpp
+++ b/Libraries/LibWebView/CookieJar.cpp
@@ -225,7 +225,7 @@ void CookieJar::expire_cookies_with_time_offset(AK::Duration offset)
 // https://www.ietf.org/archive/id/draft-ietf-httpbis-rfc6265bis-15.html#section-5.1.2
 Optional<String> CookieJar::canonicalize_domain(const URL::URL& url)
 {
-    if (!url.is_valid() || !url.host().has_value())
+    if (!url.host().has_value())
         return {};
 
     // 1. Convert the host name to a sequence of individual domain name labels.

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -45,11 +45,11 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
     }
 
     static constexpr Array SUPPORTED_SCHEMES { "about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv };
-    if (!any_of(SUPPORTED_SCHEMES, [&](StringView const& scheme) { return scheme == url.scheme(); }))
+    if (!any_of(SUPPORTED_SCHEMES, [&](StringView const& scheme) { return scheme == url->scheme(); }))
         return search_url_or_error();
     // FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.
 
-    auto const& host = url.host();
+    auto const& host = url->host();
     if (host.has_value() && host->is_domain()) {
         auto const& domain = host->get<String>();
 
@@ -64,7 +64,7 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
         auto public_suffix = URL::get_public_suffix(domain);
         if (!public_suffix.has_value() || *public_suffix == domain) {
             if (append_tld == AppendTLD::Yes)
-                url.set_host(MUST(String::formatted("{}.com", domain)));
+                url->set_host(MUST(String::formatted("{}.com", domain)));
             else if (https_scheme_was_guessed && domain != "localhost"sv)
                 return search_url_or_error();
         }

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -35,10 +35,10 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
 
     auto url = URL::create_with_url_or_path(location);
 
-    if (!url.is_valid()) {
+    if (!url.has_value()) {
         url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
 
-        if (!url.is_valid())
+        if (!url.has_value())
             return search_url_or_error();
 
         https_scheme_was_guessed = true;
@@ -140,9 +140,10 @@ static URLParts break_web_url_into_parts(URL::URL const& url, StringView url_str
 
 Optional<URLParts> break_url_into_parts(StringView url_string)
 {
-    auto url = URL::create_with_url_or_path(url_string);
-    if (!url.is_valid())
+    auto maybe_url = URL::create_with_url_or_path(url_string);
+    if (!maybe_url.has_value())
         return {};
+    auto const& url = maybe_url.value();
 
     auto const& scheme = url.scheme();
     auto scheme_length = scheme.bytes_as_string_view().length();

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -10,11 +10,6 @@
 #include <LibURL/Parser.h>
 #include <LibURL/URL.h>
 
-TEST_CASE(construct)
-{
-    EXPECT_EQ(URL::URL().is_valid(), false);
-}
-
 TEST_CASE(basic)
 {
     {

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -270,8 +270,9 @@ TEST_CASE(equality)
 
 TEST_CASE(create_with_file_scheme)
 {
-    auto url = URL::create_with_file_scheme("/home/anon/README.md");
-    EXPECT(url.is_valid());
+    auto maybe_url = URL::create_with_file_scheme("/home/anon/README.md");
+    EXPECT(maybe_url.has_value());
+    auto url = maybe_url.release_value();
     EXPECT_EQ(url.scheme(), "file");
     EXPECT_EQ(url.port_or_default(), 0);
     EXPECT_EQ(url.path_segment_count(), 3u);
@@ -282,8 +283,9 @@ TEST_CASE(create_with_file_scheme)
     EXPECT(!url.query().has_value());
     EXPECT(!url.fragment().has_value());
 
-    url = URL::create_with_file_scheme("/home/anon/");
-    EXPECT(url.is_valid());
+    maybe_url = URL::create_with_file_scheme("/home/anon/");
+    EXPECT(maybe_url.has_value());
+    url = maybe_url.release_value();
     EXPECT_EQ(url.path_segment_count(), 3u);
     EXPECT_EQ(url.path_segment_at_index(0), "home");
     EXPECT_EQ(url.path_segment_at_index(1), "anon");

--- a/UI/AppKit/Interface/Event.mm
+++ b/UI/AppKit/Interface/Event.mm
@@ -119,8 +119,8 @@ Web::DragEvent ns_event_to_drag_event(Web::DragEvent::Type type, id<NSDraggingIn
         Vector<URL::URL> urls;
 
         for_each_file([&](ByteString const& file_path) {
-            if (auto url = URL::create_with_url_or_path(file_path); url.is_valid())
-                urls.append(move(url));
+            if (auto url = URL::create_with_url_or_path(file_path); url.has_value())
+                urls.append(url.release_value());
         });
 
         browser_data = make<DragData>(move(urls));

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -422,7 +422,7 @@ static void run_test(HeadlessWebView& view, Test& test, Application& app)
     view.on_test_finish = {};
 
     promise->when_resolved([&view, &test, &app](auto) {
-        auto url = URL::create_with_file_scheme(MUST(FileSystem::real_path(test.input_path)));
+        auto url = URL::create_with_file_scheme(MUST(FileSystem::real_path(test.input_path))).release_value();
 
         switch (test.mode) {
         case TestMode::Crash:

--- a/UI/Headless/main.cpp
+++ b/UI/Headless/main.cpp
@@ -85,10 +85,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     VERIFY(!WebView::Application::browser_options().urls.is_empty());
     auto const& url = WebView::Application::browser_options().urls.first();
-    if (!url.is_valid()) {
-        warnln("Invalid URL: \"{}\"", url);
-        return Error::from_string_literal("Invalid URL");
-    }
 
     if (app->dump_layout_tree || app->dump_text) {
         Ladybird::Test test { app->dump_layout_tree ? Ladybird::TestMode::Layout : Ladybird::TestMode::Text };

--- a/Utilities/xml.cpp
+++ b/Utilities/xml.cpp
@@ -435,7 +435,7 @@ static void do_run_tests(XML::Document& document)
             path_builder.append(suite.attributes.find("URI")->value);
             auto url = URL::create_with_file_scheme(path_builder.string_view());
 
-            auto file_path = URL::percent_decode(url.serialize_path());
+            auto file_path = URL::percent_decode(url->serialize_path());
             auto file_result = Core::File::open(file_path, Core::File::OpenMode::Read);
             if (file_result.is_error()) {
                 warnln("Read error for {}: {}", file_path, file_result.error());


### PR DESCRIPTION
This finally removes the URL validity state as we should never have a URL which is in an invalid state (which should be enforced by the URL parser).