### PR TITLE
LibWeb/CSS: Use CSS URLs for `<url>` and `<paint>` types

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -32,6 +32,7 @@
 #include <LibWeb/CSS/StyleValues/CursorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ShadowStyleValue.h>
 #include <LibWeb/CSS/Transformation.h>
+#include <LibWeb/CSS/URL.h>
 
 namespace Web::CSS {
 
@@ -225,40 +226,40 @@ public:
         : m_value(color)
     {
     }
-    SVGPaint(::URL::URL const& url)
+    SVGPaint(URL const& url)
         : m_value(url)
     {
     }
 
     bool is_color() const { return m_value.has<Color>(); }
-    bool is_url() const { return m_value.has<::URL::URL>(); }
+    bool is_url() const { return m_value.has<URL>(); }
     Color as_color() const { return m_value.get<Color>(); }
-    ::URL::URL const& as_url() const { return m_value.get<::URL::URL>(); }
+    URL const& as_url() const { return m_value.get<URL>(); }
 
 private:
-    Variant<::URL::URL, Color> m_value;
+    Variant<URL, Color> m_value;
 };
 
 // https://drafts.fxtf.org/css-masking-1/#typedef-mask-reference
 class MaskReference {
 public:
     // TODO: Support other mask types.
-    MaskReference(::URL::URL const& url)
+    MaskReference(URL const& url)
         : m_url(url)
     {
     }
 
-    ::URL::URL const& url() const { return m_url; }
+    URL const& url() const { return m_url; }
 
 private:
-    ::URL::URL m_url;
+    URL m_url;
 };
 
 // https://drafts.fxtf.org/css-masking/#the-clip-path
 // TODO: Support clip sources.
 class ClipPathReference {
 public:
-    ClipPathReference(::URL::URL const& url)
+    ClipPathReference(URL const& url)
         : m_clip_source(url)
     {
     }
@@ -270,16 +271,16 @@ public:
 
     bool is_basic_shape() const { return m_clip_source.has<BasicShape>(); }
 
-    bool is_url() const { return m_clip_source.has<::URL::URL>(); }
+    bool is_url() const { return m_clip_source.has<URL>(); }
 
-    ::URL::URL const& url() const { return m_clip_source.get<::URL::URL>(); }
+    URL const& url() const { return m_clip_source.get<URL>(); }
 
     BasicShapeStyleValue const& basic_shape() const { return *m_clip_source.get<BasicShape>(); }
 
 private:
     using BasicShape = NonnullRefPtr<BasicShapeStyleValue const>;
 
-    Variant<::URL::URL, BasicShape> m_clip_source;
+    Variant<URL, BasicShape> m_clip_source;
 };
 
 struct BackgroundLayerData {

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -282,7 +282,7 @@ private:
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
 
     Optional<URL> parse_url_function(TokenStream<ComponentValue>&);
-    RefPtr<CSSStyleValue const> parse_url_value(TokenStream<ComponentValue>&);
+    RefPtr<URLStyleValue const> parse_url_value(TokenStream<ComponentValue>&);
 
     Optional<ShapeRadius> parse_shape_radius(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue const> parse_basic_shape_value(TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -55,6 +55,7 @@
 #include <LibWeb/CSS/StyleValues/TimeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/TransformationStyleValue.h>
 #include <LibWeb/CSS/StyleValues/TransitionStyleValue.h>
+#include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnresolvedStyleValue.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Infra/Strings.h>

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2197,7 +2197,7 @@ RefPtr<CSSStyleValue const> Parser::parse_paint_value(TokenStream<ComponentValue
         return OptionalNone {};
     };
 
-    // FIMXE: Allow context-fill/context-stroke here
+    // FIXME: Allow context-fill/context-stroke here
     if (auto color_or_none = parse_color_or_none(); color_or_none.has_value())
         return *color_or_none;
 

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2725,16 +2725,12 @@ Optional<URL> Parser::parse_url_function(TokenStream<ComponentValue>& tokens)
     return {};
 }
 
-RefPtr<CSSStyleValue const> Parser::parse_url_value(TokenStream<ComponentValue>& tokens)
+RefPtr<URLStyleValue const> Parser::parse_url_value(TokenStream<ComponentValue>& tokens)
 {
     auto url = parse_url_function(tokens);
     if (!url.has_value())
         return nullptr;
-    // FIXME: Stop completing the URL here
-    auto completed_url = complete_url(url->url());
-    if (!completed_url.has_value())
-        return nullptr;
-    return URLStyleValue::create(completed_url.release_value());
+    return URLStyleValue::create(url.release_value());
 }
 
 // https://www.w3.org/TR/css-shapes-1/#typedef-shape-radius

--- a/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
@@ -1,43 +1,43 @@
 /*
  * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <LibURL/URL.h>
 #include <LibWeb/CSS/CSSStyleValue.h>
-#include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/URL.h>
 
 namespace Web::CSS {
 
 class URLStyleValue final : public StyleValueWithDefaultOperators<URLStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<URLStyleValue const> create(::URL::URL const& url)
+    static ValueComparingNonnullRefPtr<URLStyleValue const> create(URL const& url)
     {
         return adopt_ref(*new (nothrow) URLStyleValue(url));
     }
 
     virtual ~URLStyleValue() override = default;
 
-    ::URL::URL const& url() const { return m_url; }
+    URL const& url() const { return m_url; }
 
     bool properties_equal(URLStyleValue const& other) const { return m_url == other.m_url; }
 
     virtual String to_string(SerializationMode) const override
     {
-        return serialize_a_url(m_url.to_string());
+        return m_url.to_string();
     }
 
 private:
-    URLStyleValue(::URL::URL const& url)
+    URLStyleValue(URL const& url)
         : StyleValueWithDefaultOperators(Type::URL)
         , m_url(url)
     {
     }
 
-    ::URL::URL m_url;
+    URL m_url;
 };
 
 }

--- a/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -29,7 +29,7 @@ void CanvasPatternPaintStyle::paint(Gfx::IntRect physical_bounding_box, PaintFun
     // is "repeat-x", or vertically up and down, if the repetition behavior is "repeat-y", or in all four directions
     // all over the bitmap, if the repetition behavior is "repeat".
 
-    // FIMXE: If the original image data is a bitmap image, then the value painted at a point in the area of
+    // FIXME: If the original image data is a bitmap image, then the value painted at a point in the area of
     // the repetitions is computed by filtering the original image data. When scaling up, if the imageSmoothingEnabled
     // attribute is set to false, then the image must be rendered using nearest-neighbor interpolation.
     // Otherwise, the user agent may use any filtering algorithm (for example bilinear interpolation or nearest-neighbor).

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -80,19 +80,6 @@ protected:
     Gfx::AffineTransform m_transform = {};
 
     template<typename T>
-    GC::Ptr<T> try_resolve_url_to(URL::URL const& url) const
-    {
-        if (!url.fragment().has_value())
-            return {};
-        auto node = document().get_element_by_id(*url.fragment());
-        if (!node)
-            return {};
-        if (is<T>(*node))
-            return static_cast<T&>(*node);
-        return {};
-    }
-
-    template<typename T>
     GC::Ptr<T> try_resolve_url_to(CSS::URL const& url) const
     {
         // FIXME: Complete and use the entire URL, not just the fragment.

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibGfx/PaintStyle.h>
+#include <LibWeb/CSS/URL.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGAnimatedTransformList.h>
@@ -87,6 +88,21 @@ protected:
         if (!node)
             return {};
         if (is<T>(*node))
+            return static_cast<T&>(*node);
+        return {};
+    }
+
+    template<typename T>
+    GC::Ptr<T> try_resolve_url_to(CSS::URL const& url) const
+    {
+        // FIXME: Complete and use the entire URL, not just the fragment.
+        Optional<FlyString> fragment;
+        if (auto fragment_offset = url.url().find_byte_offset('#'); fragment_offset.has_value()) {
+            fragment = MUST(url.url().substring_from_byte_offset_with_shared_superstring(fragment_offset.value() + 1));
+        }
+        if (!fragment.has_value())
+            return {};
+        if (auto node = document().get_element_by_id(*fragment); node && is<T>(*node))
             return static_cast<T&>(*node);
         return {};
     }

--- a/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
@@ -24,10 +24,7 @@ GC::Ptr<SVGGeometryElement const> SVGTextPathElement::path_or_shape() const
     auto href = get_attribute(AttributeNames::href);
     if (!href.has_value())
         return {};
-    auto url = document().url().complete_url(*href);
-    if (!url.has_value())
-        return {};
-    return try_resolve_url_to<SVGGeometryElement const>(*url);
+    return try_resolve_url_to<SVGGeometryElement const>(*href);
 }
 
 void SVGTextPathElement::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/WebAudio/AnalyserNode.cpp
+++ b/Libraries/LibWeb/WebAudio/AnalyserNode.cpp
@@ -94,7 +94,7 @@ Vector<f32> AnalyserNode::smoothing_over_time(Vector<f32> const& current_block)
     Vector<f32> result;
     result.ensure_capacity(m_fft_size);
     for (unsigned long i = 0; i < m_fft_size; i++) {
-        // FIMXE: Complex modulus on X[i]
+        // FIXME: Complex modulus on X[i]
         result.unchecked_append(m_smoothing_time_constant * m_previous_block[i] + (1.f - m_smoothing_time_constant) * abs(X[i]));
     }
 


### PR DESCRIPTION
With :sparkles: **_bonus_** :sparkles: typo fixes.