### PR TITLE
Meta: Update vcpkg to latest master

### DIFF
--- a/Toolchain/BuildVcpkg.py
+++ b/Toolchain/BuildVcpkg.py
@@ -10,7 +10,7 @@ def main() -> int:
     script_dir = pathlib.Path(__file__).parent.resolve()
 
     git_repo = "https://github.com/microsoft/vcpkg.git"
-    git_rev = "bc994510d2eb11aac7b43b03f67a7751d5bfe0e4"  # main on 2025-04-12
+    git_rev = "d6995a0cf3cafda5e9e52749fad075dd62bfd90c"  # main on 2025-05-22
 
     build_dir = script_dir.parent / "Build"
     build_dir.mkdir(parents=True, exist_ok=True)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -202,7 +202,7 @@
     },
     {
       "name": "woff2",
-      "version": "1.0.2#4"
+      "version": "1.0.2#5"
     },
     {
       "name": "zlib",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "bc994510d2eb11aac7b43b03f67a7751d5bfe0e4",
+  "builtin-baseline": "d6995a0cf3cafda5e9e52749fad075dd62bfd90c",
   "dependencies": [
     {
       "name": "angle",
@@ -123,7 +123,7 @@
       "features": [
         "zstd"
       ]
-    }, 
+    },
     {
       "name": "vulkan-headers",
       "platform": "!android"


### PR DESCRIPTION
This includes a patch to woff2, which lets it build on GCC 15. See https://github.com/microsoft/vcpkg/pull/45132

Fixes the build on Fedora 42. :tada: 