### PR TITLE
LibJS: Add and use PrimitiveString::length_in_utf16_code_units

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -980,7 +980,7 @@ inline ThrowCompletionOr<Value> get_by_id(VM& vm, Optional<IdentifierTableIndex>
 {
     if constexpr (mode == GetByIdMode::Length) {
         if (base_value.is_string()) {
-            return Value(base_value.as_string().utf16_string().length_in_code_units());
+            return Value(base_value.as_string().length_in_utf16_code_units());
         }
     }
 

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -106,6 +106,11 @@ Utf16View PrimitiveString::utf16_string_view() const
     return m_utf16_string->view();
 }
 
+size_t PrimitiveString::length_in_utf16_code_units() const
+{
+    return utf16_string_view().length_in_code_units();
+}
+
 bool PrimitiveString::operator==(PrimitiveString const& other) const
 {
     if (this == &other)
@@ -123,8 +128,7 @@ ThrowCompletionOr<Optional<Value>> PrimitiveString::get(VM& vm, PropertyKey cons
         return Optional<Value> {};
     if (property_key.is_string()) {
         if (property_key.as_string() == vm.names.length.as_string()) {
-            auto length = utf16_string().length_in_code_units();
-            return Value(static_cast<double>(length));
+            return Value(static_cast<double>(length_in_utf16_code_units()));
         }
     }
     auto index = canonical_numeric_index_string(property_key, CanonicalIndexMode::IgnoreNumericRoundtrip);

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -45,6 +45,8 @@ public:
     [[nodiscard]] Utf16View utf16_string_view() const;
     bool has_utf16_string() const { return m_utf16_string.has_value(); }
 
+    size_t length_in_utf16_code_units() const;
+
     ThrowCompletionOr<Optional<Value>> get(VM&, PropertyKey const&) const;
 
     [[nodiscard]] bool operator==(PrimitiveString const&) const;

--- a/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Libraries/LibJS/Runtime/StringObject.cpp
@@ -42,7 +42,7 @@ void StringObject::initialize(Realm& realm)
     auto& vm = this->vm();
     Base::initialize(realm);
 
-    define_direct_property(vm.names.length, Value(m_string->utf16_string_view().length_in_code_units()), 0);
+    define_direct_property(vm.names.length, Value(m_string->length_in_utf16_code_units()), 0);
 }
 
 void StringObject::visit_edges(Cell::Visitor& visitor)
@@ -136,12 +136,9 @@ ThrowCompletionOr<GC::RootVector<Value>> StringObject::internal_own_property_key
     auto keys = GC::RootVector<Value> { heap() };
 
     // 2. Let str be O.[[StringData]].
-    auto str = m_string->utf16_string_view();
-
     // 3. Assert: str is a String.
-
     // 4. Let len be the length of str.
-    auto length = str.length_in_code_units();
+    auto length = m_string->length_in_utf16_code_units();
 
     // 5. For each integer i starting with 0 such that i < len, in ascending order, do
     for (size_t i = 0; i < length; ++i) {

--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -921,7 +921,7 @@ WebIDL::ExceptionOr<ErrorOr<JS::Value>> evaluate_key_path_on_a_value(JS::Realm& 
         // If Type(value) is String, and identifier is "length"
         if (value.is_string() && identifier == "length") {
             // Let value be a Number equal to the number of elements in value.
-            value = JS::Value(value.as_string().utf16_string_view().length_in_code_units());
+            value = JS::Value(value.as_string().length_in_utf16_code_units());
         }
 
         // If value is an Array and identifier is "length"


### PR DESCRIPTION
I was investigating an optimization in this area, and while it didn't seem to have a noticable improvement, it still seems useful to apply this change I made while investigating the fast path.