### PR TITLE
LibWeb: Remove application of vertical float clearance to BFC's Y offset

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -918,10 +918,8 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
 
             // First, find the lowest margin box edge on this float side and calculate the Y offset just below it.
             CSSPixels clearance_y_in_root = 0;
-            for (auto const& floating_box : float_side.current_boxes) {
-                auto floating_box_rect_in_root = margin_box_rect_in_ancestor_coordinate_space(floating_box.used_values, root());
-                clearance_y_in_root = max(clearance_y_in_root, floating_box_rect_in_root.bottom());
-            }
+            for (auto const& floating_box : float_side.current_boxes)
+                clearance_y_in_root = max(clearance_y_in_root, floating_box.margin_box_rect_in_root_coordinate_space.bottom());
 
             // Then, convert the clearance Y to a coordinate relative to the containing block of `child_box`.
             CSSPixels clearance_y_in_containing_block = clearance_y_in_root;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -564,10 +564,6 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
         block_container_state.set_content_width(used_width_px);
         block_container_state.set_content_height(context.automatic_content_height());
     }
-
-    // If we end up with remaining vertical clearance, we should make sure the next block is moved down accordingly.
-    if (context.vertical_float_clearance() > 0)
-        m_y_offset_of_current_block_container = context.vertical_float_clearance();
 }
 
 CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Box const& box, AvailableSpace const& available_space)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-right-should-not-affect-inline-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-right-should-not-affect-inline-left.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 650x466 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 634x384 children: not-inline
+      BlockContainer <div.a> at (342,16) content-size 300x225 floating [BFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 634x0 children: inline
+        TextNode <#text>
+      BlockContainer <p> at (8,16) content-size 634x68 children: inline
+        frag 0 from TextNode start: 0, length: 27, rect: [8,16 232.84375x17] baseline: 13.296875
+            "Lorem ipsum dolor sit amet,"
+        frag 1 from TextNode start: 28, length: 35, rect: [8,33 278.125x17] baseline: 13.296875
+            "consectetur adipiscing elit, sed do"
+        frag 2 from TextNode start: 64, length: 38, rect: [8,50 316.5x17] baseline: 13.296875
+            "eiusmod tempor incididunt ut labore et"
+        frag 3 from TextNode start: 103, length: 20, rect: [8,67 167.078125x17] baseline: 13.296875
+            "dolore magna aliqua."
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,100) content-size 634x0 children: inline
+        TextNode <#text>
+        BlockContainer <div.a> at (342,241) content-size 300x225 floating [BFC] children: not-inline
+        TextNode <#text>
+      BlockContainer <div.b> at (8,100) content-size 634x300 children: not-inline
+      BlockContainer <(anonymous)> at (8,400) content-size 634x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 650x466]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 634x384]
+      PaintableWithLines (BlockContainer<DIV>.a) [342,16 300x225]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 634x0]
+      PaintableWithLines (BlockContainer<P>) [8,16 634x68]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,100 634x0]
+        PaintableWithLines (BlockContainer<DIV>.a) [342,241 300x225]
+      PaintableWithLines (BlockContainer<DIV>.b) [8,100 634x300]
+      PaintableWithLines (BlockContainer(anonymous)) [8,400 634x0]

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-clear-right-should-not-affect-inline-left.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-clear-right-should-not-affect-inline-left.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    html {
+        font-family: sans-serif;
+        width: 650px;
+    }
+    .a {
+        background: rgba(0, 255, 0, 0.6);
+        clear: right;
+        float: right;
+        height: 225px;
+        width: 300px;
+    }
+    .b {
+        background: rgba(255, 0, 0, 0.6);
+        height: 300px;
+    }
+</style>
+<div class="a"></div>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+<div class="a"></div>
+<div class="b"></div>


### PR DESCRIPTION
In https://github.com/LadybirdBrowser/ladybird/commit/15103d172c2a4279c611d8a9d6262e15d3a3351e we applied any remaining vertical float clearance to the BFC's current Y offset for the next block to layout, because a `<br style="clear: left">` could introduce clearance that would otherwise be ignored. However, a `<div>` that floats _and_ clears `right` also introduces this clearance and it is obvious that this should not push down any subsequent blocks to layout in the current BFC.

Turns out, we don't need this change anymore. Some other later change also fixed the underlying issue, and by getting rid of the original fix we can now render https://en.wikipedia.org/wiki/SerenityOS correctly again.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4418.