### PR TITLE
LibWeb: Add support for trees of pseudo-elements

### DIFF
--- a/Documentation/CSSGeneratedFiles.md
+++ b/Documentation/CSSGeneratedFiles.md
@@ -169,8 +169,9 @@ Each entry has the following properties:
 |----------------------|----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `alias-for`          | No       | Nothing        | Use to specify that this should be treated as an alias for the named pseudo-element.                                                                                   |
 | `function-syntax`    | No       | Nothing        | Syntax for the function arguments if this is a function-type pseudo-element. Copied directly from the spec.                                                            |
-| `is-generated`       | No       | `false`        | Whether this is a [generated pseudo-element.](https://drafts.csswg.org/css-pseudo-4/#generated-content)                                                                |
-| `is-allowed-in-has`  | No       | `false`        | Whether this is a [`:has`-allowed pseudo-element.](https://drafts.csswg.org/selectors/#has-allowed-pseudo-element)                                                     |
+| `is-generated`       | No       | `false`        | Whether this is a [generated pseudo-element](https://drafts.csswg.org/css-pseudo-4/#generated-content).                                                                |
+| `is-allowed-in-has`  | No       | `false`        | Whether this is a [`:has`-allowed pseudo-element](https://drafts.csswg.org/selectors/#has-allowed-pseudo-element).                                                     |
+| `is-pseudo-root`     | No       | `false` | Whether this is a [pseudo-element root](https://drafts.csswg.org/css-view-transitions/#pseudo-element-root).                                                                  |
 | `property-whitelist` | No       | Nothing        | Some pseudo-elements only permit certain properties. If so, name them in an array here. Some special values are allowed here for categories of properties - see below. |
 | `spec`               | No       | Nothing        | Link to the spec definition, for reference. Not used in generated code.                                                                                                |
 | `type`               | No       | `"identifier"` | What type of pseudo-element is this. Either "identifier", "function", or "both".                                                                                       |
@@ -181,6 +182,7 @@ The generated code provides:
 - `Optional<PseudoElement> aliased_pseudo_element_from_string(StringView)` is similar, but returns the `PseudoElement` this name is an alias for
 - `StringView pseudo_element_name(PseudoElement)` to convert a `PseudoElement` back into a string
 - `bool is_has_allowed_pseudo_element(PseudoElement)` returns whether the pseudo-element is valid inside `:has()`
+- `bool is_pseudo_element_root(PseudoElement)` returns whether the pseudo-element is a [pseudo-element root](https://drafts.csswg.org/css-view-transitions/#pseudo-element-root)
 - `bool pseudo_element_supports_property(PseudoElement, PropertyID)` returns whether the property can be applied to this pseudo-element
 - A `GeneratedPseudoElement` enum listing only the pseudo-elements that are [generated content](https://drafts.csswg.org/css-pseudo-4/#generated-content)
 - `Optional<GeneratedPseudoElement> to_generated_pseudo_element(PseudoElement)` for converting from `PseudoElement` to `GeneratedPseudoElement`. Returns nothing if it's not a generated pseudo-element

--- a/Libraries/LibWeb/CSS/PseudoElements.json
+++ b/Libraries/LibWeb/CSS/PseudoElements.json
@@ -114,7 +114,8 @@
     "spec": "https://drafts.csswg.org/css-forms-1/#selectordef-slider-track"
   },
   "view-transition": {
-    "spec": "https://drafts.csswg.org/css-view-transitions-1/#selectordef-view-transition"
+    "spec": "https://drafts.csswg.org/css-view-transitions-1/#selectordef-view-transition",
+    "is-pseudo-root": true
   },
   "view-transition-group": {
     "spec": "https://drafts.csswg.org/css-view-transitions-1/#selectordef-view-transition-group",

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -525,15 +525,26 @@ private:
     GC::Ptr<CSS::ComputedProperties> m_computed_properties;
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
 
-    struct PseudoElement {
+    struct PseudoElement : public JS::Cell {
+        GC_CELL(PseudoElement, JS::Cell);
+        GC_DECLARE_ALLOCATOR(PseudoElement);
+
         GC::Ptr<Layout::NodeWithStyle> layout_node;
         GC::Ptr<CSS::CascadedProperties> cascaded_properties;
         GC::Ptr<CSS::ComputedProperties> computed_properties;
         HashMap<FlyString, CSS::StyleProperty> custom_properties;
+
+    private:
+        virtual void visit_edges(JS::Cell::Visitor&) override;
     };
-    // TODO: CSS::Selector::PseudoElement includes a lot of pseudo-elements that exist in shadow trees,
-    //       and so we don't want to include data for them here.
-    using PseudoElementData = Array<PseudoElement, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)>;
+    // https://drafts.csswg.org/css-view-transitions/#pseudo-element-tree
+    struct PseudoElementTreeNode
+        : public PseudoElement
+        , TreeNode<PseudoElementTreeNode> {
+        GC_CELL(PseudoElementTreeNode, PseudoElement);
+        GC_DECLARE_ALLOCATOR(PseudoElementTreeNode);
+    };
+    using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;
     mutable OwnPtr<PseudoElementData> m_pseudo_element_data;
     Optional<PseudoElement&> get_pseudo_element(CSS::PseudoElement) const;
     PseudoElement& ensure_pseudo_element(CSS::PseudoElement) const;
@@ -616,7 +627,10 @@ inline bool Element::has_pseudo_element(CSS::PseudoElement type) const
         return false;
     if (!CSS::Selector::PseudoElementSelector::is_known_pseudo_element_type(type))
         return false;
-    return m_pseudo_element_data->at(to_underlying(type)).layout_node;
+    auto pseudo_element = m_pseudo_element_data->get(type);
+    if (!pseudo_element.has_value())
+        return false;
+    return pseudo_element.value()->layout_node;
 }
 
 WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, FlyString const& qualified_name);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoElement.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoElement.cpp
@@ -86,6 +86,7 @@ Optional<PseudoElement> aliased_pseudo_element_from_string(StringView);
 StringView pseudo_element_name(PseudoElement);
 
 bool is_has_allowed_pseudo_element(PseudoElement);
+bool is_pseudo_element_root(PseudoElement);
 bool pseudo_element_supports_property(PseudoElement, PropertyID);
 
 struct PseudoElementMetadata {
@@ -217,6 +218,33 @@ bool is_has_allowed_pseudo_element(PseudoElement pseudo_element)
         if (pseudo_element.has("alias-for"sv))
             return;
         if (!pseudo_element.get_bool("is-allowed-in-has"sv).value_or(false))
+            return;
+
+        auto member_generator = generator.fork();
+        member_generator.set("name:titlecase", title_casify(name));
+
+        member_generator.append(R"~~~(
+    case PseudoElement::@name:titlecase@:
+        return true;
+)~~~");
+    });
+
+    generator.append(R"~~~(
+    default:
+        return false;
+    }
+}
+
+bool is_pseudo_element_root(PseudoElement pseudo_element)
+{
+    switch (pseudo_element) {
+)~~~");
+
+    pseudo_elements_data.for_each_member([&](auto& name, JsonValue const& value) {
+        auto& pseudo_element = value.as_object();
+        if (pseudo_element.has("alias-for"sv))
+            return;
+        if (!pseudo_element.get_bool("is-pseudo-root"sv).value_or(false))
             return;
 
         auto member_generator = generator.fork();


### PR DESCRIPTION
This is needed for CSS view transitions and it should allow us to construct pseudo-elements and build trees out of them.
It also takes care of the pseudo-element TODO:  that used to be here. 
It'll probably need more stuff for CSS to properly match these and all that, but that'll be easier to add once I'm actually building trees out of them for the view transitions.