### PR TITLE
CI: Use a raw actions/cache step for vcpkg instead of the x-gha source

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -31,11 +31,18 @@ inputs:
     description: 'Path to the download cache directory'
     required: false
     default: 'caches'
+  vcpkg_cache_path:
+    description: 'Path to vcpkg binary cache'
+    required: false
+    default: ''
 
 outputs:
   ccache_primary_key:
     description: 'Primary ccache key'
     value: ${{ steps.ccache.outputs.cache-primary-key }}
+  vcpkg_cache_primary_key:
+    description: 'Primary vcpkg binary cache key'
+    value: ${{ steps.vcpkg.outputs.cache-primary-key }}
 
 runs:
   using: "composite"
@@ -68,9 +75,12 @@ runs:
           CCACHE_DIR=${{ inputs.ccache_path }} ccache -s
           CCACHE_DIR=${{ inputs.ccache_path }} ccache -z
 
-    - name: Export vcpkg GitHub Actions cache environment variables
-      uses: actions/github-script@v7
+    - name: 'Restore vcpkg cache'
+      uses: actions/cache/restore@v4
+      if: ${{ inputs.vcpkg_cache_path != '' }}
+      id: 'vcpkg'
       with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+        path: ${{ inputs.vcpkg_cache_path }}
+        key: '"vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
+        restore-keys: |
+          "vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -15,6 +15,14 @@ inputs:
     description: 'Primary ccache key'
     required: false
     default: ''
+  vcpkg_cache_path:
+    description: 'Path to the vcpkg binary cache directory'
+    required: false
+    default: ''
+  vcpkg_cache_primary_key:
+    description: 'Primary vcpkg binary cache key'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -36,3 +44,10 @@ runs:
       shell: bash
       run: |
         CCACHE_DIR=${{ inputs.ccache_path }} ccache -s
+
+    - name: 'vcpkg binary cache'
+      uses: actions/cache/save@v4
+      if: ${{ inputs.vcpkg_cache_path != '' }}
+      with:
+        path: ${{ inputs.vcpkg_cache_path }}
+        key: ${{ inputs.vcpkg_cache_primary_key }}

--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -8,7 +8,6 @@ env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   VCPKG_ROOT:  ${{ github.workspace }}/Build/vcpkg
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   build-and-package:
@@ -47,6 +46,7 @@ jobs:
           cache_key_extra: 'LibJS Artifacts'
           ccache_path: ${{ env.CCACHE_DIR }}
           download_cache_path: ${{ github.workspace }}/Build/caches
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
 
       - name: Create build directory Ubuntu
         run: |
@@ -79,6 +79,8 @@ jobs:
           arch: 'Lagom'
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}
 
       - name: Upload js package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -29,7 +29,6 @@ env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   VCPKG_ROOT:  ${{ github.workspace }}/Build/vcpkg
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
   # Use the compiler version for the ccache compiler hash. Otherwise, if plugins are enabled, the plugin .so files
   # are included in the hash. This results in clean builds on every run as the .so files are rebuilt.
@@ -110,6 +109,7 @@ jobs:
           cache_key_extra: ${{ steps.build-parameters.outputs.ccache_key }}
           ccache_path: ${{ env.CCACHE_DIR }}
           download_cache_path: ${{ github.workspace }}/Build/caches
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
 
       - name: Set dynamic environment variables
         run: |
@@ -180,6 +180,8 @@ jobs:
           arch: ${{ inputs.arch }}
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}
 
       # === TEST ===
 

--- a/.github/workflows/nightly-android.yml
+++ b/.github/workflows/nightly-android.yml
@@ -11,7 +11,6 @@ env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
   CCACHE_DIR: ${{ github.workspace }}/.ccache
   VCPKG_ROOT:  ${{ github.workspace }}/Build/vcpkg
-  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
@@ -56,6 +55,7 @@ jobs:
           cache_key_extra: 'Nightly Android'
           ccache_path: ${{ env.CCACHE_DIR }}
           download_cache_path: ${{ github.workspace }}/Build/caches
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
 
       - name: Assign Build Parameters
         id: 'build-parameters'
@@ -103,3 +103,5 @@ jobs:
           arch: 'Lagom'
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -125,10 +125,7 @@
     {
       "hidden": true,
       "name": "vcpkg_ci",
-      "description": "Use the GitHub Actions vcpkg cache",
-      "environment": {
-        "VCPKG_BINARY_SOURCES": "clear;x-gha,readwrite"
-      }
+      "description": "FIXME: Use the GitHub Actions vcpkg cache"
     },
     {
       "name": "CI",


### PR DESCRIPTION
This is a workaround for the deprecation of the cache v1 REST API that was replaced with a new protobuf RPC based API this month. vcpkg was using the private cache backend API without the knowledge of the GitHub actions team, and was thus broken by the deprecation.

While we wait for Microsoft to talk to Microsoft to get this feature restored, we can use the raw actions/cache step to get almost the same cache behavior. The only difference is that the cache will be less fine grained than the per-package cache that VCPKG_BINARY_SOURCES of x-gha was giving us before.

re: https://github.com/LadybirdBrowser/ladybird/issues/4391
upstream: https://github.com/microsoft/vcpkg/issues/45073 