### PR TITLE
AK+LibJS: Use simdutf for all base64 operations

### DIFF
--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -15,8 +15,14 @@ namespace AK {
 
 size_t size_required_to_decode_base64(StringView);
 
-ErrorOr<ByteBuffer> decode_base64(StringView);
-ErrorOr<ByteBuffer> decode_base64url(StringView);
+enum class LastChunkHandling {
+    Loose,
+    Strict,
+    StopBeforePartial,
+};
+
+ErrorOr<ByteBuffer> decode_base64(StringView, LastChunkHandling = LastChunkHandling::Loose);
+ErrorOr<ByteBuffer> decode_base64url(StringView, LastChunkHandling = LastChunkHandling::Loose);
 
 struct InvalidBase64 {
     Error error;
@@ -25,8 +31,8 @@ struct InvalidBase64 {
 
 // On success, these return the number of input bytes that were decoded. This might be less than the
 // string length if the output buffer was not large enough.
-ErrorOr<size_t, InvalidBase64> decode_base64_into(StringView, ByteBuffer&);
-ErrorOr<size_t, InvalidBase64> decode_base64url_into(StringView, ByteBuffer&);
+ErrorOr<size_t, InvalidBase64> decode_base64_into(StringView, ByteBuffer&, LastChunkHandling = LastChunkHandling::Loose);
+ErrorOr<size_t, InvalidBase64> decode_base64url_into(StringView, ByteBuffer&, LastChunkHandling = LastChunkHandling::Loose);
 
 enum class OmitPadding {
     No,

--- a/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Libraries/LibJS/Runtime/Uint8Array.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Base64.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Optional.h>
 #include <AK/StringView.h>
@@ -41,12 +42,6 @@ enum class Alphabet {
     Base64URL,
 };
 
-enum class LastChunkHandling {
-    Loose,
-    Strict,
-    StopBeforePartial,
-};
-
 struct DecodeResult {
     size_t read { 0 };          // [[Read]]
     ByteBuffer bytes;           // [[Bytes]]
@@ -56,7 +51,7 @@ struct DecodeResult {
 ThrowCompletionOr<GC::Ref<TypedArrayBase>> validate_uint8_array(VM&);
 ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM&, TypedArrayBase const&);
 void set_uint8_array_bytes(TypedArrayBase&, ReadonlyBytes);
-DecodeResult from_base64(VM&, StringView string, Alphabet alphabet, LastChunkHandling last_chunk_handling, Optional<size_t> max_length = {});
+DecodeResult from_base64(VM&, StringView string, Alphabet alphabet, AK::LastChunkHandling last_chunk_handling, Optional<size_t> max_length = {});
 DecodeResult from_hex(VM&, StringView string, Optional<size_t> max_length = {});
 
 }

--- a/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
+++ b/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
@@ -40,25 +40,25 @@ describe("errors", () => {
     test("invalid padding", () => {
         expect(() => {
             Uint8Array.fromBase64("Zm9v=", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
 
         expect(() => {
             Uint8Array.fromBase64("Zm9vaa=", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Incomplete number of padding characters");
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
 
         expect(() => {
             Uint8Array.fromBase64("Zm9vaa=a", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
     });
 
     test("invalid alphabet", () => {
         expect(() => {
             Uint8Array.fromBase64("-", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Invalid character '-'");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
 
         expect(() => {
             Uint8Array.fromBase64("+", { alphabet: "base64url", lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Invalid character '+'");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
     });
 
     test("overlong chunk", () => {

--- a/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromBase64.js
+++ b/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromBase64.js
@@ -79,28 +79,28 @@ describe("errors", () => {
     test("invalid padding", () => {
         expect(() => {
             new Uint8Array(10).setFromBase64("Zm9v=", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
 
         expect(() => {
             new Uint8Array(10).setFromBase64("Zm9vaa=", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Incomplete number of padding characters");
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
 
         expect(() => {
             new Uint8Array(10).setFromBase64("Zm9vaa=a", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
     });
 
     test("invalid alphabet", () => {
         expect(() => {
             new Uint8Array(10).setFromBase64("-", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Invalid character '-'");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
 
         expect(() => {
             new Uint8Array(10).setFromBase64("+", {
                 alphabet: "base64url",
                 lastChunkHandling: "strict",
             });
-        }).toThrowWithMessage(SyntaxError, "Invalid character '+'");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
     });
 
     test("overlong chunk", () => {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -190,7 +190,7 @@
     },
     {
       "name": "simdutf",
-      "version": "5.6.0#0"
+      "version": "7.0.0#0"
     },
     {
       "name": "skia",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "d6995a0cf3cafda5e9e52749fad075dd62bfd90c",
+  "builtin-baseline": "41c447cc210dc39aa85d4a5f58b4a1b9e573b3dc",
   "dependencies": [
     {
       "name": "angle",


### PR DESCRIPTION
We were previously unable to use simdutf for base64 decoding operations other than "loose". Upstream has added support for the "strict" and "stop-before-partial" operations, so let's make use of them!

No test262 diff.