### PR TITLE
LibGfx+LibWeb: Prepare Gfx::Filter for SVG Filters

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     Color.cpp
     ColorSpace.cpp
     Cursor.cpp
+    Filter.cpp
     FontCascadeList.cpp
     Font/Font.cpp
     Font/FontData.cpp

--- a/Libraries/LibGfx/Filter.cpp
+++ b/Libraries/LibGfx/Filter.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2025, Lucien Fiorini <lucienfiorini@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Filter.h>
+#include <LibGfx/FilterImpl.h>
+#include <LibGfx/SkiaUtils.h>
+#include <core/SkBlendMode.h>
+#include <core/SkColorFilter.h>
+#include <effects/SkColorMatrix.h>
+#include <effects/SkImageFilters.h>
+
+namespace Gfx {
+
+using Impl = FilterImpl;
+
+Filter::Filter(Filter const& other)
+    : m_impl(other.m_impl->clone())
+{
+}
+
+Filter& Filter::operator=(Filter const& other)
+{
+    if (this != &other) {
+        m_impl = other.m_impl->clone();
+    }
+    return *this;
+}
+
+Filter::~Filter() = default;
+
+Filter::Filter(NonnullOwnPtr<FilterImpl>&& impl)
+    : m_impl(impl->clone())
+{
+}
+
+FilterImpl const& Filter::impl() const
+{
+    return *m_impl;
+}
+
+Filter Filter::compose(Filter const& outer, Filter const& inner)
+{
+    auto inner_skia = inner.m_impl->filter;
+    auto outer_skia = outer.m_impl->filter;
+
+    auto filter = SkImageFilters::Compose(outer_skia, inner_skia);
+    return Filter(Impl::create(filter));
+}
+
+Filter Filter::blend(Filter const& background, Filter const& foreground, Gfx::CompositingAndBlendingOperator mode)
+{
+    auto filter = SkImageFilters::Blend(to_skia_blender(mode), background.m_impl->filter, foreground.m_impl->filter);
+    return Filter(Impl::create(filter));
+}
+
+Filter Filter::blur(float radius, Optional<Filter const&> input)
+{
+    sk_sp<SkImageFilter> input_skia = input.has_value() ? input->m_impl->filter : nullptr;
+
+    auto filter = SkImageFilters::Blur(radius, radius, input_skia);
+    return Filter(Impl::create(filter));
+}
+
+Filter Filter::flood(Gfx::Color color, float opacity)
+{
+    auto color_skia = to_skia_color(color);
+    color_skia = SkColorSetA(color_skia, static_cast<u8>(opacity * 255));
+
+    return Filter(Impl::create(SkImageFilters::Shader(SkShaders::Color(color_skia))));
+}
+
+Filter Filter::drop_shadow(float offset_x, float offset_y, float radius, Gfx::Color color,
+    Optional<Filter const&> input)
+{
+    sk_sp<SkImageFilter> input_skia = input.has_value() ? input->m_impl->filter : nullptr;
+    auto shadow_color = to_skia_color(color);
+
+    auto filter = SkImageFilters::DropShadow(offset_x, offset_y, radius, radius, shadow_color, input_skia);
+    return Filter(Impl::create(filter));
+}
+
+Filter Filter::color(ColorFilterType type, float amount, Optional<Filter const&> input)
+{
+    sk_sp<SkImageFilter> input_skia = input.has_value() ? input->m_impl->filter : nullptr;
+
+    sk_sp<SkColorFilter> color_filter;
+
+    // Matrices are taken from https://drafts.fxtf.org/filter-effects-1/#FilterPrimitiveRepresentation
+    switch (type) {
+    case ColorFilterType::Grayscale: {
+        float matrix[20] = {
+            0.2126f + 0.7874f * (1 - amount), 0.7152f - 0.7152f * (1 - amount),
+            0.0722f - 0.0722f * (1 - amount), 0, 0,
+            0.2126f - 0.2126f * (1 - amount), 0.7152f + 0.2848f * (1 - amount),
+            0.0722f - 0.0722f * (1 - amount), 0, 0,
+            0.2126f - 0.2126f * (1 - amount), 0.7152f - 0.7152f * (1 - amount),
+            0.0722f + 0.9278f * (1 - amount), 0, 0,
+            0, 0, 0, 1, 0
+        };
+        color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
+        break;
+    }
+    case Gfx::ColorFilterType::Brightness: {
+        float matrix[20] = {
+            amount, 0, 0, 0, 0,
+            0, amount, 0, 0, 0,
+            0, 0, amount, 0, 0,
+            0, 0, 0, 1, 0
+        };
+        color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
+        break;
+    }
+    case Gfx::ColorFilterType::Contrast: {
+        float intercept = -(0.5f * amount) + 0.5f;
+        float matrix[20] = {
+            amount, 0, 0, 0, intercept,
+            0, amount, 0, 0, intercept,
+            0, 0, amount, 0, intercept,
+            0, 0, 0, 1, 0
+        };
+        color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
+        break;
+    }
+    case Gfx::ColorFilterType::Invert: {
+        float matrix[20] = {
+            1 - 2 * amount, 0, 0, 0, amount,
+            0, 1 - 2 * amount, 0, 0, amount,
+            0, 0, 1 - 2 * amount, 0, amount,
+            0, 0, 0, 1, 0
+        };
+        color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
+        break;
+    }
+    case Gfx::ColorFilterType::Opacity: {
+        float matrix[20] = {
+            1, 0, 0, 0, 0,
+            0, 1, 0, 0, 0,
+            0, 0, 1, 0, 0,
+            0, 0, 0, amount, 0
+        };
+        color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
+        break;
+    }
+    case Gfx::ColorFilterType::Sepia: {
+        float matrix[20] = {
+            0.393f + 0.607f * (1 - amount), 0.769f - 0.769f * (1 - amount), 0.189f - 0.189f * (1 - amount), 0,
+            0,
+            0.349f - 0.349f * (1 - amount), 0.686f + 0.314f * (1 - amount), 0.168f - 0.168f * (1 - amount), 0,
+            0,
+            0.272f - 0.272f * (1 - amount), 0.534f - 0.534f * (1 - amount), 0.131f + 0.869f * (1 - amount), 0,
+            0,
+            0, 0, 0, 1, 0
+        };
+        color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
+        break;
+    }
+    case Gfx::ColorFilterType::Saturate: {
+        float matrix[20] = {
+            0.213f + 0.787f * amount, 0.715f - 0.715f * amount, 0.072f - 0.072f * amount, 0, 0,
+            0.213f - 0.213f * amount, 0.715f + 0.285f * amount, 0.072f - 0.072f * amount, 0, 0,
+            0.213f - 0.213f * amount, 0.715f - 0.715f * amount, 0.072f + 0.928f * amount, 0, 0,
+            0, 0, 0, 1, 0
+        };
+        color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
+        break;
+    }
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    return Filter(Impl::create(SkImageFilters::ColorFilter(color_filter, input_skia)));
+}
+
+Filter Filter::color_matrix(float matrix[20], Optional<Filter const&> input)
+{
+    sk_sp<SkImageFilter> input_skia = input.has_value() ? input->m_impl->filter : nullptr;
+
+    return Filter(Impl::create(SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix), input_skia)));
+}
+
+Filter Filter::saturate(float value, Optional<Filter const&> input)
+{
+    sk_sp<SkImageFilter> input_skia = input.has_value() ? input->m_impl->filter : nullptr;
+
+    SkColorMatrix matrix;
+    matrix.setSaturation(value);
+
+    return Filter(Impl::create(SkImageFilters::ColorFilter(SkColorFilters::Matrix(matrix), input_skia)));
+}
+
+Filter Filter::hue_rotate(float angle_degrees, Optional<Filter const&> input)
+{
+    sk_sp<SkImageFilter> input_skia = input.has_value() ? input->m_impl->filter : nullptr;
+
+    float radians = AK::to_radians(angle_degrees);
+
+    auto cosA = cos(radians);
+    auto sinA = sin(radians);
+
+    auto a00 = 0.213f + cosA * 0.787f - sinA * 0.213f;
+    auto a01 = 0.715f - cosA * 0.715f - sinA * 0.715f;
+    auto a02 = 0.072f - cosA * 0.072f + sinA * 0.928f;
+    auto a10 = 0.213f - cosA * 0.213f + sinA * 0.143f;
+    auto a11 = 0.715f + cosA * 0.285f + sinA * 0.140f;
+    auto a12 = 0.072f - cosA * 0.072f - sinA * 0.283f;
+    auto a20 = 0.213f - cosA * 0.213f - sinA * 0.787f;
+    auto a21 = 0.715f - cosA * 0.715f + sinA * 0.715f;
+    auto a22 = 0.072f + cosA * 0.928f + sinA * 0.072f;
+
+    float matrix[20] = {
+        a00, a01, a02, 0, 0,
+        a10, a11, a12, 0, 0,
+        a20, a21, a22, 0, 0,
+        0, 0, 0, 1, 0
+    };
+
+    auto color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
+    return Filter(Impl::create(SkImageFilters::ColorFilter(color_filter, input_skia)));
+}
+
+}

