### PR TITLE
Meta: Ensure wptreport `browser_version` field is always populated

### DIFF
--- a/Libraries/LibCore/Version.cpp
+++ b/Libraries/LibCore/Version.cpp
@@ -5,27 +5,12 @@
  */
 
 #include <AK/String.h>
-#include <LibCore/Environment.h>
 #include <LibCore/Version.h>
 
 namespace Core::Version {
 
 String read_long_version_string()
 {
-    auto validate_git_hash = [](auto hash) {
-        if (hash.length() < 4 || hash.length() > 40)
-            return false;
-        for (auto ch : hash) {
-            if (!is_ascii_hex_digit(ch))
-                return false;
-        }
-        return true;
-    };
-
-    auto maybe_git_hash = Core::Environment::get("LADYBIRD_GIT_VERSION"sv);
-
-    if (maybe_git_hash.has_value() && validate_git_hash(maybe_git_hash.value()))
-        return MUST(String::formatted("Version 1.0-{}", maybe_git_hash.value()));
     return "Version 1.0"_string;
 }
 


### PR DESCRIPTION
This was previously done by passing the `LADYBIRD_GIT_VERSION` environment variable to `wpt`, but this doesn't work in chunked mode.