### PR TITLE
Fix `-Wunnecessary-virtual-specifier` Clang trunk warnings

### DIFF
--- a/Libraries/LibGC/ConservativeVector.h
+++ b/Libraries/LibGC/ConservativeVector.h
@@ -42,7 +42,7 @@ public:
     {
     }
 
-    virtual ~ConservativeVector() = default;
+    ~ConservativeVector() = default;
 
     ConservativeVector(ConservativeVector const& other)
         : ConservativeVectorBase(*other.m_heap)

--- a/Libraries/LibGC/RootHashMap.h
+++ b/Libraries/LibGC/RootHashMap.h
@@ -45,7 +45,7 @@ public:
     {
     }
 
-    virtual ~RootHashMap() = default;
+    ~RootHashMap() = default;
 
     virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>& roots) const override
     {

--- a/Libraries/LibGC/RootVector.h
+++ b/Libraries/LibGC/RootVector.h
@@ -46,7 +46,7 @@ public:
     {
     }
 
-    virtual ~RootVector() = default;
+    ~RootVector() = default;
 
     RootVector(Heap& heap, ReadonlySpan<T> other)
         : RootVectorBase(heap)

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -193,7 +193,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     FlyString const& label() const { return m_label; }
     FlyString& label() { return m_label; }
@@ -221,7 +221,7 @@ class IterationStatement : public Statement {
 public:
     using Statement::Statement;
 
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const = 0;
 
 private:
     virtual bool is_iteration_statement() const final { return true; }
@@ -869,7 +869,7 @@ public:
     virtual void dump(int indent) const override;
 
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     bool has_name() const override { return !name().is_empty(); }
 
@@ -1513,7 +1513,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode_with_lhs_name(Bytecode::Generator&, Optional<Bytecode::IdentifierTableIndex> lhs_name, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     bool has_name() const { return m_name; }
 
@@ -2208,7 +2208,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
-    virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
+    Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
 
     void add_case(NonnullRefPtr<SwitchCase const> switch_case) { m_cases.append(move(switch_case)); }
 

--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -873,14 +873,6 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> LabelledStatement::gene
     return stmt_result;
 }
 
-Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> IterationStatement::generate_labelled_evaluation(Bytecode::Generator&, Vector<FlyString> const&, [[maybe_unused]] Optional<ScopedOperand> preferred_dst) const
-{
-    return Bytecode::CodeGenerationError {
-        this,
-        "Missing generate_labelled_evaluation()"sv,
-    };
-}
-
 Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> WhileStatement::generate_bytecode(Bytecode::Generator& generator, [[maybe_unused]] Optional<ScopedOperand> preferred_dst) const
 {
     Bytecode::Generator::SourceLocationScope scope(generator, *this);

--- a/Libraries/LibThreading/Thread.h
+++ b/Libraries/LibThreading/Thread.h
@@ -55,7 +55,7 @@ public:
         return adopt_nonnull_ref_or_enomem(new (nothrow) Thread(move(action), thread_name));
     }
 
-    virtual ~Thread();
+    ~Thread();
 
     ErrorOr<void> set_priority(int priority);
     ErrorOr<int> get_priority() const;

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -38,12 +38,14 @@ public:
 private:
     HTMLAnchorElement(DOM::Document&, DOM::QualifiedName);
 
+    bool has_download_preference() const;
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
+    // ^DOM::EventTarget
     virtual bool has_activation_behavior() const override;
     virtual void activation_behavior(Web::DOM::Event const&) override;
-    virtual bool has_download_preference() const;
 
     // ^DOM::Element
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;


### PR DESCRIPTION
**LibGC: Make destructors non-virtual where possible**

`ConservativeVector`, `RootVector` and `RootHashMap` are final types, and their base classes have a protected destructor, so when their destructor is called, the static and dynamic types will be the same (can't destruct them through a pointer to a base or derived class). Therefore, there is no need for a virtual destructor.

This fixes the newly introduced `-Wunnecessary-virtual-specifier` Clang warning (https://github.com/llvm/llvm-project/pull/131188).

**LibJS: Make generate_labelled_evaluation non-virtual if possible**

We don't override anything with definitions of this function in `SwitchStatement` and `LabelledStatement`. Also, we can make the `IterationStatement` abstract, there is no need to add a fallback error-generating stub implementation of this method.

**Everywhere: Fix trivial `-Wunnecessary-virtual-specifier` instances**

- `Threading::Thread` is not polymorphic, there is no need for a virtual destructor.
- `HTMLAnchorElement::has_download_preference` isn't overridden by anything.

This warning was introduced in https://github.com/llvm/llvm-project/pull/131188.

---

Didn't measure anything, but I don't see any downsides and this might actually result in some small binary size savings.

We could possibly find more cases of classes/functions not needing to be virtual by marking more classes/methos `final` (GCC's LTO-time `-Wsuggest-final-types` warning could help).