### PR TITLE
LibWeb: Set transition property name when firing transition events

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2714,8 +2714,8 @@ void Document::dispatch_events_for_transition(GC::Ref<CSS::CSSTransition> transi
                 type,
                 CSS::TransitionEventInit {
                     { .bubbles = true },
-                    // FIXME: Correctly set property_name and pseudo_element
-                    String {},
+                    // FIXME: Correctly set pseudo_element
+                    MUST(String::from_utf8(transition->transition_property())),
                     elapsed_time,
                     String {},
                 }),

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/events-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/events-001.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 9 tests
+
+9 Pass
+Pass	transition:all changing padding-left
+Pass	transition:all changing padding
+Pass	transition:all changing padding but not padding-bottom
+Pass	transition:padding changing padding-left
+Pass	transition:padding changing padding
+Pass	transition:padding changing padding but not padding-bottom
+Pass	transition:padding-left changing padding-left
+Pass	transition:padding-left changing padding
+Pass	transition:padding-left changing padding but not padding-bottom

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/properties-value-002.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/properties-value-002.txt
@@ -2,23 +2,23 @@ Harness status: OK
 
 Found 18 tests
 
-8 Pass
-10 Fail
+17 Pass
+1 Fail
 Pass	margin-bottom percentage(%) / values
-Fail	margin-bottom percentage(%) / events
+Pass	margin-bottom percentage(%) / events
 Pass	margin-left percentage(%) / values
-Fail	margin-left percentage(%) / events
+Pass	margin-left percentage(%) / events
 Pass	margin-right percentage(%) / values
-Fail	margin-right percentage(%) / events
+Pass	margin-right percentage(%) / events
 Pass	margin-top percentage(%) / values
-Fail	margin-top percentage(%) / events
+Pass	margin-top percentage(%) / events
 Pass	padding-bottom percentage(%) / values
-Fail	padding-bottom percentage(%) / events
+Pass	padding-bottom percentage(%) / events
 Pass	padding-left percentage(%) / values
-Fail	padding-left percentage(%) / events
+Pass	padding-left percentage(%) / events
 Pass	padding-right percentage(%) / values
-Fail	padding-right percentage(%) / events
+Pass	padding-right percentage(%) / events
 Pass	padding-top percentage(%) / values
-Fail	padding-top percentage(%) / events
+Pass	padding-top percentage(%) / events
 Fail	vertical-align vertical(keyword) / values
-Fail	vertical-align vertical(keyword) / events
+Pass	vertical-align vertical(keyword) / events

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/events-001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/events-001.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html>
+<head>
+<meta charset=utf-8>
+<title>CSS Transitions Test: transitionend event for shorthand property</title>
+<meta name="assert" content="This test checks that all transitionend events are triggered for shorthand property">
+<link rel="help" href="http://www.w3.org/TR/css3-transitions/#transition-property-property">
+<link rel="help" href="http://www.w3.org/TR/css3-transitions/#transition-events">
+<link rel="author" title="Rodney Rehm" href="http://rodneyrehm.de/en/">
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="./support/helper.js"></script>
+
+</head>
+<body>
+
+<script>
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: all .01s linear; ' +
+                                 'padding-left: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.paddingLeft = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:all changing padding-left');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: all .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(4).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-bottom',
+                                   'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:all changing padding');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: all .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px 10px 1px 10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(3).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:all changing padding but not padding-bottom');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding .01s linear; ' +
+                                 'padding-left: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.paddingLeft = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding changing padding-left');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(4).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-bottom',
+                                   'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:padding changing padding');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px 10px 1px 10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(3).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:padding changing padding but not padding-bottom');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding-left .01s linear; ' +
+                                 'padding-left: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.paddingLeft = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding-left changing padding-left');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding-left .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding-left changing padding');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding-left .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px 10px 1px 10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding-left changing padding but not padding-bottom');
+</script>
+</body>
+</html>


### PR DESCRIPTION
This fixes 645 subtests in the `css/css-transitions` directory.