### PR TITLE
LibWeb/HTML: Add missing include to CanvasRenderingContext2D.cpp

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -13,6 +13,7 @@
 #include <LibGfx/CompositingAndBlendingOperator.h>
 #include <LibGfx/PainterSkia.h>
 #include <LibGfx/Rect.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibUnicode/Segmenter.h>
 #include <LibWeb/Bindings/CanvasRenderingContext2DPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>


### PR DESCRIPTION
Fixes linking of CanvasRenderingContext2D on some systems:

    [2959/3075] Linking CXX shared library lib/liblagom-web.so.0.0.0
    FAILED: lib/liblagom-web.so.0.0.0
    : && /nix/store/f0m6caffiykyvsjim9376a3hx2yj2ghj-gcc-wrapper-14.2.1.20250322/bin/g++ -fPIC -O3 -DNDEBUG  -fstack-protector-strong -Wl,-z,defs -Wl,--no-undefined -Wl,--no-allow-shlib-undefined -Wl,--dependency-file=Lagom/Libraries/LibWeb/CMakeFiles/LibWeb.dir/link.d -shared -Wl,-soname,liblagom-web.so.0 -o lib/liblagom-web.so.0.0.0 @CMakeFiles/LibWeb.rsp && :
    /nix/store/hzw38c3f7s0w200cgk9645z53al7k8lw-binutils-2.44/bin/ld: Lagom/Libraries/LibWeb/CMakeFiles/LibWeb.dir/HTML/CanvasRenderingContext2D.cpp.o: in function `Web::HTML::CanvasRenderingContext2D::context_attributes_from_options(JS::VM&, JS::Value) [clone .localalias]':
    CanvasRenderingContext2D.cpp:(.text+0x355a): undefined reference to `JS::Value::to_boolean() const'
    /nix/store/hzw38c3f7s0w200cgk9645z53al7k8lw-binutils-2.44/bin/ld: CanvasRenderingContext2D.cpp:(.text+0x38e6): undefined reference to `JS::Value::to_boolean() const'
    /nix/store/hzw38c3f7s0w200cgk9645z53al7k8lw-binutils-2.44/bin/ld: CanvasRenderingContext2D.cpp:(.text+0x3d67): undefined reference to `JS::Value::to_boolean() const'
    collect2: error: ld returned 1 exit status
    ninja: build stopped: subcommand failed.

https://discord.com/channels/1247070541085671459/1247090705013280769/1369745991208534016