### PR TITLE
LibWeb+UI: Implement remaining `navigator.clipboard` APIs

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     Clipboard/Clipboard.cpp
     Clipboard/ClipboardEvent.cpp
     Clipboard/ClipboardItem.cpp
+    Clipboard/SystemClipboard.cpp
     Compression/CompressionStream.cpp
     Compression/DecompressionStream.cpp
     ContentSecurityPolicy/Directives/Directive.cpp

--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -167,10 +167,10 @@ GC::Ref<WebIDL::Promise> Clipboard::write_text(String data)
             return;
         }
 
-        // 1. Queue a global task on the clipboard task source, given realm’s global object, to perform the below steps:
+        // 3. Queue a global task on the clipboard task source, given realm’s global object, to perform the below steps:
         queue_global_task(HTML::Task::Source::Clipboard, realm.global_object(), GC::create_function(realm.heap(), [&realm, promise, data = move(data)]() mutable {
             // 1. Let itemList be an empty sequence<Blob>.
-            Vector<GC::Ref<FileAPI::Blob>> item_list;
+            GC::RootVector<GC::Ref<FileAPI::Blob>> item_list(realm.heap());
 
             // 2. Let textBlob be a new Blob created with: type attribute set to "text/plain;charset=utf-8", and its
             //    underlying byte sequence set to the UTF-8 encoding of data.

--- a/Libraries/LibWeb/Clipboard/Clipboard.h
+++ b/Libraries/LibWeb/Clipboard/Clipboard.h
@@ -15,6 +15,11 @@
 
 namespace Web::Clipboard {
 
+struct ClipboardUnsanitizedFormats {
+    // FIXME: This should not actually be an Optional, but the IDL generator creates it as such.
+    Optional<Vector<String>> unsanitized;
+};
+
 class Clipboard final : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(Clipboard, DOM::EventTarget);
     GC_DECLARE_ALLOCATOR(Clipboard);
@@ -23,6 +28,7 @@ public:
     static WebIDL::ExceptionOr<GC::Ref<Clipboard>> construct_impl(JS::Realm&);
     virtual ~Clipboard() override;
 
+    GC::Ref<WebIDL::Promise> read(ClipboardUnsanitizedFormats formats = {});
     GC::Ref<WebIDL::Promise> read_text();
 
     GC::Ref<WebIDL::Promise> write(GC::RootVector<GC::Root<ClipboardItem>>&);

--- a/Libraries/LibWeb/Clipboard/Clipboard.h
+++ b/Libraries/LibWeb/Clipboard/Clipboard.h
@@ -25,6 +25,7 @@ public:
 
     GC::Ref<WebIDL::Promise> read_text();
 
+    GC::Ref<WebIDL::Promise> write(GC::RootVector<GC::Root<ClipboardItem>>&);
     GC::Ref<WebIDL::Promise> write_text(String);
 
 private:

--- a/Libraries/LibWeb/Clipboard/Clipboard.h
+++ b/Libraries/LibWeb/Clipboard/Clipboard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,6 +22,8 @@ class Clipboard final : public DOM::EventTarget {
 public:
     static WebIDL::ExceptionOr<GC::Ref<Clipboard>> construct_impl(JS::Realm&);
     virtual ~Clipboard() override;
+
+    GC::Ref<WebIDL::Promise> read_text();
 
     GC::Ref<WebIDL::Promise> write_text(String);
 

--- a/Libraries/LibWeb/Clipboard/Clipboard.idl
+++ b/Libraries/LibWeb/Clipboard/Clipboard.idl
@@ -6,8 +6,12 @@ typedef sequence<ClipboardItem> ClipboardItems;
 // https://w3c.github.io/clipboard-apis/#clipboard
 [SecureContext, Exposed=Window]
 interface Clipboard : EventTarget {
-    [FIXME] Promise<ClipboardItems> read();
+    Promise<ClipboardItems> read(optional ClipboardUnsanitizedFormats formats = {});
     Promise<DOMString> readText();
     Promise<undefined> write(ClipboardItems data);
     Promise<undefined> writeText(DOMString data);
+};
+
+dictionary ClipboardUnsanitizedFormats {
+    sequence<DOMString> unsanitized;
 };

--- a/Libraries/LibWeb/Clipboard/Clipboard.idl
+++ b/Libraries/LibWeb/Clipboard/Clipboard.idl
@@ -1,12 +1,13 @@
+#import <Clipboard/ClipboardItem.idl>
 #import <DOM/EventTarget.idl>
 
-// FIXME: typedef sequence<ClipboardItem> ClipboardItems;
+typedef sequence<ClipboardItem> ClipboardItems;
 
 // https://w3c.github.io/clipboard-apis/#clipboard
 [SecureContext, Exposed=Window]
 interface Clipboard : EventTarget {
     [FIXME] Promise<ClipboardItems> read();
     Promise<DOMString> readText();
-    [FIXME] Promise<undefined> write(ClipboardItems data);
+    Promise<undefined> write(ClipboardItems data);
     Promise<undefined> writeText(DOMString data);
 };

--- a/Libraries/LibWeb/Clipboard/Clipboard.idl
+++ b/Libraries/LibWeb/Clipboard/Clipboard.idl
@@ -6,7 +6,7 @@
 [SecureContext, Exposed=Window]
 interface Clipboard : EventTarget {
     [FIXME] Promise<ClipboardItems> read();
-    [FIXME] Promise<DOMString> readText();
+    Promise<DOMString> readText();
     [FIXME] Promise<undefined> write(ClipboardItems data);
     Promise<undefined> writeText(DOMString data);
 };

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.cpp
@@ -89,6 +89,12 @@ WebIDL::ExceptionOr<GC::Ref<ClipboardItem>> ClipboardItem::construct_impl(JS::Re
     return clipboard_item;
 }
 
+void ClipboardItem::append_representation(Representation representation)
+{
+    m_types.append(representation.mime_type);
+    m_representations.append(move(representation));
+}
+
 // https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype
 WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> ClipboardItem::get_type(String const& type)
 {

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.h
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.h
@@ -18,7 +18,8 @@ namespace Web::Clipboard {
 
 constexpr auto WEB_CUSTOM_FORMAT_PREFIX = "web "sv;
 
-inline constexpr Array MANDATORY_DATA_TYPES = {
+// https://w3c.github.io/clipboard-apis/#mandatory-data-types
+constexpr inline Array MANDATORY_DATA_TYPES = {
     "text/plain"sv, "text/html"sv, "image/png"sv
 };
 
@@ -45,6 +46,7 @@ public:
     Bindings::PresentationStyle presentation_style() const { return m_presentation_style; }
 
     Vector<String> const& types() const { return m_types; }
+    Vector<Representation> const& representations() const { return m_representations; }
 
     WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> get_type(String const& type);
 

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.h
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.h
@@ -34,7 +34,7 @@ class ClipboardItem : public Bindings::PlatformObject {
 public:
     struct Representation {
         String mime_type;              // The MIME type (e.g., "text/plain").
-        bool is_custom;                // Whether this is a web custom format.
+        bool is_custom { false };      // Whether this is a web custom format.
         GC::Ref<WebIDL::Promise> data; // The actual data for this representation.
     };
 

--- a/Libraries/LibWeb/Clipboard/ClipboardItem.h
+++ b/Libraries/LibWeb/Clipboard/ClipboardItem.h
@@ -46,7 +46,9 @@ public:
     Bindings::PresentationStyle presentation_style() const { return m_presentation_style; }
 
     Vector<String> const& types() const { return m_types; }
+
     Vector<Representation> const& representations() const { return m_representations; }
+    void append_representation(Representation);
 
     WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> get_type(String const& type);
 

--- a/Libraries/LibWeb/Clipboard/SystemClipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/SystemClipboard.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::Clipboard::SystemClipboardRepresentation const& output)
+{
+    TRY(encoder.encode(output.data));
+    TRY(encoder.encode(output.mime_type));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Clipboard::SystemClipboardRepresentation> IPC::decode(Decoder& decoder)
+{
+    auto data = TRY(decoder.decode<ByteString>());
+    auto mime_type = TRY(decoder.decode<String>());
+
+    return Web::Clipboard::SystemClipboardRepresentation { move(data), move(mime_type) };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::Clipboard::SystemClipboardItem const& output)
+{
+    TRY(encoder.encode(output.system_clipboard_representations));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Clipboard::SystemClipboardItem> IPC::decode(Decoder& decoder)
+{
+    auto system_clipboard_representation = TRY(decoder.decode<Vector<Web::Clipboard::SystemClipboardRepresentation>>());
+
+    return Web::Clipboard::SystemClipboardItem { move(system_clipboard_representation) };
+}

--- a/Libraries/LibWeb/Clipboard/SystemClipboard.h
+++ b/Libraries/LibWeb/Clipboard/SystemClipboard.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibIPC/Forward.h>
+
+namespace Web::Clipboard {
+
+// https://w3c.github.io/clipboard-apis/#system-clipboard-representation
+struct SystemClipboardRepresentation {
+    ByteString data;
+    String mime_type;
+};
+
+// https://w3c.github.io/clipboard-apis/#system-clipboard-item
+struct SystemClipboardItem {
+    Vector<SystemClipboardRepresentation> system_clipboard_representations;
+};
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::Clipboard::SystemClipboardRepresentation const&);
+
+template<>
+ErrorOr<Web::Clipboard::SystemClipboardRepresentation> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::Clipboard::SystemClipboardItem const&);
+
+template<>
+ErrorOr<Web::Clipboard::SystemClipboardItem> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -92,6 +92,9 @@ enum class XMLHttpRequestResponseType : u8;
 namespace Web::Clipboard {
 class Clipboard;
 class ClipboardItem;
+
+struct SystemClipboardItem;
+struct SystemClipboardRepresentation;
 }
 
 namespace Web::Compression {

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -164,6 +164,10 @@ public:
     void did_request_select_dropdown(WeakPtr<HTML::HTMLSelectElement> target, Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items);
     void select_dropdown_closed(Optional<u32> const& selected_item_id);
 
+    using ClipboardRequest = GC::Ref<GC::Function<void(Vector<Clipboard::SystemClipboardItem>)>>;
+    void request_clipboard_entries(ClipboardRequest);
+    void retrieved_clipboard_entries(u64 request_id, Vector<Clipboard::SystemClipboardItem>);
+
     enum class PendingNonBlockingDialog {
         None,
         ColorPicker,
@@ -271,6 +275,9 @@ private:
 
     PendingNonBlockingDialog m_pending_non_blocking_dialog { PendingNonBlockingDialog::None };
     WeakPtr<HTML::HTMLElement> m_pending_non_blocking_dialog_target;
+
+    HashMap<u64, ClipboardRequest> m_pending_clipboard_requests;
+    u64 m_next_clipboard_request_id { 0 };
 
     Vector<UniqueNodeID> m_media_elements;
     Optional<UniqueNodeID> m_media_context_menu_element_id;
@@ -393,7 +400,8 @@ public:
 
     virtual void page_did_change_theme_color(Gfx::Color) { }
 
-    virtual void page_did_insert_clipboard_entry([[maybe_unused]] StringView data, [[maybe_unused]] StringView presentation_style, [[maybe_unused]] StringView mime_type) { }
+    virtual void page_did_insert_clipboard_entry(Clipboard::SystemClipboardRepresentation const&, [[maybe_unused]] StringView presentation_style) { }
+    virtual void page_did_request_clipboard_entries([[maybe_unused]] u64 request_id) { }
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/ImageFormats/PNGWriter.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWebView/Application.h>
@@ -453,6 +454,11 @@ void ViewImplementation::file_picker_closed(Vector<Web::HTML::SelectedFile> sele
 void ViewImplementation::select_dropdown_closed(Optional<u32> const& selected_item_id)
 {
     client().async_select_dropdown_closed(page_id(), selected_item_id);
+}
+
+void ViewImplementation::retrieved_clipboard_entries(u64 request_id, ReadonlySpan<Web::Clipboard::SystemClipboardItem> items)
+{
+    client().async_retrieved_clipboard_entries(page_id(), request_id, items);
 }
 
 void ViewImplementation::toggle_media_play_state()

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -130,6 +130,8 @@ public:
     void file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files);
     void select_dropdown_closed(Optional<u32> const& selected_item_id);
 
+    void retrieved_clipboard_entries(u64 request_id, ReadonlySpan<Web::Clipboard::SystemClipboardItem>);
+
     void toggle_media_play_state();
     void toggle_media_mute_state();
     void toggle_media_loop_state();
@@ -225,7 +227,8 @@ public:
     Function<void(double factor)> on_set_browser_zoom;
     Function<void(size_t current_match_index, Optional<size_t> const& total_match_count)> on_find_in_page;
     Function<void(Gfx::Color)> on_theme_color_change;
-    Function<void(String const&, String const&, String const&)> on_insert_clipboard_entry;
+    Function<void(Web::Clipboard::SystemClipboardRepresentation, String const&)> on_insert_clipboard_entry;
+    Function<void(u64 request_id)> on_request_clipboard_entries;
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
     Function<void(bool, bool)> on_navigation_buttons_state_changed;
     Function<void()> on_web_content_crashed;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -633,11 +633,19 @@ void WebContentClient::did_change_theme_color(u64 page_id, Gfx::Color color)
     }
 }
 
-void WebContentClient::did_insert_clipboard_entry(u64 page_id, String data, String presentation_style, String mime_type)
+void WebContentClient::did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String presentation_style)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_insert_clipboard_entry)
-            view->on_insert_clipboard_entry(data, presentation_style, mime_type);
+            view->on_insert_clipboard_entry(move(entry), presentation_style);
+    }
+}
+
+void WebContentClient::did_request_clipboard_entries(u64 page_id, u64 request_id)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_request_clipboard_entries)
+            view->on_request_clipboard_entries(request_id);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -126,7 +126,8 @@ private:
     virtual void did_set_browser_zoom(u64 page_id, double factor) override;
     virtual void did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> total_match_count) override;
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
-    virtual void did_insert_clipboard_entry(u64 page_id, String data, String presentation_style, String mime_type) override;
+    virtual void did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation, String presentation_style) override;
+    virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual void did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap, i32 back_bitmap_id, Gfx::ShareableBitmap) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1257,6 +1257,12 @@ void ConnectionFromClient::select_dropdown_closed(u64 page_id, Optional<u32> sel
         page->page().select_dropdown_closed(selected_item_id);
 }
 
+void ConnectionFromClient::retrieved_clipboard_entries(u64 page_id, u64 request_id, Vector<Web::Clipboard::SystemClipboardItem> items)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().retrieved_clipboard_entries(request_id, move(items));
+}
+
 void ConnectionFromClient::toggle_media_play_state(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -129,6 +129,8 @@ private:
     virtual void file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> selected_files) override;
     virtual void select_dropdown_closed(u64 page_id, Optional<u32> selected_item_id) override;
 
