### PR TITLE
LibRegex: Use `NO_UNIQUE_ADDRESS` in RegexMatch for Windows support

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -2,7 +2,7 @@
 
 ## Build Prerequisites
 
-Qt6 development packages, nasm, additional build tools, and a C++23 capable compiler like g++-13 or clang-17 are required.
+Qt6 development packages, nasm, additional build tools, and a C++23 capable compiler like g++-13 or clang-19 are required.
 
 CMake 3.25 or newer must be available in $PATH.
 
@@ -40,7 +40,7 @@ sudo apt update -y && sudo apt install cmake -y
 
 #### C++23-capable compiler:
 
-- Recommendation: Install `clang-17` or newer from [LLVM's apt repository](https://apt.llvm.org/):
+- Recommendation: Install `clang-19` or newer from [LLVM's apt repository](https://apt.llvm.org/):
 
 ```bash
 # Add LLVM GPG signing key
@@ -163,7 +163,7 @@ choco install pkgconfiglite -y
 Note that OpenIndiana's latest GCC port (GCC 11) is too old to build Ladybird, so you need Clang, which is available in the repository.
 
 ```
-pfexec pkg install clang-17 cmake libglvnd ninja qt6
+pfexec pkg install clang-19 cmake libglvnd ninja qt6
 ```
 
 ### Haiku:

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -301,8 +301,8 @@ public:
     }
 
 private:
-    [[no_unique_address]] Variant<StringView, Utf16View> m_view { StringView {} };
-    [[no_unique_address]] bool m_unicode { false };
+    NO_UNIQUE_ADDRESS Variant<StringView, Utf16View> m_view { StringView {} };
+    NO_UNIQUE_ADDRESS bool m_unicode { false };
 };
 
 class Match final {


### PR DESCRIPTION
I found a spot not using `NO_UNIQUE_ADDRESS` when trying to build some AK unit tests on Windows. This macro [properly uses the required [[msvc::no_unique_address]]](https://github.com/LadybirdBrowser/ladybird/blob/master/AK/Platform.h#L249-L250). 

Also note that [Clang version 18+ is required](https://github.com/llvm/llvm-project/issues/83445#issuecomment-1974291952) to build on Windows as `[[msvc::no_unique_address]]` was not supported in clang-cl until then, and since the [documentation also uses clang-19](https://github.com/LadybirdBrowser/ladybird/blob/43defa90cc724fb848140620fe5613329dea9f8b/Documentation/BuildInstructionsLadybird.md?plain=1#L55) in the compiler installation example, I updated the remaining references to clang-17 to be clang-19 for consistency