### PR TITLE
LibWeb: Don't crash when processing a transition with value `none`

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -912,7 +912,7 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
             set_longhand_property(CSS::PropertyID::TransitionProperty, CSSKeywordValue::create(Keyword::All));
             set_longhand_property(CSS::PropertyID::TransitionDuration, TimeStyleValue::create(CSS::Time::make_seconds(0)));
             set_longhand_property(CSS::PropertyID::TransitionDelay, TimeStyleValue::create(CSS::Time::make_seconds(0)));
-            set_longhand_property(CSS::PropertyID::TransitionTimingFunction, CSSKeywordValue::create(Keyword::Ease));
+            set_longhand_property(CSS::PropertyID::TransitionTimingFunction, EasingStyleValue::create(EasingStyleValue::CubicBezier::ease()));
             return;
         }
         auto const& transitions = value.as_transition().transitions();


### PR DESCRIPTION
This fixes a regression introduced by: #4387

Fixes a crash on: https://bbc.co.uk

I was able to reproduce the crash on `master` with the following test file by mousing over the red square:

```html
<!DOCTYPE html>
<style>
    div {
        width: 100px;
        height: 100px;
        background-color: red;
    }
    div:hover {
        transition: none;
    }
</style>
<div></div>
```

For some reason I can't recreate the crash using either `internals.moveMouseTo()` or `internals.hitTest()`.