### PR TITLE
ByteString: Propagate potential OOM errors from ByteString::to_byte_buffer()

### DIFF
--- a/AK/ByteString.cpp
+++ b/AK/ByteString.cpp
@@ -137,10 +137,9 @@ Vector<StringView> ByteString::split_view(char const separator, SplitBehavior sp
     return split_view([separator](char ch) { return ch == separator; }, split_behavior);
 }
 
-ByteBuffer ByteString::to_byte_buffer() const
+ErrorOr<ByteBuffer> ByteString::to_byte_buffer() const
 {
-    // FIXME: Handle OOM failure.
-    return ByteBuffer::copy(bytes()).release_value_but_fixme_should_propagate_errors();
+    return ByteBuffer::copy(bytes());
 }
 
 bool ByteString::starts_with(StringView str, CaseSensitivity case_sensitivity) const

--- a/AK/ByteString.h
+++ b/AK/ByteString.h
@@ -264,7 +264,7 @@ public:
         return m_impl->hash();
     }
 
-    [[nodiscard]] ByteBuffer to_byte_buffer() const;
+    [[nodiscard]] ErrorOr<ByteBuffer> to_byte_buffer() const;
 
     template<typename BufferType>
     [[nodiscard]] static ByteString copy(BufferType const& buffer, ShouldChomp should_chomp = NoChomp)

--- a/Libraries/LibCore/MimeData.cpp
+++ b/Libraries/LibCore/MimeData.cpp
@@ -42,9 +42,10 @@ ByteString MimeData::text() const
     return ByteString::copy(m_data.get("text/plain"sv).value_or({}));
 }
 
-void MimeData::set_text(ByteString const& text)
+ErrorOr<void> MimeData::set_text(ByteString const& text)
 {
-    set_data("text/plain"_string, text.to_byte_buffer());
+    set_data("text/plain"_string, TRY(text.to_byte_buffer()));
+    return {};
 }
 
 // FIXME: Share this, TextEditor and HackStudio language detection somehow.

--- a/Libraries/LibCore/MimeData.h
+++ b/Libraries/LibCore/MimeData.h
@@ -29,7 +29,7 @@ public:
     // Convenience helpers for "text/plain"
     bool has_text() const { return has_format("text/plain"sv); }
     ByteString text() const;
-    void set_text(ByteString const&);
+    ErrorOr<void> set_text(ByteString const&);
 
     // Convenience helpers for "text/uri-list"
     bool has_urls() const { return has_format("text/uri-list"sv); }

--- a/Libraries/LibWeb/Fetch/Infrastructure/URL.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/URL.cpp
@@ -68,7 +68,7 @@ ErrorOr<DataURL> process_data_url(URL::URL const& data_url)
     auto encoded_body = input.substring_view(position.value());
 
     // 10. Let body be the percent-decoding of encodedBody.
-    auto body = URL::percent_decode(encoded_body).to_byte_buffer();
+    auto body = TRY(URL::percent_decode(encoded_body).to_byte_buffer());
 
     // 11. If mimeType ends with U+003B (;), followed by zero or more U+0020 SPACE, followed by an ASCII case-insensitive match for "base64", then:
     if (mime_type.ends_with("base64"sv, CaseSensitivity::CaseInsensitive)) {

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -270,7 +270,7 @@ void ResourceLoader::load(LoadRequest& request, GC::Root<SuccessCallback> succes
         }
 
         Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(m_heap, [success_callback, response_headers = move(response_headers), fixme_implement_timing_info = move(fixme_implement_timing_info)] {
-            success_callback->function()(ByteString::empty().to_byte_buffer(), fixme_implement_timing_info, response_headers, {}, {});
+            success_callback->function()(MUST(ByteString::empty().to_byte_buffer()), fixme_implement_timing_info, response_headers, {}, {});
         }));
         return;
     }


### PR DESCRIPTION
Change ByteString::to_byte_buffer() to return ErrorOr<ByteBuffer>, allowing potential OOM errors from ByteBuffer::copy() to be propagated.

Update callers to handle the ErrorOr<> using TRY() or MUST(). 