### PR TITLE
LibJS: Allow using local variable for catch parameters

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1378,19 +1378,17 @@ void TryStatement::dump(int indent) const
 void CatchClause::dump(int indent) const
 {
     print_indent(indent);
+    outln("CatchClause");
     m_parameter.visit(
-        [&](FlyString const& parameter) {
-            if (parameter.is_empty())
-                outln("CatchClause");
-            else
-                outln("CatchClause ({})", parameter);
+        [&](NonnullRefPtr<Identifier const> const& parameter) {
+            parameter->dump(indent + 1);
         },
         [&](NonnullRefPtr<BindingPattern const> const& pattern) {
-            outln("CatchClause");
             print_indent(indent);
             outln("(Parameter)");
             pattern->dump(indent + 2);
-        });
+        },
+        [&](Empty) {});
 
     body().dump(indent + 1);
 }

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -2075,7 +2075,7 @@ private:
 
 class CatchClause final : public ASTNode {
 public:
-    CatchClause(SourceRange source_range, FlyString parameter, NonnullRefPtr<BlockStatement const> body)
+    CatchClause(SourceRange source_range, NonnullRefPtr<Identifier const> parameter, NonnullRefPtr<BlockStatement const> body)
         : ASTNode(move(source_range))
         , m_parameter(move(parameter))
         , m_body(move(body))
@@ -2089,13 +2089,20 @@ public:
     {
     }
 
+    CatchClause(SourceRange source_range, NonnullRefPtr<BlockStatement const> body)
+        : ASTNode(move(source_range))
+        , m_parameter(Empty {})
+        , m_body(move(body))
+    {
+    }
+
     auto& parameter() const { return m_parameter; }
     BlockStatement const& body() const { return m_body; }
 
     virtual void dump(int indent) const override;
 
 private:
-    Variant<FlyString, NonnullRefPtr<BindingPattern const>> m_parameter;
+    Variant<NonnullRefPtr<Identifier const>, NonnullRefPtr<BindingPattern const>, Empty> m_parameter;
     NonnullRefPtr<BlockStatement const> m_body;
 };
 

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -659,7 +659,7 @@ struct BindingPattern : RefCounted<BindingPattern> {
 
     bool contains_expression() const;
 
-    Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&, Bytecode::Op::BindingInitializationMode initialization_mode, Bytecode::ScopedOperand const& object, bool create_variables) const;
+    Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&, Bytecode::Op::BindingInitializationMode initialization_mode, Bytecode::ScopedOperand const& object) const;
 
     Vector<BindingEntry> entries;
     Kind kind { Kind::Object };

--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -114,7 +114,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
             auto input_operand = allocate_register();
             emit<Op::GetArgument>(input_operand.operand(), param_index);
             auto init_mode = function.shared_data().m_has_duplicates ? Op::BindingInitializationMode::Set : Bytecode::Op::BindingInitializationMode::Initialize;
-            TRY((*binding_pattern)->generate_bytecode(*this, init_mode, input_operand, false));
+            TRY((*binding_pattern)->generate_bytecode(*this, init_mode, input_operand));
         }
     }
 

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -105,7 +105,7 @@ public:
         return scope_pusher;
     }
 
-    static ScopePusher catch_scope(Parser& parser, RefPtr<BindingPattern const> const& pattern, FlyString const& parameter)
+    static ScopePusher catch_scope(Parser& parser, RefPtr<BindingPattern const> const& pattern, RefPtr<Identifier const> const& parameter)
     {
         ScopePusher scope_pusher(parser, nullptr, ScopeLevel::NotTopLevel, ScopeType::Catch);
         if (pattern) {
@@ -114,9 +114,9 @@ public:
                 scope_pusher.m_forbidden_var_names.set(identifier.string());
                 scope_pusher.m_bound_names.set(identifier.string());
             }));
-        } else if (!parameter.is_empty()) {
-            scope_pusher.m_var_names.set(parameter);
-            scope_pusher.m_bound_names.set(parameter);
+        } else if (parameter) {
+            scope_pusher.m_var_names.set(parameter->string());
+            scope_pusher.m_bound_names.set(parameter->string());
         }
 
         return scope_pusher;
@@ -3777,7 +3777,7 @@ NonnullRefPtr<CatchClause const> Parser::parse_catch_clause()
     auto rule_start = push_start();
     consume(TokenType::Catch);
 
