### PR TITLE
LibWeb: Fix bug in Infra::code_unit_less_than

### DIFF
--- a/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/Bindings/URLSearchParamsPrototype.h>
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/DOMURL/URLSearchParams.h>
+#include <LibWeb/Infra/Strings.h>
 
 namespace Web::DOMURL {
 
@@ -324,20 +325,9 @@ void URLSearchParams::set(String const& name, String const& value)
 // https://url.spec.whatwg.org/#dom-urlsearchparams-sort
 void URLSearchParams::sort()
 {
-    // 1. Sort all name-value pairs, if any, by their names. Sorting must be done by comparison of code units. The relative order between name-value pairs with equal names must be preserved.
+    // 1. Set this’s list to the result of sorting in ascending order this’s list, with a being less than b if a’s name is code unit less than b’s name.
     insertion_sort(m_list, [](auto& a, auto& b) {
-        // FIXME: There should be a way to do this without converting to utf16
-        auto a_utf16 = MUST(utf8_to_utf16(a.name)).data;
-        auto b_utf16 = MUST(utf8_to_utf16(b.name)).data;
-
-        auto common_length = min(a_utf16.size(), b_utf16.size());
-
-        for (size_t position = 0; position < common_length; ++position) {
-            if (a_utf16[position] != b_utf16[position])
-                return a_utf16[position] < b_utf16[position];
-        }
-
-        return a_utf16.size() < b_utf16.size();
+        return Infra::code_unit_less_than(a.name, b.name);
     });
 
     // 2. Update this.

--- a/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Libraries/LibWeb/Infra/Strings.cpp
@@ -150,6 +150,8 @@ String isomorphic_decode(ReadonlyBytes input)
 // https://infra.spec.whatwg.org/#code-unit-less-than
 bool code_unit_less_than(StringView a, StringView b)
 {
+    // FIXME: There should be a way to do this without converting to utf16
+
     // 1. If b is a code unit prefix of a, then return false.
     if (is_code_unit_prefix(b, a))
         return false;

--- a/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Libraries/LibWeb/Infra/Strings.cpp
@@ -71,8 +71,8 @@ ErrorOr<String> strip_and_collapse_whitespace(StringView string)
 // https://infra.spec.whatwg.org/#code-unit-prefix
 bool is_code_unit_prefix(StringView potential_prefix, StringView input)
 {
-    auto potential_prefix_utf16 = utf8_to_utf16(potential_prefix).release_value_but_fixme_should_propagate_errors();
-    auto input_utf16 = utf8_to_utf16(input).release_value_but_fixme_should_propagate_errors();
+    auto potential_prefix_utf16 = MUST(utf8_to_utf16(potential_prefix));
+    auto input_utf16 = MUST(utf8_to_utf16(input));
 
     // 1. Let i be 0.
     size_t i = 0;

--- a/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Libraries/LibWeb/Infra/Strings.cpp
@@ -69,10 +69,12 @@ ErrorOr<String> strip_and_collapse_whitespace(StringView string)
 }
 
 // https://infra.spec.whatwg.org/#code-unit-prefix
-bool is_code_unit_prefix(StringView potential_prefix, StringView input)
+bool is_code_unit_prefix(StringView potential_prefix_utf8, StringView input_utf8)
 {
-    auto potential_prefix_utf16 = MUST(utf8_to_utf16(potential_prefix));
-    auto input_utf16 = MUST(utf8_to_utf16(input));
+    auto potential_prefix_utf16_bytes = MUST(utf8_to_utf16(potential_prefix_utf8));
+    auto input_utf16_bytes = MUST(utf8_to_utf16(input_utf8));
+    Utf16View potential_prefix { potential_prefix_utf16_bytes };
+    Utf16View input { input_utf16_bytes };
 
     // 1. Let i be 0.
     size_t i = 0;
@@ -80,18 +82,18 @@ bool is_code_unit_prefix(StringView potential_prefix, StringView input)
     // 2. While true:
     while (true) {
         // 1. If i is greater than or equal to potentialPrefix’s length, then return true.
-        if (i >= potential_prefix.length())
+        if (i >= potential_prefix.length_in_code_units())
             return true;
 
         // 2. If i is greater than or equal to input’s length, then return false.
-        if (i >= input.length())
+        if (i >= input.length_in_code_units())
             return false;
 
         // 3. Let potentialPrefixCodeUnit be the ith code unit of potentialPrefix.
-        auto potential_prefix_code_unit = Utf16View(potential_prefix_utf16).code_unit_at(i);
+        auto potential_prefix_code_unit = potential_prefix.code_unit_at(i);
 
         // 4. Let inputCodeUnit be the ith code unit of input.
-        auto input_code_unit = Utf16View(input_utf16).code_unit_at(i);
+        auto input_code_unit = input.code_unit_at(i);
 
         // 5. Return false if potentialPrefixCodeUnit is not inputCodeUnit.
         if (potential_prefix_code_unit != input_code_unit)

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     TestMicrosyntax.cpp
     TestMimeSniff.cpp
     TestNumbers.cpp
+    TestStrings.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibWeb/TestStrings.cpp
+++ b/Tests/LibWeb/TestStrings.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibWeb/Infra/Strings.h>
+
+TEST_CASE(is_code_unit_prefix)
+{
+
+    // Basic prefix match
+    EXPECT(Web::Infra::is_code_unit_prefix("abc"sv, "abcde"sv));
+
+    // Exact match
+    EXPECT(Web::Infra::is_code_unit_prefix("abc"sv, "abc"sv));
+
+    // Empty prefix
+    EXPECT(Web::Infra::is_code_unit_prefix(""sv, "abc"sv));
+
+    // Empty input string
+    EXPECT(!Web::Infra::is_code_unit_prefix("abc"sv, ""sv));
+
+    // Both strings empty
+    EXPECT(Web::Infra::is_code_unit_prefix(""sv, ""sv));
+
+    // Prefix longer than input string
+    EXPECT(!Web::Infra::is_code_unit_prefix("abcdef"sv, "abc"sv));
+
+    // Non-ASCII characters
+    EXPECT(Web::Infra::is_code_unit_prefix("こんにちは"sv, "こんにちは世界"sv));
+    EXPECT(!Web::Infra::is_code_unit_prefix("世界"sv, "こんにちは世界"sv));
+
+    EXPECT(Web::Infra::is_code_unit_prefix("こ"sv, "こん"sv));
+    EXPECT(!Web::Infra::is_code_unit_prefix("こん"sv, "こ"sv));
+
+    // Special characters
+    EXPECT(Web::Infra::is_code_unit_prefix("!@#"sv, "!@#$%^"sv));
+    EXPECT(!Web::Infra::is_code_unit_prefix("!@#$"sv, "!@#"sv));
+
+    // Case sensitivity
+    EXPECT(!Web::Infra::is_code_unit_prefix("abc"sv, "ABC"sv));
+    EXPECT(!Web::Infra::is_code_unit_prefix("ABC"sv, "abc"sv));
+}


### PR DESCRIPTION
I noticed `Infra::code_unit_less_than` when looking at the IDB merge request, and remembered that it would be useful in URLSearchParams, so made a MR to the URL spec to adopt that. But turns out our implementation has a bug which made our URL test import crash when using that, so fix that.

...I've also noticed that our implementation of less than is not correct for Strings in LibJS either: https://github.com/LadybirdBrowser/ladybird/blob/096eed35cc8c3b635db28ab6407713add9981137/Libraries/LibJS/Runtime/Value.cpp#L2393 since it goes over code points instead of code units, but will make a follow up MR for that.