### PR TITLE
Meta: Add doctypes to a few more layout tests

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-counters/basic.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/basic.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x356 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x324 children: not-inline
       BlockContainer <div> at (8,16) content-size 784x154 children: not-inline
         BlockContainer <p> at (8,16) content-size 784x18 children: inline
@@ -87,7 +87,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x356]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x324]
       PaintableWithLines (BlockContainer<DIV>) [8,16 784x154]
         PaintableWithLines (BlockContainer<P>) [8,16 784x18]

--- a/Tests/LibWeb/Layout/expected/css-counters/counters-function-single-argument.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/counters-function-single-argument.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: inline
       frag 0 from TextNode start: 0, length: 19, rect: [8,8 162.109375x18] baseline: 13.796875
           "PASS (didn't crash)"
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-counters/counters-function.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/counters-function.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x286 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x270 children: not-inline
       BlockContainer <div.ol> at (24,8) content-size 768x270 children: not-inline
         BlockContainer <(anonymous)> at (24,8) content-size 768x0 children: inline
@@ -166,7 +166,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x286]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x270]
       PaintableWithLines (BlockContainer<DIV>.ol) [8,8 784x270]
         PaintableWithLines (BlockContainer(anonymous)) [24,8 768x0]

--- a/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x186 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x154 children: not-inline
       BlockContainer <p> at (8,16) content-size 784x18 children: inline
         frag 0 from TextNode start: 0, length: 1, rect: [26.125,16 14.265625x18] baseline: 13.796875
@@ -43,7 +43,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x186]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x154]
       PaintableWithLines (BlockContainer<P>) [8,16 784x18]
         PaintableWithLines (InlineNode(anonymous))

--- a/Tests/LibWeb/Layout/expected/css-values/rect-non-token-contents-crash.txt
+++ b/Tests/LibWeb/Layout/expected/css-values/rect-non-token-contents-crash.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/simple-update-inside-svg-subtree.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/simple-update-inside-svg-subtree.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
         SVGGraphicsPaintable (SVGGraphicsBox<symbol>) [8,8 300x150]

--- a/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
+++ b/Tests/LibWeb/Layout/expected/misc/grid-template-block-components-whitespace-crash.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/input/css-counters/basic.html
+++ b/Tests/LibWeb/Layout/input/css-counters/basic.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 div {
     counter-increment: line;

--- a/Tests/LibWeb/Layout/input/css-counters/counters-function-single-argument.html
+++ b/Tests/LibWeb/Layout/input/css-counters/counters-function-single-argument.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     html {
         content: counters(index);

--- a/Tests/LibWeb/Layout/input/css-counters/counters-function.html
+++ b/Tests/LibWeb/Layout/input/css-counters/counters-function.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 div.ol {
     counter-reset: index;

--- a/Tests/LibWeb/Layout/input/css-counters/hidden-elements.html
+++ b/Tests/LibWeb/Layout/input/css-counters/hidden-elements.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 p {
     counter-increment: a;

--- a/Tests/LibWeb/Layout/input/css-values/rect-non-token-contents-crash.html
+++ b/Tests/LibWeb/Layout/input/css-values/rect-non-token-contents-crash.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <div style="clip: rect({})"></div>

--- a/Tests/LibWeb/Layout/input/layout-tree-update/simple-update-inside-svg-subtree.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/simple-update-inside-svg-subtree.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <body><svg><symbol><set id="set"></set></symbol></body>
 <script>
     document.body.offsetWidth;

--- a/Tests/LibWeb/Layout/input/misc/grid-template-block-components-whitespace-crash.html
+++ b/Tests/LibWeb/Layout/input/misc/grid-template-block-components-whitespace-crash.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     test {
         display: grid;


### PR DESCRIPTION
This adds doctypes to layout tests in a bunch of miscellaneous folders.
None of these are supposed to be in quirks more from what I can tell.
The only thing that changed on all of them is that the HTML element is no longer 600 pixels tall, so none of the relevant layout information changed.

This is a step towards making the CI enforce these and I've decided to do them per-directory to make it more manageable.
This takes care of all directories except for the flex and grid ones.