### PR TITLE
LibJS: Make mapped arguments objects way less allocation-happy

### DIFF
--- a/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2021-2025, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,24 +20,26 @@ public:
     virtual void initialize(Realm&) override;
     virtual ~ArgumentsObject() override = default;
 
-    Environment& environment() { return m_environment; }
-
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
 
-    // [[ParameterMap]]
-    Object& parameter_map() { return *m_parameter_map; }
+    void set_mapped_names(Vector<FlyString> mapped_names) { m_mapped_names = move(mapped_names); }
 
 private:
     ArgumentsObject(Realm&, Environment&);
 
+    [[nodiscard]] bool parameter_map_has(PropertyKey const&) const;
+    [[nodiscard]] Value get_from_parameter_map(PropertyKey const&) const;
+    void set_in_parameter_map(PropertyKey const&, Value);
+    void delete_from_parameter_map(PropertyKey const&);
+
     virtual void visit_edges(Cell::Visitor&) override;
 
     GC::Ref<Environment> m_environment;
-    GC::Ptr<Object> m_parameter_map;
+    Vector<FlyString> m_mapped_names;
 };
 
 }


### PR DESCRIPTION
By following the spec to the letter, our mapped arguments objects ended up with many extra GC allocations:

- 1 extra Object for the internal [[ParameterMap]].
- 2 extra NativeFunctions for each mapped parameter accessor.
- 1 extra Accessor to hold the aforementioned NativeFunctions.

This patch removes all those allocations and lets ArgumentsObject model the desired behavior in custom C++ instead of using script primitives.

1.06x speedup on Speedometer's TodoMVC-jQuery.