### PR TITLE
More LibJS things to make function calls faster

### DIFF
--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -503,7 +503,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(ExecutionContex
 {
     auto& vm = this->vm();
 
-    VERIFY(m_bytecode_executable);
+    ASSERT(m_bytecode_executable);
 
     // 1. Let callerContext be the running execution context.
     // NOTE: No-op, kept by the VM in its execution context stack.
@@ -513,7 +513,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(ExecutionContex
     TRY(prepare_for_ordinary_call(vm, callee_context, nullptr));
 
     // 3. Assert: calleeContext is now the running execution context.
-    VERIFY(&vm.running_execution_context() == &callee_context);
+    ASSERT(&vm.running_execution_context() == &callee_context);
 
     // 4. If F.[[IsClassConstructor]] is true, then
     if (is_class_constructor()) {
@@ -543,7 +543,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(ExecutionContex
         return result.value();
 
     // 9. Assert: result is a throw completion.
-    VERIFY(result.type() == Completion::Type::Throw);
+    ASSERT(result.type() == Completion::Type::Throw);
 
     // 10. Return ? result.
     return result.release_error();

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -499,7 +499,7 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::get_stack_frame_size(size_t& r
 }
 
 // 10.2.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
-ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(ExecutionContext& callee_context, Value this_argument)
+FLATTEN ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(ExecutionContext& callee_context, Value this_argument)
 {
     auto& vm = this->vm();
 

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -190,7 +190,7 @@ private:
 
     virtual bool is_strict_mode() const override { return shared_data().m_strict; }
 
-    Completion ordinary_call_evaluate_body(VM&);
+    ThrowCompletionOr<Value> ordinary_call_evaluate_body(VM&);
 
     [[nodiscard]] bool function_environment_needed() const { return shared_data().m_function_environment_needed; }
     SharedFunctionInstanceData const& shared_data() const { return m_shared_data; }

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -181,11 +181,6 @@ public:
 
     friend class Bytecode::Generator;
 
-protected:
-    virtual bool is_strict_mode() const override { return shared_data().m_strict; }
-
-    virtual Completion ordinary_call_evaluate_body();
-
 private:
     ECMAScriptFunctionObject(
         NonnullRefPtr<SharedFunctionInstanceData>,
@@ -193,14 +188,18 @@ private:
         PrivateEnvironment* private_environment,
         Object& prototype);
 
+    virtual bool is_strict_mode() const override { return shared_data().m_strict; }
+
+    Completion ordinary_call_evaluate_body(VM&);
+
     [[nodiscard]] bool function_environment_needed() const { return shared_data().m_function_environment_needed; }
     SharedFunctionInstanceData const& shared_data() const { return m_shared_data; }
 
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;
 
-    ThrowCompletionOr<void> prepare_for_ordinary_call(ExecutionContext& callee_context, Object* new_target);
-    void ordinary_call_bind_this(ExecutionContext&, Value this_argument);
+    ThrowCompletionOr<void> prepare_for_ordinary_call(VM&, ExecutionContext& callee_context, Object* new_target);
+    void ordinary_call_bind_this(VM&, ExecutionContext&, Value this_argument);
 
     NonnullRefPtr<SharedFunctionInstanceData> m_shared_data;
 


### PR DESCRIPTION
Handful of simple little things that add up to a lot:

```
Suite       Test               Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  ---------------  ---------  ---------------------  ---------------------
MicroBench  call-00-args.js      1.048  1.730 ± 1.690 … 1.770  1.650 ± 1.620 … 1.680
MicroBench  call-01-args.js      1.024  1.730 ± 1.720 … 1.740  1.690 ± 1.680 … 1.700
MicroBench  call-02-args.js      1.035  1.760 ± 1.720 … 1.800  1.700 ± 1.700 … 1.700
MicroBench  call-03-args.js      1.061  1.750 ± 1.740 … 1.760  1.650 ± 1.630 … 1.670
MicroBench  call-04-args.js      1.038  1.760 ± 1.750 … 1.770  1.695 ± 1.680 … 1.710
MicroBench  call-16-args.js      1.069  1.940 ± 1.940 … 1.940  1.815 ± 1.800 … 1.830
MicroBench  call-32-args.js      1.072  2.240 ± 2.210 … 2.270  2.090 ± 2.060 … 2.120
MicroBench  Total                1.05   12.910                 12.290
```