### PR TITLE
LibWeb: Implement caching of reflected element array attributes

### DIFF
--- a/Libraries/LibWeb/ARIA/ARIAMixin.cpp
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/Array.h>
 #include <LibWeb/ARIA/ARIAMixin.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/DOM/Element.h>
@@ -13,6 +14,13 @@ namespace Web::ARIA {
 
 ARIAMixin::ARIAMixin() = default;
 ARIAMixin::~ARIAMixin() = default;
+
+void ARIAMixin::visit_edges(GC::Cell::Visitor& visitor) {
+#define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
+    visitor.visit(m_cached_##attribute);
+    ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
+#undef __ENUMERATE_ARIA_ATTRIBUTE
+}
 
 // https://www.w3.org/TR/wai-aria-1.2/#introroles
 Optional<Role> ARIAMixin::role_from_role_attribute_value() const
@@ -247,6 +255,16 @@ ENUMERATE_ARIA_ELEMENT_REFERENCING_ATTRIBUTES
     void ARIAMixin::set_##attribute(Optional<Vector<WeakPtr<DOM::Element>>> value) \
     {                                                                              \
         m_##attribute = move(value);                                               \
+    }                                                                              \
+                                                                                   \
+    GC::Ptr<JS::Array> ARIAMixin::cached_##attribute() const                       \
+    {                                                                              \
+        return m_cached_##attribute;                                               \
+    }                                                                              \
+                                                                                   \
+    void ARIAMixin::set_cached_##attribute(GC::Ptr<JS::Array> value)               \
+    {                                                                              \
+        m_cached_##attribute = value;                                              \
     }
 ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE

--- a/Libraries/LibWeb/ARIA/ARIAMixin.h
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.h
@@ -68,12 +68,17 @@ public:
 
 #define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute)  \
     Optional<Vector<WeakPtr<DOM::Element>>> const& attribute() const; \
-    void set_##attribute(Optional<Vector<WeakPtr<DOM::Element>>> value);
+    void set_##attribute(Optional<Vector<WeakPtr<DOM::Element>>>);    \
+                                                                      \
+    GC::Ptr<JS::Array> cached_##attribute() const;                    \
+    void set_cached_##attribute(GC::Ptr<JS::Array>);
     ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE
 
 protected:
     ARIAMixin();
+
+    void visit_edges(GC::Cell::Visitor&);
 
     virtual bool id_reference_exists(String const&) const = 0;
 
@@ -84,7 +89,8 @@ private:
 #undef __ENUMERATE_ARIA_ATTRIBUTE
 
 #define __ENUMERATE_ARIA_ATTRIBUTE(attribute, referencing_attribute) \
-    Optional<Vector<WeakPtr<DOM::Element>>> m_##attribute;
+    Optional<Vector<WeakPtr<DOM::Element>>> m_##attribute;           \
+    GC::Ptr<JS::Array> m_cached_##attribute;
     ENUMERATE_ARIA_ELEMENT_LIST_REFERENCING_ATTRIBUTES
 #undef __ENUMERATE_ARIA_ATTRIBUTE
 };

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -105,6 +105,7 @@ void Element::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     SlottableMixin::visit_edges(visitor);
     Animatable::visit_edges(visitor);
+    ARIAMixin::visit_edges(visitor);
 
     visitor.visit(m_attributes);
     visitor.visit(m_inline_style);

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -10,6 +10,7 @@
 
 #include <AK/Forward.h>
 #include <LibGC/Ptr.h>
+#include <LibGC/RootVector.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Forward.h>
 
@@ -53,5 +54,7 @@ enum class Clamp {
 // https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
 template<Integral T>
 JS::ThrowCompletionOr<T> convert_to_int(JS::VM& vm, JS::Value, EnforceRange enforce_range = EnforceRange::No, Clamp clamp = Clamp::No);
+
+bool lists_contain_same_elements(GC::Ptr<JS::Array> array, Optional<GC::RootVector<GC::Ref<DOM::Element>>> const& elements);
 
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/aria-element-reflection.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/aria-element-reflection.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 27 tests
 
-22 Pass
-5 Fail
+25 Pass
+2 Fail
 Pass	aria-activedescendant element reflection
 Pass	aria-activedescendant If the content attribute is set directly, the IDL attribute getter always returns the first element whose ID matches the content attribute.
 Pass	aria-activedescendant Setting the IDL attribute to an element which is not the first element in DOM order with its ID causes the content attribute to be an empty string
@@ -16,7 +16,7 @@ Pass	aria-activedescendant Changing the ID of an element doesn't lose the refere
 Pass	aria-activedescendant Reparenting an element into a descendant shadow scope hides the element reference.
 Pass	aria-activedescendant Reparenting referenced element cannot cause retargeting of reference.
 Pass	aria-activedescendant Element reference set in invalid scope remains intact throughout move to valid scope.
-Fail	aria-labelledby.
+Pass	aria-labelledby.
 Pass	aria-controls.
 Pass	aria-describedby.
 Pass	aria-flowto.
@@ -28,6 +28,6 @@ Pass	aria-activedescendant Reparenting.
 Pass	aria-activedescendant Attaching element reference before it's inserted into the DOM.
 Pass	aria-activedescendant Cross-document references and moves.
 Pass	aria-activedescendant Adopting element keeps references.
-Fail	Caching invariant different attributes.
-Fail	Caching invariant different elements.
+Pass	Caching invariant different attributes.
+Pass	Caching invariant different elements.
 Pass	Passing values of the wrong type should throw a TypeError


### PR DESCRIPTION
For attributes like `Element.ariaControlsElements`, which are a reflection of `FrozenArray<Element>`, we must return the same `JS::Array` object every time the attribute is invoked - until its contents have changed. This patch implements caching of the reflected array in accordance with the spec.