### PR TITLE
Polymorphic inline caches for LibJS

### DIFF
--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -23,11 +23,16 @@
 
 namespace JS::Bytecode {
 
+// Represents one polymorphic inline cache used for property lookups.
 struct PropertyLookupCache {
-    WeakPtr<Shape> shape;
-    Optional<u32> property_offset;
-    WeakPtr<Object> prototype;
-    WeakPtr<PrototypeChainValidity> prototype_chain_validity;
+    static constexpr size_t max_number_of_shapes_to_remember = 4;
+    struct Entry {
+        WeakPtr<Shape> shape;
+        Optional<u32> property_offset;
+        WeakPtr<Object> prototype;
+        WeakPtr<PrototypeChainValidity> prototype_chain_validity;
+    };
+    AK::Array<Entry, max_number_of_shapes_to_remember> entries;
 };
 
 struct GlobalVariableCache : public PropertyLookupCache {


### PR DESCRIPTION
Instead of monomorphic (1 shape), GetById* and PutById* inline caches are now polymorphic (4 shapes).

This improves inline cache hit rates greatly on most web JavaScript.

For example, Speedometer 2.1 sees 88% -> 97% cache hit rate improvement.