### PR TITLE
LibWeb: Add missing WebIDL/Types include to MediaCapabilities.h

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -101,7 +101,7 @@ runs:
 
         echo "swiftly version: $(swiftly --version)" >&2
 
-        swiftly install --use main-snapshot-2025-04-12
+        swiftly install --use main-snapshot-2025-04-30
         swiftly list
 
     - name: 'Install Dependencies'

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -243,14 +243,10 @@
 #ifdef NO_UNIQUE_ADDRESS
 #    undef NO_UNIQUE_ADDRESS
 #endif
-#if defined(AK_DISABLE_NO_UNIQUE_ADDRESS)
-#    define NO_UNIQUE_ADDRESS
+#if defined(AK_OS_WINDOWS)
+#    define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else
-#    if defined(AK_OS_WINDOWS)
-#        define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#    else
-#        define NO_UNIQUE_ADDRESS [[no_unique_address]]
-#    endif
+#    define NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
 // GCC doesn't have __has_feature but clang does

--- a/Libraries/LibWeb/MediaCapabilitiesAPI/MediaCapabilities.h
+++ b/Libraries/LibWeb/MediaCapabilitiesAPI/MediaCapabilities.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/EncryptedMediaExtensions/EncryptedMediaExtensions.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::MediaCapabilitiesAPI {
 

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -138,8 +138,3 @@ endif()
 if (NOT MSVC)
     add_cxx_compile_options(-fstrict-flex-arrays=2)
 endif()
-
-# FIXME: https://github.com/swiftlang/swift/issues/80764
-if (CMAKE_Swift_COMPILER_LOADED)
-    add_cxx_compile_definitions(AK_DISABLE_NO_UNIQUE_ADDRESS)
-endif()


### PR DESCRIPTION
This causes a build failure when building a clang module for LibWeb.