### PR TITLE
LibJS: Implement `rawJSON` and `isRawJSON`

### DIFF
--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -177,6 +177,7 @@ set(SOURCES
     Runtime/PropertyDescriptor.cpp
     Runtime/ProxyConstructor.cpp
     Runtime/ProxyObject.cpp
+    Runtime/RawJSONObject.cpp
     Runtime/Realm.cpp
     Runtime/Reference.cpp
     Runtime/ReflectObject.cpp

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -285,6 +285,7 @@ namespace JS {
     P(isLockFree)                            \
     P(isNaN)                                 \
     P(isPrototypeOf)                         \
+    P(isRawJSON)                             \
     P(isSafeInteger)                         \
     P(isSealed)                              \
     P(isSubsetOf)                            \
@@ -403,6 +404,7 @@ namespace JS {
     P(race)                                  \
     P(random)                                \
     P(raw)                                   \
+    P(rawJSON)                               \
     P(read)                                  \
     P(reason)                                \
     P(reduce)                                \

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -96,6 +96,7 @@
     M(JsonBigInt, "Cannot serialize BigInt value to JSON")                                                                          \
     M(JsonCircular, "Cannot stringify circular object")                                                                             \
     M(JsonMalformed, "Malformed JSON string")                                                                                       \
+    M(JsonRawJSONNonPrimitive, "JSON.rawJSON cannot accept object or array as outermost value")                                     \
     M(MathSumPreciseOverflow, "Overflow in Math.sumPrecise")                                                                        \
     M(MissingRequiredProperty, "Required property {} is missing or undefined")                                                      \
     M(ModuleNoEnvironment, "Cannot find module environment for imported binding")                                                   \

--- a/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Libraries/LibJS/Runtime/JSONObject.h
@@ -48,6 +48,8 @@ private:
 
     JS_DECLARE_NATIVE_FUNCTION(stringify);
     JS_DECLARE_NATIVE_FUNCTION(parse);
+    JS_DECLARE_NATIVE_FUNCTION(raw_json);
+    JS_DECLARE_NATIVE_FUNCTION(is_raw_json);
 };
 
 }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -210,6 +210,7 @@ public:
     virtual bool is_native_function() const { return false; }
     virtual bool is_ecmascript_function_object() const { return false; }
     virtual bool is_array_iterator() const { return false; }
+    virtual bool is_raw_json_object() const { return false; }
 
     // B.3.7 The [[IsHTMLDDA]] Internal Slot, https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
     virtual bool is_htmldda() const { return false; }

--- a/Libraries/LibJS/Runtime/RawJSONObject.cpp
+++ b/Libraries/LibJS/Runtime/RawJSONObject.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025, Artsiom Yafremau <aplefull@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/RawJSONObject.h>
+
+namespace JS {
+
+GC_DEFINE_ALLOCATOR(RawJSONObject);
+
+GC::Ref<RawJSONObject> RawJSONObject::create(Realm& realm, Object* prototype)
+{
+    if (!prototype)
+        return realm.create<RawJSONObject>(realm.intrinsics().empty_object_shape());
+
+    return realm.create<RawJSONObject>(ConstructWithPrototypeTag::Tag, *prototype);
+}
+
+}

--- a/Libraries/LibJS/Runtime/RawJSONObject.h
+++ b/Libraries/LibJS/Runtime/RawJSONObject.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, Artsiom Yafremau <aplefull@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+
+namespace JS {
+
+class RawJSONObject final : public Object {
+    JS_OBJECT(RawJSONObject, Object);
+    GC_DECLARE_ALLOCATOR(RawJSONObject);
+
+public:
+    static GC::Ref<RawJSONObject> create(Realm& realm, Object* prototype);
+    virtual ~RawJSONObject() override = default;
+
+private:
+    explicit RawJSONObject(Shape& shape)
+        : Object(shape)
+    {
+    }
+
+    RawJSONObject(ConstructWithPrototypeTag tag, Object& prototype)
+        : Object(tag, prototype)
+    {
+    }
+
+    virtual bool is_raw_json_object() const final { return true; }
+};
+
+template<>
+inline bool Object::fast_is<RawJSONObject>() const { return is_raw_json_object(); }
+
+}

--- a/Libraries/LibJS/Tests/builtins/JSON/JSON.isRawJSON.js
+++ b/Libraries/LibJS/Tests/builtins/JSON/JSON.isRawJSON.js
@@ -1,0 +1,14 @@
+test("JSON.isRawJSON basic functionality", () => {
+    const values = [1, 1.1, null, false, true, "123"];
+
+    for (const value of values) {
+        expect(JSON.isRawJSON(value)).toBeFalse();
+        expect(JSON.isRawJSON(JSON.rawJSON(value))).toBeTrue();
+    }
+
+    expect(JSON.isRawJSON(undefined)).toBeFalse();
+    expect(JSON.isRawJSON(Symbol("123"))).toBeFalse();
+    expect(JSON.isRawJSON([])).toBeFalse();
+    expect(JSON.isRawJSON({})).toBeFalse();
+    expect(JSON.isRawJSON({ rawJSON: "123" })).toBeFalse();
+});

--- a/Libraries/LibJS/Tests/builtins/JSON/JSON.rawJSON.js
+++ b/Libraries/LibJS/Tests/builtins/JSON/JSON.rawJSON.js
@@ -1,0 +1,57 @@
+test("JSON.rawJSON basic functionality", () => {
+    expect(Object.isExtensible(JSON.rawJSON)).toBeTrue();
+    expect(typeof JSON.rawJSON).toBe("function");
+    expect(Object.getPrototypeOf(JSON.rawJSON)).toBe(Function.prototype);
+    expect(Object.getOwnPropertyDescriptor(JSON.rawJSON, "prototype")).toBeUndefined();
+
+    expect(JSON.stringify(JSON.rawJSON(1))).toBe("1");
+    expect(JSON.stringify(JSON.rawJSON(1.1))).toBe("1.1");
+    expect(JSON.stringify(JSON.rawJSON(-1))).toBe("-1");
+    expect(JSON.stringify(JSON.rawJSON(-1.1))).toBe("-1.1");
+    expect(JSON.stringify(JSON.rawJSON(1.1e1))).toBe("11");
+    expect(JSON.stringify(JSON.rawJSON(1.1e-1))).toBe("0.11");
+    expect(JSON.stringify(JSON.rawJSON(null))).toBe("null");
+    expect(JSON.stringify(JSON.rawJSON(true))).toBe("true");
+    expect(JSON.stringify(JSON.rawJSON(false))).toBe("false");
+    expect(JSON.stringify(JSON.rawJSON('"foo"'))).toBe('"foo"');
+
+    expect(JSON.stringify({ 42: JSON.rawJSON(37) })).toBe('{"42":37}');
+    expect(JSON.stringify({ x: JSON.rawJSON(1), y: JSON.rawJSON(2) })).toBe('{"x":1,"y":2}');
+    expect(JSON.stringify({ x: { x: JSON.rawJSON(1), y: JSON.rawJSON(2) } })).toBe(
+        '{"x":{"x":1,"y":2}}'
+    );
+
+    expect(JSON.stringify([JSON.rawJSON(1), JSON.rawJSON(1.1)])).toBe("[1,1.1]");
+    expect(
+        JSON.stringify([
+            JSON.rawJSON('"1"'),
+            JSON.rawJSON(true),
+            JSON.rawJSON(null),
+            JSON.rawJSON(false),
+        ])
+    ).toBe('["1",true,null,false]');
+    expect(JSON.stringify([{ x: JSON.rawJSON(1), y: JSON.rawJSON(1) }])).toBe('[{"x":1,"y":1}]');
+});
+
+test("JSON.rawJSON error cases", () => {
+    expect(() => JSON.rawJSON(Symbol("123"))).toThrow(TypeError);
+    expect(() => JSON.rawJSON(undefined)).toThrow(SyntaxError);
+    expect(() => JSON.rawJSON({})).toThrow(SyntaxError);
+    expect(() => JSON.rawJSON([])).toThrow(SyntaxError);
+
+    const illegalChars = ["\n", "\t", "\r", " "];
+
+    illegalChars.forEach(char => {
+        expect(() => {
+            JSON.rawJSON(`${char}123`);
+        }).toThrow(SyntaxError);
+
+        expect(() => {
+            JSON.rawJSON(`123${char}`);
+        }).toThrow(SyntaxError);
+    });
+
+    expect(() => {
+        JSON.rawJSON("");
+    }).toThrow(SyntaxError);
+});


### PR DESCRIPTION
This pr implements `rawJSON` and `isRawJSON` functions from this proposal: [https://tc39.es/proposal-json-parse-with-source/](https://tc39.es/proposal-json-parse-with-source/)

These functions are now fully implemented, but they represent only a portion of the proposal. The remaining parts involve extending `JSON.parse` to expose source text access via [Parse Nodes](https://tc39.es/ecma262/#sec-syntactic-grammar) which our JSON parser doesn't currently produce. I’ll look into whether I can tackle that part too, but it seems pretty complex, so I decided to start with this smaller PR.

Summary:
        +15 ✅    -15 ❌   

Diff Tests:
    test/built-ins/JSON/isRawJSON/basic.js                           ❌ -> ✅
    test/built-ins/JSON/isRawJSON/builtin.js                         ❌ -> ✅
    test/built-ins/JSON/isRawJSON/length.js                          ❌ -> ✅
    test/built-ins/JSON/isRawJSON/name.js                            ❌ -> ✅
    test/built-ins/JSON/isRawJSON/not-a-constructor.js               ❌ -> ✅
    test/built-ins/JSON/isRawJSON/prop-desc.js                       ❌ -> ✅
    test/built-ins/JSON/rawJSON/basic.js                             ❌ -> ✅
    test/built-ins/JSON/rawJSON/builtin.js                           ❌ -> ✅
    test/built-ins/JSON/rawJSON/illegal-empty-and-start-end-chars.js ❌ -> ✅
    test/built-ins/JSON/rawJSON/invalid-JSON-text.js                 ❌ -> ✅
    test/built-ins/JSON/rawJSON/length.js                            ❌ -> ✅
    test/built-ins/JSON/rawJSON/name.js                              ❌ -> ✅
    test/built-ins/JSON/rawJSON/not-a-constructor.js                 ❌ -> ✅
    test/built-ins/JSON/rawJSON/prop-desc.js                         ❌ -> ✅
    test/built-ins/JSON/rawJSON/returns-expected-object.js           ❌ -> ✅
