### PR TITLE
LibWeb: Some scrollbar UX improvements

### DIFF
--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -403,14 +403,15 @@ struct PaintNestedDisplayList {
 };
 
 struct PaintScrollBar {
-    int scroll_frame_id;
-    Gfx::IntRect rect;
+    int scroll_frame_id { 0 };
+    Gfx::IntRect gutter_rect;
+    Gfx::IntRect thumb_rect;
     CSSPixelFraction scroll_size;
     bool vertical;
 
     void translate_by(Gfx::IntPoint const& offset)
     {
-        rect.translate_by(offset);
+        thumb_rect.translate_by(offset);
     }
 };
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -69,10 +69,10 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
             auto scroll_offset = scroll_state.own_offset_for_frame_with_id(paint_scroll_bar.scroll_frame_id);
             if (paint_scroll_bar.vertical) {
                 auto offset = scroll_offset.y() * paint_scroll_bar.scroll_size;
-                paint_scroll_bar.rect.translate_by(0, -offset.to_int() * device_pixels_per_css_pixel);
+                paint_scroll_bar.thumb_rect.translate_by(0, -offset.to_int() * device_pixels_per_css_pixel);
             } else {
                 auto offset = scroll_offset.x() * paint_scroll_bar.scroll_size;
-                paint_scroll_bar.rect.translate_by(-offset.to_int() * device_pixels_per_css_pixel, 0);
+                paint_scroll_bar.thumb_rect.translate_by(-offset.to_int() * device_pixels_per_css_pixel, 0);
             }
         }
 

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -993,16 +993,23 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
 
 void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)
 {
-    auto rect = to_skia_rect(command.rect);
-    auto radius = rect.width() / 2;
-    auto rrect = SkRRect::MakeRectXY(rect, radius, radius);
+    auto gutter_rect = to_skia_rect(command.gutter_rect);
+
+    auto thumb_rect = to_skia_rect(command.thumb_rect);
+    auto radius = thumb_rect.width() / 2;
+    auto thumb_rrect = SkRRect::MakeRectXY(thumb_rect, radius, radius);
 
     auto& canvas = surface().canvas();
 
-    auto fill_color = Color(Color::NamedColor::DarkGray).with_alpha(128);
-    SkPaint fill_paint;
-    fill_paint.setColor(to_skia_color(fill_color));
-    canvas.drawRRect(rrect, fill_paint);
+    auto gutter_fill_color = Color(Color::NamedColor::WarmGray).with_alpha(192);
+    SkPaint gutter_fill_paint;
+    gutter_fill_paint.setColor(to_skia_color(gutter_fill_color));
+    canvas.drawRect(gutter_rect, gutter_fill_paint);
+
+    auto thumb_fill_color = Color(Color::NamedColor::DarkGray).with_alpha(gutter_rect.isEmpty() ? 128 : 192);
+    SkPaint thumb_fill_paint;
+    thumb_fill_paint.setColor(to_skia_color(thumb_fill_color));
+    canvas.drawRRect(thumb_rrect, thumb_fill_paint);
 
     auto stroke_color = Color(Color::NamedColor::LightGray).with_alpha(128);
     SkPaint stroke_paint;
@@ -1010,7 +1017,7 @@ void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)
     stroke_paint.setStrokeWidth(1);
     stroke_paint.setAntiAlias(true);
     stroke_paint.setColor(to_skia_color(stroke_color));
-    canvas.drawRRect(rrect, stroke_paint);
+    canvas.drawRRect(thumb_rrect, stroke_paint);
 }
 
 void DisplayListPlayerSkia::apply_opacity(ApplyOpacity const& command)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1008,6 +1008,7 @@ void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)
     SkPaint stroke_paint;
     stroke_paint.setStroke(true);
     stroke_paint.setStrokeWidth(1);
+    stroke_paint.setAntiAlias(true);
     stroke_paint.setColor(to_skia_color(stroke_color));
     canvas.drawRRect(rrect, stroke_paint);
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -404,11 +404,12 @@ void DisplayListRecorder::draw_triangle_wave(Gfx::IntPoint a_p1, Gfx::IntPoint a
         .thickness = thickness });
 }
 
