### PR TITLE
LibWeb: Re-evaluate the style block when the type attribute changes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -59,6 +59,8 @@ void HTMLStyleElement::attribute_changed(FlyString const& name, Optional<String>
     if (name == HTML::AttributeNames::media) {
         if (auto* sheet = m_style_element_utils.sheet())
             sheet->set_media(value.value_or({}));
+    } else if (name == HTML::AttributeNames::type) {
+        m_style_element_utils.update_a_style_block(*this);
     }
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/document-metadata/the-style-element/style_type_change.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/document-metadata/the-style-element/style_type_change.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	Check initial styleSheets length type
+Pass	Change type from invalid type to valid type
+Pass	Change type from valid type to invalid type

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/document-metadata/the-style-element/style_type_change.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/document-metadata/the-style-element/style_type_change.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically changing HTMLStyleElement.type should change the rendering accordingly</title>
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-style-element">
+    <style type="no/mime">
+      body { color: green }
+    </style>
+  </head>
+  <body>
+    Text content.
+    <script>
+      var style = document.querySelector("style");
+      test(function() {
+        assert_equals(document.styleSheets.length, 0);
+      }, "Check initial styleSheets length type");
+
+      test(function() {
+        assert_not_equals(getComputedStyle(document.querySelector("body")).color, "rgb(0, 128, 0)");
+        assert_equals(document.styleSheets.length, 0);
+        style.type = "text/css";
+        assert_equals(getComputedStyle(document.querySelector("body")).color, "rgb(0, 128, 0)");
+        assert_equals(document.styleSheets.length, 1);
+      }, "Change type from invalid type to valid type");
+
+      test(function() {
+        assert_equals(getComputedStyle(document.querySelector("body")).color, "rgb(0, 128, 0)");
+        assert_equals(document.styleSheets.length, 1);
+        style.type = "no/mime";
+        assert_not_equals(getComputedStyle(document.querySelector("body")).color, "rgb(0, 128, 0)");
+        assert_equals(document.styleSheets.length, 0);
+      }, "Change type from valid type to invalid type");
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Fixes at least 2 WPT sub-tests.

Basically re-evaluates `update_a_style_block` when type attribute changes.