### PR TITLE
LibJS: Catch up on some spec updates

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1898,10 +1898,10 @@ ModuleRequest::ModuleRequest(FlyString module_specifier_, Vector<ImportAttribute
     : module_specifier(move(module_specifier_))
     , attributes(move(attributes))
 {
-    // Perform step 10.e. from EvaluateImportCall, https://tc39.es/proposal-import-attributes/#sec-evaluate-import-call
-    // or step 2. from WithClauseToAttributes, https://tc39.es/proposal-import-attributes/#sec-with-clause-to-attributes
-    // e. / 2. Sort assertions by the code point order of the [[Key]] of each element.
-    // NOTE: This sorting is observable only in that hosts are prohibited from distinguishing among assertions by the order they occur in.
+    // 13.3.10.2 EvaluateImportCall ( specifierExpression [ , optionsExpression ] ), https://tc39.es/ecma262/#sec-evaluate-import-call
+    // 16.2.2.4 Static Semantics: WithClauseToAttributes, https://tc39.es/ecma262/#sec-withclausetoattributes
+    // 2. Sort attributes according to the lexicographic order of their [[Key]] field, treating the value of each such
+    //    field as a sequence of UTF-16 code unit values.
     quick_sort(this->attributes, [](ImportAttribute const& lhs, ImportAttribute const& rhs) {
         return lhs.key < rhs.key;
     });

--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1693,16 +1693,15 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
     TRY(for_each_lexically_declared_identifier([&](Identifier const& identifier) -> ThrowCompletionOr<void> {
         auto const& name = identifier.string();
 
-        // a. If env.HasVarDeclaration(name) is true, throw a SyntaxError exception.
-        if (global_environment.has_var_declaration(name))
-            return vm.throw_completion<SyntaxError>(ErrorType::TopLevelVariableAlreadyDeclared, name);
-
-        // b. If env.HasLexicalDeclaration(name) is true, throw a SyntaxError exception.
+        // a. If HasLexicalDeclaration(env, name) is true, throw a SyntaxError exception.
         if (global_environment.has_lexical_declaration(name))
             return vm.throw_completion<SyntaxError>(ErrorType::TopLevelVariableAlreadyDeclared, name);
 
-        // c. Let hasRestrictedGlobal be ? env.HasRestrictedGlobalProperty(name).
+        // b. Let hasRestrictedGlobal be ? HasRestrictedGlobalProperty(env, name).
         auto has_restricted_global = TRY(global_environment.has_restricted_global_property(name));
+
+        // c. NOTE: Global var and function bindings (except those that are introduced by non-strict direct eval) are
+        //    non-configurable and are therefore restricted global properties.
 
         // d. If hasRestrictedGlobal is true, throw a SyntaxError exception.
         if (has_restricted_global)

--- a/Libraries/LibJS/CyclicModule.h
+++ b/Libraries/LibJS/CyclicModule.h
@@ -33,7 +33,7 @@ public:
     // Note: Do not call these methods directly unless you are HostResolveImportedModule.
     //       Badges cannot be used because other hosts must be able to call this (and it is called recursively)
     virtual ThrowCompletionOr<void> link(VM& vm) override final;
-    virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override final;
+    virtual ThrowCompletionOr<GC::Ref<Promise>> evaluate(VM& vm) override final;
 
     virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) override;
 

--- a/Libraries/LibJS/Module.h
+++ b/Libraries/LibJS/Module.h
@@ -104,13 +104,15 @@ public:
 
     Script::HostDefined* host_defined() const { return m_host_defined; }
 
-    ThrowCompletionOr<Object*> get_module_namespace(VM& vm);
+    GC::Ref<Object> get_module_namespace(VM& vm);
 
     virtual ThrowCompletionOr<void> link(VM& vm) = 0;
-    virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) = 0;
+    virtual ThrowCompletionOr<GC::Ref<Promise>> evaluate(VM& vm) = 0;
 
-    virtual ThrowCompletionOr<Vector<FlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set = {}) = 0;
-    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) = 0;
+    Vector<FlyString> get_exported_names(VM& vm);
+    virtual Vector<FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) = 0;
+
+    virtual ResolvedBinding resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) = 0;
 
     virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index);
     virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index);
@@ -128,7 +130,7 @@ protected:
     }
 
 private:
-    Object* module_namespace_create(Vector<FlyString> unambiguous_names);
+    GC::Ref<Object> module_namespace_create(Vector<FlyString> unambiguous_names);
 
     // These handles are only safe as long as the VM they live in is valid.
     // But evaluated modules SHOULD be stored in the VM so unless you intentionally

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -171,7 +171,6 @@ inline size_t array_buffer_byte_length(ArrayBuffer const& array_buffer, ArrayBuf
 }
 
 // 25.1.3.14 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric
-// 5 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/proposal-float16array/#sec-rawbytestonumeric
 template<typename T>
 static Value raw_bytes_to_numeric(VM& vm, Bytes raw_value, bool is_little_endian)
 {
@@ -305,7 +304,6 @@ Value ArrayBuffer::get_value(size_t byte_index, [[maybe_unused]] bool is_typed_a
 }
 
 // 25.1.3.17 NumericToRawBytes ( type, value, isLittleEndian ), https://tc39.es/ecma262/#sec-numerictorawbytes
-// 6 NumericToRawBytes ( type, value, isLittleEndian ), https://tc39.es/proposal-float16array/#sec-numerictorawbytes
 template<typename T>
 static void numeric_to_raw_bytes(VM& vm, Value value, bool is_little_endian, Bytes raw_bytes)
 {

--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -214,12 +214,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
             // v. If mapping is true, then
             if (mapfn) {
                 // 1. Let mappedValue be Completion(Call(mapfn, thisArg, « nextValue, 𝔽(k) »)).
-                auto mapped_value_or_error = JS::call(vm, *mapfn, this_arg, next.release_value(), Value(k));
-
                 // 2. IfAbruptCloseIterator(mappedValue, iteratorRecord).
-                if (mapped_value_or_error.is_error())
-                    return TRY(iterator_close(vm, iterator, mapped_value_or_error.release_error()));
-                mapped_value = mapped_value_or_error.release_value();
+                mapped_value = TRY_OR_CLOSE_ITERATOR(vm, iterator, JS::call(vm, *mapfn, this_arg, next.release_value(), Value(k)));
             }
             // vi. Else, let mappedValue be nextValue.
             else {
@@ -227,11 +223,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from)
             }
 
             // vii. Let defineStatus be Completion(CreateDataPropertyOrThrow(A, Pk, mappedValue)).
-            auto result_or_error = array->create_data_property_or_throw(property_key, mapped_value);
-
             // viii. IfAbruptCloseIterator(defineStatus, iteratorRecord).
-            if (result_or_error.is_error())
-                return TRY(iterator_close(vm, iterator, result_or_error.release_error()));
+            TRY_OR_CLOSE_ITERATOR(vm, iterator, array->create_data_property_or_throw(property_key, mapped_value));
 
             // ix. Set k to k + 1.
         }

--- a/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -32,12 +32,19 @@ void AsyncFromSyncIteratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.throw_, throw_, 1, attr);
 }
 
-// 27.1.4.4 AsyncFromSyncIteratorContinuation ( result, promiseCapability ), https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation
-static Object* async_from_sync_iterator_continuation(VM& vm, Object& result, PromiseCapability& promise_capability)
+enum class CloseOnRejection {
+    No,
+    Yes,
+};
+
+// 27.1.4.4 AsyncFromSyncIteratorContinuation ( result, promiseCapability, syncIteratorRecord, closeOnRejection ), https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation
+static Object* async_from_sync_iterator_continuation(VM& vm, Object& result, PromiseCapability& promise_capability, IteratorRecord const& sync_iterator_record, CloseOnRejection close_on_rejection)
 {
     auto& realm = *vm.current_realm();
 
-    // 1. NOTE: Because promiseCapability is derived from the intrinsic %Promise%, the calls to promiseCapability.[[Reject]] entailed by the use IfAbruptRejectPromise below are guaranteed not to throw.
+    // 1. NOTE: Because promiseCapability is derived from the intrinsic %Promise%, the calls to promiseCapability.[[Reject]]
+    //    entailed by the use IfAbruptRejectPromise below are guaranteed not to throw.
+
     // 2. Let done be Completion(IteratorComplete(result)).
     // 3. IfAbruptRejectPromise(done, promiseCapability).
     auto done = TRY_OR_MUST_REJECT(vm, &promise_capability, iterator_complete(vm, result));
@@ -46,24 +53,58 @@ static Object* async_from_sync_iterator_continuation(VM& vm, Object& result, Pro
     // 5. IfAbruptRejectPromise(value, promiseCapability).
     auto value = TRY_OR_MUST_REJECT(vm, &promise_capability, iterator_value(vm, result));
 
-    // 6. Let valueWrapper be PromiseResolve(%Promise%, value).
-    // 7. IfAbruptRejectPromise(valueWrapper, promiseCapability).
-    auto value_wrapper = TRY_OR_MUST_REJECT(vm, &promise_capability, promise_resolve(vm, realm.intrinsics().promise_constructor(), value));
+    // 6. Let valueWrapper be Completion(PromiseResolve(%Promise%, value)).
+    auto value_wrapper_completion = [&]() -> ThrowCompletionOr<JS::Value> {
+        return TRY(promise_resolve(vm, realm.intrinsics().promise_constructor(), value));
+    }();
 
-    // 8. Let unwrap be a new Abstract Closure with parameters (value) that captures done and performs the following steps when called:
+    // 7. If valueWrapper is an abrupt completion, done is false, and closeOnRejection is true, then
+    if (value_wrapper_completion.is_error() && !done && close_on_rejection == CloseOnRejection::Yes) {
+        // a. Set valueWrapper to Completion(IteratorClose(syncIteratorRecord, valueWrapper)).
+        value_wrapper_completion = iterator_close(vm, sync_iterator_record, value_wrapper_completion);
+    }
+
+    // 8. IfAbruptRejectPromise(valueWrapper, promiseCapability).
+    auto value_wrapper = TRY_OR_MUST_REJECT(vm, &promise_capability, value_wrapper_completion);
+
+    // 9. Let unwrap be a new Abstract Closure with parameters (value) that captures done and performs the following steps when called:
     auto unwrap = [done](VM& vm) -> ThrowCompletionOr<Value> {
         // a. Return CreateIterResultObject(value, done).
         return create_iterator_result_object(vm, vm.argument(0), done).ptr();
     };
 
-    // 9. Let onFulfilled be CreateBuiltinFunction(unwrap, 1, "", « »).
-    // 10. NOTE: onFulfilled is used when processing the "value" property of an IteratorResult object in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" IteratorResult object.
+    // 10. Let onFulfilled be CreateBuiltinFunction(unwrap, 1, "", « »).
+    // 11. NOTE: onFulfilled is used when processing the "value" property of an IteratorResult object in order to wait for its value if it is a promise and re-package the result in a new "unwrapped" IteratorResult object.
     auto on_fulfilled = NativeFunction::create(realm, move(unwrap), 1);
 
-    // 11. Perform PerformPromiseThen(valueWrapper, onFulfilled, undefined, promiseCapability).
-    as<Promise>(value_wrapper)->perform_then(move(on_fulfilled), js_undefined(), &promise_capability);
+    Value on_rejected;
 
-    // 12. Return promiseCapability.[[Promise]].
+    // 12. If done is true, or if closeOnRejection is false, then
+    if (done || close_on_rejection == CloseOnRejection::No) {
+        // a. Let onRejected be undefined.
+        on_rejected = js_undefined();
+    }
+    // 13. Else,
+    else {
+        // a. Let closeIterator be a new Abstract Closure with parameters (error) that captures syncIteratorRecord and performs the following steps when called:
+        auto close_iterator = [&sync_iterator_record](VM& vm) -> ThrowCompletionOr<Value> {
+            auto error = vm.argument(0);
+
+            // i. Return ? IteratorClose(syncIteratorRecord, ThrowCompletion(error)).
+            return iterator_close(vm, sync_iterator_record, throw_completion(error));
+        };
+
+        // b. Let onRejected be CreateBuiltinFunction(closeIterator, 1, "", « »).
+        on_rejected = NativeFunction::create(realm, move(close_iterator), 1);
+
+        // c. NOTE: onRejected is used to close the Iterator when the "value" property of an IteratorResult object it
+        //    yields is a rejected promise.
+    }
+
+    // 14. Perform PerformPromiseThen(valueWrapper, onFulfilled, onRejected, promiseCapability).
+    as<Promise>(value_wrapper.as_object()).perform_then(on_fulfilled, on_rejected, promise_capability);
+
+    // 15. Return promiseCapability.[[Promise]].
     return promise_capability.promise();
 }
 
@@ -91,8 +132,8 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncFromSyncIteratorPrototype::next)
         (vm.argument_count() > 0 ? iterator_next(vm, sync_iterator_record, vm.argument(0))
                                  : iterator_next(vm, sync_iterator_record)));
 
