### PR TITLE
LibJS: Add StackFrame to avoid indirection in VM register access

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -56,9 +56,6 @@ public:
         return m_registers_and_constants_and_locals_arguments.data()[r.index()];
     }
 
-    [[nodiscard]] Value get(Operand) const;
-    void set(Operand, Value);
-
     Value do_yield(Value value, Optional<Label> continuation);
     void do_return(Value value)
     {

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -68,7 +68,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -132,34 +132,34 @@ private:
     O(StrictlyInequals, strict_inequals)                    \
     O(StrictlyEquals, strict_equals)
 
-#define JS_DECLARE_COMMON_BINARY_OP(OpTitleCase, op_snake_case)             \
-    class OpTitleCase final : public Instruction {                          \
-    public:                                                                 \
-        explicit OpTitleCase(Operand dst, Operand lhs, Operand rhs)         \
-            : Instruction(Type::OpTitleCase)                                \
-            , m_dst(dst)                                                    \
-            , m_lhs(lhs)                                                    \
-            , m_rhs(rhs)                                                    \
-        {                                                                   \
-        }                                                                   \
-                                                                            \
-        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const; \
-        ByteString to_byte_string_impl(Bytecode::Executable const&) const;  \
-        void visit_operands_impl(Function<void(Operand&)> visitor)          \
-        {                                                                   \
-            visitor(m_dst);                                                 \
-            visitor(m_lhs);                                                 \
-            visitor(m_rhs);                                                 \
-        }                                                                   \
-                                                                            \
-        Operand dst() const { return m_dst; }                               \
-        Operand lhs() const { return m_lhs; }                               \
-        Operand rhs() const { return m_rhs; }                               \
-                                                                            \
-    private:                                                                \
-        Operand m_dst;                                                      \
-        Operand m_lhs;                                                      \
-        Operand m_rhs;                                                      \
+#define JS_DECLARE_COMMON_BINARY_OP(OpTitleCase, op_snake_case)                          \
+    class OpTitleCase final : public Instruction {                                       \
+    public:                                                                              \
+        explicit OpTitleCase(Operand dst, Operand lhs, Operand rhs)                      \
+            : Instruction(Type::OpTitleCase)                                             \
+            , m_dst(dst)                                                                 \
+            , m_lhs(lhs)                                                                 \
+            , m_rhs(rhs)                                                                 \
+        {                                                                                \
+        }                                                                                \
+                                                                                         \
+        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const; \
+        ByteString to_byte_string_impl(Bytecode::Executable const&) const;               \
+        void visit_operands_impl(Function<void(Operand&)> visitor)                       \
+        {                                                                                \
+            visitor(m_dst);                                                              \
+            visitor(m_lhs);                                                              \
+            visitor(m_rhs);                                                              \
+        }                                                                                \
+                                                                                         \
+        Operand dst() const { return m_dst; }                                            \
+        Operand lhs() const { return m_lhs; }                                            \
+        Operand rhs() const { return m_rhs; }                                            \
+                                                                                         \
+    private:                                                                             \
+        Operand m_dst;                                                                   \
+        Operand m_lhs;                                                                   \
+        Operand m_rhs;                                                                   \
     };
 
 JS_ENUMERATE_COMMON_BINARY_OPS_WITHOUT_FAST_PATH(JS_DECLARE_COMMON_BINARY_OP)
@@ -173,30 +173,30 @@ JS_ENUMERATE_COMMON_BINARY_OPS_WITH_FAST_PATH(JS_DECLARE_COMMON_BINARY_OP)
     O(UnaryMinus, unary_minus)           \
     O(Typeof, typeof_)
 
-#define JS_DECLARE_COMMON_UNARY_OP(OpTitleCase, op_snake_case)              \
-    class OpTitleCase final : public Instruction {                          \
-    public:                                                                 \
-        OpTitleCase(Operand dst, Operand src)                               \
-            : Instruction(Type::OpTitleCase)                                \
-            , m_dst(dst)                                                    \
-            , m_src(src)                                                    \
-        {                                                                   \
-        }                                                                   \
-                                                                            \
-        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const; \
-        ByteString to_byte_string_impl(Bytecode::Executable const&) const;  \
-        void visit_operands_impl(Function<void(Operand&)> visitor)          \
-        {                                                                   \
-            visitor(m_dst);                                                 \
-            visitor(m_src);                                                 \
-        }                                                                   \
-                                                                            \
-        Operand dst() const { return m_dst; }                               \
-        Operand src() const { return m_src; }                               \
-                                                                            \
-    private:                                                                \
-        Operand m_dst;                                                      \
-        Operand m_src;                                                      \
+#define JS_DECLARE_COMMON_UNARY_OP(OpTitleCase, op_snake_case)                           \
+    class OpTitleCase final : public Instruction {                                       \
+    public:                                                                              \
+        OpTitleCase(Operand dst, Operand src)                                            \
+            : Instruction(Type::OpTitleCase)                                             \
+            , m_dst(dst)                                                                 \
+            , m_src(src)                                                                 \
+        {                                                                                \
+        }                                                                                \
+                                                                                         \
+        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const; \
+        ByteString to_byte_string_impl(Bytecode::Executable const&) const;               \
+        void visit_operands_impl(Function<void(Operand&)> visitor)                       \
+        {                                                                                \
+            visitor(m_dst);                                                              \
+            visitor(m_src);                                                              \
+        }                                                                                \
+                                                                                         \
+        Operand dst() const { return m_dst; }                                            \
+        Operand src() const { return m_src; }                                            \
+                                                                                         \
+    private:                                                                             \
+        Operand m_dst;                                                                   \
+        Operand m_src;                                                                   \
     };
 
 JS_ENUMERATE_COMMON_UNARY_OPS(JS_DECLARE_COMMON_UNARY_OP)
@@ -210,7 +210,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -234,7 +234,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -266,7 +266,7 @@ private:
         {                                                                  \
         }                                                                  \
                                                                            \
-        void execute_impl(Bytecode::Interpreter&) const;                   \
+        void execute_impl(Bytecode::Interpreter&, StackFrame&) const;      \
         ByteString to_byte_string_impl(Bytecode::Executable const&) const; \
         void visit_operands_impl(Function<void(Operand&)> visitor)         \
         {                                                                  \
@@ -299,7 +299,7 @@ public:
             m_excluded_names[i] = excluded_names[i];
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -348,7 +348,7 @@ public:
             m_elements[i] = elements[i];
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -392,7 +392,7 @@ public:
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Value) * m_element_count);
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -416,7 +416,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
 private:
@@ -433,7 +433,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -461,7 +461,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -489,7 +489,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -515,7 +515,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -550,7 +550,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
 private:
@@ -565,7 +565,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
 private:
@@ -579,7 +579,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -591,7 +591,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand object() const { return m_object; }
@@ -613,7 +613,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -634,7 +634,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -645,7 +645,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -661,7 +661,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     IdentifierTableIndex identifier() const { return m_identifier; }
@@ -687,7 +687,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -712,7 +712,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -737,7 +737,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -762,7 +762,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -788,7 +788,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -816,7 +816,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -843,7 +843,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -870,7 +870,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
@@ -898,7 +898,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -929,7 +929,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -957,7 +957,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -983,7 +983,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1017,7 +1017,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1047,7 +1047,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1078,7 +1078,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1106,7 +1106,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1141,7 +1141,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1170,7 +1170,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1206,7 +1206,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1242,7 +1242,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1271,7 +1271,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1300,7 +1300,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1332,7 +1332,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1363,7 +1363,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1397,7 +1397,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1431,7 +1431,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1465,7 +1465,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1500,7 +1500,7 @@ public:
     Operand this_value() const { return m_this_value; }
     Operand property() const { return m_property; }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1654,7 +1654,7 @@ private:
         {                                                                                            \
         }                                                                                            \
                                                                                                      \
-        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;                          \
+        ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;             \
         ByteString to_byte_string_impl(Bytecode::Executable const&) const;                           \
         void visit_labels_impl(Function<void(Label&)> visitor)                                       \
         {                                                                                            \
@@ -1782,7 +1782,7 @@ public:
 
     u32 argument_count() const { return m_argument_count; }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1834,7 +1834,7 @@ public:
 
     Builtin const& builtin() const { return m_builtin; }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1882,7 +1882,7 @@ public:
 
     u32 argument_count() const { return m_argument_count; }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1929,7 +1929,7 @@ public:
 
     u32 argument_count() const { return m_argument_count; }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1969,7 +1969,7 @@ public:
     Operand arguments() const { return m_arguments; }
     Optional<StringTableIndex> const& expression_string() const { return m_expression_string; }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -1998,7 +1998,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2040,7 +2040,7 @@ public:
         return round_up_to_power_of_two(alignof(void*), sizeof(*this) + sizeof(Optional<Operand>) * m_element_keys_count);
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2078,7 +2078,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2107,7 +2107,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     ScopeNode const& scope_node() const { return m_scope_node; }
@@ -2126,7 +2126,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2148,7 +2148,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2170,7 +2170,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2194,7 +2194,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2216,7 +2216,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2242,7 +2242,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2263,7 +2263,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2284,7 +2284,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2305,7 +2305,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2371,7 +2371,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -2382,7 +2382,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -2393,7 +2393,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 };
 
@@ -2436,7 +2436,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -2465,7 +2465,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2492,7 +2492,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_labels_impl(Function<void(Label&)> visitor)
     {
@@ -2521,7 +2521,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2548,7 +2548,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2573,7 +2573,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2599,7 +2599,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2626,7 +2626,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2652,7 +2652,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2679,7 +2679,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2705,7 +2705,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2728,7 +2728,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)>) { }
 };
