### PR TITLE
LibWeb: Implement `FrozenArray` IDL attributes

### DIFF
--- a/Libraries/LibWeb/ARIA/ARIAMixin.idl
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.idl
@@ -12,28 +12,28 @@ interface mixin ARIAMixin {
     [CEReactions] attribute DOMString? ariaColIndex;
     [CEReactions] attribute DOMString? ariaColIndexText;
     [CEReactions] attribute DOMString? ariaColSpan;
-    [Reflect=aria-controls, CEReactions] attribute sequence<Element>? ariaControlsElements; // FIXME: Should `FrozenArray<Element>?`
+    [Reflect=aria-controls, CEReactions] attribute FrozenArray<Element>? ariaControlsElements;
     [CEReactions] attribute DOMString? ariaCurrent;
-    [Reflect=aria-describedby, CEReactions] attribute sequence<Element>? ariaDescribedByElements; // FIXME: Should `FrozenArray<Element>?`
+    [Reflect=aria-describedby, CEReactions] attribute FrozenArray<Element>? ariaDescribedByElements;
     [CEReactions] attribute DOMString? ariaDescription;
-    [Reflect=aria-details, CEReactions] attribute sequence<Element>? ariaDetailsElements; // FIXME: Should `FrozenArray<Element>?`
+    [Reflect=aria-details, CEReactions] attribute FrozenArray<Element>? ariaDetailsElements;
     [CEReactions] attribute DOMString? ariaDisabled;
-    [Reflect=aria-errormessage, CEReactions] attribute sequence<Element>? ariaErrorMessageElements; // FIXME: Should `FrozenArray<Element>?`
+    [Reflect=aria-errormessage, CEReactions] attribute FrozenArray<Element>? ariaErrorMessageElements;
     [CEReactions] attribute DOMString? ariaExpanded;
-    [Reflect=aria-flowto, CEReactions] attribute sequence<Element>? ariaFlowToElements; // FIXME: Should `FrozenArray<Element>?`
+    [Reflect=aria-flowto, CEReactions] attribute FrozenArray<Element>? ariaFlowToElements;
     [CEReactions] attribute DOMString? ariaHasPopup;
     [CEReactions] attribute DOMString? ariaHidden;
     [CEReactions] attribute DOMString? ariaInvalid;
     [CEReactions] attribute DOMString? ariaKeyShortcuts;
     [CEReactions] attribute DOMString? ariaLabel;
-    [Reflect=aria-labelledby, CEReactions] attribute sequence<Element>? ariaLabelledByElements; // FIXME: Should `FrozenArray<Element>?`
+    [Reflect=aria-labelledby, CEReactions] attribute FrozenArray<Element>? ariaLabelledByElements;
     [CEReactions] attribute DOMString? ariaLevel;
     [CEReactions] attribute DOMString? ariaLive;
     [CEReactions] attribute DOMString? ariaModal;
     [CEReactions] attribute DOMString? ariaMultiLine;
     [CEReactions] attribute DOMString? ariaMultiSelectable;
     [CEReactions] attribute DOMString? ariaOrientation;
-    [Reflect=aria-owns, CEReactions] attribute sequence<Element>? ariaOwnsElements; // FIXME: Should `FrozenArray<Element>?`
+    [Reflect=aria-owns, CEReactions] attribute FrozenArray<Element>? ariaOwnsElements;
     [CEReactions] attribute DOMString? ariaPlaceholder;
     [CEReactions] attribute DOMString? ariaPosInSet;
     [CEReactions] attribute DOMString? ariaPressed;

--- a/Libraries/LibWeb/CSS/CSSLayerStatementRule.idl
+++ b/Libraries/LibWeb/CSS/CSSLayerStatementRule.idl
@@ -3,6 +3,5 @@
 // https://drafts.csswg.org/css-cascade-5/#the-csslayerstatementrule-interface
 [Exposed=Window]
 interface CSSLayerStatementRule : CSSRule {
-    // FIXME: Should be a FrozenArray<CSSOMString>
-    readonly attribute sequence<CSSOMString> nameList;
+    readonly attribute FrozenArray<CSSOMString> nameList;
 };

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.idl
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.idl
@@ -7,8 +7,7 @@ interface ClipboardItem {
               optional ClipboardItemOptions options = {});
 
     readonly attribute PresentationStyle presentationStyle;
-    // FIXME: Should be a FrozenArray<DOMString>
-    readonly attribute sequence<DOMString> types;
+    readonly attribute FrozenArray<DOMString> types;
 
     Promise<Blob> getType(DOMString type);
 

--- a/Libraries/LibWeb/HTML/DataTransfer.idl
+++ b/Libraries/LibWeb/HTML/DataTransfer.idl
@@ -14,7 +14,7 @@ interface DataTransfer {
     [FIXME] undefined setDragImage(Element image, long x, long y);
 
     // old interface
-    readonly attribute sequence<DOMString> types; // FIXME: This should be FrozenArray<DOMString>
+    readonly attribute FrozenArray<DOMString> types;
     DOMString getData(DOMString format);
     [FIXME] undefined setData(DOMString format, DOMString data);
     [FIXME] undefined clearData(optional DOMString format);

--- a/Libraries/LibWeb/HTML/MessageEvent.idl
+++ b/Libraries/LibWeb/HTML/MessageEvent.idl
@@ -13,7 +13,7 @@ interface MessageEvent : Event {
     readonly attribute USVString origin;
     readonly attribute DOMString lastEventId;
     readonly attribute MessageEventSource? source;
-    // FIXME: readonly attribute FrozenArray<MessagePort> ports;
+    // FIXME: This should be FrozenArray<MessagePort>, but must also always return the same object.
     readonly attribute any ports;
 
     undefined initMessageEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any data = null, optional USVString origin = "", optional DOMString lastEventId = "", optional MessageEventSource? source = null, optional sequence<MessagePort> ports = []);

--- a/Libraries/LibWeb/HTML/NavigatorLanguage.idl
+++ b/Libraries/LibWeb/HTML/NavigatorLanguage.idl
@@ -1,7 +1,6 @@
 // https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage
 interface mixin NavigatorLanguage {
     readonly attribute DOMString language;
-    // FIXME: readonly attribute FrozenArray<DOMString> languages;
-    //        This is supposed to be a FrozenArray that always returns the same object
-    readonly attribute sequence<DOMString> languages;
+    // FIXME: This is supposed always return the same object
+    readonly attribute FrozenArray<DOMString> languages;
 };

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.idl
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.idl
@@ -13,8 +13,7 @@ interface IntersectionObserver {
     readonly attribute (Element or Document)? root;
     readonly attribute DOMString rootMargin;
     readonly attribute DOMString scrollMargin;
-    // FIXME: `sequence<double>` should be `FrozenArray<double>`
-    readonly attribute sequence<double> thresholds;
+    readonly attribute FrozenArray<double> thresholds;
     readonly attribute long delay;
     readonly attribute boolean trackVisibility;
     undefined observe(Element target);

--- a/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.idl
+++ b/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.idl
@@ -21,6 +21,6 @@ interface PerformanceObserver {
     undefined observe(optional PerformanceObserverInit options = {});
     undefined disconnect();
     PerformanceEntryList takeRecords();
-    // FIXME: [SameObject] static readonly attribute FrozenArray<DOMString> supportedEntryTypes;
+    // FIXME: This should be FrozenArray<DOMString>, but must also always return the same object.
     [SameObject] static readonly attribute any supportedEntryTypes;
 };

--- a/Libraries/LibWeb/ResizeObserver/ResizeObserverEntry.idl
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObserverEntry.idl
@@ -6,10 +6,7 @@
 interface ResizeObserverEntry {
     readonly attribute Element target;
     readonly attribute DOMRectReadOnly contentRect;
-    // FIXME: Return FrozenArray<ResizeObserverSize> instead of any.
-    [ImplementedAs=border_box_size_js_array] readonly attribute any borderBoxSize;
-    // FIXME: Return FrozenArray<ResizeObserverSize> instead of any.
-    [ImplementedAs=content_box_size_js_array] readonly attribute any contentBoxSize;
-    // FIXME: Return FrozenArray<ResizeObserverSize> instead of any.
-    [ImplementedAs=device_pixel_content_box_size_js_array] readonly attribute any devicePixelContentBoxSize;
+    readonly attribute FrozenArray<ResizeObserverSize> borderBoxSize;
+    readonly attribute FrozenArray<ResizeObserverSize> contentBoxSize;
+    readonly attribute FrozenArray<ResizeObserverSize> devicePixelContentBoxSize;
 };

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -172,9 +172,9 @@ static StringView sequence_storage_type_to_cpp_storage_type_name(SequenceStorage
     }
 }
 
-static bool is_nullable_sequence_of_single_type(Type const& type, StringView type_name)
+static bool is_nullable_frozen_array_of_single_type(Type const& type, StringView type_name)
 {
-    if (!type.is_nullable() || !type.is_sequence())
+    if (!type.is_nullable() || type.name() != "FrozenArray"sv)
         return false;
 
     auto const& parameters = type.as_parameterized().parameters();
@@ -4053,8 +4053,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
             // If a reflected IDL attribute has the type FrozenArray<T>?, where T is either Element or an interface that
             // inherits from Element, then with attr being the reflected content attribute name:
             // FIXME: Handle "an interface that inherits from Element".
-            // FIXME: This should handle "FrozenArray" rather than "sequence".
-            else if (is_nullable_sequence_of_single_type(attribute.type, "Element"sv)) {
+            else if (is_nullable_frozen_array_of_single_type(attribute.type, "Element"sv)) {
                 // 1. Let elements be the result of running this's get the attr-associated elements.
                 attribute_generator.append(R"~~~(
     static auto content_attribute = "@attribute.reflect_name@"_fly_string;
@@ -4216,8 +4215,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
                 // If a reflected IDL attribute has the type FrozenArray<T>?, where T is either Element or an interface
                 // that inherits from Element, then with attr being the reflected content attribute name:
                 // FIXME: Handle "an interface that inherits from Element".
-                // FIXME: This should handle "FrozenArray" rather than "sequence".
-                else if (is_nullable_sequence_of_single_type(attribute.type, "Element"sv)) {
+                else if (is_nullable_frozen_array_of_single_type(attribute.type, "Element"sv)) {
                     // 1. If the given value is null:
                     //     1. Set this's explicitly set attr-elements to null.
                     //     2. Run this's delete the content attribute.


### PR DESCRIPTION
A `FrozenArray` is simply a `sequence` whose integrity level is "frozen".

This doesn't seem to really affect tests, but I was tired of writing "FIXME: should be a FrozenArray" in IDL files 🙃 