-void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect rect, CSSPixelFraction scroll_size, bool vertical)
+void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, CSSPixelFraction scroll_size, bool vertical)
 {
     append(PaintScrollBar {
         .scroll_frame_id = scroll_frame_id,
-        .rect = rect,
+        .gutter_rect = gutter_rect,
+        .thumb_rect = thumb_rect,
         .scroll_size = scroll_size,
         .vertical = vertical });
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -146,7 +146,7 @@ public:
 
     void draw_triangle_wave(Gfx::IntPoint a_p1, Gfx::IntPoint a_p2, Color color, int amplitude, int thickness);
 
-    void paint_scrollbar(int scroll_frame_id, Gfx::IntRect, CSSPixelFraction scroll_size, bool vertical);
+    void paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, CSSPixelFraction scroll_size, bool vertical);
 
     void apply_opacity(float opacity);
     void apply_compositing_and_blending_operator(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator);

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -412,16 +412,22 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
     auto min_thumb_length = min(scrollbar_rect_length, 24);
     auto thumb_length = max(scrollbar_rect_length * (scrollport_size / scroll_overflow_size), min_thumb_length);
 
-    CSSPixelFraction scroll_size = 0;
-    if (scroll_overflow_size > scrollport_size)
-        scroll_size = (scrollbar_rect_length - thumb_length) / (scroll_overflow_size - scrollport_size);
-    CSSPixelRect rect;
-    if (is_horizontal)
-        rect = { padding_rect.left(), padding_rect.bottom() - thickness, thumb_length, thickness };
-    else
-        rect = { padding_rect.right() - thickness, padding_rect.top(), thickness, thumb_length };
+    ScrollbarData scrollbar_data;
 
-    return PaintableBox::ScrollbarData { rect, scroll_size };
+    if (scroll_overflow_size > scrollport_size)
+        scrollbar_data.scroll_length = (scrollbar_rect_length - thumb_length) / (scroll_overflow_size - scrollport_size);
+
+    if (is_horizontal) {
+        if (m_draw_enlarged_horizontal_scrollbar)
+            scrollbar_data.gutter_rect = { padding_rect.left(), padding_rect.bottom() - thickness, padding_rect.width(), thickness };
+        scrollbar_data.thumb_rect = { padding_rect.left(), padding_rect.bottom() - thickness, thumb_length, thickness };
+    } else {
+        if (m_draw_enlarged_vertical_scrollbar)
+            scrollbar_data.gutter_rect = { padding_rect.right() - thickness, padding_rect.top(), thickness, padding_rect.height() };
+        scrollbar_data.thumb_rect = { padding_rect.right() - thickness, padding_rect.top(), thickness, thumb_length };
+    }
+
+    return scrollbar_data;
 }
 
 void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
@@ -471,15 +477,17 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         }
     }
 
