### PR TITLE
LibWeb: Implement more of the "script-blocking style sheet" mechanism

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -583,6 +583,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     }
 
     visitor.visit(m_adopted_style_sheets);
+    visitor.visit(m_script_blocking_style_sheet_set);
 
     for (auto& shadow_root : m_shadow_roots)
         visitor.visit(shadow_root);
@@ -3242,11 +3243,18 @@ String Document::dump_dom_tree_as_json() const
     return MUST(builder.to_string());
 }
 
+// https://html.spec.whatwg.org/multipage/semantics.html#has-no-style-sheet-that-is-blocking-scripts
+bool Document::has_no_style_sheet_that_is_blocking_scripts() const
+{
+    // A Document has no style sheet that is blocking scripts if it does not have a style sheet that is blocking scripts.
+    return !has_a_style_sheet_that_is_blocking_scripts();
+}
+
 // https://html.spec.whatwg.org/multipage/semantics.html#has-a-style-sheet-that-is-blocking-scripts
 bool Document::has_a_style_sheet_that_is_blocking_scripts() const
 {
-    // FIXME: 1. If document's script-blocking style sheet set is not empty, then return true.
-    if (m_script_blocking_style_sheet_counter > 0)
+    // 1. If document's script-blocking style sheet set is not empty, then return true.
+    if (!m_script_blocking_style_sheet_set.is_empty())
         return true;
 
     // 2. If document's node navigable is null, then return false.
@@ -3256,8 +3264,8 @@ bool Document::has_a_style_sheet_that_is_blocking_scripts() const
     // 3. Let containerDocument be document's node navigable's container document.
     auto container_document = navigable()->container_document();
 
-    // FIXME: 4. If containerDocument is non-null and containerDocument's script-blocking style sheet set is not empty, then return true.
-    if (container_document && container_document->m_script_blocking_style_sheet_counter > 0)
+    // 4. If containerDocument is non-null and containerDocument's script-blocking style sheet set is not empty, then return true.
+    if (container_document && !container_document->m_script_blocking_style_sheet_set.is_empty())
         return true;
 
     // 5. Return false

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -499,7 +499,8 @@ public:
 
     String dump_dom_tree_as_json() const;
 
-    bool has_a_style_sheet_that_is_blocking_scripts() const;
+    [[nodiscard]] bool has_a_style_sheet_that_is_blocking_scripts() const;
+    [[nodiscard]] bool has_no_style_sheet_that_is_blocking_scripts() const;
 
     bool is_fully_active() const;
     bool is_active() const;
@@ -897,6 +898,9 @@ public:
 
     ElementByIdMap& element_by_id() const;
 
+    auto& script_blocking_style_sheet_set() { return m_script_blocking_style_sheet_set; }
+    auto const& script_blocking_style_sheet_set() const { return m_script_blocking_style_sheet_set; }
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -1030,8 +1034,8 @@ private:
     // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#throw-on-dynamic-markup-insertion-counter
     u32 m_throw_on_dynamic_markup_insertion_counter { 0 };
 
-    // https://html.spec.whatwg.org/multipage/semantics.html#script-blocking-style-sheet-counter
-    u32 m_script_blocking_style_sheet_counter { 0 };
+    // https://html.spec.whatwg.org/multipage/semantics.html#script-blocking-style-sheet-set
+    HashTable<GC::Ref<DOM::Element>> m_script_blocking_style_sheet_set;
 
     GC::Ptr<HTML::History> m_history;
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -471,6 +471,8 @@ public:
     void release_pointer_capture(WebIDL::Long pointer_id);
     bool has_pointer_capture(WebIDL::Long pointer_id);
 
+    virtual bool contributes_a_script_blocking_style_sheet() const { return false; }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;

--- a/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -87,6 +87,12 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
         {},
         nullptr,
         nullptr);
+
+    // 7. If element contributes a script-blocking style sheet, append element to its node document's script-blocking style sheet set.
+    if (style_element.contributes_a_script_blocking_style_sheet())
+        style_element.document().script_blocking_style_sheet_set().set(style_element);
+
+    // FIXME: 8. If element's media attribute's value matches the environment and element is potentially render-blocking, then block rendering on element.
 }
 
 void StyleElementUtils::visit_edges(JS::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -50,6 +50,8 @@ public:
 
     GC::Ptr<CSS::CSSStyleSheet> sheet() const;
 
+    virtual bool contributes_a_script_blocking_style_sheet() const final;
+
 private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -103,4 +103,27 @@ CSS::CSSStyleSheet const* HTMLStyleElement::sheet() const
     return m_style_element_utils.sheet();
 }
 
+// https://html.spec.whatwg.org/multipage/semantics.html#contributes-a-script-blocking-style-sheet
+bool HTMLStyleElement::contributes_a_script_blocking_style_sheet() const
+{
+    // An element el in the context of a Document of an HTML parser or XML parser
+    // contributes a script-blocking style sheet if all of the following are true:
+
+    // FIXME: el was created by that Document's parser.
+
+    // el is either a style element or a link element that was an external resource link that contributes to the styling processing model when the el was created by the parser.
+    // NOTE: This is a style element, so all good!
+
+    // FIXME: el's media attribute's value matches the environment.
+
+    // FIXME: el's style sheet was enabled when the element was created by the parser.
+
+    // FIXME: The last time the event loop reached step 1, el's root was that Document.
+
+    // FIXME: The user agent hasn't given up on loading that particular style sheet yet.
+    //        A user agent may give up on loading a style sheet at any time.
+
+    return false;
+}
+
 }

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -30,6 +30,8 @@ public:
     CSS::CSSStyleSheet* sheet();
     CSS::CSSStyleSheet const* sheet() const;
 
+    virtual bool contributes_a_script_blocking_style_sheet() const final;
+
 private:
     HTMLStyleElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Tests/LibWeb/Text/input/link-re-enable-crash.html
+++ b/Tests/LibWeb/Text/input/link-re-enable-crash.html
@@ -1,13 +1,11 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
-<link rel="stylesheet" href="valid.css">
+<script>
+    var scriptOnloadWasInvoked = false;
+</script>
+<link id="link" rel="stylesheet" href="valid.css" onload="link.disabled = true; link.disabled = false;">
 <script>
     test(() => {
-        const link = document.querySelector("link");
-        link.onload = () => {
-            link.disabled = true;
-            link.disabled = false;
-            println("PASS (didn't crash)");
-        };
+        println("PASS (didn't crash)");
     });
 </script>


### PR DESCRIPTION
The basic idea is that style sheets can block script execution under some circumstances. With this commit, we now handle the simplest cases where a parser-inserted link element gets to download its style sheet before script execution continues.

This improves performance on Speedometer 3 where JavaScript APIs that depend on layout results (like Element.scrollIntoView()) would get called too early (before the relevant CSS was downloaded), and so we'd perform premature layout work. This work then had to be redone after downloading the CSS anyway, wasting time.

Note that our Text/input/link-re-enable-crash.html test had to be tweaked after these changes, since it relied on the old, incorrect, behavior where scripts would run before downloading CSS.