+    virtual void retrieved_clipboard_entries(u64 page_id, u64 request_id, Vector<Web::Clipboard::SystemClipboardItem>) override;
+
     virtual void toggle_media_play_state(u64 page_id) override;
     virtual void toggle_media_mute_state(u64 page_id) override;
     virtual void toggle_media_loop_state(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -649,9 +649,14 @@ void PageClient::page_did_change_theme_color(Gfx::Color color)
     client().async_did_change_theme_color(m_id, color);
 }
 
-void PageClient::page_did_insert_clipboard_entry(StringView data, StringView presentation_style, StringView mime_type)
+void PageClient::page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const& entry, StringView presentation_style)
 {
-    client().async_did_insert_clipboard_entry(m_id, data, presentation_style, mime_type);
+    client().async_did_insert_clipboard_entry(m_id, entry, presentation_style);
+}
+
+void PageClient::page_did_request_clipboard_entries(u64 request_id)
+{
+    client().async_did_request_clipboard_entries(m_id, request_id);
 }
 
 void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play_state)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -169,7 +169,8 @@ private:
     virtual void page_did_set_test_timeout(double milliseconds) override;
     virtual void page_did_set_browser_zoom(double factor) override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;
-    virtual void page_did_insert_clipboard_entry(StringView data, StringView presentation_style, StringView mime_type) override;
+    virtual void page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const&, StringView presentation_style) override;
+    virtual void page_did_request_clipboard_entries(u64 request_id) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual void page_did_allocate_backing_stores(i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) override;
     virtual IPC::File request_worker_agent(Web::Bindings::AgentType) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -3,6 +3,8 @@
 #include <LibGfx/Cursor.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/CSS/Selector.h>