-    // 8. Return AsyncFromSyncIteratorContinuation(result, promiseCapability).
-    return async_from_sync_iterator_continuation(vm, result, promise_capability);
+    // 8. Return AsyncFromSyncIteratorContinuation(result, promiseCapability, syncIteratorRecord, true).
+    return async_from_sync_iterator_continuation(vm, result, promise_capability, sync_iterator_record, CloseOnRejection::Yes);
 }
 
 // 27.1.4.2.2 %AsyncFromSyncIteratorPrototype%.return ( [ value ] ), https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return
@@ -107,45 +148,49 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncFromSyncIteratorPrototype::return_)
     // 3. Let promiseCapability be ! NewPromiseCapability(%Promise%).
     auto promise_capability = MUST(new_promise_capability(vm, realm.intrinsics().promise_constructor()));
 
-    // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
-    auto sync_iterator = this_object->sync_iterator_record().iterator;
+    // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
+    auto& sync_iterator_record = this_object->sync_iterator_record();
 
-    // 5. Let return be Completion(GetMethod(syncIterator, "return")).
-    // 6. IfAbruptRejectPromise(return, promiseCapability).
+    // 5. Let syncIterator be syncIteratorRecord.[[Iterator]].
+    auto sync_iterator = sync_iterator_record.iterator;
+
+    // 6. Let return be Completion(GetMethod(syncIterator, "return")).
+    // 7. IfAbruptRejectPromise(return, promiseCapability).
     auto return_method = TRY_OR_REJECT(vm, promise_capability, Value(sync_iterator).get_method(vm, vm.names.return_));
 
-    // 7. If return is undefined, then
+    // 8. If return is undefined, then
     if (return_method == nullptr) {
-        // a. Let iterResult be CreateIterResultObject(value, true).
-        auto iter_result = create_iterator_result_object(vm, vm.argument(0), true);
+        // a. Let iteratorResult be CreateIteratorResultObject(value, true).
+        auto iterator_result = create_iterator_result_object(vm, vm.argument(0), true);
 
-        // b. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iterResult »).
-        MUST(call(vm, *promise_capability->resolve(), js_undefined(), iter_result));
+        // b. Perform ! Call(promiseCapability.[[Resolve]], undefined, « iteratorResult »).
+        MUST(call(vm, *promise_capability->resolve(), js_undefined(), iterator_result));
 
         // c. Return promiseCapability.[[Promise]].
         return promise_capability->promise();
     }
 
-    // 8. If value is present, then
+    // 9. If value is present, then
     //     a. Let result be Completion(Call(return, syncIterator, « value »)).
-    // 9. Else,
+    // 10. Else,
     //     a. Let result be Completion(Call(return, syncIterator)).
-    // 10. IfAbruptRejectPromise(result, promiseCapability).
+    // 11. IfAbruptRejectPromise(result, promiseCapability).
     auto result = TRY_OR_REJECT(vm, promise_capability,
         (vm.argument_count() > 0 ? call(vm, return_method, sync_iterator, vm.argument(0))
                                  : call(vm, return_method, sync_iterator)));
 
-    // 11. If Type(result) is not Object, then
+    // 12. If Type(result) is not Object, then
     if (!result.is_object()) {
         auto error = TypeError::create(realm, TRY_OR_THROW_OOM(vm, String::formatted(ErrorType::NotAnObject.message(), "SyncIteratorReturnResult")));
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
         MUST(call(vm, *promise_capability->reject(), js_undefined(), error));
+
         // b. Return promiseCapability.[[Promise]].
         return promise_capability->promise();
     }
 
-    // 12. Return AsyncFromSyncIteratorContinuation(result, promiseCapability).
-    return async_from_sync_iterator_continuation(vm, result.as_object(), promise_capability);
+    // 13. Return AsyncFromSyncIteratorContinuation(result, promiseCapability, syncIteratorRecord, false).
+    return async_from_sync_iterator_continuation(vm, result.as_object(), promise_capability, sync_iterator_record, CloseOnRejection::No);
 }
 
 // 27.1.4.2.3 %AsyncFromSyncIteratorPrototype%.throw ( [ value ] ), https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw
@@ -160,42 +205,59 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncFromSyncIteratorPrototype::throw_)
     // 3. Let promiseCapability be ! NewPromiseCapability(%Promise%).
     auto promise_capability = MUST(new_promise_capability(vm, realm.intrinsics().promise_constructor()));
 
-    // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
-    auto sync_iterator = this_object->sync_iterator_record().iterator;
+    // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
+    auto& sync_iterator_record = this_object->sync_iterator_record();
 
-    // 5. Let throw be Completion(GetMethod(syncIterator, "throw")).
-    // 6. IfAbruptRejectPromise(throw, promiseCapability).
+    // 5. Let syncIterator be syncIteratorRecord.[[Iterator]].
+    auto sync_iterator = sync_iterator_record.iterator;
+
+    // 6. Let throw be Completion(GetMethod(syncIterator, "throw")).
+    // 7. IfAbruptRejectPromise(throw, promiseCapability).
     auto throw_method = TRY_OR_REJECT(vm, promise_capability, Value(sync_iterator).get_method(vm, vm.names.throw_));
 
-    // 7. If throw is undefined, then
+    // 8. If throw is undefined, then
     if (throw_method == nullptr) {
-        // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « value »).
-        MUST(call(vm, *promise_capability->reject(), js_undefined(), vm.argument(0)));
-        // b. Return promiseCapability.[[Promise]].
+        // a. NOTE: If syncIterator does not have a throw method, close it to give it a chance to clean up before we reject the capability.
+
+        // b. Let closeCompletion be NormalCompletion(empty).
+        auto close_completion = normal_completion({});
+
+        // c. Let result be Completion(IteratorClose(syncIteratorRecord, closeCompletion)).
+        // d. IfAbruptRejectPromise(result, promiseCapability).
+        TRY_OR_REJECT(vm, promise_capability, iterator_close(vm, sync_iterator_record, close_completion));
+
+        // e. NOTE: The next step throws a TypeError to indicate that there was a protocol violation: syncIterator does not have a throw method.
+        // f. NOTE: If closing syncIterator does not throw then the result of that operation is ignored, even if it yields a rejected promise.
+
+        // g. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+        auto error = TypeError::create(realm, MUST(String::formatted(ErrorType::IsUndefined.message(), "throw method")));
+        MUST(call(vm, *promise_capability->reject(), js_undefined(), error));
+
+        // h. Return promiseCapability.[[Promise]].
         return promise_capability->promise();
     }
-    // 8. If value is present, then
+
+    // 9. If value is present, then
     //     a. Let result be Completion(Call(throw, syncIterator, « value »)).
-    // 9. Else,
+    // 10. Else,
     //     a. Let result be Completion(Call(throw, syncIterator)).
-    // 10. IfAbruptRejectPromise(result, promiseCapability).
+    // 11. IfAbruptRejectPromise(result, promiseCapability).
     auto result = TRY_OR_REJECT(vm, promise_capability,
         (vm.argument_count() > 0 ? call(vm, throw_method, sync_iterator, vm.argument(0))
                                  : call(vm, throw_method, sync_iterator)));
 
-    // 11. If Type(result) is not Object, then
+    // 12. If result is not an Object, then
     if (!result.is_object()) {
-        auto error = TypeError::create(realm, TRY_OR_THROW_OOM(vm, String::formatted(ErrorType::NotAnObject.message(), "SyncIteratorThrowResult")));
-
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+        auto error = TypeError::create(realm, MUST(String::formatted(ErrorType::NotAnObject.message(), "SyncIteratorThrowResult")));
         MUST(call(vm, *promise_capability->reject(), js_undefined(), error));
 
         // b. Return promiseCapability.[[Promise]].
         return promise_capability->promise();
     }
 
