### PR TITLE
LibJS: Avoid roundtrip through Value for comparison bytecode evaluation

### DIFF
--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -113,13 +113,13 @@ static ThrowCompletionOr<ScopedOperand> constant_fold_binary_expression(Generato
     case BinaryOp::Exponentiation:
         return generator.add_constant(TRY(exp(generator.vm(), lhs, rhs)));
     case BinaryOp::GreaterThan:
-        return generator.add_constant(TRY(greater_than(generator.vm(), lhs, rhs)));
+        return generator.add_constant(Value { TRY(greater_than(generator.vm(), lhs, rhs)) });
     case BinaryOp::GreaterThanEquals:
-        return generator.add_constant(TRY(greater_than_equals(generator.vm(), lhs, rhs)));
+        return generator.add_constant(Value { TRY(greater_than_equals(generator.vm(), lhs, rhs)) });
     case BinaryOp::LessThan:
-        return generator.add_constant(TRY(less_than(generator.vm(), lhs, rhs)));
+        return generator.add_constant(Value { TRY(less_than(generator.vm(), lhs, rhs)) });
     case BinaryOp::LessThanEquals:
-        return generator.add_constant(TRY(less_than_equals(generator.vm(), lhs, rhs)));
+        return generator.add_constant(Value { TRY(less_than_equals(generator.vm(), lhs, rhs)) });
     case BinaryOp::LooselyInequals:
         return generator.add_constant(Value(!TRY(is_loosely_equal(generator.vm(), lhs, rhs))));
     case BinaryOp::LooselyEquals:

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -1261,7 +1261,7 @@ ThrowCompletionOr<GC::Ptr<FunctionObject>> Value::get_method(VM& vm, PropertyKey
 
 // 13.10 Relational Operators, https://tc39.es/ecma262/#sec-relational-operators
 // RelationalExpression : RelationalExpression > ShiftExpression
-ThrowCompletionOr<Value> greater_than(VM& vm, Value lhs, Value rhs)
+ThrowCompletionOr<bool> greater_than(VM& vm, Value lhs, Value rhs)
 {
     // 1. Let lref be ? Evaluation of RelationalExpression.
     // 2. Let lval be ? GetValue(lref).
@@ -1278,13 +1278,13 @@ ThrowCompletionOr<Value> greater_than(VM& vm, Value lhs, Value rhs)
 
     // 6. If r is undefined, return false. Otherwise, return r.
     if (relation == TriState::Unknown)
-        return Value(false);
-    return Value(relation == TriState::True);
+        return false;
+    return relation == TriState::True;
 }
 
 // 13.10 Relational Operators, https://tc39.es/ecma262/#sec-relational-operators
 // RelationalExpression : RelationalExpression >= ShiftExpression
-ThrowCompletionOr<Value> greater_than_equals(VM& vm, Value lhs, Value rhs)
+ThrowCompletionOr<bool> greater_than_equals(VM& vm, Value lhs, Value rhs)
 {
     // 1. Let lref be ? Evaluation of RelationalExpression.
     // 2. Let lval be ? GetValue(lref).
@@ -1301,13 +1301,13 @@ ThrowCompletionOr<Value> greater_than_equals(VM& vm, Value lhs, Value rhs)
 
     // 6. If r is true or undefined, return false. Otherwise, return true.
     if (relation == TriState::Unknown || relation == TriState::True)
-        return Value(false);
-    return Value(true);
+        return false;
+    return true;
 }
 
 // 13.10 Relational Operators, https://tc39.es/ecma262/#sec-relational-operators
 // RelationalExpression : RelationalExpression < ShiftExpression
-ThrowCompletionOr<Value> less_than(VM& vm, Value lhs, Value rhs)
+ThrowCompletionOr<bool> less_than(VM& vm, Value lhs, Value rhs)
 {
     // 1. Let lref be ? Evaluation of RelationalExpression.
     // 2. Let lval be ? GetValue(lref).
@@ -1324,13 +1324,13 @@ ThrowCompletionOr<Value> less_than(VM& vm, Value lhs, Value rhs)
 
     // 6. If r is undefined, return false. Otherwise, return r.
     if (relation == TriState::Unknown)
-        return Value(false);
-    return Value(relation == TriState::True);
+        return false;
+    return relation == TriState::True;
 }
 
 // 13.10 Relational Operators, https://tc39.es/ecma262/#sec-relational-operators
 // RelationalExpression : RelationalExpression <= ShiftExpression
-ThrowCompletionOr<Value> less_than_equals(VM& vm, Value lhs, Value rhs)
+ThrowCompletionOr<bool> less_than_equals(VM& vm, Value lhs, Value rhs)
 {
     // 1. Let lref be ? Evaluation of RelationalExpression.
     // 2. Let lval be ? GetValue(lref).
@@ -1347,8 +1347,8 @@ ThrowCompletionOr<Value> less_than_equals(VM& vm, Value lhs, Value rhs)
 
     // 6. If r is true or undefined, return false. Otherwise, return true.
     if (relation == TriState::True || relation == TriState::Unknown)
-        return Value(false);
-    return Value(true);
+        return false;
+    return true;
 }
 
 // 13.12 Binary Bitwise Operators, https://tc39.es/ecma262/#sec-binary-bitwise-operators

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -461,10 +461,10 @@ private:
     friend constexpr Value js_undefined();
     friend constexpr Value js_null();
     friend constexpr Value js_special_empty_value();
-    friend ThrowCompletionOr<Value> greater_than(VM&, Value lhs, Value rhs);
-    friend ThrowCompletionOr<Value> greater_than_equals(VM&, Value lhs, Value rhs);
-    friend ThrowCompletionOr<Value> less_than(VM&, Value lhs, Value rhs);
-    friend ThrowCompletionOr<Value> less_than_equals(VM&, Value lhs, Value rhs);
+    friend ThrowCompletionOr<bool> greater_than(VM&, Value lhs, Value rhs);
+    friend ThrowCompletionOr<bool> greater_than_equals(VM&, Value lhs, Value rhs);
+    friend ThrowCompletionOr<bool> less_than(VM&, Value lhs, Value rhs);
+    friend ThrowCompletionOr<bool> less_than_equals(VM&, Value lhs, Value rhs);
     friend ThrowCompletionOr<Value> add(VM&, Value lhs, Value rhs);
     friend bool same_value_non_number(Value lhs, Value rhs);
 };
@@ -499,10 +499,10 @@ inline Value js_negative_infinity()
     return Value(-INFINITY);
 }
 
