### PR TITLE
LibWeb: Avoid drawing things that are off-screen

### DIFF
--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -98,8 +98,12 @@ struct DrawRepeatedImmutableBitmap {
     void translate_by(Gfx::IntPoint const& offset) { dst_rect.translate_by(offset); }
 };
 
-struct Save { };
-struct SaveLayer { };
+struct Save {
+    bool performs_save() const { return true; }
+};
+struct SaveLayer {
+    bool performs_save() const { return true; }
+};
 struct Restore { };
 
 struct Translate {
@@ -115,6 +119,9 @@ struct AddClipRect {
     bool is_clip_or_mask() const { return true; }
     void translate_by(Gfx::IntPoint const& offset) { rect.translate_by(offset); }
 };
+
+struct StartNonLocalEffect { };
+struct EndNonLocalEffect { };
 
 struct StackingContextTransform {
     Gfx::FloatPoint origin;
@@ -417,14 +424,20 @@ struct PaintScrollBar {
 
 struct ApplyOpacity {
     float opacity;
+
+    bool performs_save() const { return true; }
 };
 
 struct ApplyCompositeAndBlendingOperator {
     Gfx::CompositingAndBlendingOperator compositing_and_blending_operator;
+
+    bool performs_save() const { return true; }
 };
 
 struct ApplyFilters {
     Vector<Gfx::Filter> filter;
+
+    bool performs_save() const { return true; }
 };
 
 struct ApplyTransform {
@@ -459,6 +472,8 @@ using Command = Variant<
     Restore,
     Translate,
     AddClipRect,
+    StartNonLocalEffect,
+    EndNonLocalEffect,
     PushStackingContext,
     PopStackingContext,
     PaintLinearGradient,

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -22,6 +22,11 @@ namespace Web::Painting {
 
 class DisplayList;
 
+struct PaintContainmentInfo {
+    Gfx::IntRect visible_area;
+    int non_local_effects;
+};
+
 class DisplayListPlayer {
 public:
     virtual ~DisplayListPlayer() = default;
@@ -30,7 +35,7 @@ public:
 
 protected:
     Gfx::PaintingSurface& surface() const { return m_surfaces.last(); }
-    void execute_impl(DisplayList&, ScrollStateSnapshot const& scroll_state, RefPtr<Gfx::PaintingSurface>);
+    void execute_impl(DisplayList&, ScrollStateSnapshot const& scroll_state, RefPtr<Gfx::PaintingSurface>, Gfx::Point<int>);
 
 private:
     virtual void flush() = 0;
@@ -75,6 +80,7 @@ private:
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
 
     Vector<NonnullRefPtr<Gfx::PaintingSurface>, 1> m_surfaces;
+    Vector<PaintContainmentInfo> m_containment_stack;
 };
 
 class DisplayList : public AtomicRefCounted<DisplayList> {

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -975,7 +975,7 @@ void DisplayListPlayerSkia::add_mask(AddMask const& command)
     auto mask_surface = Gfx::PaintingSurface::create_with_size(m_context, rect.size(), Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
 
     ScrollStateSnapshot scroll_state_snapshot;
-    execute_impl(*command.display_list, scroll_state_snapshot, mask_surface);
+    execute_impl(*command.display_list, scroll_state_snapshot, mask_surface, rect.location());
 
     SkMatrix mask_matrix;
     mask_matrix.setTranslate(rect.x(), rect.y());
@@ -988,7 +988,7 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
 {
     auto& canvas = surface().canvas();
     canvas.translate(command.rect.x(), command.rect.y());
-    execute_impl(*command.display_list, command.scroll_state_snapshot, {});
+    execute_impl(*command.display_list, command.scroll_state_snapshot, {}, command.rect.location());
 }
 
 void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -270,6 +270,16 @@ void DisplayListRecorder::add_clip_rect(Gfx::IntRect const& rect)
     append(AddClipRect { rect });
 }
 
+void DisplayListRecorder::start_non_local_effect()
+{
+    append(StartNonLocalEffect {});
+}
+
+void DisplayListRecorder::end_non_local_effect()
+{
+    append(EndNonLocalEffect {});
+}
+
 void DisplayListRecorder::translate(Gfx::IntPoint delta)
 {
     append(Translate { delta });

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -108,6 +108,9 @@ public:
 
     void add_clip_rect(Gfx::IntRect const& rect);
 
+    void start_non_local_effect();
+    void end_non_local_effect();
+
     void translate(Gfx::IntPoint delta);
 
     void push_scroll_frame_id(Optional<i32> id);


### PR DESCRIPTION
This avoids drawing anything that cannot possibly have an on-screen effect.
It does so by tracking what area is currently visible, restricting it from the initial viewport down every time we clip to a specific region. (for things like 'overflow: clip')
Then, before drawing a display list command, we check if it would lie outside of this region entirely, and if so, skip drawing it.

Note that this optimization gets disabled when non-local effects, like a blur() filter, are affecting what is drawn.
Otherwise, blurred, off-screen elements would pop into view only once their actual boundary intersects with the visible portion of the screen. (as opposed to the blur, which extends beyond that)

This also means that, when going into a new clip region, if there are non-local effects, restricting the visible area further does not have any benefit, because the non-local effects still disable the optimization.
What we do instead is to pretend that that new clipped region is visible in its entirety (and is the only thing visible), allowing us to ignore the outer non-local effect since it will never be able to blur something we already clipped away inside of the region back into view.
Thus, more optimization can be had.
In essence, the visible area now represents what is visible to any non-local effects outside of the new clip region, instead of what is visible to the user in general.

All of this is inspired by the optimizations that the spec for paint containment talks about, but it turns out that you don't actually need to consider any paint containment for this part.

In the future, this may be further optimized by measuring the maximum size of the non-local effect and, instead of disabling the optimization altogether, just growing the boundaries of the to-be-optimized-away painting operation by that much.
Also, once we have a sensible way of partially re-layouting the page or building only parts of the paint tree on demand, this can probably be expanded into those areas.