### PR TITLE
LibWeb: Avoid O(n^2) traversal in play-or-cancel-animations logic

### DIFF
--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -499,6 +499,8 @@ protected:
 
     CustomElementState custom_element_state() const { return m_custom_element_state; }
 
+    void play_or_cancel_animations_after_display_property_change();
+
 private:
     FlyString make_html_uppercased_qualified_name() const;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1645,16 +1645,12 @@ void Node::post_connection()
 void Node::inserted()
 {
     set_needs_style_update(true);
-
-    play_or_cancel_animations_after_display_property_change();
 }
 
 void Node::removed_from(Node*, Node&)
 {
     m_layout_node = nullptr;
     m_paintable = nullptr;
-
-    play_or_cancel_animations_after_display_property_change();
 }
 
 // https://dom.spec.whatwg.org/#concept-node-move-ext
@@ -3117,44 +3113,6 @@ bool Node::has_inclusive_ancestor_with_display_none()
         }
     }
     return false;
-}
-
-void Node::play_or_cancel_animations_after_display_property_change()
-{
-    // OPTIMIZATION: We don't care about animations in disconnected subtrees.
-    if (!is_connected())
-        return;
-
-    // https://www.w3.org/TR/css-animations-1/#animations
-    // Setting the display property to none will terminate any running animation applied to the element and its descendants.
-    // If an element has a display of none, updating display to a value other than none will start all animations applied to
-    // the element by the animation-name property, as well as all animations applied to descendants with display other than none.
-
-    auto has_display_none_inclusive_ancestor = this->has_inclusive_ancestor_with_display_none();
-
-    auto play_or_cancel_depending_on_display = [&](Animations::Animation& animation) {
-        if (has_display_none_inclusive_ancestor) {
-            animation.cancel();
-        } else {
-            HTML::TemporaryExecutionContext context(realm());
-            animation.play().release_value_but_fixme_should_propagate_errors();
-        }
-    };
-
-    for_each_shadow_including_inclusive_descendant([&](auto& node) {
-        if (!node.is_element())
-            return TraversalDecision::Continue;
-
-        auto const& element = static_cast<Element const&>(node);
-        if (auto animation = element.cached_animation_name_animation({}))
-            play_or_cancel_depending_on_display(*animation);
-        for (auto i = 0; i < to_underlying(CSS::PseudoElement::KnownPseudoElementCount); i++) {
-            auto pseudo_element = static_cast<CSS::PseudoElement>(i);
-            if (auto animation = element.cached_animation_name_animation(pseudo_element))
-                play_or_cancel_depending_on_display(*animation);
-        }
-        return TraversalDecision::Continue;
-    });
 }
 
 }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -562,7 +562,6 @@ public:
     bool is_inert() const;
 
     bool has_inclusive_ancestor_with_display_none();
-    void play_or_cancel_animations_after_display_property_change();
 
 protected:
     Node(JS::Realm&, Document&, NodeType);


### PR DESCRIPTION
The play_or_cancel_animations_after_display_property_change() helper was being called by Node::inserted() and Node::removed_from() and then recursing into the shadow-including subtree.

This had quadratic complexity since inserted() and removed_from() are themselves already invoked recursively for everything in the shadow-including subtree.

Only one caller of this API actually needed the recursive behavior, so this patch moves that responsibility to the caller and puts the logic in style recomputation instead.

1.02x speedup on Speedometer's TodoMVC-jQuery.