### PR TITLE
LibWeb: Stop crashing WebContent processes after their exit has been requested

### DIFF
--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -65,6 +65,11 @@ void EventLoop::quit(int code)
     m_impl->quit(code);
 }
 
+bool EventLoop::was_exit_requested()
+{
+    return m_impl->was_exit_requested();
+}
+
 struct EventLoopPusher {
 public:
     EventLoopPusher(EventLoop& event_loop)

--- a/Libraries/LibCore/EventLoop.h
+++ b/Libraries/LibCore/EventLoop.h
@@ -78,6 +78,8 @@ public:
 
     void quit(int);
 
+    bool was_exit_requested();
+
     // The registration functions act upon the current loop of the current thread.
     static intptr_t register_timer(EventReceiver&, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible);
     static void unregister_timer(intptr_t timer_id);

--- a/Libraries/LibCore/EventLoopImplementation.h
+++ b/Libraries/LibCore/EventLoopImplementation.h
@@ -52,6 +52,7 @@ public:
     virtual size_t pump(PumpMode) = 0;
     virtual void quit(int) = 0;
     virtual void wake() = 0;
+    virtual bool was_exit_requested() const = 0;
 
     virtual void post_event(EventReceiver& receiver, NonnullOwnPtr<Event>&&) = 0;
 

--- a/Libraries/LibCore/EventLoopImplementationUnix.h
+++ b/Libraries/LibCore/EventLoopImplementationUnix.h
@@ -46,6 +46,7 @@ public:
     virtual int exec() override;
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
+    virtual bool was_exit_requested() const override { return m_exit_requested; }
 
     virtual void wake() override;
 

--- a/Libraries/LibCore/EventLoopImplementationWindows.h
+++ b/Libraries/LibCore/EventLoopImplementationWindows.h
@@ -39,8 +39,8 @@ public:
     virtual int exec() override;
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
-
     virtual void wake() override;
+    virtual bool was_exit_requested() const override { return m_exit_requested; }
 
     virtual void post_event(EventReceiver& receiver, NonnullOwnPtr<Event>&&) override;
 

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -73,8 +73,7 @@ TransportSocket::TransportSocket(NonnullOwnPtr<Core::LocalSocket> socket)
             auto result = send_message(*m_socket, remaining_to_send_bytes, fds);
             if (result.is_error()) {
                 if (result.error().is_errno() && result.error().code() == EPIPE) {
-                    // The socket is closed, we can stop sending.
-                    VERIFY(!m_socket->is_open());
+                    // The socket is closed from the other end, we can stop sending.
                     break;
                 }
                 dbgln("TransportSocket::send_thread: {}", result.error());

--- a/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
+++ b/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
@@ -23,7 +23,6 @@ void EventLoopPluginSerenity::spin_until(GC::Root<GC::Function<bool()>> goal_con
 
 void EventLoopPluginSerenity::deferred_invoke(GC::Root<GC::Function<void()>> function)
 {
-    VERIFY(function);
     Core::deferred_invoke([function = move(function)]() {
         function->function()();
     });

--- a/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
+++ b/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp
@@ -17,6 +17,8 @@ EventLoopPluginSerenity::~EventLoopPluginSerenity() = default;
 void EventLoopPluginSerenity::spin_until(GC::Root<GC::Function<bool()>> goal_condition)
 {
     Core::EventLoop::current().spin_until([goal_condition = move(goal_condition)]() {
+        if (Core::EventLoop::current().was_exit_requested())
+            ::exit(0);
         return goal_condition->function()();
     });
 }

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.h
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.h
@@ -39,6 +39,7 @@ public:
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
     virtual void wake() override;
+    virtual bool was_exit_requested() const override;
     virtual void post_event(Core::EventReceiver& receiver, NonnullOwnPtr<Core::Event>&&) override;
 
 private:

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.mm
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.mm
@@ -404,6 +404,11 @@ void EventLoopImplementationMacOS::wake()
     CFRunLoopWakeUp(CFRunLoopGetCurrent());
 }
 
+bool EventLoopImplementationMacOS::was_exit_requested() const
+{
+    return ![NSApp isRunning];
+}
+
 void EventLoopImplementationMacOS::post_event(Core::EventReceiver& receiver, NonnullOwnPtr<Core::Event>&& event)
 {
     m_thread_event_queue.post_event(receiver, move(event));

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.cpp
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.cpp
@@ -222,6 +222,13 @@ void EventLoopImplementationQt::wake()
         m_event_loop->wakeUp();
 }
 
+bool EventLoopImplementationQt::was_exit_requested() const
+{
+    if (is_main_loop())
+        return QCoreApplication::closingDown();
+    return !m_event_loop->isRunning();
+}
+
 void EventLoopImplementationQt::post_event(Core::EventReceiver& receiver, NonnullOwnPtr<Core::Event>&& event)
 {
     m_thread_event_queue.post_event(receiver, move(event));

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.h
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.h
@@ -57,6 +57,8 @@ public:
     virtual size_t pump(PumpMode) override;
     virtual void quit(int) override;
     virtual void wake() override;
+    virtual bool was_exit_requested() const override;
+
     virtual void post_event(Core::EventReceiver& receiver, NonnullOwnPtr<Core::Event>&&) override;
 
     void set_main_loop();


### PR DESCRIPTION
See commit descriptions for the gory details.

This should prevent a majority of the `Trying to post_message during IPC shutdown` error messages we've been seeing.

This should also fix #4500.

There's a few more instances of that error message in the issue list, but I don't think they are root-caused to this, they just get that as a side-effect.