### PR TITLE
LibJS: Avoid Value->PropertyKey->Value roundtrip in for..in iteration

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -57,12 +57,12 @@ public:
     void clear() { m_table.clear(); }
     void clear_with_capacity() { m_table.clear_with_capacity(); }
 
-    HashSetResult set(K const& key, V const& value) { return m_table.set({ key, value }); }
-    HashSetResult set(K const& key, V&& value) { return m_table.set({ key, move(value) }); }
-    HashSetResult set(K&& key, V&& value) { return m_table.set({ move(key), move(value) }); }
-    ErrorOr<HashSetResult> try_set(K const& key, V const& value) { return m_table.try_set({ key, value }); }
-    ErrorOr<HashSetResult> try_set(K const& key, V&& value) { return m_table.try_set({ key, move(value) }); }
-    ErrorOr<HashSetResult> try_set(K&& key, V&& value) { return m_table.try_set({ move(key), move(value) }); }
+    HashSetResult set(K const& key, V const& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace) { return m_table.set({ key, value }, existing_entry_behavior); }
+    HashSetResult set(K const& key, V&& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace) { return m_table.set({ key, move(value) }, existing_entry_behavior); }
+    HashSetResult set(K&& key, V&& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace) { return m_table.set({ move(key), move(value) }, existing_entry_behavior); }
+    ErrorOr<HashSetResult> try_set(K const& key, V const& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace) { return m_table.try_set({ key, value }, existing_entry_behavior); }
+    ErrorOr<HashSetResult> try_set(K const& key, V&& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace) { return m_table.try_set({ key, move(value) }, existing_entry_behavior); }
+    ErrorOr<HashSetResult> try_set(K&& key, V&& value, HashSetExistingEntryBehavior existing_entry_behavior = HashSetExistingEntryBehavior::Replace) { return m_table.try_set({ move(key), move(value) }, existing_entry_behavior); }
 
     bool remove(K const& key)
     {

--- a/Libraries/LibGC/CMakeLists.txt
+++ b/Libraries/LibGC/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ConservativeVector.cpp
     ForeignCell.cpp
     Root.cpp
+    RootHashMap.cpp
     RootVector.cpp
     Heap.cpp
     HeapBlock.cpp

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -282,6 +282,9 @@ void Heap::gather_roots(HashMap<Cell*, HeapRoot>& roots)
     for (auto& vector : m_root_vectors)
         vector.gather_roots(roots);
 
+    for (auto& hash_map : m_root_hash_maps)
+        hash_map.gather_roots(roots);
+
     if constexpr (HEAP_DEBUG) {
         dbgln("gather_roots:");
         for (auto* root : roots.keys())

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -24,6 +24,7 @@
 #include <LibGC/HeapRoot.h>
 #include <LibGC/Internals.h>
 #include <LibGC/Root.h>
+#include <LibGC/RootHashMap.h>
 #include <LibGC/RootVector.h>
 #include <LibGC/WeakContainer.h>
 
@@ -63,6 +64,9 @@ public:
 
     void did_create_root_vector(Badge<RootVectorBase>, RootVectorBase&);
     void did_destroy_root_vector(Badge<RootVectorBase>, RootVectorBase&);
+
+    void did_create_root_hash_map(Badge<RootHashMapBase>, RootHashMapBase&);
+    void did_destroy_root_hash_map(Badge<RootHashMapBase>, RootHashMapBase&);
 
     void did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
     void did_destroy_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
@@ -142,6 +146,7 @@ private:
 
     RootImpl::List m_roots;
     RootVectorBase::List m_root_vectors;
+    RootHashMapBase::List m_root_hash_maps;
     ConservativeVectorBase::List m_conservative_vectors;
     WeakContainer::List m_weak_containers;
 
@@ -179,6 +184,18 @@ inline void Heap::did_destroy_root_vector(Badge<RootVectorBase>, RootVectorBase&
 {
     VERIFY(m_root_vectors.contains(vector));
     m_root_vectors.remove(vector);
+}
+
+inline void Heap::did_create_root_hash_map(Badge<RootHashMapBase>, RootHashMapBase& hash_map)
+{
+    VERIFY(!m_root_hash_maps.contains(hash_map));
+    m_root_hash_maps.append(hash_map);
+}
+
+inline void Heap::did_destroy_root_hash_map(Badge<RootHashMapBase>, RootHashMapBase& hash_map)
+{
+    VERIFY(m_root_hash_maps.contains(hash_map));
+    m_root_hash_maps.remove(hash_map);
 }
 
 inline void Heap::did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase& vector)

--- a/Libraries/LibGC/HeapRoot.h
+++ b/Libraries/LibGC/HeapRoot.h
@@ -15,6 +15,7 @@ struct HeapRoot {
         HeapFunctionCapturedPointer,
         Root,
         RootVector,
+        RootHashMap,
         ConservativeVector,
         RegisterPointer,
         StackPointer,

--- a/Libraries/LibGC/RootHashMap.cpp
+++ b/Libraries/LibGC/RootHashMap.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGC/Heap.h>
+#include <LibGC/RootHashMap.h>
+
+namespace GC {
+
+RootHashMapBase::RootHashMapBase(Heap& heap)
+    : m_heap(&heap)
+{
+    m_heap->did_create_root_hash_map({}, *this);
+}
+
+RootHashMapBase::~RootHashMapBase()
+{
+    m_heap->did_destroy_root_hash_map({}, *this);
+}
+
+void RootHashMapBase::assign_heap(Heap* heap)
+{
+    if (m_heap == heap)
+        return;
+
+    m_heap = heap;
+
+    // NOTE: IntrusiveList will remove this RootHashMap from the old heap it was part of.
+    m_heap->did_create_root_hash_map({}, *this);
+}
+
+}

--- a/Libraries/LibGC/RootHashMap.h
+++ b/Libraries/LibGC/RootHashMap.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/IntrusiveList.h>
+#include <AK/Vector.h>
+#include <LibGC/Cell.h>
+#include <LibGC/Forward.h>
+#include <LibGC/HeapRoot.h>
+
+namespace GC {
+
+class RootHashMapBase {
+public:
+    virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>&) const = 0;
+
+protected:
+    explicit RootHashMapBase(Heap&);
+    ~RootHashMapBase();
+
+    void assign_heap(Heap*);
+
+    Heap* m_heap { nullptr };
+    IntrusiveListNode<RootHashMapBase> m_list_node;
+
+public:
+    using List = IntrusiveList<&RootHashMapBase::m_list_node>;
+};
+
+template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>, bool IsOrdered = false>
+class RootHashMap final
+    : public RootHashMapBase
+    , public HashMap<K, V, KeyTraits, ValueTraits, IsOrdered> {
+
+    using HashMapBase = HashMap<K, V, KeyTraits, ValueTraits, IsOrdered>;
+
+public:
+    explicit RootHashMap(Heap& heap)
+        : RootHashMapBase(heap)
+    {
+    }
+
+    virtual ~RootHashMap() = default;
+
+    virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>& roots) const override
+    {
+        for (auto& [key, value] : *this) {
+            if constexpr (IsBaseOf<NanBoxedValue, V>) {
+                if (value.is_cell())
+                    roots.set(&const_cast<V&>(value).as_cell(), HeapRoot { .type = HeapRoot::Type::RootHashMap });
+            } else {
+                roots.set(value, HeapRoot { .type = HeapRoot::Type::RootHashMap });
+            }
+        }
+    }
+};
+
+template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>>
+using OrderedRootHashMap = RootHashMap<K, V, KeyTraits, ValueTraits, true>;
+
+}


### PR DESCRIPTION
Before this change, we would call [[OwnPropertyKeys]] on the target
objects, then convert the returned keys from Value into PropertyKey.
Then, when actually iterating, we'd convert them back into Value again.
This was particularly costly for numeric property keys, since we had
to go through string-from-number construction.
    
Now, we simply keep the original values returned by [[OwnPropertyKeys]]
around and use them for the enumeration.
    
1.09x speedup on MicroBench/for-in-indexed-properties.js
1.01x speedup on MicroBench/for-in-named-properties.js