### PR TITLE
LibJS: Optimize reading known-to-be-initialized `var` bindings

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -1158,6 +1158,8 @@ void VariableDeclaration::dump(int indent) const
 {
     char const* declaration_kind_string = nullptr;
     switch (m_declaration_kind) {
+    case DeclarationKind::None:
+        VERIFY_NOT_REACHED();
     case DeclarationKind::Let:
         declaration_kind_string = "Let";
         break;

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -159,6 +159,13 @@ private:
     u32 m_tail_size { 0 };
 };
 
+enum class DeclarationKind {
+    None,
+    Var,
+    Let,
+    Const,
+};
+
 class Statement : public ASTNode {
 public:
     explicit Statement(SourceRange source_range)
@@ -702,6 +709,9 @@ public:
     bool is_global() const { return m_is_global; }
     void set_is_global() { m_is_global = true; }
 
+    [[nodiscard]] DeclarationKind declaration_kind() const { return m_declaration_kind; }
+    void set_declaration_kind(DeclarationKind kind) { m_declaration_kind = kind; }
+
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 
@@ -712,6 +722,7 @@ private:
 
     Optional<Local> m_local_index;
     bool m_is_global { false };
+    DeclarationKind m_declaration_kind { DeclarationKind::None };
 };
 
 struct FunctionParameter {
@@ -1762,12 +1773,6 @@ private:
     UpdateOp m_op;
     NonnullRefPtr<Expression const> m_argument;
     bool m_prefixed;
-};
-
-enum class DeclarationKind {
-    Var,
-    Let,
-    Const,
 };
 
 class VariableDeclarator final : public ASTNode {

--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -482,7 +482,11 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> Identifier::generate_by
     if (is_global()) {
         generator.emit<Bytecode::Op::GetGlobal>(dst, generator.intern_identifier(m_string), generator.next_global_variable_cache());
     } else {
-        generator.emit<Bytecode::Op::GetBinding>(dst, generator.intern_identifier(m_string));
+        if (declaration_kind() == DeclarationKind::Var) {
+            generator.emit<Bytecode::Op::GetInitializedBinding>(dst, generator.intern_identifier(m_string));
+        } else {
+            generator.emit<Bytecode::Op::GetBinding>(dst, generator.intern_identifier(m_string));
+        }
     }
     return dst;
 }

--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -69,6 +69,7 @@
     O(GetObjectPropertyIterator)       \
     O(GetPrivateById)                  \
     O(GetBinding)                      \
+    O(GetInitializedBinding)           \
     O(GreaterThan)                     \
     O(GreaterThanEquals)               \
     O(HasPrivateId)                    \

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -833,6 +833,32 @@ private:
     mutable EnvironmentCoordinate m_cache;
 };
 
