### PR TITLE
LibWeb+LibGfx: Support `alpha` context attribute for CanvasRenderingContext2D

### DIFF
--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -125,11 +125,11 @@ PainterSkia::~PainterSkia() = default;
 
 void PainterSkia::clear_rect(Gfx::FloatRect const& rect, Gfx::Color color)
 {
-    SkPaint paint;
-    paint.setColor(to_skia_color(color));
-    paint.setBlendMode(SkBlendMode::kClear);
     impl().with_canvas([&](auto& canvas) {
-        canvas.drawRect(to_skia_rect(rect), paint);
+        canvas.save();
+        canvas.clipRect(to_skia_rect(rect));
+        canvas.clear(to_skia_color(color));
+        canvas.restore();
     });
 }
 

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -30,7 +30,7 @@ struct PaintingSurface::Impl {
 NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(RefPtr<SkiaBackendContext> context, IntSize size, BitmapFormat color_type, AlphaType alpha_type)
 {
     auto sk_color_type = to_skia_color_type(color_type);
-    auto sk_alpha_type = alpha_type == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto sk_alpha_type = to_skia_alpha_type(color_type, alpha_type);
     auto image_info = SkImageInfo::Make(size.width(), size.height(), sk_color_type, sk_alpha_type, SkColorSpace::MakeSRGB());
 
     if (!context) {
@@ -50,7 +50,7 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(RefPtr<SkiaBack
 NonnullRefPtr<PaintingSurface> PaintingSurface::wrap_bitmap(Bitmap& bitmap)
 {
     auto color_type = to_skia_color_type(bitmap.format());
-    auto alpha_type = bitmap.alpha_type() == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto alpha_type = to_skia_alpha_type(bitmap.format(), bitmap.alpha_type());
     auto size = bitmap.size();
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     auto surface = SkSurfaces::WrapPixels(image_info, bitmap.begin(), bitmap.pitch());
@@ -102,7 +102,7 @@ PaintingSurface::~PaintingSurface()
 void PaintingSurface::read_into_bitmap(Bitmap& bitmap)
 {
     auto color_type = to_skia_color_type(bitmap.format());
-    auto alpha_type = bitmap.alpha_type() == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto alpha_type = to_skia_alpha_type(bitmap.format(), bitmap.alpha_type());
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->readPixels(pixmap, 0, 0);
@@ -111,7 +111,7 @@ void PaintingSurface::read_into_bitmap(Bitmap& bitmap)
 void PaintingSurface::write_from_bitmap(Bitmap const& bitmap)
 {
     auto color_type = to_skia_color_type(bitmap.format());
-    auto alpha_type = bitmap.alpha_type() == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto alpha_type = to_skia_alpha_type(bitmap.format(), bitmap.alpha_type());
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->writePixels(pixmap, 0, 0);

--- a/Libraries/LibGfx/SkiaUtils.h
+++ b/Libraries/LibGfx/SkiaUtils.h
@@ -40,6 +40,20 @@ constexpr SkColorType to_skia_color_type(Gfx::BitmapFormat format)
     VERIFY_NOT_REACHED();
 }
 
+constexpr SkAlphaType to_skia_alpha_type(Gfx::BitmapFormat format, Gfx::AlphaType alpha_type)
+{
+    if (format == BitmapFormat::BGRx8888 || format == BitmapFormat::RGBx8888)
+        return kOpaque_SkAlphaType;
+
+    switch (alpha_type) {
+    case AlphaType::Premultiplied:
+        return kPremul_SkAlphaType;
+    case AlphaType::Unpremultiplied:
+        return kUnpremul_SkAlphaType;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 constexpr SkRect to_skia_rect(auto const& rect)
 {
     return SkRect::MakeXYWH(rect.x(), rect.y(), rect.width(), rect.height());

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -160,6 +160,8 @@ private:
     [[nodiscard]] Gfx::Path rect_path(float x, float y, float width, float height);
     [[nodiscard]] Gfx::Path text_path(StringView text, float x, float y, Optional<double> max_width);
 
+    Gfx::Color clear_color() const;
+
     void stroke_internal(Gfx::Path const&);
     void fill_internal(Gfx::Path const&, Gfx::WindingRule);
     void clip_internal(Gfx::Path&, Gfx::WindingRule);

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -64,5 +64,5 @@ CanvasRenderingContext2D includes CanvasPath;
 // https://html.spec.whatwg.org/multipage/canvas.html#canvassettings
 interface mixin CanvasSettings {
     // settings
-    [FIXME] CanvasRenderingContext2DSettings getContextAttributes();
+    CanvasRenderingContext2DSettings getContextAttributes();
 };

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -208,12 +208,12 @@ void HTMLCanvasElement::adjust_computed_style(CSS::ComputedProperties& style)
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
 }
 
-HTMLCanvasElement::HasOrCreatedContext HTMLCanvasElement::create_2d_context()
+JS::ThrowCompletionOr<HTMLCanvasElement::HasOrCreatedContext> HTMLCanvasElement::create_2d_context(JS::Value options)
 {
     if (!m_context.has<Empty>())
         return m_context.has<GC::Ref<CanvasRenderingContext2D>>() ? HasOrCreatedContext::Yes : HasOrCreatedContext::No;
 
-    m_context = CanvasRenderingContext2D::create(realm(), *this);
+    m_context = TRY(CanvasRenderingContext2D::create(realm(), *this, options));
     return HasOrCreatedContext::Yes;
 }
 
@@ -244,7 +244,7 @@ JS::ThrowCompletionOr<HTMLCanvasElement::RenderingContext> HTMLCanvasElement::ge
     // 3. Run the steps in the cell of the following table whose column header matches this canvas element's canvas context mode and whose row header matches contextId:
     // NOTE: See the spec for the full table.
     if (type == "2d"sv) {
-        if (create_2d_context() == HasOrCreatedContext::Yes)
+        if (TRY(create_2d_context(options)) == HasOrCreatedContext::Yes)
             return GC::make_root(*m_context.get<GC::Ref<HTML::CanvasRenderingContext2D>>());
 
         return Empty {};

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibWeb/HTML/HTMLElement.h>
@@ -30,7 +29,7 @@ public:
         No,
         Yes,
     };
-    HasOrCreatedContext create_2d_context();
+    JS::ThrowCompletionOr<HasOrCreatedContext> create_2d_context(JS::Value options);
 
     WebIDL::UnsignedLong width() const;
     WebIDL::UnsignedLong height() const;

--- a/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -43,7 +43,7 @@ ErrorOr<GC::Ref<HTML::HTMLCanvasElement>, WebDriver::Error> draw_bounding_box_fr
     MUST(canvas.set_height(paint_height));
 
     // FIXME: 5. Let context, a canvas context mode, be the result of invoking the 2D context creation algorithm given canvas as the target.
-    canvas.create_2d_context();
+    MUST(canvas.create_2d_context({}));
     canvas.allocate_painting_surface_if_needed();
     if (!canvas.surface())
         return Error::from_code(ErrorCode::UnableToCaptureScreen, "Failed to allocate painting surface"sv);

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/canvas/element/manual/context-attributes/clearRect_alpha_false-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/canvas/element/manual/context-attributes/clearRect_alpha_false-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CanvasRenderingContext 2D with alpha=flase, fillRect with semi-transparent color.</title>
+<p>Test passes if a 100x100 black square is displayed below.</p>
+<canvas id="c" width=100 height=100></canvas>
+<script>
+const ctx = document.getElementById("c").getContext("2d");
+ctx.fillStyle = 'black';
+ctx.fillRect(-1, -1, 102, 102);
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/canvas/element/manual/context-attributes/clearRect_alpha_false.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/canvas/element/manual/context-attributes/clearRect_alpha_false.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CanvasRenderingContext 2D with alpha=flase, clearRect</title>
+<link rel="author" title="Justin Novosad" href="mailto:junov@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/#concept-canvas-alpha">
+<link rel="match" href="../../../../../../../expected/wpt-import/html/canvas/element/manual/context-attributes/clearRect_alpha_false-ref.html">
+<meta name="assert" content="Canvas pixels remain opaque black when drawing semi-transparent rectangle.">
+<p>Test passes if a 100x100 black square is displayed below.</p>
+<canvas id="c" width=100 height=100></canvas>
+<script>
+const ctx = document.getElementById("c").getContext("2d", {alpha: false});
+ctx.fillColor = 'red';
+ctx.fillRect(25, 25, 50, 25);
+ctx.clearRect(24, 24, 52, 52);
+</script>


### PR DESCRIPTION
There's still more needed for a full implementation, but this deals with parsing and returning the context's attributes and supporting the right clearing behavior for contexts created with `{"alpha": false}`.

Adds +20 WPT passes in `html/canvas/element`.