### PR TITLE
AK: Expose `dump_backtrace()` publicly for debugging purposes

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -33,18 +33,17 @@
 #    define ERRORLN warnln
 #endif
 
+extern "C" {
+
 #if defined(AK_HAS_STD_STACKTRACE)
-namespace {
-ALWAYS_INLINE void dump_backtrace()
+void dump_backtrace()
 {
     // We assume the stacktrace implementation demangles symbols, as does microsoft/STL
     PRINT_ERROR(std::to_string(std::stacktrace::current(2)).c_str());
     PRINT_ERROR("\n");
 }
-}
 #elif defined(AK_HAS_BACKTRACE_HEADER)
-namespace {
-ALWAYS_INLINE void dump_backtrace()
+void dump_backtrace()
 {
     // Grab symbols and dso name for up to 256 frames
     void* trace[256] = {};
@@ -89,10 +88,12 @@ ALWAYS_INLINE void dump_backtrace()
     }
     free(syms);
 }
+#else
+void dump_backtrace()
+{
+    PRINT_ERROR("dump_backtrace() is not supported with the current compilation options.\n");
 }
 #endif
-
-extern "C" {
 
 bool ak_colorize_output(void)
 {

--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+extern "C" void dump_backtrace();
 extern "C" bool ak_colorize_output(void);
 extern "C" __attribute__((noreturn)) void ak_trap(void);
 


### PR DESCRIPTION
At this point, I've repeatedly felt the desire to be able to log stacktraces to be able to see more easily what kind of call-sites exist for a given piece of code. So this commit exposes `dump_backtrace()` in the header so it can be used for this purpose.