### PR TITLE
LibWeb: Exclude fixed positioned boxes from scrollable overflow

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -85,6 +85,13 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box)
             if (child.containing_block() != &box)
                 return TraversalDecision::Continue;
 
+            // https://drafts.csswg.org/css-position/#fixed-positioning-containing-block
+            // [..] As a result, parts of fixed-positioned boxes that extend outside the layout viewport/page area
+            //      cannot be scrolled to and will not print.
+            // FIXME: Properly establish the fixed positioning containing block for `position: fixed`
+            if (child.is_fixed_position())
+                return TraversalDecision::Continue;
+
             auto child_border_box = child.paintable_box()->absolute_border_box_rect();
 
             // Border boxes with zero area do not affect the scrollable overflow area.

--- a/Tests/LibWeb/Text/expected/scrollable-viewport-with-position-fixed.txt
+++ b/Tests/LibWeb/Text/expected/scrollable-viewport-with-position-fixed.txt
@@ -1,0 +1,1 @@
+{"x":8,"y":8,"width":784,"height":17,"top":8,"right":792,"bottom":25,"left":8}

--- a/Tests/LibWeb/Text/input/scrollable-viewport-with-position-fixed.html
+++ b/Tests/LibWeb/Text/input/scrollable-viewport-with-position-fixed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    #main {
+        background: red;
+    }
+    #side {
+        background: green;
+        position: fixed;
+        right: -200px;
+        width: 200px;
+    }
+</style>
+<div id="main">bar</div>
+<div id="side">foo</div>
+<script>
+    test(() => {
+        document.querySelector('#side').scrollIntoView();
+        println(JSON.stringify(document.querySelector('#main').getBoundingClientRect()));
+    });
+</script>


### PR DESCRIPTION
Sometimes fixed positioned boxes would extend the viewport's scrollable overflow, which according to the spec should never happen. There are some nuances to this, such as properly determining the fixed positioning containing block for a fixed position box, but for now this prevents some pages from being overly scrollable.

Fixes horizontal scrollability of https://tweakers.net.