### PR TITLE
Meta: Add doctypes to all table layout tests

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200.328125x100 [BFC] children: not-inline
         Box <table> at (9,9) content-size 198.328125x98 table-box [TFC] children: not-inline
@@ -46,7 +46,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200.328125x100]
         PaintableBox (Box<TABLE>) [8,8 200.328125x100]

--- a/Tests/LibWeb/Layout/expected/table/auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-margins.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       BlockContainer <div.wrapper> at (8,8) content-size 784x17 children: not-inline
         TableWrapper <(anonymous)> at (235.265625,8) content-size 329.46875x17 [BFC] children: not-inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
       PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x17]
         PaintableWithLines (TableWrapper(anonymous)) [235.265625,8 329.46875x17]

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x39 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x23 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 6x23 [BFC] children: not-inline
         Box <table> at (8,8) content-size 6x23 table-box [TFC] children: not-inline
@@ -24,7 +24,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 6x23]
         PaintableBox (Box<TABLE>) [8,8 6x23]

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x117 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x101 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 2x2 [BFC] children: not-inline
         Box <table#empty-table> at (8,8) content-size 2x2 table-box [TFC] children: not-inline
@@ -71,7 +71,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x117]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x101]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 2x2]
         PaintableBox (Box<TABLE>#empty-table) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x61 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x45 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 42.265625x45 [BFC] children: not-inline
         Box <table> at (18,18) content-size 22.265625x25 table-box [TFC] children: not-inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x61]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x45]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 42.265625x45]
         PaintableBox (Box<TABLE>) [8,8 42.265625x45]

--- a/Tests/LibWeb/Layout/expected/table/border-attribute.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x51 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x35 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 32.265625x35 [BFC] children: not-inline
         Box <table> at (13,13) content-size 22.265625x25 table-box [TFC] children: not-inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x51]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x35]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 32.265625x35]
         PaintableBox (Box<TABLE>) [8,8 32.265625x35]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x102 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x86 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 172.671875x86 [BFC] children: not-inline
         Box <table> at (8,8) content-size 172.671875x86 table-box [TFC] children: not-inline
@@ -64,7 +64,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x102]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x86]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 172.671875x86]
         PaintableBox (Box<TABLE>) [8,8 172.671875x86]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x145 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x129 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 114.8125x129 [BFC] children: not-inline
         Box <table> at (8,8) content-size 114.8125x129 table-box [TFC] children: not-inline
@@ -69,7 +69,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x145]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x129]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 114.8125x129]
         PaintableBox (Box<TABLE>) [8,8 114.8125x129]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x139 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x123 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 113.40625x123 [BFC] children: not-inline
         Box <table> at (8,8) content-size 113.40625x123 table-box [TFC] children: not-inline
@@ -70,7 +70,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x139]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x123]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 113.40625x123]
         PaintableBox (Box<TABLE>) [8,8 113.40625x123]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x35 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x19 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
@@ -55,7 +55,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x35]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x19]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 53.0625x19]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x93 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x77 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 143.609375x77 [BFC] children: not-inline
         Box <table> at (23,13) content-size 113.609375x67 table-box [TFC] children: not-inline
@@ -27,7 +27,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x93]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x77]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 143.609375x77]
         PaintableBox (Box<TABLE>) [8,8 143.609375x77]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x31 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
       BlockContainer <div.left> at (8,8) content-size 117.59375x17 floating [BFC] children: inline
         frag 0 from TextNode start: 0, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
@@ -34,7 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x31]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>.left) [8,8 117.59375x17]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x276 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x260 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 174.296875x73 [BFC] children: not-inline
         Box <table.table-border-black> at (9,9) content-size 172.296875x71 table-box [TFC] children: not-inline
@@ -260,7 +260,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x276]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x260]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 174.296875x73]
         PaintableBox (Box<TABLE>.table-border-black) [8,8 174.296875x73]

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x39 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x23 children: not-inline
       BlockContainer <div#container> at (8,8) content-size 80x23 children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 80x0 children: inline