--- a/Libraries/LibGfx/Filter.h
+++ b/Libraries/LibGfx/Filter.h
@@ -1,44 +1,51 @@
 /*
- * Copyright (c) 2024, Lucien Fiorini <lucienfiorini@gmail.com>
+ * Copyright (c) 2024-2025, Lucien Fiorini <lucienfiorini@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Variant.h>
+#include <AK/NonnullOwnPtr.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/CompositingAndBlendingOperator.h>
 
 namespace Gfx {
 
-struct BlurFilter {
-    float radius;
+enum class ColorFilterType {
+    Brightness,
+    Contrast,
+    Grayscale,
+    Invert,
+    Opacity,
+    Saturate,
+    Sepia
 };
 
-struct DropShadowFilter {
-    float offset_x;
-    float offset_y;
-    float radius;
-    Gfx::Color color;
-};
+struct FilterImpl;
 
-struct HueRotateFilter {
-    float angle_degrees;
-};
+class Filter {
+public:
+    Filter(Filter const&);
+    Filter& operator=(Filter const&);
 
-struct ColorFilter {
-    enum class Type {
-        Brightness,
-        Contrast,
-        Grayscale,
-        Invert,
-        Opacity,
-        Saturate,
-        Sepia
-    } type;
-    float amount;
-};
+    ~Filter();
 
-using Filter = Variant<BlurFilter, DropShadowFilter, HueRotateFilter, ColorFilter>;
+    static Filter compose(Filter const& outer, Filter const& inner);
+    static Filter blend(Filter const& background, Filter const& foreground, CompositingAndBlendingOperator mode);
+    static Filter flood(Gfx::Color color, float opacity);
+    static Filter drop_shadow(float offset_x, float offset_y, float radius, Gfx::Color color, Optional<Filter const&> input = {});
+    static Filter blur(float radius, Optional<Filter const&> input = {});
+    static Filter color(ColorFilterType type, float amount, Optional<Filter const&> input = {});
+    static Filter color_matrix(float matrix[20], Optional<Filter const&> input = {});
+    static Filter saturate(float value, Optional<Filter const&> input = {});
+    static Filter hue_rotate(float angle_degrees, Optional<Filter const&> input = {});
+
+    FilterImpl const& impl() const;
+
+private:
+    Filter(NonnullOwnPtr<FilterImpl>&&);
+    NonnullOwnPtr<FilterImpl> m_impl;
+};
 
 }

--- a/Libraries/LibGfx/FilterImpl.h
+++ b/Libraries/LibGfx/FilterImpl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024-2025, Lucien Fiorini <lucienfiorini@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+#include <core/SkColorFilter.h>
+#include <effects/SkImageFilters.h>
+
+namespace Gfx {
+
+struct FilterImpl {
+    sk_sp<SkImageFilter> filter;
+
+    static NonnullOwnPtr<FilterImpl> create(sk_sp<SkImageFilter> filter)
+    {
+        return adopt_own(*new FilterImpl(move(filter)));
+    }
+
+    NonnullOwnPtr<FilterImpl> clone() const
+    {
+        return adopt_own(*new FilterImpl(filter));
+    }
+};
+
+}

--- a/Libraries/LibGfx/Painter.h
+++ b/Libraries/LibGfx/Painter.h
@@ -26,16 +26,16 @@ public:
     virtual void clear_rect(Gfx::FloatRect const&, Gfx::Color) = 0;
     virtual void fill_rect(Gfx::FloatRect const&, Gfx::Color) = 0;
 
-    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, ReadonlySpan<Gfx::Filter> filters, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
+    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, Optional<Gfx::Filter> filters, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
 
     virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness) = 0;
     virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, ReadonlySpan<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, ReadonlySpan<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const&, Gfx::Path::JoinStyle const&, float miter_limit, Vector<float> const&, float dash_offset) = 0;
+    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
+    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const&, Gfx::Path::JoinStyle const&, float miter_limit, Vector<float> const&, float dash_offset) = 0;
 
     virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule) = 0;
     virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) = 0;
-    virtual void fill_path(Gfx::Path const&, Gfx::PaintStyle const&, ReadonlySpan<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule) = 0;
+    virtual void fill_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule) = 0;
 
     virtual void set_transform(Gfx::AffineTransform const&) = 0;
 

--- a/Libraries/LibGfx/PainterSkia.h
+++ b/Libraries/LibGfx/PainterSkia.h
@@ -21,14 +21,14 @@ public:
 
     virtual void clear_rect(Gfx::FloatRect const&, Color) override;
     virtual void fill_rect(Gfx::FloatRect const&, Color) override;
-    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, ReadonlySpan<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
+    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, Optional<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
     virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness) override;
     virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, ReadonlySpan<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
-    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, ReadonlySpan<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const&, Gfx::Path::JoinStyle const&, float miter_limit, Vector<float> const&, float dash_offset) override;
+    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
+    virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float thickness, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::Path::CapStyle const&, Gfx::Path::JoinStyle const&, float miter_limit, Vector<float> const&, float dash_offset) override;
     virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule) override;
     virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule, float blur_radius, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator) override;
-    virtual void fill_path(Gfx::Path const&, Gfx::PaintStyle const&, ReadonlySpan<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule) override;
+    virtual void fill_path(Gfx::Path const&, Gfx::PaintStyle const&, Optional<Gfx::Filter>, float global_alpha, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Gfx::WindingRule) override;
     virtual void set_transform(Gfx::AffineTransform const&) override;
     virtual void save() override;
     virtual void restore() override;

--- a/Libraries/LibGfx/SkiaUtils.cpp
+++ b/Libraries/LibGfx/SkiaUtils.cpp
@@ -6,12 +6,11 @@
 
 #include <AK/Assertions.h>
 #include <LibGfx/Filter.h>
+#include <LibGfx/FilterImpl.h>
 #include <LibGfx/SkiaUtils.h>
 #include <core/SkBlender.h>
-#include <core/SkColorFilter.h>
 #include <core/SkImageFilter.h>
 #include <core/SkString.h>
-#include <effects/SkImageFilters.h>
 #include <effects/SkRuntimeEffect.h>
 
 namespace Gfx {
@@ -23,124 +22,7 @@ SkPath to_skia_path(Path const& path)
 
 sk_sp<SkImageFilter> to_skia_image_filter(Gfx::Filter const& filter)
 {
-    // See: https://drafts.fxtf.org/filter-effects-1/#supported-filter-functions
-    return filter.visit(
-        [&](Gfx::BlurFilter blur_filter) {
-            return SkImageFilters::Blur(blur_filter.radius, blur_filter.radius, nullptr);
-        },
-        [&](Gfx::ColorFilter color_filter) {
-            sk_sp<SkColorFilter> skia_color_filter;
-            float amount = color_filter.amount;
-
-            // Matrices are taken from https://drafts.fxtf.org/filter-effects-1/#FilterPrimitiveRepresentation
-            switch (color_filter.type) {
-            case ColorFilter::Type::Grayscale: {
-                float matrix[20] = {
-                    0.2126f + 0.7874f * (1 - amount), 0.7152f - 0.7152f * (1 - amount), 0.0722f - 0.0722f * (1 - amount), 0, 0,
-                    0.2126f - 0.2126f * (1 - amount), 0.7152f + 0.2848f * (1 - amount), 0.0722f - 0.0722f * (1 - amount), 0, 0,
-                    0.2126f - 0.2126f * (1 - amount), 0.7152f - 0.7152f * (1 - amount), 0.0722f + 0.9278f * (1 - amount), 0, 0,
-                    0, 0, 0, 1, 0
-                };
-                skia_color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
-                break;
-            }
-            case Gfx::ColorFilter::Type::Brightness: {
-                float matrix[20] = {
-                    amount, 0, 0, 0, 0,
-                    0, amount, 0, 0, 0,
-                    0, 0, amount, 0, 0,
-                    0, 0, 0, 1, 0
-                };
-                skia_color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
-                break;
-            }
-            case Gfx::ColorFilter::Type::Contrast: {
-                float intercept = -(0.5f * amount) + 0.5f;
-                float matrix[20] = {
-                    amount, 0, 0, 0, intercept,
-                    0, amount, 0, 0, intercept,
-                    0, 0, amount, 0, intercept,
-                    0, 0, 0, 1, 0
-                };
-                skia_color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
-                break;
-            }
-            case Gfx::ColorFilter::Type::Invert: {
-                float matrix[20] = {
-                    1 - 2 * amount, 0, 0, 0, amount,
-                    0, 1 - 2 * amount, 0, 0, amount,
-                    0, 0, 1 - 2 * amount, 0, amount,
-                    0, 0, 0, 1, 0
-                };
-                skia_color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
-                break;
-            }
-            case Gfx::ColorFilter::Type::Opacity: {
-                float matrix[20] = {
-                    1, 0, 0, 0, 0,
-                    0, 1, 0, 0, 0,
-                    0, 0, 1, 0, 0,
-                    0, 0, 0, amount, 0
-                };
-                skia_color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
-                break;
-            }
-            case Gfx::ColorFilter::Type::Sepia: {
-                float matrix[20] = {
-                    0.393f + 0.607f * (1 - amount), 0.769f - 0.769f * (1 - amount), 0.189f - 0.189f * (1 - amount), 0, 0,
-                    0.349f - 0.349f * (1 - amount), 0.686f + 0.314f * (1 - amount), 0.168f - 0.168f * (1 - amount), 0, 0,
-                    0.272f - 0.272f * (1 - amount), 0.534f - 0.534f * (1 - amount), 0.131f + 0.869f * (1 - amount), 0, 0,
-                    0, 0, 0, 1, 0
-                };
-                skia_color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kYes);
-                break;
-            }
-            case Gfx::ColorFilter::Type::Saturate: {
-                float matrix[20] = {
-                    0.213f + 0.787f * amount, 0.715f - 0.715f * amount, 0.072f - 0.072f * amount, 0, 0,
-                    0.213f - 0.213f * amount, 0.715f + 0.285f * amount, 0.072f - 0.072f * amount, 0, 0,
-                    0.213f - 0.213f * amount, 0.715f - 0.715f * amount, 0.072f + 0.928f * amount, 0, 0,
-                    0, 0, 0, 1, 0
-                };
-                skia_color_filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
-                break;
-            }
-            default:
-                VERIFY_NOT_REACHED();
-            }
-
-            return SkImageFilters::ColorFilter(skia_color_filter, nullptr);
-        },
-        [&](Gfx::HueRotateFilter hue_rotate_filter) {
-            float radians = AK::to_radians(hue_rotate_filter.angle_degrees);
-
-            auto cosA = cos(radians);
-            auto sinA = sin(radians);
-
-            auto a00 = 0.213f + cosA * 0.787f - sinA * 0.213f;
-            auto a01 = 0.715f - cosA * 0.715f - sinA * 0.715f;
-            auto a02 = 0.072f - cosA * 0.072f + sinA * 0.928f;
-            auto a10 = 0.213f - cosA * 0.213f + sinA * 0.143f;
-            auto a11 = 0.715f + cosA * 0.285f + sinA * 0.140f;
-            auto a12 = 0.072f - cosA * 0.072f - sinA * 0.283f;
-            auto a20 = 0.213f - cosA * 0.213f - sinA * 0.787f;
-            auto a21 = 0.715f - cosA * 0.715f + sinA * 0.715f;
-            auto a22 = 0.072f + cosA * 0.928f + sinA * 0.072f;
-
-            float matrix[20] = {
-                a00, a01, a02, 0, 0,
-                a10, a11, a12, 0, 0,
-                a20, a21, a22, 0, 0,
-                0, 0, 0, 1, 0
-            };
-
-            auto filter = SkColorFilters::Matrix(matrix, SkColorFilters::Clamp::kNo);
-            return SkImageFilters::ColorFilter(filter, nullptr);
-        },
-        [&](Gfx::DropShadowFilter drop_shadow_filter) {
-            auto shadow_color = to_skia_color(drop_shadow_filter.color);
-            return SkImageFilters::DropShadow(drop_shadow_filter.offset_x, drop_shadow_filter.offset_y, drop_shadow_filter.radius, drop_shadow_filter.radius, shadow_color, nullptr);
-        });
+    return filter.impl().filter;
 }
 
 sk_sp<SkBlender> to_skia_blender(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)

--- a/Libraries/LibGfx/SkiaUtils.h
+++ b/Libraries/LibGfx/SkiaUtils.h
@@ -20,6 +20,7 @@
 #include <core/SkImageFilter.h>
 #include <core/SkPaint.h>
 #include <core/SkPath.h>
+#include <core/SkPathEffect.h>
 #include <core/SkSamplingOptions.h>
 
 namespace Gfx {

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -117,8 +117,8 @@ public:
     static CSS::Display display() { return CSS::Display { CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow }; }
     static Color color() { return Color::Black; }
     static Color stop_color() { return Color::Black; }
-    static Vector<Gfx::Filter> backdrop_filter() { return {}; }
-    static Vector<Gfx::Filter> filter() { return {}; }
+    static Optional<Gfx::Filter> backdrop_filter() { return {}; }
+    static Optional<Gfx::Filter> filter() { return {}; }
     static Color background_color() { return Color::Transparent; }
     static CSS::ListStyleType list_style_type() { return CSS::CounterStyleNameKeyword::Disc; }
     static CSS::ListStylePosition list_style_position() { return CSS::ListStylePosition::Outside; }
@@ -442,8 +442,8 @@ public:
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
     CSS::JustifySelf justify_self() const { return m_noninherited.justify_self; }
     CSS::JustifyItems justify_items() const { return m_noninherited.justify_items; }
-    Vector<Gfx::Filter> const& backdrop_filter() const { return m_noninherited.backdrop_filter; }
-    Vector<Gfx::Filter> const& filter() const { return m_noninherited.filter; }
+    Optional<Gfx::Filter> const& backdrop_filter() const { return m_noninherited.backdrop_filter; }
+    Optional<Gfx::Filter> const& filter() const { return m_noninherited.filter; }
     Vector<ShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
     CSS::BoxSizing box_sizing() const { return m_noninherited.box_sizing; }
     CSS::Size const& width() const { return m_noninherited.width; }
@@ -670,8 +670,8 @@ protected:
         CSS::LengthBox inset { InitialValues::inset() };
         CSS::LengthBox margin { InitialValues::margin() };
         CSS::LengthBox padding { InitialValues::padding() };
-        Vector<Gfx::Filter> backdrop_filter { InitialValues::backdrop_filter() };
-        Vector<Gfx::Filter> filter { InitialValues::filter() };
+        Optional<Gfx::Filter> backdrop_filter { InitialValues::backdrop_filter() };
+        Optional<Gfx::Filter> filter { InitialValues::filter() };
         BorderData border_left;
         BorderData border_top;
         BorderData border_right;
@@ -836,8 +836,8 @@ public:
     void set_list_style_type(CSS::ListStyleType value) { m_inherited.list_style_type = value; }
     void set_list_style_position(CSS::ListStylePosition value) { m_inherited.list_style_position = value; }
     void set_display(CSS::Display value) { m_noninherited.display = value; }
-    void set_backdrop_filter(Vector<Gfx::Filter> backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }
-    void set_filter(Vector<Gfx::Filter> filter) { m_noninherited.filter = move(filter); }
+    void set_backdrop_filter(Optional<Gfx::Filter> backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }
+    void set_filter(Optional<Gfx::Filter> filter) { m_noninherited.filter = move(filter); }
     void set_border_bottom_left_radius(CSS::BorderRadiusData value)
     {
         m_noninherited.has_noninitial_border_radii = true;

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -4525,7 +4525,7 @@ RefPtr<CSSStyleValue const> Parser::parse_filter_value_list_value(TokenStream<Co
 
     auto filter_token_to_operation = [&](auto filter) {
         VERIFY(to_underlying(filter) < to_underlying(FilterToken::Blur));
-        return static_cast<Gfx::ColorFilter::Type>(filter);
+        return static_cast<Gfx::ColorFilterType>(filter);
     };
 
     auto parse_filter_function_name = [&](auto name) -> Optional<FilterToken> {

--- a/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -78,19 +78,19 @@ String FilterValueListStyleValue::to_string(SerializationMode) const
                 builder.appendff("{}(",
                     [&] {
                         switch (color.operation) {
-                        case Gfx::ColorFilter::Type::Brightness:
+                        case Gfx::ColorFilterType::Brightness:
                             return "brightness"sv;
-                        case Gfx::ColorFilter::Type::Contrast:
+                        case Gfx::ColorFilterType::Contrast:
                             return "contrast"sv;
-                        case Gfx::ColorFilter::Type::Grayscale:
+                        case Gfx::ColorFilterType::Grayscale:
                             return "grayscale"sv;
-                        case Gfx::ColorFilter::Type::Invert:
+                        case Gfx::ColorFilterType::Invert:
                             return "invert"sv;
-                        case Gfx::ColorFilter::Type::Opacity:
+                        case Gfx::ColorFilterType::Opacity:
                             return "opacity"sv;
-                        case Gfx::ColorFilter::Type::Saturate:
+                        case Gfx::ColorFilterType::Saturate:
                             return "saturate"sv;
-                        case Gfx::ColorFilter::Type::Sepia:
+                        case Gfx::ColorFilterType::Sepia:
                             return "sepia"sv;
                         default:
                             VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
@@ -45,7 +45,7 @@ struct HueRotate {
 };
 
 struct Color {
-    Gfx::ColorFilter::Type operation;
+    Gfx::ColorFilterType operation;
     NumberPercentage amount { Number { Number::Type::Integer, 1.0 } };
     float resolved_amount() const;
     bool operator==(Color const&) const = default;

--- a/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -87,8 +87,8 @@ public:
         float shadow_offset_y { 0.0f };
         float shadow_blur { 0.0f };
         Gfx::Color shadow_color { Gfx::Color::Transparent };
-        Vector<Gfx::Filter> filters;
-        Optional<String> filters_string;
+        Optional<Gfx::Filter> filter;
+        Optional<String> filter_string;
         float line_width { 1 };
         Bindings::CanvasLineCap line_cap { Bindings::CanvasLineCap::Butt };
         Bindings::CanvasLineJoin line_join { Bindings::CanvasLineJoin::Miter };

--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -308,7 +308,7 @@ struct DrawLine {
 struct ApplyBackdropFilter {
     Gfx::IntRect backdrop_region;
     BorderRadiiData border_radii_data;
-    Vector<Gfx::Filter> backdrop_filter;
+    Optional<Gfx::Filter> backdrop_filter;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return backdrop_region; }
 
@@ -422,8 +422,8 @@ struct ApplyCompositeAndBlendingOperator {
     Gfx::CompositingAndBlendingOperator compositing_and_blending_operator;
 };
 
-struct ApplyFilters {
-    Vector<Gfx::Filter> filter;
+struct ApplyFilter {
+    Gfx::Filter filter;
 };
 
 struct ApplyTransform {
@@ -483,7 +483,7 @@ using Command = Variant<
     PaintScrollBar,
     ApplyOpacity,
     ApplyCompositeAndBlendingOperator,
-    ApplyFilters,
+    ApplyFilter,
     ApplyTransform,
     ApplyMaskBitmap>;
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -142,7 +142,7 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
         else HANDLE_COMMAND(PaintNestedDisplayList, paint_nested_display_list)
         else HANDLE_COMMAND(ApplyOpacity, apply_opacity)
         else HANDLE_COMMAND(ApplyCompositeAndBlendingOperator, apply_composite_and_blending_operator)
-        else HANDLE_COMMAND(ApplyFilters, apply_filters)
+        else HANDLE_COMMAND(ApplyFilter, apply_filters)
         else HANDLE_COMMAND(ApplyTransform, apply_transform)
         else HANDLE_COMMAND(ApplyMaskBitmap, apply_mask_bitmap)
         else VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -69,7 +69,7 @@ private:
     virtual void paint_scrollbar(PaintScrollBar const&) = 0;
     virtual void apply_opacity(ApplyOpacity const&) = 0;
     virtual void apply_composite_and_blending_operator(ApplyCompositeAndBlendingOperator const&) = 0;
-    virtual void apply_filters(ApplyFilters const&) = 0;
+    virtual void apply_filters(ApplyFilter const&) = 0;
     virtual void apply_transform(ApplyTransform const&) = 0;
     virtual void apply_mask_bitmap(ApplyMaskBitmap const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -56,7 +56,7 @@ private:
     void paint_nested_display_list(PaintNestedDisplayList const&) override;
     void apply_opacity(ApplyOpacity const&) override;
     void apply_composite_and_blending_operator(ApplyCompositeAndBlendingOperator const&) override;
-    void apply_filters(ApplyFilters const&) override;
+    void apply_filters(ApplyFilter const&) override;
     void apply_transform(ApplyTransform const&) override;
     void apply_mask_bitmap(ApplyMaskBitmap const&) override;
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -319,7 +319,7 @@ void DisplayListRecorder::pop_stacking_context()
     append(PopStackingContext {});
 }
 
-void DisplayListRecorder::apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, Vector<Gfx::Filter> const& backdrop_filter)
+void DisplayListRecorder::apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, Gfx::Filter const& backdrop_filter)
 {
     if (backdrop_region.is_empty())
         return;
@@ -422,9 +422,9 @@ void DisplayListRecorder::apply_compositing_and_blending_operator(Gfx::Compositi
     append(ApplyCompositeAndBlendingOperator { .compositing_and_blending_operator = compositing_and_blending_operator });
 }
 
-void DisplayListRecorder::apply_filters(Vector<Gfx::Filter> filter)
+void DisplayListRecorder::apply_filter(Gfx::Filter filter)
 {
-    append(ApplyFilters { .filter = move(filter) });
+    append(ApplyFilter { .filter = move(filter) });
 }
 
 void DisplayListRecorder::apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 matrix)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -134,7 +134,7 @@ public:
     void add_rounded_rect_clip(CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip);
     void add_mask(RefPtr<DisplayList> display_list, Gfx::IntRect rect);
 
-    void apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, Vector<Gfx::Filter> const& backdrop_filter);
+    void apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, Gfx::Filter const& backdrop_filter);
 
     void paint_outer_box_shadow_params(PaintBoxShadowParams params);
     void paint_inner_box_shadow_params(PaintBoxShadowParams params);
@@ -150,7 +150,7 @@ public:
 
     void apply_opacity(float opacity);
     void apply_compositing_and_blending_operator(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator);
-    void apply_filters(Vector<Gfx::Filter> filter);
+    void apply_filter(Gfx::Filter filter);
     void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4);
     void apply_mask_bitmap(Gfx::IntPoint origin, Gfx::ImmutableBitmap const&, Gfx::Bitmap::MaskKind);
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -572,14 +572,14 @@ void PaintableBox::paint_border(PaintContext& context) const
 void PaintableBox::paint_backdrop_filter(PaintContext& context) const
 {
     auto const& backdrop_filter = computed_values().backdrop_filter();
-    if (backdrop_filter.is_empty()) {
+    if (!backdrop_filter.has_value()) {
         return;
     }
 
     auto backdrop_region = context.rounded_device_rect(absolute_border_box_rect());
     auto border_radii_data = normalized_border_radii_data();
     ScopedCornerRadiusClip corner_clipper { context, backdrop_region, border_radii_data };
-    context.display_list_recorder().apply_backdrop_filter(backdrop_region.to_type<int>(), border_radii_data, backdrop_filter);
+    context.display_list_recorder().apply_backdrop_filter(backdrop_region.to_type<int>(), border_radii_data, backdrop_filter.value());
 }
 
 void PaintableBox::paint_background(PaintContext& context) const

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -73,8 +73,8 @@ void SVGSVGPaintable::paint_svg_box(PaintContext& context, PaintableBox const& s
         context.display_list_recorder().apply_opacity(computed_values.opacity());
     }
 
-    if (!filter.is_empty()) {
-        context.display_list_recorder().apply_filters(filter);
+    if (filter.has_value()) {
+        context.display_list_recorder().apply_filter(filter.value());
     }
 
     if (compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal) {
@@ -114,7 +114,7 @@ void SVGSVGPaintable::paint_svg_box(PaintContext& context, PaintableBox const& s
         context.display_list_recorder().restore();
     }
 
-    if (!filter.is_empty()) {
+    if (filter.has_value()) {
         context.display_list_recorder().restore();
     }
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -348,8 +348,8 @@ void StackingContext::paint(PaintContext& context) const
     context.display_list_recorder().push_stacking_context(push_stacking_context_params);
 
     auto const& filter = computed_values.filter();
-    if (!filter.is_empty()) {
-        context.display_list_recorder().apply_filters(paintable_box().computed_values().filter());
+    if (filter.has_value()) {
+        context.display_list_recorder().apply_filter(paintable_box().computed_values().filter().value());
     }
 
     if (auto mask_image = computed_values.mask_image()) {
@@ -373,7 +373,7 @@ void StackingContext::paint(PaintContext& context) const
 
     paint_internal(context);
 
-    if (!filter.is_empty()) {
+    if (filter.has_value()) {
         context.display_list_recorder().restore();
     }
 


### PR DESCRIPTION
This is the first PR in a series aimed at implementing SVG filter support. This PR touches on many areas, so I wanted to get it merged first to avoid too many merge conflicts later on.

Until now, with CSS and canvas filters, we only needed linear combinations of filters, represented as a `Vector<Gfx::Filter>` when passed to the painter, which were then converted into one merged Skia filter with each paint. However, this approach is not suitable for SVG filters, which behave in a graph-like manner (https://www.w3.org/TR/filter-effects-1/).

There are two options I can think of for implementing filter graphs:
1) Make a `Gfx::Filter` behave like a graph and convert it to the equivalent Skia filter graph on each paint.
2) Make `Gfx::Filter` a wrapper for Skia filter graphs, as is done for `Gfx::Path`.

I opted for the second option because it requires less translation code and avoids the need for filter conversion on each paint.