### PR TITLE
LibWeb: Do not forget to unapply empty masks

### DIFF
--- a/Tests/LibWeb/Ref/expected/svg/zero-area-mask-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/zero-area-mask-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+This should be visible.
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="width: 0px"></svg>

--- a/Tests/LibWeb/Ref/input/svg/zero-area-mask.html
+++ b/Tests/LibWeb/Ref/input/svg/zero-area-mask.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/zero-area-mask-ref.html" />
+This should be visible.
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="width: 0px">
+    <mask id="abc"></mask>
+    <g mask="url(#abc)"></g>
+</svg>


### PR DESCRIPTION
Fixes #4699

We can't just push a save to the display list and then nope out of the function before restoring that.