### PR TITLE
Meta: Add doctypes to all grid layout tests

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-item.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.outer-grid> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.inner-absolute-block> at (8,8) content-size 80.765625x18 positioned [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.outer-grid) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.inner-absolute-block) [8,8 80.765625x18]

--- a/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
+++ b/Tests/LibWeb/Layout/expected/grid/all-implicit-rows.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x200 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x200]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392.140625x100]

--- a/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
+++ b/Tests/LibWeb/Layout/expected/grid/anonymous-inline-child.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <(anonymous)> at (8,8) content-size 784x18 [BFC] children: inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid) [8,8 784x18]
         PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fill.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -24,7 +24,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 261.328125x18]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-collapse-empty-tracks.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x114 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x98 children: not-inline
       Box <div.container> at (18,18) content-size 764x78 [GFC] children: not-inline
         BlockContainer <div.item> at (48,48) content-size 704x18 [BFC] children: inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x114]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x98]
       PaintableBox (Box<DIV>.container) [8,8 784x98]
         PaintableWithLines (BlockContainer<DIV>.item) [18,18 764x78]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit-is-invalid-when-min-and-max-are-both-not-definite.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit-is-invalid-when-min-and-max-are-both-not-definite.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x224 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x208 children: not-inline
       Box <div.grid> at (8,8) content-size 784x208 [GFC] children: not-inline
         BlockContainer <div.item> at (10,10) content-size 780x100 [BFC] children: not-inline
         BlockContainer <div.item> at (10,114) content-size 780x100 [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x224]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x208]
       PaintableBox (Box<DIV>.grid) [8,8 784x208]
         PaintableWithLines (BlockContainer<DIV>.item) [8,8 784x104]

--- a/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-fit.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -24,7 +24,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 261.328125x18]

--- a/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-track-sizes.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x76 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x60 children: not-inline
       Box <div.grid> at (8,8) content-size 784x60 [GFC] children: not-inline
         BlockContainer <div#c1> at (8,8) content-size 23x11 [BFC] children: not-inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div#c4> at (8,8) content-size 120x60 [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x76]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
       PaintableBox (Box<DIV>.grid) [8,8 784x60]
         PaintableWithLines (BlockContainer<DIV>#c1) [8,8 23x11]

--- a/Tests/LibWeb/Layout/expected/grid/basic-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div#grid> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div#title> at (8,8) content-size 88.171875x18 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>#grid) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>#title) [8,8 88.171875x18]

--- a/Tests/LibWeb/Layout/expected/grid/basic.txt
+++ b/Tests/LibWeb/Layout/expected/grid/basic.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x52 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x36 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x36]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392.140625x18]

--- a/Tests/LibWeb/Layout/expected/grid/borders.txt
+++ b/Tests/LibWeb/Layout/expected/grid/borders.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x448 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x432 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x76 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -145,7 +145,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x448]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x432] overflow: [8,8 784x440]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x76]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392.140625x38]

--- a/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/calc-track-size.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.grid-item> at (8,8) content-size 200x18 [BFC] children: inline
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 200x18]

--- a/Tests/LibWeb/Layout/expected/grid/column-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/column-1fr-1fr.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       Box <div.grid> at (8,8) content-size 100x100 [GFC] children: not-inline
         BlockContainer <div.test> at (8,8) content-size 100x100 [BFC] children: not-inline
           BlockContainer <div.big-child> at (8,8) content-size 500x100 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.grid) [8,8 100x100] overflow: [8,8 500x100]
         PaintableWithLines (BlockContainer<DIV>.test) [8,8 100x100] overflow: [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/grid/column-auto-auto.txt
+++ b/Tests/LibWeb/Layout/expected/grid/column-auto-auto.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       Box <div.grid> at (8,8) content-size 100x100 [GFC] children: not-inline
         BlockContainer <div.test> at (8,8) content-size 500x100 [BFC] children: not-inline
           BlockContainer <div.big-child> at (8,8) content-size 500x100 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.grid) [8,8 100x100] overflow: [8,8 500x100]
         PaintableWithLines (BlockContainer<DIV>.test) [8,8 500x100]

--- a/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
+++ b/Tests/LibWeb/Layout/expected/grid/different-column-sizes.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x52 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x36 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x36]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 50x18]

--- a/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/distribute-extra-space-across-spanned-tracks.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -25,7 +25,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.right) [400,8 392x18]

