### PR TITLE
LibWeb: Return correct type from `CSSNestedDeclarations::style`

### DIFF
--- a/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
+++ b/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
@@ -38,7 +38,7 @@ void CSSNestedDeclarations::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_parent_style_rule);
 }
 
-CSSStyleDeclaration* CSSNestedDeclarations::style()
+GC::Ref<CSSStyleProperties> CSSNestedDeclarations::style()
 {
     return m_declaration;
 }

--- a/Libraries/LibWeb/CSS/CSSNestedDeclarations.h
+++ b/Libraries/LibWeb/CSS/CSSNestedDeclarations.h
@@ -22,7 +22,7 @@ public:
 
     CSSStyleProperties const& declaration() const { return m_declaration; }
 
-    CSSStyleDeclaration* style();
+    GC::Ref<CSSStyleProperties> style();
 
     CSSStyleRule const& parent_style_rule() const;
 

--- a/Libraries/LibWeb/CSS/CSSNestedDeclarations.idl
+++ b/Libraries/LibWeb/CSS/CSSNestedDeclarations.idl
@@ -1,9 +1,8 @@
 #import <CSS/CSSRule.idl>
-#import <CSS/CSSStyleDeclaration.idl>
+#import <CSS/CSSStyleProperties.idl>
 
 // https://drafts.csswg.org/css-nesting-1/#cssnesteddeclarations
 [Exposed=Window]
 interface CSSNestedDeclarations : CSSRule {
-    // FIXME: Should be a CSSStyleProperties, once we have that
-    [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
+    [SameObject, PutForwards=cssText] readonly attribute CSSStyleProperties style;
 };


### PR DESCRIPTION
We implement `CSSStyleProperties` so let's use it.

Not sure if there are any tests that rely on this, I just stumbled across this fixme.