-    if (g_paint_viewport_scrollbars || !is_viewport()) {
-        auto scrollbar_width = computed_values().scrollbar_width();
-        if (phase == PaintPhase::Overlay && scrollbar_width != CSS::ScrollbarWidth::None) {
-            if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Vertical); scrollbar_data.has_value()) {
-                context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(), scrollbar_data->scroll_length, true);
-            }
-            if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Horizontal); scrollbar_data.has_value()) {
-                context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(), scrollbar_data->scroll_length, false);
-            }
+    if (phase == PaintPhase::Overlay && (g_paint_viewport_scrollbars || !is_viewport()) && computed_values().scrollbar_width() != CSS::ScrollbarWidth::None) {
+        if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Vertical); scrollbar_data.has_value()) {
+            auto gutter_rect = context.rounded_device_rect(scrollbar_data->gutter_rect).to_type<int>();
+            auto thumb_rect = context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>();
+            context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), gutter_rect, thumb_rect, scrollbar_data->scroll_length, true);
+        }
+
+        if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Horizontal); scrollbar_data.has_value()) {
+            auto gutter_rect = context.rounded_device_rect(scrollbar_data->gutter_rect).to_type<int>();
+            auto thumb_rect = context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>();
+            context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), gutter_rect, thumb_rect, scrollbar_data->scroll_length, false);
         }
     }
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -910,18 +910,35 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
 
 Paintable::DispatchEventOfSameName PaintableBox::handle_mousedown(Badge<EventHandler>, CSSPixelPoint position, unsigned, unsigned)
 {
-    auto vertical_scroll_data = compute_scrollbar_data(ScrollDirection::Vertical, AdjustThumbRectForScrollOffset::Yes);
-    auto horizontal_scroll_data = compute_scrollbar_data(ScrollDirection::Horizontal, AdjustThumbRectForScrollOffset::Yes);
+    auto handle_scrollbar = [&](auto direction) {
+        auto scrollbar_data = compute_scrollbar_data(direction, AdjustThumbRectForScrollOffset::Yes);
+        if (!scrollbar_data.has_value())
+            return false;
 
-    if (vertical_scroll_data.has_value() && vertical_scroll_data->thumb_rect.contains(position)) {
-        m_last_mouse_tracking_position = position;
-        m_scroll_thumb_dragging_direction = ScrollDirection::Vertical;
-        const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(this);
-    } else if (horizontal_scroll_data.has_value() && horizontal_scroll_data->thumb_rect.contains(position)) {
-        m_last_mouse_tracking_position = position;
-        m_scroll_thumb_dragging_direction = ScrollDirection::Horizontal;
-        const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(this);
-    }
+        if (scrollbar_data->thumb_rect.contains(position)) {
+            m_last_mouse_tracking_position = position;
+            m_scroll_thumb_dragging_direction = direction;
+
+            navigable()->event_handler().set_mouse_event_tracking_paintable(this);
+            return true;
+        }
+
+        if (scrollbar_data->gutter_rect.contains(position)) {
+            m_last_mouse_tracking_position = scrollbar_data->thumb_rect.center();
+            m_scroll_thumb_dragging_direction = direction;
+
+            navigable()->event_handler().set_mouse_event_tracking_paintable(this);
+            scroll_to_mouse_postion(position);
+            return true;
+        }
+
+        return false;
+    };
+
+    if (handle_scrollbar(ScrollDirection::Vertical))
+        return Paintable::DispatchEventOfSameName::No;
+    if (handle_scrollbar(ScrollDirection::Horizontal))
+        return Paintable::DispatchEventOfSameName::No;
 
     return Paintable::DispatchEventOfSameName::Yes;
 }