@@ -43,7 +43,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
       PaintableWithLines (BlockContainer<DIV>#container) [8,8 80x23]
         PaintableWithLines (BlockContainer(anonymous)) [8,8 80x0]

--- a/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-px-height.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     TableWrapper <(anonymous)> at (8,8) content-size 102x100 [BFC] children: not-inline
       Box <body> at (8,8) content-size 102x100 table-box [TFC] children: not-inline
         Box <div.row> at (8,8) content-size 102x100 table-row children: not-inline
           BlockContainer <div.cell> at (9,9) content-size 100x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (TableWrapper(anonymous)) [8,8 102x100]
       PaintableBox (Box<BODY>) [8,8 102x100]
         PaintableBox (Box<DIV>.row) [8,8 102x100]

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 784x44 [BFC] children: not-inline
         Box <table> at (8,8) content-size 784x44 table-box [TFC] children: not-inline
@@ -64,7 +64,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x44]
         PaintableBox (Box<TABLE>) [8,8 784x44]

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x133 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x117 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 93.359375x117 [BFC] children: not-inline
         Box <table> at (8,8) content-size 93.359375x117 table-box [TFC] children: not-inline
@@ -66,7 +66,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x133]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x117]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 93.359375x117]
         PaintableBox (Box<TABLE>) [8,8 93.359375x117]

--- a/Tests/LibWeb/Layout/expected/table/col-span-crash.txt
+++ b/Tests/LibWeb/Layout/expected/table/col-span-crash.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x35 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x19 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 4x2 [BFC] children: not-inline
         Box <table> at (8,8) content-size 4x2 table-box [TFC] children: not-inline
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x35]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x19]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 4x2]
         PaintableBox (Box<TABLE>) [8,8 4x2]

--- a/Tests/LibWeb/Layout/expected/table/colgroup-with-two-cols.txt
+++ b/Tests/LibWeb/Layout/expected/table/colgroup-with-two-cols.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x18 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x2 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 46x2 [BFC] children: not-inline
         Box <table> at (8,8) content-size 46x2 table-box [TFC] children: not-inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <tbody> at (10,10) content-size 0x0 table-row-group children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x18]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x2]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 46x2]
         PaintableBox (Box<TABLE>) [8,8 46x2]

--- a/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x77 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x61 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 27.90625x44 [BFC] children: not-inline
         Box <table> at (8,8) content-size 27.90625x44 table-box [TFC] children: not-inline
@@ -45,7 +45,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x77]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x61]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 27.90625x44]
         PaintableBox (Box<TABLE>) [8,8 27.90625x44]

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 420x44 [BFC] children: not-inline
         Box <table> at (9,9) content-size 418x42 table-box [TFC] children: not-inline
@@ -53,7 +53,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x44]
         PaintableBox (Box<TABLE>) [8,8 420x44]

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 210x44 [BFC] children: not-inline
         Box <table> at (9,9) content-size 208x42 table-box [TFC] children: not-inline
@@ -39,7 +39,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 210x44]
         PaintableBox (Box<TABLE>) [8,8 210x44]

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x126 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x110 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 784x110 [BFC] children: not-inline
         Box <table.ambox> at (9,9) content-size 782x108 table-box [TFC] children: not-inline
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x126]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x110]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x110]
         PaintableBox (Box<TABLE>.ambox) [8,8 784x110]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 600x44 [BFC] children: not-inline
         Box <table> at (9,9) content-size 598x42 table-box [TFC] children: not-inline
@@ -74,7 +74,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44]
         PaintableBox (Box<TABLE>) [8,8 600x44]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 600x44 [BFC] children: not-inline
         Box <table> at (9,9) content-size 598x42 table-box [TFC] children: not-inline
@@ -74,7 +74,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44]
         PaintableBox (Box<TABLE>) [8,8 600x44]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 600x44 [BFC] children: not-inline
         Box <table> at (9,9) content-size 598x42 table-box [TFC] children: not-inline
@@ -74,7 +74,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44]
         PaintableBox (Box<TABLE>) [8,8 600x44]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x94 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x78 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 600x78 [BFC] children: not-inline
         Box <table> at (9,9) content-size 598x76 table-box [TFC] children: not-inline
