### PR TITLE
LibRegex: Better estimate the cost of laying out alts as a chain

### DIFF
--- a/Libraries/LibRegex/RegexByteCode.h
+++ b/Libraries/LibRegex/RegexByteCode.h
@@ -190,6 +190,8 @@ class ByteCode : public DisjointChunks<ByteCodeValueType> {
     using Base = DisjointChunks<ByteCodeValueType>;
 
 public:
+    using Base::append;
+
     ByteCode()
     {
         ensure_opcodes_initialized();

--- a/Libraries/LibRegex/RegexMatcher.h
+++ b/Libraries/LibRegex/RegexMatcher.h
@@ -228,6 +228,7 @@ public:
 
 private:
     void run_optimization_passes();
+    void rewrite_with_useless_jumps_removed();
     void attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&);
     bool attempt_rewrite_entire_match_as_substring_search(BasicBlockList const&);
     void fill_optimization_data(BasicBlockList const&);

--- a/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Libraries/LibRegex/RegexOptimizer.cpp
@@ -1264,7 +1264,7 @@ void Optimizer::append_alternation(ByteCode& target, Span<ByteCode> alternatives
 
     // This is really only worth it if we don't blow up the size by the 2-extra-instruction-per-node scheme, similarly, if no nodes are shared, we're better off not using a tree.
     auto tree_cost = (total_nodes - common_hits) * 2;
-    auto chain_cost = total_nodes + alternatives.size() * 2;
+    auto chain_cost = total_bytecode_entries_in_tree + alternatives.size() * 2;
     dbgln_if(REGEX_DEBUG, "Total nodes: {}, common hits: {} (tree cost = {}, chain cost = {})", total_nodes, common_hits, tree_cost, chain_cost);
 
     if (common_hits == 0 || tree_cost > chain_cost) {


### PR DESCRIPTION
Previously we were counting the total number of *nodes* in the tree for the chain cost, which greatly underestimated its cost when large bytecode entries were present,
This commit switches to estimating it using the total bytecode *size*, which is a closer value to the true cost than the tree node count.

This corresponds to a ~4x perf improvement on /<script|<style|<link/ in speedometer.