### PR TITLE
LibWeb: Implement XML Char validation for Text node serialization

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/domparsing/innerhtml-01.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domparsing/innerhtml-01.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
+2 Pass
 Pass	innerHTML in XHTML: getting while the document is in an invalid state
-Fail	innerHTML in XHTML: getting while the document is in an invalid state 1
+Pass	innerHTML in XHTML: getting while the document is in an invalid state 1


### PR DESCRIPTION
With this fix, the second test in domparsing/innerhtml-01.xhtml passes.