### PR TITLE
LibWeb/HTML: Implement `report_validity`

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Position.h>
 #include <LibWeb/DOM/SelectionchangeEventDispatching.h>
+#include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>
 #include <LibWeb/HTML/HTMLDataListElement.h>
@@ -245,6 +246,36 @@ bool FormAssociatedElement::check_validity_steps()
         // 2. Return false.
         return false;
     }
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#report-validity-steps
+bool FormAssociatedElement::report_validity_steps()
+{
+    // 1. If element is a candidate for constraint validation and does not satisfy its constraints, then:
+    if (is_candidate_for_constraint_validation() && !satisfies_its_constraints()) {
+        auto& element = form_associated_element_to_html_element();
+        // 1. Let report be the result of firing an event named invalid at element, with the cancelable attribute initialized to true.
+        auto report = element.dispatch_event(DOM::Event::create(element.realm(), EventNames::invalid, { .cancelable = true }));
+
+        // 2. If report is true, then report the problems with the constraints of this element to the user. When reporting the problem with the constraints to the user,
+        //    the user agent may run the focusing steps for element, and may change the scrolling position of the document, or perform some other action that brings
+        //    element to the user's attention. User agents may report more than one constraint violation, if element suffers from multiple problems at once.
+        // FIXME: Does this align with other browsers?
+        if (report && element.check_visibility({})) {
+            run_focusing_steps(&element);
+            DOM::ScrollIntoViewOptions scroll_options;
+            scroll_options.block = Bindings::ScrollLogicalPosition::Nearest;
+            scroll_options.inline_ = Bindings::ScrollLogicalPosition::Nearest;
+            scroll_options.behavior = Bindings::ScrollBehavior::Instant;
+            (void)element.scroll_into_view(scroll_options);
+        }
+
+        // 3. Return false.
+        return false;
+    }
+
+    // 2. Return true.
     return true;
 }
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -101,6 +101,9 @@ public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#check-validity-steps
     bool check_validity_steps();
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#report-validity-steps
+    bool report_validity_steps();
+
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#candidate-for-constraint-validation
     bool is_candidate_for_constraint_validation() const;
 

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -84,6 +84,7 @@ public:
     };
 
     StaticValidationResult statically_validate_constraints();
+    bool interactively_validate_constraints();
     WebIDL::ExceptionOr<bool> check_validity();
     WebIDL::ExceptionOr<bool> report_validity();
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2785,8 +2785,7 @@ WebIDL::ExceptionOr<bool> HTMLInputElement::check_validity()
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
 WebIDL::ExceptionOr<bool> HTMLInputElement::report_validity()
 {
-    dbgln("(STUBBED) HTMLInputElement::report_validity(). Called on: {}", debug_description());
-    return true;
+    return report_validity_steps();
 }
 
 Optional<ARIA::Role> HTMLInputElement::default_role() const

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -711,6 +711,12 @@ bool HTMLSelectElement::check_validity()
     return check_validity_steps();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
+bool HTMLSelectElement::report_validity()
+{
+    return report_validity_steps();
+}
+
 bool HTMLSelectElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -63,6 +63,7 @@ public:
 
     bool will_validate();
     bool check_validity();
