### PR TITLE
LibWeb: Improve parsing for the CSS contain property

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -345,6 +345,7 @@ private:
     };
     RefPtr<PositionStyleValue const> parse_position_value(TokenStream<ComponentValue>&, PositionParsingMode = PositionParsingMode::Normal);
     RefPtr<CSSStyleValue const> parse_filter_value_list_value(TokenStream<ComponentValue>&);
+    RefPtr<CSSStyleValue const> parse_contain_value(TokenStream<ComponentValue>&);
     RefPtr<StringStyleValue const> parse_opentype_tag_value(TokenStream<ComponentValue>&);
     RefPtr<FontSourceStyleValue const> parse_font_source_value(TokenStream<ComponentValue>&);
 

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1110,7 +1110,6 @@
     ]
   },
   "contain": {
-    "__comment": "FIXME: Some values of contain need to be mutually exclusive. The grammar this should adhere to is 'none | strict | content | [ [size | inline-size] || layout || style || paint ]'.",
     "affects-stacking-context": true,
     "animation-type": "none",
     "inherited": false,

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 15 tests
 
-8 Pass
-7 Fail
+13 Pass
+2 Fail
 Pass	Property contain value 'none'
 Pass	Property contain value 'strict'
 Pass	Property contain value 'content'
@@ -11,11 +11,11 @@ Pass	Property contain value 'size'
 Pass	Property contain value 'layout'
 Pass	Property contain value 'style'
 Pass	Property contain value 'paint'
-Fail	Property contain value 'size layout'
-Fail	Property contain value 'style paint'
+Pass	Property contain value 'size layout'
+Pass	Property contain value 'style paint'
 Fail	Property contain value 'style layout paint'
 Fail	Property contain value 'size style layout paint'
-Fail	Property contain value 'size layout paint'
-Fail	Property contain value 'layout paint'
+Pass	Property contain value 'size layout paint'
+Pass	Property contain value 'layout paint'
 Pass	Property contain value 'inline-size'
-Fail	Property contain value 'inline-size layout style paint'
+Pass	Property contain value 'inline-size layout style paint'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 13 tests
 
-8 Pass
-5 Fail
+9 Pass
+4 Fail
 Pass	e.style['contain'] = "none" should set the property value
 Pass	e.style['contain'] = "strict" should set the property value
 Pass	e.style['contain'] = "content" should set the property value
@@ -13,7 +13,7 @@ Pass	e.style['contain'] = "style" should set the property value
 Pass	e.style['contain'] = "paint" should set the property value
 Fail	e.style['contain'] = "layout size" should set the property value
 Fail	e.style['contain'] = "paint style" should set the property value
-Fail	e.style['contain'] = "layout style paint" should set the property value
+Pass	e.style['contain'] = "layout style paint" should set the property value
 Fail	e.style['contain'] = "layout paint style size" should set the property value
 Pass	e.style['contain'] = "inline-size" should set the property value
 Fail	e.style['contain'] = "layout inline-size" should set the property value


### PR DESCRIPTION
This makes us actually respect the grammar and nets us a couple extra WPT passes in the parsing section.
(any maybe others, if they use weird combinations of stuff)

We still struggle with preserving the order of stuff when serializing but I'll leave that for some other time.
