### PR TITLE
LibJS+LibWeb: Add fast path for builtin iterators in iterator_step()

### DIFF
--- a/Libraries/LibJS/Runtime/Iterator.h
+++ b/Libraries/LibJS/Runtime/Iterator.h
@@ -76,6 +76,13 @@ protected:
     bool m_next_method_was_redefined { false };
 };
 
+struct IterationResult {
+    ThrowCompletionOr<Value> done;
+    ThrowCompletionOr<Value> value;
+};
+struct IterationDone { };
+using IterationResultOrDone = Variant<IterationResult, IterationDone>;
+
 // 7.4.12 IfAbruptCloseIterator ( value, iteratorRecord ), https://tc39.es/ecma262/#sec-ifabruptcloseiterator
 #define TRY_OR_CLOSE_ITERATOR(vm, iterator_record, expression)                                                    \
     ({                                                                                                            \
@@ -101,7 +108,7 @@ ThrowCompletionOr<GC::Ref<IteratorRecord>> get_iterator_flattenable(VM&, Value, 
 ThrowCompletionOr<GC::Ref<Object>> iterator_next(VM&, IteratorRecord&, Optional<Value> = {});
 ThrowCompletionOr<bool> iterator_complete(VM&, Object& iterator_result);
 ThrowCompletionOr<Value> iterator_value(VM&, Object& iterator_result);
-ThrowCompletionOr<GC::Ptr<Object>> iterator_step(VM&, IteratorRecord&);
+ThrowCompletionOr<IterationResultOrDone> iterator_step(VM&, IteratorRecord&);
 ThrowCompletionOr<Optional<Value>> iterator_step_value(VM&, IteratorRecord&);
 Completion iterator_close(VM&, IteratorRecord const&, Completion);
 Completion async_iterator_close(VM&, IteratorRecord const&, Completion);

--- a/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -128,10 +128,10 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::drop)
             iterator.increment_counter();
 
             // ii. Let next be ? IteratorStep(iterated).
-            auto next = TRY(iterator_step(vm, iterated));
+            IterationResultOrDone next = TRY(iterator_step(vm, iterated));
 
             // iii. If next is DONE, return ReturnCompletion(undefined).
-            if (!next)
+            if (next.has<IterationDone>())
                 return iterator.result(js_undefined());
         }
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -346,12 +346,12 @@ static WebIDL::ExceptionOr<Vector<BaseKeyframe>> process_a_keyframes_argument(JS
             auto next = TRY(JS::iterator_step(vm, iter));
 
             // 3. If next is false abort this loop.
-            if (!next)
+            if (!next.has<JS::IterationResult>())
                 break;
 
             // 4. Let nextItem be IteratorValue(next).
             // 5. Check the completion record of nextItem.
-            auto next_item = TRY(JS::iterator_value(vm, *next));
+            auto next_item = TRY(next.get<JS::IterationResult>().value);
 
             // 6. If Type(nextItem) is not Undefined, Null or Object, then throw a TypeError and abort these steps.
             if (!next_item.is_nullish() && !next_item.is_object())

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -89,11 +89,11 @@ static JS::ThrowCompletionOr<Vector<String>> convert_value_to_sequence_of_string
         auto next = TRY(JS::iterator_step(vm, iterator));
 
         // 2. If next is false, then return an IDL sequence value of type sequence<T> of length i, where the value of the element at index j is Sj.
-        if (!next)
+        if (!next.has<JS::IterationResult>())
             return sequence_of_strings;
 
         // 3. Let nextItem be ? IteratorValue(next).
-        auto next_item = TRY(JS::iterator_value(vm, *next));
+        auto next_item = TRY(next.get<JS::IterationResult>().value);
 
         // 4. Initialize Si to the result of converting nextItem to an IDL value of type T.
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1766,10 +1766,10 @@ void IDL::ParameterizedType::generate_sequence_from_iterable(SourceGenerator& ge
     sequence_generator.append(R"~~~(
     for (;;) {
         auto next@recursion_depth@ = TRY(JS::iterator_step(vm, @iterable_cpp_name@_iterator@recursion_depth@));
-        if (!next@recursion_depth@)
+        if (!next@recursion_depth@.has<JS::IterationResult>())
             break;
 
-        auto next_item@recursion_depth@ = TRY(JS::iterator_value(vm, *next@recursion_depth@));
+        auto next_item@recursion_depth@ = TRY(next@recursion_depth@.get<JS::IterationResult>().value);
 )~~~");
 
     // FIXME: Sequences types should be TypeWithExtendedAttributes, which would allow us to get [LegacyNullToEmptyString] here.


### PR DESCRIPTION
We already have fast path for built-in iterators that skips `next()`
lookup and iteration result object allocation applied for `for..of` and
`for..in` loops. This change extends it to `iterator_step()` to cover
`Array.from()`, `[...arr]` and many other cases.

Makes following function go 2.35x faster on my computer:
```js
(function f() {
  let arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
  for (let i = 0; i < 1000000; i++) {
    let [a, ...rest] = arr;
  }
})();
```