### PR TITLE
Everywhere: Replace allocation funcs with kmalloc

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -8,6 +8,7 @@
 #include <AK/Backtrace.h>
 #include <AK/Format.h>
 #include <AK/Platform.h>
+#include <AK/kmalloc.h>
 
 #ifdef AK_OS_WINDOWS
 #    include <Windows.h>
@@ -70,13 +71,13 @@ void dump_backtrace()
             syms[i][idx.value() + end_of_sym] = '\0';
 
             size_t buf_size = 128u;
-            char* buf = static_cast<char*>(malloc(buf_size));
+            char* buf = static_cast<char*>(kmalloc(buf_size));
             auto* raw_str = &syms[i][idx.value()];
             buf = abi::__cxa_demangle(raw_str, buf, &buf_size, nullptr);
 
             auto* buf_to_print = buf ? buf : raw_str;
             error_builder.append(buf_to_print, strlen(buf_to_print));
-            free(buf);
+            kfree(buf);
 
             error_builder.append(' ');
             auto* end_of_line = &syms[i][idx.value() + end_of_sym + 1];
@@ -90,7 +91,7 @@ void dump_backtrace()
         error_builder.append('\0');
         PRINT_ERROR(error_builder.string_view().characters_without_null_termination());
     }
-    free(syms);
+    kfree(syms);
 }
 #else
 void dump_backtrace()

--- a/AK/Demangle.h
+++ b/AK/Demangle.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/StringView.h>
+#include <AK/kmalloc.h>
 
 #ifndef AK_OS_WINDOWS
 #    include <cxxabi.h>
@@ -22,7 +23,7 @@ inline ByteString demangle(StringView name)
     auto* demangled_name = abi::__cxa_demangle(name.to_byte_string().characters(), nullptr, nullptr, &status);
     auto string = ByteString(status == 0 ? StringView { demangled_name, strlen(demangled_name) } : name);
     if (status == 0)
-        free(demangled_name);
+        kfree(demangled_name);
     return string;
 }
 #else

