### PR TITLE
perf: Optimize git checkout of vcpkg

### DIFF
--- a/Toolchain/BuildVcpkg.py
+++ b/Toolchain/BuildVcpkg.py
@@ -32,7 +32,7 @@ def main() -> int:
     print(f"Building vcpkg@{git_rev}")
 
     subprocess.check_call(args=["git", "fetch", "origin"], cwd=vcpkg_checkout)
-    subprocess.check_call(args=["git", "checkout", git_rev], cwd=vcpkg_checkout)
+    subprocess.check_call(args=["git", "checkout", "--depth=1", git_rev], cwd=vcpkg_checkout)
 
     bootstrap_script = "bootstrap-vcpkg.bat" if os.name == 'nt' else "bootstrap-vcpkg.sh"
     subprocess.check_call(args=[vcpkg_checkout / bootstrap_script, "-disableMetrics"], cwd=vcpkg_checkout)


### PR DESCRIPTION
fixes: #4492

This improves the build process by performing a shallow clone of the `vcpkg` repository, reducing the download size from \~60MB to \~6MB.