### PR TITLE
LibWeb: Overlap float space and left margins for all shared ancestors

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float-and-margin-left.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-with-hidden-overflow-after-float-and-margin-left.txt
@@ -1,0 +1,37 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x48 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x22 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        BlockContainer <div#a> at (8,8) content-size 100x40 floating [BFC] children: not-inline
+        TextNode <#text>
+      BlockContainer <div#b> at (109,9) content-size 682x20 children: not-inline
+        BlockContainer <(anonymous)> at (109,9) content-size 682x0 children: inline
+          TextNode <#text>
+        BlockContainer <div> at (109,9) content-size 682x20 children: not-inline
+          BlockContainer <(anonymous)> at (109,9) content-size 682x0 children: inline
+            TextNode <#text>
+          BlockContainer <div#c> at (110,10) content-size 680x18 [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 3, rect: [110,10 27.15625x18] baseline: 13.796875
+                "foo"
+            TextNode <#text>
+          BlockContainer <(anonymous)> at (109,29) content-size 682x0 children: inline
+            TextNode <#text>
+        BlockContainer <(anonymous)> at (109,29) content-size 682x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,30) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x22]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>#a) [8,8 100x40]
+      PaintableWithLines (BlockContainer<DIV>#b) [108,8 684x22]
+        PaintableWithLines (BlockContainer(anonymous)) [109,9 682x0]
+        PaintableWithLines (BlockContainer<DIV>) [109,9 682x20]
+          PaintableWithLines (BlockContainer(anonymous)) [109,9 682x0]
+          PaintableWithLines (BlockContainer<DIV>#c) [109,9 682x20]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer(anonymous)) [109,29 682x0]
+        PaintableWithLines (BlockContainer(anonymous)) [109,29 682x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,30 784x0]

--- a/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-float-and-margin-left.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/block-with-hidden-overflow-after-float-and-margin-left.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+#a {
+    background: green;
+    float: left;
+    height: 40px;
+    width: 100px;
+}
+#b {
+    border: 1px solid black;
+    margin-left: 100px;
+}
+#c {
+    border: 1px solid red;
+    overflow: hidden;
+}
+</style>
+<div id="a"></div>
+<div id="b">
+    <div>
+        <div id="c">foo</div>
+    </div>
+</div>


### PR DESCRIPTION
We would only correct for the left margin of the containing block of the child box that we are laying out, but we actually need to correct for all left margins up until the containing block that contains both the float and the child box.

Fixes #4639, the sidebar on https://security.nl:

| Before | After |
|--|--|
| ![Screenshot_20250509_120726](https://github.com/user-attachments/assets/819cd53f-0d19-4b8d-9071-45381c993b91) | ![Screenshot_20250509_120705](https://github.com/user-attachments/assets/82409ef9-d872-41fd-a17a-3444cde5c683) |