-    // 12. Return AsyncFromSyncIteratorContinuation(result, promiseCapability).
-    return async_from_sync_iterator_continuation(vm, result.as_object(), promise_capability);
+    // 13. Return AsyncFromSyncIteratorContinuation(result, promiseCapability, syncIteratorRecord, true).
+    return async_from_sync_iterator_continuation(vm, result.as_object(), promise_capability, sync_iterator_record, CloseOnRejection::Yes);
 }
 
 // 27.1.4.1 CreateAsyncFromSyncIterator ( syncIteratorRecord ), https://tc39.es/ecma262/#sec-createasyncfromsynciterator

--- a/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -51,7 +51,7 @@ void DataViewPrototype::initialize(Realm& realm)
     define_native_accessor(realm, vm.names.byteLength, byte_length_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.byteOffset, byte_offset_getter, {}, Attribute::Configurable);
 
-    // 25.3.4.25 DataView.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-dataview.prototype-@@tostringtag
+    // 25.3.4.27 DataView.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-dataview.prototype-@@tostringtag
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, vm.names.DataView.as_string()), Attribute::Configurable);
 }
 
@@ -238,7 +238,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_big_uint_64)
     return get_view_value<u64>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 7.1 DataView.prototype.getFloat16 ( byteOffset [ , littleEndian ] ), https://tc39.es/proposal-float16array/#sec-dataview.prototype.getfloat16
+// 25.3.4.7 DataView.prototype.getFloat16 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_float_16)
 {
     // 1. Let v be the this value.
@@ -247,7 +247,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_float_16)
     return get_view_value<f16>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 25.3.4.7 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32
+// 25.3.4.8 DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_float_32)
 {
     // 1. Let v be the this value.
@@ -256,7 +256,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_float_32)
     return get_view_value<float>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 25.3.4.8 DataView.prototype.getFloat64 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64
+// 25.3.4.9 DataView.prototype.getFloat64 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_float_64)
 {
     // 1. Let v be the this value.
@@ -265,7 +265,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_float_64)
     return get_view_value<double>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 25.3.4.9 DataView.prototype.getInt8 ( byteOffset ), https://tc39.es/ecma262/#sec-dataview.prototype.getint8
+// 25.3.4.10 DataView.prototype.getInt8 ( byteOffset ), https://tc39.es/ecma262/#sec-dataview.prototype.getint8
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_int_8)
 {
     // 1. Let v be the this value.
@@ -273,7 +273,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_int_8)
     return get_view_value<i8>(vm, vm.argument(0), Value(true));
 }
 
-// 25.3.4.10 DataView.prototype.getInt16 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getint16
+// 25.3.4.11 DataView.prototype.getInt16 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getint16
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_int_16)
 {
     // 1. Let v be the this value.
@@ -282,7 +282,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_int_16)
     return get_view_value<i16>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 25.3.4.11 DataView.prototype.getInt32 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getint32
+// 25.3.4.12 DataView.prototype.getInt32 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getint32
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_int_32)
 {
     // 1. Let v be the this value.
@@ -291,7 +291,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_int_32)
     return get_view_value<i32>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 25.3.4.12 DataView.prototype.getUint8 ( byteOffset ), https://tc39.es/ecma262/#sec-dataview.prototype.getuint8
+// 25.3.4.13 DataView.prototype.getUint8 ( byteOffset ), https://tc39.es/ecma262/#sec-dataview.prototype.getuint8
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_uint_8)
 {
     // 1. Let v be the this value.
@@ -299,7 +299,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_uint_8)
     return get_view_value<u8>(vm, vm.argument(0), Value(true));
 }
 
-// 25.3.4.13 DataView.prototype.getUint16 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getuint16
+// 25.3.4.14 DataView.prototype.getUint16 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getuint16
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_uint_16)
 {
     // 1. Let v be the this value.
@@ -308,7 +308,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_uint_16)
     return get_view_value<u16>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 25.3.4.14 DataView.prototype.getUint32 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getuint32
+// 25.3.4.15 DataView.prototype.getUint32 ( byteOffset [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.getuint32
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_uint_32)
 {
     // 1. Let v be the this value.
@@ -317,7 +317,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::get_uint_32)
     return get_view_value<u32>(vm, vm.argument(0), vm.argument(1));
 }
 
-// 25.3.4.15 DataView.prototype.setBigInt64 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64
+// 25.3.4.16 DataView.prototype.setBigInt64 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_big_int_64)
 {
     // 1. Let v be the this value.
@@ -325,7 +325,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_big_int_64)
     return set_view_value<i64>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 25.3.4.16 DataView.prototype.setBigUint64 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64
+// 25.3.4.17 DataView.prototype.setBigUint64 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_big_uint_64)
 {
     // 1. Let v be the this value.
@@ -333,7 +333,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_big_uint_64)
     return set_view_value<u64>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 7.2 DataView.prototype.setFloat16 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/proposal-float16array/#sec-dataview.prototype.setfloat16
+// 25.3.4.18 DataView.prototype.setFloat16 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setfloat16
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_float_16)
 {
     // 1. Let v be the this value.
@@ -342,7 +342,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_float_16)
     return set_view_value<f16>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 25.3.4.17 DataView.prototype.setFloat32 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setfloat32
+// 25.3.4.19 DataView.prototype.setFloat32 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setfloat32
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_float_32)
 {
     // 1. Let v be the this value.
@@ -351,7 +351,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_float_32)
     return set_view_value<float>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 25.3.4.18 DataView.prototype.setFloat64 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setfloat64
+// 25.3.4.20 DataView.prototype.setFloat64 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setfloat64
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_float_64)
 {
     // 1. Let v be the this value.
@@ -360,7 +360,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_float_64)
     return set_view_value<double>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 25.3.4.19 DataView.prototype.setInt8 ( byteOffset, value ), https://tc39.es/ecma262/#sec-dataview.prototype.setint8
+// 25.3.4.21 DataView.prototype.setInt8 ( byteOffset, value ), https://tc39.es/ecma262/#sec-dataview.prototype.setint8
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_int_8)
 {
     // 1. Let v be the this value.
@@ -368,7 +368,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_int_8)
     return set_view_value<i8>(vm, vm.argument(0), Value(true), vm.argument(1));
 }
 
-// 25.3.4.20 DataView.prototype.setInt16 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setint16
+// 25.3.4.22 DataView.prototype.setInt16 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setint16
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_int_16)
 {
     // 1. Let v be the this value.
@@ -377,7 +377,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_int_16)
     return set_view_value<i16>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 25.3.4.21 DataView.prototype.setInt32 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setint32
+// 25.3.4.23 DataView.prototype.setInt32 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setint32
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_int_32)
 {
     // 1. Let v be the this value.
@@ -386,7 +386,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_int_32)
     return set_view_value<i32>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 25.3.4.22 DataView.prototype.setUint8 ( byteOffset, value ), https://tc39.es/ecma262/#sec-dataview.prototype.setuint8
+// 25.3.4.24 DataView.prototype.setUint8 ( byteOffset, value ), https://tc39.es/ecma262/#sec-dataview.prototype.setuint8
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_uint_8)
 {
     // 1. Let v be the this value.
@@ -394,7 +394,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_uint_8)
     return set_view_value<u8>(vm, vm.argument(0), Value(true), vm.argument(1));
 }
 
-// 25.3.4.23 DataView.prototype.setUint16 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setuint16
+// 25.3.4.25 DataView.prototype.setUint16 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setuint16
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_uint_16)
 {
     // 1. Let v be the this value.
@@ -403,7 +403,7 @@ JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_uint_16)
     return set_view_value<u16>(vm, vm.argument(0), vm.argument(2), vm.argument(1));
 }
 
-// 25.3.4.24 DataView.prototype.setUint32 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setuint32
+// 25.3.4.26 DataView.prototype.setUint32 ( byteOffset, value [ , littleEndian ] ), https://tc39.es/ecma262/#sec-dataview.prototype.setuint32
 JS_DEFINE_NATIVE_FUNCTION(DataViewPrototype::set_uint_32)
 {
     // 1. Let v be the this value.

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -52,6 +52,7 @@
         "Legacy RegExp static property getter must be called with the RegExp constructor for the this value")                       \
     M(GetLegacyRegExpStaticPropertyValueEmpty, "Legacy RegExp static property getter value is empty")                               \
     M(GlobalEnvironmentAlreadyHasBinding, "Global environment already has binding '{}'")                                            \
+    M(ImportAttributeUnsupported, "Every import attribute is not supported")                                                        \
     M(IndexOutOfRange, "Index {} is out of range of array length {}")                                                               \
     M(InOperatorWithObject, "'in' operator must be used on an object")                                                              \
     M(InstanceOfOperatorBadPrototype, "'prototype' property of {} is not an object")                                                \

--- a/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/GlobalEnvironment.cpp
@@ -146,34 +146,15 @@ ThrowCompletionOr<bool> GlobalEnvironment::delete_binding(VM& vm, FlyString cons
 
     // 6. If existingProp is true, then
     if (existing_prop) {
-        // a. Let status be ? ObjRec.DeleteBinding(N).
-        bool status = TRY(m_object_record->delete_binding(vm, name));
-
-        // b. If status is true, then
-        if (status) {
-            // i. Let varNames be envRec.[[VarNames]].
-            // ii. If N is an element of varNames, remove that element from the varNames.
-            m_var_names.remove_all_matching([&](auto& entry) { return entry == name; });
-        }
-
-        // c. Return status.
-        return status;
+        // a. Return ? ObjRec.DeleteBinding(N).
+        return TRY(m_object_record->delete_binding(vm, name));
     }
 
     // 7. Return true.
     return true;
 }
 
-// 9.1.1.4.12 HasVarDeclaration ( N ), https://tc39.es/ecma262/#sec-hasvardeclaration
-bool GlobalEnvironment::has_var_declaration(FlyString const& name) const
-{
-    // 1. Let varDeclaredNames be envRec.[[VarNames]].
-    // 2. If varDeclaredNames contains N, return true.
-    // 3. Return false.
-    return m_var_names.contains_slow(name);
-}
-
-// 9.1.1.4.13 HasLexicalDeclaration ( N ), https://tc39.es/ecma262/#sec-haslexicaldeclaration
+// 9.1.1.4.12 HasLexicalDeclaration ( envRec, N ), https://tc39.es/ecma262/#sec-haslexicaldeclaration
 bool GlobalEnvironment::has_lexical_declaration(FlyString const& name) const
 {
     // 1. Let DclRec be envRec.[[DeclarativeRecord]].
@@ -181,7 +162,7 @@ bool GlobalEnvironment::has_lexical_declaration(FlyString const& name) const
     return MUST(m_declarative_record->has_binding(name));
 }
 
