### PR TITLE
LibGC: Make GC::Ptr, GC::Ref, and GC::Root formattable

### DIFF
--- a/Libraries/LibGC/Ptr.h
+++ b/Libraries/LibGC/Ptr.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Format.h>
 #include <AK/Traits.h>
 #include <AK/Types.h>
 
@@ -235,6 +236,31 @@ struct Traits<GC::Ref<T>> : public DefaultTraits<GC::Ref<T>> {
     static unsigned hash(GC::Ref<T> const& value)
     {
         return Traits<T*>::hash(value.ptr());
+    }
+};
+
+template<typename T>
+struct Formatter<GC::Ptr<T>> : Formatter<T const*> {
+    ErrorOr<void> format(FormatBuilder& builder, GC::Ptr<T> const& value)
+    {
+        return Formatter<T const*>::format(builder, value.ptr());
+    }
+};
+
+template<Formattable T>
+struct Formatter<GC::Ref<T>> : Formatter<T> {
+    ErrorOr<void> format(FormatBuilder& builder, GC::Ref<T> const& value)
+    {
+        return Formatter<T>::format(builder, *value);
+    }
+};
+
+template<typename T>
+requires(!HasFormatter<T>)
+struct Formatter<GC::Ref<T>> : Formatter<T const*> {
+    ErrorOr<void> format(FormatBuilder& builder, GC::Ref<T> const& value)
+    {
+        return Formatter<T const*>::format(builder, value.ptr());
     }
 };
 

--- a/Libraries/LibGC/Root.h
+++ b/Libraries/LibGC/Root.h
@@ -170,6 +170,14 @@ struct Traits<GC::Root<T>> : public DefaultTraits<GC::Root<T>> {
     static unsigned hash(GC::Root<T> const& handle) { return Traits<T>::hash(handle); }
 };
 
+template<typename T>
+struct Formatter<GC::Root<T>> : Formatter<T const*> {
+    ErrorOr<void> format(FormatBuilder& builder, GC::Root<T> const& value)
+    {
+        return Formatter<T const*>::format(builder, value.ptr());
+    }
+};
+
 namespace Detail {
 template<typename T>
 inline constexpr bool IsHashCompatible<GC::Root<T>, T> = true;


### PR DESCRIPTION
This is a copy of the Formatters we have for AK's pointer types.

It was annoying me having to type `.ptr()` whenever I wanted to `dbgln()` something.