--- a/Tests/LibWeb/Layout/expected/grid/fit-content-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fit-content-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 6.34375x18 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.one) [8,8 6.34375x18]

--- a/Tests/LibWeb/Layout/expected/grid/fit-content-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fit-content-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       Box <div#container> at (18,18) content-size 764x180 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>#container) [8,8 784x200]
         PaintableWithLines (BlockContainer<DIV>) [18,18 242.234375x180]

--- a/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/float-container-columns-1fr-1fr.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x44 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       Box <div.container> at (8,8) content-size 203.28125x36 floating [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 101.640625x18 [BFC] children: inline
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x44]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 203.28125x36]
       PaintableBox (Box<DIV>.container) [8,8 203.28125x36]
         PaintableWithLines (BlockContainer<DIV>.item) [8,8 101.640625x18]

--- a/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x44 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x28 children: not-inline
       Box <div.grid> at (8,8) content-size 784x28 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 784x28 [BFC] children: not-inline
@@ -29,7 +29,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x44]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x28]
       PaintableBox (Box<DIV>.grid) [8,8 784x28]
         PaintableWithLines (BlockContainer<DIV>) [8,8 784x28]

--- a/Tests/LibWeb/Layout/expected/grid/grid-area-non-token-parts-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-area-non-token-parts-crash.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-column-non-token-parts-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-column-non-token-parts-crash.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-container-min-height-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-container-min-height-border-box.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
       Box <div.box> at (8,208) content-size 784x100 [GFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
       PaintableBox (Box<DIV>.box) [8,8 784x300]

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x102 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x86 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x86 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 342.140625x18 [BFC] children: inline
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x102]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x86]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x86]
         PaintableWithLines (BlockContainer<DIV>.one) [8,8 342.140625x18]

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x68 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x52 children: not-inline
       Box <div.container> at (8,8) content-size 784x52 [GFC] children: not-inline
         BlockContainer <div.item> at (435.4375,8) content-size 356.5625x18 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x68]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x52]
       PaintableBox (Box<DIV>.container) [8,8 784x52]
         PaintableWithLines (BlockContainer<DIV>.item) [435.4375,8 356.5625x18]

--- a/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-gap-3.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.item> at (410,8) content-size 382x18 [BFC] children: inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.item) [410,8 382x18]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-paddings.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x374 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x358 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x358 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x374]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x358]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x358]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 137.046875x154]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-fixed-size.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x200 [GFC] children: not-inline
         BlockContainer <div.first> at (8,8) content-size 100x200 [BFC] children: inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x200]
         PaintableWithLines (BlockContainer<DIV>.first) [8,8 100x200]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-min-size.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x212 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       Box <div.grid> at (8,8) content-size 102x204 floating [GFC] children: not-inline
         BlockContainer <div.first> at (9,9) content-size 100x100 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x212]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 102x204]
       PaintableBox (Box<DIV>.grid) [8,8 102x204]
         PaintableWithLines (BlockContainer<DIV>.first) [8,8 102x102]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-margins.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x18 children: not-inline
         Box <div.grid> at (8,8) content-size 784x18 [GFC] children: not-inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x18]
         PaintableBox (Box<DIV>.grid) [8,8 784x18]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x332 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       Box <div.container> at (8,8) content-size 200x324 floating [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 100x324 [BFC] children: inline
@@ -42,7 +42,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x332]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 200x324]
       PaintableBox (Box<DIV>.container) [8,8 200x324]
         PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x324]

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-percentage-width.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.first> at (8,8) content-size 307.484375x18 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.first) [8,8 307.484375x18]

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-overflow-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-overflow-crash.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       Box <div> at (8,8) content-size 784x0 positioned [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableBox (Box<DIV>) [8,8 784x0]
         PaintableWithLines (BlockContainer<DIV>) [8,8 0x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-start-non-token-parts-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-start-non-token-parts-crash.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-shorthand-property.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       Box <div.container> at (8,8) content-size 784x100 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 200x100 [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.container) [8,8 784x100]
         PaintableWithLines (BlockContainer<DIV>.item) [8,8 200x100]

--- a/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template-areas-basics.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x52 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       Box <div.container> at (8,8) content-size 784x36 [GFC] children: not-inline
         BlockContainer <div.item.right-bottom> at (400,26) content-size 392x18 [BFC] children: inline
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableBox (Box<DIV>.container) [8,8 784x36]
         PaintableWithLines (BlockContainer<DIV>.item.right-bottom) [400,26 392x18]

--- a/Tests/LibWeb/Layout/expected/grid/grid-template.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-template.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       Box <div.mw-page-container-inner> at (8,8) content-size 784x0 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -50,7 +50,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.mw-page-container-inner) [8,8 784x0]
         PaintableWithLines (BlockContainer<DIV>.vector-main-menu-container) [8,8 196x0]

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x40 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x24 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x24 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x24]
         PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 64.03125x24]

