### PR TITLE
Even more LibJS shenanigans for faster calls

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -726,8 +726,6 @@ Interpreter::ResultAndReturnRegister Interpreter::run_executable(Executable& exe
     TemporaryChange restore_global_object { m_global_object, GC::Ptr { m_realm->global_object() } };
     TemporaryChange restore_global_declarative_environment { m_global_declarative_environment, GC::Ptr { m_realm->global_environment().declarative_record() } };
 
-    VERIFY(!vm().execution_context_stack().is_empty());
-
     auto& running_execution_context = vm().running_execution_context();
     u32 registers_and_constants_and_locals_count = executable.number_of_registers + executable.constants.size() + executable.local_variable_names.size();
     VERIFY(registers_and_constants_and_locals_count <= running_execution_context.registers_and_constants_and_locals_and_arguments_span().size());

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -371,7 +371,7 @@ NEVER_INLINE Interpreter::HandleExceptionResponse Interpreter::handle_exception(
 
 FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 {
-    if (vm().did_reach_stack_space_limit()) {
+    if (vm().did_reach_stack_space_limit()) [[unlikely]] {
         reg(Register::exception()) = vm().throw_completion<InternalError>(ErrorType::CallStackSizeExceeded).value();
         return;
     }

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -377,7 +377,6 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
     }
 
     auto& running_execution_context = this->running_execution_context();
-    auto& accumulator = this->accumulator();
     auto& executable = current_executable();
     auto const* bytecode = executable.bytecode.data();
 
@@ -417,7 +416,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
 
         handle_End: {
             auto& instruction = *reinterpret_cast<Op::End const*>(&bytecode[program_counter]);
-            accumulator = get(instruction.value());
+            accumulator() = get(instruction.value());
             return;
         }
 

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -309,6 +309,7 @@ public:
             visitor(m_excluded_names[i]);
     }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_excluded_names_count);
@@ -358,6 +359,7 @@ public:
 
     Operand dst() const { return m_dst; }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_element_count);
@@ -384,6 +386,7 @@ public:
             m_elements[i] = elements[i];
     }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Value) * m_element_count);
@@ -1766,6 +1769,7 @@ public:
             m_arguments[i] = arguments[i];
     }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_argument_count);
@@ -1815,6 +1819,7 @@ public:
             m_arguments[i] = arguments[i];
     }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_argument_count);
@@ -1865,6 +1870,7 @@ public:
             m_arguments[i] = arguments[i];
     }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_argument_count);
@@ -1910,6 +1916,7 @@ public:
             m_arguments[i] = arguments[i];
     }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Operand) * m_argument_count);
@@ -2027,6 +2034,7 @@ public:
         }
     }
 
+    size_t length() const { return length_impl(); }
     size_t length_impl() const
     {
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Optional<Operand>) * m_element_keys_count);

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -905,8 +905,9 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::ordinary_call_evaluate_body(V
 
     auto result_and_frame = vm.bytecode_interpreter().run_executable(*m_bytecode_executable, {});
 
-    if (result_and_frame.value.is_error())
+    if (result_and_frame.value.is_error()) [[unlikely]] {
         return result_and_frame.value.release_error();
+    }
 
     auto result = result_and_frame.value.release_value();
 

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -901,8 +901,6 @@ template void async_function_start(VM&, PromiseCapability const&, GC::Function<C
 // 15.8.4 Runtime Semantics: EvaluateAsyncFunctionBody, https://tc39.es/ecma262/#sec-runtime-semantics-evaluatefunctionbody
 ThrowCompletionOr<Value> ECMAScriptFunctionObject::ordinary_call_evaluate_body(VM& vm)
 {
-    auto& realm = *vm.current_realm();
-
     auto result_and_frame = vm.bytecode_interpreter().run_executable(*m_bytecode_executable, {});
 
     if (result_and_frame.value.is_error()) [[unlikely]] {
@@ -916,6 +914,7 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::ordinary_call_evaluate_body(V
     if (kind() == FunctionKind::Normal)
         return result;
 
+    auto& realm = *vm.current_realm();
     if (kind() == FunctionKind::AsyncGenerator) {
         auto async_generator_object = TRY(AsyncGenerator::create(realm, result, this, vm.running_execution_context().copy()));
         return async_generator_object;

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -198,7 +198,7 @@ private:
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;
 
-    ThrowCompletionOr<void> prepare_for_ordinary_call(VM&, ExecutionContext& callee_context, Object* new_target);
+    void prepare_for_ordinary_call(VM&, ExecutionContext& callee_context, Object* new_target);
     void ordinary_call_bind_this(VM&, ExecutionContext&, Value this_argument);
 
     NonnullRefPtr<SharedFunctionInstanceData> m_shared_data;

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -214,11 +214,6 @@ String const& VM::error_message(ErrorMessage type) const
     return message;
 }
 
-Bytecode::Interpreter& VM::bytecode_interpreter()
-{
-    return *m_bytecode_interpreter;
-}
-
 struct ExecutionContextRootsCollector : public Cell::Visitor {
     virtual void visit_impl(GC::Cell& cell) override
     {

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -53,7 +53,7 @@ public:
     GC::Heap& heap() { return m_heap; }
     GC::Heap const& heap() const { return m_heap; }
 
-    Bytecode::Interpreter& bytecode_interpreter();
+    Bytecode::Interpreter& bytecode_interpreter() { return *m_bytecode_interpreter; }
 
     void dump_backtrace() const;
 


### PR DESCRIPTION
Funny how there's so much juice to squeeze out of this thing..

```
Suite       Test               Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  ---------------  ---------  ---------------------  ---------------------
MicroBench  call-00-args.js      1.019  1.443 ± 1.410 … 1.500  1.417 ± 1.370 … 1.490
MicroBench  call-01-args.js      1.024  1.440 ± 1.420 … 1.480  1.407 ± 1.380 … 1.450
MicroBench  call-02-args.js      1.052  1.477 ± 1.430 … 1.540  1.403 ± 1.390 … 1.430
MicroBench  call-03-args.js      1.04   1.487 ± 1.450 … 1.550  1.430 ± 1.400 … 1.490
MicroBench  call-04-args.js      1.054  1.503 ± 1.470 … 1.570  1.427 ± 1.420 … 1.430
MicroBench  call-16-args.js      1.027  1.663 ± 1.640 … 1.700  1.620 ± 1.590 … 1.670
MicroBench  call-32-args.js      1.038  1.923 ± 1.910 … 1.950  1.853 ± 1.830 … 1.880
MicroBench  Total                1.036  10.937                 10.557
```