### PR TITLE
LibWeb: Use the correct target realm to tee a stream

### DIFF
--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -54,7 +54,7 @@ GC::Ref<Body> Body::clone(JS::Realm& realm)
 
     // To clone a body body, run these steps:
     // 1. Let « out1, out2 » be the result of teeing body’s stream.
-    auto [out1, out2] = m_stream->tee().release_value_but_fixme_should_propagate_errors();
+    auto [out1, out2] = m_stream->tee(&realm).release_value_but_fixme_should_propagate_errors();
 
     // 2. Set body’s stream to out1.
     m_stream = out1;

--- a/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -173,10 +173,13 @@ GC::Ref<WebIDL::Promise> ReadableStream::pipe_to(WritableStream& destination, St
 }
 
 // https://streams.spec.whatwg.org/#readablestream-tee
-WebIDL::ExceptionOr<ReadableStreamPair> ReadableStream::tee()
+WebIDL::ExceptionOr<ReadableStreamPair> ReadableStream::tee(GC::Ptr<JS::Realm> target_realm)
 {
+    if (!target_realm)
+        target_realm = &realm();
+
     // To tee a ReadableStream stream, return ? ReadableStreamTee(stream, true).
-    return TRY(readable_stream_tee(realm(), *this, true));
+    return TRY(readable_stream_tee(*target_realm, *this, true));
 }
 
 // https://streams.spec.whatwg.org/#readablestream-close

--- a/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Libraries/LibWeb/Streams/ReadableStream.h
@@ -80,7 +80,7 @@ public:
     WebIDL::ExceptionOr<ReadableStreamReader> get_reader(ReadableStreamGetReaderOptions const& = {});
     WebIDL::ExceptionOr<GC::Ref<ReadableStream>> pipe_through(ReadableWritablePair transform, StreamPipeOptions const& = {});
     GC::Ref<WebIDL::Promise> pipe_to(WritableStream& destination, StreamPipeOptions const& = {});
-    WebIDL::ExceptionOr<ReadableStreamPair> tee();
+    WebIDL::ExceptionOr<ReadableStreamPair> tee(GC::Ptr<JS::Realm> target_realm = {});
 
     void close();
     void error(JS::Value);

--- a/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -49,18 +49,15 @@ public:
     // AD-HOC: callback triggered on every chunk received from the stream.
     using ChunkSteps = GC::Function<void(ByteBuffer)>;
 
-    ReadLoopReadRequest(JS::VM& vm, JS::Realm& realm, ReadableStreamDefaultReader& reader, GC::Ref<SuccessSteps> success_steps, GC::Ref<FailureSteps> failure_steps, GC::Ptr<ChunkSteps> chunk_steps = {});
-
-    virtual void on_chunk(JS::Value chunk) override;
-
-    virtual void on_close() override;
-
-    virtual void on_error(JS::Value error) override;
-
 private:
+    ReadLoopReadRequest(JS::Realm&, ReadableStreamDefaultReader&, GC::Ref<SuccessSteps>, GC::Ref<FailureSteps>, GC::Ptr<ChunkSteps> = {});
+
     virtual void visit_edges(Visitor&) override;
 
-    JS::VM& m_vm;
+    virtual void on_chunk(JS::Value chunk) override;
+    virtual void on_close() override;
+    virtual void on_error(JS::Value error) override;
+
     GC::Ref<JS::Realm> m_realm;
     GC::Ref<ReadableStreamDefaultReader> m_reader;
     ByteBuffer m_bytes;


### PR DESCRIPTION
We currently store `Web::Fetch::Infrastructure::Response` objects in the HTTP cache. They are associated with their original realm, but when we use a cached response, we clone it into the target realm. For example, two `<iframe>` objects loading the same HTML will be in different realms.

When we clone the response, we must use the target realm throughout the entire cloning process. We neglected to do this for the cloned response body stream, which is cloned via teeing. The result was the the stream for the "cloned" response was created in the original realm, causing issues down the line when reading from that stream tried to handle read promises on behalf of the original realm. There are protections in place to prevent this from happening, and the cached response read would never complete.

This lets us run speedometer with HTTP caching enabled.

No test on this one - it requires HTTP (not file:// like our tests use), and it requires HTTP caching to be enabled.