### PR TITLE
LibJS: Skip "return" method call while closing built-in iterators

### DIFF
--- a/Libraries/LibJS/Runtime/Iterator.cpp
+++ b/Libraries/LibJS/Runtime/Iterator.cpp
@@ -271,6 +271,10 @@ static Completion iterator_close_impl(VM& vm, IteratorRecord const& iterator_rec
     // 2. Let iterator be iteratorRecord.[[Iterator]].
     auto iterator = iterator_record.iterator;
 
+    // OPTIMIZATION: "return" method is not defined on any of iterators we treat as built-in.
+    if (iterator->as_builtin_iterator())
+        return completion;
+
     // 3. Let innerResult be Completion(GetMethod(iterator, "return")).
     auto inner_result = ThrowCompletionOr<Value> { js_undefined() };
     auto get_method_result = Value(iterator).get_method(vm, vm.names.return_);


### PR DESCRIPTION
"return" method is not defined on any of builtin iterators, so we could skip it, avoiding method lookup.

I measured 10% improvement in array-destructuring-assignment.js micro benchmark with this change.