### PR TITLE
Documentation: Add patchelf as a dependency for on Fedora

### DIFF
--- a/.devcontainer/features/ladybird/install-fedora.sh
+++ b/.devcontainer/features/ladybird/install-fedora.sh
@@ -6,5 +6,5 @@ dnf install -y git gh
 
 # Ladybird dev dependencies
 dnf install -y autoconf-archive automake ccache cmake curl google-noto-sans-mono-fonts liberation-sans-fonts libglvnd-devel \
-    nasm ninja-build perl-FindBin perl-IPC-Cmd perl-lib qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel \
+    nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel \
     qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static

--- a/.devcontainer/fedora-ci/devcontainer.json
+++ b/.devcontainer/fedora-ci/devcontainer.json
@@ -6,7 +6,7 @@
         "context": ".",
         "dockerfile": "Dockerfile",
         "args": {
-            "VERSION": "${localEnv:VERSION:41}"
+            "VERSION": "${localEnv:VERSION:42}"
         }
     },
 

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -84,7 +84,7 @@ sudo pacman -S --needed autoconf-archive automake base-devel ccache cmake curl l
 
 ### Fedora or derivatives:
 ```
-sudo dnf install autoconf-archive automake ccache cmake curl liberation-sans-fonts libglvnd-devel nasm ninja-build perl-FindBin perl-IPC-Cmd perl-lib qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
+sudo dnf install autoconf-archive automake ccache cmake curl liberation-sans-fonts libglvnd-devel nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
 ```
 
 ### openSUSE:


### PR DESCRIPTION
The provided patchelf from vcpkg is only version 0.14.3, which is too
old to produce working binaries on Fedora 42. Using that old version
causes hard to debug issues where applications segfault during startup.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/2149
Fixes https://github.com/LadybirdBrowser/ladybird/issues/4563