### PR TITLE
LibWeb: fix copyright headers with inconsistent > sign

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLToken.swift
+++ b/Libraries/LibWeb/HTML/Parser/HTMLToken.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>>
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.swift
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>>
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.swift
+++ b/Libraries/LibWeb/HTML/Parser/SpeculativeHTMLParser.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Andrew Kaster <andrew@ladybird.org>>
+ * Copyright (c) 2025, Andrew Kaster <andrew@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
I was curious about the state of Swift in Ladybird and started looking through the repo.
I stumbled upon this small inconsistency in the copyright headers and thought I'd send a patch.