### PR TITLE
Skip allocating locals for arguments that allowed to be local

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1027,7 +1027,7 @@ void Identifier::dump(int indent) const
 {
     print_indent(indent);
     if (is_local()) {
-        outln("Identifier \"{}\" is_local=(true) index=({})", m_string, m_local_variable_index);
+        outln("Identifier \"{}\" is_local=(true) index=({})", m_string, m_local_index->index);
     } else if (is_global()) {
         outln("Identifier \"{}\" is_global=(true)", m_string);
     } else {
@@ -1668,7 +1668,12 @@ void ScopeNode::block_declaration_instantiation(VM& vm, Environment* environment
                 auto& running_execution_context = vm.running_execution_context();
                 auto number_of_registers = running_execution_context.executable->number_of_registers;
                 auto number_of_constants = running_execution_context.executable->constants.size();
-                running_execution_context.local(function_declaration.name_identifier()->local_variable_index() + number_of_registers + number_of_constants) = function;
+                auto local_index = function_declaration.name_identifier()->local_index();
+                if (local_index.is_variable()) {
+                    running_execution_context.local(local_index.index + number_of_registers + number_of_constants) = function;
+                } else {
+                    VERIFY_NOT_REACHED();
+                }
             } else {
                 VERIFY(is<DeclarativeEnvironment>(*environment));
                 static_cast<DeclarativeEnvironment&>(*environment).initialize_or_set_mutable_binding({}, vm, function_declaration.name(), function);

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -87,6 +87,7 @@ public:
 
     Vector<FlyString> local_variable_names;
     size_t local_index_base { 0 };
+    size_t argument_index_base { 0 };
 
     Optional<IdentifierTableIndex> length_identifier;
 

--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -58,7 +58,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
         Optional<Operand> dst;
         auto local_var_index = function.shared_data().m_local_variables_names.find_first_index("arguments"_fly_string);
         if (local_var_index.has_value())
-            dst = local(local_var_index.value());
+            dst = local(Identifier::Local::variable(local_var_index.value()));
 
         if (function.is_strict_mode() || !function.has_simple_parameter_list()) {
             emit<Op::CreateArguments>(dst, Op::CreateArguments::Kind::Unmapped, function.is_strict_mode());
@@ -77,11 +77,8 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
             auto& if_undefined_block = make_block();
             auto& if_not_undefined_block = make_block();
 
-            auto argument_reg = allocate_register();
-            emit<Op::Mov>(argument_reg.operand(), Operand { Operand::Type::Argument, param_index });
-
             emit<Op::JumpUndefined>(
-                argument_reg.operand(),
+                Operand { Operand::Type::Argument, param_index },
                 Label { if_undefined_block },
                 Label { if_not_undefined_block });
 
@@ -95,9 +92,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
 
         if (auto const* identifier = parameter.binding.get_pointer<NonnullRefPtr<Identifier const>>(); identifier) {
             if ((*identifier)->is_local()) {
-                auto local_variable_index = (*identifier)->local_variable_index();
-                emit<Op::Mov>(local(local_variable_index), Operand { Operand::Type::Argument, param_index });
-                set_local_initialized((*identifier)->local_variable_index());
+                set_local_initialized((*identifier)->local_index());
             } else {
                 auto id = intern_identifier((*identifier)->string());
                 if (function.shared_data().m_has_duplicates) {
@@ -122,7 +117,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
             for (auto const& variable_to_initialize : function.shared_data().m_var_names_to_initialize_binding) {
                 auto const& id = variable_to_initialize.identifier;
                 if (id.is_local()) {
-                    emit<Op::Mov>(local(id.local_variable_index()), add_constant(js_undefined()));
+                    emit<Op::Mov>(local(id.local_index()), add_constant(js_undefined()));
                 } else {
                     auto intern_id = intern_identifier(id.string());
                     emit<Op::CreateVariable>(intern_id, Op::EnvironmentMode::Var, false);
@@ -153,14 +148,14 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
                     emit<Op::Mov>(initial_value, add_constant(js_undefined()));
                 } else {
                     if (id.is_local()) {
-                        emit<Op::Mov>(initial_value, local(id.local_variable_index()));
+                        emit<Op::Mov>(initial_value, local(id.local_index()));
                     } else {
                         emit<Op::GetBinding>(initial_value, intern_identifier(id.string()));
                     }
                 }
 
                 if (id.is_local()) {
-                    emit<Op::Mov>(local(id.local_variable_index()), initial_value);
+                    emit<Op::Mov>(local(id.local_index()), initial_value);
                 } else {
                     auto intern_id = intern_identifier(id.string());
                     emit<Op::CreateVariable>(intern_id, Op::EnvironmentMode::Var, false);
@@ -204,7 +199,7 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
     for (auto const& declaration : function.shared_data().m_functions_to_initialize) {
         auto const& identifier = *declaration.name_identifier();
         if (identifier.is_local()) {
-            auto local_index = identifier.local_variable_index();
+            auto local_index = identifier.local_index();
             emit<Op::NewFunction>(local(local_index), declaration, OptionalNone {});
             set_local_initialized(local_index);
         } else {
@@ -516,9 +511,11 @@ void Generator::free_register(Register reg)
     m_free_registers.append(reg);
 }
 
-ScopedOperand Generator::local(u32 local_index)
+ScopedOperand Generator::local(Identifier::Local const& local)
 {
-    return ScopedOperand { *this, Operand { Operand::Type::Local, static_cast<u32>(local_index) } };
+    if (local.is_variable())
+        return ScopedOperand { *this, Operand { Operand::Type::Local, static_cast<u32>(local.index) } };
+    return ScopedOperand { *this, Operand { Operand::Type::Argument, static_cast<u32>(local.index) } };
 }
 
 Generator::SourceLocationScope::SourceLocationScope(Generator& generator, ASTNode const& node)
@@ -880,11 +877,12 @@ CodeGenerationErrorOr<Optional<ScopedOperand>> Generator::emit_delete_reference(
 void Generator::emit_set_variable(JS::Identifier const& identifier, ScopedOperand value, Bytecode::Op::BindingInitializationMode initialization_mode, Bytecode::Op::EnvironmentMode environment_mode)
 {
     if (identifier.is_local()) {
-        if (value.operand().is_local() && value.operand().index() == identifier.local_variable_index()) {
+        auto local_index = identifier.local_index();
+        if (value.operand().is_local() && local_index.is_variable() && value.operand().index() == local_index.index) {
             // Moving a local to itself is a no-op.
             return;
         }
-        emit<Bytecode::Op::Mov>(local(identifier.local_variable_index()), value);
+        emit<Bytecode::Op::Mov>(local(local_index), value);
     } else {
         auto identifier_index = intern_identifier(identifier.string());
         if (environment_mode == Bytecode::Op::EnvironmentMode::Lexical) {
@@ -1186,9 +1184,24 @@ bool Generator::is_local_initialized(u32 local_index) const
     return m_initialized_locals.find(local_index) != m_initialized_locals.end();
 }
 
-void Generator::set_local_initialized(u32 local_index)
+bool Generator::is_local_initialized(Identifier::Local const& local) const
 {
-    m_initialized_locals.set(local_index);
+    if (local.is_variable())
+        return m_initialized_locals.find(local.index) != m_initialized_locals.end();
+    if (local.is_argument())
+        return m_initialized_arguments.find(local.index) != m_initialized_arguments.end();
+    return true;
+}
+
+void Generator::set_local_initialized(Identifier::Local const& local)
+{
+    if (local.is_variable()) {
+        m_initialized_locals.set(local.index);
+    } else if (local.is_argument()) {
+        m_initialized_arguments.set(local.index);
+    } else {
+        VERIFY_NOT_REACHED();
+    }
 }
 
 ScopedOperand Generator::get_this(Optional<ScopedOperand> preferred_dst)

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -44,14 +44,15 @@ public:
     CodeGenerationErrorOr<void> emit_function_declaration_instantiation(ECMAScriptFunctionObject const& function);
 
     [[nodiscard]] ScopedOperand allocate_register();
-    [[nodiscard]] ScopedOperand local(u32 local_index);
+    [[nodiscard]] ScopedOperand local(Identifier::Local const&);
     [[nodiscard]] ScopedOperand accumulator();
     [[nodiscard]] ScopedOperand this_value();
 
     void free_register(Register);
 
-    void set_local_initialized(u32 local_index);
+    void set_local_initialized(Identifier::Local const&);
     [[nodiscard]] bool is_local_initialized(u32 local_index) const;
+    [[nodiscard]] bool is_local_initialized(Identifier::Local const&) const;
 
     class SourceLocationScope {
     public:
@@ -411,6 +412,7 @@ private:
     Vector<ScopedOperand> m_home_objects;
 
     HashTable<u32> m_initialized_locals;
+    HashTable<u32> m_initialized_arguments;
 
     bool m_finished { false };
     bool m_must_propagate_completion { true };

--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -51,7 +51,6 @@
     O(EnterObjectEnvironment)          \
     O(EnterUnwindContext)              \
     O(Exp)                             \
-    O(GetArgument)                     \
     O(GetById)                         \
     O(GetByIdWithThis)                 \
     O(GetByValue)                      \
@@ -131,7 +130,6 @@
     O(Return)                          \
     O(RightShift)                      \
     O(ScheduleJump)                    \
-    O(SetArgument)                     \
     O(SetCompletionType)               \
     O(SetLexicalBinding)               \
     O(SetVariableBinding)              \

--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -49,11 +49,11 @@ public:
     ALWAYS_INLINE Value& saved_return_value() { return reg(Register::saved_return_value()); }
     Value& reg(Register const& r)
     {
-        return m_registers_and_constants_and_locals.data()[r.index()];
+        return m_registers_and_constants_and_locals_arguments.data()[r.index()];
     }
     Value reg(Register const& r) const
     {
-        return m_registers_and_constants_and_locals.data()[r.index()];
+        return m_registers_and_constants_and_locals_arguments.data()[r.index()];
     }
 
     [[nodiscard]] Value get(Operand) const;
@@ -101,7 +101,7 @@ private:
     GC::Ptr<Object> m_global_object { nullptr };
     GC::Ptr<DeclarativeEnvironment> m_global_declarative_environment { nullptr };
     Optional<size_t&> m_program_counter;
-    Span<Value> m_registers_and_constants_and_locals;
+    Span<Value> m_registers_and_constants_and_locals_arguments;
     Vector<Value> m_argument_values_buffer;
     ExecutionContext* m_running_execution_context { nullptr };
 };

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -775,52 +775,6 @@ private:
     mutable EnvironmentCoordinate m_cache;
 };
 
-class SetArgument final : public Instruction {
-public:
-    SetArgument(size_t index, Operand src)
-        : Instruction(Type::SetArgument)
-        , m_index(index)
-        , m_src(src)
-    {
-    }
-
-    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-    void visit_operands_impl(Function<void(Operand&)> visitor)
-    {
-        visitor(m_src);
-    }
-
-    size_t index() const { return m_index; }
-    Operand src() const { return m_src; }
-
-private:
-    u32 m_index;
-    Operand m_src;
-};
-
-class GetArgument final : public Instruction {
-public:
-    GetArgument(Operand dst, size_t index)
-        : Instruction(Type::GetArgument)
-        , m_index(index)
-        , m_dst(dst)
-    {
-    }
-
-    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-    void visit_operands_impl(Function<void(Operand&)> visitor)
-    {
-        visitor(m_dst);
-    }
-
-    u32 index() const { return m_index; }
-    Operand dst() const { return m_dst; }
-
-private:
-    u32 m_index;
-    Operand m_dst;
-};
-
 class GetCalleeAndThisFromEnvironment final : public Instruction {
 public:
     explicit GetCalleeAndThisFromEnvironment(Operand callee, Operand this_value, IdentifierTableIndex identifier)

--- a/Libraries/LibJS/Bytecode/Operand.h
+++ b/Libraries/LibJS/Bytecode/Operand.h
@@ -22,6 +22,7 @@ public:
         Register,
         Local,
         Constant,
+        Argument,
     };
 
     [[nodiscard]] bool operator==(Operand const&) const = default;
@@ -53,8 +54,8 @@ private:
     //       Because this type is absolutely essential to the interpreter, we allow
     //       ourselves this little ifdef.
 #if ARCH(AARCH64)
-    Type m_type : 2 {};
-    u32 m_index : 30 { 0 };
+    Type m_type : 3 {};
+    u32 m_index : 29 { 0 };
 #else
     Type m_type { Type::Invalid };
     u32 m_index { 0 };


### PR DESCRIPTION
This allows us to get rid of instructions that move arguments to locals
and allocate smaller JS::Value vector in ExecutionContext by reusing
slots that were already allocated for arguments.

With this change for following function:
```js
function f(x, y) {
    return x + y;
}
```

we now produce following bytecode:
```
[   0]    0: Add dst:reg6, lhs:arg0, rhs:arg1
[  10]       Return value:reg6
```

instead of:
```
[   0]    0: GetArgument 0, dst:x~1
[  10]       GetArgument 1, dst:y~0
[  20]       Add dst:reg6, lhs:x~1, rhs:y~0
[  30]       Return value:reg6
```

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
Kraken      ai-astar.js                              1.012  0.840 ± 0.830 … 0.850     0.830 ± 0.830 … 0.830
Kraken      audio-beat-detection.js                  1.028  0.730 ± 0.730 … 0.730     0.710 ± 0.710 … 0.710
Kraken      audio-dft.js                             1.099  0.500 ± 0.470 … 0.530     0.455 ± 0.450 … 0.460
Kraken      audio-fft.js                             1.033  0.635 ± 0.630 … 0.640     0.615 ± 0.610 … 0.620
Kraken      audio-oscillator.js                      1.013  0.760 ± 0.760 … 0.760     0.750 ± 0.750 … 0.750
Kraken      imaging-darkroom.js                      1.04   0.900 ± 0.880 … 0.920     0.865 ± 0.860 … 0.870
Kraken      imaging-desaturate.js                    1.018  0.830 ± 0.830 … 0.830     0.815 ± 0.810 … 0.820
Kraken      imaging-gaussian-blur.js                 1.021  3.470 ± 3.470 … 3.470     3.400 ± 3.400 … 3.400
Kraken      json-parse-financial.js                  1      0.060 ± 0.060 … 0.060     0.060 ± 0.060 … 0.060
Kraken      json-stringify-tinderbox.js              1      0.080 ± 0.080 … 0.080     0.080 ± 0.080 … 0.080
Kraken      stanford-crypto-aes.js                   1.062  0.340 ± 0.330 … 0.350     0.320 ± 0.320 … 0.320
Kraken      stanford-crypto-ccm.js                   1.093  0.295 ± 0.290 … 0.300     0.270 ± 0.270 … 0.270
Kraken      stanford-crypto-pbkdf2.js                1.087  0.565 ± 0.560 … 0.570     0.520 ± 0.520 … 0.520
Kraken      stanford-crypto-sha256-iterative.js      1.048  0.220 ± 0.220 … 0.220     0.210 ± 0.210 … 0.210
Octane      box2d.js                                 0.955  1.060 ± 1.040 … 1.080     1.110 ± 1.110 … 1.110
Octane      code-load.js                             0.998  2.015 ± 2.010 … 2.020     2.020 ± 2.020 … 2.020
Octane      crypto.js                                0.997  5.055 ± 5.050 … 5.060     5.070 ± 5.030 … 5.110
Octane      deltablue.js                             1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      earley-boyer.js                          1.017  9.695 ± 9.620 … 9.770     9.530 ± 9.520 … 9.540
Octane      gbemu.js                                 1.022  1.155 ± 1.150 … 1.160     1.130 ± 1.130 … 1.130
Octane      mandreel.js                              1.022  5.665 ± 5.610 … 5.720     5.545 ± 5.500 … 5.590
Octane      navier-stokes.js                         1      2.070 ± 2.060 … 2.080     2.070 ± 2.060 … 2.080
Octane      pdfjs.js                                 1      1.370 ± 1.360 … 1.380     1.370 ± 1.370 … 1.370
Octane      raytrace.js                              0.997  3.110 ± 3.090 … 3.130     3.120 ± 3.110 … 3.130
Octane      regexp.js                                1.002  12.660 ± 12.640 … 12.680  12.630 ± 12.620 … 12.640
Octane      richards.js                              1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      splay.js                                 1.002  2.300 ± 2.300 … 2.300     2.295 ± 2.290 … 2.300
Octane      typescript.js                            1.016  11.430 ± 11.410 … 11.450  11.250 ± 11.190 … 11.310
Octane      zlib.js                                  0.987  36.995 ± 36.890 … 37.100  37.485 ± 37.250 … 37.720
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                           1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                   1      0.025 ± 0.020 … 0.030     0.025 ± 0.020 … 0.030
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    1      0.115 ± 0.110 … 0.120     0.115 ± 0.110 … 0.120
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.030 ± 0.030 … 0.030     0.030 ± 0.030 … 0.030
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.040 ± 0.040 … 0.040     0.040 ± 0.040 … 0.040
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   math-partial-sums.js                     1      0.040 ± 0.040 … 0.040     0.040 ± 0.040 … 0.040
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            1.02   0.260 ± 0.260 … 0.260     0.255 ± 0.250 … 0.260
SunSpider   string-base64.js                         1.5    0.015 ± 0.010 … 0.020     0.010 ± 0.010 … 0.010
SunSpider   string-fasta.js                          1      0.130 ± 0.130 … 0.130     0.130 ± 0.130 … 0.130
SunSpider   string-tagcloud.js                       1.04   0.130 ± 0.130 … 0.130     0.125 ± 0.120 … 0.130
SunSpider   string-unpack-code.js                    1      0.090 ± 0.090 … 0.090     0.090 ± 0.090 … 0.090
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030     0.030 ± 0.030 … 0.030
JetStream   bigfib.cpp.js                            1.009  6.420 ± 6.410 … 6.430     6.365 ± 6.360 … 6.370
JetStream   cdjs.js                                  0.986  4.565 ± 4.550 … 4.580     4.630 ± 4.550 … 4.710
JetStream   container.cpp.js                         0.998  27.315 ± 27.060 … 27.570  27.380 ± 27.350 … 27.410
JetStream   dry.c.js                                 1.032  15.980 ± 15.890 … 16.070  15.485 ± 15.420 … 15.550
JetStream   float-mm.c.js                            1.047  16.635 ± 16.630 … 16.640  15.895 ± 15.850 … 15.940
JetStream   gcc-loops.cpp.js                         1.051  89.780 ± 89.430 … 90.130  85.435 ± 85.230 … 85.640
JetStream   hash-map.js                              1.034  2.595 ± 2.590 … 2.600     2.510 ± 2.510 … 2.510
JetStream   n-body.c.js                              1.018  22.875 ± 22.800 … 22.950  22.475 ± 22.440 … 22.510
JetStream   quicksort.c.js                           1.007  3.805 ± 3.800 … 3.810     3.780 ± 3.770 … 3.790
JetStream   towers.c.js                              1.024  5.375 ± 5.370 … 5.380     5.250 ± 5.250 … 5.250
JetStream3  js-tokens.js                             1.029  0.705 ± 0.690 … 0.720     0.685 ± 0.680 … 0.690
JetStream3  lazy-collections.js                      1.12   1.405 ± 1.400 … 1.410     1.255 ± 1.250 … 1.260
JetStream3  raytrace-private-class-fields.js         1.06   4.975 ± 4.950 … 5.000     4.695 ± 4.690 … 4.700
JetStream3  raytrace-public-class-fields.js          1.018  3.590 ± 3.580 … 3.600     3.525 ± 3.520 … 3.530
JetStream3  sync-file-system.js                      1      1.840 ± 1.840 … 1.840     1.840 ± 1.830 … 1.850
Kraken      Total                                    1.033  10.225                    9.900
Octane      Total                                    1      98.600                    98.645
SunSpider   Total                                    1.014  1.115                     1.100
JetStream   Total                                    1.032  195.345                   189.205
JetStream3  Total                                    1.043  12.515                    12.000
All Suites  Total                                    1.022  317.800                   310.850
```