### PR TITLE
AK: Fix error is_errno

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -89,7 +89,7 @@ public:
     int code() const { return m_code; }
     bool is_errno() const
     {
-        return m_kind == Kind::Errno;
+        return m_kind == Kind::Errno || m_kind == Kind::Syscall;
     }
     bool is_syscall() const
     {


### PR DESCRIPTION
Previously the check for is_errno did not check if the error kind was syscall, which also set errno so that behavior was incorrect.