### PR TITLE
Meta: Add doctypes to all svg layout tests

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/inline-svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/inline-svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
       frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0] baseline: 0
       frag 1 from TextNode start: 0, length: 1, rect: [8,8 8x17] baseline: 13.296875
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
       ImagePaintable (ImageBox<IMG>) [8,21 0x0]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
+++ b/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
       SVGSVGBox <svg#a> at (8,8) content-size 200x200 [SVG] children: inline
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       SVGSVGPaintable (SVGSVGBox<svg>#a) [8,8 200x200]
         SVGSVGPaintable (SVGSVGBox<svg>#b) [8,8 200x200]

--- a/Tests/LibWeb/Layout/expected/svg/svg-g-inside-g.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-g-inside-g.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
         SVGGraphicsPaintable (SVGGraphicsBox<g>) [58,58 10x10]

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg-with-xy.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg-with-xy.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
@@ -17,7 +17,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
         SVGSVGPaintable (SVGSVGBox<svg>) [18,8 300x150]

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x150]

--- a/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
         SVGGraphicsPaintable (SVGGraphicsBox<use>) [8,8 300x150]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
       SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
@@ -10,6 +10,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: not-inline
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
         SVGPathPaintable (SVGTextBox<text>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/input/svg/inline-svg-with-zero-intrinsic-size-and-no-viewbox.html
+++ b/Tests/LibWeb/Layout/input/svg/inline-svg-with-zero-intrinsic-size-and-no-viewbox.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <img src="svg-with-zero-intrinsic-size-and-no-viewbox.svg">
 <svg width=0 height=0>
     <rect x=0 y=0 width=1 height=1 />

--- a/Tests/LibWeb/Layout/input/svg/nested-viewports.html
+++ b/Tests/LibWeb/Layout/input/svg/nested-viewports.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <svg id="a" viewBox="0 0 10 10" width="200" height="200">
   <svg id="b" viewBox="0 0 6 6">
     <svg id="c" viewBox="-1 -1 10 10" width="8" height="8">

--- a/Tests/LibWeb/Layout/input/svg/svg-different-types-of-opacity.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-different-types-of-opacity.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <circle
     cx="40"

--- a/Tests/LibWeb/Layout/input/svg/svg-g-inside-g.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-g-inside-g.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <svg width="100" height="100">
   <!-- Both <g> elements should have the same size -->
   <g>

--- a/Tests/LibWeb/Layout/input/svg/svg-g-with-opacity.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-g-with-opacity.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
   <g fill="white" stroke="green" opacity="0.6">
       <circle cx="40" cy="40" r="25" />

--- a/Tests/LibWeb/Layout/input/svg/svg-inside-svg-with-xy.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-inside-svg-with-xy.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <svg xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
   <svg x="10">

--- a/Tests/LibWeb/Layout/input/svg/svg-symbol-with-viewbox.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-symbol-with-viewbox.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <body>
   <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <symbol id="braces" viewBox="0 0 16 16">

--- a/Tests/LibWeb/Layout/input/svg/svg-use-element-crashtest.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-use-element-crashtest.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <svg>
   <use href="../../data/svg-with-id.svg#myid"></use>
 </svg>

--- a/Tests/LibWeb/Layout/input/svg/svg-with-zero-sized-viewBox.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-with-zero-sized-viewBox.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <svg width="100" height="100" viewBox="0 0 0 0">
   <text>Hello!</text>
 </svg>

--- a/Tests/LibWeb/Layout/input/svg/text-fill-none.html
+++ b/Tests/LibWeb/Layout/input/svg/text-fill-none.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <svg><text fill="none"></text></svg>


### PR DESCRIPTION
This adds an html doctype to every SVG layout test that didn't have one and was in an HTML file.
None of these are supposed to be in quirks more from what I can tell.
The only thing that changed on all of them is that the HTML element is no longer 600 pixels tall, so none of the relevant SVG layout changed.

This is a step towards making the CI enforce the presence of these doctypes and I've decided to do them one directory at a time since it's more manageable that way.
