### PR TITLE
LibWebView: A couple of `--profile-process` ergonomic improvements

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -252,6 +252,9 @@ void Application::launch_spare_web_content_process()
     // Disable spare processes when debugging WebContent. Otherwise, it breaks running `gdb attach -p $(pidof WebContent)`.
     if (browser_options().debug_helper_process == ProcessType::WebContent)
         return;
+    // Disable spare processes when profiling WebContent. This reduces callgrind logging we are not interested in.
+    if (browser_options().profile_helper_process == ProcessType::WebContent)
+        return;
 
     if (m_has_queued_task_to_launch_spare_web_content_process)
         return;

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -62,8 +62,8 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
 
             if (browser_options.profile_helper_process == process_type) {
                 dbgln();
-                dbgln("\033[1;45mLaunched {} process under callgrind!\033[0m", server_name);
-                dbgln("\033[100mRun `\033[4mcallgrind_control -i on\033[24m` to start instrumentation and `\033[4mcallgrind_control -i off\033[24m` stop it again.\033[0m");
+                dbgln("\033[1;34mLaunched {} process under callgrind!\033[0m", server_name);
+                dbgln("\033[1;36mRun `\033[4mcallgrind_control -i on\033[24m` to start instrumentation and `\033[4mcallgrind_control -i off\033[24m` stop it again.\033[0m");
                 dbgln();
             }
 


### PR DESCRIPTION
Maybe my terminal colors are weird, but I just could not read the callgrind commands before:
![before](https://github.com/user-attachments/assets/23558b2d-9e50-443d-88bf-a70fe714765a)

So this removes the background color from the ANSI sequence:
![after](https://github.com/user-attachments/assets/9a22a734-92da-4fb9-88b8-f0767ef1c249)
