### PR TITLE
LibJS: Let invokers (callers) of [[Call]] allocate ExecutionContext

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -65,6 +65,9 @@ CodeGenerationErrorOr<void> Generator::emit_function_declaration_instantiation(E
         } else {
             emit<Op::CreateArguments>(dst, Op::CreateArguments::Kind::Mapped, function.is_strict_mode());
         }
+
+        if (local_var_index.has_value())
+            set_local_initialized(Identifier::Local::variable(local_var_index.value()));
     }
 
     auto const& formal_parameters = function.formal_parameters();

--- a/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Libraries/LibJS/Runtime/BoundFunction.h
@@ -20,7 +20,7 @@ public:
 
     virtual ~BoundFunction() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
     virtual bool is_strict_mode() const override { return m_bound_target_function->is_strict_mode(); }

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -481,46 +481,39 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
     }
 }
 
-// 10.2.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
-ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argument, ReadonlySpan<Value> arguments_list)
+ThrowCompletionOr<void> ECMAScriptFunctionObject::get_stack_frame_size(size_t& registers_and_constants_and_locals_count, size_t& argument_count)
 {
-    auto& vm = this->vm();
-
-    // 1. Let callerContext be the running execution context.
-    // NOTE: No-op, kept by the VM in its execution context stack.
-
     if (!m_bytecode_executable) {
         if (!ecmascript_code().bytecode_executable()) {
             if (is_module_wrapper()) {
-                const_cast<Statement&>(ecmascript_code()).set_bytecode_executable(TRY(Bytecode::compile(vm, ecmascript_code(), kind(), name())));
+                const_cast<Statement&>(ecmascript_code()).set_bytecode_executable(TRY(Bytecode::compile(vm(), ecmascript_code(), kind(), name())));
             } else {
-                const_cast<Statement&>(ecmascript_code()).set_bytecode_executable(TRY(Bytecode::compile(vm, *this)));
+                const_cast<Statement&>(ecmascript_code()).set_bytecode_executable(TRY(Bytecode::compile(vm(), *this)));
             }
         }
         m_bytecode_executable = ecmascript_code().bytecode_executable();
     }
+    registers_and_constants_and_locals_count = m_bytecode_executable->number_of_registers + m_bytecode_executable->constants.size() + m_bytecode_executable->local_variable_names.size();
+    argument_count = max(argument_count, formal_parameters().size());
+    return {};
+}
 
-    u32 arguments_count = max(arguments_list.size(), formal_parameters().size());
-    auto registers_and_constants_and_locals_count = m_bytecode_executable->number_of_registers + m_bytecode_executable->constants.size() + m_bytecode_executable->local_variable_names.size();
-    ExecutionContext* callee_context = nullptr;
-    ALLOCATE_EXECUTION_CONTEXT_ON_NATIVE_STACK(callee_context, registers_and_constants_and_locals_count, arguments_count);
+// 10.2.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
+ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(ExecutionContext& callee_context, Value this_argument)
+{
+    auto& vm = this->vm();
 
-    // Non-standard
-    auto arguments = callee_context->arguments;
-    if (!arguments_list.is_empty())
-        arguments.overwrite(0, arguments_list.data(), arguments_list.size() * sizeof(Value));
-    callee_context->passed_argument_count = arguments_list.size();
-    if (arguments_list.size() < formal_parameters().size()) {
-        for (size_t i = arguments_list.size(); i < formal_parameters().size(); ++i)
-            arguments[i] = js_undefined();
-    }
+    VERIFY(m_bytecode_executable);
+
+    // 1. Let callerContext be the running execution context.
+    // NOTE: No-op, kept by the VM in its execution context stack.
 
     // 2. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
     // NOTE: We throw if the end of the native stack is reached, so unlike in the spec this _does_ need an exception check.
-    TRY(prepare_for_ordinary_call(*callee_context, nullptr));
+    TRY(prepare_for_ordinary_call(callee_context, nullptr));
 
     // 3. Assert: calleeContext is now the running execution context.
-    VERIFY(&vm.running_execution_context() == callee_context);
+    VERIFY(&vm.running_execution_context() == &callee_context);
 
     // 4. If F.[[IsClassConstructor]] is true, then
     if (is_class_constructor()) {
@@ -537,7 +530,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argu
 
     // 5. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
     if (uses_this())
-        ordinary_call_bind_this(*callee_context, this_argument);
+        ordinary_call_bind_this(callee_context, this_argument);
 
     // 6. Let result be Completion(OrdinaryCallEvaluateBody(F, argumentsList)).
     auto result = ordinary_call_evaluate_body();

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -116,7 +116,8 @@ public:
     virtual void initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<void> get_stack_frame_size(size_t& registers_and_constants_and_locals_slots, size_t& argument_count) override;
+    virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
     void make_method(Object& home_object);

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -118,8 +118,8 @@ private:
     registers_and_constants_and_locals_count,                                                \
     arguments_count)                                                                         \
     auto execution_context_size = sizeof(JS::ExecutionContext)                               \
-        + ((registers_and_constants_and_locals_count) + (arguments_count))                   \
-            * sizeof(JS::Value);                                                             \
+        + (((registers_and_constants_and_locals_count) + (arguments_count))                  \
+            * sizeof(JS::Value));                                                            \
                                                                                              \
     void* execution_context_memory = alloca(execution_context_size);                         \
                                                                                              \

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -114,7 +114,7 @@ private:
     u32 registers_and_constants_and_locals_and_arguments_count { 0 };
 };
 
