### PR TITLE
LibWeb: Pass a null sourceDocument to Browser UI initiated navigations

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3870,32 +3870,6 @@ void Document::set_policy_container(GC::Ref<HTML::PolicyContainer> policy_contai
     m_policy_container = policy_container;
 }
 
-// https://html.spec.whatwg.org/multipage/browsing-the-web.html#snapshotting-source-snapshot-params
-GC::Ref<HTML::SourceSnapshotParams> Document::snapshot_source_snapshot_params() const
-{
-    // To snapshot source snapshot params given a Document sourceDocument, return a new source snapshot params with
-    return heap().allocate<HTML::SourceSnapshotParams>(
-        // has transient activation
-        //    true if sourceDocument's relevant global object has transient activation; otherwise false
-        as<HTML::Window>(HTML::relevant_global_object(*this)).has_transient_activation(),
-
-        // sandboxing flags
-        //     sourceDocument's active sandboxing flag set
-        m_active_sandboxing_flag_set,
-
-        // allows downloading
-        //     false if sourceDocument's active sandboxing flag set has the sandboxed downloads browsing context flag set; otherwise true
-        !has_flag(m_active_sandboxing_flag_set, HTML::SandboxingFlagSet::SandboxedDownloads),
-
-        // fetch client
-        //     sourceDocument's relevant settings object
-        relevant_settings_object(),
-
-        // source policy container
-        //     a clone of sourceDocument's policy container
-        policy_container()->clone(heap()));
-}
-
 // https://html.spec.whatwg.org/multipage/document-sequences.html#descendant-navigables
 Vector<GC::Root<HTML::Navigable>> Document::descendant_navigables()
 {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -711,8 +711,6 @@ public:
 
     u32 unload_counter() const { return m_unload_counter; }
 
-    GC::Ref<HTML::SourceSnapshotParams> snapshot_source_snapshot_params() const;
-
     void update_for_history_step_application(GC::Ref<HTML::SessionHistoryEntry>, bool do_not_reactivate, size_t script_history_length, size_t script_history_index, Optional<Bindings::NavigationType> navigation_type, Optional<Vector<GC::Ref<HTML::SessionHistoryEntry>>> entries_for_navigation_api = {}, GC::Ptr<HTML::SessionHistoryEntry> previous_entry_for_activation = {}, bool update_navigation_api = true);
 
     HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>>& shared_resource_requests();

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -725,14 +725,12 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
         });
 
         // FIXME: Handle 'parallel queue' task destination
-        auto task_destination = fetch_params.task_destination().get<GC::Ref<JS::Object>>();
-
         // 5. Queue a fetch task to run processResponseEndOfBodyTask with fetchParams’s task destination.
-        Infrastructure::queue_fetch_task(fetch_params.controller(), task_destination, move(process_response_end_of_body_task));
+        Infrastructure::queue_fetch_task(fetch_params.controller(), fetch_params.task_destination(), move(process_response_end_of_body_task));
     };
 
     // FIXME: Handle 'parallel queue' task destination
-    auto task_destination = fetch_params.task_destination().get<GC::Ref<JS::Object>>();
+    auto task_destination = fetch_params.task_destination();
 
     // 4. If fetchParams’s process response is non-null, then queue a fetch task to run fetchParams’s process response
     //    given response, with fetchParams’s task destination.

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -70,20 +70,18 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
 
     // FIXME: 1. If taskDestination is null, then set taskDestination to the result of starting a new parallel queue.
     // FIXME: Handle 'parallel queue' task destination
-    VERIFY(!task_destination.has<Empty>());
-    auto task_destination_object = task_destination.get<GC::Ref<JS::Object>>();
 
     // 2. Let successSteps given a byte sequence bytes be to queue a fetch task to run processBody given bytes, with taskDestination.