@@ -939,26 +956,7 @@ Paintable::DispatchEventOfSameName PaintableBox::handle_mouseup(Badge<EventHandl
 Paintable::DispatchEventOfSameName PaintableBox::handle_mousemove(Badge<EventHandler>, CSSPixelPoint position, unsigned, unsigned)
 {
     if (m_last_mouse_tracking_position.has_value()) {
-        Gfx::Point<double> scroll_delta;
-        if (m_scroll_thumb_dragging_direction == ScrollDirection::Horizontal)
-            scroll_delta.set_x((position.x() - m_last_mouse_tracking_position->x()).to_double());
-        else
-            scroll_delta.set_y((position.y() - m_last_mouse_tracking_position->y()).to_double());
-
-        auto padding_rect = absolute_padding_box_rect();
-        auto scrollable_overflow_rect = this->scrollable_overflow_rect().value();
-        auto scroll_overflow_size = m_scroll_thumb_dragging_direction == ScrollDirection::Horizontal ? scrollable_overflow_rect.width() : scrollable_overflow_rect.height();
-        auto scrollport_size = m_scroll_thumb_dragging_direction == ScrollDirection::Horizontal ? padding_rect.width() : padding_rect.height();
-        auto scroll_px_per_mouse_position_delta_px = scroll_overflow_size.to_double() / scrollport_size.to_double();
-        scroll_delta *= scroll_px_per_mouse_position_delta_px;
-
-        if (is_viewport()) {
-            document().window()->scroll_by(scroll_delta.x(), scroll_delta.y());
-        } else {
-            scroll_by(scroll_delta.x(), scroll_delta.y());
-        }
-
-        m_last_mouse_tracking_position = position;
+        scroll_to_mouse_postion(position);
         return Paintable::DispatchEventOfSameName::No;
     }
 
@@ -990,6 +988,32 @@ bool PaintableBox::scrollbar_contains_mouse_position(ScrollDirection direction, 
     if (direction == ScrollDirection::Horizontal)
         return position.y() >= scrollbar_data->thumb_rect.top();
     return position.x() >= scrollbar_data->thumb_rect.left();
+}
+
+void PaintableBox::scroll_to_mouse_postion(CSSPixelPoint position)
+{
+    VERIFY(m_last_mouse_tracking_position.has_value());
+    VERIFY(m_scroll_thumb_dragging_direction.has_value());
+
+    Gfx::Point<double> scroll_delta;
+    if (m_scroll_thumb_dragging_direction == ScrollDirection::Horizontal)
+        scroll_delta.set_x((position.x() - m_last_mouse_tracking_position->x()).to_double());
+    else
+        scroll_delta.set_y((position.y() - m_last_mouse_tracking_position->y()).to_double());
+
+    auto padding_rect = absolute_padding_box_rect();
+    auto scrollable_overflow_rect = this->scrollable_overflow_rect().value();
+    auto scroll_overflow_size = m_scroll_thumb_dragging_direction == ScrollDirection::Horizontal ? scrollable_overflow_rect.width() : scrollable_overflow_rect.height();
+    auto scrollport_size = m_scroll_thumb_dragging_direction == ScrollDirection::Horizontal ? padding_rect.width() : padding_rect.height();
+    auto scroll_px_per_mouse_position_delta_px = scroll_overflow_size.to_double() / scrollport_size.to_double();
+    scroll_delta *= scroll_px_per_mouse_position_delta_px;
+
+    if (is_viewport())
+        document().window()->scroll_by(scroll_delta.x(), scroll_delta.y());
+    else
+        scroll_by(scroll_delta.x(), scroll_delta.y());
+
+    m_last_mouse_tracking_position = position;
 }
 
 bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <AK/GenericShorthands.h>
+#include <AK/TemporaryChange.h>
 #include <LibGfx/Font/Font.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibWeb/CSS/SystemColor.h>
@@ -355,7 +356,8 @@ bool PaintableBox::could_be_scrolled_by_wheel_event() const
     return could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal) || could_be_scrolled_by_wheel_event(ScrollDirection::Vertical);
 }
 
-static constexpr CSSPixels scrollbar_thumb_thickness = 8;
+static constexpr CSSPixels SCROLLBAR_THUMB_NORMAL_THICKNESS = 5;
+static constexpr CSSPixels SCROLLBAR_THUMB_WIDENED_THICKNESS = 10;
 
 Optional<CSSPixelRect> PaintableBox::scroll_thumb_rect(ScrollDirection direction) const
 {
@@ -399,7 +401,13 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
     if (scroll_overflow_size == 0)
         return {};
 
-    auto scrollbar_rect_length = is_horizontal ? scrollport_size - scrollbar_thumb_thickness : scrollport_size;
+    auto thickness = [&]() {
+        if (is_horizontal)
+            return m_draw_enlarged_horizontal_scrollbar ? SCROLLBAR_THUMB_WIDENED_THICKNESS : SCROLLBAR_THUMB_NORMAL_THICKNESS;
+        return m_draw_enlarged_vertical_scrollbar ? SCROLLBAR_THUMB_WIDENED_THICKNESS : SCROLLBAR_THUMB_NORMAL_THICKNESS;
+    }();
+
+    auto scrollbar_rect_length = is_horizontal ? scrollport_size - thickness : scrollport_size;
 
     auto min_thumb_length = min(scrollbar_rect_length, 24);
     auto thumb_length = max(scrollbar_rect_length * (scrollport_size / scroll_overflow_size), min_thumb_length);
@@ -409,9 +417,9 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
         scroll_size = (scrollbar_rect_length - thumb_length) / (scroll_overflow_size - scrollport_size);
     CSSPixelRect rect;
     if (is_horizontal)
-        rect = { padding_rect.left(), padding_rect.bottom() - scrollbar_thumb_thickness, thumb_length, scrollbar_thumb_thickness };
+        rect = { padding_rect.left(), padding_rect.bottom() - thickness, thumb_length, thickness };
     else
-        rect = { padding_rect.right() - scrollbar_thumb_thickness, padding_rect.top(), scrollbar_thumb_thickness, thumb_length };
+        rect = { padding_rect.right() - thickness, padding_rect.top(), thickness, thumb_length };
 
     return PaintableBox::ScrollbarData { rect, scroll_size };
 }