--- a/AK/StringData.h
+++ b/AK/StringData.h
@@ -10,6 +10,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/StringBuilder.h>
+#include <AK/kmalloc.h>
 
 namespace AK::Detail {
 
@@ -26,7 +27,7 @@ public:
         VERIFY(byte_count);
 
         auto capacity = allocation_size_for_string_data(byte_count);
-        void* slot = malloc(capacity);
+        void* slot = kmalloc(capacity);
         if (!slot)
             return Error::from_errno(ENOMEM);
 
@@ -52,7 +53,7 @@ public:
         VERIFY(byte_count > MAX_SHORT_STRING_BYTE_COUNT);
 
         auto capacity = sizeof(StringData) + sizeof(StringData::SubstringData);
-        void* slot = malloc(capacity);
+        void* slot = kmalloc(capacity);
         if (!slot)
             return Error::from_errno(ENOMEM);
 
@@ -66,7 +67,7 @@ public:
 
     void operator delete(void* ptr)
     {
-        free(ptr);
+        kfree(ptr);
     }
 
     ~StringData()

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -12,13 +12,43 @@
 #include <new>
 #include <stdlib.h>
 
+// Allocation functions
 #define kcalloc calloc
+#define kfree free
 #define kmalloc malloc
 #define kmalloc_good_size malloc_good_size
+#define krealloc realloc
+
+// Allocating library functions
+// Some allocator libraries provide their own versions of these. If they don't and we use a different free
+// for kfree we need to be careful to use libc free when not overriding malloc
+#define krealpath realpath
+#define kstrdup strdup
+#define kstrndup strndup
+
+// Microsoft extensions
+#if defined(AK_OS_WINDOWS)
+#    define k_expand _expand
+#    define k_msize _msize
+#    define k_recalloc _recalloc
+// Aligned versions
+#    define kaligned_alloc(alignment, size) _aligned_malloc(size, alignment)
+#    define kaligned_free _aligned_free
+#else
+#    define kaligned_alloc(alignment, size) aligned_alloc(alignment, size)
+#    define kaligned_free free
+#endif
+
+// Posix functions
+#if !defined(AK_OS_WINDOWS)
+
+#else
+
+#endif
 
 inline void kfree_sized(void* ptr, size_t)
 {
-    free(ptr);
+    kfree(ptr);
 }
 
 #ifndef AK_OS_SERENITY

--- a/Libraries/LibCore/Environment.cpp
+++ b/Libraries/LibCore/Environment.cpp
@@ -10,6 +10,7 @@
 
 #include "Environment.h"
 #include <AK/ByteString.h>
+#include <AK/kmalloc.h>
 
 #if defined(AK_OS_MACOS) || defined(AK_OS_IOS)
 #    include <crt_externs.h>
@@ -159,7 +160,7 @@ ErrorOr<void> put(StringView env)
     auto rc = ::putenv(str.characters());
 #else
     // Leak somewhat unavoidable here due to the putenv API.
-    auto leaked_new_env = strndup(env.characters_without_null_termination(), env.length());
+    auto leaked_new_env = kstrndup(env.characters_without_null_termination(), env.length());
     auto rc = ::putenv(leaked_new_env);
 #endif
     if (rc < 0)

--- a/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Libraries/LibFileSystem/FileSystem.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
+#include <AK/kmalloc.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
@@ -52,8 +53,8 @@ ErrorOr<ByteString> real_path(StringView path)
         return Error::from_errno(ENOENT);
 
     ByteString dep_path = path;
-    char* real_path = realpath(dep_path.characters(), nullptr);
-    ScopeGuard free_path = [real_path]() { free(real_path); };
+    char* real_path = krealpath(dep_path.characters(), nullptr);
+    ScopeGuard free_path = [real_path]() { kfree(real_path); };
 
     if (!real_path)
         return Error::from_syscall("realpath"sv, errno);

--- a/Libraries/LibLine/Editor.cpp
+++ b/Libraries/LibLine/Editor.cpp
@@ -17,6 +17,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
+#include <AK/kmalloc.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
@@ -752,7 +753,7 @@ auto Editor::get_line(ByteString const& prompt) -> Result<ByteString, Editor::Er
         // getline() returns -1 and sets errno=0 on EOF.
         if (line_length == -1) {
             if (line)
-                free(line);
+                kfree(line);
             if (errno == 0)
                 return Error::Eof;
 
@@ -761,7 +762,7 @@ auto Editor::get_line(ByteString const& prompt) -> Result<ByteString, Editor::Er
         restore();
         if (line) {
             ByteString result { line, (size_t)line_length, Chomp };
-            free(line);
+            kfree(line);
             return result;
         }
 

--- a/Libraries/LibMedia/VideoFrame.cpp
+++ b/Libraries/LibMedia/VideoFrame.cpp
@@ -6,16 +6,10 @@
 
 #include <AK/FixedArray.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/kmalloc.h>
 #include <LibMedia/Color/ColorConverter.h>
 
 #include "VideoFrame.h"
-
-#ifdef AK_OS_WINDOWS
-#    define aligned_alloc(alignment, size) _aligned_malloc(size, alignment)
-#    define aligned_free _aligned_free
-#else
-#    define aligned_free free
-#endif
 
 namespace Media {
 
@@ -30,7 +24,7 @@ ErrorOr<NonnullOwnPtr<SubsampledYUVFrame>> SubsampledYUVFrame::try_create(
     size_t alignment_size = max(bit_depth > 8 ? sizeof(u16) : sizeof(u8), sizeof(void*));
 
     auto alloc_buffer = [&](size_t size) -> ErrorOr<u8*> {
-        void* buffer = aligned_alloc(alignment_size, round_up_to_power_of_two(size, alignment_size));
+        void* buffer = kaligned_alloc(alignment_size, round_up_to_power_of_two(size, alignment_size));
         if (!buffer)
             return Error::from_errno(ENOMEM);
         return reinterpret_cast<u8*>(buffer);
@@ -70,9 +64,9 @@ ErrorOr<NonnullOwnPtr<SubsampledYUVFrame>> SubsampledYUVFrame::try_create_from_d
 
 SubsampledYUVFrame::~SubsampledYUVFrame()
 {
-    aligned_free(m_y_buffer);
-    aligned_free(m_u_buffer);
-    aligned_free(m_v_buffer);
+    kaligned_free(m_y_buffer);
+    kaligned_free(m_u_buffer);
+    kaligned_free(m_v_buffer);
 }
 
 template<u32 subsampling_horizontal, typename T>

--- a/Meta/Lagom/Fuzzers/EntryShim.cpp
+++ b/Meta/Lagom/Fuzzers/EntryShim.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/kmalloc.h>
 #include <fcntl.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -25,7 +26,7 @@ int fuzz_from_file(char const* filename)
 
     size_t file_size = file_stats.st_size;
 
-    uint8_t* file_buffer = (uint8_t*)malloc(file_size);
+    uint8_t* file_buffer = (uint8_t*)kmalloc(file_size);
 
     if (!file_buffer) {
         fprintf(stderr, "EntryShim: Failed to allocate file buffer\n");
@@ -57,7 +58,7 @@ int fuzz_from_stdin()
     size_t file_size = 0;
 
     while (true) {
-        file_buffer = (uint8_t*)realloc(file_buffer, file_size + chunk_size);
+        file_buffer = (uint8_t*)krealloc(file_buffer, file_size + chunk_size);
 
         if (!file_buffer) {
             fprintf(stderr, "EntryShim: Failed to reallocate buffer to a size of %lu bytes\n", file_size + chunk_size);

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -7,6 +7,7 @@
 #include <AK/Format.h>
 #include <AK/Function.h>
 #include <AK/StringView.h>
+#include <AK/kmalloc.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Lexer.h>
@@ -83,7 +84,7 @@ extern "C" void __sanitizer_cov_trace_pc_guard_init(uint32_t* start, uint32_t* s
     char const* shm_key = getenv("SHM_ID");
     if (!shm_key) {
         puts("[COV] no shared memory bitmap available, skipping");
-        __shmem = (struct shmem_data*)malloc(SHM_SIZE);
+        __shmem = (struct shmem_data*)kmalloc(SHM_SIZE);
     } else {
         int fd = shm_open(shm_key, O_RDWR, S_IREAD | S_IWRITE);
         if (fd <= -1) {


### PR DESCRIPTION
This commit replaces allocation and free functions with kmalloc and friends. This will allow for changing allocators more easily in the future, or adding logging, double free protection, etc.