### PR TITLE
LibWeb: Add support for CSS content property with images

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -591,6 +591,7 @@ set(SOURCES
     Internals/WebUI.cpp
     IntersectionObserver/IntersectionObserver.cpp
     IntersectionObserver/IntersectionObserverEntry.cpp
+    Layout/AnonymousImageBox.cpp
     Layout/AudioBox.cpp
     Layout/AvailableSpace.cpp
     Layout/BlockContainer.cpp
@@ -668,6 +669,7 @@ set(SOURCES
     Page/EventHandler.cpp
     Page/InputEvent.cpp
     Page/Page.cpp
+    Painting/AnonymousImagePaintable.cpp
     Painting/AudioPaintable.cpp
     Painting/BackgroundPainting.cpp
     Painting/BackingStore.cpp

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -351,10 +351,13 @@ struct ContentData {
         Normal,
         None,
         String,
+        Image,
     } type { Type::Normal };
 
     // FIXME: Data is a list of identifiers, strings and image values.
     String data {};
+    Optional<RefPtr<AbstractImageStyleValue const>> image {};
+
     Optional<String> alt_text {};
 };
 
@@ -760,6 +763,8 @@ protected:
         Vector<CounterData, 0> counter_increment;
         Vector<CounterData, 0> counter_reset;
         Vector<CounterData, 0> counter_set;
+
+        RefPtr<CSS::AbstractImageStyleValue const> content_image;
     } m_noninherited;
 };
 

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1140,7 +1140,8 @@
     "__comment": "FIXME: This accepts a whole lot of other types and identifiers!",
     "valid-types": [
       "counter",
-      "string"
+      "string",
+      "image"
     ],
     "valid-identifiers": [
       "normal",

--- a/Libraries/LibWeb/Layout/AnonymousImageBox.cpp
+++ b/Libraries/LibWeb/Layout/AnonymousImageBox.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025, Bohdan Sverdlov <freezar92@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/HTML/DecodedImageData.h>
+#include <LibWeb/Layout/AnonymousImageBox.h>
+#include <LibWeb/Painting/AnonymousImagePaintable.h>
+#include <LibWeb/Platform/FontPlugin.h>
+
+namespace Web::Layout {
+
+GC_DEFINE_ALLOCATOR(AnonymousImageBox);
+
+AnonymousImageBox::AnonymousImageBox(DOM::Document& document, DOM::Element& element, GC::Ref<CSS::ComputedProperties> style)
+    : ReplacedBox(document, element, move(style))
+{
+}
+
+AnonymousImageBox::~AnonymousImageBox() = default;
+
+void AnonymousImageBox::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+}
+
+GC::Ptr<Painting::Paintable> AnonymousImageBox::create_paintable() const
+{
+    return Painting::AnonymousImagePaintable::create(*this);
+}
+
+}

--- a/Libraries/LibWeb/Layout/AnonymousImageBox.h
+++ b/Libraries/LibWeb/Layout/AnonymousImageBox.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Bohdan Sverdlov <freezar92@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Layout/ReplacedBox.h>
+
+namespace Web::Layout {
+
+class AnonymousImageBox final : public ReplacedBox {
+    GC_CELL(AnonymousImageBox, ReplacedBox);
+    GC_DECLARE_ALLOCATOR(AnonymousImageBox);
+
+public:
+    AnonymousImageBox(DOM::Document&, DOM::Element&, GC::Ref<CSS::ComputedProperties>);
+    virtual ~AnonymousImageBox() override;
+
+    virtual GC::Ptr<Painting::Paintable> create_paintable() const override;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+};
+
+}

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
+#include <LibWeb/Layout/AnonymousImageBox.h>
 #include <LibWeb/Layout/FieldSetBox.h>
 #include <LibWeb/Layout/ListItemBox.h>
 #include <LibWeb/Layout/ListItemMarkerBox.h>
@@ -222,7 +223,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Ps
     pseudo_element_node->set_generated_for(generated_for, element);
     pseudo_element_node->set_initial_quote_nesting_level(initial_quote_nesting_level);
 
