### PR TITLE
LibWeb: Draw text even if it needs to go into a 0-size inline box

### DIFF
--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -46,8 +46,6 @@ struct DrawGlyphRun {
     Color color;
     Gfx::Orientation orientation { Gfx::Orientation::Horizontal };
 
-    [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
-
     void translate_by(Gfx::IntPoint const& offset);
 };
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -253,8 +253,6 @@ void DisplayListRecorder::draw_text(Gfx::IntRect const& rect, String raw_text, G
 
 void DisplayListRecorder::draw_text_run(Gfx::FloatPoint baseline_start, Gfx::GlyphRun const& glyph_run, Color color, Gfx::IntRect const& rect, double scale, Orientation orientation)
 {
-    if (rect.is_empty())
-        return;
     append(DrawGlyphRun {
         .glyph_run = glyph_run,
         .scale = scale,

--- a/Tests/LibWeb/Ref/expected/css/line-height-zero-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/line-height-zero-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="line-height:100px; transform: translateY(-50px);">Hello!</div>

--- a/Tests/LibWeb/Ref/input/css/line-height-zero.html
+++ b/Tests/LibWeb/Ref/input/css/line-height-zero.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/line-height-zero-ref.html">
+<div style="line-height:0">Hello!</div>


### PR DESCRIPTION
Fixes #3578

We can't ignore 0-height inline boxes and the painting command can't just give the rect of the inline box as its bounding rect since that box only cares about the font's ascent and descent, modified to match the `line-height`, but glyphs may extend beyond that.
For example, I'm pretty sure diacritics on capital letters extend outside that box, like for Ä, Ö or Ü.
They definitely would once you start stacking multiple diacritics.

Here's the spec that says that inline boxes should have their height calculated this way: https://drafts.csswg.org/css-inline-3/#inline-height