### PR TITLE
LibWeb: Load fonts with Fetch

### DIFF
--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -25,6 +25,13 @@ ErrorOr<NonnullRefPtr<Typeface>> Typeface::try_load_from_font_data(NonnullOwnPtr
     return typeface;
 }
 
+ErrorOr<NonnullRefPtr<Typeface>> Typeface::try_load_from_temporary_memory(ReadonlyBytes bytes, int ttc_index)
+{
+    auto buffer = TRY(ByteBuffer::copy(bytes));
+    auto font_data = FontData::create_from_byte_buffer(move(buffer));
+    return try_load_from_font_data(move(font_data), ttc_index);
+}
+
 ErrorOr<NonnullRefPtr<Typeface>> Typeface::try_load_from_externally_owned_memory(ReadonlyBytes bytes, int ttc_index)
 {
     return TypefaceSkia::load_from_buffer(bytes, ttc_index);

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -38,6 +38,7 @@ class Typeface : public RefCounted<Typeface> {
 public:
     static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_resource(Core::Resource const&, int ttc_index = 0);
     static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_font_data(NonnullOwnPtr<Gfx::FontData>, int ttc_index = 0);
+    static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_temporary_memory(ReadonlyBytes bytes, int ttc_index = 0);
     static ErrorOr<NonnullRefPtr<Typeface>> try_load_from_externally_owned_memory(ReadonlyBytes bytes, int ttc_index = 0);
 
     virtual ~Typeface();

--- a/Libraries/LibGfx/Font/WOFF/Loader.cpp
+++ b/Libraries/LibGfx/Font/WOFF/Loader.cpp
@@ -70,7 +70,7 @@ static u16 pow_2_less_than_or_equal(u16 x)
 
 ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_resource(Core::Resource const& resource, unsigned index)
 {
-    return try_load_from_externally_owned_memory(resource.data(), index);
+    return try_load_from_bytes(resource.data(), index);
 }
 
 using Uint8 = u8;
@@ -102,7 +102,7 @@ struct [[gnu::packed]] TableRecord {
 };
 static_assert(AssertSize<TableRecord, 16>());
 
-ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_externally_owned_memory(ReadonlyBytes buffer, unsigned int index)
+ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes buffer, unsigned int index)
 {
     FixedMemoryStream stream(buffer);
     auto header = TRY(stream.read_value<Header>());

--- a/Libraries/LibGfx/Font/WOFF/Loader.h
+++ b/Libraries/LibGfx/Font/WOFF/Loader.h
@@ -14,6 +14,6 @@
 namespace WOFF {
 
 ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_resource(Core::Resource const&, unsigned index = 0);
-ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_externally_owned_memory(ReadonlyBytes bytes, unsigned index = 0);
+ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes bytes, unsigned index = 0);
 
 }

--- a/Libraries/LibGfx/Font/WOFF2/Loader.cpp
+++ b/Libraries/LibGfx/Font/WOFF2/Loader.cpp
@@ -53,7 +53,7 @@ private:
     ByteBuffer& m_buffer;
 };
 
-ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_externally_owned_memory(ReadonlyBytes bytes)
+ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes bytes)
 {
     auto ttf_buffer = TRY(ByteBuffer::create_uninitialized(0));
     auto output = WOFF2ByteBufferOut { ttf_buffer };

--- a/Libraries/LibGfx/Font/WOFF2/Loader.h
+++ b/Libraries/LibGfx/Font/WOFF2/Loader.h
@@ -13,6 +13,6 @@
 
 namespace WOFF2 {
 
-ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_externally_owned_memory(ReadonlyBytes);
+ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_from_bytes(ReadonlyBytes);
 
 }

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -26,6 +26,7 @@ CSSFontFaceRule::CSSFontFaceRule(JS::Realm& realm, GC::Ref<CSSFontFaceDescriptor
     : CSSRule(realm, Type::FontFace)
     , m_style(style)
 {
+    m_style->set_parent_rule(*this);
 }
 
 void CSSFontFaceRule::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -116,7 +116,7 @@ void CSSImportRule::fetch()
     m_document_load_event_delayer.emplace(*m_document);
 
     // 4. Fetch a style resource from parsedUrl, with stylesheet parentStylesheet, destination "style", CORS mode "no-cors", and processResponse being the following steps given response response and byte stream, null or failure byteStream:
-    fetch_a_style_resource(parsed_url.value(), { parent_style_sheet }, Fetch::Infrastructure::Request::Destination::Style, CorsMode::NoCors,
+    (void)fetch_a_style_resource(parsed_url.value(), { parent_style_sheet }, Fetch::Infrastructure::Request::Destination::Style, CorsMode::NoCors,
         [strong_this = GC::Ref { *this }, parent_style_sheet = GC::Ref { parent_style_sheet }, parsed_url = parsed_url.value()](auto response, auto maybe_byte_stream) {
             // AD-HOC: Stop delaying the load event.
             ScopeGuard guard = [strong_this] {

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -156,7 +156,7 @@ void CSSImportRule::fetch()
             }
             auto decoded = decoded_or_error.release_value();
 
-            auto imported_style_sheet = parse_css_stylesheet(Parser::ParsingParams(*strong_this->m_document, parsed_url), decoded, parsed_url, strong_this->m_media_query_list);
+            auto imported_style_sheet = parse_css_stylesheet(Parser::ParsingParams(*strong_this->m_document), decoded, parsed_url, strong_this->m_media_query_list);
 
             // 5. Set importedStylesheet’s origin-clean flag to parentStylesheet’s origin-clean flag.
             imported_style_sheet->set_origin_clean(parent_style_sheet->is_origin_clean());

--- a/Libraries/LibWeb/CSS/Fetch.h
+++ b/Libraries/LibWeb/CSS/Fetch.h
@@ -25,7 +25,7 @@ using StyleResourceURL = Variant<::URL::URL, CSS::URL>;
 using StyleSheetOrDocument = Variant<GC::Ref<CSSStyleSheet>, GC::Ref<DOM::Document>>;
 
 // https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
-void fetch_a_style_resource(StyleResourceURL const& url, StyleSheetOrDocument, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
+WebIDL::ExceptionOr<GC::Ref<Fetch::Infrastructure::FetchController>> fetch_a_style_resource(StyleResourceURL const& url, StyleSheetOrDocument, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
 
 // https://drafts.csswg.org/css-images-4/#fetch-an-external-image-for-a-stylesheet
 GC::Ptr<HTML::SharedResourceRequest> fetch_an_external_image_for_a_stylesheet(StyleResourceURL const&, StyleSheetOrDocument);

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -483,6 +483,7 @@ GC::Ref<WebIDL::Promise> FontFace::load()
 
             // FIXME: The ParsedFontFace is kind of expensive to create. We should be using a shared sub-object for the data
             ParsedFontFace parsed_font_face {
+                nullptr,
                 font->m_family,
                 font->m_weight.to_number<int>(),
                 0,                      // FIXME: slope

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -63,7 +63,6 @@ GC_DEFINE_ALLOCATOR(FontFace);
 GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, FontFaceSource source, FontFaceDescriptors const& descriptors)
 {
     auto& vm = realm.vm();
-    auto base_url = HTML::relevant_settings_object(realm.global_object()).api_base_url();
 
     // 1. Let font face be a fresh FontFace object. Set font face’s status attribute to "unloaded",
     //    Set its internal [[FontStatusPromise]] slot to a fresh pending Promise object.
@@ -76,7 +75,7 @@ GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, Font
     //    set font face’s corresponding attributes to the empty string, and set font face’s status attribute to "error".
     //    Otherwise, set font face’s corresponding attributes to the serialization of the parsed values.
 
-    Parser::ParsingParams parsing_params { realm, base_url };
+    Parser::ParsingParams parsing_params { realm };
     auto try_parse_descriptor = [&parsing_params, &font_face, &realm](DescriptorID descriptor_id, String const& string) -> String {
         auto result = parse_css_descriptor(parsing_params, AtRuleID::FontFace, descriptor_id, string);
         if (!result) {

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -41,12 +41,12 @@ static NonnullRefPtr<Core::Promise<NonnullRefPtr<Gfx::Typeface const>>> load_vec
             promise->resolve(ttf.release_value());
             return;
         }
-        auto woff = WOFF::try_load_from_externally_owned_memory(data);
+        auto woff = WOFF::try_load_from_bytes(data);
         if (!woff.is_error()) {
             promise->resolve(woff.release_value());
             return;
         }
-        auto woff2 = WOFF2::try_load_from_externally_owned_memory(data);
+        auto woff2 = WOFF2::try_load_from_bytes(data);
         if (!woff2.is_error()) {
             promise->resolve(woff2.release_value());
             return;

--- a/Libraries/LibWeb/CSS/ParsedFontFace.cpp
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/CSS/CSSFontFaceDescriptors.h>
+#include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/ParsedFontFace.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
@@ -38,7 +39,7 @@ Vector<ParsedFontFace::Source> ParsedFontFace::sources_from_style_value(CSSStyle
             [&](FontSourceStyleValue::Local const& local) {
                 sources.empend(extract_font_name(local.name), OptionalNone {});
             },
-            [&](::URL::URL const& url) {
+            [&](URL const& url) {
                 // FIXME: tech()
                 sources.empend(url, font_source.format());
             });
@@ -171,6 +172,7 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
     }
 
     return ParsedFontFace {
+        descriptors.parent_rule()->parent_style_sheet(),
         move(font_family),
         move(weight),
         move(slope),
@@ -188,8 +190,9 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
     };
 }
 
-ParsedFontFace::ParsedFontFace(FlyString font_family, Optional<int> weight, Optional<int> slope, Optional<int> width, Vector<Source> sources, Vector<Gfx::UnicodeRange> unicode_ranges, Optional<Percentage> ascent_override, Optional<Percentage> descent_override, Optional<Percentage> line_gap_override, FontDisplay font_display, Optional<FlyString> font_named_instance, Optional<FlyString> font_language_override, Optional<OrderedHashMap<FlyString, i64>> font_feature_settings, Optional<OrderedHashMap<FlyString, double>> font_variation_settings)
-    : m_font_family(move(font_family))
+ParsedFontFace::ParsedFontFace(GC::Ptr<CSSStyleSheet> parent_style_sheet, FlyString font_family, Optional<int> weight, Optional<int> slope, Optional<int> width, Vector<Source> sources, Vector<Gfx::UnicodeRange> unicode_ranges, Optional<Percentage> ascent_override, Optional<Percentage> descent_override, Optional<Percentage> line_gap_override, FontDisplay font_display, Optional<FlyString> font_named_instance, Optional<FlyString> font_language_override, Optional<OrderedHashMap<FlyString, i64>> font_feature_settings, Optional<OrderedHashMap<FlyString, double>> font_variation_settings)
+    : m_parent_style_sheet(parent_style_sheet)
+    , m_font_family(move(font_family))
     , m_font_named_instance(move(font_named_instance))
     , m_weight(weight)
     , m_slope(slope)

--- a/Libraries/LibWeb/CSS/ParsedFontFace.h
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.h
@@ -10,16 +10,16 @@
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <LibGfx/Font/UnicodeRange.h>
-#include <LibURL/URL.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Percentage.h>
+#include <LibWeb/CSS/URL.h>
 
 namespace Web::CSS {
 
 class ParsedFontFace {
 public:
     struct Source {
-        Variant<FlyString, ::URL::URL> local_or_url;
+        Variant<FlyString, URL> local_or_url;
         // FIXME: Do we need to keep this around, or is it only needed to discard unwanted formats during parsing?
         Optional<FlyString> format;
     };
@@ -27,9 +27,10 @@ public:
     static Vector<Source> sources_from_style_value(CSSStyleValue const&);
     static ParsedFontFace from_descriptors(CSSFontFaceDescriptors const&);
 
-    ParsedFontFace(FlyString font_family, Optional<int> weight, Optional<int> slope, Optional<int> width, Vector<Source> sources, Vector<Gfx::UnicodeRange> unicode_ranges, Optional<Percentage> ascent_override, Optional<Percentage> descent_override, Optional<Percentage> line_gap_override, FontDisplay font_display, Optional<FlyString> font_named_instance, Optional<FlyString> font_language_override, Optional<OrderedHashMap<FlyString, i64>> font_feature_settings, Optional<OrderedHashMap<FlyString, double>> font_variation_settings);
+    ParsedFontFace(GC::Ptr<CSSStyleSheet> parent_style_sheet, FlyString font_family, Optional<int> weight, Optional<int> slope, Optional<int> width, Vector<Source> sources, Vector<Gfx::UnicodeRange> unicode_ranges, Optional<Percentage> ascent_override, Optional<Percentage> descent_override, Optional<Percentage> line_gap_override, FontDisplay font_display, Optional<FlyString> font_named_instance, Optional<FlyString> font_language_override, Optional<OrderedHashMap<FlyString, i64>> font_feature_settings, Optional<OrderedHashMap<FlyString, double>> font_variation_settings);
     ~ParsedFontFace() = default;
 
+    GC::Ptr<CSSStyleSheet> parent_style_sheet() const { return m_parent_style_sheet; }
     Optional<Percentage> ascent_override() const { return m_ascent_override; }
     Optional<Percentage> descent_override() const { return m_descent_override; }
     FontDisplay font_display() const { return m_font_display; }
@@ -46,6 +47,7 @@ public:
     Vector<Gfx::UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
 
 private:
+    GC::Ptr<CSSStyleSheet> m_parent_style_sheet;
     FlyString m_font_family;
     Optional<FlyString> m_font_named_instance;
     Optional<int> m_weight;

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -45,25 +45,9 @@ ParsingParams::ParsingParams(JS::Realm& realm, ParsingMode mode)
 {
 }
 
-ParsingParams::ParsingParams(JS::Realm& realm, ::URL::URL url, ParsingMode mode)
-    : realm(realm)
-    , url(move(url))
-    , mode(mode)
-{
-}
-
-ParsingParams::ParsingParams(DOM::Document const& document, ::URL::URL url, ParsingMode mode)
-    : realm(const_cast<JS::Realm&>(document.realm()))
-    , document(&document)
-    , url(move(url))
-    , mode(mode)
-{
-}
-
 ParsingParams::ParsingParams(DOM::Document const& document, ParsingMode mode)
     : realm(const_cast<JS::Realm&>(document.realm()))
     , document(&document)
-    , url(document.url())
     , mode(mode)
 {
 }
@@ -77,7 +61,6 @@ Parser Parser::create(ParsingParams const& context, StringView input, StringView
 Parser::Parser(ParsingParams const& context, Vector<Token> tokens)
     : m_document(context.document)
     , m_realm(context.realm)
-    , m_url(context.url)
     , m_parsing_mode(context.mode)
     , m_tokens(move(tokens))
     , m_token_stream(m_tokens)
@@ -1862,15 +1845,6 @@ bool Parser::in_quirks_mode() const
 bool Parser::is_parsing_svg_presentation_attribute() const
 {
     return m_parsing_mode == ParsingMode::SVGPresentationAttribute;
-}
-
-// https://www.w3.org/TR/css-values-4/#relative-urls
-// FIXME: URLs shouldn't be completed during parsing, but when used.
-Optional<::URL::URL> Parser::complete_url(StringView relative_url) const
-{
-    if (!m_url.has_value())
-        return ::URL::Parser::basic_parse(relative_url);
-    return m_url->complete_url(relative_url);
 }
 
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -71,13 +71,10 @@ enum class ParsingMode {
 struct ParsingParams {
     explicit ParsingParams(ParsingMode = ParsingMode::Normal);
     explicit ParsingParams(JS::Realm&, ParsingMode = ParsingMode::Normal);
-    explicit ParsingParams(JS::Realm&, ::URL::URL, ParsingMode = ParsingMode::Normal);
-    explicit ParsingParams(DOM::Document const&, ::URL::URL, ParsingMode = ParsingMode::Normal);
     explicit ParsingParams(DOM::Document const&, ParsingMode = ParsingMode::Normal);
 
     GC::Ptr<JS::Realm> realm;
     GC::Ptr<DOM::Document const> document;
-    ::URL::URL url;
     ParsingMode mode { ParsingMode::Normal };
 
     Vector<RuleContext> rule_context;
@@ -479,11 +476,9 @@ private:
     JS::Realm& realm() const;
     bool in_quirks_mode() const;
     bool is_parsing_svg_presentation_attribute() const;
-    Optional<::URL::URL> complete_url(StringView) const;
 
     GC::Ptr<DOM::Document const> m_document;
     GC::Ptr<JS::Realm> m_realm;
-    Optional<::URL::URL> m_url;
     ParsingMode m_parsing_mode { ParsingMode::Normal };
 
     Vector<Token> m_tokens;

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -3813,10 +3813,6 @@ RefPtr<FontSourceStyleValue const> Parser::parse_font_source_value(TokenStream<C
     auto url = parse_url_function(tokens);
     if (!url.has_value())
         return nullptr;
-    // FIXME: Stop completing the URL here
-    auto completed_url = complete_url(url->url());
-    if (!completed_url.has_value())
-        return nullptr;
 
     Optional<FlyString> format;
 
@@ -3859,7 +3855,7 @@ RefPtr<FontSourceStyleValue const> Parser::parse_font_source_value(TokenStream<C
     // FIXME: [ tech( <font-tech>#)]?
 
     transaction.commit();
-    return FontSourceStyleValue::create(completed_url.release_value(), move(format));
+    return FontSourceStyleValue::create(url.release_value(), move(format));
 }
 
 NonnullRefPtr<CSSStyleValue const> Parser::resolve_unresolved_style_value(ParsingParams const& context, DOM::Element& element, Optional<PseudoElement> pseudo_element, PropertyID property_id, UnresolvedStyleValue const& unresolved)

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -274,12 +274,12 @@ ErrorOr<NonnullRefPtr<Gfx::Typeface const>> FontLoader::try_load_font()
             }
         }
         if (mime_type->essence() == "font/woff"sv || mime_type->essence() == "application/font-woff"sv) {
-            if (auto result = WOFF::try_load_from_externally_owned_memory(resource()->encoded_data()); !result.is_error()) {
+            if (auto result = WOFF::try_load_from_bytes(resource()->encoded_data()); !result.is_error()) {
                 return result;
             }
         }
         if (mime_type->essence() == "font/woff2"sv || mime_type->essence() == "application/font-woff2"sv) {
-            if (auto result = WOFF2::try_load_from_externally_owned_memory(resource()->encoded_data()); !result.is_error()) {
+            if (auto result = WOFF2::try_load_from_bytes(resource()->encoded_data()); !result.is_error()) {
                 return result;
             }
         }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -315,7 +315,7 @@ private:
 
 class FontLoader : public Weakable<FontLoader> {
 public:
-    FontLoader(StyleComputer& style_computer, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<::URL::URL> urls, ESCAPING Function<void(RefPtr<Gfx::Typeface const>)> on_load = {});
+    FontLoader(StyleComputer& style_computer, GC::Ptr<CSSStyleSheet> parent_style_sheet, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<URL> urls, ESCAPING Function<void(RefPtr<Gfx::Typeface const>)> on_load = {});
 
     virtual ~FontLoader();
 
@@ -333,10 +333,11 @@ private:
     void font_did_load_or_fail(RefPtr<Gfx::Typeface const>);
 
     StyleComputer& m_style_computer;
+    GC::Ptr<CSSStyleSheet> m_parent_style_sheet;
     FlyString m_family_name;
     Vector<Gfx::UnicodeRange> m_unicode_ranges;
     RefPtr<Gfx::Typeface const> m_vector_font;
-    Vector<::URL::URL> m_urls;
+    Vector<URL> m_urls;
     GC::Root<Fetch::Infrastructure::FetchController> m_fetch_controller;
     Function<void(RefPtr<Gfx::Typeface const>)> m_on_load;
 };

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -174,7 +174,7 @@ public:
 
     void did_load_font(FlyString const& family_name);
 
-    Optional<FontLoader&> load_font_face(ParsedFontFace const&, ESCAPING Function<void(FontLoader const&)> on_load = {}, ESCAPING Function<void()> on_fail = {});
+    Optional<FontLoader&> load_font_face(ParsedFontFace const&, ESCAPING Function<void(RefPtr<Gfx::Typeface const>)> on_load = {});
 
     void load_fonts_from_sheet(CSSStyleSheet&);
     void unload_fonts_from_sheet(CSSStyleSheet&);
@@ -313,11 +313,11 @@ private:
     CountingBloomFilter<u8, 14> m_ancestor_filter;
 };
 
-class FontLoader : public ResourceClient {
+class FontLoader : public Weakable<FontLoader> {
 public:
-    FontLoader(StyleComputer& style_computer, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<::URL::URL> urls, ESCAPING Function<void(FontLoader const&)> on_load = {}, ESCAPING Function<void()> on_fail = {});
+    FontLoader(StyleComputer& style_computer, FlyString family_name, Vector<Gfx::UnicodeRange> unicode_ranges, Vector<::URL::URL> urls, ESCAPING Function<void(RefPtr<Gfx::Typeface const>)> on_load = {});
 
-    virtual ~FontLoader() override;
+    virtual ~FontLoader();
 
     Vector<Gfx::UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
     RefPtr<Gfx::Typeface const> vector_font() const { return m_vector_font; }
@@ -325,24 +325,20 @@ public:
     RefPtr<Gfx::Font const> font_with_point_size(float point_size);
     void start_loading_next_url();
 
-    bool is_loading() const { return resource() && resource()->is_pending(); }
+    bool is_loading() const;
 
 private:
-    // ^ResourceClient
-    virtual void resource_did_load() override;
-    virtual void resource_did_fail() override;
+    ErrorOr<NonnullRefPtr<Gfx::Typeface const>> try_load_font(Fetch::Infrastructure::Response const&, ByteBuffer const&);
 
-    void resource_did_load_or_fail();
-
-    ErrorOr<NonnullRefPtr<Gfx::Typeface const>> try_load_font();
+    void font_did_load_or_fail(RefPtr<Gfx::Typeface const>);
 
     StyleComputer& m_style_computer;
     FlyString m_family_name;
     Vector<Gfx::UnicodeRange> m_unicode_ranges;
     RefPtr<Gfx::Typeface const> m_vector_font;
     Vector<::URL::URL> m_urls;
-    Function<void(FontLoader const&)> m_on_load;
-    Function<void()> m_on_fail;
+    GC::Root<Fetch::Infrastructure::FetchController> m_fetch_controller;
+    Function<void(RefPtr<Gfx::Typeface const>)> m_on_load;
 };
 
 inline bool StyleComputer::should_reject_with_ancestor_filter(Selector const& selector) const

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -78,7 +78,6 @@ GC::Ref<CSSStyleSheet> StyleSheetList::create_a_css_style_sheet(String const& cs
     sheet->set_title(move(title));
     sheet->set_alternate(alternate == Alternate::Yes);
     sheet->set_origin_clean(origin_clean == OriginClean::Yes);
-    sheet->set_location(move(location));
 
     // 2. Then run the add a CSS style sheet steps for the newly created CSS style sheet.
     add_a_css_style_sheet(*sheet);

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -68,7 +68,7 @@ GC::Ref<CSSStyleSheet> StyleSheetList::create_a_css_style_sheet(String const& cs
     // AD-HOC: The spec never tells us when to parse this style sheet, but the most logical place is here.
     // AD-HOC: Are we supposed to use the document's URL for the stylesheet's location during parsing? Not doing it breaks things.
     auto location_url = location.value_or(document().url());
-    auto sheet = parse_css_stylesheet(Parser::ParsingParams { document(), location_url }, css_text, location_url);
+    auto sheet = parse_css_stylesheet(Parser::ParsingParams { document() }, css_text, location_url);
 
     sheet->set_parent_css_style_sheet(parent_style_sheet);
     sheet->set_owner_css_rule(owner_rule);

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -66,9 +66,7 @@ GC::Ref<CSSStyleSheet> StyleSheetList::create_a_css_style_sheet(String const& cs
 {
     // 1. Create a new CSS style sheet object and set its properties as specified.
     // AD-HOC: The spec never tells us when to parse this style sheet, but the most logical place is here.
-    // AD-HOC: Are we supposed to use the document's URL for the stylesheet's location during parsing? Not doing it breaks things.
-    auto location_url = location.value_or(document().url());
-    auto sheet = parse_css_stylesheet(Parser::ParsingParams { document() }, css_text, location_url);
+    auto sheet = parse_css_stylesheet(Parser::ParsingParams { document() }, css_text, location);
 
     sheet->set_parent_css_style_sheet(parent_style_sheet);
     sheet->set_owner_css_rule(owner_rule);

--- a/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.cpp
@@ -34,11 +34,11 @@ String FontSourceStyleValue::to_string(SerializationMode) const
             builder.append(')');
             return builder.to_string_without_validation();
         },
-        [this](::URL::URL const& url) {
+        [this](URL const& url) {
             // <url> [ format(<font-format>)]? [ tech( <font-tech>#)]?
             // FIXME: tech()
             StringBuilder builder;
-            serialize_a_url(builder, url.to_string());
+            builder.append(url.to_string());
 
             if (m_format.has_value()) {
                 builder.append(" format("sv);
@@ -59,8 +59,8 @@ bool FontSourceStyleValue::properties_equal(FontSourceStyleValue const& other) c
             }
             return false;
         },
-        [&other](::URL::URL const& url) {
-            if (auto* other_url = other.m_source.get_pointer<::URL::URL>()) {
+        [&other](URL const& url) {
+            if (auto* other_url = other.m_source.get_pointer<URL>()) {
                 return url == *other_url;
             }
             return false;

--- a/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FontSourceStyleValue.h
@@ -8,6 +8,7 @@
 
 #include <AK/FlyString.h>
 #include <LibWeb/CSS/CSSStyleValue.h>
+#include <LibWeb/CSS/URL.h>
 
 namespace Web::CSS {
 
@@ -16,7 +17,7 @@ public:
     struct Local {
         NonnullRefPtr<CSSStyleValue const> name;
     };
-    using Source = Variant<Local, ::URL::URL>;
+    using Source = Variant<Local, URL>;
 
     static ValueComparingNonnullRefPtr<FontSourceStyleValue const> create(Source source, Optional<FlyString> format)
     {

--- a/Libraries/LibWeb/CSS/URL.h
+++ b/Libraries/LibWeb/CSS/URL.h
@@ -25,3 +25,11 @@ private:
 };
 
 }
+
+template<>
+struct AK::Formatter<Web::CSS::URL> : AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::CSS::URL const& value)
+    {
+        return Formatter<StringView>::format(builder, value.to_string());
+    }
+};

--- a/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -84,7 +84,8 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
             : String {},
         CSS::StyleSheetList::Alternate::No,
         CSS::StyleSheetList::OriginClean::Yes,
-        {},
+        // AD-HOC: Use the document's base URL as the location instead. Spec issue: https://github.com/whatwg/html/issues/11281
+        style_element.document().base_url(),
         nullptr,
         nullptr);
 

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -728,12 +728,15 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
 
     indent(builder, indent_levels + 1);
     builder.append("sources:\n"sv);
-    for (auto const& source : font_face.sources()) {
+    for (auto const& [local_or_url, format] : font_face.sources()) {
         indent(builder, indent_levels + 2);
-        if (source.local_or_url.has<URL::URL>())
-            builder.appendff("url={}, format={}\n", source.local_or_url.get<URL::URL>(), source.format.value_or("???"_string));
-        else
-            builder.appendff("local={}\n", source.local_or_url.get<FlyString>());
+        local_or_url.visit(
+            [&builder, &format](CSS::URL const& url) {
+                builder.appendff("url={}, format={}\n", url, format.value_or("???"_string));
+            },
+            [&builder](FlyString const& local) {
+                builder.appendff("local={}\n", local);
+            });
     }
 
     indent(builder, indent_levels + 1);

--- a/Meta/Lagom/Fuzzers/FuzzWOFF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWOFF.cpp
@@ -10,6 +10,6 @@
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
     AK::set_debug_enabled(false);
-    (void)WOFF::try_load_from_externally_owned_memory({ data, size });
+    (void)WOFF::try_load_from_bytes({ data, size });
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzWOFF2.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWOFF2.cpp
@@ -10,6 +10,6 @@
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
     AK::set_debug_enabled(false);
-    (void)WOFF2::try_load_from_externally_owned_memory({ data, size });
+    (void)WOFF2::try_load_from_bytes({ data, size });
     return 0;
 }

--- a/Tests/LibGfx/TestWOFF.cpp
+++ b/Tests/LibGfx/TestWOFF.cpp
@@ -17,7 +17,7 @@ TEST_CASE(malformed_woff)
 
     for (auto test_input : test_inputs) {
         auto file = MUST(Core::MappedFile::map(test_input));
-        auto font_or_error = WOFF::try_load_from_externally_owned_memory(file->bytes());
+        auto font_or_error = WOFF::try_load_from_bytes(file->bytes());
         EXPECT(font_or_error.is_error());
     }
 }

--- a/Tests/LibGfx/TestWOFF2.cpp
+++ b/Tests/LibGfx/TestWOFF2.cpp
@@ -23,7 +23,7 @@ struct Global {
 TEST_CASE(tolerate_incorrect_sfnt_size)
 {
     auto file = MUST(Core::MappedFile::map(TEST_INPUT("woff2/incorrect_sfnt_size.woff2"sv)));
-    auto font = TRY_OR_FAIL(WOFF2::try_load_from_externally_owned_memory(file->bytes()));
+    auto font = TRY_OR_FAIL(WOFF2::try_load_from_bytes(file->bytes()));
     EXPECT_EQ(font->family(), "Test"_string);
     EXPECT_EQ(font->glyph_count(), 4u);
 }
@@ -37,7 +37,7 @@ TEST_CASE(malformed_woff2)
 
     for (auto test_input : test_inputs) {
         auto file = MUST(Core::MappedFile::map(test_input));
-        auto font_or_error = WOFF2::try_load_from_externally_owned_memory(file->bytes());
+        auto font_or_error = WOFF2::try_load_from_bytes(file->bytes());
         EXPECT(font_or_error.is_error());
     }
 }


### PR DESCRIPTION
Fonts are the last place we were using the old, wrong, URL-resolution in the CSS parser. In order to fix that I also had to convert our font loader to use fetch, so that's another tick on the list in #2634!