### PR TITLE
LibWeb: Remove Web::Infra ASCII case conversion methods

### DIFF
--- a/Libraries/LibWeb/ContentSecurityPolicy/Policy.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Policy.cpp
@@ -58,7 +58,7 @@ GC::Ref<Policy> Policy::parse_a_serialized_csp(GC::Heap& heap, Variant<ByteBuffe
         // 4. Set directive name to be the result of running ASCII lowercase on directive name.
         // Spec Note: Directive names are case-insensitive, that is: script-SRC 'none' and ScRiPt-sRc 'none' are
         //            equivalent.
-        auto lowercase_directive_name = MUST(Infra::to_ascii_lowercase(directive_name));
+        auto lowercase_directive_name = directive_name.to_ascii_lowercase_string();
 
         // 5. If policy’s directive set contains a directive whose name is directive name, continue.
         if (policy->contains_directive_with_name(lowercase_directive_name)) {

--- a/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -271,7 +271,7 @@ void on_domain_attribute(ParsedCookie& parsed_cookie, StringView attribute_value
         cookie_domain = cookie_domain.substring_view(1);
 
     // 3. Convert the cookie-domain to lower case.
-    auto lowercase_cookie_domain = MUST(Infra::to_ascii_lowercase(cookie_domain));
+    auto lowercase_cookie_domain = cookie_domain.to_ascii_lowercase_string();
 
     // 4. Append an attribute to the cookie-attribute-list with an attribute-name of Domain and an attribute-value of
     //    cookie-domain.

--- a/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Libraries/LibWeb/Infra/Strings.cpp
@@ -116,34 +116,6 @@ ErrorOr<String> convert_to_scalar_value_string(StringView string)
     return scalar_value_builder.to_string();
 }
 
-// https://infra.spec.whatwg.org/#ascii-lowercase
-ErrorOr<String> to_ascii_lowercase(StringView string)
-{
-    // To ASCII lowercase a string, replace all ASCII upper alphas in the string with their
-    // corresponding code point in ASCII lower alpha.
-    StringBuilder string_builder;
-    auto utf8_view = Utf8View { string };
-    for (u32 code_point : utf8_view) {
-        code_point = AK::to_ascii_lowercase(code_point);
-        string_builder.append_code_point(code_point);
-    }
-    return string_builder.to_string();
-}
-
-// https://infra.spec.whatwg.org/#ascii-uppercase
-ErrorOr<String> to_ascii_uppercase(StringView string)
-{
-    // To ASCII uppercase a string, replace all ASCII lower alphas in the string with their
-    // corresponding code point in ASCII upper alpha.
-    StringBuilder string_builder;
-    auto utf8_view = Utf8View { string };
-    for (u32 code_point : utf8_view) {
-        code_point = AK::to_ascii_uppercase(code_point);
-        string_builder.append_code_point(code_point);
-    }
-    return string_builder.to_string();
-}
-
 // https://infra.spec.whatwg.org/#isomorphic-encode
 ByteBuffer isomorphic_encode(StringView input)
 {

--- a/Libraries/LibWeb/Infra/Strings.h
+++ b/Libraries/LibWeb/Infra/Strings.h
@@ -18,8 +18,6 @@ String normalize_newlines(String const&);
 ErrorOr<String> strip_and_collapse_whitespace(StringView string);
 bool is_code_unit_prefix(StringView potential_prefix, StringView input);
 ErrorOr<String> convert_to_scalar_value_string(StringView string);
-ErrorOr<String> to_ascii_lowercase(StringView string);
-ErrorOr<String> to_ascii_uppercase(StringView string);
 ByteBuffer isomorphic_encode(StringView input);
 String isomorphic_decode(ReadonlyBytes input);
 bool code_unit_less_than(StringView a, StringView b);

--- a/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -118,7 +118,7 @@ Optional<MimeType> MimeType::parse(StringView string)
         return OptionalNone {};
 
     // 10. Let mimeType be a new MIME type record whose type is type, in ASCII lowercase, and subtype is subtype, in ASCII lowercase.
-    auto mime_type = MimeType::create(MUST(Infra::to_ascii_lowercase(type)), MUST(Infra::to_ascii_lowercase(subtype)));
+    auto mime_type = MimeType::create(type.to_ascii_lowercase_string(), subtype.to_ascii_lowercase_string());
 
     // 11. While position is not past the end of input:
     while (!lexer.is_eof()) {
@@ -134,7 +134,7 @@ Optional<MimeType> MimeType::parse(StringView string)
         });
 
         // 4. Set parameterName to parameterName, in ASCII lowercase.
-        auto parameter_name = MUST(Infra::to_ascii_lowercase(parameter_name_view));
+        auto parameter_name = parameter_name_view.to_ascii_lowercase_string();
 
         // 5. If position is not past the end of input, then:
         if (!lexer.is_eof()) {


### PR DESCRIPTION
We have more optimized versions of these methods in AK.