### PR TITLE
LibWeb: Factor out CanvasSettings mixin into separate file

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasSettings.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasSettings.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::HTML {
+
+struct CanvasRenderingContext2DSettings {
+    bool alpha { true };
+    bool desynchronized { false };
+    Bindings::PredefinedColorSpace color_space { Bindings::PredefinedColorSpace::Srgb };
+    Bindings::CanvasColorType color_type { Bindings::CanvasColorType::Unorm8 };
+    bool will_read_frequently { false };
+};
+
+// https://html.spec.whatwg.org/multipage/canvas.html#canvassettings
+class CanvasSettings {
+public:
+    virtual ~CanvasSettings() = default;
+
+    virtual CanvasRenderingContext2DSettings get_context_attributes() const = 0;
+
+protected:
+    CanvasSettings() = default;
+};
+
+}

--- a/Libraries/LibWeb/HTML/Canvas/CanvasSettings.idl
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasSettings.idl
@@ -1,0 +1,5 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvassettings
+interface mixin CanvasSettings {
+    // settings
+    CanvasRenderingContext2DSettings getContextAttributes();
+};

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -24,6 +24,7 @@
 #include <LibWeb/HTML/Canvas/CanvasPath.h>
 #include <LibWeb/HTML/Canvas/CanvasPathDrawingStyles.h>
 #include <LibWeb/HTML/Canvas/CanvasRect.h>
+#include <LibWeb/HTML/Canvas/CanvasSettings.h>
 #include <LibWeb/HTML/Canvas/CanvasShadowStyles.h>
 #include <LibWeb/HTML/Canvas/CanvasState.h>
 #include <LibWeb/HTML/Canvas/CanvasText.h>
@@ -32,14 +33,6 @@
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {
-
-struct CanvasRenderingContext2DSettings {
-    bool alpha { true };
-    bool desynchronized { false };
-    Bindings::PredefinedColorSpace color_space { Bindings::PredefinedColorSpace::Srgb };
-    Bindings::CanvasColorType color_type { Bindings::CanvasColorType::Unorm8 };
-    bool will_read_frequently { false };
-};
 
 class CanvasRenderingContext2D
     : public Bindings::PlatformObject
@@ -56,6 +49,7 @@ class CanvasRenderingContext2D
     , public CanvasImageData
     , public CanvasImageSmoothing
     , public CanvasCompositing
+    , public CanvasSettings
     , public CanvasPathDrawingStyles<CanvasRenderingContext2D>
     , public CanvasTextDrawingStyles<CanvasRenderingContext2D> {
 
@@ -91,7 +85,7 @@ public:
 
     GC::Ref<HTMLCanvasElement> canvas_for_binding() const;
 
-    CanvasRenderingContext2DSettings get_context_attributes() const { return m_context_attributes; }
+    virtual CanvasRenderingContext2DSettings get_context_attributes() const override { return m_context_attributes; }
 
     virtual GC::Ref<TextMetrics> measure_text(StringView text) override;
 

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -10,15 +10,20 @@
 #import <HTML/Canvas/CanvasPathDrawingStyles.idl>
 #import <HTML/Canvas/CanvasTextDrawingStyles.idl>
 #import <HTML/Canvas/CanvasRect.idl>
+#import <HTML/Canvas/CanvasSettings.idl>
 #import <HTML/Canvas/CanvasShadowStyles.idl>
 #import <HTML/Canvas/CanvasState.idl>
 #import <HTML/Canvas/CanvasText.idl>
 #import <HTML/Canvas/CanvasTransform.idl>
 #import <HTML/Canvas/CanvasUserInterface.idl>
 
+// FIXME: This should be in CanvasSettings.idl but then it is not exported
+// https://html.spec.whatwg.org/multipage/canvas.html#predefinedcolorspace
 enum PredefinedColorSpace { "srgb", "display-p3" };
+// https://html.spec.whatwg.org/multipage/canvas.html#canvascolortype
 enum CanvasColorType { "unorm8", "float16" };
 
+// https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2dsettings
 dictionary CanvasRenderingContext2DSettings {
     boolean alpha = true;
     boolean desynchronized = false;
@@ -60,9 +65,3 @@ CanvasRenderingContext2D includes CanvasImageData;
 CanvasRenderingContext2D includes CanvasPathDrawingStyles;
 CanvasRenderingContext2D includes CanvasTextDrawingStyles;
 CanvasRenderingContext2D includes CanvasPath;
-
-// https://html.spec.whatwg.org/multipage/canvas.html#canvassettings
-interface mixin CanvasSettings {
-    // settings
-    CanvasRenderingContext2DSettings getContextAttributes();
-};


### PR DESCRIPTION
This refactors this mixin, that was introduced in #4506 to be the same as all other mixins, so that it can be used for #3788

This is necessary, to use `CanvasSettings` in #3788 . It also does the same as all other mixins, I have no plan, why it was not done like this in #4506 in the first place