-// 9.1.1.4.14 HasRestrictedGlobalProperty ( N ), https://tc39.es/ecma262/#sec-hasrestrictedglobalproperty
+// 9.1.1.4.13 HasRestrictedGlobalProperty ( envRec, N ), https://tc39.es/ecma262/#sec-hasrestrictedglobalproperty
 ThrowCompletionOr<bool> GlobalEnvironment::has_restricted_global_property(FlyString const& name) const
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
@@ -203,7 +184,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::has_restricted_global_property(FlyStr
     return true;
 }
 
-// 9.1.1.4.15 CanDeclareGlobalVar ( N ), https://tc39.es/ecma262/#sec-candeclareglobalvar
+// 9.1.1.4.14 CanDeclareGlobalVar ( envRec, N ), https://tc39.es/ecma262/#sec-candeclareglobalvar
 ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_var(FlyString const& name) const
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
@@ -221,7 +202,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_var(FlyString cons
     return global_object.is_extensible();
 }
 
-// 9.1.1.4.16 CanDeclareGlobalFunction ( N ), https://tc39.es/ecma262/#sec-candeclareglobalfunction
+// 9.1.1.4.15 CanDeclareGlobalFunction ( envRec, N ), https://tc39.es/ecma262/#sec-candeclareglobalfunction
 ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_function(FlyString const& name) const
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
@@ -247,7 +228,7 @@ ThrowCompletionOr<bool> GlobalEnvironment::can_declare_global_function(FlyString
     return false;
 }
 
-// 9.1.1.4.17 CreateGlobalVarBinding ( N, D ), https://tc39.es/ecma262/#sec-createglobalvarbinding
+// 9.1.1.4.16 CreateGlobalVarBinding ( envRec, N, D ), https://tc39.es/ecma262/#sec-createglobalvarbinding
 ThrowCompletionOr<void> GlobalEnvironment::create_global_var_binding(FlyString const& name, bool can_be_deleted)
 {
     auto& vm = this->vm();
@@ -271,18 +252,11 @@ ThrowCompletionOr<void> GlobalEnvironment::create_global_var_binding(FlyString c
         TRY(m_object_record->initialize_binding(vm, name, js_undefined(), Environment::InitializeBindingHint::Normal));
     }
 
-    // 6. Let varDeclaredNames be envRec.[[VarNames]].
-    // 7. If varDeclaredNames does not contain N, then
-    if (!m_var_names.contains_slow(name)) {
-        // a. Append N to varDeclaredNames.
-        m_var_names.append(name);
-    }
-
-    // 8. Return unused.
+    // 6. Return UNUSED.
     return {};
 }
 
-// 9.1.1.4.18 CreateGlobalFunctionBinding ( N, V, D ), https://tc39.es/ecma262/#sec-createglobalfunctionbinding
+// 9.1.1.4.17 CreateGlobalFunctionBinding ( envRec, N, V, D ), https://tc39.es/ecma262/#sec-createglobalfunctionbinding
 ThrowCompletionOr<void> GlobalEnvironment::create_global_function_binding(FlyString const& name, Value value, bool can_be_deleted)
 {
     // 1. Let ObjRec be envRec.[[ObjectRecord]].
@@ -311,14 +285,7 @@ ThrowCompletionOr<void> GlobalEnvironment::create_global_function_binding(FlyStr
     // 7. Perform ? Set(globalObject, N, V, false).
     TRY(global_object.set(name, value, Object::ShouldThrowExceptions::Yes));
 
-    // 8. Let varDeclaredNames be envRec.[[VarNames]].
-    // 9. If varDeclaredNames does not contain N, then
-    if (!m_var_names.contains_slow(name)) {
-        // a. Append N to varDeclaredNames.
-        m_var_names.append(name);
-    }
-
-    // 10. Return unused.
+    // 8. Return UNUSED.
     return {};
 }
 

--- a/Libraries/LibJS/Runtime/GlobalEnvironment.h
+++ b/Libraries/LibJS/Runtime/GlobalEnvironment.h
@@ -30,7 +30,6 @@ public:
     Object& global_this_value() { return *m_global_this_value; }
     DeclarativeEnvironment& declarative_record() { return *m_declarative_record; }
 
-    bool has_var_declaration(FlyString const& name) const;
     bool has_lexical_declaration(FlyString const& name) const;
     ThrowCompletionOr<bool> has_restricted_global_property(FlyString const& name) const;
     ThrowCompletionOr<bool> can_declare_global_var(FlyString const& name) const;
@@ -47,7 +46,6 @@ private:
     GC::Ptr<ObjectEnvironment> m_object_record;           // [[ObjectRecord]]
     GC::Ptr<Object> m_global_this_value;                  // [[GlobalThisValue]]
     GC::Ptr<DeclarativeEnvironment> m_declarative_record; // [[DeclarativeRecord]]
-    Vector<FlyString> m_var_names;                        // [[VarNames]]
 };
 
 template<>

--- a/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Libraries/LibJS/Runtime/JSONObject.h
@@ -22,6 +22,7 @@ public:
     // test-js to communicate between the JS tests and the C++ test runner.
     static ThrowCompletionOr<Optional<String>> stringify_impl(VM&, Value value, Value replacer, Value space);
 
+    static ThrowCompletionOr<Value> parse_json(VM&, StringView text);
     static Value parse_json_value(VM&, JsonValue const&);
 
 private:

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -30,6 +30,7 @@ void MathObject::initialize(Realm& realm)
 {
     auto& vm = this->vm();
     Base::initialize(realm);
+
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.abs, abs, 1, attr, Bytecode::Builtin::MathAbs);
     define_native_function(realm, vm.names.random, random, 0, attr, Bytecode::Builtin::MathRandom);
@@ -517,7 +518,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::fround)
     return Value((float)number.as_double());
 }
 
-// 3.1 Math.f16round ( x ), https://tc39.es/proposal-float16array/#sec-math.f16round
+// 21.3.2.18 Math.f16round ( x ), https://tc39.es/ecma262/#sec-math.f16round
 JS_DEFINE_NATIVE_FUNCTION(MathObject::f16round)
 {
     // 1. Let n be ? ToNumber(x).
@@ -537,7 +538,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::f16round)
     return Value(static_cast<f16>(number.as_double()));
 }
 
-// 21.3.2.18 Math.hypot ( ...args ), https://tc39.es/ecma262/#sec-math.hypot
+// 21.3.2.19 Math.hypot ( ...args ), https://tc39.es/ecma262/#sec-math.hypot
 JS_DEFINE_NATIVE_FUNCTION(MathObject::hypot)
 {
     // 1. Let coerced be a new empty List.
@@ -586,7 +587,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::hypot)
     return Value(::sqrt(sum_of_squares));
 }
 
-// 21.3.2.19 Math.imul ( x, y ), https://tc39.es/ecma262/#sec-math.imul
+// 21.3.2.20 Math.imul ( x, y ), https://tc39.es/ecma262/#sec-math.imul
 ThrowCompletionOr<Value> MathObject::imul_impl(VM& vm, Value arg_a, Value arg_b)
 {
     // 1. Let a be ℝ(? ToUint32(x)).
@@ -600,13 +601,13 @@ ThrowCompletionOr<Value> MathObject::imul_impl(VM& vm, Value arg_a, Value arg_b)
     return Value(static_cast<i32>(a * b));
 }
 
-// 21.3.2.19 Math.imul ( x, y ), https://tc39.es/ecma262/#sec-math.imul
+// 21.3.2.20 Math.imul ( x, y ), https://tc39.es/ecma262/#sec-math.imul
 JS_DEFINE_NATIVE_FUNCTION(MathObject::imul)
 {
     return imul_impl(vm, vm.argument(0), vm.argument(1));
 }
 
-// 21.3.2.20 Math.log ( x ), https://tc39.es/ecma262/#sec-math.log
+// 21.3.2.21 Math.log ( x ), https://tc39.es/ecma262/#sec-math.log
 ThrowCompletionOr<Value> MathObject::log_impl(VM& vm, Value x)
 {
     // 1. Let n be ? ToNumber(x).
@@ -632,13 +633,13 @@ ThrowCompletionOr<Value> MathObject::log_impl(VM& vm, Value x)
     return Value(::log(number.as_double()));
 }
 
-// 21.3.2.20 Math.log ( x ), https://tc39.es/ecma262/#sec-math.log
+// 21.3.2.21 Math.log ( x ), https://tc39.es/ecma262/#sec-math.log
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log)
 {
     return log_impl(vm, vm.argument(0));
 }
 
-// 21.3.2.21 Math.log1p ( x ), https://tc39.es/ecma262/#sec-math.log1p
+// 21.3.2.22 Math.log1p ( x ), https://tc39.es/ecma262/#sec-math.log1p
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log1p)
 {
     // 1. Let n be ? ToNumber(x).
@@ -660,7 +661,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::log1p)
     return Value(::log1p(number.as_double()));
 }
 
-// 21.3.2.22 Math.log10 ( x ), https://tc39.es/ecma262/#sec-math.log10
+// 21.3.2.23 Math.log10 ( x ), https://tc39.es/ecma262/#sec-math.log10
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log10)
 {
     // 1. Let n be ? ToNumber(x).
@@ -686,7 +687,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::log10)
     return Value(::log10(number.as_double()));
 }
 
-// 21.3.2.23 Math.log2 ( x ), https://tc39.es/ecma262/#sec-math.log2
+// 21.3.2.24 Math.log2 ( x ), https://tc39.es/ecma262/#sec-math.log2
 JS_DEFINE_NATIVE_FUNCTION(MathObject::log2)
 {
     // 1. Let n be ? ToNumber(x).
@@ -712,7 +713,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::log2)
     return Value(::log2(number.as_double()));
 }
 
-// 21.3.2.24 Math.max ( ...args ), https://tc39.es/ecma262/#sec-math.max
+// 21.3.2.25 Math.max ( ...args ), https://tc39.es/ecma262/#sec-math.max
 JS_DEFINE_NATIVE_FUNCTION(MathObject::max)
 {
     // 1. Let coerced be a new empty List.
@@ -746,7 +747,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::max)
     return highest;
 }
 
