### PR TITLE
LibWeb/HTML: Fix parsing of protocol in Location.protocol setter

### DIFF
--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -195,7 +195,7 @@ WebIDL::ExceptionOr<void> Location::set_protocol(String const& value)
     auto copy_url = this->url();
 
     // 4. Let possibleFailure be the result of basic URL parsing the given value, followed by ":", with copyURL as url and scheme start state as state override.
-    auto possible_failure = URL::Parser::basic_parse(value, {}, &copy_url, URL::Parser::State::SchemeStart);
+    auto possible_failure = URL::Parser::basic_parse(MUST(String::formatted("{}:", value)), {}, &copy_url, URL::Parser::State::SchemeStart);
 
     // 5. If possibleFailure is failure, then throw a "SyntaxError" DOMException.
     if (!possible_failure.has_value())


### PR DESCRIPTION
This never worked properly when implemented as it would always throw an error for an invalid scheme on URL parsing.

Fixes at least some tests in:

https://wpt.live/html/browsers/history/the-location-interface/location-protocol-setter-non-broken.html

And all tests in:

https://wpt.live/html/browsers/history/the-location-interface/location-protocol-setter-non-broken-weird.html

And maybe tests in some other places too, but these are not imported as the tests are written with delays that makes them take a long time to run, and some of them rely on HTTP(s).