-    // FIXME: Handle images, and multiple values
+    // FIXME: Handle multiple values
     if (pseudo_element_content.type == CSS::ContentData::Type::String) {
         auto text = document.realm().create<DOM::Text>(document, pseudo_element_content.data);
         auto text_node = document.heap().allocate<Layout::TextNode>(document, *text);
@@ -230,6 +231,14 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Ps
 
         push_parent(*pseudo_element_node);
         insert_node_into_inline_or_block_ancestor(*text_node, text_node->display(), AppendOrPrepend::Append);
+        pop_parent();
+    } else if (pseudo_element_content.type == CSS::ContentData::Type::Image) {
+        auto image_box = document.heap().allocate<Layout::AnonymousImageBox>(document, element, *pseudo_element_style);
+        image_box->set_generated_for(generated_for, element);
+        image_box->mutable_computed_values().set_content(pseudo_element_content);
+
+        push_parent(*pseudo_element_node);
+        insert_node_into_inline_or_block_ancestor(*image_box, image_box->display(), AppendOrPrepend::Append);
         pop_parent();
     } else {
         TODO();

--- a/Libraries/LibWeb/Painting/AnonymousImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/AnonymousImagePaintable.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, Bohdan Sverdlov <freezar92@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
+#include <LibWeb/HTML/DecodedImageData.h>
+#include <LibWeb/Painting/AnonymousImagePaintable.h>
+#include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/PixelUnits.h>
+#include <LibWeb/Platform/FontPlugin.h>
+
+namespace Web::Painting {
+
+GC_DEFINE_ALLOCATOR(AnonymousImagePaintable);
+
+GC::Ref<AnonymousImagePaintable> AnonymousImagePaintable::create(Layout::AnonymousImageBox const& layout_box)
+{
+    return layout_box.heap().allocate<AnonymousImagePaintable>(layout_box);
+}
+
+AnonymousImagePaintable::AnonymousImagePaintable(Layout::Box const& layout_box)
+    : PaintableBox(layout_box)
+{
+    const_cast<DOM::Document&>(layout_box.document()).register_viewport_client(*this);
+}
+
+void AnonymousImagePaintable::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+}
+
+void AnonymousImagePaintable::finalize()
+{
+    Base::finalize();
+
+    // NOTE: We unregister from the document in finalize() to avoid trouble
+    //       in the scenario where our Document has already been swept by GC.
+    document().unregister_viewport_client(*this);
+}
+
+void AnonymousImagePaintable::paint(PaintContext& context, PaintPhase phase) const
+{
+    if (computed_values().content().type != CSS::ContentData::Type::Image) {
+        return;
+    }
+
+    VERIFY(computed_values().content().image.has_value());
+
+    // TODO: Support for other AbstractImageStyleValue's heirs.
+    if (!computed_values().content().image.value()->is_image()) {
+        return;
+    }
+
+    auto& image = computed_values().content().image.value()->as_image();
+    if (!image.is_paintable()) {
+        return;
+    }
+
+    Base::paint(context, phase);
+
+    // TODO: Alternative text painting.
+    if (phase == PaintPhase::Foreground) {
+        auto image_rect = absolute_rect();
+        auto image_rect_device_pixels = context.rounded_device_rect(image_rect);
+        auto image_int_rect_device_pixels = image_rect_device_pixels.to_type<int>();
+
+        auto const* bitmap = image.current_frame_bitmap(image_rect_device_pixels);
+        auto bitmap_rect = bitmap->rect();
+        auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), bitmap_rect, image_int_rect_device_pixels);
+
+        auto scaled_bitmap_width = CSSPixels::nearest_value_for(static_cast<float>(bitmap_rect.width()));
+        auto scaled_bitmap_height = CSSPixels::nearest_value_for(static_cast<float>(bitmap_rect.height()));
+
+        Gfx::IntRect draw_rect = {
+            image_int_rect_device_pixels.x(),
+            image_int_rect_device_pixels.y(),
+            context.rounded_device_pixels(scaled_bitmap_width).value(),
+            context.rounded_device_pixels(scaled_bitmap_height).value()
+        };
+
+        context.display_list_recorder().draw_scaled_immutable_bitmap(draw_rect, image_int_rect_device_pixels, *bitmap, scaling_mode);
+    }
+}
+
+void AnonymousImagePaintable::did_set_viewport_rect(CSSPixelRect const&)
+{
+}
+
+}

--- a/Libraries/LibWeb/Painting/AnonymousImagePaintable.h
+++ b/Libraries/LibWeb/Painting/AnonymousImagePaintable.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, Bohdan Sverdlov <freezar92@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Layout/AnonymousImageBox.h>
+#include <LibWeb/Painting/PaintableBox.h>
+
+namespace Web::Painting {
+
+class AnonymousImagePaintable final
+    : public PaintableBox
+    , public DOM::Document::ViewportClient {
+    GC_CELL(AnonymousImagePaintable, PaintableBox);
+    GC_DECLARE_ALLOCATOR(AnonymousImagePaintable);
+
+public:
+    static GC::Ref<AnonymousImagePaintable> create(Layout::AnonymousImageBox const& layout_box);
+
+    virtual void paint(PaintContext&, PaintPhase) const override;
+
+private:
+    // ^JS::Cell
+    virtual void visit_edges(Visitor&) override;
+    virtual void finalize() override;
+
+    // ^Document::ViewportClient
+    virtual void did_set_viewport_rect(CSSPixelRect const&) final;
+
+    AnonymousImagePaintable(Layout::Box const& layout_box);
+};
+
+}

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-content-url.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-content-url.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x166 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x150 children: inline
+      TextNode <#text>
+      InlineNode <span.content-url>
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 300x150] baseline: 150
+        frag 1 from AnonymousImageBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
+        BlockContainer <(anonymous)> at (8,8) content-size 300x150 inline-block [BFC] children: inline
+          AnonymousImageBox <span.content-url> at (8,8) content-size 300x150 inline-block children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x166]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      PaintableWithLines (InlineNode<SPAN>.content-url)
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 300x150]
+          AnonymousImagePaintable (AnonymousImageBox<SPAN>.content-url) [8,8 300x150]

--- a/Tests/LibWeb/Layout/input/pseudo-element-with-content-url.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-with-content-url.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<head>
+<style>
+    .content-url::before {
+        content: url('./svg/standalone.svg');
+        display: inline-block;
+    }
+</style>
+</head>
+<body>
+    <span class="content-url"></span>
+</body>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/serialize-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/serialize-values.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 687 tests
 
-654 Pass
-33 Fail
+656 Pass
+31 Fail
 Pass	background-attachment: scroll
 Pass	background-attachment: fixed
 Pass	background-attachment: inherit
@@ -322,8 +322,8 @@ Pass	content: normal
 Pass	content: none
 Pass	content: "string"
 Pass	content: 'string'
-Fail	content: url("http://localhost/")
-Fail	content: url(http://localhost/)
+Pass	content: url("http://localhost/")
+Pass	content: url(http://localhost/)
 Pass	content: counter(par-num)
 Pass	content: counter(par-num, decimal)
 Pass	content: counter(par-num, upper-roman)


### PR DESCRIPTION
Extend the CSS content property to handle image types. Add AnonymousImageBox and AnonymousImagePaintable
for painting content image from ComputedValues.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/448