-// 21.3.2.25 Math.min ( ...args ), https://tc39.es/ecma262/#sec-math.min
+// 21.3.2.26 Math.min ( ...args ), https://tc39.es/ecma262/#sec-math.min
 JS_DEFINE_NATIVE_FUNCTION(MathObject::min)
 {
     // 1. Let coerced be a new empty List.
@@ -780,7 +781,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::min)
     return lowest;
 }
 
-// 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
+// 21.3.2.27 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
 ThrowCompletionOr<Value> MathObject::pow_impl(VM& vm, Value base, Value exponent)
 {
     // Set base to ? ToNumber(base).
@@ -793,7 +794,7 @@ ThrowCompletionOr<Value> MathObject::pow_impl(VM& vm, Value base, Value exponent
     return JS::exp(vm, base, exponent);
 }
 
-// 21.3.2.26 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
+// 21.3.2.27 Math.pow ( base, exponent ), https://tc39.es/ecma262/#sec-math.pow
 JS_DEFINE_NATIVE_FUNCTION(MathObject::pow)
 {
     return pow_impl(vm, vm.argument(0), vm.argument(1));
@@ -849,13 +850,13 @@ Value MathObject::random_impl()
     return Value(rng.get());
 }
 
-// 21.3.2.27 Math.random ( ), https://tc39.es/ecma262/#sec-math.random
+// 21.3.2.28 Math.random ( ), https://tc39.es/ecma262/#sec-math.random
 JS_DEFINE_NATIVE_FUNCTION(MathObject::random)
 {
     return random_impl();
 }
 
-// 21.3.2.28 Math.round ( x ), https://tc39.es/ecma262/#sec-math.round
+// 21.3.2.29 Math.round ( x ), https://tc39.es/ecma262/#sec-math.round
 ThrowCompletionOr<Value> MathObject::round_impl(VM& vm, Value x)
 {
     // 1. Let n be ? ToNumber(x).
@@ -874,13 +875,13 @@ ThrowCompletionOr<Value> MathObject::round_impl(VM& vm, Value x)
     return Value(integer);
 }
 
-// 21.3.2.28 Math.round ( x ), https://tc39.es/ecma262/#sec-math.round
+// 21.3.2.29 Math.round ( x ), https://tc39.es/ecma262/#sec-math.round
 JS_DEFINE_NATIVE_FUNCTION(MathObject::round)
 {
     return round_impl(vm, vm.argument(0));
 }
 
-// 21.3.2.29 Math.sign ( x ), https://tc39.es/ecma262/#sec-math.sign
+// 21.3.2.30 Math.sign ( x ), https://tc39.es/ecma262/#sec-math.sign
 JS_DEFINE_NATIVE_FUNCTION(MathObject::sign)
 {
     // 1. Let n be ? ToNumber(x).
@@ -898,7 +899,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::sign)
     return Value(1);
 }
 
-// 21.3.2.30 Math.sin ( x ), https://tc39.es/ecma262/#sec-math.sin
+// 21.3.2.31 Math.sin ( x ), https://tc39.es/ecma262/#sec-math.sin
 JS_DEFINE_NATIVE_FUNCTION(MathObject::sin)
 {
     // 1. Let n be ? ToNumber(x).
@@ -916,7 +917,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::sin)
     return Value(::sin(number.as_double()));
 }
 
-// 21.3.2.31 Math.sinh ( x ), https://tc39.es/ecma262/#sec-math.sinh
+// 21.3.2.32 Math.sinh ( x ), https://tc39.es/ecma262/#sec-math.sinh
 JS_DEFINE_NATIVE_FUNCTION(MathObject::sinh)
 {
     // 1. Let n be ? ToNumber(x).
@@ -930,7 +931,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::sinh)
     return Value(::sinh(number.as_double()));
 }
 
-// 21.3.2.32 Math.sqrt ( x ), https://tc39.es/ecma262/#sec-math.sqrt
+// 21.3.2.33 Math.sqrt ( x ), https://tc39.es/ecma262/#sec-math.sqrt
 ThrowCompletionOr<Value> MathObject::sqrt_impl(VM& vm, Value x)
 {
     // Let n be ? ToNumber(x).
@@ -948,13 +949,13 @@ ThrowCompletionOr<Value> MathObject::sqrt_impl(VM& vm, Value x)
     return Value(::sqrt(number.as_double()));
 }
 
-// 21.3.2.32 Math.sqrt ( x ), https://tc39.es/ecma262/#sec-math.sqrt
+// 21.3.2.33 Math.sqrt ( x ), https://tc39.es/ecma262/#sec-math.sqrt
 JS_DEFINE_NATIVE_FUNCTION(MathObject::sqrt)
 {
     return sqrt_impl(vm, vm.argument(0));
 }
 
-// 21.3.2.33 Math.tan ( x ), https://tc39.es/ecma262/#sec-math.tan
+// 21.3.2.34 Math.tan ( x ), https://tc39.es/ecma262/#sec-math.tan
 JS_DEFINE_NATIVE_FUNCTION(MathObject::tan)
 {
     // Let n be ? ToNumber(x).
@@ -972,7 +973,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::tan)
     return Value(::tan(number.as_double()));
 }
 
-// 21.3.2.34 Math.tanh ( x ), https://tc39.es/ecma262/#sec-math.tanh
+// 21.3.2.35 Math.tanh ( x ), https://tc39.es/ecma262/#sec-math.tanh
 JS_DEFINE_NATIVE_FUNCTION(MathObject::tanh)
 {
     // 1. Let n be ? ToNumber(x).
@@ -994,7 +995,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::tanh)
     return Value(::tanh(number.as_double()));
 }
 
-// 21.3.2.35 Math.trunc ( x ), https://tc39.es/ecma262/#sec-math.trunc
+// 21.3.2.36 Math.trunc ( x ), https://tc39.es/ecma262/#sec-math.trunc
 JS_DEFINE_NATIVE_FUNCTION(MathObject::trunc)
 {
     // 1. Let n be ? ToNumber(x).

--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -1025,25 +1025,15 @@ static TwoSumResult two_sum(double x, double y)
     return { hi, lo };
 }
 
-// https://tc39.es/proposal-math-sum/#sec-math.sumprecise
-ThrowCompletionOr<Value> MathObject::sum_precise_impl(VM& vm, Value iterable)
+// 2 Math.sumPrecise ( items ), https://tc39.es/proposal-math-sum/#sec-math.sumprecise
+JS_DEFINE_NATIVE_FUNCTION(MathObject::sumPrecise)
 {
-    constexpr double MAX_DOUBLE = 1.79769313486231570815e+308;         // std::numeric_limits<double>::max()
-    constexpr double PENULTIMATE_DOUBLE = 1.79769313486231550856e+308; // std::nextafter(DBL_MAX, 0)
-    constexpr double MAX_ULP = MAX_DOUBLE - PENULTIMATE_DOUBLE;
-    constexpr double POW_2_1023 = 8.98846567431158e+307; // 2^1023
+    static constexpr double MAX_DOUBLE = 1.79769313486231570815e+308;         // std::numeric_limits<double>::max()
+    static constexpr double PENULTIMATE_DOUBLE = 1.79769313486231550856e+308; // std::nextafter(DBL_MAX, 0)
+    static constexpr double MAX_ULP = MAX_DOUBLE - PENULTIMATE_DOUBLE;
+    static constexpr double POW_2_1023 = 8.98846567431158e+307; // 2^1023
 
-    // 1. Perform ? RequireObjectCoercible(items).
-    TRY(require_object_coercible(vm, iterable));
-
-    // 2. Let iteratorRecord be ? GetIterator(items, sync).
-    auto using_iterator = TRY(iterable.get_method(vm, vm.well_known_symbol_iterator()));
-    if (!using_iterator)
-        return vm.throw_completion<TypeError>(ErrorType::NotIterable, iterable.to_string_without_side_effects());
-
-    auto iterator = TRY(get_iterator_from_method(vm, iterable, *using_iterator));
-
-    enum State {
+    enum class State {
         MinusZero,
         PlusInfinity,
         MinusInfinity,
@@ -1051,7 +1041,15 @@ ThrowCompletionOr<Value> MathObject::sum_precise_impl(VM& vm, Value iterable)
         Finite
     };
 
-    // 3. Let state be minus-zero.
+    auto items = vm.argument(0);
+
+    // 1. Perform ? RequireObjectCoercible(items).
+    TRY(require_object_coercible(vm, items));
+
+    // 2. Let iteratorRecord be ? GetIterator(items, SYNC).
+    auto iterator_record = TRY(get_iterator(vm, items, IteratorHint::Sync));
+
+    // 3. Let state be MINUS-ZERO.
     State state = State::MinusZero;
 
     // 4. Let sum be 0.
@@ -1060,56 +1058,66 @@ ThrowCompletionOr<Value> MathObject::sum_precise_impl(VM& vm, Value iterable)
     u64 count = 0;
     Vector<double> partials;
 
-    // 6. Let next be not-started.
-    // 7. Repeat, while next is not done
+    // 6. Let next be NOT-STARTED.
+    // 7. Repeat, while next is not DONE
     for (;;) {
         // a. Set next to ? IteratorStepValue(iteratorRecord).
-        auto next = TRY(iterator_step_value(vm, iterator));
-
+        auto next = TRY(iterator_step_value(vm, iterator_record));
         if (!next.has_value())
             break;
 
-        // If next is not done, then
-        // i. Set count to count + 1.
-        count++;
-        // ii. If count ≥ 2**53, then
-        // 1. Let error be ThrowCompletion(a newly created RangeError object).
-        // 2. Return ? IteratorClose(iteratorRecord, error).
-        if (count >= (1ULL << 53))
-            return iterator_close(vm, iterator, vm.throw_completion<RangeError>(ErrorType::ArrayMaxSize));
+        auto next_value = next.value();
 
-        // iii. NOTE: The above case is not expected to be reached in practice and is included only so that implementations may rely on inputs being
-        // "reasonably sized" without violating this specification.
+        // b. If next is not DONE, then
+        // i. Set count to count + 1.
+        ++count;
+
+        // ii. If count ≥ 2**53, then
+        if (count >= (1ULL << 53)) {
+            // 1. Let error be ThrowCompletion(a newly created RangeError object).
+            auto error = vm.throw_completion<RangeError>(ErrorType::ArrayMaxSize);
+
+            // 2. Return ? IteratorClose(iteratorRecord, error).
+            return iterator_close(vm, iterator_record, error);
+        }
+
+        // iii. NOTE: The above case is not expected to be reached in practice and is included only so that implementations
+        //      may rely on inputs being "reasonably sized" without violating this specification.
 
         // iv. If next is not a Number, then
-        auto value = next.value();
-        if (!value.is_number())
+        if (!next_value.is_number()) {
             // 1. Let error be ThrowCompletion(a newly created TypeError object).
+            auto error = vm.throw_completion<TypeError>(ErrorType::IsNotA, next_value, "number");
+
             // 2. Return ? IteratorClose(iteratorRecord, error).
-            return iterator_close(vm, iterator, vm.throw_completion<TypeError>(ErrorType::IsNotA, value.to_string_without_side_effects(), "number"));
+            return iterator_close(vm, iterator_record, error);
+        }
 
         // v. Let n be next.
-        auto n = value.as_double();
+        auto n = next_value.as_double();
 
-        // vi. If state is not not-a-number, then
+        // vi. If state is not NOT-A-NUMBER, then
         if (state != State::NotANumber) {
             // 1. If n is NaN, then
-            if (isnan(n)) {
-                // a. Set state to not-a-number.
+            if (next_value.is_nan()) {
+                // a. Set state to NOT-A-NUMBER.
                 state = State::NotANumber;
-            } // 2. Else if n is +∞𝔽, then
-            else if (Value(n).is_positive_infinity()) {
-                // a. If state is minus-infinity, set state to not-a-number.
-                // b. Else, set state to plus-infinity.
-                state = (state == State::MinusInfinity) ? State::NotANumber : State::PlusInfinity;
-            } // 3. Else if n is -∞𝔽, then
-            else if (Value(n).is_negative_infinity()) {
-                // a. If state is plus-infinity, set state to not-a-number.
-                // b. Else, set state to minus-infinity.
-                state = (state == State::PlusInfinity) ? State::NotANumber : State::MinusInfinity;
-            } // 4. Else if n is not -0𝔽 and state is either minus-zero or finite, then
-            else if (!Value(n).is_negative_zero() && (state == State::MinusZero || state == State::Finite)) {
-                // a. Set state to finite.
+            }
+            // 2. Else if n is +∞𝔽, then
+            else if (next_value.is_positive_infinity()) {
+                // a. If state is MINUS-INFINITY, set state to NOT-A-NUMBER.
+                // b. Else, set state to PLUS-INFINITY.
+                state = state == State::MinusInfinity ? State::NotANumber : State::PlusInfinity;
+            }
+            // 3. Else if n is -∞𝔽, then
+            else if (next_value.is_negative_infinity()) {
+                // a. If state is PLUS-INFINITY, set state to NOT-A-NUMBER.
+                // b. Else, set state to MINUS-INFINITY.
+                state = state == State::PlusInfinity ? State::NotANumber : State::MinusInfinity;
+            }
+            // 4. Else if n is not -0𝔽 and state is either MINUS-ZERO or FINITE, then
+            else if (!next_value.is_negative_zero() && (state == State::MinusZero || state == State::Finite)) {
+                // a. Set state to FINITE.
                 state = State::Finite;
 
                 // b. Set sum to sum + ℝ(n).
@@ -1159,19 +1167,19 @@ ThrowCompletionOr<Value> MathObject::sum_precise_impl(VM& vm, Value iterable)
         }
     }
 
-    // 8. If state is not-a-number, return NaN.
+    // 8. If state is NOT-A-NUMBER, return NaN.
     if (state == State::NotANumber)
         return js_nan();
 
-    // 9. If state is plus-infinity, return +∞𝔽.
+    // 9. If state is PLUS-INFINITY, return +∞𝔽.
     if (state == State::PlusInfinity)
         return js_infinity();
 
-    // 10. If state is minus-infinity, return -∞𝔽.
+    // 10. If state is MINUS-INFINITY, return -∞𝔽.
     if (state == State::MinusInfinity)
         return js_negative_infinity();
 
-    // 11. If state is minus-zero, return -0𝔽.
+    // 11. If state is MINUS-ZERO, return -0𝔽.
     if (state == State::MinusZero)
         return Value(-0.0);
 
@@ -1241,13 +1249,7 @@ ThrowCompletionOr<Value> MathObject::sum_precise_impl(VM& vm, Value iterable)
         }
     }
 
-    return Value(hi);
-}
-
-// https://tc39.es/proposal-math-sum/#sec-math.sumprecise
-JS_DEFINE_NATIVE_FUNCTION(MathObject::sumPrecise)
-{
-    return sum_precise_impl(vm, vm.argument(0));
+    return hi;
 }
 
 }

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -155,8 +155,8 @@ ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& 
         return js_undefined();
 
     // 4. Let m be O.[[Module]].