--- a/Tests/LibWeb/Layout/expected/grid/image-with-percentage-width-and-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-with-percentage-width-and-auto-height.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
       Box <div#item> at (8,8) content-size 100x50 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
       PaintableBox (Box<DIV>#item) [8,8 100x50]
         ImagePaintable (ImageBox<IMG>) [8,8 50x50]

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -24,7 +24,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 100x18]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 300x18 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.one) [8,8 300x18]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       Box <div.container> at (8,8) content-size 784x100 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 300x50 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableBox (Box<DIV>.container) [8,8 784x100]
         PaintableWithLines (BlockContainer<DIV>.one) [8,8 300x50]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-3.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 292x18 [BFC] children: inline
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.one) [8,8 292x18]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-auto-track-definition.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-auto-track-definition.txt
@@ -1,11 +1,11 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
       Box <div.grid> at (8,8) content-size 200x200 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 100x100 [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableBox (Box<DIV>.grid) [8,8 200x200]
         PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x100]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-invalid-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x52 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       Box <div.container> at (8,8) content-size 784x36 [GFC] children: not-inline
         BlockContainer <div.one> at (8,8) content-size 784x18 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableBox (Box<DIV>.container) [8,8 784x36]
         PaintableWithLines (BlockContainer<DIV>.one) [8,8 784x18]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-non-token-contents-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-non-token-contents-crash.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
+++ b/Tests/LibWeb/Layout/expected/grid/minmax-with-max-function-inside.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x52 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       Box <div.grid> at (8,8) content-size 784x36 [GFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 261.328125x18 [BFC] children: inline
@@ -20,7 +20,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableBox (Box<DIV>.grid) [8,8 784x36]
         PaintableWithLines (BlockContainer<DIV>) [8,8 261.328125x18]

--- a/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
+++ b/Tests/LibWeb/Layout/expected/grid/negative-grid-item-column-index.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x88 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x72 children: not-inline
       Box <div.grid> at (8,8) content-size 784x72 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -62,7 +62,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x88]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x72]
       PaintableBox (Box<DIV>.grid) [8,8 784x72]
         PaintableWithLines (BlockContainer<DIV>.a) [8,8 196.453125x18]

--- a/Tests/LibWeb/Layout/expected/grid/order.txt
+++ b/Tests/LibWeb/Layout/expected/grid/order.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x122 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x104 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x102 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -25,8 +25,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (10,114) content-size 780x0 children: inline
         TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x124]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x106]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x104]
         PaintableWithLines (BlockContainer<DIV>.grid-item.item-1) [270.328125,11 102x102]

--- a/Tests/LibWeb/Layout/expected/grid/placement-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x40 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x22 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x20 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 516.625x18 [BFC] children: inline
@@ -11,8 +11,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x24]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x22]
         PaintableWithLines (BlockContainer<DIV>.a) [11,11 518.625x20]

--- a/Tests/LibWeb/Layout/expected/grid/placement-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x40 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x22 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x20 [GFC] children: not-inline
         BlockContainer <div.grid-item.a> at (12,12) content-size 257.3125x18 [BFC] children: inline
@@ -11,8 +11,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x24]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x22]
         PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.3125x20]

--- a/Tests/LibWeb/Layout/expected/grid/placement-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-3.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x120 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x102 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x100 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 776x38 [BFC] children: inline
@@ -11,8 +11,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x104]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x102]
         PaintableWithLines (BlockContainer<DIV>.a) [11,11 778x40]

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x40 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x22 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x20 [GFC] children: not-inline
         BlockContainer <div.a> at (12,12) content-size 385.765625x18 [BFC] children: inline
@@ -11,8 +11,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "2"
           TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x24]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x22]
         PaintableWithLines (BlockContainer<DIV>.a) [11,11 387.765625x20]

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x95 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x77 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x75 [GFC] children: not-inline
         BlockContainer <div.grid-item.a> at (12,12) content-size 257.328125x73 [BFC] children: inline
