### PR TITLE
LibWeb: Don't crash when interpolating non `<number>` scale values

### DIFF
--- a/Tests/LibWeb/Crash/wpt-import/css/css-values/animations/scale-interpolation-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-values/animations/scale-interpolation-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="help" href="https://issues.chromium.org/issues/396584141">
+<style>
+body { animation: foo 1s; }
+@keyframes foo { to { scale: calc(100% * 1); } }
+</style>


### PR DESCRIPTION
The `x` and `y` values of the `scale` property are a `<length-percentage>`, but we previously only handled the case where they were `<number>` and crashed otherwise.