-    // 5. Let binding be ! m.ResolveExport(P).
-    auto binding = MUST(m_module->resolve_export(vm, property_key.to_string()));
+    // 5. Let binding be m.ResolveExport(P).
+    auto binding = m_module->resolve_export(vm, property_key.to_string());
 
     // 6. Assert: binding is a ResolvedBinding Record.
     VERIFY(binding.is_valid());
@@ -169,8 +169,8 @@ ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& 
 
     // 9. If binding.[[BindingName]] is namespace, then
     if (binding.is_namespace()) {
-        // a. Return ? GetModuleNamespace(targetModule).
-        return TRY(target_module->get_module_namespace(vm));
+        // a. Return GetModuleNamespace(targetModule)..
+        return target_module->get_module_namespace(vm);
     }
 
     // 10. Let targetEnv be targetModule.[[Environment]].

--- a/Libraries/LibJS/Runtime/ModuleRequest.h
+++ b/Libraries/LibJS/Runtime/ModuleRequest.h
@@ -18,7 +18,7 @@ struct ModuleWithSpecifier {
     GC::Ref<Module> module; // [[Module]]
 };
 
-// https://tc39.es/proposal-import-attributes/#importattribute-record
+// https://tc39.es/ecma262/#importattribute-record
 struct ImportAttribute {
     String key;
     String value;
@@ -26,7 +26,7 @@ struct ImportAttribute {
     bool operator==(ImportAttribute const&) const = default;
 };
 
-// https://tc39.es/proposal-import-attributes/#modulerequest-record
+// https://tc39.es/ecma262/#modulerequest-record
 struct ModuleRequest {
     ModuleRequest() = default;
 

--- a/Libraries/LibJS/Runtime/PromiseCapability.h
+++ b/Libraries/LibJS/Runtime/PromiseCapability.h
@@ -64,26 +64,6 @@ private:
 #define TRY_OR_MUST_REJECT(vm, capability, expression) \
     __TRY_OR_REJECT(vm, capability, expression, MUST)
 
-// 27.2.1.1.1 IfAbruptRejectPromise ( value, capability ), https://tc39.es/ecma262/#sec-ifabruptrejectpromise
-#define TRY_OR_REJECT_WITH_VALUE(vm, capability, expression)                                                                     \
-    ({                                                                                                                           \
-        auto&& _temporary_try_or_reject_result = (expression);                                                                   \
-        /* 1. If value is an abrupt completion, then */                                                                          \
-        if (_temporary_try_or_reject_result.is_error()) {                                                                        \
-            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                      \
-            TRY(JS::call(vm, *(capability)->reject(), js_undefined(), _temporary_try_or_reject_result.release_error().value())); \
-                                                                                                                                 \
-            /* b. Return capability.[[Promise]]. */                                                                              \
-            return Value { (capability)->promise() };                                                                            \
-        }                                                                                                                        \
-                                                                                                                                 \
-        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_try_or_reject_result.release_value())>,               \
-            "Do not return a reference from a fallible expression");                                                             \
-                                                                                                                                 \
-        /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                             \
-        _temporary_try_or_reject_result.release_value();                                                                         \
-    })
-
 // 27.2.1.5 NewPromiseCapability ( C ), https://tc39.es/ecma262/#sec-newpromisecapability
 ThrowCompletionOr<GC::Ref<PromiseCapability>> new_promise_capability(VM& vm, Value constructor);
 

--- a/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -27,7 +27,7 @@ void RegExpConstructor::initialize(Realm& realm)
     auto& vm = this->vm();
     Base::initialize(realm);
 
-    // 22.2.5.1 RegExp.prototype, https://tc39.es/ecma262/#sec-regexp.prototype
+    // 22.2.5.2 RegExp.prototype, https://tc39.es/ecma262/#sec-regexp.prototype
     define_direct_property(vm.names.prototype, realm.intrinsics().regexp_prototype(), 0);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -147,7 +147,7 @@ ThrowCompletionOr<GC::Ref<Object>> RegExpConstructor::construct(FunctionObject& 
     return TRY(regexp_object->regexp_initialize(vm, pattern_value, flags_value));
 }
 
-// 22.2.5.1.1 EncodeForRegExpEscape ( c ), https://tc39.es/proposal-regex-escaping/#sec-encodeforregexpescape
+// 22.2.5.1.1 EncodeForRegExpEscape ( cp ), https://tc39.es/ecma262/#sec-encodeforregexpescape
 static String encode_for_regexp_escape(u32 code_point)
 {
     // https://tc39.es/ecma262/#table-controlescape-code-point-values
@@ -209,7 +209,7 @@ static String encode_for_regexp_escape(u32 code_point)
     return String::from_code_point(code_point);
 }
 
-// 22.2.5.1 RegExp.escape ( S ), https://tc39.es/proposal-regex-escaping/
+// 22.2.5.1 RegExp.escape ( S ), https://tc39.es/ecma262/#sec-regexp.escape
 JS_DEFINE_NATIVE_FUNCTION(RegExpConstructor::escape)
 {
     auto string = vm.argument(0);
@@ -250,7 +250,7 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpConstructor::escape)
     return JS::PrimitiveString::create(vm, MUST(escaped.to_string()));
 }
 