@@ -21,7 +23,6 @@
 #include <LibWebView/Mutation.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/ProcessHandle.h>
-#include <LibWeb/Bindings/MainThreadVM.h>
 
 endpoint WebContentClient
 {
@@ -91,7 +92,10 @@ endpoint WebContentClient
     did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) =|
     did_finish_handling_input_event(u64 page_id, Web::EventResult event_result) =|
     did_change_theme_color(u64 page_id, Gfx::Color color) =|
-    did_insert_clipboard_entry(u64 page_id, String data, String presentation_style, String mime_type) =|
+
+    did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String presentation_style) =|
+    did_request_clipboard_entries(u64 page_id, u64 request_id) =|
+
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
     did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) =|
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -1,6 +1,7 @@
 #include <LibGfx/Rect.h>
 #include <LibIPC/File.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
@@ -116,6 +117,8 @@ endpoint WebContentServer
     color_picker_update(u64 page_id, Optional<Color> picked_color, Web::HTML::ColorPickerUpdateState state) =|
     file_picker_closed(u64 page_id, Vector<Web::HTML::SelectedFile> selected_files) =|
     select_dropdown_closed(u64 page_id, Optional<u32> selected_item_id) =|
+
+    retrieved_clipboard_entries(u64 page_id, u64 request_id, Vector<Web::Clipboard::SystemClipboardItem> items) =|
 
     toggle_media_play_state(u64 page_id) =|
     toggle_media_mute_state(u64 page_id) =|