-    auto success_steps = [&realm, process_body, task_destination_object](ByteBuffer bytes) {
-        queue_fetch_task(*task_destination_object, GC::create_function(realm.heap(), [process_body, bytes = move(bytes)]() mutable {
+    auto success_steps = [&realm, process_body, task_destination](ByteBuffer bytes) {
+        queue_fetch_task(task_destination, GC::create_function(realm.heap(), [process_body, bytes = move(bytes)]() mutable {
             process_body->function()(move(bytes));
         }));
     };
 
     // 3. Let errorSteps optionally given an exception exception be to queue a fetch task to run processBodyError given
     //    exception, with taskDestination.
-    auto error_steps = [&realm, process_body_error, task_destination_object](JS::Value exception) {
-        queue_fetch_task(*task_destination_object, GC::create_function(realm.heap(), [process_body_error, exception]() {
+    auto error_steps = [&realm, process_body_error, task_destination](JS::Value exception) {
+        queue_fetch_task(task_destination, GC::create_function(realm.heap(), [process_body_error, exception]() {
             process_body_error->function()(exception);
         }));
     };

--- a/Libraries/LibWeb/Fetch/Infrastructure/Task.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/Task.cpp
@@ -11,22 +11,25 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#queue-a-fetch-task
-HTML::TaskID queue_fetch_task(JS::Object& task_destination, GC::Ref<GC::Function<void()>> algorithm)
+HTML::TaskID queue_fetch_task(TaskDestination task_destination, GC::Ref<GC::Function<void()>> algorithm)
 {
     // FIXME: 1. If taskDestination is a parallel queue, then enqueue algorithm to taskDestination.
-
     // 2. Otherwise, queue a global task on the networking task source with taskDestination and algorithm.
-    return HTML::queue_global_task(HTML::Task::Source::Networking, task_destination, algorithm);
+
+    if (auto* destination = task_destination.get_pointer<GC::Ref<JS::Object>>())
+        return HTML::queue_global_task(HTML::Task::Source::Networking, *destination, algorithm);
+
+    return HTML::queue_a_task(HTML::Task::Source::Networking, nullptr, nullptr, algorithm);
 }
 
 // AD-HOC: This overload allows tracking the queued task within the fetch controller so that we may cancel queued tasks
 //         when the spec indicates that we must stop an ongoing fetch.
-HTML::TaskID queue_fetch_task(GC::Ref<FetchController> fetch_controller, JS::Object& task_destination, GC::Ref<GC::Function<void()>> algorithm)
+HTML::TaskID queue_fetch_task(GC::Ref<FetchController> fetch_controller, TaskDestination task_destination, GC::Ref<GC::Function<void()>> algorithm)
 {
     auto fetch_task_id = fetch_controller->next_fetch_task_id();
 
-    auto& heap = task_destination.heap();
-    auto html_task_id = queue_fetch_task(task_destination, GC::create_function(heap, [fetch_controller, fetch_task_id, algorithm]() {
+    auto& heap = fetch_controller->heap();
+    auto html_task_id = queue_fetch_task(move(task_destination), GC::create_function(heap, [fetch_controller, fetch_task_id, algorithm]() {
         fetch_controller->fetch_task_complete(fetch_task_id);
         algorithm->function()();
     }));

--- a/Libraries/LibWeb/Fetch/Infrastructure/Task.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/Task.h
@@ -17,7 +17,7 @@ namespace Web::Fetch::Infrastructure {
 // FIXME: 'or a parallel queue'
 using TaskDestination = Variant<Empty, GC::Ref<JS::Object>>;
 
-HTML::TaskID queue_fetch_task(JS::Object&, GC::Ref<GC::Function<void()>>);
-HTML::TaskID queue_fetch_task(GC::Ref<FetchController>, JS::Object&, GC::Ref<GC::Function<void()>>);
+HTML::TaskID queue_fetch_task(TaskDestination, GC::Ref<GC::Function<void()>>);
+HTML::TaskID queue_fetch_task(GC::Ref<FetchController>, TaskDestination, GC::Ref<GC::Function<void()>>);
 
 }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -521,7 +521,7 @@ GC::Ptr<Navigable> Navigable::find_a_navigable_by_target_name(StringView name)
     auto& current_document = *active_document();
 
     // 2. Let sourceSnapshotParams be the result of snapshotting source snapshot params given currentDocument.
-    auto source_snapshot_params = current_document.snapshot_source_snapshot_params();
+    auto source_snapshot_params = snapshot_source_snapshot_params(current_document.heap(), current_document);
 
     // 3. Let subtreesToSearch be an implementation-defined choice of one of the following:
     //    - « currentNavigable's traversable navigable, currentNavigable »
@@ -1414,7 +1414,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
     }
 
     // 2. Let sourceSnapshotParams be the result of snapshotting source snapshot params given sourceDocument.
-    auto source_snapshot_params = source_document->snapshot_source_snapshot_params();
+    auto source_snapshot_params = snapshot_source_snapshot_params(realm.heap(), source_document);
 
     // 3. Let initiatorOriginSnapshot be sourceDocument's origin.
     auto initiator_origin_snapshot = source_document->origin();
@@ -1481,7 +1481,7 @@ void Navigable::begin_navigation(NavigateParams params)
     auto csp_navigation_type = form_data_entry_list.has_value() ? ContentSecurityPolicy::Directives::Directive::NavigationType::FormSubmission : ContentSecurityPolicy::Directives::Directive::NavigationType::Other;
 
     // 2. Let sourceSnapshotParams be the result of snapshotting source snapshot params given sourceDocument.
-    auto source_snapshot_params = source_document->snapshot_source_snapshot_params();
+    auto source_snapshot_params = snapshot_source_snapshot_params(vm.heap(), source_document);
 
     // 3. Let initiatorOriginSnapshot be sourceDocument's origin.
     auto initiator_origin_snapshot = source_document->origin();

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -132,7 +132,7 @@ public:
 
     struct NavigateParams {
         URL::URL url;
-        GC::Ref<DOM::Document> source_document;
+        GC::Ptr<DOM::Document> source_document = nullptr;
         Variant<Empty, String, POSTResource> document_resource = Empty {};
         GC::Ptr<Fetch::Infrastructure::Response> response = nullptr;
         bool exceptions_enabled = false;

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -659,7 +659,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
     auto traversable = navigable->traversable_navigable();
 
     // 11. Let sourceSnapshotParams be the result of snapshotting source snapshot params given document.
-    auto source_snapshot_params = document.snapshot_source_snapshot_params();
+    auto source_snapshot_params = snapshot_source_snapshot_params(realm.heap(), document);
 
     // 12. Append the following session history traversal steps to traversable:
     traversable->append_session_history_traversal_steps(GC::create_function(heap(), [key, api_method_tracker, navigable, source_snapshot_params, traversable, this] {

--- a/Libraries/LibWeb/HTML/SourceSnapshotParams.cpp
+++ b/Libraries/LibWeb/HTML/SourceSnapshotParams.cpp
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/SourceSnapshotParams.h>
+#include <LibWeb/HTML/Window.h>
 
 namespace Web::HTML {
 
@@ -17,6 +19,60 @@ void SourceSnapshotParams::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(fetch_client);
     visitor.visit(source_policy_container);
+}
+
+// https://whatpr.org/html/11250/4ae3173...51371a5/browsing-the-web.html
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#snapshotting-source-snapshot-params
+GC::Ref<SourceSnapshotParams> snapshot_source_snapshot_params(GC::Heap& heap, GC::Ptr<DOM::Document> source_document)
+{
+    //  To snapshot source snapshot params given a Document-or-null sourceDocument:
+
+    // 1.  If sourceDocument is null, then return a new source snapshot params with
+    if (!source_document) {
+        return heap.allocate<SourceSnapshotParams>(
+            // has transient activation
+            //    true
+            true,
+
+            // sandboxing flags
+            //    an empty sandboxing flag set
+            SandboxingFlagSet {},
+
+            // allows downloading
+            //    true
+            true,
+
+            // fetch client
+            //    null
+            nullptr,
+
+            // source policy container
+            //    a new policy container
+            heap.allocate<PolicyContainer>(heap));
+        // NOTE:  This only occurs in the case of a browser UI-initiated navigation.
+    }
+
+    // 2. Return a new source snapshot params with
+    return heap.allocate<SourceSnapshotParams>(
+        // has transient activation
+        //    true if sourceDocument's relevant global object has transient activation; otherwise false
+        as<HTML::Window>(HTML::relevant_global_object(*source_document)).has_transient_activation(),
+
+        // sandboxing flags
+        //     sourceDocument's active sandboxing flag set
+        source_document->active_sandboxing_flag_set(),
+
+        // allows downloading
+        //     false if sourceDocument's active sandboxing flag set has the sandboxed downloads browsing context flag set; otherwise true
+        !has_flag(source_document->active_sandboxing_flag_set(), HTML::SandboxingFlagSet::SandboxedDownloads),
+
+        // fetch client
+        //     sourceDocument's relevant settings object
+        relevant_settings_object(*source_document),
+
+        // source policy container
+        //     a clone of sourceDocument's policy container
+        source_document->policy_container()->clone(heap));
 }
 
 }

--- a/Libraries/LibWeb/HTML/SourceSnapshotParams.h
+++ b/Libraries/LibWeb/HTML/SourceSnapshotParams.h
@@ -18,7 +18,7 @@ struct SourceSnapshotParams : public GC::Cell {
     GC_DECLARE_ALLOCATOR(SourceSnapshotParams);
 
 public:
-    SourceSnapshotParams(bool has_transient_activation, SandboxingFlagSet sandboxing_flags, bool allows_downloading, GC::Ref<EnvironmentSettingsObject> fetch_client, GC::Ref<PolicyContainer> source_policy_container)
+    SourceSnapshotParams(bool has_transient_activation, SandboxingFlagSet sandboxing_flags, bool allows_downloading, GC::Ptr<EnvironmentSettingsObject> fetch_client, GC::Ref<PolicyContainer> source_policy_container)
         : has_transient_activation(has_transient_activation)
         , sandboxing_flags(sandboxing_flags)
         , allows_downloading(allows_downloading)
@@ -38,8 +38,8 @@ public:
     // a boolean
     bool allows_downloading;
 
-    // an environment settings object, only to be used as a request client
-    GC::Ref<EnvironmentSettingsObject> fetch_client;
+    // an environment settings object or null, only to be used as a request client
+    GC::Ptr<EnvironmentSettingsObject> fetch_client;
 
     // a policy container
     GC::Ref<PolicyContainer> source_policy_container;
@@ -47,5 +47,7 @@ public:
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
 };
+
+GC::Ref<SourceSnapshotParams> snapshot_source_snapshot_params(GC::Heap&, GC::Ptr<DOM::Document>);
 
 }

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -638,7 +638,8 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
 
                 // 4. If potentiallyTargetSpecificSourceSnapshotParams is null, then set it to the result of snapshotting source snapshot params given navigable's active document.
                 if (!potentially_target_specific_source_snapshot_params) {
-                    potentially_target_specific_source_snapshot_params = navigable->active_document()->snapshot_source_snapshot_params();
+                    auto navigables_document = navigable->active_document();
+                    potentially_target_specific_source_snapshot_params = snapshot_source_snapshot_params(navigable->heap(), navigables_document);
                 }
 
                 // 5. Set targetEntry's document state's reload pending to false.
@@ -1152,7 +1153,7 @@ void TraversableNavigable::traverse_the_history_by_delta(int delta, GC::Ptr<DOM:
     // 1. If sourceDocument is given, then:
     if (source_document) {
         // 1. Set sourceSnapshotParams to the result of snapshotting source snapshot params given sourceDocument.
-        source_snapshot_params = source_document->snapshot_source_snapshot_params();
+        source_snapshot_params = snapshot_source_snapshot_params(source_document->heap(), source_document);
 
         // 2. Set initiatorToCheck to sourceDocument's node navigable.
         initiator_to_check = source_document->navigable();

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -819,7 +819,7 @@ void Window::close()
     auto browsing_context = traversable->active_browsing_context();
 
     // 5. Let sourceSnapshotParams be the result of snapshotting source snapshot params given thisTraversable's active document.
-    auto source_snapshot_params = traversable->active_document()->snapshot_source_snapshot_params();
+    auto source_snapshot_params = snapshot_source_snapshot_params(heap(), traversable->active_document());
 
     auto& incumbent_global_object = as<HTML::Window>(HTML::incumbent_global_object());
 

--- a/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
+++ b/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
@@ -14,6 +14,10 @@ namespace Web::MixedContent {
 // https://w3c.github.io/webappsec-mixed-content/#upgrade-algorithm
 void upgrade_a_mixed_content_request_to_a_potentially_trustworthy_url_if_appropriate(Fetch::Infrastructure::Request& request)
 {
+    // AD-HOC: Browser-UI initiated navigations should not be upgraded.
+    if (!request.client())
+        return;
+
     // 1. If one or more of the following conditions is met, return without modifying request:
     if (
         // 1. request’s URL is a potentially trustworthy URL.
@@ -22,7 +26,7 @@ void upgrade_a_mixed_content_request_to_a_potentially_trustworthy_url_if_appropr
         // 2. request’s URL’s host is an IP address.
         || (request.url().host().has_value() && (request.url().host()->has<URL::IPv4Address>() || request.url().host()->has<URL::IPv6Address>()))
 
-        // 3. § 4.3 Does settings prohibit mixed security contexts? returns "Does Not Restrict Mixed Security Contents" when applied to request’s client.
+        // 3. § 4.3 Does settings prohibit mixed security contexts? returns "Does Not Restrict Mixed Security Contents" when applied to request’s client.
         || does_settings_prohibit_mixed_security_contexts(request.client()) == ProhibitsMixedSecurityContexts::DoesNotRestrictMixedSecurityContexts
 
         // 4. request’s destination is not "image", "audio", or "video".
@@ -68,6 +72,10 @@ ProhibitsMixedSecurityContexts does_settings_prohibit_mixed_security_contexts(GC
 // https://w3c.github.io/webappsec-mixed-content/#should-block-fetch
 Fetch::Infrastructure::RequestOrResponseBlocking should_fetching_request_be_blocked_as_mixed_content(Fetch::Infrastructure::Request& request)
 {
+    // AD-HOC: Browser-UI initiated navigations should not be blocked.
+    if (!request.client())
+        return Fetch::Infrastructure::RequestOrResponseBlocking::Allowed;
+
     // 1. Return allowed if one or more of the following conditions are met:
     if (
         // 1. § 4.3 Does settings prohibit mixed security contexts? returns "Does Not Restrict Mixed Security Contexts" when applied to request’s client.
@@ -93,6 +101,10 @@ Fetch::Infrastructure::RequestOrResponseBlocking should_fetching_request_be_bloc
 // https://w3c.github.io/webappsec-mixed-content/#should-block-response
 Web::Fetch::Infrastructure::RequestOrResponseBlocking should_response_to_request_be_blocked_as_mixed_content(Fetch::Infrastructure::Request& request, GC::Ref<Fetch::Infrastructure::Response>& response)
 {
+    // AD-HOC: Browser-UI initiated navigations should not be blocked.
+    if (!request.client())
+        return Fetch::Infrastructure::RequestOrResponseBlocking::Allowed;
+
     // 1. Return allowed if one or more of the following conditions are met:
     if (
         // 1. § 4.3 Does settings prohibit mixed security contexts? returns Does Not Restrict Mixed Content when applied to request’s client.

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -71,7 +71,7 @@ void Page::navigable_document_destroyed(Badge<DOM::Document>, HTML::Navigable& n
 
 void Page::load(URL::URL const& url)
 {
-    (void)top_level_traversable()->navigate({ .url = url, .source_document = *top_level_traversable()->active_document(), .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });
+    (void)top_level_traversable()->navigate({ .url = url, .source_document = nullptr, .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });
 }
 
 void Page::load_html(StringView html)
@@ -80,7 +80,7 @@ void Page::load_html(StringView html)
     heap().collect_garbage();
 
     (void)top_level_traversable()->navigate({ .url = URL::about_srcdoc(),
-        .source_document = *top_level_traversable()->active_document(),
+        .source_document = nullptr,
         .document_resource = String::from_utf8(html).release_value_but_fixme_should_propagate_errors(),
         .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });
 }

--- a/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
@@ -1,5 +1,10 @@
 entries[length - 1] is current entry: true
 currentEntry is a [object NavigationHistoryEntry]
 transition is null: true
+canGoBack: false
+canGoForward: true
+entries[length - 1] is current entry: false
+currentEntry is a [object NavigationHistoryEntry]
+transition is null: true
 canGoBack: true
 canGoForward: true

--- a/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
+++ b/Tests/LibWeb/Text/input/HTML/Navigation-object-properties.html
@@ -11,6 +11,15 @@
 
         println(`transition is null: ${n.transition == null}`);
         println(`canGoBack: ${n.canGoBack}`);
-        println(`canGoForward: ${n.canGoForward}`);       
+        println(`canGoForward: ${n.canGoForward}`);
+
+        history.pushState({}, "", "#foo");
+
+        println(`entries[length - 1] is current entry: ${n.entries()[len - 1] === n.currentEntry}`);
+        println(`currentEntry is a ${n.currentEntry}`);
+
+        println(`transition is null: ${n.transition == null}`);
+        println(`canGoBack: ${n.canGoBack}`);
+        println(`canGoForward: ${n.canGoForward}`);
     });
 </script>


### PR DESCRIPTION
Buildup and implementation for https://github.com/whatwg/html/pull/11250

This does some .. interesting things to the m_current_entry_index of `window.navigation`. But as far as I could tell, it doesn't actually regress our UI-initiated fwd/back buttons, so I guess we'll have to untangle that later :)