### PR TITLE
LibIPC+LibWeb: Fix some race conditions found cycling headless-browser a bunch

### DIFF
--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -8,6 +8,7 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/Queue.h>
+#include <LibCore/Promise.h>
 #include <LibThreading/ConditionVariable.h>
 #include <LibThreading/Mutex.h>
 #include <LibThreading/Thread.h>
@@ -43,6 +44,7 @@ private:
 
     RefPtr<Threading::Thread> m_thread;
     Atomic<bool> m_exit { false };
+    NonnullRefPtr<Core::Promise<NonnullRefPtr<Core::EventReceiver>>> m_main_thread_exit_promise;
 
     struct Task {
         NonnullRefPtr<Painting::DisplayList> display_list;


### PR DESCRIPTION
Two fixes that came about by running `./Meta/ladybird.sh run headless-browser -R $PWD/Tests/LibWeb -f Text/input/HTML` over and over and seeing what was unhappy.

There's a new RequestServer 'EPIPE b/c WebContent disappeared when we had data for it in the queue' crash that comes about by fixing this, but a new crash is better than two old crashes, right? ...right?