### PR TITLE
LibJS: Use PrimitiveString more instead of Utf16String in RegExp/String code

### DIFF
--- a/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -12,7 +12,7 @@
 
 namespace JS {
 
-ThrowCompletionOr<Value> regexp_exec(VM&, Object& regexp_object, Utf16String string);
+ThrowCompletionOr<Value> regexp_exec(VM&, Object& regexp_object, GC::Ref<PrimitiveString> string);
 size_t advance_string_index(Utf16View const& string, size_t index, bool unicode);
 
 class RegExpPrototype final : public PrototypeObject<RegExpPrototype, RegExpObject> {

--- a/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
+++ b/Libraries/LibJS/Runtime/RegExpStringIterator.cpp
@@ -12,7 +12,7 @@ namespace JS {
 GC_DEFINE_ALLOCATOR(RegExpStringIterator);
 
 // 22.2.9.1 CreateRegExpStringIterator ( R, S, global, fullUnicode ), https://tc39.es/ecma262/#sec-createregexpstringiterator
-GC::Ref<RegExpStringIterator> RegExpStringIterator::create(Realm& realm, Object& regexp_object, Utf16String string, bool global, bool unicode)
+GC::Ref<RegExpStringIterator> RegExpStringIterator::create(Realm& realm, Object& regexp_object, GC::Ref<PrimitiveString> string, bool global, bool unicode)
 {
     // 1. Let iterator be OrdinaryObjectCreate(%RegExpStringIteratorPrototype%, « [[IteratingRegExp]], [[IteratedString]], [[Global]], [[Unicode]], [[Done]] »).
     // 2. Set iterator.[[IteratingRegExp]] to R.
@@ -21,13 +21,13 @@ GC::Ref<RegExpStringIterator> RegExpStringIterator::create(Realm& realm, Object&
     // 5. Set iterator.[[Unicode]] to fullUnicode.
     // 6. Set iterator.[[Done]] to false.
     // 7. Return iterator.
-    return realm.create<RegExpStringIterator>(realm.intrinsics().regexp_string_iterator_prototype(), regexp_object, move(string), global, unicode);
+    return realm.create<RegExpStringIterator>(realm.intrinsics().regexp_string_iterator_prototype(), regexp_object, string, global, unicode);
 }
 
-RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_object, Utf16String string, bool global, bool unicode)
+RegExpStringIterator::RegExpStringIterator(Object& prototype, Object& regexp_object, GC::Ref<PrimitiveString> string, bool global, bool unicode)
     : Object(ConstructWithPrototypeTag::Tag, prototype)
     , m_regexp_object(regexp_object)
-    , m_string(move(string))
+    , m_string(string)
     , m_global(global)
     , m_unicode(unicode)
 {
@@ -37,6 +37,7 @@ void RegExpStringIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_regexp_object);
+    visitor.visit(m_string);
 }
 
 }

--- a/Libraries/LibJS/Runtime/RegExpStringIterator.h
+++ b/Libraries/LibJS/Runtime/RegExpStringIterator.h
@@ -6,9 +6,8 @@
 
 #pragma once
 
-#include <AK/Utf16View.h>
 #include <LibJS/Runtime/Object.h>
-#include <LibJS/Runtime/Utf16String.h>
+#include <LibJS/Runtime/PrimitiveString.h>
 
 namespace JS {
 
@@ -17,12 +16,12 @@ class RegExpStringIterator final : public Object {
     GC_DECLARE_ALLOCATOR(RegExpStringIterator);
 
 public:
-    static GC::Ref<RegExpStringIterator> create(Realm&, Object& regexp_object, Utf16String string, bool global, bool unicode);
+    static GC::Ref<RegExpStringIterator> create(Realm&, Object& regexp_object, GC::Ref<PrimitiveString> string, bool global, bool unicode);
 
     virtual ~RegExpStringIterator() override = default;
 
     Object& regexp_object() { return m_regexp_object; }
-    Utf16String const& string() const { return m_string; }
+    GC::Ref<PrimitiveString> string() const { return m_string; }
     bool global() const { return m_global; }
     bool unicode() const { return m_unicode; }
 
@@ -30,12 +29,12 @@ public:
     void set_done() { m_done = true; }
 
 private:
-    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, Utf16String string, bool global, bool unicode);
+    explicit RegExpStringIterator(Object& prototype, Object& regexp_object, GC::Ref<PrimitiveString> string, bool global, bool unicode);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
     GC::Ref<Object> m_regexp_object;
-    Utf16String m_string;
+    GC::Ref<PrimitiveString> m_string;
     bool m_global { false };
     bool m_unicode { false };
     bool m_done { false };

--- a/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpStringIteratorPrototype.cpp
@@ -79,15 +79,15 @@ JS_DEFINE_NATIVE_FUNCTION(RegExpStringIteratorPrototype::next)
     }
 
     // 12. Let matchStr be ? ToString(? Get(match, "0")).
-    auto match_string = TRY(TRY(match.get(vm, 0)).to_utf16_string(vm));
+    auto match_string = TRY(TRY(match.get(vm, 0)).to_primitive_string(vm));
 
     // 13. If matchStr is the empty String, then
-    if (match_string.is_empty()) {
+    if (match_string->is_empty()) {
         // a. Let thisIndex be ℝ(? ToLength(? Get(R, "lastIndex"))).
         auto this_index = TRY(TRY(regexp.get(vm.names.lastIndex)).to_length(vm));
 
         // b. Let nextIndex be AdvanceStringIndex(S, thisIndex, fullUnicode).
-        auto next_index = advance_string_index(string.view(), this_index, full_unicode);
+        auto next_index = advance_string_index(string->utf16_string_view(), this_index, full_unicode);
 
         // c. Perform ? Set(R, "lastIndex", 𝔽(nextIndex), true).
         TRY(regexp.set(vm.names.lastIndex, Value { next_index }, Object::ShouldThrowExceptions::Yes));


### PR DESCRIPTION
PrimitiveString has an internal UTF-16 string cache anyway, and so this
actually avoids repeatedly converting between UTF-8 and UTF-16.

1.02x speedup on Octane/regexp.js