### PR TITLE
LibJS: Skip iteration result allocation in AsyncFunctionDriverWrapper

### DIFF
--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -131,11 +131,8 @@ void AsyncFunctionDriverWrapper::continue_async_execution(VM& vm, Value value, b
                 return generator_result.throw_completion();
 
             auto result = generator_result.release_value();
-            VERIFY(result.is_object());
-
-            auto promise_value = TRY(result.get(vm, vm.names.value));
-
-            if (TRY(result.get(vm, vm.names.done)).to_boolean()) {
+            auto promise_value = result.value;
+            if (result.done) {
                 // When returning a promise, we need to unwrap it.
                 if (promise_value.is_object() && is<Promise>(promise_value.as_object())) {
                     auto& returned_promise = static_cast<Promise&>(promise_value.as_object());

--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -75,7 +75,8 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
     };
 
     // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
+    if (!m_on_fulfilled)
+        m_on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
 
     // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the
     //    following steps when called:
@@ -103,11 +104,12 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
     };
 
     // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
+    if (!m_on_rejected)
+        m_on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
 
     // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
     m_current_promise = as<Promise>(promise_object);
-    m_current_promise->perform_then(on_fulfilled, on_rejected, {});
+    m_current_promise->perform_then(m_on_fulfilled, m_on_rejected, {});
 
     // NOTE: None of these are necessary. 8-12 are handled by step d of the above lambdas.
     // 8. Remove asyncContext from the execution context stack and restore the execution context that is at the top of the
@@ -176,6 +178,8 @@ void AsyncFunctionDriverWrapper::visit_edges(Cell::Visitor& visitor)
         visitor.visit(m_current_promise);
     if (m_suspended_execution_context)
         m_suspended_execution_context->visit_edges(visitor);
+    visitor.visit(m_on_fulfilled);
+    visitor.visit(m_on_rejected);
 }
 
 }

--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -34,6 +34,9 @@ private:
     GC::Ref<Promise> m_top_level_promise;
     GC::Ptr<Promise> m_current_promise { nullptr };
     OwnPtr<ExecutionContext> m_suspended_execution_context;
+
+    GC::Ptr<NativeFunction> m_on_fulfilled;
+    GC::Ptr<NativeFunction> m_on_rejected;
 };
 
 }

--- a/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -21,8 +21,20 @@ public:
     virtual ~GeneratorObject() override = default;
     void visit_edges(Cell::Visitor&) override;
 
-    ThrowCompletionOr<Value> resume(VM&, Value value, Optional<StringView> const& generator_brand);
-    ThrowCompletionOr<Value> resume_abrupt(VM&, JS::Completion abrupt_completion, Optional<StringView> const& generator_brand);
+    struct IterationResult {
+        IterationResult() = delete;
+        explicit IterationResult(Value value, bool done)
+            : done(done)
+            , value(value)
+        {
+        }
+
+        bool done { false };
+        Value value;
+    };
+
+    ThrowCompletionOr<IterationResult> resume(VM&, Value value, Optional<StringView> const& generator_brand);
+    ThrowCompletionOr<IterationResult> resume_abrupt(VM&, JS::Completion abrupt_completion, Optional<StringView> const& generator_brand);
 
     enum class GeneratorState {
         SuspendedStart,
@@ -37,7 +49,7 @@ protected:
     GeneratorObject(Realm&, Object& prototype, NonnullOwnPtr<ExecutionContext>, Optional<StringView> generator_brand = {});
 
     ThrowCompletionOr<GeneratorState> validate(VM&, Optional<StringView> const& generator_brand);
-    virtual ThrowCompletionOr<Value> execute(VM&, JS::Completion const& completion);
+    virtual ThrowCompletionOr<IterationResult> execute(VM&, JS::Completion const& completion);
 
 private:
     NonnullOwnPtr<ExecutionContext> m_execution_context;

--- a/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
@@ -34,7 +34,8 @@ JS_DEFINE_NATIVE_FUNCTION(GeneratorPrototype::next)
 {
     // 1. Return ? GeneratorResume(this value, value, empty).
     auto generator_object = TRY(typed_this_object(vm));
-    return generator_object->resume(vm, vm.argument(0), {});
+    auto iteration_result = TRY(generator_object->resume(vm, vm.argument(0), {}));
+    return create_iterator_result_object(vm, iteration_result.value, iteration_result.done);
 }
 
 // 27.5.1.3 Generator.prototype.return ( value ), https://tc39.es/ecma262/#sec-generator.prototype.return
@@ -47,7 +48,8 @@ JS_DEFINE_NATIVE_FUNCTION(GeneratorPrototype::return_)
     auto completion = Completion(Completion::Type::Return, vm.argument(0));
 
     // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
-    return generator_object->resume_abrupt(vm, completion, {});
+    auto iteration_result = TRY(generator_object->resume_abrupt(vm, completion, {}));
+    return create_iterator_result_object(vm, iteration_result.value, iteration_result.done);
 }
 
 // 27.5.1.4 Generator.prototype.throw ( exception ), https://tc39.es/ecma262/#sec-generator.prototype.throw