@@ -951,7 +959,35 @@ Paintable::DispatchEventOfSameName PaintableBox::handle_mousemove(Badge<EventHan
         m_last_mouse_tracking_position = position;
         return Paintable::DispatchEventOfSameName::No;
     }
+
+    auto previous_draw_enlarged_horizontal_scrollbar = m_draw_enlarged_horizontal_scrollbar;
+    m_draw_enlarged_horizontal_scrollbar = scrollbar_contains_mouse_position(ScrollDirection::Horizontal, position);
+    if (previous_draw_enlarged_horizontal_scrollbar != m_draw_enlarged_horizontal_scrollbar)
+        set_needs_display();
+
+    auto previous_draw_enlarged_vertical_scrollbar = m_draw_enlarged_vertical_scrollbar;
+    m_draw_enlarged_vertical_scrollbar = scrollbar_contains_mouse_position(ScrollDirection::Vertical, position);
+    if (previous_draw_enlarged_vertical_scrollbar != m_draw_enlarged_vertical_scrollbar)
+        set_needs_display();
+
+    if (m_draw_enlarged_horizontal_scrollbar || m_draw_enlarged_vertical_scrollbar)
+        return Paintable::DispatchEventOfSameName::No;
+
     return Paintable::DispatchEventOfSameName::Yes;
+}
+
+bool PaintableBox::scrollbar_contains_mouse_position(ScrollDirection direction, CSSPixelPoint position)
+{
+    TemporaryChange force_enlarged_horizontal_scrollbar { m_draw_enlarged_horizontal_scrollbar, true };
+    TemporaryChange force_enlarged_vertical_scrollbar { m_draw_enlarged_vertical_scrollbar, true };
+
+    auto scrollbar_data = compute_scrollbar_data(direction);
+    if (!scrollbar_data.has_value())
+        return false;
+
+    if (direction == ScrollDirection::Horizontal)
+        return position.y() >= scrollbar_data->thumb_rect.top();
+    return position.x() >= scrollbar_data->thumb_rect.left();
 }
 
 bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
@@ -977,12 +1013,25 @@ Layout::NodeWithStyleAndBoxModelMetrics& PaintableWithLines::layout_node_with_st
 
 TraversalDecision PaintableBox::hit_test_scrollbars(CSSPixelPoint position, Function<TraversalDecision(HitTestResult)> const& callback) const
 {
-    auto vertical_scroll_thumb_rect = scroll_thumb_rect(ScrollDirection::Vertical);
-    if (vertical_scroll_thumb_rect.has_value() && vertical_scroll_thumb_rect.value().contains(position))
+    // FIXME: This const_cast is not great, but this method is invoked from overrides of virtual const methods.
+    auto& self = const_cast<PaintableBox&>(*this);
+
+    if (self.scrollbar_contains_mouse_position(ScrollDirection::Horizontal, position))
         return callback(HitTestResult { const_cast<PaintableBox&>(*this) });
-    auto horizontal_scroll_thumb_rect = scroll_thumb_rect(ScrollDirection::Horizontal);
-    if (horizontal_scroll_thumb_rect.has_value() && horizontal_scroll_thumb_rect.value().contains(position))
+
+    if (m_draw_enlarged_horizontal_scrollbar) {
+        self.m_draw_enlarged_horizontal_scrollbar = false;
+        self.set_needs_display();
+    }
+
+    if (self.scrollbar_contains_mouse_position(ScrollDirection::Vertical, position))
         return callback(HitTestResult { const_cast<PaintableBox&>(*this) });
+
+    if (m_draw_enlarged_vertical_scrollbar) {
+        self.m_draw_enlarged_vertical_scrollbar = false;
+        self.set_needs_display();
+    }
+
     return TraversalDecision::Continue;
 }
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -308,9 +308,9 @@ Optional<CSSPixelRect> PaintableBox::get_clip_rect() const
 
 bool PaintableBox::wants_mouse_events() const
 {
-    if (scroll_thumb_rect(ScrollDirection::Vertical).has_value())
+    if (compute_scrollbar_data(ScrollDirection::Vertical).has_value())
         return true;
-    if (scroll_thumb_rect(ScrollDirection::Horizontal).has_value())
+    if (compute_scrollbar_data(ScrollDirection::Horizontal).has_value())
         return true;
     return false;
 }
