### PR TITLE
LibJS: Mark sync module evaluation promise as handled

### DIFF
--- a/Libraries/LibJS/Module.h
+++ b/Libraries/LibJS/Module.h
@@ -131,6 +131,7 @@ protected:
 
 private:
     GC::Ref<Object> module_namespace_create(Vector<FlyString> unambiguous_names);
+    ThrowCompletionOr<void> evaluate_module_sync(VM&);
 
     // These handles are only safe as long as the VM they live in is valid.
     // But evaluated modules SHOULD be stored in the VM so unless you intentionally


### PR DESCRIPTION
This is a normative change in the ECMA-262 spec. See:
https://github.com/tc39/ecma262/commit/0fb1859

As noted in the PR for this change, this is not actually testable via either test262 or WPT.