@@ -78,7 +78,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x94]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x78]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x78]
         PaintableBox (Box<TABLE>) [8,8 600x78]

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x60 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x44 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 600x44 [BFC] children: not-inline
         Box <table> at (9,9) content-size 598x42 table-box [TFC] children: not-inline
@@ -74,7 +74,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 600x44]
         PaintableBox (Box<TABLE>) [8,8 600x44]

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x50 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
       BlockContainer <div.wrapper> at (8,8) content-size 784x34 children: not-inline
         TableWrapper <(anonymous)> at (108,8) content-size 584x34 [BFC] children: not-inline
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
       PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x34]
         PaintableWithLines (TableWrapper(anonymous)) [108,8 584x34]

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x62 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x46 children: inline
       frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x44] baseline: 14.296875
       BlockContainer <table> at (9,9) content-size 135.984375x44 inline-block [BFC] children: not-inline
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                     TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x62]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x46]
       PaintableWithLines (BlockContainer<TABLE>) [8,8 137.984375x46]
         PaintableWithLines (TableWrapper(anonymous)) [9,9 135.984375x44]

--- a/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
+++ b/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x39 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x23 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 37.609375x23 [BFC] children: not-inline
         Box <table> at (8,8) content-size 37.609375x23 table-box [TFC] children: not-inline
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 37.609375x23]
         PaintableBox (Box<TABLE>) [8,8 37.609375x23]

--- a/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x54 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x38 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 61x38 [BFC] children: not-inline
         Box <table> at (8,8) content-size 61x38 table-box [TFC] children: not-inline
@@ -42,7 +42,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x54]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x38]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 61x38]
         PaintableBox (Box<TABLE>) [8,8 61x38]

--- a/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x135 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x119 children: not-inline
       Box <div> at (8,8) content-size 784x119 [GFC] children: not-inline
         TableWrapper <(anonymous)> at (8,8) content-size 100x119 [BFC] children: not-inline
@@ -34,7 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 BlockContainer <(anonymous)> at (84.28125,106) content-size 21.71875x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x135]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x119]
       PaintableBox (Box<DIV>) [8,8 784x119]
         PaintableWithLines (TableWrapper(anonymous)) [8,8 100x119]

--- a/Tests/LibWeb/Layout/expected/table/missing-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x135 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x119 children: not-inline
       Box <div> at (8,8) content-size 784x119 [GFC] children: not-inline
         TableWrapper <(anonymous)> at (8,8) content-size 100x119 [BFC] children: not-inline
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 BlockContainer <(anonymous)> at (62.5625,106) content-size 43.4375x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x135]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x119]
       PaintableBox (Box<DIV>) [8,8 784x119]
         PaintableWithLines (TableWrapper(anonymous)) [8,8 100x119]

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x83 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x67 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 81.4375x67 [BFC] children: not-inline
         Box <table> at (9,9) content-size 79.4375x65 table-box [TFC] children: not-inline
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x83]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x67]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 81.4375x67]
         PaintableBox (Box<TABLE>) [8,8 81.4375x67]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x39 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x23 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 94x23 [BFC] children: not-inline
         Box <table> at (9,9) content-size 92x21 table-box [TFC] children: not-inline
@@ -38,7 +38,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 94x23]
         PaintableBox (Box<TABLE>) [8,8 94x23]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x47 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x31 children: not-inline
       Box <div.grid_layout> at (8,8) content-size 784x31 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 200x31 [BFC] children: not-inline
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                                 TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x47]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x31]
       PaintableBox (Box<DIV>.grid_layout) [8,8 784x31]
         PaintableWithLines (BlockContainer<DIV>) [8,8 200x31]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 119x21 [BFC] children: not-inline
         Box <table> at (8,8) content-size 119x21 table-box [TFC] children: not-inline
@@ -34,7 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x37]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 119x21]
         PaintableBox (Box<TABLE>) [8,8 119x21]

--- a/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 6x6 positioned [BFC] children: not-inline
         Box <table#t> at (8,8) content-size 6x6 table-box [TFC] children: not-inline
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 6x6]
         PaintableBox (Box<TABLE>#t) [8,8 6x6]

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x41 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x25 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 49.21875x25 [BFC] children: not-inline
         Box <table> at (8,8) content-size 49.21875x25 table-box [TFC] children: not-inline
@@ -34,7 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x41]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x25]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 49.21875x25]
         PaintableBox (Box<TABLE>) [8,8 49.21875x25]

