### PR TITLE
Documentation: Mention requirements for ENABLE_CLANG_PLUGINS

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -30,7 +30,7 @@ There are some optional features that can be enabled during compilation that are
 - `INCLUDE_FLAC_SPEC_TESTS`: downloads and includes the xiph.org FLAC test suite.
 - `SERENITY_CACHE_DIR`: sets the location of a shared cache of downloaded files. Should not need to be set manually unless managing a distribution package.
 - `ENABLE_NETWORK_DOWNLOADS`: allows downloading files from the internet during the build. Default on, turning off enables offline builds. For offline builds, the structure of the SERENITY_CACHE_DIR must be set up the way that the build expects.
-- `ENABLE_CLANG_PLUGINS`: enables clang plugins which analyze the code for programming mistakes.
+- `ENABLE_CLANG_PLUGINS`: enables clang plugins which analyze the code for programming mistakes. See [Clang Plugins](#clang-plugins) below.
 
 Many parts of the codebase have debug functionality, mostly consisting of additional messages printed to the debug console. This is done via the `<component_name>_DEBUG` macros, which can be enabled individually at build time. They are listed in [this file](../Meta/CMake/all_the_debug_macros.cmake).
 
@@ -86,6 +86,9 @@ can use the `Meta/configure-clangd.sh` script.
 
 Clang plugins are used to validate the code at compile time. Currently, they are used to detect JavaScript-related
 garbage collection faux pas, such as neglecting to visit a garbage-collected type.
+
+In order to enable clang plugins, you will need clang's development headers installed. For example, on Ubuntu this is
+the `libclang-dev` package.
 
 When clang plugins are enabled, it is recommended to have the following environment variable set for ccache:
 


### PR DESCRIPTION
I arbitrarily listed the Ubuntu package name because that's probably the most common OS people are using, and I thought listing an example is better than not doing so.