### PR TITLE
LibWeb: Temporarily disable site isolation for subframes

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1402,12 +1402,14 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
 
     auto source_document = params.source_document;
     auto exceptions_enabled = params.exceptions_enabled;
+
     auto& active_document = *this->active_document();
     auto& realm = active_document.realm();
+    auto& page_client = active_document.page().client();
 
     // AD-HOC: If we are not able to continue in this process, request a new process from the UI.
-    if (!active_document.page().client().is_url_suitable_for_same_process_navigation(active_document.url(), params.url)) {
-        active_document.page().client().request_new_process_for_navigation(params.url);
+    if (is_top_level_traversable() && !page_client.is_url_suitable_for_same_process_navigation(active_document.url(), params.url)) {
+        page_client.request_new_process_for_navigation(params.url);
         return {};
     }
 

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -256,11 +256,14 @@ void NavigableContainer::navigate_an_iframe_or_frame(URL::URL url, ReferrerPolic
     Variant<Empty, String, POSTResource> document_resource = Empty {};
     if (srcdoc_string.has_value())
         document_resource = srcdoc_string.value();
-    MUST(m_content_navigable->navigate({ .url = url,
+
+    MUST(m_content_navigable->navigate({
+        .url = move(url),
         .source_document = document(),
         .document_resource = document_resource,
         .history_handling = history_handling,
-        .referrer_policy = referrer_policy }));
+        .referrer_policy = referrer_policy,
+    }));
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#destroy-a-child-navigable


### PR DESCRIPTION
We don't yet support out-of-process subframes. Explicitly disable even attempting to isolate subframes. Otherwise, navigating a subframe to a non-same-site URL would actually cause the top-level frame to navigate with our current implementation.