### PR TITLE
LibJS: Optimize array destructuring assignment for builtin iterators

### DIFF
--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -51,7 +51,6 @@
     O(EnterObjectEnvironment)          \
     O(EnterUnwindContext)              \
     O(Exp)                             \
-    O(ForOfNext)                       \
     O(GetById)                         \
     O(GetByIdWithThis)                 \
     O(GetByValue)                      \
@@ -81,6 +80,7 @@
     O(InstanceOf)                      \
     O(IteratorClose)                   \
     O(IteratorNext)                    \
+    O(IteratorNextUnpack)              \
     O(IteratorToArray)                 \
     O(Jump)                            \
     O(JumpFalse)                       \

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -612,7 +612,6 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(Dump);
             HANDLE_INSTRUCTION(EnterObjectEnvironment);
             HANDLE_INSTRUCTION(Exp);
-            HANDLE_INSTRUCTION(ForOfNext);
             HANDLE_INSTRUCTION(GetById);
             HANDLE_INSTRUCTION(GetByIdWithThis);
             HANDLE_INSTRUCTION(GetByValue);
@@ -642,6 +641,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(InstanceOf);
             HANDLE_INSTRUCTION(IteratorClose);
             HANDLE_INSTRUCTION(IteratorNext);
+            HANDLE_INSTRUCTION(IteratorNextUnpack);
             HANDLE_INSTRUCTION(IteratorToArray);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(LeaveFinally);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(LeaveLexicalEnvironment);
@@ -2982,7 +2982,7 @@ ThrowCompletionOr<void> IteratorNext::execute_impl(Bytecode::Interpreter& interp
     return {};
 }
 
-ThrowCompletionOr<void> ForOfNext::execute_impl(Bytecode::Interpreter& interpreter) const
+ThrowCompletionOr<void> IteratorNextUnpack::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
     auto& iterator_record = static_cast<IteratorRecord&>(interpreter.get(m_iterator_record).as_cell());
@@ -3777,9 +3777,9 @@ ByteString IteratorNext::to_byte_string_impl(Executable const& executable) const
         format_operand("iterator_record"sv, m_iterator_record, executable));
 }
 
-ByteString ForOfNext::to_byte_string_impl(Executable const& executable) const
+ByteString IteratorNextUnpack::to_byte_string_impl(Executable const& executable) const
 {
-    return ByteString::formatted("ForOfNext {}, {}, {}",
+    return ByteString::formatted("IteratorNextUnpack {}, {}, {}",
         format_operand("dst_value"sv, m_dst_value, executable),
         format_operand("dst_done"sv, m_dst_done, executable),
         format_operand("iterator_record"sv, m_iterator_record, executable));

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -2721,10 +2721,10 @@ private:
     Operand m_iterator_record;
 };
 
-class ForOfNext final : public Instruction {
+class IteratorNextUnpack final : public Instruction {
 public:
-    ForOfNext(Operand dst_value, Operand dst_done, Operand iterator_record)
-        : Instruction(Type::ForOfNext)
+    IteratorNextUnpack(Operand dst_value, Operand dst_done, Operand iterator_record)
+        : Instruction(Type::IteratorNextUnpack)
         , m_dst_value(dst_value)
         , m_dst_done(dst_done)
         , m_iterator_record(iterator_record)


### PR DESCRIPTION
...by avoiding `{ value, done }` iterator result value allocation. This change applies the same otimization 81b6a11 added for `for..in` and `for..of`.

Makes following micro benchmark go 22% faster on my computer:
```js
function f() {
    const arr = [];
    for (let i = 0; i < 10_000_000; i++) {
        arr.push([i]);
    }
    let sum = 0;
    for (let [i] of arr) {
        sum += i;
    }
}

f();
```