### PR TITLE
LibWeb: Two DOMMatrix CSS parser fixes

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -370,7 +370,7 @@ Parser::ParseErrorOr<NonnullRefPtr<CSSStyleValue const>> Parser::parse_css_value
 
         if (token.is(Token::Type::Semicolon)) {
             unprocessed_tokens.reconsume_current_input_token();
-            break;
+            return ParseError::SyntaxError;
         }
 
         if (property_id != PropertyID::Custom) {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/geometry/DOMMatrix-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/geometry/DOMMatrix-001.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 126 tests
 
-122 Pass
-4 Fail
+124 Pass
+2 Fail
 Pass	new DOMMatrix()
 Pass	new DOMMatrix(undefined)
 Pass	new DOMMatrix(new DOMMatrix())
@@ -23,7 +23,7 @@ Pass	new DOMMatrix(sequence) 6 elements
 Pass	new DOMMatrix("scale(2) translateX(5px) translateY(5px)")
 Pass	new DOMMatrix("scale(2, 2) translateX(5px) translateY(5px)")
 Pass	new DOMMatrix("scale(2)translateX(5px)translateY(5px)")
-Fail	new DOMMatrix("scale(2) translateX(calc(2 * 2.5px)) translateY(5px)")
+Pass	new DOMMatrix("scale(2) translateX(calc(2 * 2.5px)) translateY(5px)")
 Pass	new DOMMatrix("scale(2) translateX(5px) translateY(5px) rotate(5deg) rotate(-5deg)")
 Pass	new DOMMatrix("translateX    (5px)")
 Pass	new DOMMatrix("scale(2 2) translateX(5) translateY(5)")
@@ -86,7 +86,7 @@ Pass	new DOMMatrixReadOnly(sequence) 6 elements
 Pass	new DOMMatrixReadOnly("scale(2) translateX(5px) translateY(5px)")
 Pass	new DOMMatrixReadOnly("scale(2, 2) translateX(5px) translateY(5px)")
 Pass	new DOMMatrixReadOnly("scale(2)translateX(5px)translateY(5px)")
-Fail	new DOMMatrixReadOnly("scale(2) translateX(calc(2 * 2.5px)) translateY(5px)")
+Pass	new DOMMatrixReadOnly("scale(2) translateX(calc(2 * 2.5px)) translateY(5px)")
 Pass	new DOMMatrixReadOnly("scale(2) translateX(5px) translateY(5px) rotate(5deg) rotate(-5deg)")
 Pass	new DOMMatrixReadOnly("translateX    (5px)")
 Pass	new DOMMatrixReadOnly("scale(2 2) translateX(5) translateY(5)")

--- a/Tests/LibWeb/Text/expected/wpt-import/css/geometry/DOMMatrix-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/geometry/DOMMatrix-001.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 126 tests
 
-124 Pass
-2 Fail
+126 Pass
 Pass	new DOMMatrix()
 Pass	new DOMMatrix(undefined)
 Pass	new DOMMatrix(new DOMMatrix())
@@ -53,7 +52,7 @@ Pass	new DOMMatrix(" ")
 Pass	new DOMMatrix("/**/")
 Pass	new DOMMatrix("\0")
 Pass	new DOMMatrix(";")
-Fail	new DOMMatrix("none;")
+Pass	new DOMMatrix("none;")
 Pass	new DOMMatrix("null")
 Pass	new DOMMatrix(null)
 Pass	new DOMMatrix("undefined")
@@ -116,7 +115,7 @@ Pass	new DOMMatrixReadOnly(" ")
 Pass	new DOMMatrixReadOnly("/**/")
 Pass	new DOMMatrixReadOnly("\0")
 Pass	new DOMMatrixReadOnly(";")
-Fail	new DOMMatrixReadOnly("none;")
+Pass	new DOMMatrixReadOnly("none;")
 Pass	new DOMMatrixReadOnly("null")
 Pass	new DOMMatrixReadOnly(null)
 Pass	new DOMMatrixReadOnly("undefined")


### PR DESCRIPTION
Here are two small CSS parser fixes that improve the DOMMatrix string constructor. It also fixes the last 4 fails on http://wpt.live/css/geometry/DOMMatrix-001.html

I've also rearranged the code in `Transformation.cpp` to be in the same order as the `TransformValue` variant