--- a/Tests/LibWeb/Layout/expected/table/row-px-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-px-height.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     TableWrapper <(anonymous)> at (8,8) content-size 102x100 [BFC] children: not-inline
       Box <body> at (8,8) content-size 102x100 table-box [TFC] children: not-inline
         Box <div.row> at (8,8) content-size 102x100 table-row children: not-inline
           BlockContainer <div.cell> at (9,9) content-size 100x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (TableWrapper(anonymous)) [8,8 102x100]
       PaintableBox (Box<BODY>) [8,8 102x100]
         PaintableBox (Box<DIV>.row) [8,8 102x100]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x150 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x150 table-box [TFC] children: not-inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <div.cell> at (8,58) content-size 200x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x150]
         PaintableBox (Box<DIV>.table) [8,8 200x150]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <div.cell> at (8,158) content-size 200x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]
         PaintableBox (Box<DIV>.table) [8,8 200x300]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]
         PaintableBox (Box<DIV>.table) [8,8 200x300]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x300]
         PaintableBox (Box<DIV>.table) [8,8 200x300]

--- a/Tests/LibWeb/Layout/expected/table/size.txt
+++ b/Tests/LibWeb/Layout/expected/table/size.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
       TableWrapper <(anonymous)> at (350,8) content-size 100x17 [BFC] children: not-inline
         Box <div> at (350,8) content-size 100x17 table-box [TFC] children: not-inline
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 2350x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600] overflow: [0,0 2350x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33] overflow: [0,0 2350x33]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 2342x17]
       PaintableWithLines (TableWrapper(anonymous)) [350,8 100x17] overflow: [350,8 2000x17]
         PaintableBox (Box<DIV>) [350,8 100x17]

--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 24x100 [BFC] children: not-inline
         Box <table> at (19,19) content-size 2x78 table-box [TFC] children: not-inline
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 24x100]
         PaintableBox (Box<TABLE>) [8,8 24x100]

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x43 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x27 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 102x27 [BFC] children: not-inline
         Box <table> at (9,9) content-size 100x25 table-box [TFC] children: not-inline
@@ -34,7 +34,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x43]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 102x27]
         PaintableBox (Box<TABLE>) [8,8 102x27]

--- a/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cell-not-paintable.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
       frag 0 from BlockContainer start: 0, length: 0, rect: [13,19 0x0] baseline: 4
       BlockContainer <button> at (13,19) content-size 0x0 inline-block [BFC] children: not-inline
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <(anonymous)> at (13,19) content-size 0x0 [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
       PaintableWithLines (BlockContainer<BUTTON>) [8,17 10x4]
         PaintableWithLines (BlockContainer(anonymous)) [13,19 0x0]

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x174 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x158 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 103.421875x158 [BFC] children: not-inline
         Box <table> at (9,9) content-size 101.421875x156 table-box [TFC] children: not-inline
@@ -86,7 +86,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x174]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x158]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 103.421875x158]
         PaintableBox (Box<TABLE>) [8,8 103.421875x158]

--- a/Tests/LibWeb/Layout/expected/table/table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x230 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x214 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 784x214 [BFC] children: not-inline
         Box <table.table> at (108,108) content-size 584x14 table-box [TFC] children: not-inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <td.cell> at (111,115) content-size 578x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x230]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x214]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x214]
         PaintableBox (Box<TABLE>.table) [8,8 784x214]

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x103 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x87 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 60.46875x87 [BFC] children: not-inline
         Box <table> at (8,35) content-size 60.46875x23 table-box [TFC] children: not-inline
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,-2 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600] overflow: [0,-2 800x602]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x103] overflow: [0,-2 800x105]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x87] overflow: [8,-2 784x97]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 60.46875x87] overflow: [8,-2 60.46875x97]
         PaintableBox (Box<TABLE>) [8,35 60.46875x23]

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-td-vs-div.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-td-vs-div.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x220 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 42.84375x104 [BFC] children: not-inline
         Box <table> at (8,8) content-size 42.84375x104 table-box [TFC] children: not-inline
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x220]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 42.84375x104]
         PaintableBox (Box<TABLE>) [8,8 42.84375x104]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x43 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x27 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 420x27 [BFC] children: not-inline
         Box <table> at (9,9) content-size 418x25 table-box [TFC] children: not-inline
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x43]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27]
         PaintableBox (Box<TABLE>) [8,8 420x27]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x43 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x27 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 420x27 [BFC] children: not-inline
         Box <table> at (9,9) content-size 418x25 table-box [TFC] children: not-inline
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x43]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27]
         PaintableBox (Box<TABLE>) [8,8 420x27]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x43 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x27 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 420x27 [BFC] children: not-inline
         Box <table> at (9,9) content-size 418x25 table-box [TFC] children: not-inline
