### PR TITLE
LibJS: Store bytecode VM program counter in ExecutionContext

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -381,9 +381,8 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
     auto& executable = current_executable();
     auto const* bytecode = executable.bytecode.data();
 
-    size_t program_counter = entry_point;
-
-    TemporaryChange change(m_program_counter, Optional<size_t&>(program_counter));
+    size_t& program_counter = running_execution_context.program_counter;
+    program_counter = entry_point;
 
     // Declare a lookup table for computed goto with each of the `handle_*` labels
     // to avoid the overhead of a switch statement.

--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -76,7 +76,6 @@ public:
 
     Executable& current_executable() { return *m_current_executable; }
     Executable const& current_executable() const { return *m_current_executable; }
-    Optional<size_t> program_counter() const { return m_program_counter; }
     Span<Value> allocate_argument_values(size_t argument_count)
     {
         m_argument_values_buffer.resize_and_keep_capacity(argument_count);
@@ -100,7 +99,6 @@ private:
     GC::Ptr<Realm> m_realm { nullptr };
     GC::Ptr<Object> m_global_object { nullptr };
     GC::Ptr<DeclarativeEnvironment> m_global_declarative_environment { nullptr };
-    Optional<size_t&> m_program_counter;
     Span<Value> m_registers_and_constants_and_locals_arguments;
     Vector<Value> m_argument_values_buffer;
     ExecutionContext* m_running_execution_context { nullptr };

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -58,7 +58,7 @@ public:
     // Non-standard: This points at something that owns this ExecutionContext, in case it needs to be protected from GC.
     GC::Ptr<Cell> context_owner;
 
-    Optional<size_t> program_counter;
+    size_t program_counter { 0 };
 
     mutable RefPtr<CachedSourceRange> cached_source_range;
 

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -115,12 +115,21 @@ public:
         if (did_reach_stack_space_limit()) [[unlikely]] {
             return throw_completion<InternalError>(ErrorType::CallStackSizeExceeded);
         }
-        push_execution_context(context);
+        m_execution_context_stack.append(&context);
         return {};
     }
 
-    void push_execution_context(ExecutionContext&);
-    void pop_execution_context();
+    void push_execution_context(ExecutionContext& context)
+    {
+        m_execution_context_stack.append(&context);
+    }
+
+    void pop_execution_context()
+    {
+        m_execution_context_stack.take_last();
+        if (m_execution_context_stack.is_empty() && on_call_stack_emptied)
+            on_call_stack_emptied();
+    }
 
     // https://tc39.es/ecma262/#running-execution-context
     // At any point in time, there is at most one execution context per agent that is actually executing code.

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -913,8 +913,8 @@ static ErrorInformation extract_error_information(JS::VM& vm, JS::Value exceptio
     else {
         for (ssize_t i = vm.execution_context_stack().size() - 1; i >= 0; --i) {
             auto& frame = vm.execution_context_stack()[i];
-            if (frame->executable && frame->program_counter.has_value()) {
-                auto source_range = frame->executable->source_range_at(frame->program_counter.value()).realize();
+            if (frame->executable) {
+                auto source_range = frame->executable->source_range_at(frame->program_counter).realize();
                 attributes.filename = MUST(String::from_byte_string(source_range.filename()));
                 attributes.lineno = source_range.start.line;
                 attributes.colno = source_range.start.column;


### PR DESCRIPTION
This way it's always automatically correct, and we don't have to manually flush it in push_execution_context().

~7% speedup on the MicroBench/call* tests :^)

```
Suite       Test               Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  ---------------  ---------  ---------------------  ---------------------
MicroBench  call-00-args.js      1.059  1.553 ± 1.520 … 1.610  1.467 ± 1.420 … 1.500
MicroBench  call-01-args.js      1.056  1.560 ± 1.530 … 1.580  1.477 ± 1.430 … 1.540
MicroBench  call-02-args.js      1.097  1.577 ± 1.550 … 1.630  1.437 ± 1.430 … 1.440
MicroBench  call-03-args.js      1.073  1.563 ± 1.550 … 1.580  1.457 ± 1.450 … 1.470
MicroBench  call-04-args.js      1.075  1.580 ± 1.580 … 1.580  1.470 ± 1.460 … 1.480
MicroBench  call-16-args.js      1.076  1.757 ± 1.740 … 1.770  1.633 ± 1.630 … 1.640
MicroBench  call-32-args.js      1.047  1.993 ± 1.990 … 2.000  1.903 ± 1.900 … 1.910
MicroBench  Total                1.068  11.583                 10.843
```