### PR TITLE
LibWeb: Make a bunch of CSP classes not realm associated 

### DIFF
--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/Directive.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/Directive.cpp
@@ -19,9 +19,9 @@ Directive::Directive(String name, Vector<String> value)
 {
 }
 
-GC::Ref<Directive> Directive::clone(JS::Realm& realm) const
+GC::Ref<Directive> Directive::clone(GC::Heap& heap) const
 {
-    return create_directive(realm, m_name, m_value);
+    return create_directive(heap, m_name, m_value);
 }
 
 SerializedDirective Directive::serialize() const

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/Directive.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/Directive.h
@@ -17,8 +17,8 @@ namespace Web::ContentSecurityPolicy::Directives {
 // https://w3c.github.io/webappsec-csp/#directives
 // Each policy contains an ordered set of directives (its directive set), each of which controls a specific behavior.
 // The directives defined in this document are described in detail in § 6 Content Security Policy Directives.
-class Directive : public JS::Cell {
-    GC_CELL(Directive, JS::Cell)
+class Directive : public GC::Cell {
+    GC_CELL(Directive, GC::Cell)
     GC_DECLARE_ALLOCATOR(Directive);
 
 public:
@@ -94,7 +94,7 @@ public:
     [[nodiscard]] String const& name() const { return m_name; }
     [[nodiscard]] Vector<String> const& value() const { return m_value; }
 
-    [[nodiscard]] GC::Ref<Directive> clone(JS::Realm&) const;
+    [[nodiscard]] GC::Ref<Directive> clone(GC::Heap&) const;
     [[nodiscard]] SerializedDirective serialize() const;
 
 protected:

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -10,10 +10,10 @@
 
 namespace Web::ContentSecurityPolicy::Directives {
 
-GC::Ref<Directive> create_directive(JS::Realm& realm, String name, Vector<String> value)
+GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> value)
 {
     dbgln("Potential FIXME: Creating unknown Content Security Policy directive: {}", name);
-    return realm.create<Directive>(move(name), move(value));
+    return heap.allocate<Directive>(move(name), move(value));
 }
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.h
@@ -8,11 +8,12 @@
 
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibGC/Forward.h>
 #include <LibGC/Ptr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
 
-[[nodiscard]] GC::Ref<Directive> create_directive(JS::Realm&, String name, Vector<String> value);
+[[nodiscard]] GC::Ref<Directive> create_directive(GC::Heap&, String name, Vector<String> value);
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Policy.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Policy.h
@@ -20,8 +20,8 @@ namespace Web::ContentSecurityPolicy {
 // https://w3c.github.io/webappsec-csp/#content-security-policy-object
 // A policy defines allowed and restricted behaviors, and may be applied to a Document, WorkerGlobalScope,
 // or WorkletGlobalScope.
-class Policy final : public JS::Cell {
-    GC_CELL(Policy, JS::Cell);
+class Policy final : public GC::Cell {
+    GC_CELL(Policy, GC::Cell);
     GC_DECLARE_ALLOCATOR(Policy);
 
 public:
@@ -38,9 +38,9 @@ public:
 
     ~Policy() = default;
 
-    [[nodiscard]] static GC::Ref<Policy> parse_a_serialized_csp(JS::Realm&, Variant<ByteBuffer, String> serialized, Source source, Disposition disposition);
-    [[nodiscard]] static GC::Ref<PolicyList> parse_a_responses_content_security_policies(JS::Realm&, GC::Ref<Fetch::Infrastructure::Response const> response);
-    [[nodiscard]] static GC::Ref<Policy> create_from_serialized_policy(JS::Realm&, SerializedPolicy const&);
+    [[nodiscard]] static GC::Ref<Policy> parse_a_serialized_csp(GC::Heap&, Variant<ByteBuffer, String> serialized, Source source, Disposition disposition);
+    [[nodiscard]] static GC::Ref<PolicyList> parse_a_responses_content_security_policies(GC::Heap&, GC::Ref<Fetch::Infrastructure::Response const> response);
+    [[nodiscard]] static GC::Ref<Policy> create_from_serialized_policy(GC::Heap&, SerializedPolicy const&);
 
     [[nodiscard]] Vector<GC::Ref<Directives::Directive>> const& directives() const { return m_directives; }
     [[nodiscard]] Disposition disposition() const { return m_disposition; }
@@ -51,7 +51,7 @@ public:
     [[nodiscard]] bool contains_directive_with_name(StringView name) const;
     [[nodiscard]] GC::Ptr<Directives::Directive> get_directive_by_name(StringView) const;
 
-    [[nodiscard]] GC::Ref<Policy> clone(JS::Realm&) const;
+    [[nodiscard]] GC::Ref<Policy> clone(GC::Heap&) const;
     [[nodiscard]] SerializedPolicy serialize() const;
 
 protected:

--- a/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.cpp
@@ -18,19 +18,19 @@ namespace Web::ContentSecurityPolicy {
 
 GC_DEFINE_ALLOCATOR(PolicyList);
 
-GC::Ref<PolicyList> PolicyList::create(JS::Realm& realm, GC::RootVector<GC::Ref<Policy>> const& policies)
+GC::Ref<PolicyList> PolicyList::create(GC::Heap& heap, GC::RootVector<GC::Ref<Policy>> const& policies)
 {
-    auto policy_list = realm.create<PolicyList>();
+    auto policy_list = heap.allocate<PolicyList>();
     for (auto policy : policies)
         policy_list->m_policies.append(policy);
     return policy_list;
 }
 
-GC::Ref<PolicyList> PolicyList::create(JS::Realm& realm, Vector<SerializedPolicy> const& serialized_policies)
+GC::Ref<PolicyList> PolicyList::create(GC::Heap& heap, Vector<SerializedPolicy> const& serialized_policies)
 {
-    auto policy_list = realm.create<PolicyList>();
+    auto policy_list = heap.allocate<PolicyList>();
     for (auto const& serialized_policy : serialized_policies) {
-        auto policy = Policy::create_from_serialized_policy(realm, serialized_policy);
+        auto policy = Policy::create_from_serialized_policy(heap, serialized_policy);
         policy_list->m_policies.append(policy);
     }
     return policy_list;
@@ -79,11 +79,11 @@ HTML::SandboxingFlagSet PolicyList::csp_derived_sandboxing_flags() const
     return HTML::SandboxingFlagSet {};
 }
 
-GC::Ref<PolicyList> PolicyList::clone(JS::Realm& realm) const
+GC::Ref<PolicyList> PolicyList::clone(GC::Heap& heap) const
 {
-    auto policy_list = realm.create<PolicyList>();
+    auto policy_list = heap.allocate<PolicyList>();
     for (auto policy : m_policies) {
-        auto cloned_policy = policy->clone(realm);
+        auto cloned_policy = policy->clone(heap);
         policy_list->m_policies.append(cloned_policy);
     }
     return policy_list;

--- a/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/PolicyList.h
@@ -12,13 +12,13 @@
 
 namespace Web::ContentSecurityPolicy {
 
-class PolicyList final : public JS::Cell {
-    GC_CELL(PolicyList, JS::Cell);
+class PolicyList final : public GC::Cell {
+    GC_CELL(PolicyList, GC::Cell);
     GC_DECLARE_ALLOCATOR(PolicyList);
 
 public:
-    [[nodiscard]] static GC::Ref<PolicyList> create(JS::Realm&, GC::RootVector<GC::Ref<Policy>> const&);
-    [[nodiscard]] static GC::Ref<PolicyList> create(JS::Realm&, Vector<SerializedPolicy> const&);
+    [[nodiscard]] static GC::Ref<PolicyList> create(GC::Heap&, GC::RootVector<GC::Ref<Policy>> const&);
+    [[nodiscard]] static GC::Ref<PolicyList> create(GC::Heap&, Vector<SerializedPolicy> const&);
     [[nodiscard]] static GC::Ptr<PolicyList> from_object(JS::Object&);
 
     virtual ~PolicyList() = default;
@@ -29,7 +29,7 @@ public:
 
     [[nodiscard]] HTML::SandboxingFlagSet csp_derived_sandboxing_flags() const;
 
-    [[nodiscard]] GC::Ref<PolicyList> clone(JS::Realm&) const;
+    [[nodiscard]] GC::Ref<PolicyList> clone(GC::Heap&) const;
     [[nodiscard]] Vector<SerializedPolicy> serialize() const;
 
 protected:

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3858,9 +3858,9 @@ void Document::set_active_sandboxing_flag_set(HTML::SandboxingFlagSet sandboxing
 
 GC::Ref<HTML::PolicyContainer> Document::policy_container() const
 {
-    auto& realm = this->realm();
+    auto& heap = this->heap();
     if (!m_policy_container) {
-        m_policy_container = realm.create<HTML::PolicyContainer>(realm);
+        m_policy_container = heap.allocate<HTML::PolicyContainer>(heap);
     }
     return *m_policy_container;
 }
@@ -3873,10 +3873,8 @@ void Document::set_policy_container(GC::Ref<HTML::PolicyContainer> policy_contai
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#snapshotting-source-snapshot-params
 GC::Ref<HTML::SourceSnapshotParams> Document::snapshot_source_snapshot_params() const
 {
-    auto& realm = this->realm();
-
     // To snapshot source snapshot params given a Document sourceDocument, return a new source snapshot params with
-    return realm.create<HTML::SourceSnapshotParams>(
+    return heap().allocate<HTML::SourceSnapshotParams>(
         // has transient activation
         //    true if sourceDocument's relevant global object has transient activation; otherwise false
         as<HTML::Window>(HTML::relevant_global_object(*this)).has_transient_activation(),
@@ -3895,7 +3893,7 @@ GC::Ref<HTML::SourceSnapshotParams> Document::snapshot_source_snapshot_params() 
 
         // source policy container
         //     a clone of sourceDocument's policy container
-        policy_container()->clone(realm));
+        policy_container()->clone(heap()));
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#descendant-navigables

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -22,7 +22,6 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
 {
     auto& vm = navigable->vm();
     VERIFY(navigable->active_document());
-    auto& realm = navigable->active_document()->realm();
 
     // 1. Let origin be a new opaque origin.
     URL::Origin origin {};
@@ -59,7 +58,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     auto response = Fetch::Infrastructure::Response::create(vm);
     response->url_list().append(URL::about_error()); // AD-HOC: https://github.com/whatwg/html/issues/9122
     auto navigation_params = vm.heap().allocate<HTML::NavigationParams>();
-    navigation_params->id = navigation_id;
+    navigation_params->id = move(navigation_id);
     navigation_params->navigable = navigable;
     navigation_params->request = nullptr;
     navigation_params->response = response;
@@ -68,7 +67,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     navigation_params->coop_enforcement_result = move(coop_enforcement_result);
     navigation_params->reserved_environment = {};
     navigation_params->origin = move(origin);
-    navigation_params->policy_container = vm.heap().allocate<HTML::PolicyContainer>(realm);
+    navigation_params->policy_container = vm.heap().allocate<HTML::PolicyContainer>(vm.heap());
     navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
     navigation_params->opener_policy = move(coop);
     navigation_params->about_base_url = {};

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -83,6 +83,7 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
     dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'fetch' with: request @ {}", &request);
 
     auto& vm = realm.vm();
+    auto& heap = vm.heap();
 
     // 1. Assert: request’s mode is "navigate" or processEarlyHintsResponse is null.
     VERIFY(request.mode() == Infrastructure::Request::Mode::Navigate || !algorithms.process_early_hints_response());
@@ -185,10 +186,10 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
         // 1. If request’s client is non-null, then set request’s policy container to a clone of request’s client’s
         //    policy container.
         if (request.client() != nullptr)
-            request.set_policy_container(request.client()->policy_container()->clone(realm));
+            request.set_policy_container(request.client()->policy_container()->clone(heap));
         // 2. Otherwise, set request’s policy container to a new policy container.
         else
-            request.set_policy_container(realm.create<HTML::PolicyContainer>(realm));
+            request.set_policy_container(heap.allocate<HTML::PolicyContainer>(heap));
     }
 
     // 13. If request’s header list does not contain `Accept`, then:

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -251,7 +251,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
         document->set_referrer(creator->url().serialize());
 
         // 2. Set document's policy container to a clone of creator's policy container.
-        document->set_policy_container(creator->policy_container()->clone(document->realm()));
+        document->set_policy_container(creator->policy_container()->clone(document->heap()));
 
         // 3. If creator's origin is same origin with creator's relevant settings object's top-level origin,
         if (creator->origin().is_same_origin(creator->relevant_settings_object().top_level_origin)) {

--- a/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Libraries/LibWeb/HTML/NavigationParams.h
@@ -28,8 +28,8 @@ enum class UserNavigationInvolvement {
 };
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params
-struct NavigationParams : JS::Cell {
-    GC_CELL(NavigationParams, JS::Cell);
+struct NavigationParams : GC::Cell {
+    GC_CELL(NavigationParams, GC::Cell);
     GC_DECLARE_ALLOCATOR(NavigationParams);
 
     // null or a navigation ID

--- a/Libraries/LibWeb/HTML/PolicyContainers.cpp
+++ b/Libraries/LibWeb/HTML/PolicyContainers.cpp
@@ -18,8 +18,8 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(PolicyContainer);
 
-PolicyContainer::PolicyContainer(JS::Realm& realm)
-    : csp_list(realm.create<ContentSecurityPolicy::PolicyList>())
+PolicyContainer::PolicyContainer(GC::Heap& heap)
+    : csp_list(heap.allocate<ContentSecurityPolicy::PolicyList>())
 {
 }
 
@@ -36,16 +36,16 @@ bool url_requires_storing_the_policy_container_in_history(URL::URL const& url)
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#creating-a-policy-container-from-a-fetch-response
-GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(JS::Realm& realm, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ptr<Environment>)
+GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(GC::Heap& heap, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ptr<Environment>)
 {
     // FIXME: 1. If response's URL's scheme is "blob", then return a clone of response's URL's blob URL entry's
     //           environment's policy container.
 
     // 2. Let result be a new policy container.
-    GC::Ref<PolicyContainer> result = realm.create<PolicyContainer>(realm);
+    GC::Ref<PolicyContainer> result = heap.allocate<PolicyContainer>(heap);
 
     // 3. Set result's CSP list to the result of parsing a response's Content Security Policies given response.
-    result->csp_list = ContentSecurityPolicy::Policy::parse_a_responses_content_security_policies(realm, response);
+    result->csp_list = ContentSecurityPolicy::Policy::parse_a_responses_content_security_policies(heap, response);
 
     // FIXME: 4. If environment is non-null, then set result's embedder policy to the result of obtaining an embedder
     //           policy given response and environment. Otherwise, set it to "unsafe-none".
@@ -58,23 +58,23 @@ GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(JS::Rea
     return result;
 }
 
-GC::Ref<PolicyContainer> create_a_policy_container_from_serialized_policy_container(JS::Realm& realm, SerializedPolicyContainer const& serialized_policy_container)
+GC::Ref<PolicyContainer> create_a_policy_container_from_serialized_policy_container(GC::Heap& heap, SerializedPolicyContainer const& serialized_policy_container)
 {
-    GC::Ref<PolicyContainer> result = realm.create<PolicyContainer>(realm);
-    result->csp_list = ContentSecurityPolicy::PolicyList::create(realm, serialized_policy_container.csp_list);
+    GC::Ref<PolicyContainer> result = heap.allocate<PolicyContainer>(heap);
+    result->csp_list = ContentSecurityPolicy::PolicyList::create(heap, serialized_policy_container.csp_list);
     result->embedder_policy = serialized_policy_container.embedder_policy;
     result->referrer_policy = serialized_policy_container.referrer_policy;
     return result;
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#clone-a-policy-container
-GC::Ref<PolicyContainer> PolicyContainer::clone(JS::Realm& realm) const
+GC::Ref<PolicyContainer> PolicyContainer::clone(GC::Heap& heap) const
 {
     // 1. Let clone be a new policy container.
-    auto clone = realm.create<PolicyContainer>(realm);
+    auto clone = heap.allocate<PolicyContainer>(heap);
 
     // 2. For each policy in policyContainer's CSP list, append a copy of policy into clone's CSP list.
-    clone->csp_list = csp_list->clone(realm);
+    clone->csp_list = csp_list->clone(heap);
 
     // 3. Set clone's embedder policy to a copy of policyContainer's embedder policy.
     // NOTE: This is a C++ copy.

--- a/Libraries/LibWeb/HTML/PolicyContainers.h
+++ b/Libraries/LibWeb/HTML/PolicyContainers.h
@@ -18,8 +18,8 @@ namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/origin.html#policy-container
 // A policy container is a struct containing policies that apply to a Document, a WorkerGlobalScope, or a WorkletGlobalScope. It has the following items:
-struct PolicyContainer : public JS::Cell {
-    GC_CELL(PolicyContainer, JS::Cell)
+struct PolicyContainer : public GC::Cell {
+    GC_CELL(PolicyContainer, GC::Cell)
     GC_DECLARE_ALLOCATOR(PolicyContainer);
 
 public:
@@ -37,22 +37,22 @@ public:
     // A referrer policy, which is a referrer policy. It is initially the default referrer policy.
     ReferrerPolicy::ReferrerPolicy referrer_policy { ReferrerPolicy::DEFAULT_REFERRER_POLICY };
 
-    [[nodiscard]] GC::Ref<PolicyContainer> clone(JS::Realm&) const;
+    [[nodiscard]] GC::Ref<PolicyContainer> clone(GC::Heap&) const;
     [[nodiscard]] SerializedPolicyContainer serialize() const;
 
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    PolicyContainer(JS::Realm&);
+    PolicyContainer(GC::Heap&);
 };
 
 // https://html.spec.whatwg.org/multipage/browsers.html#requires-storing-the-policy-container-in-history
 [[nodiscard]] bool url_requires_storing_the_policy_container_in_history(URL::URL const& url);
 
 // https://html.spec.whatwg.org/multipage/browsers.html#creating-a-policy-container-from-a-fetch-response
-[[nodiscard]] GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(JS::Realm&, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ptr<Environment> environment);
+[[nodiscard]] GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(GC::Heap&, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ptr<Environment> environment);
 
-[[nodiscard]] GC::Ref<PolicyContainer> create_a_policy_container_from_serialized_policy_container(JS::Realm&, SerializedPolicyContainer const&);
+[[nodiscard]] GC::Ref<PolicyContainer> create_a_policy_container_from_serialized_policy_container(GC::Heap&, SerializedPolicyContainer const&);
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/EnvironmentSettingsSnapshot.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/EnvironmentSettingsSnapshot.cpp
@@ -15,7 +15,7 @@ EnvironmentSettingsSnapshot::EnvironmentSettingsSnapshot(JS::Realm& realm, Nonnu
     , m_api_url_character_encoding(serialized_settings.api_url_character_encoding)
     , m_url(serialized_settings.api_base_url)
     , m_origin(serialized_settings.origin)
-    , m_policy_container(create_a_policy_container_from_serialized_policy_container(realm, serialized_settings.policy_container))
+    , m_policy_container(create_a_policy_container_from_serialized_policy_container(realm.heap(), serialized_settings.policy_container))
     , m_time_origin(serialized_settings.time_origin)
 {
     // Why can't we put these in the init list? grandparent class members are strange it seems

--- a/Libraries/LibWeb/HTML/SourceSnapshotParams.h
+++ b/Libraries/LibWeb/HTML/SourceSnapshotParams.h
@@ -13,8 +13,8 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-snapshot-params
-struct SourceSnapshotParams : public JS::Cell {
-    GC_CELL(SourceSnapshotParams, JS::Cell)
+struct SourceSnapshotParams : public GC::Cell {
+    GC_CELL(SourceSnapshotParams, GC::Cell)
     GC_DECLARE_ALLOCATOR(SourceSnapshotParams);
 
 public:

--- a/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -173,9 +173,9 @@ GC::Ref<CSS::FontFaceSet> WorkerGlobalScope::fonts()
 
 GC::Ref<PolicyContainer> WorkerGlobalScope::policy_container() const
 {
-    auto& realm = this->realm();
+    auto& heap = this->heap();
     if (!m_policy_container) {
-        m_policy_container = realm.create<PolicyContainer>(realm);
+        m_policy_container = heap.allocate<PolicyContainer>(heap);
     }
     return *m_policy_container;
 }
@@ -195,7 +195,7 @@ void WorkerGlobalScope::initialize_policy_container(GC::Ref<Fetch::Infrastructur
 
     // 2. Otherwise, set workerGlobalScope's policy container to the result of creating a policy container from a fetch
     //    response given response and environment.
-    m_policy_container = create_a_policy_container_from_a_fetch_response(realm, response, environment);
+    m_policy_container = create_a_policy_container_from_a_fetch_response(realm.heap(), response, environment);
 }
 
 // https://w3c.github.io/webappsec-csp/#run-global-object-csp-initialization

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -41,7 +41,7 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& rea
     navigation_params->navigable = navigable;
     navigation_params->response = response;
     navigation_params->origin = URL::Origin {};
-    navigation_params->policy_container = navigable->heap().allocate<HTML::PolicyContainer>(navigable->active_document()->realm());
+    navigation_params->policy_container = navigable->heap().allocate<HTML::PolicyContainer>(realm.heap());
     navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
     navigation_params->opener_policy = HTML::OpenerPolicy {};
 


### PR DESCRIPTION
These are not associated with a javascript realm, so to avoid confusion about which realm these need to be created in, make all of these objects a GC::Cell, and deal with the fallout.