### PR TITLE
LibWeb+RequestServer: Handle WPT improperly closing TLS connections and handle errored responses better

### DIFF
--- a/Libraries/LibRequests/NetworkError.h
+++ b/Libraries/LibRequests/NetworkError.h
@@ -19,7 +19,8 @@ enum class NetworkError {
     SSLHandshakeFailed,
     SSLVerificationFailed,
     MalformedUrl,
-    Unknown
+    InvalidContentEncoding,
+    Unknown,
 };
 
 constexpr StringView network_error_to_string(NetworkError network_error)
@@ -41,6 +42,8 @@ constexpr StringView network_error_to_string(NetworkError network_error)
         return "SSL verification failed"sv;
     case NetworkError::MalformedUrl:
         return "The URL is not formatted properly"sv;
+    case NetworkError::InvalidContentEncoding:
+        return "Response could not be decoded with its Content-Encoding"sv;
     case NetworkError::Unknown:
         return "An unexpected network error occurred"sv;
     }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -527,6 +527,8 @@ static Requests::NetworkError map_curl_code_to_network_error(CURLcode const& cod
         return Requests::NetworkError::SSLVerificationFailed;
     case CURLE_URL_MALFORMAT:
         return Requests::NetworkError::MalformedUrl;
+    case CURLE_BAD_CONTENT_ENCODING:
+        return Requests::NetworkError::InvalidContentEncoding;
     default:
         return Requests::NetworkError::Unknown;
     }


### PR DESCRIPTION
This fixes the following WPT tests:
https://wpt.fyi/results/fetch/content-encoding/br/bad-br-body.https.any.html?product=ladybird
https://wpt.fyi/results/fetch/content-encoding/gzip/bad-gzip-body.any.html?product=ladybird
https://wpt.fyi/results/fetch/content-encoding/zstd/bad-zstd-body.https.any.html?product=ladybird

which unfortunately cannot be imported because they depend on a python web server.

Fixes #2927

<img width="1460" alt="wpt" src="https://github.com/user-attachments/assets/2c143b78-c85e-4e7e-a008-6b64ac9803ae" />
