### PR TITLE
LibWeb/Wasm+IDLGenerators: Define the silly "native" errors given in the wasm spec

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -79,6 +79,8 @@ ErrorOr<void, ValidationError> Validator::validate(Module& module)
     for (auto& memory : module.memory_section().memories())
         m_context.memories.append(memory.type());
 
+    auto imported_globals = m_context.globals;
+
     m_context.globals.ensure_capacity(m_context.globals.size() + module.global_section().entries().size());
     for (auto& global : module.global_section().entries())
         m_context.globals.append(global.type());
@@ -117,11 +119,23 @@ ErrorOr<void, ValidationError> Validator::validate(Module& module)
     TRY(validate(module.import_section()));
     TRY(validate(module.export_section()));
     TRY(validate(module.start_section()));
-    TRY(validate(module.data_section()));
-    TRY(validate(module.element_section()));
-    TRY(validate(module.global_section()));
-    TRY(validate(module.memory_section()));
-    TRY(validate(module.table_section()));
+    {
+        // Let C′ be the same context as C, except that C′.globals is just the sequence globals(it∗).
+
+        // Under the context C′:
+        //    For each table_i in module.tables, the definition table_i must be val_i with a table type tt_i.
+        //    For each mem_i in module.mems, the definition mem_i must be val_i with a memory type mt_i.
+        //    For each global_i in module.globals, the definition global_i must be val_i with a global type gt_i.
+        //    For each elem_i in module.elems, the segment elem_i must be val_i with reference type rt_i.
+        //    For each data_i in module.datas, the segment data_i must be val_i.
+
+        TemporaryChange omit_internal_globals { m_context.globals, imported_globals };
+        TRY(validate(module.data_section()));
+        TRY(validate(module.element_section()));
+        TRY(validate(module.global_section()));
+        TRY(validate(module.memory_section()));
+        TRY(validate(module.table_section()));
+    }
     TRY(validate(module.code_section()));
 
     module.set_validation_status(Module::ValidationStatus::Valid, {});

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -12,12 +12,15 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/BigInt.h>
+#include <LibJS/Runtime/ErrorConstructor.h>
+#include <LibJS/Runtime/Intrinsics.h>
 #include <LibJS/Runtime/Iterator.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibWasm/AbstractMachine/Validator.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ResponsePrototype.h>
 #include <LibWeb/Fetch/Response.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