@@ -19,8 +19,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "4"
           TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x97]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x79]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x77]
         PaintableWithLines (BlockContainer<DIV>.grid-item.a) [11,11 259.328125x75]

--- a/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-using-named-tracks-3.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x60 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x42 children: not-inline
       Box <div.grid-container> at (11,11) content-size 778x40 [GFC] children: not-inline
         BlockContainer <div.a> at (62,12) content-size 98x18 [BFC] children: inline
@@ -19,8 +19,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "4"
           TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x62]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x44]
       PaintableBox (Box<DIV>.grid-container) [10,10 780x42]
         PaintableWithLines (BlockContainer<DIV>.a) [61,11 100x20]

--- a/Tests/LibWeb/Layout/expected/grid/repeat-non-token-contents-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat-non-token-contents-crash.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x0 children: not-inline
       BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/repeat.txt
+++ b/Tests/LibWeb/Layout/expected/grid/repeat.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x234 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x218 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x200 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -73,7 +73,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x234]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x218]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x200]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x200]

--- a/Tests/LibWeb/Layout/expected/grid/row-gaps-with-overflowing-spans-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-gaps-with-overflowing-spans-crash.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x64 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x48 children: not-inline
       Box <div> at (8,8) content-size 784x48 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x64]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x48]
       PaintableBox (Box<DIV>) [8,8 784x48]
         PaintableWithLines (BlockContainer<DIV>) [8,24 784x32]

--- a/Tests/LibWeb/Layout/expected/grid/row-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-height.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x84 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x68 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x68 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -30,7 +30,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x84]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x68]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x68]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392.140625x50]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-maxcontent.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x340 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x324 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x324 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -76,7 +76,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x340]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x324]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x324]
         PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [401.46875,8 390.53125x135]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-mincontent.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x592 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x576 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x576 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -130,7 +130,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x592]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x576]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x576]
         PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [108.640625,8 101.515625x252]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2-with-gaps.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x358 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x342 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x342 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -78,7 +78,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x358]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x342]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x342]
         PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [411.46875,8 380.53125x134]

--- a/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-span-2.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x340 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x324 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x324 [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -76,7 +76,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x340]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x324]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x324]
         PaintableWithLines (BlockContainer<DIV>.grid-item.item-span-one-one) [401.46875,8 390.53125x135]

--- a/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
+++ b/Tests/LibWeb/Layout/expected/grid/rows-1fr-1fr.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x52 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
       Box <div.container> at (8,8) content-size 784x36 [GFC] children: not-inline
         BlockContainer <div.item> at (8,8) content-size 784x18 [BFC] children: inline
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableBox (Box<DIV>.container) [8,8 784x36]
         PaintableWithLines (BlockContainer<DIV>.item) [8,8 784x18]

--- a/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
+++ b/Tests/LibWeb/Layout/expected/grid/template-lines-and-areas.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.item-left> at (8,8) content-size 261.328125x18 [BFC] children: inline
@@ -12,7 +12,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.item-left) [8,8 261.328125x18]

--- a/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
+++ b/Tests/LibWeb/Layout/expected/grid/track-size-calc-with-percentage.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.ipc-page-grid> at (8,8) content-size 784x18 flex-container(row) [FFC] children: not-inline
         Box <div.ipc-sub-grid> at (8,8) content-size 401.28125x18 flex-item [GFC] children: not-inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.ipc-page-grid) [8,8 784x18]
         PaintableBox (Box<DIV>.ipc-sub-grid) [8,8 401.28125x18]

--- a/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
+++ b/Tests/LibWeb/Layout/expected/grid/unresolvable-percentage-track.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.ipc-page-grid> at (8,8) content-size 784x18 flex-container(row) [FFC] children: not-inline
         Box <div.ipc-sub-grid> at (8,8) content-size 36.84375x18 flex-item [GFC] children: not-inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.ipc-page-grid) [8,8 784x18]
         PaintableBox (Box<DIV>.ipc-sub-grid) [8,8 36.84375x18]

--- a/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/valid-grid-areas-1.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.grid-container> at (8,8) content-size 784x18 [GFC] children: not-inline
         BlockContainer <div.grid-item> at (8,8) content-size 392x18 [BFC] children: inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 392x18]

