### PR TITLE
LibWebView: Some search settings ergonomic improvements

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -115,6 +115,13 @@
                 opacity: 0.6;
             }
 
+            .description {
+                margin-bottom: 10px;
+
+                font-size: 14px;
+                opacity: 0.7;
+            }
+
             label {
                 display: block;
                 margin-bottom: 8px;
@@ -236,13 +243,6 @@
 
             dialog .dialog-button:disabled {
                 opacity: 0.3;
-            }
-
-            dialog .dialog-description {
-                margin-bottom: 10px;
-
-                font-size: 14px;
-                opacity: 0.7;
             }
 
             dialog .dialog-list {
@@ -433,9 +433,7 @@
                 <button id="languages-close" class="close-button dialog-button">&times;</button>
             </div>
             <div class="dialog-body">
-                <p class="dialog-description">
-                    Choose languages for websites in order of preference
-                </p>
+                <p class="description">Choose languages for websites in order of preference</p>
                 <div id="languages-list" class="dialog-list"></div>
                 <div class="dialog-controls">
                     <select id="languages-select">
@@ -452,7 +450,7 @@
                 <button id="search-close" class="close-button dialog-button">&times;</button>
             </div>
             <div class="dialog-body" style="height: 300px">
-                <p class="dialog-description">Manage custom search engines</p>
+                <p class="description">Manage custom search engines</p>
                 <div id="search-list" class="dialog-list"></div>
             </div>
             <div class="dialog-form">
@@ -462,7 +460,7 @@
                 </div>
                 <div class="form-group">
                     <label for="search-custom-url">Search URL</label>
-                    <p class="dialog-description">Use %s as a placeholder for the search query</p>
+                    <p class="description">Use %s as a placeholder for the search query</p>
                     <input
                         id="search-custom-url"
                         type="url"

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -329,31 +329,25 @@
         <div class="card">
             <div class="card-header">Search</div>
             <div class="card-body">
-                <div class="card-group inline-container">
-                    <label for="search-toggle">Enable Search</label>
-                    <input id="search-toggle" type="checkbox" switch />
-                </div>
-                <div class="card-group hidden">
-                    <label for="search-engine">Default Search Engine</label>
+                <div class="card-group">
                     <div class="inline-container">
-                        <select id="search-engine">
-                            <option value="">Please select a search engine</option>
-                            <hr />
-                        </select>
+                        <label for="search-engine">Default Search Engine</label>
                         <button id="search-settings" class="secondary-button">Settings...</button>
                     </div>
+                    <p class="description">Select the search engine to use in the address bar.</p>
+                    <select id="search-engine">
+                        <option value="">Disable search</option>
+                        <hr />
+                    </select>
                 </div>
 
                 <hr />
 
-                <div class="card-group inline-container">
-                    <label for="autocomplete-toggle">Enable Autocomplete</label>
-                    <input id="autocomplete-toggle" type="checkbox" switch />
-                </div>
-                <div class="card-group hidden">
-                    <label for="autocomplete-engine">Default Autocomplete Engine</label>
+                <div class="card-group">
+                    <label for="autocomplete-engine">Search Suggestions</label>
+                    <p class="description">Select the engine that will provide search suggestions.</p>
                     <select id="autocomplete-engine">
-                        <option value="">Please select an autocomplete engine</option>
+                        <option value="">Disable search suggestions</option>
                         <hr />
                     </select>
                 </div>

--- a/Base/res/ladybird/about-pages/settings/search.js
+++ b/Base/res/ladybird/about-pages/settings/search.js
@@ -6,10 +6,8 @@ const searchDialog = document.querySelector("#search-dialog");
 const searchEngine = document.querySelector("#search-engine");
 const searchList = document.querySelector("#search-list");
 const searchSettings = document.querySelector("#search-settings");
-const searchToggle = document.querySelector("#search-toggle");
 
 const autocompleteEngine = document.querySelector("#autocomplete-engine");
-const autocompleteToggle = document.querySelector("#autocomplete-toggle");
 
 let SEARCH_ENGINE = {};
 let AUTOCOMPLETE_ENGINE = {};
@@ -25,22 +23,9 @@ function loadEngineSettings(settings) {
     SEARCH_ENGINE = settings.searchEngine || {};
     AUTOCOMPLETE_ENGINE = settings.autocompleteEngine || {};
 
-    const renderEngineSettings = (type, setting) => {
-        const [name, toggle, engine] = engineForType(type);
-
-        if (setting.name) {
-            toggle.checked = true;
-            engine.value = setting.name;
-        } else {
-            toggle.checked = false;
-        }
-
-        renderEngine(type);
-    };
-
     loadCustomSearchEngines();
-    renderEngineSettings(Engine.search, SEARCH_ENGINE);
-    renderEngineSettings(Engine.autocomplete, AUTOCOMPLETE_ENGINE);
+    renderEngine(Engine.search, SEARCH_ENGINE);
+    renderEngine(Engine.autocomplete, AUTOCOMPLETE_ENGINE);
 
     if (searchDialog.open) {
         showSearchEngineSettings();
@@ -49,16 +34,16 @@ function loadEngineSettings(settings) {
 
 function engineForType(engine) {
     if (engine === Engine.search) {
-        return ["Search", searchToggle, searchEngine];
+        return ["Search", searchEngine];
     }
     if (engine === Engine.autocomplete) {
-        return ["Autocomplete", autocompleteToggle, autocompleteEngine];
+        return ["Autocomplete", autocompleteEngine];
     }
     throw Error(`Unrecognized engine type ${engine}`);
 }
 
 function loadEngines(type, engines) {
-    const [name, toggle, engine] = engineForType(type);
+    const [name, engine] = engineForType(type);
 
     for (const engineName of engines) {
         const option = document.createElement("option");
@@ -74,41 +59,29 @@ function loadEngines(type, engines) {
     }
 }
 
-function renderEngine(type) {
-    const [name, toggle, engine] = engineForType(type);
+function renderEngine(type, setting) {
+    const [name, engine] = engineForType(type);
 
-    if (toggle.checked) {
-        engine.closest(".card-group").classList.remove("hidden");
+    if (setting.name) {
+        engine.value = setting.name;
     } else {
-        engine.closest(".card-group").classList.add("hidden");
-    }
-
-    if (toggle.checked && engine.selectedIndex !== 0) {
-        engine.item(0).disabled = true;
-    } else if (!toggle.checked) {
-        engine.item(0).disabled = false;
         engine.selectedIndex = 0;
     }
 }
 
 function saveEngine(type) {
-    const [name, toggle, engine] = engineForType(type);
+    const [name, engine] = engineForType(type);
 
-    if (toggle.checked && engine.selectedIndex !== 0) {
+    if (engine.selectedIndex !== 0) {
         ladybird.sendMessage(`set${name}Engine`, engine.value);
-    } else if (!toggle.checked) {
+    } else {
         ladybird.sendMessage(`set${name}Engine`, null);
     }
-
-    renderEngine(type);
 }
 
 function setSaveEngineListeners(type) {
-    const [name, toggle, engine] = engineForType(type);
+    const [name, engine] = engineForType(type);
 
-    toggle.addEventListener("change", () => {
-        saveEngine(type);
-    });
     engine.addEventListener("change", () => {
         saveEngine(type);
     });

--- a/Base/res/ladybird/about-pages/settings/search.js
+++ b/Base/res/ladybird/about-pages/settings/search.js
@@ -23,6 +23,8 @@ function loadEngineSettings(settings) {
     SEARCH_ENGINE = settings.searchEngine || {};
     AUTOCOMPLETE_ENGINE = settings.autocompleteEngine || {};
 
+    autocompleteEngine.disabled = !SEARCH_ENGINE.name;
+
     loadCustomSearchEngines();
     renderEngine(Engine.search, SEARCH_ENGINE);
     renderEngine(Engine.autocomplete, AUTOCOMPLETE_ENGINE);

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -108,9 +108,11 @@ Settings Settings::create(Badge<Application>)
             settings.m_search_engine = settings.find_search_engine_by_name(*search_engine_name);
     }
 
-    if (auto autocomplete_engine = settings_json.value().get_object(autocomplete_engine_key); autocomplete_engine.has_value()) {
-        if (auto autocomplete_engine_name = autocomplete_engine->get_string(autocomplete_engine_name_key); autocomplete_engine_name.has_value())
-            settings.m_autocomplete_engine = find_autocomplete_engine_by_name(*autocomplete_engine_name);
+    if (settings.m_search_engine.has_value()) {
+        if (auto autocomplete_engine = settings_json.value().get_object(autocomplete_engine_key); autocomplete_engine.has_value()) {
+            if (auto autocomplete_engine_name = autocomplete_engine->get_string(autocomplete_engine_name_key); autocomplete_engine_name.has_value())
+                settings.m_autocomplete_engine = find_autocomplete_engine_by_name(*autocomplete_engine_name);
+        }
     }
 
     auto load_site_setting = [&](SiteSetting& site_setting, StringView key) {

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -120,10 +120,14 @@ void SettingsUI::load_available_engines()
 
 void SettingsUI::set_search_engine(JsonValue const& search_engine)
 {
-    if (search_engine.is_null())
+    if (search_engine.is_null()) {
         WebView::Application::settings().set_search_engine({});
-    else if (search_engine.is_string())
+        WebView::Application::settings().set_autocomplete_engine({});
+    } else if (search_engine.is_string()) {
         WebView::Application::settings().set_search_engine(search_engine.as_string());
+    }
+
+    load_current_settings();
 }
 
 void SettingsUI::add_custom_search_engine(JsonValue const& search_engine)


### PR DESCRIPTION
Currently, enabling search is a bit hokey. You have to click a checkbox to get the search engines to show up, then you have to click a drop down to select an engine. Let's go with a simpler approach; now you only have to interact with the drop down.

This also auto-disables autocomplete when search is disabled, as search suggestions cannot work in that case.

![search](https://github.com/user-attachments/assets/f0dc4c74-4532-40e9-b064-b8e232086646)
