### PR TITLE
AK: Silence -Wfree-nonheap-object more generally in Function for gcc

### DIFF
--- a/AK/Function.h
+++ b/AK/Function.h
@@ -296,7 +296,8 @@ private:
             break;
         case FunctionKind::Outline:
             VERIFY(wrapper);
-            wrapper->destroy();
+            // This code is a bit too clever for gcc. Pinky promise we're only deleting heap objects.
+            AK_IGNORE_DIAGNOSTIC("-Wfree-nonheap-object", wrapper->destroy());
             break;
         case FunctionKind::Block:
             VERIFY(wrapper);

--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -14,6 +14,8 @@ if (POLICY CMP0140)
     cmake_policy(SET CMP0140 NEW)
 endif()
 
+serenity_option(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries instead of static libraries")
+
 serenity_option(ENABLE_COMPILETIME_FORMAT_CHECK ON CACHE BOOL "Enable compiletime format string checks")
 serenity_option(ENABLE_UNDEFINED_SANITIZER OFF CACHE BOOL "Enable undefined behavior sanitizer testing in gcc/clang")
 serenity_option(UNDEFINED_BEHAVIOR_IS_FATAL OFF CACHE BOOL "Make undefined behavior sanitizer errors non-recoverable")

--- a/Meta/CMake/lagom_options.cmake
+++ b/Meta/CMake/lagom_options.cmake
@@ -5,6 +5,14 @@
 include(${CMAKE_CURRENT_LIST_DIR}/common_options.cmake NO_POLICY_SCOPE)
 include(${CMAKE_CURRENT_LIST_DIR}/lagom_install_options.cmake)
 
+# lto1 uses a crazy amount of RAM in static builds.
+# Disable LTO for static gcc builds unless explicitly asked for.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT BUILD_SHARED_LIBS)
+    set(RELEASE_LTO_DEFAULT OFF)
+else()
+    set(RELEASE_LTO_DEFAULT ON)
+endif()
+
 serenity_option(ENABLE_ADDRESS_SANITIZER OFF CACHE BOOL "Enable address sanitizer testing in gcc/clang")
 serenity_option(ENABLE_MEMORY_SANITIZER OFF CACHE BOOL "Enable memory sanitizer testing in gcc/clang")
 serenity_option(ENABLE_FUZZERS OFF CACHE BOOL "Build fuzzing targets")
@@ -14,7 +22,7 @@ serenity_option(LAGOM_TOOLS_ONLY OFF CACHE BOOL "Don't build libraries, utilitie
 serenity_option(ENABLE_LAGOM_CCACHE ON CACHE BOOL "Enable ccache for Lagom builds")
 serenity_option(LAGOM_USE_LINKER "" CACHE STRING "The linker to use (e.g. lld, mold) instead of the system default")
 serenity_option(LAGOM_LINK_POOL_SIZE "" CACHE STRING "The maximum number of parallel jobs to use for linking")
-serenity_option(ENABLE_LTO_FOR_RELEASE ON CACHE BOOL "Enable link-time optimization for release builds")
+serenity_option(ENABLE_LTO_FOR_RELEASE ${RELEASE_LTO_DEFAULT} CACHE BOOL "Enable link-time optimization for release builds")
 serenity_option(ENABLE_LAGOM_COVERAGE_COLLECTION OFF CACHE STRING "Enable code coverage instrumentation for lagom binaries in clang")
 
 if (ANDROID OR APPLE)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -56,12 +56,6 @@ if(ENABLE_ALL_THE_DEBUG_MACROS)
     include(all_the_debug_macros)
 endif()
 
-# FIXME: BUILD_SHARED_LIBS has a default of OFF, as it's intended to be set by the
-#        user when configuring the project. We should instead change libjs-test262
-#        and oss-fuzz to set this option on their end, and enable it by default in
-#        Meta/ladybird.sh. This is #9867.
-option(BUILD_SHARED_LIBS "Build shared libraries instead of static libraries" ON)
-
 find_package(Threads REQUIRED)
 # FIXME: This global link libraries is required to workaround linker issues (on some systems)
 # from the Ladybird import. See https://github.com/SerenityOS/serenity/issues/16847


### PR DESCRIPTION
We were already silencing it at the site of the delete call, but gcc in
distribution mode is more aggressive about inlining and still sees a
delete that it doesn't like.

With these two changes, a gcc-13 Distribution preset builds and passes tests locally on Ubuntu 24.04.