### PR TITLE
LibWeb: Make elements with 'opacity: 0' respond to hit-testing

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1069,7 +1069,7 @@ TraversalDecision PaintableBox::hit_test(CSSPixelPoint position, HitTestType typ
 
     auto position_adjusted_by_scroll_offset = position.translated(-cumulative_offset_of_enclosing_scroll_frame());
 
-    if (!is_visible())
+    if (computed_values().visibility() != CSS::Visibility::Visible)
         return TraversalDecision::Continue;
 
     if (hit_test_scrollbars(position_adjusted_by_scroll_offset, callback) == TraversalDecision::Break)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/css-filters-opacity-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/css-filters-opacity-hit-testing.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Elements with 'opacity: 0' should respond to hit testing.

--- a/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/css-filters-opacity-hit-testing.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/css-filters-opacity-hit-testing.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Elements with 'opacity: 0' should respond to hit testing.</title>
+<link rel="author" title="Psychpsyo" href="psychpsyo@gmail.com">
+<meta name="assert" content="element with 'opacity: 0' responds to hit testing">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    opacity: 0;
+  }
+</style>
+<div></div>
+<script>
+  test(() => {
+    assert_equals(document.elementFromPoint(50, 50).tagName, "DIV", "element with 'opacity: 0' doesn't respond to hit testing");
+  });
+</script>


### PR DESCRIPTION
This brings us in line with Chrome and Firefox, but I could not find a spec for it.
I did find https://github.com/w3c/csswg-drafts/issues/2325, about hit testing not being defined anywhere, so that might be why.
The test is imported manually by me since I don't think WPT covers this case yet, so I opened a PR there as well. (https://github.com/web-platform-tests/wpt/pull/52375)
I hope that's fine.

This fixes some sliders on https://streamcreatures.com but you can't see them yet because the login doesn't work in Ladybird.