### PR TITLE
LibJS: Don't run promise and cleanup jobs in Interpreter::run

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -303,14 +303,6 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, GC::Ptr<Environ
 
     // FIXME: 16. Resume the context that is now on the top of the execution context stack as the running execution context.
 
-    // FIXME: These three should be moved out of Interpreter::run and give the host an option to run these, as it's up to the host when these get run.
-    //        https://tc39.es/ecma262/#sec-jobs for jobs and https://tc39.es/ecma262/#_ref_3508 for ClearKeptObjects
-    //        finish_execution_generation is particularly an issue for LibWeb, as the HTML spec wants to run it specifically after performing a microtask checkpoint.
-    //        The promise and registry cleanup queues don't cause LibWeb an issue, as LibWeb overrides the hooks that push onto these queues.
-    vm.run_queued_promise_jobs();
-
-    vm.run_queued_finalization_registry_cleanup_jobs();
-
     vm.finish_execution_generation();
 
     // 17. Return ? result.


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-jobs specifies that we should only be running queued promise jobs and host-defined cleanup when the execution context stack is empty. It is asserted to _not_ be empty the line above, so remove it.

No impact on test262 or our test suites, Interpreter::run_executable is already (incorrectly) performing this unconditionally. run_promise_jobs also happens to do nothing when LibJS is embedded into LibWeb.