### PR TITLE
LibWeb/CSS: Update spec comment in calc() simplification algorithm

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -3243,8 +3243,7 @@ NonnullRefPtr<CalculationNode const> simplify_a_calculation_tree(CalculationNode
         return ProductCalculationNode::create(move(children));
     }
 
-    // AD-HOC: Math-function nodes that cannot be fully simplified will reach here.
-    //         Spec bug: https://github.com/w3c/csswg-drafts/issues/11572
+    // 10. Return root.
     return root;
 }
 


### PR DESCRIPTION
This was corrected in https://github.com/w3c/csswg-drafts/commit/8bcf3ada9e8b732f93daee5749b46503017cc4bd