@@ -359,25 +359,7 @@ bool PaintableBox::could_be_scrolled_by_wheel_event() const
 static constexpr CSSPixels SCROLLBAR_THUMB_NORMAL_THICKNESS = 5;
 static constexpr CSSPixels SCROLLBAR_THUMB_WIDENED_THICKNESS = 10;
 
-Optional<CSSPixelRect> PaintableBox::scroll_thumb_rect(ScrollDirection direction) const
-{
-    auto maybe_scrollbar_data = compute_scrollbar_data(direction);
-    if (!maybe_scrollbar_data.has_value())
-        return {};
-
-    auto scroll_offset = direction == ScrollDirection::Horizontal ? -own_scroll_frame_offset().x() : -own_scroll_frame_offset().y();
-    auto thumb_offset = scroll_offset * maybe_scrollbar_data->scroll_length;
-
-    CSSPixelRect thumb_rect = maybe_scrollbar_data->thumb_rect;
-    if (direction == ScrollDirection::Horizontal) {
-        thumb_rect.translate_by(thumb_offset, 0);
-    } else {
-        thumb_rect.translate_by(0, thumb_offset);
-    }
-    return thumb_rect;
-}
-
-Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(ScrollDirection direction) const
+Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(ScrollDirection direction, AdjustThumbRectForScrollOffset adjust_thumb_rect_for_scroll_offset) const
 {
     bool is_horizontal = direction == ScrollDirection::Horizontal;
     bool display_scrollbar = could_be_scrolled_by_wheel_event(direction);
@@ -425,6 +407,16 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
         if (m_draw_enlarged_vertical_scrollbar)
             scrollbar_data.gutter_rect = { padding_rect.right() - thickness, padding_rect.top(), thickness, padding_rect.height() };
         scrollbar_data.thumb_rect = { padding_rect.right() - thickness, padding_rect.top(), thickness, thumb_length };
+    }
+
+    if (adjust_thumb_rect_for_scroll_offset == AdjustThumbRectForScrollOffset::Yes) {
+        auto scroll_offset = is_horizontal ? -own_scroll_frame_offset().x() : -own_scroll_frame_offset().y();
+        auto thumb_offset = scroll_offset * scrollbar_data.scroll_length;
+
+        if (is_horizontal)
+            scrollbar_data.thumb_rect.translate_by(thumb_offset, 0);
+        else
+            scrollbar_data.thumb_rect.translate_by(0, thumb_offset);
     }
 
     return scrollbar_data;