-// 22.2.5.2 get RegExp [ @@species ], https://tc39.es/ecma262/#sec-get-regexp-@@species
+// 22.2.5.3 get RegExp [ %Symbol.species% ], https://tc39.es/ecma262/#sec-get-regexp-@@species
 JS_DEFINE_NATIVE_FUNCTION(RegExpConstructor::symbol_species_getter)
 {
     // 1. Return the this value.

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -568,7 +568,7 @@ ThrowCompletionOr<void> VM::link_and_eval_module(CyclicModule& module)
     if (evaluated_or_error.is_error())
         return evaluated_or_error.throw_completion();
 
-    auto* evaluated_value = evaluated_or_error.value();
+    auto evaluated_value = evaluated_or_error.value();
 
     run_queued_promise_jobs();
     VERIFY(m_promise_jobs.is_empty());

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -530,10 +530,9 @@ VM::StoredModule* VM::get_stored_module(ImportedModuleReferrer const&, ByteStrin
     // FinishLoadingImportedModule(referrer, specifier, payload, result) where result is a normal completion,
     // then it must perform FinishLoadingImportedModule(referrer, specifier, payload, result) with the same result each time.
 
-    // Editor's Note from https://tc39.es/proposal-json-modules/#sec-hostresolveimportedmodule
-    // The above text implies that is recommended but not required that hosts do not use moduleRequest.[[Assertions]]
-    // as part of the module cache key. In either case, an exception thrown from an import with a given assertion list
-    // does not rule out success of another import with the same specifier but a different assertion list.
+    // Editor's Note from https://tc39.es/ecma262/#sec-hostresolveimportedmodule
+    // The above text requires that hosts support JSON modules when imported with type: "json" (and HostLoadImportedModule
+    // completes normally), but it does not prohibit hosts from supporting JSON modules when imported without type: "json".
 
     // FIXME: This should probably check referrer as well.
     auto end_or_module = m_loaded_modules.find_if([&](StoredModule const& stored_module) {
@@ -617,6 +616,9 @@ void VM::load_imported_module(ImportedModuleReferrer referrer, ModuleRequest con
     // - If this operation is called multiple times with the same (referrer, specifier) pair and it performs
     //   FinishLoadingImportedModule(referrer, specifier, payload, result) where result is a normal completion,
     //   then it must perform FinishLoadingImportedModule(referrer, specifier, payload, result) with the same result each time.
+    // - If moduleRequest.[[Attributes]] has an entry entry such that entry.[[Key]] is "type" and entry.[[Value]] is "json",
+    //   when the host environment performs FinishLoadingImportedModule(referrer, moduleRequest, payload, result), result
+    //   must either be the Completion Record returned by an invocation of ParseJSONModule or a throw completion.
     // - The operation must treat payload as an opaque value to be passed through to FinishLoadingImportedModule.
     //
     // The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to
@@ -685,10 +687,9 @@ void VM::load_imported_module(ImportedModuleReferrer referrer, ModuleRequest con
     dbgln_if(JS_MODULE_DEBUG, "[JS MODULE]     resolved {} + {} -> {}", base_path, module_request.module_specifier, filename);
 #endif
 
-    auto* loaded_module_or_end = get_stored_module(referrer, filename, module_type);
-    if (loaded_module_or_end != nullptr) {
-        dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] load_imported_module({}) already loaded at {}", filename, loaded_module_or_end->module.ptr());
-        finish_loading_imported_module(referrer, module_request, payload, *loaded_module_or_end->module);
+    if (auto* loaded_module = get_stored_module(referrer, filename, module_type)) {
+        dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] load_imported_module({}) already loaded at {}", filename, loaded_module->module.ptr());
+        finish_loading_imported_module(referrer, module_request, payload, *loaded_module->module);
         return;
     }
 
@@ -715,12 +716,13 @@ void VM::load_imported_module(ImportedModuleReferrer referrer, ModuleRequest con
 
     StringView const content_view { file_content_or_error.value().bytes() };
 
-    auto module = [&]() -> ThrowCompletionOr<GC::Ref<Module>> {
-        // If assertions has an entry entry such that entry.[[Key]] is "type", let type be entry.[[Value]]. The following requirements apply:
-        // If type is "json", then this algorithm must either invoke ParseJSONModule and return the resulting Completion Record, or throw an exception.
+    auto module = [&, content = file_content_or_error.release_value()]() -> ThrowCompletionOr<GC::Ref<Module>> {
+        // If moduleRequest.[[Attributes]] has an entry entry such that entry.[[Key]] is "type" and entry.[[Value]] is "json",
+        // when the host environment performs FinishLoadingImportedModule(referrer, moduleRequest, payload, result), result
+        // must either be the Completion Record returned by an invocation of ParseJSONModule or a throw completion.
         if (module_type == "json"sv) {
             dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] reading and parsing JSON module {}", filename);
-            return parse_json_module(content_view, *current_realm(), filename);
+            return parse_json_module(*current_realm(), content_view, filename);
         }
 
         dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] reading and parsing as SourceTextModule module {}", filename);
@@ -732,16 +734,17 @@ void VM::load_imported_module(ImportedModuleReferrer referrer, ModuleRequest con
             return throw_completion<SyntaxError>(module_or_errors.error().first().to_byte_string());
         }
 
-        auto module = module_or_errors.release_value();
+        return module_or_errors.release_value();
+    }();
+
+    if (!module.is_error()) {
         m_loaded_modules.empend(
             referrer,
-            module->filename(),
+            module.value()->filename(),
             String {}, // Null type
-            make_root<Module>(*module),
+            make_root(module.value()),
             true);
-
-        return module;
-    }();
+    }
 
     finish_loading_imported_module(referrer, module_request, payload, module);
 }

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -269,11 +269,7 @@ public:
 
     ScriptOrModule get_active_script_or_module() const;
 
-    // NOTE: The host defined implementation described in the web spec https://html.spec.whatwg.org/multipage/webappapis.html#hostloadimportedmodule
-    //       currently references proposal-import-attributes.
-    //       Our implementation of this proposal is outdated however, as such we try to adapt the proposal and living standard
-    //       to match our implementation for now.
-    // 16.2.1.8 HostLoadImportedModule ( referrer, moduleRequest, hostDefined, payload ), https://tc39.es/proposal-import-attributes/#sec-HostLoadImportedModule
+    // 16.2.1.10 HostLoadImportedModule ( referrer, moduleRequest, hostDefined, payload ), https://tc39.es/ecma262/#sec-HostLoadImportedModule
     Function<void(ImportedModuleReferrer, ModuleRequest const&, GC::Ptr<GraphLoadingState::HostDefined>, ImportedModulePayload)> host_load_imported_module;
 
     Function<HashMap<PropertyKey, Value>(SourceTextModule&)> host_get_import_meta_properties;

--- a/Libraries/LibJS/SourceTextModule.h
+++ b/Libraries/LibJS/SourceTextModule.h
@@ -25,8 +25,8 @@ public:
 
     Program const& parse_node() const { return *m_ecmascript_code; }
 
-    virtual ThrowCompletionOr<Vector<FlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set) override;
-    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) override;
+    virtual Vector<FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) override;
+    virtual ResolvedBinding resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set = {}) override;
 
     Object* import_meta() { return m_import_meta; }
     void set_import_meta(Badge<VM>, Object* import_meta) { m_import_meta = import_meta; }

--- a/Libraries/LibJS/SyntheticModule.cpp
+++ b/Libraries/LibJS/SyntheticModule.cpp
@@ -27,14 +27,14 @@ SyntheticModule::SyntheticModule(Vector<FlyString> export_names, SyntheticModule
 }
 
 // 1.2.3.1 GetExportedNames( exportStarSet ), https://tc39.es/proposal-json-modules/#sec-smr-getexportednames
-ThrowCompletionOr<Vector<FlyString>> SyntheticModule::get_exported_names(VM&, Vector<Module*>)
+Vector<FlyString> SyntheticModule::get_exported_names(VM&, HashTable<Module const*>&)
 {
     // 1. Return module.[[ExportNames]].
     return m_export_names;
 }
 
 // 1.2.3.2 ResolveExport( exportName, resolveSet ), https://tc39.es/proposal-json-modules/#sec-smr-resolveexport
-ThrowCompletionOr<ResolvedBinding> SyntheticModule::resolve_export(VM&, FlyString const& export_name, Vector<ResolvedBinding>)
+ResolvedBinding SyntheticModule::resolve_export(VM&, FlyString const& export_name, Vector<ResolvedBinding>)
 {
     // 1. If module.[[ExportNames]] does not contain exportName, return null.
     if (!m_export_names.contains_slow(export_name))
@@ -74,7 +74,7 @@ ThrowCompletionOr<void> SyntheticModule::link(VM& vm)
 }
 
 // 1.2.3.4 Evaluate ( ), https://tc39.es/proposal-json-modules/#sec-smr-Evaluate
-ThrowCompletionOr<Promise*> SyntheticModule::evaluate(VM& vm)
+ThrowCompletionOr<GC::Ref<Promise>> SyntheticModule::evaluate(VM& vm)
 {
     // Note: Has some changes from PR: https://github.com/tc39/proposal-json-modules/pull/13.
     // 1. Suspend the currently running execution context.
@@ -119,7 +119,8 @@ ThrowCompletionOr<Promise*> SyntheticModule::evaluate(VM& vm)
         // Note: This value probably isn't visible to JS code? But undefined is fine anyway.
         promise->fulfill(js_undefined());
     }
-    return promise.ptr();
+
+    return promise;
 }
 
 // 1.2.2 SetSyntheticModuleExport ( module, exportName, exportValue ), https://tc39.es/proposal-json-modules/#sec-setsyntheticmoduleexport

--- a/Libraries/LibJS/SyntheticModule.h
+++ b/Libraries/LibJS/SyntheticModule.h
@@ -6,35 +6,39 @@
 
 #pragma once
 
+#include <LibGC/Function.h>
+#include <LibGC/Ptr.h>
 #include <LibJS/Module.h>
 
 namespace JS {
 
-// 1.2 Synthetic Module Records, https://tc39.es/proposal-json-modules/#sec-synthetic-module-records
+// 16.2.1.8 Synthetic Module Records, https://tc39.es/ecma262/#sec-synthetic-module-records
 class SyntheticModule final : public Module {
     GC_CELL(SyntheticModule, Module);
     GC_DECLARE_ALLOCATOR(SyntheticModule);
 
 public:
-    using EvaluationFunction = Function<ThrowCompletionOr<void>(SyntheticModule&)>;
+    using EvaluationFunction = GC::Ref<GC::Function<ThrowCompletionOr<void>(SyntheticModule&)>>;
 
-    static GC::Ref<SyntheticModule> create_default_export_synthetic_module(Value default_export, Realm& realm, StringView filename);
+    static GC::Ref<SyntheticModule> create_default_export_synthetic_module(Realm& realm, Value default_export, ByteString filename);
 
     ThrowCompletionOr<void> set_synthetic_module_export(FlyString const& export_name, Value export_value);
 
-    virtual ThrowCompletionOr<void> link(VM& vm) override;
-    virtual ThrowCompletionOr<GC::Ref<Promise>> evaluate(VM& vm) override;
+    virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) override;
     virtual Vector<FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) override;
     virtual ResolvedBinding resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set) override;
