### PR TITLE
LibWeb/HTML: Make environments top level creation URL nullable

### DIFF
--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -184,7 +184,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
         });
 
     // 11. Let topLevelCreationURL be about:blank if embedder is null; otherwise embedder's relevant settings object's top-level creation URL.
-    auto top_level_creation_url = !embedder ? URL::about_blank() : relevant_settings_object(*embedder).top_level_creation_url;
+    auto top_level_creation_url = !embedder ? URL::about_blank() : relevant_settings_object(*embedder).top_level_creation_url.value();
 
     // 12. Let topLevelOrigin be origin if embedder is null; otherwise embedder's relevant settings object's top-level origin.
     auto top_level_origin = !embedder ? origin : relevant_settings_object(*embedder).origin();

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -946,7 +946,7 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
         // 2. If request's reserved client is null, then:
         if (!request->reserved_client()) {
             // 1. Let topLevelCreationURL be currentURL.
-            auto top_level_creation_url = current_url;
+            Optional<URL::URL> top_level_creation_url = current_url;
 
             // 2. Let topLevelOrigin be null.
             URL::Origin top_level_origin;

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -548,7 +548,7 @@ bool is_secure_context(Environment const& environment)
     }
 
     // 2. If the result of Is url potentially trustworthy? given environment's top-level creation URL is "Potentially Trustworthy", then return true.
-    if (SecureContexts::is_url_potentially_trustworthy(environment.top_level_creation_url) == SecureContexts::Trustworthiness::PotentiallyTrustworthy)
+    if (SecureContexts::is_url_potentially_trustworthy(environment.top_level_creation_url.value()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy)
         return true;
 
     // 3. Return false.

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -33,7 +33,8 @@ public:
     URL::URL creation_url;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url
-    URL::URL top_level_creation_url;
+    // Null or a URL that represents the creation URL of the "top-level" environment. It is null for workers and worklets.
+    Optional<URL::URL> top_level_creation_url;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin
     URL::Origin top_level_origin;
@@ -51,7 +52,7 @@ public:
 
 protected:
     Environment() = default;
-    Environment(String id, URL::URL creation_url, URL::URL top_level_creation_url, URL::Origin top_level_origin, GC::Ptr<BrowsingContext> target_browsing_context)
+    Environment(String id, URL::URL creation_url, Optional<URL::URL> top_level_creation_url, URL::Origin top_level_origin, GC::Ptr<BrowsingContext> target_browsing_context)
         : id(move(id))
         , creation_url(move(creation_url))
         , top_level_creation_url(move(top_level_creation_url))

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
@@ -34,7 +34,7 @@ ErrorOr<Web::HTML::SerializedEnvironmentSettingsObject> decode(Decoder& decoder)
 
     object.id = TRY(decoder.decode<String>());
     object.creation_url = TRY(decoder.decode<URL::URL>());
-    object.top_level_creation_url = TRY(decoder.decode<URL::URL>());
+    object.top_level_creation_url = TRY(decoder.decode<Optional<URL::URL>>());
     object.top_level_origin = TRY(decoder.decode<URL::Origin>());
     object.api_url_character_encoding = TRY(decoder.decode<String>());
     object.api_base_url = TRY(decoder.decode<URL::URL>());

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
@@ -22,7 +22,7 @@ enum class CanUseCrossOriginIsolatedAPIs {
 struct SerializedEnvironmentSettingsObject {
     String id;
     URL::URL creation_url;
-    URL::URL top_level_creation_url;
+    Optional<URL::URL> top_level_creation_url;
     URL::Origin top_level_origin;
 
     String api_url_character_encoding;


### PR DESCRIPTION
This is explicitly set to null for Workers.

Continues upstreaming some minor changes picked up slowly working toward implementing the ServiceWorker worker process.