### PR TITLE
LibJS: Avoid naming conflict between Object's and Error's `is_error`

### DIFF
--- a/Libraries/LibJS/Runtime/Error.h
+++ b/Libraries/LibJS/Runtime/Error.h
@@ -47,14 +47,14 @@ protected:
     explicit Error(Object& prototype);
 
 private:
-    virtual bool is_error() const final { return true; }
+    virtual bool is_error_object() const final { return true; }
 
     void populate_stack();
     Vector<TracebackFrame, 32> m_traceback;
 };
 
 template<>
-inline bool Object::fast_is<Error>() const { return is_error(); }
+inline bool Object::fast_is<Error>() const { return is_error_object(); }
 
 // NOTE: Making these inherit from Error is not required by the spec but
 //       our way of implementing the [[ErrorData]] internal slot, which is

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -197,7 +197,7 @@ public:
 
     virtual bool is_function() const { return false; }
     virtual bool is_promise() const { return false; }
-    virtual bool is_error() const { return false; }
+    virtual bool is_error_object() const { return false; }
     virtual bool is_date() const { return false; }
     virtual bool is_number_object() const { return false; }
     virtual bool is_boolean_object() const { return false; }

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -139,8 +139,6 @@ add_library(JSClangPlugin INTERFACE)
 add_library(GenericClangPlugin INTERFACE)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-    add_cxx_compile_options(-Wno-overloaded-virtual)
-
     if (ENABLE_FUZZERS_LIBFUZZER)
         add_cxx_compile_options(-fsanitize=fuzzer)
         set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=fuzzer")


### PR DESCRIPTION
Object defines an `is_error` virtual method to be overridden by Error for fast-is. This is the same name as the `Error.isError` constructor method. Rename the former to avoid conflicts, as GCC 15 just started warning on this.

Fixes #4486