--- a/UI/AppKit/Utilities/Conversions.h
+++ b/UI/AppKit/Utilities/Conversions.h
@@ -23,6 +23,7 @@ String ns_string_to_string(NSString*);
 ByteString ns_string_to_byte_string(NSString*);
 NSString* string_to_ns_string(StringView);
 
+ByteString ns_data_to_string(NSData*);
 NSData* string_to_ns_data(StringView);
 
 NSDictionary* deserialize_json_to_dictionary(StringView);

--- a/UI/AppKit/Utilities/Conversions.mm
+++ b/UI/AppKit/Utilities/Conversions.mm
@@ -28,6 +28,11 @@ NSString* string_to_ns_string(StringView string)
     return [[NSString alloc] initWithData:string_to_ns_data(string) encoding:NSUTF8StringEncoding];
 }
 
+ByteString ns_data_to_string(NSData* data)
+{
+    return { reinterpret_cast<char const*>([data bytes]), [data length] };
+}
+
 NSData* string_to_ns_data(StringView string)
 {
     return [NSData dataWithBytes:string.characters_without_null_termination() length:string.length()];

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -125,6 +125,20 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
 
         m_pending_dialog = Web::Page::PendingDialog::None;
         m_pending_prompt_text.clear();
+    };
+
+    on_insert_clipboard_entry = [this](Web::Clipboard::SystemClipboardRepresentation entry, auto const&) {
+        Web::Clipboard::SystemClipboardItem item;
+        item.system_clipboard_representations.append(move(entry));
+
+        m_clipboard = move(item);
+    };
+
+    on_request_clipboard_entries = [this](auto request_id) {
+        if (m_clipboard.has_value())
+            retrieved_clipboard_entries(request_id, { { *m_clipboard } });
+        else
+            retrieved_clipboard_entries(request_id, {});
     };
 
     m_system_visibility_state = Web::HTML::VisibilityState::Visible;

