### PR TITLE
LibJS: Update to normative change to avoid Symbol methods for RegExp on primitives

### DIFF
--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -564,9 +564,9 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match)
     // 1. Let O be ? RequireObjectCoercible(this value).
     auto this_object = TRY(require_object_coercible(vm, vm.this_value()));
 
-    // 2. If regexp is neither undefined nor null, then
+    // 2. If regexp is an Object, then
     auto regexp = vm.argument(0);
-    if (!regexp.is_nullish()) {
+    if (regexp.is_object()) {
         // a. Let matcher be ? GetMethod(regexp, @@match).
         auto matcher = TRY(regexp.get_method(vm, vm.well_known_symbol_match()));
 
@@ -595,8 +595,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::match_all)
     // 1. Let O be ? RequireObjectCoercible(this value).
     auto this_object = TRY(require_object_coercible(vm, vm.this_value()));
 
-    // 2. If regexp is neither undefined nor null, then
-    if (!regexp.is_nullish()) {
+    // 2. If regexp is an Object, then
+    if (regexp.is_object()) {
         // a. Let isRegExp be ? IsRegExp(regexp).
         auto is_regexp = TRY(regexp.is_regexp(vm));
 
@@ -782,8 +782,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace)
     // 1. Let O be ? RequireObjectCoercible(this value).
     auto this_object = TRY(require_object_coercible(vm, vm.this_value()));
 
-    // 2. If searchValue is neither undefined nor null, then
-    if (!search_value.is_nullish()) {
+    // 2. If searchValue is an Object, then
+    if (search_value.is_object()) {
         // a. Let replacer be ? GetMethod(searchValue, @@replace).
         auto replacer = TRY(search_value.get_method(vm, vm.well_known_symbol_replace()));
 
@@ -861,8 +861,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::replace_all)
     // 1. Let O be ? RequireObjectCoercible(this value).
     auto this_object = TRY(require_object_coercible(vm, vm.this_value()));
 
-    // 2. If searchValue is neither undefined nor null, then
-    if (!search_value.is_nullish()) {
+    // 2. If searchValue is an Object, then
+    if (search_value.is_object()) {
         // a. Let isRegExp be ? IsRegExp(searchValue).
         bool is_regexp = TRY(search_value.is_regexp(vm));
 
@@ -977,8 +977,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::search)
     // 1. Let O be ? RequireObjectCoercible(this value).
     auto this_object = TRY(require_object_coercible(vm, vm.this_value()));
 
-    // 2. If regexp is neither undefined nor null, then
-    if (!regexp.is_nullish()) {
+    // 2. If regexp is an Object, then
+    if (regexp.is_object()) {
         // a. Let searcher be ? GetMethod(regexp, @@search).
         auto searcher = TRY(regexp.get_method(vm, vm.well_known_symbol_search()));
 
@@ -1058,8 +1058,8 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::split)
     // 1. Let O be ? RequireObjectCoercible(this value).
     auto object = TRY(require_object_coercible(vm, vm.this_value()));
 
-    // 2. If separator is neither undefined nor null, then
-    if (!separator_argument.is_nullish()) {
+    // 2. If separator is an Object, then
+    if (separator_argument.is_object()) {
         // a. Let splitter be ? GetMethod(separator, @@split).
         auto splitter = TRY(separator_argument.get_method(vm, vm.well_known_symbol_split()));
         // b. If splitter is not undefined, then


### PR DESCRIPTION
Normative PR: https://github.com/tc39/ecma262/pull/3009 (unmerged as of this commit)

There are 24 test262 tests for this, see [https://test262.fyi/#built-ins/String/prototype](https://test262.fyi/#built-ins/String/prototype) and https://github.com/tc39/test262/pull/4404. JSC and Rhino have already added these changes.

Let me know if you would like to wait until the Normative PR is merged. I am subscribed to that PR.