### PR TITLE
LibJS: Add SetGlobal bytecode instruction for cached global writes

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -892,7 +892,11 @@ void Generator::emit_set_variable(JS::Identifier const& identifier, ScopedOperan
             if (initialization_mode == Bytecode::Op::BindingInitializationMode::Initialize) {
                 emit<Bytecode::Op::InitializeLexicalBinding>(identifier_index, value);
             } else if (initialization_mode == Bytecode::Op::BindingInitializationMode::Set) {
-                emit<Bytecode::Op::SetLexicalBinding>(identifier_index, value);
+                if (identifier.is_global()) {
+                    emit<Bytecode::Op::SetGlobal>(identifier_index, value, next_global_variable_cache());
+                } else {
+                    emit<Bytecode::Op::SetLexicalBinding>(identifier_index, value);
+                }
             }
         } else if (environment_mode == Bytecode::Op::EnvironmentMode::Var) {
             if (initialization_mode == Bytecode::Op::BindingInitializationMode::Initialize) {

--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -132,6 +132,7 @@
     O(RightShift)                      \
     O(ScheduleJump)                    \
     O(SetCompletionType)               \
+    O(SetGlobal)                       \
     O(SetLexicalBinding)               \
     O(SetVariableBinding)              \
     O(StrictlyEquals)                  \

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -861,6 +861,34 @@ private:
     u32 m_cache_index { 0 };
 };
 
+class SetGlobal final : public Instruction {
+public:
+    SetGlobal(IdentifierTableIndex identifier, Operand src, u32 cache_index)
+        : Instruction(Type::SetGlobal)
+        , m_src(src)
+        , m_identifier(identifier)
+        , m_cache_index(cache_index)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+
+    Operand src() const { return m_src; }
+    IdentifierTableIndex identifier() const { return m_identifier; }
+    u32 cache_index() const { return m_cache_index; }
+
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_src);
+    }
+
+private:
+    Operand m_src;
+    IdentifierTableIndex m_identifier;
+    u32 m_cache_index { 0 };
+};
+
 class DeleteVariable final : public Instruction {
 public:
     explicit DeleteVariable(Operand dst, IdentifierTableIndex identifier)


### PR DESCRIPTION
Before this change, setting a global would end up as SetLexicalBinding. That instruction always failed to cache the access if the global was a property of the global object.

1.14x speedup on Octane/earley-boyer.js
2.04x speedup on MicroBench/for-of.js

Note that MicroBench/for-of.js was more of a "set global" benchmark before this. After this change, it's actually a for..of benchmark. :^)