### PR TITLE
LibWeb: Add fast_is for span and div

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -207,6 +207,8 @@ public:
     virtual bool is_html_form_element() const { return false; }
     virtual bool is_html_image_element() const { return false; }
     virtual bool is_html_iframe_element() const { return false; }
+    virtual bool is_html_div_element() const { return false; }
+    virtual bool is_html_span_element() const { return false; }
     virtual bool is_html_frameset_element() const { return false; }
     virtual bool is_html_fieldset_element() const { return false; }
     virtual bool is_navigable_container() const { return false; }

--- a/Libraries/LibWeb/HTML/HTMLDivElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDivElement.h
@@ -21,6 +21,8 @@ public:
     // https://www.w3.org/TR/html-aria/#el-div
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::generic; }
 
+    virtual bool is_html_div_element() const override { return true; }
+
 protected:
     HTMLDivElement(DOM::Document&, DOM::QualifiedName);
 
@@ -30,4 +32,9 @@ private:
     virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLDivElement>() const { return is_html_div_element(); }
 }

--- a/Libraries/LibWeb/HTML/HTMLSpanElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSpanElement.h
@@ -21,10 +21,17 @@ public:
     // https://www.w3.org/TR/html-aria/#el-span
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::generic; }
 
+    virtual bool is_html_span_element() const override { return true; }
+
 private:
     HTMLSpanElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
 };
 
+}
+
+namespace Web::DOM {
+template<>
+inline bool Node::fast_is<HTML::HTMLSpanElement>() const { return is_html_span_element(); }
 }


### PR DESCRIPTION
This is the same as #4452, it was just easier to create another branch and go from there instead of messing around with git too much :^)

All changes suggested by @gmta have been implemented.