### PR TITLE
Meta: Add doctypes to some flex layout tests

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-column-reverse-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-reverse-constrained-wrap.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x268 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
       Box <div.container.column> at (9,9) content-size 250x250 flex-container(column-reverse) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x268]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
       PaintableBox (Box<DIV>.container.column) [8,8 252x252]
         PaintableWithLines (BlockContainer<DIV>.box) [9,157 102x102]

--- a/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-gap-between-items-and-lines.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (1,1) content-size 798x600 [BFC] children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x268 [BFC] children: not-inline
     BlockContainer <body> at (10,10) content-size 780x250 children: not-inline
       Box <div.flexbox> at (11,11) content-size 100x248 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (12,12) content-size 30x30 flex-item [BFC] children: not-inline
@@ -11,8 +11,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (12,228) content-size 30x30 flex-item [BFC] children: not-inline
         BlockContainer <div> at (64,228) content-size 30x30 flex-item [BFC] children: not-inline
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x602]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x602]
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x270]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x252]
       PaintableBox (Box<DIV>.flexbox) [10,10 102x250]
         PaintableWithLines (BlockContainer<DIV>) [11,11 32x32]

--- a/Tests/LibWeb/Layout/expected/flex/flex-item-on-row-with-intrinsic-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-on-row-with-intrinsic-size.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x24 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x8 children: not-inline
       Box <div> at (8,8) content-size 784x8 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x24]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x8]
       PaintableBox (Box<DIV>) [8,8 784x8]
         ImagePaintable (ImageBox<IMG>) [8,8 8x8]

--- a/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-constrained-wrap.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x222 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x206 children: not-inline
       Box <div.container> at (9,9) content-size 250x204 flex-container(row-reverse) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -26,7 +26,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x206]
       PaintableBox (Box<DIV>.container) [8,8 252x206]
         PaintableWithLines (BlockContainer<DIV>.box) [157,9 102x102]

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-on-min-content-with-gap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-on-min-content-with-gap.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x136 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x120 children: not-inline
       Box <div.container> at (8,8) content-size 160x40 flex-container(row) [FFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -45,7 +45,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x136]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x120]
       PaintableBox (Box<DIV>.container) [8,8 160x40]
         PaintableWithLines (BlockContainer<DIV>.box) [8,8 40x40]

--- a/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/justify-content-space-between-single-item.txt
@@ -1,5 +1,5 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
       Box <div.container> at (8,8) content-size 784x18 flex-container(row) [FFC] children: not-inline
         BlockContainer <div> at (8,8) content-size 14.265625x18 flex-item [BFC] children: inline
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.container) [8,8 784x18]
         PaintableWithLines (BlockContainer<DIV>) [8,8 14.265625x18]

--- a/Tests/LibWeb/Layout/input/flex/flex-column-reverse-constrained-wrap.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-column-reverse-constrained-wrap.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     body {
         font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/flex/flex-constrained-wrap-reverse.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-constrained-wrap-reverse.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     .row, .column {
         display: flex;

--- a/Tests/LibWeb/Layout/input/flex/flex-gap-between-items-and-lines.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-gap-between-items-and-lines.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     border: 1px solid black;

--- a/Tests/LibWeb/Layout/input/flex/flex-item-on-row-with-intrinsic-size.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-item-on-row-with-intrinsic-size.html
@@ -1,2 +1,3 @@
+<!DOCTYPE html>
 <div style="display:flex">
     <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII">

--- a/Tests/LibWeb/Layout/input/flex/flex-optimization-cases.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-optimization-cases.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 * {
     outline: 1px solid black;

--- a/Tests/LibWeb/Layout/input/flex/flex-row-reverse-constrained-wrap.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-row-reverse-constrained-wrap.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     body {
         font-family: 'SerenitySans';

--- a/Tests/LibWeb/Layout/input/flex/justify-content-on-min-content-with-gap.html
+++ b/Tests/LibWeb/Layout/input/flex/justify-content-on-min-content-with-gap.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
     .container {
         display: flex;

--- a/Tests/LibWeb/Layout/input/flex/justify-content-space-between-single-item.html
+++ b/Tests/LibWeb/Layout/input/flex/justify-content-space-between-single-item.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <style>
 .container {
     display: flex;


### PR DESCRIPTION
This adds doctypes to all the flexbox layout tests that didn't have them yet and rebaselines them.
The only thing that changed in all the expectation files is the size of the HTML element.
(it is always 600px tall at least in quirks mode, not so in standards mode)

Adding all the doctypes everywhere is done over multiple PRs to make it more manageable and easier to review.
