### PR TITLE
More shenanigans for JS call performance

### DIFF
--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -212,7 +212,7 @@ private:
 
     ALWAYS_INLINE RETURNS_NONNULL T* as_nonnull_ptr() const
     {
-        VERIFY(m_ptr);
+        ASSERT(m_ptr);
         return m_ptr;
     }
 

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -516,7 +516,7 @@ FLATTEN ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Executi
     ASSERT(&vm.running_execution_context() == &callee_context);
 
     // 4. If F.[[IsClassConstructor]] is true, then
-    if (is_class_constructor()) {
+    if (is_class_constructor()) [[unlikely]] {
         // a. Let error be a newly created TypeError object.
         // b. NOTE: error is created in calleeContext with F's associated Realm Record.
         auto throw_completion = vm.throw_completion<TypeError>(ErrorType::ClassConstructorWithoutNew, name());

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -419,7 +419,7 @@ bool VM::in_strict_mode() const
     return running_execution_context().is_strict_mode;
 }
 
-void VM::run_queued_promise_jobs()
+void VM::run_queued_promise_jobs_impl()
 {
     dbgln_if(PROMISE_DEBUG, "Running queued promise jobs");
 

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -112,8 +112,9 @@ public:
     ThrowCompletionOr<void> push_execution_context(ExecutionContext& context, CheckStackSpaceLimitTag)
     {
         // Ensure we got some stack space left, so the next function call doesn't kill us.
-        if (did_reach_stack_space_limit())
+        if (did_reach_stack_space_limit()) [[unlikely]] {
             return throw_completion<InternalError>(ErrorType::CallStackSizeExceeded);
+        }
         push_execution_context(context);
         return {};
     }

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -228,7 +228,13 @@ public:
         GC::Ptr<PrimitiveString> object_Object;
     } cached_strings;
 
-    void run_queued_promise_jobs();
+    void run_queued_promise_jobs()
+    {
+        if (m_promise_jobs.is_empty())
+            return;
+        run_queued_promise_jobs_impl();
+    }
+
     void enqueue_promise_job(GC::Ref<GC::Function<ThrowCompletionOr<Value>()>> job, Realm*);
 
     void run_queued_finalization_registry_cleanup_jobs();
@@ -298,6 +304,8 @@ private:
     ThrowCompletionOr<void> link_and_eval_module(CyclicModule&);
 
     void set_well_known_symbols(WellKnownSymbols well_known_symbols) { m_well_known_symbols = move(well_known_symbols); }
+
+    void run_queued_promise_jobs_impl();
 
     HashMap<String, GC::Ptr<PrimitiveString>> m_string_cache;
     HashMap<Utf16String, GC::Ptr<PrimitiveString>> m_utf16_string_cache;


### PR DESCRIPTION
Another handfull of small but helpful things.

```
Suite       Test               Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  ---------------  ---------  ---------------------  ---------------------
MicroBench  call-00-args.js      1.077  1.673 ± 1.620 … 1.730  1.553 ± 1.520 … 1.610
MicroBench  call-01-args.js      1.073  1.673 ± 1.610 … 1.750  1.560 ± 1.530 … 1.580
MicroBench  call-02-args.js      1.057  1.667 ± 1.590 … 1.720  1.577 ± 1.550 … 1.630
MicroBench  call-03-args.js      1.055  1.650 ± 1.610 … 1.730  1.563 ± 1.550 … 1.580
MicroBench  call-04-args.js      1.093  1.727 ± 1.690 … 1.800  1.580 ± 1.580 … 1.580
MicroBench  call-16-args.js      1.053  1.850 ± 1.810 … 1.900  1.757 ± 1.740 … 1.770
MicroBench  call-32-args.js      1.07   2.133 ± 2.060 … 2.230  1.993 ± 1.990 … 2.000
MicroBench  Total                1.068  12.373                 11.583
```