### PR TITLE
LibWeb: Fix missing layout invalidation for ordered lists

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3298,10 +3298,10 @@ size_t Element::number_of_owned_list_items() const
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#list-owner
-Element const* Element::list_owner() const
+Element* Element::list_owner() const
 {
     // Any element whose computed value of 'display' is 'list-item' has a list owner, which is determined as follows:
-    if (!computed_properties()->display().is_list_item())
+    if (!computed_properties() || !computed_properties()->display().is_list_item())
         return nullptr;
 
     // 1. If the element is not being rendered, return null; the element has no list owner.
@@ -3332,7 +3332,7 @@ Element const* Element::list_owner() const
         }
         return IterationDecision::Continue;
     });
-    return ancestor;
+    return const_cast<Element*>(ancestor.ptr());
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#ordinal-value

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -468,7 +468,7 @@ public:
     }
 
     size_t number_of_owned_list_items() const;
-    Element const* list_owner() const;
+    Element* list_owner() const;
     size_t ordinal_value() const;
 
     void set_pointer_capture(WebIDL::Long pointer_id);

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -114,6 +114,7 @@ enum class SetNeedsLayoutReason {
     X(ElementSetInnerHTML)                                \
     X(DetailsElementOpenedOrClosed)                       \
     X(HTMLInputElementSrcAttribute)                       \
+    X(HTMLOListElementOrdinalValues)                      \
     X(HTMLObjectElementUpdateLayoutAndChildObjects)       \
     X(KeyframeEffect)                                     \
     X(NodeInsertBefore)                                   \

--- a/Libraries/LibWeb/HTML/HTMLLIElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.cpp
@@ -27,6 +27,17 @@ void HTMLLIElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
+void HTMLLIElement::attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    Base::attribute_changed(local_name, old_value, value, namespace_);
+
+    if (local_name == HTML::AttributeNames::value) {
+        if (auto* owner = list_owner()) {
+            owner->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::HTMLOListElementOrdinalValues);
+        }
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/grouping-content.html#dom-li-value
 WebIDL::Long HTMLLIElement::value()
 {

--- a/Libraries/LibWeb/HTML/HTMLLIElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.h
@@ -45,6 +45,7 @@ private:
     HTMLLIElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual bool is_presentational_hint(FlyString const&) const override;
     virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;

--- a/Libraries/LibWeb/HTML/HTMLOListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLOListElement.h>
 #include <LibWeb/HTML/Numbers.h>
 
@@ -26,6 +27,15 @@ void HTMLOListElement::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLOListElement);
     Base::initialize(realm);
+}
+
+void HTMLOListElement::attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    Base::attribute_changed(local_name, old_value, value, namespace_);
+
+    if (local_name.is_one_of(HTML::AttributeNames::reversed, HTML::AttributeNames::start, HTML::AttributeNames::type)) {
+        set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::HTMLOListElementOrdinalValues);
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/grouping-content.html#dom-ol-start

--- a/Libraries/LibWeb/HTML/HTMLOListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.h
@@ -34,6 +34,7 @@ private:
     HTMLOListElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual bool is_presentational_hint(FlyString const&) const override;
     virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;

--- a/Tests/LibWeb/Ref/expected/li-change-value-attribute-ref.html
+++ b/Tests/LibWeb/Ref/expected/li-change-value-attribute-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<ol>
+  <li value="42">Item a</li>
+  <li>Item b</li>
+</ol>

--- a/Tests/LibWeb/Ref/expected/ol-change-reversed-attribute-ref.html
+++ b/Tests/LibWeb/Ref/expected/ol-change-reversed-attribute-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<ol reversed>
+  <li>Item a</li>
+  <li>Item b</li>
+</ol>

--- a/Tests/LibWeb/Ref/expected/ol-change-start-attribute-ref.html
+++ b/Tests/LibWeb/Ref/expected/ol-change-start-attribute-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<ol start="42">
+  <li>Item a</li>
+  <li>Item b</li>
+</ol>

--- a/Tests/LibWeb/Ref/expected/ol-change-type-attribute-ref.html
+++ b/Tests/LibWeb/Ref/expected/ol-change-type-attribute-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<ol type="I">
+  <li>Item a</li>
+  <li>Item b</li>
+</ol>

--- a/Tests/LibWeb/Ref/input/li-change-value-attribute.html
+++ b/Tests/LibWeb/Ref/input/li-change-value-attribute.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <link rel="match" href="../expected/li-change-value-attribute-ref.html" />
+  <ol>
+    <li id="first">Item a</li>
+    <li>Item b</li>
+  </ol>
+  <script>
+    // Two nested requestAnimationFrame() calls to force code execution _after_ initial paint
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.getElementById("first").value = 42;
+        document.documentElement.className = '';
+      });
+    });
+  </script>
+</html>

--- a/Tests/LibWeb/Ref/input/ol-change-reversed-attribute.html
+++ b/Tests/LibWeb/Ref/input/ol-change-reversed-attribute.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <link rel="match" href="../expected/ol-change-reversed-attribute-ref.html" />
+  <ol id="list">
+    <li>Item a</li>
+    <li>Item b</li>
+  </ol>
+  <script>
+    // Two nested requestAnimationFrame() calls to force code execution _after_ initial paint
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.getElementById("list").reversed = true;
+        document.documentElement.className = '';
+      });
+    });
+  </script>
+</html>

--- a/Tests/LibWeb/Ref/input/ol-change-start-attribute.html
+++ b/Tests/LibWeb/Ref/input/ol-change-start-attribute.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <link rel="match" href="../expected/ol-change-start-attribute-ref.html" />
+  <ol id="list">
+    <li>Item a</li>
+    <li>Item b</li>
+  </ol>
+  <script>
+    // Two nested requestAnimationFrame() calls to force code execution _after_ initial paint
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.getElementById("list").start = 42;
+        document.documentElement.className = '';
+      });
+    });
+  </script>
+</html>

--- a/Tests/LibWeb/Ref/input/ol-change-type-attribute.html
+++ b/Tests/LibWeb/Ref/input/ol-change-type-attribute.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <link rel="match" href="../expected/ol-change-type-attribute-ref.html" />
+  <ol id="list">
+    <li>Item a</li>
+    <li>Item b</li>
+  </ol>
+  <script>
+    // Two nested requestAnimationFrame() calls to force code execution _after_ initial paint
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.getElementById("list").type = 'I';
+        document.documentElement.className = '';
+      });
+    });
+  </script>
+</html>


### PR DESCRIPTION
Testcases I wrote for #4442 exposed some invalidation bugs related to ordered lists that are already present on `master`. These are separate from the performance improvements and therefore can be fixed in an independent PR.

I'm not entirely happy with the changes to `Element::list_owner()`, but the alternatives I could come up with didn't seem better either.