@@ -27,7 +27,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x43]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27]
         PaintableBox (Box<TABLE>) [8,8 420x27]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x21 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 784x21 [BFC] children: not-inline
         Box <table> at (8,8) content-size 784x21 table-box [TFC] children: not-inline
@@ -38,7 +38,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x37]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x21]
         PaintableBox (Box<TABLE>) [8,8 784x21]

--- a/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
+++ b/Tests/LibWeb/Layout/expected/table/zero-columns-gridmax.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x0 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x0 table-box [TFC] children: not-inline
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <div.cell> at (8,8) content-size 200x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x0]
         PaintableBox (Box<DIV>.table) [8,8 200x0]

--- a/Tests/LibWeb/Layout/input/table/align-top-and-bottom.html
+++ b/Tests/LibWeb/Layout/input/table/align-top-and-bottom.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/table/auto-margins.html
+++ b/Tests/LibWeb/Layout/input/table/auto-margins.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/avoid-div-by-zero-in-table-measures.html
+++ b/Tests/LibWeb/Layout/input/table/avoid-div-by-zero-in-table-measures.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table>
 	<tbody>
 		<tr>

--- a/Tests/LibWeb/Layout/input/table/basic.html
+++ b/Tests/LibWeb/Layout/input/table/basic.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/border-attribute-overridden-by-css.html
+++ b/Tests/LibWeb/Layout/input/table/border-attribute-overridden-by-css.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border: 10px solid black;

--- a/Tests/LibWeb/Layout/input/table/border-attribute.html
+++ b/Tests/LibWeb/Layout/input/table/border-attribute.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <table border="5"><tr><td>A</td></tr></table>