--- a/UI/Headless/HeadlessWebView.h
+++ b/UI/Headless/HeadlessWebView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -51,6 +51,9 @@ private:
 
     Web::Page::PendingDialog m_pending_dialog { Web::Page::PendingDialog::None };
     Optional<String> m_pending_prompt_text;
+
+    // FIXME: We should implement UI-agnostic platform APIs to interact with the system clipboard.
+    Optional<Web::Clipboard::SystemClipboardItem> m_clipboard;
 };
 
 }

--- a/UI/Qt/StringUtils.cpp
+++ b/UI/Qt/StringUtils.cpp
@@ -13,6 +13,11 @@ AK::ByteString ak_byte_string_from_qstring(QString const& qstring)
     return AK::ByteString(utf8_data.data(), utf8_data.size());
 }
 
+AK::ByteString ak_byte_string_from_qbytearray(QByteArray const& qbytearray)
+{
+    return AK::ByteString(qbytearray.data(), qbytearray.size());
+}
+
 String ak_string_from_qstring(QString const& qstring)
 {
     auto utf8_data = qstring.toUtf8();
@@ -22,6 +27,11 @@ String ak_string_from_qstring(QString const& qstring)
 QString qstring_from_ak_string(StringView ak_string)
 {
     return QString::fromUtf8(ak_string.characters_without_null_termination(), static_cast<qsizetype>(ak_string.length()));
+}
+
+QByteArray qbytearray_from_ak_string(StringView ak_string)
+{
+    return { ak_string.characters_without_null_termination(), static_cast<qsizetype>(ak_string.length()) };
 }
 
 Optional<URL::URL> ak_url_from_qstring(QString const& qstring)

--- a/UI/Qt/StringUtils.h
+++ b/UI/Qt/StringUtils.h
@@ -13,11 +13,16 @@
 #include <AK/StringView.h>
 #include <LibURL/URL.h>
 
+#include <QByteArray>
 #include <QString>
 #include <QUrl>
 
 AK::ByteString ak_byte_string_from_qstring(QString const&);
+AK::ByteString ak_byte_string_from_qbytearray(QByteArray const&);
+
 String ak_string_from_qstring(QString const&);
 QString qstring_from_ak_string(StringView);
+QByteArray qbytearray_from_ak_string(StringView);
+
 Optional<URL::URL> ak_url_from_qstring(QString const&);
 URL::URL ak_url_from_qurl(QUrl const&);


### PR DESCRIPTION
There's a healthy dose of spec bugs here, but this fleshes out `write`, `writeText`, and `read`. Fixes ~40 tests under https://wpt.fyi/results/clipboard-apis/.

These tests require both HTTPS (i.e. not file://) and WebDriver to work (i.e. can't even run them on wpt.live).