@@ -918,17 +910,19 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
 
 Paintable::DispatchEventOfSameName PaintableBox::handle_mousedown(Badge<EventHandler>, CSSPixelPoint position, unsigned, unsigned)
 {
-    auto vertical_scroll_thumb_rect = scroll_thumb_rect(ScrollDirection::Vertical);
-    auto horizontal_scroll_thumb_rect = scroll_thumb_rect(ScrollDirection::Horizontal);
-    if (vertical_scroll_thumb_rect.has_value() && vertical_scroll_thumb_rect.value().contains(position)) {
+    auto vertical_scroll_data = compute_scrollbar_data(ScrollDirection::Vertical, AdjustThumbRectForScrollOffset::Yes);
+    auto horizontal_scroll_data = compute_scrollbar_data(ScrollDirection::Horizontal, AdjustThumbRectForScrollOffset::Yes);
+
+    if (vertical_scroll_data.has_value() && vertical_scroll_data->thumb_rect.contains(position)) {
         m_last_mouse_tracking_position = position;
         m_scroll_thumb_dragging_direction = ScrollDirection::Vertical;
         const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(this);
-    } else if (horizontal_scroll_thumb_rect.has_value() && horizontal_scroll_thumb_rect.value().contains(position)) {
+    } else if (horizontal_scroll_data.has_value() && horizontal_scroll_data->thumb_rect.contains(position)) {
         m_last_mouse_tracking_position = position;
         m_scroll_thumb_dragging_direction = ScrollDirection::Horizontal;
         const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(this);
     }
+
     return Paintable::DispatchEventOfSameName::Yes;
 }
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -258,8 +258,9 @@ protected:
     virtual CSSPixelRect compute_absolute_paint_rect() const;
 
     struct ScrollbarData {
+        CSSPixelRect gutter_rect;
         CSSPixelRect thumb_rect;
-        CSSPixelFraction scroll_length;
+        CSSPixelFraction scroll_length { 0 };
     };
     enum class ScrollDirection {
         Horizontal,

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -278,6 +278,8 @@ private:
     virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
     virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers) override;
 
+    bool scrollbar_contains_mouse_position(ScrollDirection, CSSPixelPoint);
+
     OwnPtr<StackingContext> m_stacking_context;
 
     Optional<OverflowData> m_overflow_data;
@@ -304,6 +306,8 @@ private:
 
     Optional<CSSPixelPoint> m_last_mouse_tracking_position;
     Optional<ScrollDirection> m_scroll_thumb_dragging_direction;
+    bool m_draw_enlarged_horizontal_scrollbar { false };
+    bool m_draw_enlarged_vertical_scrollbar { false };
 
     ResolvedBackground m_resolved_background;
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -266,8 +266,11 @@ protected:
         Horizontal,
         Vertical,
     };
-    Optional<ScrollbarData> compute_scrollbar_data(ScrollDirection) const;
-    [[nodiscard]] Optional<CSSPixelRect> scroll_thumb_rect(ScrollDirection) const;
+    enum class AdjustThumbRectForScrollOffset {
+        No,
+        Yes,
+    };
+    Optional<ScrollbarData> compute_scrollbar_data(ScrollDirection, AdjustThumbRectForScrollOffset = AdjustThumbRectForScrollOffset::No) const;
     [[nodiscard]] bool could_be_scrolled_by_wheel_event(ScrollDirection) const;
 
     TraversalDecision hit_test_scrollbars(CSSPixelPoint position, Function<TraversalDecision(HitTestResult)> const& callback) const;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -283,6 +283,7 @@ private:
     virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers) override;
 
     bool scrollbar_contains_mouse_position(ScrollDirection, CSSPixelPoint);
+    void scroll_to_mouse_postion(CSSPixelPoint);
 
     OwnPtr<StackingContext> m_stacking_context;
 

--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -77,6 +77,9 @@ void Application::create_platform_options(WebView::BrowserOptions& browser_optio
 
         // Ensure consistent font rendering between operating systems.
         web_content_options.force_fontconfig = WebView::ForceFontconfig::Yes;
+
+        // Ensure tests are resilient to minor changes to the viewport scrollbar.
+        web_content_options.paint_viewport_scrollbars = WebView::PaintViewportScrollbars::No;
     }
 
     if (dump_gc_graph) {


### PR DESCRIPTION
* Enlarge the scrollbar a bit upon hover. I was finding myself missing the scrollbar quite a bit when I clicked.
* Draw the scrollbar thumb outline a bit smoother.
* Draw a scrollbar gutter upon hover.
  * Allow clicking in the gutter to scroll to that position.


https://github.com/user-attachments/assets/f949816e-039f-4242-b987-561b3281ca94