-#define ALLOCATE_EXECUTION_CONTEXT_ON_NATIVE_STACK(execution_context,                        \
+#define ALLOCATE_EXECUTION_CONTEXT_ON_NATIVE_STACK_WITHOUT_CLEARING_ARGS(execution_context,  \
     registers_and_constants_and_locals_count,                                                \
     arguments_count)                                                                         \
     auto execution_context_size = sizeof(JS::ExecutionContext)                               \
@@ -129,6 +129,16 @@ private:
     ScopeGuard run_execution_context_destructor([execution_context] {                        \
         execution_context->~ExecutionContext();                                              \
     })
+
+#define ALLOCATE_EXECUTION_CONTEXT_ON_NATIVE_STACK(execution_context, registers_and_constants_and_locals_count, \
+    arguments_count)                                                                                            \
+    ALLOCATE_EXECUTION_CONTEXT_ON_NATIVE_STACK_WITHOUT_CLEARING_ARGS(execution_context,                         \
+        registers_and_constants_and_locals_count, arguments_count);                                             \
+    do {                                                                                                        \
+        for (size_t i = 0; i < execution_context->arguments.size(); i++) {                                      \
+            execution_context->arguments[i] = JS::js_undefined();                                               \
+        }                                                                                                       \
+    } while (0)
 
 struct StackTraceElement {
     ExecutionContext* execution_context;

--- a/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Libraries/LibJS/Runtime/FunctionObject.h
@@ -23,7 +23,8 @@ public:
 
     // Table 5: Additional Essential Internal Methods of Function Objects, https://tc39.es/ecma262/#table-additional-essential-internal-methods-of-function-objects
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) = 0;
+    virtual ThrowCompletionOr<void> get_stack_frame_size([[maybe_unused]] size_t& registers_and_constants_and_locals_count, [[maybe_unused]] size_t& argument_count) { return {}; }
+    virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) = 0;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct([[maybe_unused]] ReadonlySpan<Value> arguments_list, [[maybe_unused]] FunctionObject& new_target) { VERIFY_NOT_REACHED(); }
 
     void set_function_name(Variant<PropertyKey, PrivateName> const& name_arg, Optional<StringView> const& prefix = {});

--- a/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -40,7 +40,7 @@ void FunctionPrototype::initialize(Realm& realm)
     define_direct_property(vm.names.name, PrimitiveString::create(vm, String {}), Attribute::Configurable);
 }
 