-ThrowCompletionOr<Value> greater_than(VM&, Value lhs, Value rhs);
-ThrowCompletionOr<Value> greater_than_equals(VM&, Value lhs, Value rhs);
-ThrowCompletionOr<Value> less_than(VM&, Value lhs, Value rhs);
-ThrowCompletionOr<Value> less_than_equals(VM&, Value lhs, Value rhs);
+ThrowCompletionOr<bool> greater_than(VM&, Value lhs, Value rhs);
+ThrowCompletionOr<bool> greater_than_equals(VM&, Value lhs, Value rhs);
+ThrowCompletionOr<bool> less_than(VM&, Value lhs, Value rhs);
+ThrowCompletionOr<bool> less_than_equals(VM&, Value lhs, Value rhs);
 ThrowCompletionOr<Value> bitwise_and(VM&, Value lhs, Value rhs);
 ThrowCompletionOr<Value> bitwise_or(VM&, Value lhs, Value rhs);
 ThrowCompletionOr<Value> bitwise_xor(VM&, Value lhs, Value rhs);


### PR DESCRIPTION
1.1x speedup on strictly-equals-object.js

Suite       Test                         Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  -------------------------  ---------  ---------------------  ---------------------
MicroBench  strictly-equals-object.js      1.105  1.170 ± 1.100 … 1.250  1.059 ± 1.050 … 1.060
MicroBench  Total                          1.105  1.170                  1.059
All Suites  Total                          1.105  1.170                  1.059