--- a/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-cell.html
+++ b/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-cell.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   table {
     border-collapse: collapse;

--- a/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-row.html
+++ b/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-row.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   table {
     border-collapse: collapse;

--- a/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-rowgroup.html
+++ b/Tests/LibWeb/Layout/input/table/border-conflict-resolution-with-rowgroup.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   table {
     border-collapse: collapse;

--- a/Tests/LibWeb/Layout/input/table/border-conflict-resolutions-with-more-cells-than-cols.html
+++ b/Tests/LibWeb/Layout/input/table/border-conflict-resolutions-with-more-cells-than-cols.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   table {
     border-collapse: collapse;

--- a/Tests/LibWeb/Layout/input/table/border-spacing-and-borders-table-width.html
+++ b/Tests/LibWeb/Layout/input/table/border-spacing-and-borders-table-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border: 5px solid black;

--- a/Tests/LibWeb/Layout/input/table/border-spacing-with-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/table/border-spacing-with-percentage-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     .left,
     .right {

--- a/Tests/LibWeb/Layout/input/table/borders.html
+++ b/Tests/LibWeb/Layout/input/table/borders.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/cell-auto-max-width-table-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/table/cell-auto-max-width-table-percentage-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     #container {
         width: 5em;

--- a/Tests/LibWeb/Layout/input/table/cell-px-height.html
+++ b/Tests/LibWeb/Layout/input/table/cell-px-height.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 body {
     display: table;

--- a/Tests/LibWeb/Layout/input/table/cell-relative-to-specified-table-width.html
+++ b/Tests/LibWeb/Layout/input/table/cell-relative-to-specified-table-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table style="width: 100%;text-align: center">
 	<tbody>
 		<tr>

--- a/Tests/LibWeb/Layout/input/table/clip-spans-to-table-end.html
+++ b/Tests/LibWeb/Layout/input/table/clip-spans-to-table-end.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border-collapse: collapse;

--- a/Tests/LibWeb/Layout/input/table/col-span-crash.html
+++ b/Tests/LibWeb/Layout/input/table/col-span-crash.html
@@ -1,2 +1,3 @@
+<!DOCTYPE html>
 <table><col span="9"></col></table>
 PASS (didn't crash)

--- a/Tests/LibWeb/Layout/input/table/colgroup-with-two-cols.html
+++ b/Tests/LibWeb/Layout/input/table/colgroup-with-two-cols.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <table><colgroup id="my-group"><col width="40"><col></colgroup><tbody></tbody></table>

--- a/Tests/LibWeb/Layout/input/table/colspan-overflow-crash.html
+++ b/Tests/LibWeb/Layout/input/table/colspan-overflow-crash.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table>
     <tr>
         <td>1</td>

--- a/Tests/LibWeb/Layout/input/table/colspan-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/table/colspan-percentage-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table,
     td {

--- a/Tests/LibWeb/Layout/input/table/colspan-weighted-width-distribution.html
+++ b/Tests/LibWeb/Layout/input/table/colspan-weighted-width-distribution.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table,
     td {

--- a/Tests/LibWeb/Layout/input/table/columns-width-distribution-1.html
+++ b/Tests/LibWeb/Layout/input/table/columns-width-distribution-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/fixed-layout-percentage-width-all-columns.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-layout-percentage-width-all-columns.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         width: 600px;

--- a/Tests/LibWeb/Layout/input/table/fixed-layout-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-layout-percentage-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         width: 600px;

--- a/Tests/LibWeb/Layout/input/table/fixed-layout-pixel-width-all-columns.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-layout-pixel-width-all-columns.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         width: 600px;

--- a/Tests/LibWeb/Layout/input/table/fixed-layout-pixel-width.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-layout-pixel-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         width: 600px;

--- a/Tests/LibWeb/Layout/input/table/fixed-layout.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-layout.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         width: 600px;

--- a/Tests/LibWeb/Layout/input/table/fixed-margins.html
+++ b/Tests/LibWeb/Layout/input/table/fixed-margins.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/inline-table-width.html
+++ b/Tests/LibWeb/Layout/input/table/inline-table-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style type="text/css">
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/keyword-value-does-not-constrain-column.html
+++ b/Tests/LibWeb/Layout/input/table/keyword-value-does-not-constrain-column.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     .ab {
         width: fit-content;

--- a/Tests/LibWeb/Layout/input/table/line-breaking-in-cells.html
+++ b/Tests/LibWeb/Layout/input/table/line-breaking-in-cells.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 	table {
 		border-collapse: collapse

--- a/Tests/LibWeb/Layout/input/table/missing-cells-with-span.html
+++ b/Tests/LibWeb/Layout/input/table/missing-cells-with-span.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     div {
         display: grid;

--- a/Tests/LibWeb/Layout/input/table/missing-cells.html
+++ b/Tests/LibWeb/Layout/input/table/missing-cells.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     div {
         display: grid;

--- a/Tests/LibWeb/Layout/input/table/multi-line-cell.html
+++ b/Tests/LibWeb/Layout/input/table/multi-line-cell.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 	table {
 		border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/table/percentage-width-columns.html
+++ b/Tests/LibWeb/Layout/input/table/percentage-width-columns.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border: 1px solid;

--- a/Tests/LibWeb/Layout/input/table/percentage-width-for-nested-table-is-like-auto.html
+++ b/Tests/LibWeb/Layout/input/table/percentage-width-for-nested-table-is-like-auto.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 	.grid_layout {
 		display: grid;

--- a/Tests/LibWeb/Layout/input/table/percentage-width-max-width-columns.html
+++ b/Tests/LibWeb/Layout/input/table/percentage-width-max-width-columns.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border-collapse: collapse;

--- a/Tests/LibWeb/Layout/input/table/propagate-style-update-to-wrapper.html
+++ b/Tests/LibWeb/Layout/input/table/propagate-style-update-to-wrapper.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <script>
     document.addEventListener("DOMContentLoaded", function () {
         let t = document.querySelector("#t");

--- a/Tests/LibWeb/Layout/input/table/row-outer-size-with-computed-size.html
+++ b/Tests/LibWeb/Layout/input/table/row-outer-size-with-computed-size.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table style="border-collapse:separate;">
     <tr>
         <td style="height:6px"></td>

--- a/Tests/LibWeb/Layout/input/table/row-px-height.html
+++ b/Tests/LibWeb/Layout/input/table/row-px-height.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 body {
     display: table;

--- a/Tests/LibWeb/Layout/input/table/rows-height-distribution-1.html
+++ b/Tests/LibWeb/Layout/input/table/rows-height-distribution-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/rows-height-distribution-2.html
+++ b/Tests/LibWeb/Layout/input/table/rows-height-distribution-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/rows-height-distribution-3.html
+++ b/Tests/LibWeb/Layout/input/table/rows-height-distribution-3.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/rows-height-distribution-4.html
+++ b/Tests/LibWeb/Layout/input/table/rows-height-distribution-4.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/size.html
+++ b/Tests/LibWeb/Layout/input/table/size.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   * {
     font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/table/stretch-to-fixed-height.html
+++ b/Tests/LibWeb/Layout/input/table/stretch-to-fixed-height.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/table/sum-of-percentage-column-widths-less-than-100.html
+++ b/Tests/LibWeb/Layout/input/table/sum-of-percentage-column-widths-less-than-100.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table style="border:1px solid">
     <tr>
         <td style="border:1px solid; width: 20%">A</td>

--- a/Tests/LibWeb/Layout/input/table/table-cell-not-paintable.html
+++ b/Tests/LibWeb/Layout/input/table/table-cell-not-paintable.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <button type="button"></button>

--- a/Tests/LibWeb/Layout/input/table/table-formation-with-rowspan-in-the-middle.html
+++ b/Tests/LibWeb/Layout/input/table/table-formation-with-rowspan-in-the-middle.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     table {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/table/table-width.html
+++ b/Tests/LibWeb/Layout/input/table/table-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .table {
     width: 100%;

--- a/Tests/LibWeb/Layout/input/table/top-caption-with-padding.html
+++ b/Tests/LibWeb/Layout/input/table/top-caption-with-padding.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   caption {
     caption-side: top;

--- a/Tests/LibWeb/Layout/input/table/vertical-align-middle-td-vs-div.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-middle-td-vs-div.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     outline: 1px solid black;

--- a/Tests/LibWeb/Layout/input/table/width-distribution-and-constrained-columns-increased-size-on-col.html
+++ b/Tests/LibWeb/Layout/input/table/width-distribution-and-constrained-columns-increased-size-on-col.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table style="width:420px;border:1px solid">
     <colgroup>
         <col style="width:50px">

--- a/Tests/LibWeb/Layout/input/table/width-distribution-and-constrained-columns-size-on-col.html
+++ b/Tests/LibWeb/Layout/input/table/width-distribution-and-constrained-columns-size-on-col.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table style="width:420px;border:1px solid">
     <colgroup>
         <col style="width:1px">

--- a/Tests/LibWeb/Layout/input/table/width-distribution-and-constrained-columns.html
+++ b/Tests/LibWeb/Layout/input/table/width-distribution-and-constrained-columns.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <table style="width:420px;border:1px solid;">
     <tr>
         <td style="border:1px solid; width:1px">A</td>

--- a/Tests/LibWeb/Layout/input/table/width-distribution-of-max-width-increment.html
+++ b/Tests/LibWeb/Layout/input/table/width-distribution-of-max-width-increment.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     td {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/table/zero-columns-gridmax.html
+++ b/Tests/LibWeb/Layout/input/table/zero-columns-gridmax.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .table {
     display: table;


### PR DESCRIPTION
This adds doctypes to every table layout test that didn't have one.
None of these are supposed to be in quirks more from what I can tell.
The only thing that changed on all of them is that the HTML element is no longer 600 pixels tall, so none of the relevant table layout changed.

This is a step towards making the CI enforce these and I've decided to do them one directory at a time since it's more manageable that way.