@@ -60,7 +62,8 @@ JS_DEFINE_NATIVE_FUNCTION(GeneratorPrototype::throw_)
     auto completion = throw_completion(vm.argument(0));
 
     // 3. Return ? GeneratorResumeAbrupt(g, C, empty).
-    return generator_object->resume_abrupt(vm, completion, {});
+    auto iteration_result = TRY(generator_object->resume_abrupt(vm, completion, {}));
+    return create_iterator_result_object(vm, iteration_result.value, iteration_result.done);
 }
 
 }

--- a/Libraries/LibJS/Runtime/IteratorHelper.h
+++ b/Libraries/LibJS/Runtime/IteratorHelper.h
@@ -37,7 +37,7 @@ private:
     IteratorHelper(Realm&, Object& prototype, GC::Ref<IteratorRecord>, GC::Ref<Closure>, GC::Ptr<AbruptClosure>);
 
     virtual void visit_edges(Visitor&) override;
-    virtual ThrowCompletionOr<Value> execute(VM&, JS::Completion const& completion) override;
+    virtual ThrowCompletionOr<IterationResult> execute(VM&, JS::Completion const& completion) override;
 
     GC::Ref<IteratorRecord> m_underlying_iterator; // [[UnderlyingIterator]]
     GC::Ref<Closure> m_closure;

--- a/Libraries/LibJS/Runtime/IteratorHelperPrototype.cpp
+++ b/Libraries/LibJS/Runtime/IteratorHelperPrototype.cpp
@@ -37,7 +37,8 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorHelperPrototype::next)
     auto iterator = TRY(typed_this_object(vm));
 
     // 1. Return ? GeneratorResume(this value, undefined, "Iterator Helper").
-    return iterator->resume(vm, js_undefined(), "Iterator Helper"sv);
+    auto iteration_result = TRY(iterator->resume(vm, js_undefined(), "Iterator Helper"sv));
+    return create_iterator_result_object(vm, iteration_result.value, iteration_result.done);
 }
 
 // 27.1.2.1.2 %IteratorHelperPrototype%.return ( ), https://tc39.es/ecma262/#sec-%iteratorhelperprototype%.return
@@ -66,7 +67,8 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorHelperPrototype::return_)
     Completion completion { Completion::Type::Return, js_undefined() };
 
     // 6. Return ? GeneratorResumeAbrupt(O, C, "Iterator Helper").
-    return TRY(iterator->resume_abrupt(vm, move(completion), "Iterator Helper"sv));
+    auto iteration_result = TRY(iterator->resume_abrupt(vm, move(completion), "Iterator Helper"sv));
+    return create_iterator_result_object(vm, iteration_result.value, iteration_result.done);
 }
 
 }


### PR DESCRIPTION
- Create less GC pressure by making each `await` in async function skip iteration result object allocation.
- Skip uncached `Object::get()` calls to extract `value` and `done` from the iteration result object.

With this change, following function goes 30% faster on my computer:
```js
(async () => {
    const resolved = Promise.resolve();
    for (let i = 0; i < 5_000_000; i++) {
        await resolved;
    }
})();
```