+class GetInitializedBinding final : public Instruction {
+public:
+    explicit GetInitializedBinding(Operand dst, IdentifierTableIndex identifier)
+        : Instruction(Type::GetInitializedBinding)
+        , m_dst(dst)
+        , m_identifier(identifier)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+
+    Operand dst() const { return m_dst; }
+    IdentifierTableIndex identifier() const { return m_identifier; }
+
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_dst);
+    }
+
+private:
+    Operand m_dst;
+    IdentifierTableIndex m_identifier;
+    mutable EnvironmentCoordinate m_cache;
+};
+
 class GetGlobal final : public Instruction {
 public:
     GetGlobal(Operand dst, IdentifierTableIndex identifier, u32 cache_index)

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -292,6 +292,12 @@ public:
             auto const& identifier_group_name = it.key;
             auto& identifier_group = it.value;
 
+            if (identifier_group.declaration_kind.has_value()) {
+                for (auto& identifier : identifier_group.identifiers) {
+                    identifier->set_declaration_kind(identifier_group.declaration_kind.value());
+                }
+            }
+
             bool scope_has_declaration = false;
             if (is_top_level() && m_var_names.contains(identifier_group_name))
                 scope_has_declaration = true;

--- a/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -59,6 +59,7 @@ public:
     ThrowCompletionOr<void> initialize_binding_direct(VM&, size_t index, Value, InitializeBindingHint);
     ThrowCompletionOr<void> set_mutable_binding_direct(VM&, size_t index, Value, bool strict);
     ThrowCompletionOr<Value> get_binding_value_direct(VM&, size_t index) const;
+    Value get_initialized_binding_value_direct(size_t index) const { return m_bindings[index].value; }
 
     void shrink_to_fit();
 


### PR DESCRIPTION
`var` bindings are never in the temporal dead zone (TDZ), and so we know accessing them will not throw.

We now take advantage of this by having a specialized environment binding value getter that doesn't check for exceptional cases.

1.08x speedup on JetStream.

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
SunSpider   3d-cube.js                               1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   3d-morph.js                              1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   3d-raytrace.js                           2      0.020 ± 0.020 … 0.020     0.010 ± 0.010 … 0.010
SunSpider   access-binary-trees.js                   1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   access-fannkuch.js                       1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   access-nbody.js                          1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   access-nsieve.js                         1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js              1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                   1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                    1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   bitops-nsieve-bits.js                    1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                 1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   crypto-aes.js                            1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                            1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     1      0.040 ± 0.040 … 0.040     0.040 ± 0.040 … 0.040
SunSpider   date-format-xparb.js                     1      0.020 ± 0.020 … 0.020     0.020 ± 0.020 … 0.020
SunSpider   math-cordic.js                           1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   math-partial-sums.js                     1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   math-spectral-norm.js                    1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                            1.018  0.280 ± 0.280 … 0.280     0.275 ± 0.270 … 0.280
SunSpider   string-base64.js                         1      0.010 ± 0.010 … 0.010     0.010 ± 0.010 … 0.010
SunSpider   string-fasta.js                          1      0.110 ± 0.110 … 0.110     0.110 ± 0.110 … 0.110
SunSpider   string-tagcloud.js                       1      0.070 ± 0.070 … 0.070     0.070 ± 0.070 … 0.070
SunSpider   string-unpack-code.js                    1      0.090 ± 0.090 … 0.090     0.090 ± 0.090 … 0.090
SunSpider   string-validate-input.js                 1      0.030 ± 0.030 … 0.030     0.030 ± 0.030 … 0.030
Kraken      ai-astar.js                              1.016  0.960 ± 0.960 … 0.960     0.945 ± 0.940 … 0.950
Kraken      audio-beat-detection.js                  1.006  0.870 ± 0.870 … 0.870     0.865 ± 0.860 … 0.870
Kraken      audio-dft.js                             1      0.530 ± 0.530 … 0.530     0.530 ± 0.530 … 0.530
Kraken      audio-fft.js                             1.007  0.680 ± 0.680 … 0.680     0.675 ± 0.670 … 0.680
Kraken      audio-oscillator.js                      1      0.820 ± 0.820 … 0.820     0.820 ± 0.820 … 0.820
Kraken      imaging-darkroom.js                      1      0.870 ± 0.870 … 0.870     0.870 ± 0.870 … 0.870
Kraken      imaging-desaturate.js                    1.011  0.900 ± 0.900 … 0.900     0.890 ± 0.890 … 0.890
Kraken      imaging-gaussian-blur.js                 1.01   4.030 ± 4.030 … 4.030     3.990 ± 3.980 … 4.000
Kraken      json-parse-financial.js                  1      0.060 ± 0.060 … 0.060     0.060 ± 0.060 … 0.060
Kraken      json-stringify-tinderbox.js              1      0.080 ± 0.080 … 0.080     0.080 ± 0.080 … 0.080
Kraken      stanford-crypto-aes.js                   1      0.330 ± 0.330 … 0.330     0.330 ± 0.330 … 0.330
Kraken      stanford-crypto-ccm.js                   1.017  0.300 ± 0.300 … 0.300     0.295 ± 0.290 … 0.300
Kraken      stanford-crypto-pbkdf2.js                1      0.540 ± 0.540 … 0.540     0.540 ± 0.540 … 0.540
Kraken      stanford-crypto-sha256-iterative.js      1      0.220 ± 0.220 … 0.220     0.220 ± 0.220 … 0.220
Octane      box2d.js                                 0.981  1.040 ± 1.040 … 1.040     1.060 ± 1.060 … 1.060
Octane      code-load.js                             1      2.010 ± 2.010 … 2.010     2.010 ± 2.010 … 2.010
Octane      crypto.js                                1.001  5.060 ± 5.060 … 5.060     5.055 ± 5.050 … 5.060
Octane      deltablue.js                             1.002  2.010 ± 2.010 … 2.010     2.005 ± 2.000 … 2.010
Octane      earley-boyer.js                          1.003  8.840 ± 8.840 … 8.840     8.810 ± 8.780 … 8.840
Octane      gbemu.js                                 1.009  1.160 ± 1.160 … 1.160     1.150 ± 1.150 … 1.150
Octane      mandreel.js                              1.002  5.370 ± 5.370 … 5.370     5.360 ± 5.350 … 5.370
Octane      navier-stokes.js                         1.005  2.030 ± 2.030 … 2.030     2.020 ± 2.020 … 2.020
Octane      pdfjs.js                                 1      1.160 ± 1.160 … 1.160     1.160 ± 1.160 … 1.160
Octane      raytrace.js                              0.972  3.070 ± 3.070 … 3.070     3.160 ± 3.150 … 3.170
Octane      regexp.js                                0.995  14.480 ± 14.480 … 14.480  14.550 ± 14.550 … 14.550
Octane      richards.js                              1      2.000 ± 2.000 … 2.000     2.000 ± 2.000 … 2.000
Octane      splay.js                                 0.987  2.280 ± 2.280 … 2.280     2.310 ± 2.280 … 2.340
Octane      typescript.js                            1.002  11.920 ± 11.920 … 11.920  11.895 ± 11.890 … 11.900
Octane      zlib.js                                  1.072  35.830 ± 35.830 … 35.830  33.430 ± 33.300 … 33.560
JetStream   bigfib.cpp.js                            1.053  6.580 ± 6.580 … 6.580     6.250 ± 6.220 … 6.280
JetStream   cdjs.js                                  1.003  4.570 ± 4.570 … 4.570     4.555 ± 4.530 … 4.580
JetStream   container.cpp.js                         1.035  26.330 ± 26.330 … 26.330  25.440 ± 25.280 … 25.600
JetStream   dry.c.js                                 1.199  16.380 ± 16.380 … 16.380  13.665 ± 13.580 … 13.750
JetStream   float-mm.c.js                            1.05   17.440 ± 17.440 … 17.440  16.605 ± 16.430 … 16.780
JetStream   gcc-loops.cpp.js                         1.088  90.630 ± 90.630 … 90.630  83.330 ± 83.310 … 83.350
JetStream   hash-map.js                              1.006  1.750 ± 1.750 … 1.750     1.740 ± 1.730 … 1.750
JetStream   n-body.c.js                              1.066  23.820 ± 23.820 … 23.820  22.345 ± 22.160 … 22.530
JetStream   quicksort.c.js                           1.053  3.660 ± 3.660 … 3.660     3.475 ± 3.460 … 3.490
JetStream   towers.c.js                              1.08   5.070 ± 5.070 … 5.070     4.695 ± 4.690 … 4.700
JetStream3  js-tokens.js                             1.007  0.770 ± 0.770 … 0.770     0.765 ± 0.760 … 0.770
JetStream3  lazy-collections.js                      0.996  1.330 ± 1.330 … 1.330     1.335 ± 1.320 … 1.350
JetStream3  raytrace-private-class-fields.js         1.004  4.970 ± 4.970 … 4.970     4.950 ± 4.950 … 4.950
JetStream3  raytrace-public-class-fields.js          1.019  3.830 ± 3.830 … 3.830     3.760 ± 3.750 … 3.770
JetStream3  sync-file-system.js                      0.985  1.920 ± 1.920 … 1.920     1.950 ± 1.940 … 1.960
RegExp      speedometer-jquery-regexp-1.js           0.986  1.390 ± 1.390 … 1.390     1.410 ± 1.410 … 1.410
RegExp      speedometer-jquery-regexp-2.js           1      0.190 ± 0.190 … 0.190     0.190 ± 0.190 … 0.190
MicroBench  array-destructuring-assignment.js        0.984  3.660 ± 3.660 … 3.660     3.720 ± 3.660 … 3.780
MicroBench  call-00-args.js                          0.978  1.350 ± 1.350 … 1.350     1.380 ± 1.350 … 1.410
MicroBench  call-01-args.js                          1.004  1.420 ± 1.420 … 1.420     1.415 ± 1.410 … 1.420
MicroBench  call-02-args.js                          1.028  1.460 ± 1.460 … 1.460     1.420 ± 1.340 … 1.500
MicroBench  call-03-args.js                          0.972  1.400 ± 1.400 … 1.400     1.440 ± 1.410 … 1.470
MicroBench  call-04-args.js                          1.022  1.420 ± 1.420 … 1.420     1.390 ± 1.390 … 1.390
MicroBench  call-16-args.js                          1      1.580 ± 1.580 … 1.580     1.580 ± 1.570 … 1.590
MicroBench  call-32-args.js                          1.019  1.860 ± 1.860 … 1.860     1.825 ± 1.810 … 1.840
MicroBench  for-in-indexed-properties.js             1.004  2.560 ± 2.560 … 2.560     2.550 ± 2.550 … 2.550
MicroBench  for-in-named-properties.js               1.003  3.040 ± 3.040 … 3.040     3.030 ± 3.020 … 3.040
MicroBench  for-of.js                                1.03   0.340 ± 0.340 … 0.340     0.330 ± 0.330 … 0.330
SunSpider   Total                                    1.017  0.880                     0.865
Kraken      Total                                    1.007  11.190                    11.110
Octane      Total                                    1.024  98.260                    95.975
JetStream   Total                                    1.078  196.230                   182.100
JetStream3  Total                                    1.005  12.820                    12.760
RegExp      Total                                    0.987  1.580                     1.600
MicroBench  Total                                    1      20.090                    20.080
All Suites  Total                                    1.051  341.050                   324.490
```