### PR TITLE
LibWeb: Use branded colors for the media element, and fix repainting when the element is paused

### DIFF
--- a/Libraries/LibGfx/Color.h
+++ b/Libraries/LibGfx/Color.h
@@ -82,16 +82,62 @@ public:
 
     using enum NamedColor;
 
+    enum class BrandedColor {
+        Indigo10,
+        Indigo20,
+        Indigo30,
+        Indigo40,
+        Indigo50,
+        Indigo60,
+        Indigo80,
+        Indigo100,
+        Indigo300,
+        Indigo500,
+        Indigo900,
+
+        Violet10,
+        Violet20,
+        Violet30,
+        Violet40,
+        Violet50,
+        Violet60,
+        Violet80,
+        Violet100,
+        Violet300,
+        Violet500,
+        Violet900,
+
+        SlateBlue10,
+        SlateBlue20,
+        SlateBlue30,
+        SlateBlue40,
+        SlateBlue50,
+        SlateBlue60,
+        SlateBlue80,
+        SlateBlue100,
+        SlateBlue300,
+        SlateBlue500,
+        SlateBlue900,
+
+        Violet = Violet100,
+        Indigo = Indigo100,
+        SlateBlue = SlateBlue100,
+    };
+
     constexpr Color() = default;
     constexpr Color(NamedColor);
+
     constexpr Color(u8 r, u8 g, u8 b)
         : m_value(0xff000000 | (r << 16) | (g << 8) | b)
     {
     }
+
     constexpr Color(u8 r, u8 g, u8 b, u8 a)
         : m_value((a << 24) | (r << 16) | (g << 8) | b)
     {
     }
+
+    static constexpr Color branded_color(BrandedColor);
 
     static constexpr Color from_rgb(unsigned rgb) { return Color(rgb | 0xff000000); }
     static constexpr Color from_argb(unsigned argb) { return Color(argb); }
@@ -641,6 +687,51 @@ constexpr Color::Color(NamedColor named)
     }
 
     m_value = 0xff000000 | (rgb.r << 16) | (rgb.g << 8) | rgb.b;