--- a/Tests/LibWeb/Layout/input/grid/abspos-item.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-item.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .outer-grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/all-implicit-rows.html
+++ b/Tests/LibWeb/Layout/input/grid/all-implicit-rows.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/anonymous-inline-child.html
+++ b/Tests/LibWeb/Layout/input/grid/anonymous-inline-child.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid { display: grid; }
 </style><div class="grid">hello</div>

--- a/Tests/LibWeb/Layout/input/grid/auto-fill.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fill.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/auto-fit-collapse-empty-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fit-collapse-empty-tracks.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/auto-fit-is-invalid-when-min-and-max-are-both-not-definite.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fit-is-invalid-when-min-and-max-are-both-not-definite.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/auto-fit.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-fit.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/auto-track-sizes.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-track-sizes.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!-- https://wpt.live/css/css-grid/grid-definition/grid-auto-explicit-rows-001.html -->
 <style>
 .grid {

--- a/Tests/LibWeb/Layout/input/grid/basic-2.html
+++ b/Tests/LibWeb/Layout/input/grid/basic-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 #grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/basic.html
+++ b/Tests/LibWeb/Layout/input/grid/basic.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/borders.html
+++ b/Tests/LibWeb/Layout/input/grid/borders.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font: 16px SerenitySans;

--- a/Tests/LibWeb/Layout/input/grid/calc-track-size.html
+++ b/Tests/LibWeb/Layout/input/grid/calc-track-size.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/column-1fr-1fr.html
+++ b/Tests/LibWeb/Layout/input/grid/column-1fr-1fr.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/column-auto-auto.html
+++ b/Tests/LibWeb/Layout/input/grid/column-auto-auto.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/different-column-sizes.html
+++ b/Tests/LibWeb/Layout/input/grid/different-column-sizes.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/distribute-extra-space-across-spanned-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/distribute-extra-space-across-spanned-tracks.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/fit-content-1.html
+++ b/Tests/LibWeb/Layout/input/grid/fit-content-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/fit-content-2.html
+++ b/Tests/LibWeb/Layout/input/grid/fit-content-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 #container {
   display: grid;

--- a/Tests/LibWeb/Layout/input/grid/float-container-columns-1fr-1fr.html
+++ b/Tests/LibWeb/Layout/input/grid/float-container-columns-1fr-1fr.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     float: left;

--- a/Tests/LibWeb/Layout/input/grid/floating-table-wrapper-width.html
+++ b/Tests/LibWeb/Layout/input/grid/floating-table-wrapper-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     .grid {
         display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-area-non-token-parts-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-area-non-token-parts-crash.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <div style="grid-area: {}"></div>

--- a/Tests/LibWeb/Layout/input/grid/grid-column-non-token-parts-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-column-non-token-parts-crash.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <div style="grid-column: {}"></div>

--- a/Tests/LibWeb/Layout/input/grid/grid-container-min-height-border-box.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-container-min-height-border-box.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style type="text/css">
 .box {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-gap-1.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-gap-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-gap-2.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-gap-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     font: 16px SerenitySans;

--- a/Tests/LibWeb/Layout/input/grid/grid-gap-3.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-gap-3.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-item-fixed-paddings.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-fixed-paddings.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-item-fixed-size.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-fixed-size.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-item-min-size.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-min-size.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     float: left;

--- a/Tests/LibWeb/Layout/input/grid/grid-item-percentage-margins.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-percentage-margins.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-item-percentage-width-2.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-percentage-width-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-item-percentage-width.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-percentage-width.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-row-overflow-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-row-overflow-crash.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <div style="display: grid; position: relative">
     <div style="position: absolute; grid-row: 3"></div>
 </div>

--- a/Tests/LibWeb/Layout/input/grid/grid-row-start-non-token-parts-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-row-start-non-token-parts-crash.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <div style="grid-row-start: {}"></div>

--- a/Tests/LibWeb/Layout/input/grid/grid-shorthand-property.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-shorthand-property.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-template-areas-basics.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-template-areas-basics.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/grid-template.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-template.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .mw-page-container-inner {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/image-in-grid.html
+++ b/Tests/LibWeb/Layout/input/grid/image-in-grid.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/image-with-percentage-width-and-auto-height.html
+++ b/Tests/LibWeb/Layout/input/grid/image-with-percentage-width-and-auto-height.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     #item {
         display: grid;

--- a/Tests/LibWeb/Layout/input/grid/inline-abspos-item.html
+++ b/Tests/LibWeb/Layout/input/grid/inline-abspos-item.html
@@ -1,5 +1,5 @@
-<!-- Reduced from https://wpt.live/css/css-grid/abspos/positioned-grid-descendants-001.html -->
 <!DOCTYPE html>
+<!-- Reduced from https://wpt.live/css/css-grid/abspos/positioned-grid-descendants-001.html -->
 <style>
   .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/min-max-content.html
+++ b/Tests/LibWeb/Layout/input/grid/min-max-content.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/minmax-1.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/minmax-2.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/minmax-3.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-3.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/minmax-auto-track-definition.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-auto-track-definition.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     .grid {
         display: grid;

--- a/Tests/LibWeb/Layout/input/grid/minmax-invalid-1.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-invalid-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/minmax-non-token-contents-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-non-token-contents-crash.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <div style="grid-template-columns: minmax({},{})"></div>

--- a/Tests/LibWeb/Layout/input/grid/minmax-with-max-function-inside.html
+++ b/Tests/LibWeb/Layout/input/grid/minmax-with-max-function-inside.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/negative-grid-item-column-index.html
+++ b/Tests/LibWeb/Layout/input/grid/negative-grid-item-column-index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
 display: grid;

--- a/Tests/LibWeb/Layout/input/grid/order.html
+++ b/Tests/LibWeb/Layout/input/grid/order.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     * {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/grid/placement-1.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     * {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/grid/placement-2.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     * {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/grid/placement-3.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-3.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     * {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-1.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     * {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-2.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     * {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-3.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-using-named-tracks-3.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     * {
         border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/grid/repeat-non-token-contents-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/repeat-non-token-contents-crash.html
@@ -1,1 +1,2 @@
+<!DOCTYPE html>
 <div style="grid-template-rows: repeat({})"></div>

--- a/Tests/LibWeb/Layout/input/grid/repeat.html
+++ b/Tests/LibWeb/Layout/input/grid/repeat.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/row-gaps-with-overflowing-spans-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/row-gaps-with-overflowing-spans-crash.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <div style="display: grid; grid-row-gap: 16px; grid-template-rows: 1fr 1fr">
     <div style="grid-row: 2 / span 3">1</div>
 </div>

--- a/Tests/LibWeb/Layout/input/grid/row-height.html
+++ b/Tests/LibWeb/Layout/input/grid/row-height.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
   .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/row-span-2-maxcontent.html
+++ b/Tests/LibWeb/Layout/input/grid/row-span-2-maxcontent.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/row-span-2-mincontent.html
+++ b/Tests/LibWeb/Layout/input/grid/row-span-2-mincontent.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/row-span-2-with-gaps.html
+++ b/Tests/LibWeb/Layout/input/grid/row-span-2-with-gaps.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/row-span-2.html
+++ b/Tests/LibWeb/Layout/input/grid/row-span-2.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/rows-1fr-1fr.html
+++ b/Tests/LibWeb/Layout/input/grid/rows-1fr-1fr.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     background-color: palevioletred;

--- a/Tests/LibWeb/Layout/input/grid/template-lines-and-areas.html
+++ b/Tests/LibWeb/Layout/input/grid/template-lines-and-areas.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid {
     display: grid;

--- a/Tests/LibWeb/Layout/input/grid/track-size-calc-with-percentage.html
+++ b/Tests/LibWeb/Layout/input/grid/track-size-calc-with-percentage.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .ipc-page-grid {
     display: flex;

--- a/Tests/LibWeb/Layout/input/grid/unresolvable-percentage-track.html
+++ b/Tests/LibWeb/Layout/input/grid/unresolvable-percentage-track.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .ipc-page-grid {
     display: flex;

--- a/Tests/LibWeb/Layout/input/grid/valid-grid-areas-1.html
+++ b/Tests/LibWeb/Layout/input/grid/valid-grid-areas-1.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .grid-container {
     display: grid;


### PR DESCRIPTION
This adds doctypes to all the grid layout tests that didn't have them yet and rebaselines them.
The only thing that changed in all the expectation files is the size of the HTML element (it is always 600px tall at least in quirks mode, not so in standards mode) and sometimes a little overflow that that caused on the viewport.

For a test or two, I moved the doctype above an introductory comment since the CI script that will enforce these once all layout tests have them doesn't like that either.

Adding all the doctypes is done over multiple PRs to make it more manageable and easier to review.