### PR TITLE
Base: Add about:settings and about:processes to about:about page

### DIFF
--- a/Base/res/ladybird/about-pages/about.html
+++ b/Base/res/ladybird/about-pages/about.html
@@ -10,6 +10,8 @@
     <ul>
         <li><a href="about:about">about:about</a></li>
         <li><a href="about:newtab">about:newtab</a></li>
+        <li><a href="about:processes">about:processes</a></li>
+        <li><a href="about:settings">about:settings</a></li>
         <li><a href="about:version">about:version</a></li>
     </ul>
 </body>


### PR DESCRIPTION
Very small pr that adds the previous added internal pages to the `about:about` links overview page, because they where missing.