@@ -70,6 +73,35 @@ void finalize(JS::Object& object)
 {
     auto& global_object = HTML::relevant_global_object(object);
     Detail::s_caches.remove(global_object);
+}
+
+// https://webassembly.github.io/spec/js-api/#error-objects
+void initialize(JS::Object& self, JS::Realm& realm)
+{
+    // 1. Let namespaceObject be the namespace object.
+    auto& namespace_object = self;
+
+    // 2. For each error of « "CompileError", "LinkError", "RuntimeError" »,
+    // 2.1. Let constructor be a new object, implementing the NativeError Object Structure, with NativeError set to error.
+    // 2.2. ! DefineMethodProperty(namespaceObject, error, constructor, false).
+
+    // 2..2.2 for error=CompileError:
+    auto descriptor = JS::PropertyDescriptor {
+        .writable = true,
+        .enumerable = false,
+        .configurable = true,
+    };
+
+    descriptor.value = &Bindings::ensure_web_constructor<CompileErrorPrototype>(realm, "CompileError"_fly_string);
+    MUST(namespace_object.define_property_or_throw("CompileError"_string, descriptor));
+
+    // 2..2.2 for error=LinkError:
+    descriptor.value = &Bindings::ensure_web_constructor<LinkErrorPrototype>(realm, "LinkError"_fly_string);
+    MUST(namespace_object.define_property_or_throw("LinkError"_string, descriptor));
+
+    // 2..2.2 for error=RuntimeError:
+    descriptor.value = &Bindings::ensure_web_constructor<RuntimeErrorPrototype>(realm, "RuntimeError"_fly_string);
+    MUST(namespace_object.define_property_or_throw("RuntimeError"_string, descriptor));
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-webassembly-validate
@@ -851,4 +883,142 @@ GC::Ref<WebIDL::Promise> compile_potential_webassembly_response(JS::VM& vm, GC::
     return return_value;
 }
 
+#define DEFINE_WASM_NATIVE_ERROR(ClassName, snake_name, PrototypeName, ConstructorName)                                \
+    GC_DEFINE_ALLOCATOR(ClassName);                                                                                    \
+    GC::Ref<ClassName> ClassName::create(JS::Realm& realm)                                                             \
+    {                                                                                                                  \
+        return realm.create<ClassName>(Bindings::ensure_web_prototype<PrototypeName>(realm, #ClassName##_fly_string)); \
+    }                                                                                                                  \
+                                                                                                                       \
+    GC::Ref<ClassName> ClassName::create(JS::Realm& realm, String message)                                             \
+    {                                                                                                                  \
+        auto& vm = realm.vm();                                                                                         \
+        auto error = ClassName::create(realm);                                                                         \
+        u8 const attr = JS::Attribute::Writable | JS::Attribute::Configurable;                                         \
+        error->define_direct_property(vm.names.message, JS::PrimitiveString::create(vm, move(message)), attr);         \
+        return error;                                                                                                  \
+    }                                                                                                                  \
+                                                                                                                       \
+    GC::Ref<ClassName> ClassName::create(JS::Realm& realm, StringView message)                                         \
+    {                                                                                                                  \
+        return create(realm, MUST(String::from_utf8(message)));                                                        \
+    }                                                                                                                  \
+                                                                                                                       \
+    ClassName::ClassName(JS::Object& prototype)                                                                        \
+        : Error(prototype)                                                                                             \
+    {                                                                                                                  \
+    }
+
+DEFINE_WASM_NATIVE_ERROR(CompileError, compile_error, CompileErrorPrototype, CompileErrorConstructor)
+DEFINE_WASM_NATIVE_ERROR(LinkError, link_error, LinkErrorPrototype, LinkErrorConstructor)
+DEFINE_WASM_NATIVE_ERROR(RuntimeError, runtime_error, RuntimeErrorPrototype, RuntimeErrorConstructor)
+
+#undef DEFINE_WASM_NATIVE_ERROR
+
+#define DEFINE_WASM_NATIVE_ERROR_CONSTRUCTOR(ClassName, snake_name, PrototypeName, ConstructorName)                                    \
+    GC_DEFINE_ALLOCATOR(ConstructorName);                                                                                              \
+    ConstructorName::ConstructorName(JS::Realm& realm)                                                                                 \
+        : NativeFunction(#ClassName##_string, *realm.intrinsics().error_constructor())                                                 \
+    {                                                                                                                                  \
+    }                                                                                                                                  \
+                                                                                                                                       \
+    void ConstructorName::initialize(JS::Realm& realm)                                                                                 \
+    {                                                                                                                                  \
+        auto& vm = this->vm();                                                                                                         \
+        Base::initialize(realm);                                                                                                       \
+                                                                                                                                       \
+        /* 20.5.6.2.1 NativeError.prototype, https://tc39.es/ecma262/#sec-nativeerror.prototype */                                     \
+        define_direct_property(vm.names.prototype, &Bindings::ensure_web_prototype<PrototypeName>(realm, #ClassName##_fly_string), 0); \
+                                                                                                                                       \
+        define_direct_property(vm.names.length, JS::Value(1), JS::Attribute::Configurable);                                            \
+    }                                                                                                                                  \
+                                                                                                                                       \
+    ConstructorName::~ConstructorName() = default;                                                                                     \
+                                                                                                                                       \
+    /* 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror */                                   \
+    JS::ThrowCompletionOr<JS::Value> ConstructorName::call()                                                                           \
+    {                                                                                                                                  \
+        /* 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget. */              \
+        return TRY(construct(*this));                                                                                                  \
+    }                                                                                                                                  \
+                                                                                                                                       \
+    /* 20.5.6.1.1 NativeError ( message [ , options ] ), https://tc39.es/ecma262/#sec-nativeerror */                                   \
+    JS::ThrowCompletionOr<GC::Ref<JS::Object>> ConstructorName::construct(JS::FunctionObject& new_target)                              \
+    {                                                                                                                                  \
+        auto& vm = this->vm();                                                                                                         \
+                                                                                                                                       \
+        auto message = vm.argument(0);                                                                                                 \
+        auto options = vm.argument(1);                                                                                                 \
+                                                                                                                                       \
+        /* 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »). */                    \
+        auto error = TRY(ordinary_create_from_constructor<ClassName>(vm, new_target, &JS::Intrinsics::error_prototype));               \
+                                                                                                                                       \
+        /* 3. If message is not undefined, then */                                                                                     \
+        if (!message.is_undefined()) {                                                                                                 \
+            /* a. Let msg be ? ToString(message). */                                                                                   \
+            auto msg = TRY(message.to_string(vm));                                                                                     \
+                                                                                                                                       \
+            /* b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg). */                                                \
+            error->create_non_enumerable_data_property_or_throw(vm.names.message, JS::PrimitiveString::create(vm, move(msg)));         \
+        }                                                                                                                              \
+                                                                                                                                       \
+        /* 4. Perform ? InstallErrorCause(O, options). */                                                                              \
+        TRY(error->install_error_cause(options));                                                                                      \
+                                                                                                                                       \
+        /* 5. Return O. */                                                                                                             \
+        return error;                                                                                                                  \
+    }
+
+DEFINE_WASM_NATIVE_ERROR_CONSTRUCTOR(CompileError, compile_error, CompileErrorPrototype, CompileErrorConstructor)
+DEFINE_WASM_NATIVE_ERROR_CONSTRUCTOR(LinkError, link_error, LinkErrorPrototype, LinkErrorConstructor)
+DEFINE_WASM_NATIVE_ERROR_CONSTRUCTOR(RuntimeError, runtime_error, RuntimeErrorPrototype, RuntimeErrorConstructor)
+
+#undef DEFINE_WASM_NATIVE_ERROR_CONSTRUCTOR
+
+#define DEFINE_WASM_NATIVE_ERROR_PROTOTYPE(ClassName, snake_name, PrototypeName, ConstructorName)          \
+    GC_DEFINE_ALLOCATOR(PrototypeName);                                                                    \
+                                                                                                           \
+    PrototypeName::PrototypeName(JS::Realm& realm)                                                         \
+        : PrototypeObject(realm.intrinsics().error_prototype())                                            \
+    {                                                                                                      \
+    }                                                                                                      \
+                                                                                                           \
+    void PrototypeName::initialize(JS::Realm& realm)                                                       \
+    {                                                                                                      \
+        auto& vm = this->vm();                                                                             \
+        Base::initialize(realm);                                                                           \
+        u8 const attr = JS::Attribute::Writable | JS::Attribute::Configurable;                             \
+        define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, #ClassName##_string), attr); \
+        define_direct_property(vm.names.message, JS::PrimitiveString::create(vm, String {}), attr);        \
+    }
+
+DEFINE_WASM_NATIVE_ERROR_PROTOTYPE(CompileError, compile_error, CompileErrorPrototype, CompileErrorConstructor)
+DEFINE_WASM_NATIVE_ERROR_PROTOTYPE(LinkError, link_error, LinkErrorPrototype, LinkErrorConstructor)
+DEFINE_WASM_NATIVE_ERROR_PROTOTYPE(RuntimeError, runtime_error, RuntimeErrorPrototype, RuntimeErrorConstructor)
+
+#undef DEFINE_WASM_NATIVE_ERROR_PROTOTYPE
+
 }
+
+#define DEFINE_WASM_ERROR_PROTOTYPE_AND_CONSTRUCTOR_WEB_INTRINSIC(ClassName, snake_name, PrototypeName, ConstructorName)                       \
+    template<>                                                                                                                                 \
+    void Intrinsics::create_web_prototype_and_constructor<WebAssembly::PrototypeName>(JS::Realm & realm)                                       \
+    {                                                                                                                                          \
+        auto& vm = realm.vm();                                                                                                                 \
+        auto prototype = heap().allocate<WebAssembly::PrototypeName>(realm);                                                                   \
+        m_prototypes.set(#ClassName##_string, prototype);                                                                                      \
+                                                                                                                                               \
+        auto constructor = heap().allocate<WebAssembly::ConstructorName>(realm);                                                               \
+        m_constructors.set(#ClassName##_string, constructor);                                                                                  \
+                                                                                                                                               \
+        prototype->define_direct_property(vm.names.constructor, constructor.ptr(), JS::Attribute::Writable | JS::Attribute::Configurable);     \
+        constructor->define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, #ClassName##_string), JS::Attribute::Configurable); \
+    }
+
+namespace Web::Bindings {
+DEFINE_WASM_ERROR_PROTOTYPE_AND_CONSTRUCTOR_WEB_INTRINSIC(CompileError, compile_error, CompileErrorPrototype, CompileErrorConstructor)
+DEFINE_WASM_ERROR_PROTOTYPE_AND_CONSTRUCTOR_WEB_INTRINSIC(LinkError, link_error, LinkErrorPrototype, LinkErrorConstructor)
+DEFINE_WASM_ERROR_PROTOTYPE_AND_CONSTRUCTOR_WEB_INTRINSIC(RuntimeError, runtime_error, RuntimeErrorPrototype, RuntimeErrorConstructor)
+}
+
+#undef DEFINE_WASM_ERROR_PROTOTYPE_AND_CONSTRUCTOR_WEB_INTRINSIC

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -12,6 +12,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/NativeFunction.h>
+#include <LibJS/Runtime/PrototypeObject.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibWasm/AbstractMachine/AbstractMachine.h>
 #include <LibWeb/Forward.h>
@@ -20,6 +21,7 @@ namespace Web::WebAssembly {
 
 void visit_edges(JS::Object&, JS::Cell::Visitor&);
 void finalize(JS::Object&);
+void initialize(JS::Object&, JS::Realm&);
 
 bool validate(JS::VM&, GC::Root<WebIDL::BufferSource>& bytes);
 WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> compile(JS::VM&, GC::Root<WebIDL::BufferSource>& bytes);
@@ -96,4 +98,69 @@ extern HashMap<GC::Ptr<JS::Object>, WebAssemblyCache> s_caches;
 
 }
 
+// NOTE: This is technically not allowed by ECMA262, as the set of native errors is closed
+//       our implementation uses this fact in places, but for the purposes of wasm returning
+//       *some* kind of error, named e.g. 'WebAssembly.RuntimeError', this is sufficient.
+#define DECLARE_WASM_NATIVE_ERROR(ClassName, snake_name, PrototypeName, ConstructorName) \
+    class ClassName final : public JS::Error {                                           \
+        JS_OBJECT(ClassName, Error);                                                     \
+        GC_DECLARE_ALLOCATOR(ClassName);                                                 \
+                                                                                         \
+    public:                                                                              \
+        static GC::Ref<ClassName> create(JS::Realm&);                                    \
+        static GC::Ref<ClassName> create(JS::Realm&, String message);                    \
+        static GC::Ref<ClassName> create(JS::Realm&, StringView message);                \
+                                                                                         \
+        explicit ClassName(Object& prototype);                                           \
+        virtual ~ClassName() override = default;                                         \
+    };
+
+#define DECLARE_WASM_NATIVE_ERROR_CONSTRUCTOR(ClassName, snake_name, PrototypeName, ConstructorName)           \
+    class ConstructorName final : public JS::NativeFunction {                                                  \
+        JS_OBJECT(ConstructorName, NativeFunction);                                                            \
+        GC_DECLARE_ALLOCATOR(ConstructorName);                                                                 \
+                                                                                                               \
+    public:                                                                                                    \
+        virtual void initialize(JS::Realm&) override;                                                          \
+        virtual ~ConstructorName() override;                                                                   \
+        virtual JS::ThrowCompletionOr<JS::Value> call() override;                                              \
+        virtual JS::ThrowCompletionOr<GC::Ref<JS::Object>> construct(JS::FunctionObject& new_target) override; \
+                                                                                                               \
+    private:                                                                                                   \
+        explicit ConstructorName(JS::Realm&);                                                                  \
+                                                                                                               \
+        virtual bool has_constructor() const override                                                          \
+        {                                                                                                      \
+            return true;                                                                                       \
+        }                                                                                                      \
+    };
+
+#define DECLARE_WASM_NATIVE_ERROR_PROTOTYPE(ClassName, snake_name, PrototypeName, ConstructorName) \
+    class PrototypeName final : public JS::PrototypeObject<PrototypeName, ClassName> {             \
+        JS_PROTOTYPE_OBJECT(PrototypeName, ClassName, ClassName);                                  \
+        GC_DECLARE_ALLOCATOR(PrototypeName);                                                       \
+                                                                                                   \
+    public:                                                                                        \
+        virtual void initialize(JS::Realm&) override;                                              \
+        virtual ~PrototypeName() override = default;                                               \
+                                                                                                   \
+    private:                                                                                       \
+        explicit PrototypeName(JS::Realm&);                                                        \
+    };
+
+DECLARE_WASM_NATIVE_ERROR_CONSTRUCTOR(CompilError, compile_error, CompileErrorPrototype, CompileErrorConstructor)
+DECLARE_WASM_NATIVE_ERROR_CONSTRUCTOR(LinkError, link_error, LinkErrorPrototype, LinkErrorConstructor)
+DECLARE_WASM_NATIVE_ERROR_CONSTRUCTOR(RuntimeError, runtime_error, RuntimeErrorPrototype, RuntimeErrorConstructor)
+
+DECLARE_WASM_NATIVE_ERROR(CompileError, compile_error, CompileErrorPrototype, CompileErrorConstructor)
+DECLARE_WASM_NATIVE_ERROR(LinkError, link_error, LinkErrorPrototype, LinkErrorConstructor)
+DECLARE_WASM_NATIVE_ERROR(RuntimeError, runtime_error, LinkErrorPrototype, LinkErrorConstructor)
+
+DECLARE_WASM_NATIVE_ERROR_PROTOTYPE(CompileError, compile_error, CompileErrorPrototype, CompileErrorConstructor)
+DECLARE_WASM_NATIVE_ERROR_PROTOTYPE(LinkError, link_error, LinkErrorPrototype, LinkErrorConstructor)
+DECLARE_WASM_NATIVE_ERROR_PROTOTYPE(RuntimeError, runtime_error, RuntimeErrorPrototype, LinkErrorConstructor)
+
+#undef DECLARE_WASM_NATIVE_ERROR
+#undef DECLARE_WASM_NATIVE_ERROR_PROTOTYPE
+#undef DECLARE_WASM_NATIVE_ERROR_CONSTRUCTOR
 }

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.idl
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.idl
@@ -9,7 +9,7 @@ dictionary WebAssemblyInstantiatedSource {
 
 // https://webassembly.github.io/spec/js-api/#webassembly-namespace
 // https://webassembly.github.io/spec/web-api/index.html#streaming-modules
-[Exposed=*, WithGCVisitor, WithFinalizer]
+[Exposed=*, WithGCVisitor, WithFinalizer, WithInitializer]
 namespace WebAssembly {
     // FIXME: Streaming APIs are supposed to be only exposed to Window, Worker
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -4824,6 +4824,13 @@ void @namespace_class@::initialize(JS::Realm& realm)
 )~~~");
     }
 
+    if (interface.extended_attributes.contains("WithInitializer"sv)) {
+        generator.append(R"~~~(
+
+    @name@::initialize(*this, realm);
+)~~~");
+    }
+
     generator.append(R"~~~(
 }
 )~~~");

--- a/Tests/LibWeb/Text/expected/namespace-objects-default-property-attributes.txt
+++ b/Tests/LibWeb/Text/expected/namespace-objects-default-property-attributes.txt
@@ -35,6 +35,21 @@ validate configurable: true
 validate enumerable: true
 validate value before: function validate() { [native code] }
 validate value after: replaced
+CompileError writable: true
+CompileError configurable: true
+CompileError enumerable: false
+CompileError value before: function CompileError() { [native code] }
+CompileError value after: replaced
+LinkError writable: true
+LinkError configurable: true
+LinkError enumerable: false
+LinkError value before: function LinkError() { [native code] }
+LinkError value after: replaced
+RuntimeError writable: true
+RuntimeError configurable: true
+RuntimeError enumerable: false
+RuntimeError value before: function RuntimeError() { [native code] }
+RuntimeError value after: replaced
 Global writable: true
 Global configurable: true
 Global enumerable: false

--- a/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/proto-from-ctor-realm.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/proto-from-ctor-realm.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 120 tests
 
-75 Pass
-45 Fail
+120 Pass
 Pass	WebAssembly.Module: cross-realm NewTarget with `undefined` prototype
 Pass	WebAssembly.Module: cross-realm NewTarget with `null` prototype
 Pass	WebAssembly.Module: cross-realm NewTarget with `false` prototype
@@ -79,48 +78,48 @@ Pass	WebAssembly.Global: bound Proxy of cross-realm NewTarget with `false` proto
 Pass	WebAssembly.Global: Proxy of cross-realm NewTarget with `true` prototype
 Pass	WebAssembly.Global: Proxy of Proxy of cross-realm NewTarget with `-0` prototype
 Pass	WebAssembly.Global: Proxy of bound cross-realm NewTarget with `NaN` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `undefined` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `null` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `false` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `true` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `0` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `-1` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `""` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `"str"` prototype
-Fail	WebAssembly.CompileError: cross-realm NewTarget with `symbol "Symbol()"` prototype
-Fail	WebAssembly.CompileError: bound cross-realm NewTarget with `undefined` prototype
-Fail	WebAssembly.CompileError: bound bound cross-realm NewTarget with `null` prototype
-Fail	WebAssembly.CompileError: bound Proxy of cross-realm NewTarget with `false` prototype
-Fail	WebAssembly.CompileError: Proxy of cross-realm NewTarget with `true` prototype
-Fail	WebAssembly.CompileError: Proxy of Proxy of cross-realm NewTarget with `-0` prototype
-Fail	WebAssembly.CompileError: Proxy of bound cross-realm NewTarget with `NaN` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `undefined` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `null` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `false` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `true` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `0` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `-1` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `""` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `"str"` prototype
-Fail	WebAssembly.LinkError: cross-realm NewTarget with `symbol "Symbol()"` prototype
-Fail	WebAssembly.LinkError: bound cross-realm NewTarget with `undefined` prototype
-Fail	WebAssembly.LinkError: bound bound cross-realm NewTarget with `null` prototype
-Fail	WebAssembly.LinkError: bound Proxy of cross-realm NewTarget with `false` prototype
-Fail	WebAssembly.LinkError: Proxy of cross-realm NewTarget with `true` prototype
-Fail	WebAssembly.LinkError: Proxy of Proxy of cross-realm NewTarget with `-0` prototype
-Fail	WebAssembly.LinkError: Proxy of bound cross-realm NewTarget with `NaN` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `undefined` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `null` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `false` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `true` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `0` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `-1` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `""` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `"str"` prototype
-Fail	WebAssembly.RuntimeError: cross-realm NewTarget with `symbol "Symbol()"` prototype
-Fail	WebAssembly.RuntimeError: bound cross-realm NewTarget with `undefined` prototype
-Fail	WebAssembly.RuntimeError: bound bound cross-realm NewTarget with `null` prototype
-Fail	WebAssembly.RuntimeError: bound Proxy of cross-realm NewTarget with `false` prototype
-Fail	WebAssembly.RuntimeError: Proxy of cross-realm NewTarget with `true` prototype
-Fail	WebAssembly.RuntimeError: Proxy of Proxy of cross-realm NewTarget with `-0` prototype
-Fail	WebAssembly.RuntimeError: Proxy of bound cross-realm NewTarget with `NaN` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `undefined` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `null` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `false` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `true` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `0` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `-1` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `""` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `"str"` prototype
+Pass	WebAssembly.CompileError: cross-realm NewTarget with `symbol "Symbol()"` prototype
+Pass	WebAssembly.CompileError: bound cross-realm NewTarget with `undefined` prototype
+Pass	WebAssembly.CompileError: bound bound cross-realm NewTarget with `null` prototype
+Pass	WebAssembly.CompileError: bound Proxy of cross-realm NewTarget with `false` prototype
+Pass	WebAssembly.CompileError: Proxy of cross-realm NewTarget with `true` prototype
+Pass	WebAssembly.CompileError: Proxy of Proxy of cross-realm NewTarget with `-0` prototype
+Pass	WebAssembly.CompileError: Proxy of bound cross-realm NewTarget with `NaN` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `undefined` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `null` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `false` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `true` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `0` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `-1` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `""` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `"str"` prototype
+Pass	WebAssembly.LinkError: cross-realm NewTarget with `symbol "Symbol()"` prototype
+Pass	WebAssembly.LinkError: bound cross-realm NewTarget with `undefined` prototype
+Pass	WebAssembly.LinkError: bound bound cross-realm NewTarget with `null` prototype
+Pass	WebAssembly.LinkError: bound Proxy of cross-realm NewTarget with `false` prototype
+Pass	WebAssembly.LinkError: Proxy of cross-realm NewTarget with `true` prototype
+Pass	WebAssembly.LinkError: Proxy of Proxy of cross-realm NewTarget with `-0` prototype
+Pass	WebAssembly.LinkError: Proxy of bound cross-realm NewTarget with `NaN` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `undefined` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `null` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `false` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `true` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `0` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `-1` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `""` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `"str"` prototype
+Pass	WebAssembly.RuntimeError: cross-realm NewTarget with `symbol "Symbol()"` prototype
+Pass	WebAssembly.RuntimeError: bound cross-realm NewTarget with `undefined` prototype
+Pass	WebAssembly.RuntimeError: bound bound cross-realm NewTarget with `null` prototype
+Pass	WebAssembly.RuntimeError: bound Proxy of cross-realm NewTarget with `false` prototype
+Pass	WebAssembly.RuntimeError: Proxy of cross-realm NewTarget with `true` prototype
+Pass	WebAssembly.RuntimeError: Proxy of Proxy of cross-realm NewTarget with `-0` prototype
+Pass	WebAssembly.RuntimeError: Proxy of bound cross-realm NewTarget with `NaN` prototype


### PR DESCRIPTION
See second commit for details, these errors cannot be true native errors, but we can get quite close.
Note that some wpt failures still remain where e.g. an instance of CompileError is not `instanceof WebAssembly.CompileError` as we can't have that as an error prototype. 