### PR TITLE
LibWeb: Canonicalize color space when parsing `color-mix()` function

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -1732,10 +1732,17 @@ RefPtr<CSSStyleValue const> Parser::parse_color_mix_function(TokenStream<Compone
                 return {};
             color_space = color_space_token.token().ident().to_string();
         }
+
         function_tokens.discard_whitespace();
 
+        auto canonical_color_space_name = [](String const& color_space_name) {
+            if (color_space_name == "xyz"sv)
+                return "xyz-d65"_string;
+            return color_space_name;
+        };
+
         return ColorMixStyleValue::ColorInterpolationMethod {
-            .color_space = color_space,
+            .color_space = canonical_color_space_name(color_space),
             .hue_interpolation_method = hue_interpolation_method,
         };
     };

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-color-mix-function.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-color-mix-function.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 587 tests
 
-559 Pass
-28 Fail
+587 Pass
 Pass	e.style['color'] = "color-mix(in srgb, red, blue)" should set the property value
 Pass	e.style['color'] = "color-mix(in srgb, 70% red, 50% blue)" should set the property value
 Pass	e.style['color'] = "color-mix(in hsl, red, blue)" should set the property value
@@ -491,34 +490,34 @@ Pass	e.style['color'] = "color-mix(in rec2020, color(rec2020 none .2 .3), color(
 Pass	e.style['color'] = "color-mix(in rec2020, color(rec2020 .1 .2 .3 / none), color(rec2020 .5 .6 .7))" should set the property value
 Pass	e.style['color'] = "color-mix(in rec2020, color(rec2020 .1 .2 .3 / none), color(rec2020 .5 .6 .7 / 0.5))" should set the property value
 Pass	e.style['color'] = "color-mix(in rec2020, color(rec2020 .1 .2 .3 / none), color(rec2020 .5 .6 .7 / none))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, 50% color(xyz .1 .2 .3), color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), 50% color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 25%, color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 .7) 25%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 25%, color(xyz .5 .6 .7) 75%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 30%, color(xyz .5 .6 .7) 90%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 12.5%, color(xyz .5 .6 .7) 37.5%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 0%, color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .5), color(xyz .5 .6 .7 / .8))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 25%, color(xyz .5 .6 .7 / .8))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4), color(xyz .5 .6 .7 / .8) 25%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 25%, color(xyz .5 .6 .7 / .8) 75%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 30%, color(xyz .5 .6 .7 / .8) 90%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 12.5%, color(xyz .5 .6 .7 / .8) 37.5%)" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 0%, color(xyz .5 .6 .7 / .8))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz 2 3 4 / 5), color(xyz 4 6 8 / 10))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz -2 -3 -4), color(xyz -4 -6 -8))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz -2 -3 -4 / -5), color(xyz -4 -6 -8 / -10))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz none none none), color(xyz none none none))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz none none none), color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz none none none))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 none), color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 none))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz none .2 .3), color(xyz .5 none .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7 / 0.5))" should set the property value
-Fail	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7 / none))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, 50% color(xyz .1 .2 .3), color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), 50% color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 25%, color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 .7) 25%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 25%, color(xyz .5 .6 .7) 75%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 30%, color(xyz .5 .6 .7) 90%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 12.5%, color(xyz .5 .6 .7) 37.5%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3) 0%, color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .5), color(xyz .5 .6 .7 / .8))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 25%, color(xyz .5 .6 .7 / .8))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4), color(xyz .5 .6 .7 / .8) 25%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 25%, color(xyz .5 .6 .7 / .8) 75%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 30%, color(xyz .5 .6 .7 / .8) 90%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 12.5%, color(xyz .5 .6 .7 / .8) 37.5%)" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / .4) 0%, color(xyz .5 .6 .7 / .8))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz 2 3 4 / 5), color(xyz 4 6 8 / 10))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz -2 -3 -4), color(xyz -4 -6 -8))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz -2 -3 -4 / -5), color(xyz -4 -6 -8 / -10))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz none none none), color(xyz none none none))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz none none none), color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz none none none))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 none), color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 none))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz none .2 .3), color(xyz .5 none .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7 / 0.5))" should set the property value
+Pass	e.style['color'] = "color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7 / none))" should set the property value
 Pass	e.style['color'] = "color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 .5 .6 .7))" should set the property value
 Pass	e.style['color'] = "color-mix(in xyz-d50, 50% color(xyz-d50 .1 .2 .3), color(xyz-d50 .5 .6 .7))" should set the property value
 Pass	e.style['color'] = "color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), 50% color(xyz-d50 .5 .6 .7))" should set the property value


### PR DESCRIPTION
This amounts to replacing the "xyz" color space with "xyz-d65".

This fixes the remaining subtests in: https://wpt.live/css/css-color/parsing/color-valid-color-mix-function.html.