### PR TITLE
AK: Rework windows error types to store the code

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -23,33 +23,9 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 }
 
 #ifdef AK_OS_WINDOWS
-Error Error::from_windows_error(u64 code)
+Error Error::from_windows_error(u32 windows_error)
 {
-    thread_local HashMap<u64, ByteString> s_windows_errors;
-
-    auto string = s_windows_errors.get(code);
-    if (string.has_value())
-        return Error::from_string_view(string->view());
-
-    char* message = nullptr;
-    auto size = FormatMessage(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        nullptr,
-        static_cast<DWORD>(code),
-        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-        reinterpret_cast<LPSTR>(&message),
-        0,
-        nullptr);
-
-    if (size == 0) {
-        static char buffer[128];
-        (void)snprintf(buffer, _countof(buffer), "Error 0x%08lX while getting text of error 0x%08llX", GetLastError(), code);
-        return Error::from_string_view({ buffer, _countof(buffer) });
-    }
-
-    auto& string_in_map = s_windows_errors.ensure(code, [message, size] { return ByteString { message, size }; });
-    LocalFree(message);
-    return Error::from_string_view(string_in_map.view());
+    return Error(static_cast<int>(windows_error), Error::Kind::Windows);
 }
 
 // This can be used both for generic Windows errors and for winsock errors because WSAGetLastError is forwarded to GetLastError.

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
+#include <AK/ByteString.h>
 #include <AK/CharacterTypes.h>
+#include <AK/Error.h>
 #include <AK/Format.h>
 #include <AK/GenericLexer.h>
+#include <AK/HashMap.h>
 #include <AK/IntegralMath.h>
 #include <AK/LexicalPath.h>
 #include <AK/String.h>
@@ -1086,6 +1090,56 @@ void vout(FILE* file, StringView fmtstr, TypeErasedFormatParams& params, bool ne
         auto error = ferror(file);
         dbgln("vout() failed ({} written out of {}), error was {} ({})", retval, string.length(), error, strerror(error));
     }
+}
+#if defined(AK_OS_WINDOWS)
+ErrorOr<void> Formatter<Error>::format_windows_error(FormatBuilder& builder, Error const& error)
+{
+    thread_local HashMap<u32, ByteString> windows_errors;
+
+    int code = error.code();
+    Optional<ByteString&> string = windows_errors.get(static_cast<u32>(code));
+    if (string.has_value()) {
+        return Formatter<StringView>::format(builder, string->view());
+    }
+
+    TCHAR* message = nullptr;
+    u32 size = FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr,
+        static_cast<DWORD>(code),
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        message,
+        0,
+        nullptr);
+    if (size == 0) {
+        auto format_error = GetLastError();
+        return Formatter<FormatString>::format(builder, "Error {:08x} when formatting code {:08x}"sv, format_error, code);
+    }
+
+    auto& string_in_map = windows_errors.ensure(code, [message, size] { return ByteString { message, size }; });
+    LocalFree(message);
+    return Formatter<StringView>::format(builder, string_in_map.view());
+}
+#else
+ErrorOr<void> Formatter<Error>::format_windows_error(FormatBuilder&, Error const&)
+{
+    VERIFY_NOT_REACHED();
+}
+#endif
+
+ErrorOr<void> Formatter<Error>::format(FormatBuilder& builder, Error const& error)
+{
+    switch (error.kind()) {
+    case Error::Kind::Syscall:
+        return Formatter<FormatString>::format(builder, "{}: {} (errno={})"sv, error.string_literal(), strerror(error.code()), error.code());
+    case Error::Kind::Errno:
+        return Formatter<FormatString>::format(builder, "{} (errno={})"sv, strerror(error.code()), error.code());
+    case Error::Kind::Windows:
+        return Formatter<Error>::format_windows_error(builder, error);
+    case Error::Kind::StringLiteral:
+        return Formatter<FormatString>::format(builder, "{}"sv, error.string_literal());
+    }
+    VERIFY_NOT_REACHED();
 }
 
 #ifdef AK_OS_ANDROID

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -737,15 +737,10 @@ struct Formatter<FormatString> : Formatter<StringView> {
 
 template<>
 struct Formatter<Error> : Formatter<FormatString> {
-    ErrorOr<void> format(FormatBuilder& builder, Error const& error)
-    {
-        if (error.is_syscall())
-            return Formatter<FormatString>::format(builder, "{}: {} (errno={})"sv, error.string_literal(), strerror(error.code()), error.code());
-        if (error.is_errno())
-            return Formatter<FormatString>::format(builder, "{} (errno={})"sv, strerror(error.code()), error.code());
+    ErrorOr<void> format(FormatBuilder& builder, Error const& error);
 
-        return Formatter<FormatString>::format(builder, "{}"sv, error.string_literal());
-    }
+private:
+    ErrorOr<void> format_windows_error(FormatBuilder& builder, Error const& error);
 };
 
 template<typename T, typename ErrorType>


### PR DESCRIPTION
This commit makes windows errors store the code instead of being a formatted string literat. This will allow comparing against the error, and checkign what it is. The formatting is now done in the formatter, and moved to an implementation file to avoid polluting headers with windows.h.