-ThrowCompletionOr<Value> FunctionPrototype::internal_call(Value, ReadonlySpan<Value>)
+ThrowCompletionOr<Value> FunctionPrototype::internal_call(ExecutionContext&, Value)
 {
     // The Function prototype object:
     // - accepts any arguments and returns undefined when invoked.

--- a/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -18,7 +18,7 @@ public:
     virtual void initialize(Realm&) override;
     virtual ~FunctionPrototype() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
 
 private:
     explicit FunctionPrototype(Realm&);

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -26,7 +26,7 @@ public:
 
     virtual ~NativeFunction() override = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
     // Used for [[Call]] / [[Construct]]'s "...result of evaluating F in a manner that conforms to the specification of F".

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -779,7 +779,7 @@ ThrowCompletionOr<GC::RootVector<Value>> ProxyObject::internal_own_property_keys
 }
 
 // 10.5.12 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist
-ThrowCompletionOr<Value> ProxyObject::internal_call(Value this_argument, ReadonlySpan<Value> arguments_list)
+ThrowCompletionOr<Value> ProxyObject::internal_call(ExecutionContext& callee_context, Value this_argument)
 {
     LIMIT_PROXY_RECURSION_DEPTH();
 
@@ -802,11 +802,11 @@ ThrowCompletionOr<Value> ProxyObject::internal_call(Value this_argument, Readonl
     // 6. If trap is undefined, then
     if (!trap) {
         // a. Return ? Call(target, thisArgument, argumentsList).
-        return call(vm, m_target, this_argument, arguments_list);
+        return call(vm, m_target, this_argument, callee_context.arguments);
     }
 
     // 7. Let argArray be CreateArrayFromList(argumentsList).
-    auto arguments_array = Array::create_from(realm, arguments_list);
+    auto arguments_array = Array::create_from(realm, callee_context.arguments);
 
     // 8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
     return call(vm, trap, m_handler, m_target, this_argument, arguments_array);

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -42,7 +42,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const override;
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
     ThrowCompletionOr<void> validate_non_revoked_proxy() const;
 

--- a/Libraries/LibJS/Runtime/WrappedFunction.h
+++ b/Libraries/LibJS/Runtime/WrappedFunction.h
@@ -20,12 +20,14 @@ public:
 
     virtual ~WrappedFunction() = default;
 
-    virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
+    virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
 
     virtual Realm* realm() const override { return m_realm; }
 
     FunctionObject const& wrapped_target_function() const { return m_wrapped_target_function; }
     FunctionObject& wrapped_target_function() { return m_wrapped_target_function; }
+
+    virtual ThrowCompletionOr<void> get_stack_frame_size(size_t& registers_and_constants_and_locals_count, size_t& argument_count) override;
 
 private:
     WrappedFunction(Realm&, FunctionObject&, Object& prototype);
@@ -37,7 +39,7 @@ private:
     GC::Ref<Realm> m_realm;                            // [[Realm]]
 };
 
-ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction const&, Value this_argument, ReadonlySpan<Value> arguments_list);
-void prepare_for_wrapped_function_call(WrappedFunction const&, ExecutionContext& callee_context);
+ThrowCompletionOr<Value> ordinary_wrapped_function_call(WrappedFunction&, Value this_argument, Span<Value> arguments_list);
+void prepare_for_wrapped_function_call(WrappedFunction&, ExecutionContext& callee_context);
 
 }

--- a/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -92,7 +92,7 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingCo
     // 9. Let completion be Function.[[Call]](window, parameters) with function as the this value.
     // NOTE: This is not entirely clear, but I don't think they mean actually passing `function` as
     // the this value argument, but using it as the object [[Call]] is executed on.
-    auto completion = function->internal_call(window, parameters);
+    auto completion = JS::call(realm.vm(), *function, window, parameters);
 
     // 10. Clean up after running a callback with environment settings.
     HTML::clean_up_after_running_callback(realm);