-    FlyString parameter;
+    RefPtr<Identifier const> parameter;
     RefPtr<BindingPattern const> pattern_parameter;
     auto should_expect_parameter = false;
     if (match(TokenType::ParenOpen)) {
@@ -3787,14 +3787,15 @@ NonnullRefPtr<CatchClause const> Parser::parse_catch_clause()
         if (match_identifier_name()
             && (!match(TokenType::Yield) || !m_state.in_generator_function_context)
             && (!match(TokenType::Async) || !m_state.await_expression_is_valid)
-            && (!match(TokenType::Await) || !m_state.in_class_static_init_block))
-            parameter = consume().fly_string_value();
-        else
+            && (!match(TokenType::Await) || !m_state.in_class_static_init_block)) {
+            parameter = parse_identifier();
+        } else {
             pattern_parameter = parse_binding_pattern(AllowDuplicates::No, AllowMemberExpressions::No);
+        }
         consume(TokenType::ParenClose);
     }
 
-    if (should_expect_parameter && parameter.is_empty() && !pattern_parameter)
+    if (should_expect_parameter && !parameter && !pattern_parameter)
         expected("an identifier or a binding pattern");
 
     HashTable<FlyString> bound_names;
@@ -3808,9 +3809,9 @@ NonnullRefPtr<CatchClause const> Parser::parse_catch_clause()
             }));
     }
 
-    if (!parameter.is_empty()) {
-        check_identifier_name_for_assignment_validity(parameter);
-        bound_names.set(parameter);
+    if (parameter) {
+        check_identifier_name_for_assignment_validity(parameter->string());
+        bound_names.set(parameter->string());
     }
 
     ScopePusher catch_scope = ScopePusher::catch_scope(*this, pattern_parameter, parameter);
@@ -3829,9 +3830,15 @@ NonnullRefPtr<CatchClause const> Parser::parse_catch_clause()
             move(body));
     }
 
+    if (parameter) {
+        return create_ast_node<CatchClause>(
+            { m_source_code, rule_start.position(), position() },
+            parameter.release_nonnull(),
+            move(body));
+    }
+
     return create_ast_node<CatchClause>(
         { m_source_code, rule_start.position(), position() },
-        move(parameter),
         move(body));
 }
 

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -320,7 +320,6 @@ private:
         bool initiated_by_eval { false };
         bool in_eval_function_context { false }; // This controls if we allow new.target or not. Note that eval("return") is not allowed, so we have to have a separate state variable for eval.
         bool in_formal_parameter_context { false };
-        bool in_catch_parameter_context { false };
         bool in_generator_function_context { false };
         bool await_expression_is_valid { false };
         bool in_arrow_function_context { false };


### PR DESCRIPTION
Local variables are faster to access and if all catch parameters are locals we can skip lexical environment allocation.

Small improvement in JetStream:
```
Suite       Test                Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  ----------------  ---------  ---------------------------  ---------------------------
JetStream   bigfib.cpp.js         0.996  6.905 ± 6.900 … 6.910        6.930 ± 6.920 … 6.940
JetStream   cdjs.js               1.01   6.450 ± 6.440 … 6.460        6.385 ± 6.360 … 6.410
JetStream   container.cpp.js      1.002  33.045 ± 32.960 … 33.130     32.990 ± 32.770 … 33.210
JetStream   dry.c.js              1.006  18.645 ± 18.290 … 19.000     18.530 ± 18.090 … 18.970
JetStream   float-mm.c.js         1.006  17.530 ± 17.450 … 17.610     17.425 ± 17.420 … 17.430
JetStream   gcc-loops.cpp.js      1.005  101.335 ± 100.960 … 101.710  100.870 ± 100.770 … 100.970
JetStream   hash-map.js           1.03   3.555 ± 3.520 … 3.590        3.450 ± 3.450 … 3.450
JetStream   n-body.c.js           0.999  25.980 ± 25.640 … 26.320     26.000 ± 26.000 … 26.000
JetStream   quicksort.c.js        1.01   4.350 ± 4.310 … 4.390        4.305 ± 4.300 … 4.310
JetStream   towers.c.js           1.008  7.105 ± 7.070 … 7.140        7.050 ± 7.040 … 7.060
JetStream   Total                 1.004  224.900                      223.935
All Suites  Total                 1.004  224.900                      223.935
```

Plus somehow progress on test262:
```
Summary:
    Diff Tests:
        +1 ✅    -1 ❌

Diff Tests:
    test/staging/sm/lexical-environment/catch-body.js ❌ -> ✅
```