### PR TITLE
LibJS: Revert ArrayIterator and RegExpStringIterator to manual iterators

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayIterator.cpp
+++ b/Libraries/LibJS/Runtime/ArrayIterator.cpp
@@ -11,8 +11,14 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(ArrayIterator);
 
+// 23.1.5.1 CreateArrayIterator ( array, kind ), https://tc39.es/ecma262/#sec-createarrayiterator
 GC::Ref<ArrayIterator> ArrayIterator::create(Realm& realm, Value array, Object::PropertyKind iteration_kind)
 {
+    // 1. Let iterator be OrdinaryObjectCreate(%ArrayIteratorPrototype%, « [[IteratedArrayLike]], [[ArrayLikeNextIndex]], [[ArrayLikeIterationKind]] »).
+    // 2. Set iterator.[[IteratedArrayLike]] to array.
+    // 3. Set iterator.[[ArrayLikeNextIndex]] to 0.
+    // 4. Set iterator.[[ArrayLikeIterationKind]] to kind.
+    // 5. Return iterator.
     return realm.create<ArrayIterator>(array, iteration_kind, realm.intrinsics().array_iterator_prototype());
 }
 

--- a/Libraries/LibJS/Runtime/ArrayIterator.h
+++ b/Libraries/LibJS/Runtime/ArrayIterator.h
@@ -20,12 +20,14 @@ public:
     virtual ~ArrayIterator() override = default;
 
     Value array() const { return m_array; }
+    void set_array(Value array) { m_array = array; }
+
     Object::PropertyKind iteration_kind() const { return m_iteration_kind; }
+
     size_t index() const { return m_index; }
+    void set_index(size_t index) { m_index = index; }
 
 private:
-    friend class ArrayIteratorPrototype;
-
     ArrayIterator(Value array, Object::PropertyKind iteration_kind, Object& prototype);
 
     virtual bool is_array_iterator() const override { return true; }

--- a/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -14,6 +14,13 @@ GC_DEFINE_ALLOCATOR(RegExpStringIterator);
 // 22.2.9.1 CreateRegExpStringIterator ( R, S, global, fullUnicode ), https://tc39.es/ecma262/#sec-createregexpstringiterator
 GC::Ref<RegExpStringIterator> RegExpStringIterator::create(Realm& realm, Object& regexp_object, Utf16String string, bool global, bool unicode)
 {
+    // 1. Let iterator be OrdinaryObjectCreate(%RegExpStringIteratorPrototype%, « [[IteratingRegExp]], [[IteratedString]], [[Global]], [[Unicode]], [[Done]] »).
+    // 2. Set iterator.[[IteratingRegExp]] to R.
+    // 3. Set iterator.[[IteratedString]] to S.
+    // 4. Set iterator.[[Global]] to global.
+    // 5. Set iterator.[[Unicode]] to fullUnicode.
+    // 6. Set iterator.[[Done]] to false.
+    // 7. Return iterator.
     return realm.create<RegExpStringIterator>(realm.intrinsics().regexp_string_iterator_prototype(), regexp_object, move(string), global, unicode);
 }
 

--- a/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -22,7 +22,7 @@ public:
     virtual ~RegExpStringIterator() override = default;
 
     Object& regexp_object() { return m_regexp_object; }
-    Utf16String string() const { return m_string; }
+    Utf16String const& string() const { return m_string; }
     bool global() const { return m_global; }
     bool unicode() const { return m_unicode; }
 


### PR DESCRIPTION
This is a normative change in the ECMA-262 spec. See: https://github.com/tc39/ecma262/commit/de62e8d

This did not actually seem to affect our implementation as we were not using generators here to begin with. So this patch is basically just adding spec comments.