### PR TITLE
LibWeb: Don't throw away HTMLInputElement shadow trees willy-nilly

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -54,12 +54,6 @@ void HTMLDetailsElement::inserted()
     update_shadow_tree_slots();
 }
 
-void HTMLDetailsElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
-{
-    Base::removed_from(old_parent, old_root);
-    set_shadow_root(nullptr);
-}
-
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element:concept-element-attributes-change-ext
 void HTMLDetailsElement::attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -32,7 +32,6 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
     virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1793,11 +1793,6 @@ void HTMLInputElement::form_associated_element_was_inserted()
     }
 }
 
-void HTMLInputElement::form_associated_element_was_removed(DOM::Node*)
-{
-    set_shadow_root(nullptr);
-}
-
 bool HTMLInputElement::is_presentational_hint(FlyString const& name) const
 {
     if (Base::is_presentational_hint(name))

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -192,7 +192,6 @@ public:
     virtual void clear_algorithm() override;
 
     virtual void form_associated_element_was_inserted() override;
-    virtual void form_associated_element_was_removed(DOM::Node*) override;
     virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
 
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -175,12 +175,6 @@ void HTMLMeterElement::inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLMeterElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
-{
-    Base::removed_from(old_parent, old_root);
-    set_shadow_root(nullptr);
-}
-
 void HTMLMeterElement::adjust_computed_style(CSS::ComputedProperties& style)
 {
     // https://drafts.csswg.org/css-display-3/#unbox

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.h
@@ -35,7 +35,6 @@ public:
 
     // ^HTMLElement
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
 
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -96,12 +96,6 @@ void HTMLProgressElement::inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLProgressElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
-{
-    Base::removed_from(old_parent, old_root);
-    set_shadow_root(nullptr);
-}
-
 void HTMLProgressElement::adjust_computed_style(CSS::ComputedProperties& style)
 {
     // https://drafts.csswg.org/css-display-3/#unbox

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -29,7 +29,6 @@ public:
 
     // ^HTMLElement
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
 
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -574,11 +574,6 @@ void HTMLSelectElement::form_associated_element_was_inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLSelectElement::form_associated_element_was_removed(DOM::Node*)
-{
-    set_shadow_root(nullptr);
-}
-
 void HTMLSelectElement::computed_properties_changed()
 {
     // Hide chevron icon when appearance is none

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -97,7 +97,6 @@ public:
     virtual void activation_behavior(DOM::Event const&) override;
 
     virtual void form_associated_element_was_inserted() override;
-    virtual void form_associated_element_was_removed(DOM::Node*) override;
 
     void did_select_item(Optional<u32> const& id);
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -154,11 +154,6 @@ void HTMLTextAreaElement::form_associated_element_was_inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLTextAreaElement::form_associated_element_was_removed(DOM::Node*)
-{
-    set_shadow_root(nullptr);
-}
-
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-defaultvalue
 String HTMLTextAreaElement::default_value() const
 {

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -70,7 +70,6 @@ public:
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;
 
     virtual void form_associated_element_was_inserted() override;
-    virtual void form_associated_element_was_removed(DOM::Node*) override;
     virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
 
     virtual void children_changed(ChildrenChangedMetadata const*) override;


### PR DESCRIPTION
We were unnecessarily discarding the shadow tree of input elements when they were removed or detached from the DOM.

This especially caused a *lot* of churn when creating input elements via setting .innerHTML on something. We ended up building each input element's shadow tree 3 times instead of 1.

The original issue that we were trying to solve by discarding the shadow tree appears to have been solved elsewhere, and nothing else seems to break by just allowing the shadow tree to stay.

1.05x speedup on Speedometer's TodoMVC-jQuery.