### PR TITLE
LibJS: Remove value_or from JS::Value

### DIFF
--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -379,15 +379,6 @@ public:
 
     [[nodiscard]] String to_string_without_side_effects() const;
 
-#if 0
-    Value value_or(Value fallback) const
-    {
-        if (is_special_empty_value())
-            return fallback;
-        return *this;
-    }
-#endif
-
     [[nodiscard]] GC::Ref<PrimitiveString> typeof_(VM&) const;
 
     bool operator==(Value const&) const;


### PR DESCRIPTION
This is no longer used after 3cf5053.