### PR TITLE
Revert "AK: Rework error types to store kind as an enum"

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -23,9 +23,33 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 }
 
 #ifdef AK_OS_WINDOWS
-Error Error::from_windows_error(u32 windows_error)
+Error Error::from_windows_error(u64 code)
 {
-    return Error(static_cast<int>(windows_error), Error::Kind::Windows);
+    thread_local HashMap<u64, ByteString> s_windows_errors;
+
+    auto string = s_windows_errors.get(code);
+    if (string.has_value())
+        return Error::from_string_view(string->view());
+
+    char* message = nullptr;
+    auto size = FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr,
+        static_cast<DWORD>(code),
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        reinterpret_cast<LPSTR>(&message),
+        0,
+        nullptr);
+
+    if (size == 0) {
+        static char buffer[128];
+        (void)snprintf(buffer, _countof(buffer), "Error 0x%08lX while getting text of error 0x%08llX", GetLastError(), code);
+        return Error::from_string_view({ buffer, _countof(buffer) });
+    }
+
+    auto& string_in_map = s_windows_errors.ensure(code, [message, size] { return ByteString { message, size }; });
+    LocalFree(message);
+    return Error::from_string_view(string_in_map.view());
 }
 
 // This can be used both for generic Windows errors and for winsock errors because WSAGetLastError is forwarded to GetLastError.

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Assertions.h>
 #include <AK/StringView.h>
 #include <AK/Variant.h>
 #include <errno.h>
@@ -18,13 +17,6 @@ public:
     ALWAYS_INLINE Error(Error&&) = default;
     ALWAYS_INLINE Error& operator=(Error&&) = default;
 
-    enum class Kind : u8 {
-        Errno,
-        Syscall,
-        Windows,
-        StringLiteral
-    };
-
     static Error from_errno(int code)
     {
         VERIFY(code != 0);
@@ -32,7 +24,7 @@ public:
     }
 
 #ifdef AK_OS_WINDOWS
-    static Error from_windows_error(u32 windows_error);
+    static Error from_windows_error(u64 code);
     static Error from_windows_error();
 #endif
 
@@ -83,53 +75,39 @@ public:
 
     bool operator==(Error const& other) const
     {
-        return m_code == other.m_code && m_string_literal == other.m_string_literal && m_kind == other.m_kind;
+        return m_code == other.m_code && m_string_literal == other.m_string_literal && m_syscall == other.m_syscall;
     }
 
     int code() const { return m_code; }
     bool is_errno() const
     {
-        return m_kind == Kind::Errno;
+        return m_code != 0;
     }
     bool is_syscall() const
     {
-        return m_kind == Kind::Syscall;
-    }
-    bool is_windows_error() const
-    {
-        return m_kind == Kind::Windows;
-    }
-    bool is_string_literal() const
-    {
-        return m_kind == Kind::StringLiteral;
+        return m_syscall;
     }
     StringView string_literal() const
     {
         return m_string_literal;
     }
-    Kind kind() const
-    {
-        return m_kind;
-    }
 
 protected:
-    Error(int code, Kind kind = Kind::Errno)
+    Error(int code)
         : m_code(code)
-        , m_kind(kind)
     {
     }
 
 private:
     Error(StringView string_literal)
         : m_string_literal(string_literal)
-        , m_kind(Kind::StringLiteral)
     {
     }
 
     Error(StringView syscall_name, int rc)
         : m_string_literal(syscall_name)
         , m_code(-rc)
-        , m_kind(Kind::Syscall)
+        , m_syscall(true)
     {
     }
 
@@ -140,7 +118,7 @@ private:
 
     int m_code { 0 };
 
-    Kind m_kind {};
+    bool m_syscall { false };
 };
 
 template<typename T, typename E>

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -737,10 +737,15 @@ struct Formatter<FormatString> : Formatter<StringView> {
 
 template<>
 struct Formatter<Error> : Formatter<FormatString> {
-    ErrorOr<void> format(FormatBuilder& builder, Error const& error);
+    ErrorOr<void> format(FormatBuilder& builder, Error const& error)
+    {
+        if (error.is_syscall())
+            return Formatter<FormatString>::format(builder, "{}: {} (errno={})"sv, error.string_literal(), strerror(error.code()), error.code());
+        if (error.is_errno())
+            return Formatter<FormatString>::format(builder, "{} (errno={})"sv, strerror(error.code()), error.code());
 
-private:
-    ErrorOr<void> format_windows_error(FormatBuilder& builder, Error const& error);
+        return Formatter<FormatString>::format(builder, "{}"sv, error.string_literal());
+    }
 };
 
 template<typename T, typename ErrorType>


### PR DESCRIPTION
This reverts commit 79b652c74e25301c39193b5ca8a1146682e3406f.

This fundamentally changed how `is_errno` should be used without updating its users. So patterns like:
```c++
if (result.error().is_errno() && result.error().code() == EINTR)
```
Will no longer work.

Similarly, we use this pattern in:
Libraries/LibGfx/Font/PathFontProvider.cpp

Which is causing lots of debug spam on startup now.