### PR TITLE
LibWeb: Translate scrollbar gutters by the cumulative scroll offset

### DIFF
--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -411,6 +411,7 @@ struct PaintScrollBar {
 
     void translate_by(Gfx::IntPoint const& offset)
     {
+        gutter_rect.translate_by(offset);
         thumb_rect.translate_by(offset);
     }
 };


### PR DESCRIPTION
This `translate_by` function is invoked with the cumulative scroll offset during display list execution. Applying the offset to the gutter was missed in 66e422b4f1d1bda1c328b99f964f3a8c2cb5d4b1.

Fixes #4603.