--- a/Libraries/LibWeb/WebDriver/JSON.cpp
+++ b/Libraries/LibWeb/WebDriver/JSON.cpp
@@ -253,7 +253,7 @@ static Response internal_json_clone(HTML::BrowsingContext const& browsing_contex
     // -> has an own property named "toJSON" that is a Function
     if (auto to_json = object.get_without_side_effects(vm.names.toJSON); to_json.is_function()) {
         // Return success with the value returned by Function.[[Call]](toJSON) with value as the this value.
-        auto to_json_result = TRY_OR_JS_ERROR(to_json.as_function().internal_call(value, GC::RootVector<JS::Value> { vm.heap() }));
+        auto to_json_result = TRY_OR_JS_ERROR(JS::call(vm, to_json.as_function(), value));
         if (!to_json_result.is_string())
             return WebDriver::Error::from_code(ErrorCode::JavascriptError, "toJSON did not return a String"sv);
 


### PR DESCRIPTION
Instead of letting every [[Call]] implementation allocate an
ExecutionContext, we now make that a responsibility of the caller.
    
The main point of this exercise is to allow the Call instruction
to write function arguments directly into the callee ExecutionContext
instead of copying them later.

This makes function calls significantly faster:
- 10-20% faster on micro-benchmarks (depending on argument count)
- 4% speedup on Kraken
- 2% speedup on Octane
- 5% speedup on JetStream

```
Suite       Test                                   Speedup  Old (Mean ± Range)          New (Mean ± Range)
----------  -----------------------------------  ---------  --------------------------  ------------------------
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.020 ± 0.020 … 0.020       0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                           1      0.020 ± 0.020 … 0.020       0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                   1      0.020 ± 0.020 … 0.020       0.020 ± 0.020 … 0.020
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020       0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    0.923  0.120 ± 0.120 … 0.120       0.130 ± 0.130 … 0.130
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.030 ± 0.030 … 0.030       0.030 ± 0.030 … 0.030
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020       0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.040 ± 0.040 … 0.040       0.040 ± 0.040 … 0.040
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020       0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.020 ± 0.020 … 0.020       0.020 ± 0.020 … 0.020
SunSpider   math-partial-sums.js                     1      0.050 ± 0.050 … 0.050       0.050 ± 0.050 … 0.050
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            1      0.280 ± 0.280 … 0.280       0.280 ± 0.280 … 0.280
SunSpider   string-base64.js                         1      0.010 ± 0.010 … 0.010       0.010 ± 0.010 … 0.010
SunSpider   string-fasta.js                          1      0.140 ± 0.140 … 0.140       0.140 ± 0.140 … 0.140
SunSpider   string-tagcloud.js                       1      0.140 ± 0.140 … 0.140       0.140 ± 0.140 … 0.140
SunSpider   string-unpack-code.js                    1      0.100 ± 0.100 … 0.100       0.100 ± 0.100 … 0.100
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030       0.030 ± 0.030 … 0.030
Kraken      ai-astar.js                              1.02   1.035 ± 1.020 … 1.050       1.015 ± 1.010 … 1.020
Kraken      audio-beat-detection.js                  1.049  0.850 ± 0.850 … 0.850       0.810 ± 0.810 … 0.810
Kraken      audio-dft.js                             1.027  0.565 ± 0.560 … 0.570       0.550 ± 0.550 … 0.550
Kraken      audio-fft.js                             1.036  0.725 ± 0.720 … 0.730       0.700 ± 0.700 … 0.700
Kraken      audio-oscillator.js                      1.012  0.855 ± 0.850 … 0.860       0.845 ± 0.840 … 0.850
Kraken      imaging-darkroom.js                      1.026  0.980 ± 0.970 … 0.990       0.955 ± 0.950 … 0.960
Kraken      imaging-desaturate.js                    1.037  0.980 ± 0.980 … 0.980       0.945 ± 0.940 … 0.950
Kraken      imaging-gaussian-blur.js                 1.066  4.430 ± 4.400 … 4.460       4.155 ± 4.140 … 4.170
Kraken      json-parse-financial.js                  1.083  0.065 ± 0.060 … 0.070       0.060 ± 0.060 … 0.060
Kraken      json-stringify-tinderbox.js              1      0.090 ± 0.090 … 0.090       0.090 ± 0.090 … 0.090
Kraken      stanford-crypto-aes.js                   1.029  0.355 ± 0.350 … 0.360       0.345 ± 0.340 … 0.350
Kraken      stanford-crypto-ccm.js                   1      0.300 ± 0.300 … 0.300       0.300 ± 0.300 … 0.300
Kraken      stanford-crypto-pbkdf2.js                1.035  0.585 ± 0.580 … 0.590       0.565 ± 0.560 … 0.570
Kraken      stanford-crypto-sha256-iterative.js      1      0.230 ± 0.230 … 0.230       0.230 ± 0.230 … 0.230
Octane      box2d.js                                 1      1.080 ± 1.020 … 1.140       1.080 ± 1.020 … 1.140
Octane      code-load.js                             0.998  2.010 ± 2.010 … 2.010       2.015 ± 2.010 … 2.020
Octane      crypto.js                                1.011  5.140 ± 5.140 … 5.140       5.085 ± 5.080 … 5.090
Octane      deltablue.js                             1.002  2.010 ± 2.010 … 2.010       2.005 ± 2.000 … 2.010
Octane      earley-boyer.js                          0.996  10.165 ± 10.150 … 10.180    10.210 ± 10.040 … 10.380
Octane      gbemu.js                                 1.008  1.270 ± 1.270 … 1.270       1.260 ± 1.260 … 1.260
Octane      mandreel.js                              1.028  6.185 ± 6.130 … 6.240       6.015 ± 6.010 … 6.020
Octane      navier-stokes.js                         0.995  2.080 ± 2.070 … 2.090       2.090 ± 2.090 … 2.090
Octane      pdfjs.js                                 1.004  1.185 ± 1.180 … 1.190       1.180 ± 1.180 … 1.180
Octane      raytrace.js                              0.99   3.040 ± 3.040 … 3.040       3.070 ± 3.060 … 3.080
Octane      regexp.js                                1.001  14.585 ± 14.530 … 14.640    14.575 ± 14.570 … 14.580
Octane      richards.js                              0.998  2.000 ± 2.000 … 2.000       2.005 ± 2.000 … 2.010
Octane      splay.js                                 1.004  2.290 ± 2.290 … 2.290       2.280 ± 2.280 … 2.280
Octane      typescript.js                            0.98   12.300 ± 12.260 … 12.340    12.555 ± 12.520 … 12.590
Octane      zlib.js                                  1.064  42.130 ± 42.030 … 42.230    39.610 ± 39.600 … 39.620
JetStream   bigfib.cpp.js                            1.052  7.390 ± 7.360 … 7.420       7.025 ± 6.980 … 7.070
JetStream   cdjs.js                                  0.988  4.910 ± 4.910 … 4.910       4.970 ± 4.940 … 5.000
JetStream   container.cpp.js                         1.03   30.035 ± 29.990 … 30.080    29.160 ± 29.130 … 29.190
JetStream   dry.c.js                                 1.043  18.255 ± 17.970 … 18.540    17.495 ± 17.470 … 17.520
JetStream   float-mm.c.js                            1.001  19.105 ± 19.070 … 19.140    19.095 ± 19.080 … 19.110
JetStream   gcc-loops.cpp.js                         1.061  100.710 ± 99.350 … 102.070  94.930 ± 94.280 … 95.580
JetStream   hash-map.js                              1      2.785 ± 2.770 … 2.800       2.785 ± 2.770 … 2.800
JetStream   n-body.c.js                              1.095  27.845 ± 27.670 … 28.020    25.420 ± 25.260 … 25.580
JetStream   quicksort.c.js                           1.032  4.010 ± 4.000 … 4.020       3.885 ± 3.880 … 3.890
JetStream   towers.c.js                              1.023  5.665 ± 5.630 … 5.700       5.540 ± 5.540 … 5.540
JetStream3  js-tokens.js                             1      0.770 ± 0.770 … 0.770       0.770 ± 0.770 … 0.770
JetStream3  lazy-collections.js                      1.004  1.360 ± 1.360 … 1.360       1.355 ± 1.350 … 1.360
JetStream3  raytrace-private-class-fields.js         0.982  5.160 ± 5.140 … 5.180       5.255 ± 5.240 … 5.270
JetStream3  raytrace-public-class-fields.js          0.987  3.885 ± 3.870 … 3.900       3.935 ± 3.920 … 3.950
JetStream3  sync-file-system.js                      1.005  2.155 ± 2.150 … 2.160       2.145 ± 2.120 … 2.170
SunSpider   Total                                    0.992  1.170                       1.180
Kraken      Total                                    1.042  12.045                      11.565
Octane      Total                                    1.023  107.470                     105.035
JetStream   Total                                    1.049  220.710                     210.305
JetStream3  Total                                    0.99   13.330                      13.460
```