-    virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) override;
+    virtual ThrowCompletionOr<void> link(VM& vm) override;
+    virtual ThrowCompletionOr<GC::Ref<Promise>> evaluate(VM& vm) override;
 
 private:
-    SyntheticModule(Vector<FlyString> export_names, EvaluationFunction evaluation_steps, Realm& realm, StringView filename);
+    SyntheticModule(Realm& realm, Vector<FlyString> export_names, EvaluationFunction evaluation_steps, ByteString filename);
+
+    virtual void visit_edges(Cell::Visitor&) override;
 
     Vector<FlyString> m_export_names;      // [[ExportNames]]
     EvaluationFunction m_evaluation_steps; // [[EvaluationSteps]]
 };
 
-ThrowCompletionOr<GC::Ref<Module>> parse_json_module(StringView source_text, Realm& realm, StringView filename);
+ThrowCompletionOr<GC::Ref<Module>> parse_json_module(Realm& realm, StringView source_text, ByteString filename);
 
 }

--- a/Libraries/LibJS/SyntheticModule.h
+++ b/Libraries/LibJS/SyntheticModule.h
@@ -23,9 +23,9 @@ public:
     ThrowCompletionOr<void> set_synthetic_module_export(FlyString const& export_name, Value export_value);
 
     virtual ThrowCompletionOr<void> link(VM& vm) override;
-    virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override;
-    virtual ThrowCompletionOr<Vector<FlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set) override;
-    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set) override;
+    virtual ThrowCompletionOr<GC::Ref<Promise>> evaluate(VM& vm) override;
+    virtual Vector<FlyString> get_exported_names(VM& vm, HashTable<Module const*>& export_star_set) override;
+    virtual ResolvedBinding resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set) override;
     virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) override;
 
 private:

--- a/Libraries/LibJS/Tests/builtins/Array/Array.fromAsync.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.fromAsync.js
@@ -77,4 +77,28 @@ describe("normal behavior", () => {
         checkResult(promise, TestArray);
         expect(callCount).toBe(1);
     });
+
+    asyncTest("sync iterable is closed upon rejection", async () => {
+        const thenable = {
+            then(resolve, reject) {
+                reject();
+            },
+        };
+
+        let counter = 0;
+
+        function* iterator() {
+            try {
+                yield thenable;
+            } finally {
+                counter++;
+            }
+        }
+
+        try {
+            await Array.fromAsync(iterator());
+        } catch (e) {}
+
+        expect(counter).toBe(1);
+    });
 });

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.drop.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.drop.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.drop(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(closed).toBeTrue();
+    });
+
     test("called with invalid numbers", () => {
         expect(() => {
             Iterator.prototype.drop(NaN);

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.every.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.every.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "predicate is not a function");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.every(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "predicate is not a function");
+
+        expect(closed).toBeTrue();
+    });
+
     test("iterator's next method throws", () => {
         function TestError() {}
 

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.filter.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.filter.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "predicate is not a function");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.filter(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "predicate is not a function");
+
+        expect(closed).toBeTrue();
+    });
+
     test("iterator's next method throws", () => {
         function TestError() {}
 

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.find.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.find.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "predicate is not a function");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.find(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "predicate is not a function");
+
+        expect(closed).toBeTrue();
+    });
+
     test("iterator's next method throws", () => {
         function TestError() {}
 

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.flatMap.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.flatMap.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "mapper is not a function");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.flatMap(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "mapper is not a function");
+
+        expect(closed).toBeTrue();
+    });
+
     test("iterator's next method throws", () => {
         function TestError() {}
 

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.forEach.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.forEach.js
@@ -2,7 +2,25 @@ describe("errors", () => {
     test("called with non-callable object", () => {
         expect(() => {
             Iterator.prototype.forEach(Symbol.hasInstance);
-        }).toThrowWithMessage(TypeError, "fn is not a function");
+        }).toThrowWithMessage(TypeError, "procedure is not a function");
+    });
+
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.forEach(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "procedure is not a function");
+
+        expect(closed).toBeTrue();
     });
 
     test("iterator's next method throws", () => {

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.map.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.map.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "mapper is not a function");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.map(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "mapper is not a function");
+
+        expect(closed).toBeTrue();
+    });
+
     test("iterator's next method throws", () => {
         function TestError() {}
 

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.reduce.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.reduce.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "reducer is not a function");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.reduce(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "reducer is not a function");
+
+        expect(closed).toBeTrue();
+    });
+
     test("iterator's next method throws", () => {
         function TestError() {}
 

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.some.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.some.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "predicate is not a function");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.some(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "predicate is not a function");
+
+        expect(closed).toBeTrue();
+    });
+
     test("iterator's next method throws", () => {
         function TestError() {}
 

--- a/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.take.js
+++ b/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.take.js
@@ -5,6 +5,24 @@ describe("errors", () => {
         }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
     });
 
+    test("argument validation closes underlying iterator", () => {
+        let closed = false;
+        let iterator = {
+            __proto__: Iterator.prototype,
+
+            return() {
+                closed = true;
+                return {};
+            },
+        };
+
+        expect(() => {
+            iterator.take(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(closed).toBeTrue();
+    });
+
     test("called with invalid numbers", () => {
         expect(() => {
             Iterator.prototype.take(NaN);

--- a/Libraries/LibJS/Tests/eval-redeclaration.js
+++ b/Libraries/LibJS/Tests/eval-redeclaration.js
@@ -1,0 +1,6 @@
+eval("var foo;");
+evaluateSource("let foo = 1;");
+
+test("redeclaration of variable in global scope succeeded", () => {
+    expect(foo).toBe(1);
+});

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -617,6 +617,37 @@ class ExpectationError extends Error {
         }
     };
 
+    asyncTest = async (message, callback) => {
+        if (!__TestResults__[suiteMessage]) __TestResults__[suiteMessage] = {};
+
+        const suite = __TestResults__[suiteMessage];
+        if (Object.prototype.hasOwnProperty.call(suite, message)) {
+            suite[message] = {
+                result: "fail",
+                details: "Another test with the same message did already run",
+                duration: 0,
+            };
+            return;
+        }
+
+        const start = Date.now();
+        const time_ms = () => Date.now() - start;
+
+        try {
+            await callback();
+            suite[message] = {
+                result: "pass",
+                duration: time_ms(),
+            };
+        } catch (e) {
+            suite[message] = {
+                result: "fail",
+                details: String(e),
+                duration: time_ms(),
+            };
+        }
+    };
+
     test.skip = (message, callback) => {
         if (typeof callback !== "function")
             throw new Error("test.skip has invalid second argument (must be a function)");

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -32,6 +32,20 @@ TESTJS_GLOBAL_FUNCTION(can_parse_source, canParseSource)
     return JS::Value(!parser.has_errors());
 }
 
+// Based on $262.evalScript
+TESTJS_GLOBAL_FUNCTION(evaluate_source, evaluateSource)
+{
+    auto& realm = *vm.current_realm();
+
+    auto source = TRY(vm.argument(0).to_string(vm));
+
+    auto script = JS::Script::parse(source, realm);
+    if (script.is_error())
+        return vm.throw_completion<JS::SyntaxError>(script.error().first().to_string());
+
+    return vm.bytecode_interpreter().run(script.value());
+}
+
 TESTJS_GLOBAL_FUNCTION(run_queued_promise_jobs, runQueuedPromiseJobs)
 {
     vm.run_queued_promise_jobs();


### PR DESCRIPTION
This isn't complete, but contains some stage 4 proposal merges and some normative changes (including some `eval` shenanigans ofc!)

test262 diff:
```
Diff Tests:
    +33 ✅    -33 ❌

test/annexB/language/eval-code/direct/script-decl-lex-no-collision.js                                ❌ -> ✅
test/built-ins/Array/fromAsync/sync-iterable-with-rejecting-thenable-closes.js                       ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/next/for-await-iterator-next-rejected-promise-close.js ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/next/for-await-next-rejected-promise-close.js          ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/next/iterator-result-poisoned-wrapper.js               ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/next/next-result-poisoned-wrapper.js                   ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/next/yield-iterator-next-rejected-promise-close.js     ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/next/yield-next-rejected-promise-close.js              ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/iterator-result-rejected-promise-close.js        ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-null.js                                    ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-result-poisoned-wrapper.js                 ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-get-return-undefined.js          ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-poisoned-return.js               ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-not-object.js             ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined-return-object.js                 ❌ -> ✅
test/built-ins/AsyncFromSyncIteratorPrototype/throw/throw-undefined.js                               ❌ -> ✅
test/built-ins/Iterator/prototype/drop/argument-validation-failure-closes-underlying.js              ❌ -> ✅
test/built-ins/Iterator/prototype/every/argument-validation-failure-closes-underlying.js             ❌ -> ✅
test/built-ins/Iterator/prototype/filter/argument-validation-failure-closes-underlying.js            ❌ -> ✅
test/built-ins/Iterator/prototype/find/argument-validation-failure-closes-underlying.js              ❌ -> ✅
test/built-ins/Iterator/prototype/flatMap/argument-validation-failure-closes-underlying.js           ❌ -> ✅
test/built-ins/Iterator/prototype/forEach/argument-validation-failure-closes-underlying.js           ❌ -> ✅
test/built-ins/Iterator/prototype/map/argument-validation-failure-closes-underlying.js               ❌ -> ✅
test/built-ins/Iterator/prototype/reduce/argument-validation-failure-closes-underlying.js            ❌ -> ✅
test/built-ins/Iterator/prototype/some/argument-validation-failure-closes-underlying.js              ❌ -> ✅
test/built-ins/Iterator/prototype/take/argument-validation-failure-closes-underlying.js              ❌ -> ✅
test/language/global-code/script-decl-lex-var-declared-via-eval.js                                   ❌ -> ✅
test/language/import/import-attributes/json-idempotency.js                                           ❌ -> ✅
test/staging/sm/Iterator/prototype/every/check-fn-after-getting-iterator.js                          ❌ -> ✅
test/staging/sm/Iterator/prototype/find/check-fn-after-getting-iterator.js                           ❌ -> ✅
test/staging/sm/Iterator/prototype/forEach/check-fn-after-getting-iterator.js                        ❌ -> ✅
test/staging/sm/Iterator/prototype/reduce/check-fn-after-getting-iterator.js                         ❌ -> ✅
test/staging/sm/Iterator/prototype/some/check-fn-after-getting-iterator.js                           ❌ -> ✅
```