+    bool report_validity();
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-select-element

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -35,7 +35,7 @@ interface HTMLSelectElement : HTMLElement {
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
     boolean checkValidity();
-    [FIXME] boolean reportValidity();
+    boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
     undefined showPicker();

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -248,8 +248,7 @@ bool HTMLTextAreaElement::check_validity()
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
 bool HTMLTextAreaElement::report_validity()
 {
-    dbgln("(STUBBED) HTMLTextAreaElement::report_validity(). Called on: {}", debug_description());
-    return true;
+    return report_validity_steps();
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-reportValidity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-reportValidity.txt
@@ -1,0 +1,135 @@
+Harness status: OK
+
+Found 130 tests
+
+130 Pass
+Pass	[INPUT in TEXT status] no constraint
+Pass	[INPUT in TEXT status] no constraint (in a form)
+Pass	[INPUT in TEXT status] not suffering from being too long
+Pass	[INPUT in TEXT status] not suffering from being too long (in a form)
+Pass	[INPUT in TEXT status] suffering from a pattern mismatch
+Pass	[INPUT in TEXT status] suffering from a pattern mismatch (in a form)
+Pass	[INPUT in TEXT status] suffering from being missing
+Pass	[INPUT in TEXT status] suffering from being missing (in a form)
+Pass	[INPUT in SEARCH status] no constraint
+Pass	[INPUT in SEARCH status] no constraint (in a form)
+Pass	[INPUT in SEARCH status] not suffering from being too long
+Pass	[INPUT in SEARCH status] not suffering from being too long (in a form)
+Pass	[INPUT in SEARCH status] suffering from a pattern mismatch
+Pass	[INPUT in SEARCH status] suffering from a pattern mismatch (in a form)
+Pass	[INPUT in SEARCH status] suffering from being missing
+Pass	[INPUT in SEARCH status] suffering from being missing (in a form)
+Pass	[INPUT in TEL status] no constraint
+Pass	[INPUT in TEL status] no constraint (in a form)
+Pass	[INPUT in TEL status] not suffering from being too long
+Pass	[INPUT in TEL status] not suffering from being too long (in a form)
+Pass	[INPUT in TEL status] suffering from a pattern mismatch
+Pass	[INPUT in TEL status] suffering from a pattern mismatch (in a form)
+Pass	[INPUT in TEL status] suffering from being missing
+Pass	[INPUT in TEL status] suffering from being missing (in a form)
+Pass	[INPUT in PASSWORD status] no constraint
+Pass	[INPUT in PASSWORD status] no constraint (in a form)
+Pass	[INPUT in PASSWORD status] not suffering from being too long
+Pass	[INPUT in PASSWORD status] not suffering from being too long (in a form)
+Pass	[INPUT in PASSWORD status] suffering from a pattern mismatch
+Pass	[INPUT in PASSWORD status] suffering from a pattern mismatch (in a form)
+Pass	[INPUT in PASSWORD status] suffering from being missing
+Pass	[INPUT in PASSWORD status] suffering from being missing (in a form)
+Pass	[INPUT in URL status] no constraint
+Pass	[INPUT in URL status] no constraint (in a form)
+Pass	[INPUT in URL status] not suffering from being too long
+Pass	[INPUT in URL status] not suffering from being too long (in a form)
+Pass	[INPUT in URL status] suffering from a pattern mismatch
+Pass	[INPUT in URL status] suffering from a pattern mismatch (in a form)
+Pass	[INPUT in URL status] suffering from a type mismatch
+Pass	[INPUT in URL status] suffering from a type mismatch (in a form)
+Pass	[INPUT in URL status] suffering from being missing
+Pass	[INPUT in URL status] suffering from being missing (in a form)
+Pass	[INPUT in EMAIL status] no constraint
+Pass	[INPUT in EMAIL status] no constraint (in a form)
+Pass	[INPUT in EMAIL status] not suffering from being too long
+Pass	[INPUT in EMAIL status] not suffering from being too long (in a form)
+Pass	[INPUT in EMAIL status] suffering from a pattern mismatch
+Pass	[INPUT in EMAIL status] suffering from a pattern mismatch (in a form)
+Pass	[INPUT in EMAIL status] suffering from a type mismatch
+Pass	[INPUT in EMAIL status] suffering from a type mismatch (in a form)
+Pass	[INPUT in EMAIL status] suffering from being missing
+Pass	[INPUT in EMAIL status] suffering from being missing (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] no constraint
+Pass	[INPUT in DATETIME-LOCAL status] no constraint (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an overflow
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an overflow (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an underflow
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an underflow (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] suffering from a step mismatch
+Pass	[INPUT in DATETIME-LOCAL status] suffering from a step mismatch (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] suffering from being missing
+Pass	[INPUT in DATETIME-LOCAL status] suffering from being missing (in a form)
+Pass	[INPUT in DATE status] no constraint
+Pass	[INPUT in DATE status] no constraint (in a form)
+Pass	[INPUT in DATE status] suffering from an overflow
+Pass	[INPUT in DATE status] suffering from an overflow (in a form)
+Pass	[INPUT in DATE status] suffering from an underflow
+Pass	[INPUT in DATE status] suffering from an underflow (in a form)
+Pass	[INPUT in DATE status] suffering from a step mismatch
+Pass	[INPUT in DATE status] suffering from a step mismatch (in a form)
+Pass	[INPUT in DATE status] suffering from being missing
+Pass	[INPUT in DATE status] suffering from being missing (in a form)
+Pass	[INPUT in MONTH status] no constraint
+Pass	[INPUT in MONTH status] no constraint (in a form)
+Pass	[INPUT in MONTH status] suffering from an overflow
+Pass	[INPUT in MONTH status] suffering from an overflow (in a form)
+Pass	[INPUT in MONTH status] suffering from an underflow
+Pass	[INPUT in MONTH status] suffering from an underflow (in a form)
+Pass	[INPUT in MONTH status] suffering from a step mismatch
+Pass	[INPUT in MONTH status] suffering from a step mismatch (in a form)
+Pass	[INPUT in MONTH status] suffering from being missing
+Pass	[INPUT in MONTH status] suffering from being missing (in a form)
+Pass	[INPUT in WEEK status] no constraint
+Pass	[INPUT in WEEK status] no constraint (in a form)
+Pass	[INPUT in WEEK status] suffering from an overflow
+Pass	[INPUT in WEEK status] suffering from an overflow (in a form)
+Pass	[INPUT in WEEK status] suffering from an underflow
+Pass	[INPUT in WEEK status] suffering from an underflow (in a form)
+Pass	[INPUT in WEEK status] suffering from a step mismatch
+Pass	[INPUT in WEEK status] suffering from a step mismatch (in a form)
+Pass	[INPUT in WEEK status] suffering from being missing
+Pass	[INPUT in WEEK status] suffering from being missing (in a form)
+Pass	[INPUT in TIME status] no constraint
+Pass	[INPUT in TIME status] no constraint (in a form)
+Pass	[INPUT in TIME status] suffering from an overflow
+Pass	[INPUT in TIME status] suffering from an overflow (in a form)
+Pass	[INPUT in TIME status] suffering from an underflow
+Pass	[INPUT in TIME status] suffering from an underflow (in a form)
+Pass	[INPUT in TIME status] suffering from a step mismatch
+Pass	[INPUT in TIME status] suffering from a step mismatch (in a form)
+Pass	[INPUT in TIME status] suffering from being missing
+Pass	[INPUT in TIME status] suffering from being missing (in a form)
+Pass	[INPUT in NUMBER status] suffering from an overflow
+Pass	[INPUT in NUMBER status] suffering from an overflow (in a form)
+Pass	[INPUT in NUMBER status] suffering from an underflow
+Pass	[INPUT in NUMBER status] suffering from an underflow (in a form)
+Pass	[INPUT in NUMBER status] suffering from a step mismatch
+Pass	[INPUT in NUMBER status] suffering from a step mismatch (in a form)
+Pass	[INPUT in NUMBER status] suffering from being missing
+Pass	[INPUT in NUMBER status] suffering from being missing (in a form)
+Pass	[INPUT in CHECKBOX status] no constraint
+Pass	[INPUT in CHECKBOX status] no constraint (in a form)
+Pass	[INPUT in CHECKBOX status] suffering from being missing
+Pass	[INPUT in CHECKBOX status] suffering from being missing (in a form)
+Pass	[INPUT in RADIO status] no constraint
+Pass	[INPUT in RADIO status] no constraint (in a form)
+Pass	[INPUT in RADIO status] suffering from being missing
+Pass	[INPUT in RADIO status] suffering from being missing (in a form)
+Pass	[INPUT in FILE status] no constraint
+Pass	[INPUT in FILE status] no constraint (in a form)
+Pass	[INPUT in FILE status] suffering from being missing
+Pass	[INPUT in FILE status] suffering from being missing (in a form)
+Pass	[select]  no constraint
+Pass	[select]  no constraint (in a form)
+Pass	[select]  suffering from being missing
+Pass	[select]  suffering from being missing (in a form)
+Pass	[textarea]  no constraint
+Pass	[textarea]  no constraint (in a form)
+Pass	[textarea]  suffering from being missing
+Pass	[textarea]  suffering from being missing (in a form)

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/constraints/form-validation-reportValidity.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/constraints/form-validation-reportValidity.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>The constraint validation API Test: element.reportValidity()</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-constraint-validation-api">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<script src="support/validator.js"></script>
+<div id="log"></div>
+<script>
+  var testElements = [
+    {
+      tag: "input",
+      types: ["text", "search", "tel", "password"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {maxLength: "4", value: "abcdef"}, expected: true, name: "[target] not suffering from being too long", dirty: true},
+        {conditions: {pattern: "[A-Z]", value: "abc"}, expected: false, name: "[target] suffering from a pattern mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["url"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {maxLength: "20", value: "http://www.example.com"}, expected: true, name: "[target] not suffering from being too long", dirty: true},
+        {conditions: {pattern: "http://www.example.com", value: "http://www.example.net"}, expected: false, name: "[target] suffering from a pattern mismatch"},
+        {conditions: {value: "abc"}, expected: false, name: "[target] suffering from a type mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["email"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {maxLength: "10", value: "test@example.com"}, expected: true, name: "[target] not suffering from being too long", dirty: true},
+        {conditions: {pattern: "test@example.com", value: "test@example.net"}, expected: false, name: "[target] suffering from a pattern mismatch"},
+        {conditions: {value: "abc"}, expected: false, name: "[target] suffering from a type mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["datetime-local"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {max: "2000-01-01T12:00:00", value: "2001-01-01T12:00:00"}, expected: false, name: "[target] suffering from an overflow"},
+        {conditions: {min: "2001-01-01T12:00:00", value: "2000-01-01T12:00:00"}, expected: false, name: "[target] suffering from an underflow"},
+        {conditions: {step: 2 * 60 * 1000, value: "2001-01-01T12:03:00"}, expected: false, name: "[target] suffering from a step mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["date"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {max: "2000-01-01", value: "2001-01-01"}, expected: false, name: "[target] suffering from an overflow"},
+        {conditions: {min: "2001-01-01", value: "2000-01-01"}, expected: false, name: "[target] suffering from an underflow"},
+        {conditions: {step: 2 * 1 * 86400000, value: "2001-01-03"}, expected: false, name: "[target] suffering from a step mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["month"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {max: "2000-01", value: "2001-01"}, expected: false, name: "[target] suffering from an overflow"},
+        {conditions: {min: "2001-01", value: "2000-01"}, expected: false, name: "[target] suffering from an underflow"},
+        {conditions: {step: 3 * 1 * 1, value: "2001-03"}, expected: false, name: "[target] suffering from a step mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["week"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {max: "2000-W01", value: "2001-W01"}, expected: false, name: "[target] suffering from an overflow"},
+        {conditions: {min: "2001-W01", value: "2000-W01"}, expected: false, name: "[target] suffering from an underflow"},
+        {conditions: {step: 2 * 1 * 604800000, value: "2001-W03"}, expected: false, name: "[target] suffering from a step mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["time"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {max: "12:00:00", value: "13:00:00"}, expected: false, name: "[target] suffering from an overflow"},
+        {conditions: {min: "12:00:00", value: "11:00:00"}, expected: false, name: "[target] suffering from an underflow"},
+        {conditions: {step: 2 * 60 * 1000, value: "12:03:00"}, expected: false, name: "[target] suffering from a step mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["number"],
+      testData: [
+        {conditions: {max: "5", value: "6"}, expected: false, name: "[target] suffering from an overflow"},
+        {conditions: {min: "5", value: "4"}, expected: false, name: "[target] suffering from an underflow"},
+        {conditions: {step: 2 * 1 * 1, value: "3"}, expected: false, name: "[target] suffering from a step mismatch"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["checkbox", "radio"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {required: true, checked: false, name: "test1"}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "input",
+      types: ["file"],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {required: true, files: null}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "select",
+      types: [],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    },
+    {
+      tag: "textarea",
+      types: [],
+      testData: [
+        {conditions: {}, expected: true, name: "[target] no constraint"},
+        {conditions: {required: true, value: ""}, expected: false, name: "[target] suffering from being missing"}
+      ]
+    }
+  ];
+
+  validator.run_test(testElements, "reportValidity");
+</script>


### PR DESCRIPTION
This implements the previously stubbed out `report_validity` method.

The specification is not very clear on how to exactly report the validity. For now, we bring the first visible invalid control into view and focus it. In the future, however, it would make sense to support more complex scenarios and be more aligned with the other implementations.