@@ -2741,7 +2741,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2762,7 +2762,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2783,7 +2783,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2805,7 +2805,7 @@ public:
     {
     }
 
-    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
@@ -2852,7 +2852,7 @@ public:
     {
     }
 
-    void execute_impl(Bytecode::Interpreter&) const;
+    void execute_impl(Bytecode::Interpreter&, StackFrame&) const;
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {

--- a/Libraries/LibJS/Forward.h
+++ b/Libraries/LibJS/Forward.h
@@ -324,6 +324,7 @@ class Interpreter;
 class Operand;
 class RegexTable;
 class Register;
+class StackFrame;
 }
 
 }


### PR DESCRIPTION
This is a simple trick to generate better native code for access to registers, locals, and constants. Before this change, each access had to first dereference the member pointer in Interpreter, and then get to the values. Now we always have a pointer directly to the values on hand.

Here's how it looks:

    class StackFrame {
    public:
        Value get(Operand) const;
        void set(Operand, Value);

    private:
        Value m_values[];
    };

And we just place one of these as a window on top of the execution context's array of values (registers, locals, and constants).

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                           1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                   1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    1.083  0.130 ± 0.130 … 0.130     0.120 ± 0.120 … 0.120
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.040 ± 0.040 … 0.040     0.040 ± 0.040 … 0.040
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   math-partial-sums.js                     1      0.040 ± 0.040 … 0.040     0.040 ± 0.040 … 0.040
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            1      0.280 ± 0.280 … 0.280     0.280 ± 0.280 … 0.280
SunSpider   string-base64.js                         1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   string-fasta.js                          1.037  0.140 ± 0.140 … 0.140     0.135 ± 0.130 … 0.140
SunSpider   string-tagcloud.js                       0.963  0.130 ± 0.130 … 0.130     0.135 ± 0.130 … 0.140
SunSpider   string-unpack-code.js                    1      0.095 ± 0.090 … 0.100     0.095 ± 0.090 … 0.100
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030     0.030 ± 0.030 … 0.030
Kraken      ai-astar.js                              1.085  0.960 ± 0.960 … 0.960     0.885 ± 0.870 … 0.900
Kraken      audio-beat-detection.js                  1.04   0.775 ± 0.770 … 0.780     0.745 ± 0.740 … 0.750
Kraken      audio-dft.js                             1.049  0.535 ± 0.530 … 0.540     0.510 ± 0.510 … 0.510
Kraken      audio-fft.js                             1.023  0.670 ± 0.670 … 0.670     0.655 ± 0.650 … 0.660
Kraken      audio-oscillator.js                      1.038  0.825 ± 0.820 … 0.830     0.795 ± 0.790 … 0.800
Kraken      imaging-darkroom.js                      1.006  0.860 ± 0.850 … 0.870     0.855 ± 0.850 … 0.860
Kraken      imaging-desaturate.js                    1.071  0.910 ± 0.910 … 0.910     0.850 ± 0.850 … 0.850
Kraken      imaging-gaussian-blur.js                 1.039  3.750 ± 3.740 … 3.760     3.610 ± 3.600 … 3.620
Kraken      json-parse-financial.js                  1.083  0.065 ± 0.060 … 0.070     0.060 ± 0.060 … 0.060
Kraken      json-stringify-tinderbox.js              1      0.090 ± 0.090 … 0.090     0.090 ± 0.090 … 0.090
Kraken      stanford-crypto-aes.js                   1.031  0.335 ± 0.330 … 0.340     0.325 ± 0.320 … 0.330
Kraken      stanford-crypto-ccm.js                   1.017  0.295 ± 0.290 … 0.300     0.290 ± 0.290 … 0.290
Kraken      stanford-crypto-pbkdf2.js                1      0.540 ± 0.540 … 0.540     0.540 ± 0.540 … 0.540
Kraken      stanford-crypto-sha256-iterative.js      1.023  0.220 ± 0.220 … 0.220     0.215 ± 0.210 … 0.220
Octane      box2d.js                                 1.014  1.065 ± 1.060 … 1.070     1.050 ± 1.050 … 1.050
Octane      code-load.js                             1.005  2.020 ± 2.020 … 2.020     2.010 ± 2.010 … 2.010
Octane      crypto.js                                1.018  5.120 ± 5.120 … 5.120     5.030 ± 5.030 … 5.030
Octane      deltablue.js                             1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      earley-boyer.js                          0.989  9.960 ± 9.950 … 9.970     10.075 ± 10.030 … 10.120
Octane      gbemu.js                                 1.022  1.170 ± 1.170 … 1.170     1.145 ± 1.140 … 1.150
Octane      mandreel.js                              1.013  5.480 ± 5.460 … 5.500     5.410 ± 5.390 … 5.430
Octane      navier-stokes.js                         1.007  2.070 ± 2.060 … 2.080     2.055 ± 2.020 … 2.090
Octane      pdfjs.js                                 0.991  1.140 ± 1.140 … 1.140     1.150 ± 1.150 … 1.150
Octane      raytrace.js                              1.016  3.150 ± 3.130 … 3.170     3.100 ± 3.090 … 3.110
Octane      regexp.js                                0.993  14.445 ± 14.440 … 14.450  14.545 ± 14.510 … 14.580
Octane      richards.js                              1      2.000 ± 2.000 … 2.000     2.000 ± 2.000 … 2.000
Octane      splay.js                                 1      2.335 ± 2.330 … 2.340     2.335 ± 2.330 … 2.340
Octane      typescript.js                            1.003  11.775 ± 11.770 … 11.780  11.735 ± 11.690 … 11.780
Octane      zlib.js                                  1.015  35.435 ± 35.420 … 35.450  34.910 ± 34.860 … 34.960
JetStream   bigfib.cpp.js                            0.999  6.480 ± 6.460 … 6.500     6.485 ± 6.480 … 6.490
JetStream   cdjs.js                                  1.003  4.535 ± 4.520 … 4.550     4.520 ± 4.480 … 4.560
JetStream   container.cpp.js                         1.003  26.310 ± 26.050 … 26.570  26.220 ± 26.110 … 26.330
JetStream   dry.c.js                                 1.038  16.560 ± 15.960 … 17.160  15.950 ± 15.930 … 15.970
JetStream   float-mm.c.js                            1.016  17.000 ± 16.900 … 17.100  16.730 ± 16.620 … 16.840
JetStream   gcc-loops.cpp.js                         1.02   88.640 ± 88.220 … 89.060  86.895 ± 86.660 … 87.130
JetStream   hash-map.js                              1.008  2.560 ± 2.530 … 2.590     2.540 ± 2.540 … 2.540
JetStream   n-body.c.js                              1.016  23.510 ± 23.130 … 23.890  23.145 ± 22.860 … 23.430
JetStream   quicksort.c.js                           0.989  3.585 ± 3.540 … 3.630     3.625 ± 3.620 … 3.630
JetStream   towers.c.js                              1.007  4.915 ± 4.910 … 4.920     4.880 ± 4.870 … 4.890
JetStream3  js-tokens.js                             1.007  0.765 ± 0.760 … 0.770     0.760 ± 0.760 … 0.760
JetStream3  lazy-collections.js                      0.968  1.215 ± 1.210 … 1.220     1.255 ± 1.250 … 1.260
JetStream3  raytrace-private-class-fields.js         0.989  4.920 ± 4.900 … 4.940     4.975 ± 4.970 … 4.980
JetStream3  raytrace-public-class-fields.js          0.996  3.720 ± 3.700 … 3.740     3.735 ± 3.720 … 3.750
JetStream3  sync-file-system.js                      1.033  1.900 ± 1.860 … 1.940     1.840 ± 1.810 … 1.870
RegExp      speedometer-jquery-regexp-1.js           1.004  1.405 ± 1.400 … 1.410     1.400 ± 1.400 … 1.400
RegExp      speedometer-jquery-regexp-2.js           1      0.200 ± 0.200 … 0.200     0.200 ± 0.200 … 0.200
MicroBench  call-00-args.js                          1.022  1.370 ± 1.360 … 1.380     1.340 ± 1.340 … 1.340
MicroBench  call-01-args.js                          0.979  1.425 ± 1.380 … 1.470     1.455 ± 1.360 … 1.550
MicroBench  call-02-args.js                          1.036  1.430 ± 1.370 … 1.490     1.380 ± 1.380 … 1.380
MicroBench  call-03-args.js                          0.965  1.395 ± 1.390 … 1.400     1.445 ± 1.380 … 1.510
MicroBench  call-04-args.js                          1.054  1.470 ± 1.410 … 1.530     1.395 ± 1.390 … 1.400
MicroBench  call-16-args.js                          1.013  1.610 ± 1.590 … 1.630     1.590 ± 1.550 … 1.630
MicroBench  call-32-args.js                          1.039  1.865 ± 1.850 … 1.880     1.795 ± 1.790 … 1.800
SunSpider   Total                                    1.009  1.145                     1.135
Kraken      Total                                    1.039  10.830                    10.425
Octane      Total                                    1.006  99.175                    98.560
JetStream   Total                                    1.016  194.095                   190.990
JetStream3  Total                                    0.996  12.520                    12.565
RegExp      Total                                    1.003  1.605                     1.600
MicroBench  Total                                    1.016  10.565                    10.400
All Suites  Total                                    1.013  329.935                   325.675
```