+}
+
+constexpr Color Color::branded_color(BrandedColor color)
+{
+    // clang-format off
+    switch (color) {
+    case BrandedColor::Indigo10:     return from_rgb(0xa5'a6'f2);
+    case BrandedColor::Indigo20:     return from_rgb(0x8a'88'eb);
+    case BrandedColor::Indigo30:     return from_rgb(0x68'51'd6);
+    case BrandedColor::Indigo40:     return from_rgb(0x55'3f'c4);
+    case BrandedColor::Indigo50:     return from_rgb(0x4d'37'b8);
+    case BrandedColor::Indigo60:     return from_rgb(0x3c'28'a1);
+    case BrandedColor::Indigo80:     return from_rgb(0x30'1f'82);
+    case BrandedColor::Indigo100:    return from_rgb(0x2a'13'73);
+    case BrandedColor::Indigo300:    return from_rgb(0x26'0f'73);
+    case BrandedColor::Indigo500:    return from_rgb(0x1d'0c'59);
+    case BrandedColor::Indigo900:    return from_rgb(0x19'0c'4a);
+
+    case BrandedColor::Violet10:     return from_rgb(0xe0'd4'ff);
+    case BrandedColor::Violet20:     return from_rgb(0xca'b5'ff);
+    case BrandedColor::Violet30:     return from_rgb(0xc3'ab'ff);
+    case BrandedColor::Violet40:     return from_rgb(0xb4'96'ff);
+    case BrandedColor::Violet50:     return from_rgb(0xab'8e'f5);
+    case BrandedColor::Violet60:     return from_rgb(0x9d'7c'f2);
+    case BrandedColor::Violet80:     return from_rgb(0x93'6f'ed);
+    case BrandedColor::Violet100:    return from_rgb(0x8a'64'e5);
+    case BrandedColor::Violet300:    return from_rgb(0x82'57'e6);
+    case BrandedColor::Violet500:    return from_rgb(0x7a'4c'e6);
+    case BrandedColor::Violet900:    return from_rgb(0x6a'39'db);
+
+    case BrandedColor::SlateBlue10:  return from_rgb(0xcb'e0'f7);
+    case BrandedColor::SlateBlue20:  return from_rgb(0xc1'd9'f5);
+    case BrandedColor::SlateBlue30:  return from_rgb(0xb6'd2'f2);
+    case BrandedColor::SlateBlue40:  return from_rgb(0xa8'c8'ed);
+    case BrandedColor::SlateBlue50:  return from_rgb(0x97'bc'e6);
+    case BrandedColor::SlateBlue60:  return from_rgb(0x86'ad'd9);
+    case BrandedColor::SlateBlue80:  return from_rgb(0x77'a1'd1);
+    case BrandedColor::SlateBlue100: return from_rgb(0x6d'98'cc);
+    case BrandedColor::SlateBlue300: return from_rgb(0x5c'8e'cc);
+    case BrandedColor::SlateBlue500: return from_rgb(0x54'84'bf);
+    case BrandedColor::SlateBlue900: return from_rgb(0x48'72'a3);
+    }
+    // clang-format on
+
+    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -132,12 +132,18 @@ public:
 
     WebIDL::ExceptionOr<bool> handle_keydown(Badge<Web::EventHandler>, UIEvents::KeyCode, u32 modifiers);
 
-    enum class MouseTrackingComponent {
+    enum class MediaComponent {
+        PlaybackButton,
+        SpeakerButton,
         Timeline,
         Volume,
     };
-    void set_layout_mouse_tracking_component(Badge<Painting::MediaPaintable>, Optional<MouseTrackingComponent> mouse_tracking_component) { m_mouse_tracking_component = move(mouse_tracking_component); }
-    Optional<MouseTrackingComponent> const& layout_mouse_tracking_component(Badge<Painting::MediaPaintable>) const { return m_mouse_tracking_component; }
+
+    void set_layout_mouse_tracking_component(Badge<Painting::MediaPaintable>, Optional<MediaComponent> mouse_tracking_component) { m_mouse_tracking_component = move(mouse_tracking_component); }
+    Optional<MediaComponent> const& layout_mouse_tracking_component(Badge<Painting::MediaPaintable>) const { return m_mouse_tracking_component; }
+
+    void set_layout_hovered_component(Badge<Painting::MediaPaintable>, Optional<MediaComponent> hovered_component) { m_hovered_component = hovered_component; }
+    Optional<MediaComponent> const& layout_hovered_component(Badge<Painting::MediaPaintable>) const { return m_hovered_component; }
 
     void set_layout_mouse_position(Badge<Painting::MediaPaintable>, Optional<CSSPixelPoint> mouse_position) { m_mouse_position = move(mouse_position); }
     Optional<CSSPixelPoint> const& layout_mouse_position(Badge<Painting::MediaPaintable>) const { return m_mouse_position; }
@@ -318,7 +324,8 @@ private:
     bool m_seek_in_progress = false;
 
     // Cached state for layout.
-    Optional<MouseTrackingComponent> m_mouse_tracking_component;
+    Optional<MediaComponent> m_mouse_tracking_component;
+    Optional<MediaComponent> m_hovered_component;
     bool m_tracking_mouse_position_while_playing { false };
     Optional<CSSPixelPoint> m_mouse_position;
     Optional<double> m_display_time;

--- a/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -19,14 +19,15 @@
 
 namespace Web::Painting {
 
-static constexpr auto control_box_color = Gfx::Color::from_rgb(0x26'26'26);
-static constexpr auto control_highlight_color = Gfx::Color::from_rgb(0x1d'99'f3);
+static constexpr auto CONTROL_BOX_COLOR = Gfx::Color::from_rgb(0x26'26'26);
+static constexpr auto CONTROL_BUTTON_COLOR = Gfx::Color::branded_color(Gfx::Color::BrandedColor::Violet);
+static constexpr auto CONTROL_HIGHLIGHT_COLOR = Gfx::Color::branded_color(Gfx::Color::BrandedColor::Violet60);
 
 static constexpr Gfx::Color control_button_color(bool is_hovered)
 {
     if (!is_hovered)
         return Color::White;
-    return control_highlight_color;
+    return CONTROL_BUTTON_COLOR;
 }
 
 MediaPaintable::MediaPaintable(Layout::ReplacedBox const& layout_box)
@@ -61,7 +62,7 @@ void MediaPaintable::fill_triangle(DisplayListRecorder& painter, Gfx::IntPoint l
 void MediaPaintable::paint_media_controls(PaintContext& context, HTML::HTMLMediaElement const& media_element, DevicePixelRect media_rect, Optional<DevicePixelPoint> const& mouse_position) const
 {
     auto components = compute_control_bar_components(context, media_element, media_rect);
-    context.display_list_recorder().fill_rect(components.control_box_rect.to_type<int>(), control_box_color.with_alpha(0xd0));
+    context.display_list_recorder().fill_rect(components.control_box_rect.to_type<int>(), CONTROL_BOX_COLOR.with_alpha(0xd0));
 
     paint_control_bar_playback_button(context, media_element, components, mouse_position);
     paint_control_bar_timeline(context, media_element, components);
@@ -182,7 +183,7 @@ void MediaPaintable::paint_control_bar_timeline(PaintContext& context, HTML::HTM
 
     auto timeline_past_rect = components.timeline_rect;
     timeline_past_rect.set_width(timeline_button_offset_x);
-    context.display_list_recorder().fill_rect(timeline_past_rect.to_type<int>(), control_highlight_color.lightened());
+    context.display_list_recorder().fill_rect(timeline_past_rect.to_type<int>(), CONTROL_HIGHLIGHT_COLOR);
 
     auto timeline_future_rect = components.timeline_rect;
     timeline_future_rect.take_from_left(timeline_button_offset_x);
@@ -261,7 +262,7 @@ void MediaPaintable::paint_control_bar_volume(PaintContext& context, HTML::HTMLM
 
     auto volume_lower_rect = components.volume_scrub_rect;
     volume_lower_rect.set_width(volume_button_offset_x);
-    context.display_list_recorder().fill_rect_with_rounded_corners(volume_lower_rect.to_type<int>(), control_highlight_color.lightened(), 4);
+    context.display_list_recorder().fill_rect_with_rounded_corners(volume_lower_rect.to_type<int>(), CONTROL_HIGHLIGHT_COLOR, 4);
 
     auto volume_higher_rect = components.volume_scrub_rect;
     volume_higher_rect.take_from_left(volume_button_offset_x);

--- a/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -272,7 +272,7 @@ void MediaPaintable::paint_control_bar_volume(PaintContext& context, HTML::HTMLM
     volume_button_rect.shrink(components.volume_scrub_rect.width() - components.volume_button_size, components.volume_scrub_rect.height() - components.volume_button_size);
     volume_button_rect.set_x(components.volume_scrub_rect.x() + volume_button_offset_x - components.volume_button_size / 2);
 
-    auto volume_is_hovered = rect_is_hovered(media_element, components.volume_rect, mouse_position, HTML::HTMLMediaElement::MouseTrackingComponent::Volume);
+    auto volume_is_hovered = rect_is_hovered(media_element, components.volume_rect, mouse_position, HTML::HTMLMediaElement::MediaComponent::Volume);
     auto volume_color = control_button_color(volume_is_hovered);
     context.display_list_recorder().fill_ellipse(volume_button_rect.to_type<int>(), volume_color);
 }
@@ -289,10 +289,10 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousedown(Badge<E
     position_adjusted_by_scroll_offset.translate_by(-cumulative_offset_of_enclosing_scroll_frame());
 
     if (cached_layout_boxes.timeline_rect.has_value() && cached_layout_boxes.timeline_rect->contains(position_adjusted_by_scroll_offset)) {
-        media_element.set_layout_mouse_tracking_component({}, HTML::HTMLMediaElement::MouseTrackingComponent::Timeline);
+        media_element.set_layout_mouse_tracking_component({}, HTML::HTMLMediaElement::MediaComponent::Timeline);
         set_current_time(media_element, *cached_layout_boxes.timeline_rect, position_adjusted_by_scroll_offset, Temporary::Yes);
     } else if (cached_layout_boxes.volume_rect.has_value() && cached_layout_boxes.volume_rect->contains(position_adjusted_by_scroll_offset)) {
-        media_element.set_layout_mouse_tracking_component({}, HTML::HTMLMediaElement::MouseTrackingComponent::Volume);
+        media_element.set_layout_mouse_tracking_component({}, HTML::HTMLMediaElement::MediaComponent::Volume);
         set_volume(media_element, *cached_layout_boxes.volume_scrub_rect, position_adjusted_by_scroll_offset);
     }
 
@@ -312,14 +312,17 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mouseup(Badge<Eve
 
     if (auto const& mouse_tracking_component = media_element.layout_mouse_tracking_component({}); mouse_tracking_component.has_value()) {
         switch (*mouse_tracking_component) {
-        case HTML::HTMLMediaElement::MouseTrackingComponent::Timeline:
+        case HTML::HTMLMediaElement::MediaComponent::Timeline:
             set_current_time(media_element, *cached_layout_boxes.timeline_rect, position_adjusted_by_scroll_offset, Temporary::No);
             media_element.set_layout_display_time({}, {});
             break;
 
-        case HTML::HTMLMediaElement::MouseTrackingComponent::Volume:
+        case HTML::HTMLMediaElement::MediaComponent::Volume:
             document().page().client().page_did_stop_tooltip_override();
             break;
+
+        default:
+            VERIFY_NOT_REACHED();
         }
 
         const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(nullptr);
@@ -361,12 +364,12 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousemove(Badge<E
 
     if (auto const& mouse_tracking_component = media_element.layout_mouse_tracking_component({}); mouse_tracking_component.has_value()) {
         switch (*mouse_tracking_component) {
-        case HTML::HTMLMediaElement::MouseTrackingComponent::Timeline:
+        case HTML::HTMLMediaElement::MediaComponent::Timeline:
             if (cached_layout_boxes.timeline_rect.has_value())
                 set_current_time(media_element, *cached_layout_boxes.timeline_rect, position_adjusted_by_scroll_offset, Temporary::Yes);
             break;
 
-        case HTML::HTMLMediaElement::MouseTrackingComponent::Volume:
+        case HTML::HTMLMediaElement::MediaComponent::Volume:
             if (cached_layout_boxes.volume_rect.has_value()) {
                 set_volume(media_element, *cached_layout_boxes.volume_scrub_rect, position_adjusted_by_scroll_offset);
 
@@ -375,8 +378,25 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousemove(Badge<E
             }
 
             break;
+
+        default:
+            VERIFY_NOT_REACHED();
         }
     }
+
+    auto previous_hovered_component = media_element.layout_hovered_component({});
+
+    if (cached_layout_boxes.playback_button_rect.has_value() && cached_layout_boxes.playback_button_rect->contains(position_adjusted_by_scroll_offset))
+        media_element.set_layout_hovered_component({}, HTML::HTMLMediaElement::MediaComponent::PlaybackButton);
+    else if (cached_layout_boxes.speaker_button_rect.has_value() && cached_layout_boxes.speaker_button_rect->contains(position_adjusted_by_scroll_offset))
+        media_element.set_layout_hovered_component({}, HTML::HTMLMediaElement::MediaComponent::SpeakerButton);
+    else if (cached_layout_boxes.volume_rect.has_value() && cached_layout_boxes.volume_rect->contains(position_adjusted_by_scroll_offset))
+        media_element.set_layout_hovered_component({}, HTML::HTMLMediaElement::MediaComponent::Volume);
+    else
+        media_element.set_layout_hovered_component({}, {});
+
+    if (previous_hovered_component != media_element.layout_hovered_component({}))
+        set_needs_display();
 
     if (absolute_rect().contains(position_adjusted_by_scroll_offset)) {
         media_element.set_layout_mouse_position({}, position_adjusted_by_scroll_offset);
@@ -416,7 +436,7 @@ void MediaPaintable::set_volume(HTML::HTMLMediaElement& media_element, CSSPixelR
     media_element.set_volume(volume).release_value_but_fixme_should_propagate_errors();
 }
 
-bool MediaPaintable::rect_is_hovered(HTML::HTMLMediaElement const& media_element, Optional<DevicePixelRect> const& rect, Optional<DevicePixelPoint> const& mouse_position, Optional<HTML::HTMLMediaElement::MouseTrackingComponent> const& allowed_mouse_tracking_component)
+bool MediaPaintable::rect_is_hovered(HTML::HTMLMediaElement const& media_element, Optional<DevicePixelRect> const& rect, Optional<DevicePixelPoint> const& mouse_position, Optional<HTML::HTMLMediaElement::MediaComponent> const& allowed_mouse_tracking_component)
 {
     if (auto const& mouse_tracking_component = media_element.layout_mouse_tracking_component({}); mouse_tracking_component.has_value())
         return mouse_tracking_component == allowed_mouse_tracking_component;

--- a/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -61,7 +61,7 @@ private:
     static void set_current_time(HTML::HTMLMediaElement& media_element, CSSPixelRect timeline_rect, CSSPixelPoint mouse_position, Temporary);
     static void set_volume(HTML::HTMLMediaElement& media_element, CSSPixelRect volume_rect, CSSPixelPoint mouse_position);
 
-    static bool rect_is_hovered(HTML::HTMLMediaElement const& media_element, Optional<DevicePixelRect> const& rect, Optional<DevicePixelPoint> const& mouse_position, Optional<HTML::HTMLMediaElement::MouseTrackingComponent> const& allowed_mouse_tracking_component = {});
+    static bool rect_is_hovered(HTML::HTMLMediaElement const& media_element, Optional<DevicePixelRect> const& rect, Optional<DevicePixelPoint> const& mouse_position, Optional<HTML::HTMLMediaElement::MediaComponent> const& allowed_mouse_tracking_component = {});
 };
 
 }


### PR DESCRIPTION
![media](https://github.com/user-attachments/assets/d646c301-f333-4e8d-8ddd-451f3406838f)
