### PR TITLE
LibWeb: Range and text search fixes

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1304,6 +1304,10 @@ void Document::update_layout(UpdateLayoutReason reason)
     if (m_created_for_appropriate_template_contents)
         return;
 
+    // Clear text blocks cache so we rebuild them on the next find action.
+    if (m_layout_root)
+        m_layout_root->invalidate_text_blocks_cache();
+
     invalidate_display_list();
 
     auto* document_element = this->document_element();

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
- * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ * Copyright (c) 2024-2025, Jelle Raaijmakers <jelle@ladybird.org>
  * Copyright (c) 2025, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -299,28 +299,40 @@ WebIDL::ExceptionOr<void> Node::normalize()
 
         // 6. While currentNode is an exclusive Text node:
         while (current_node && current_node->is_exclusive_text()) {
-            // 1. For each live range whose start node is currentNode, add length to its start offset and set its start node to node.
+            // 1. For each live range whose start node is currentNode, add length to its start offset and set its start
+            //    node to node.
             for (auto& range : Range::live_ranges()) {
-                if (range->start_container() == current_node)
-                    TRY(range->set_start(node, range->start_offset() + length));
+                if (range->start_container() == current_node) {
+                    range->increase_start_offset(length);
+                    range->set_start_node(node);
+                }
             }
 
-            // 2. For each live range whose end node is currentNode, add length to its end offset and set its end node to node.
+            // 2. For each live range whose end node is currentNode, add length to its end offset and set its end node
+            //    to node.
             for (auto& range : Range::live_ranges()) {
-                if (range->end_container() == current_node)
-                    TRY(range->set_end(node, range->end_offset() + length));
+                if (range->end_container() == current_node) {
+                    range->increase_end_offset(length);
+                    range->set_end_node(node);
+                }
             }
 
-            // 3. For each live range whose start node is currentNode’s parent and start offset is currentNode’s index, set its start node to node and its start offset to length.
+            // 3. For each live range whose start node is currentNode’s parent and start offset is currentNode’s index,
+            //    set its start node to node and its start offset to length.
             for (auto& range : Range::live_ranges()) {
-                if (range->start_container() == current_node->parent() && range->start_offset() == current_node->index())
-                    TRY(range->set_start(node, length));
+                if (range->start_container() == current_node->parent() && range->start_offset() == current_node->index()) {
+                    range->set_start_node(node);
+                    range->set_start_offset(length);
+                }
             }
 
-            // 4. For each live range whose end node is currentNode’s parent and end offset is currentNode’s index, set its end node to node and its end offset to length.
+            // 4. For each live range whose end node is currentNode’s parent and end offset is currentNode’s index, set
+            //    its end node to node and its end offset to length.
             for (auto& range : Range::live_ranges()) {
-                if (range->end_container() == current_node->parent() && range->end_offset() == current_node->index())
-                    TRY(range->set_end(node, length));
+                if (range->end_container() == current_node->parent() && range->end_offset() == current_node->index()) {
+                    range->set_end_node(node);
+                    range->set_end_offset(length);
+                }
             }
 
             // 5. Add currentNode’s length to length.
@@ -681,16 +693,18 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
 
     // 5. If child is non-null, then:
     if (child) {
-        // 1. For each live range whose start node is parent and start offset is greater than child’s index, increase its start offset by count.
+        // 1. For each live range whose start node is parent and start offset is greater than child’s index, increase
+        //    its start offset by count.
         for (auto& range : Range::live_ranges()) {
             if (range->start_container() == this && range->start_offset() > child->index())
-                range->increase_start_offset({}, count);
+                range->increase_start_offset(count);
         }
 
-        // 2. For each live range whose end node is parent and end offset is greater than child’s index, increase its end offset by count.
+        // 2. For each live range whose end node is parent and end offset is greater than child’s index, increase its
+        //    end offset by count.
         for (auto& range : Range::live_ranges()) {
             if (range->end_container() == this && range->end_offset() > child->index())
-                range->increase_end_offset({}, count);
+                range->increase_end_offset(count);
         }
     }
 
@@ -866,27 +880,28 @@ void Node::live_range_pre_remove()
     auto index = this->index();
 
     // 4. For each live range whose start node is an inclusive descendant of node, set its start to (parent, index).
-    for (auto& range : Range::live_ranges()) {
+    for (auto* range : Range::live_ranges()) {
         if (range->start_container()->is_inclusive_descendant_of(*this))
             MUST(range->set_start(*parent, index));
     }
 
     // 5. For each live range whose end node is an inclusive descendant of node, set its end to (parent, index).
-    for (auto& range : Range::live_ranges()) {
+    for (auto* range : Range::live_ranges()) {
         if (range->end_container()->is_inclusive_descendant_of(*this))
             MUST(range->set_end(*parent, index));
     }
 
-    // 6. For each live range whose start node is parent and start offset is greater than index, decrease its start offset by 1.
-    for (auto& range : Range::live_ranges()) {
+    // 6. For each live range whose start node is parent and start offset is greater than index, decrease its start
+    //    offset by 1.
+    for (auto* range : Range::live_ranges()) {
         if (range->start_container() == parent && range->start_offset() > index)
-            range->decrease_start_offset({}, 1);
+            range->decrease_start_offset(1);
     }
 
     // 7. For each live range whose end node is parent and end offset is greater than index, decrease its end offset by 1.
-    for (auto& range : Range::live_ranges()) {
+    for (auto* range : Range::live_ranges()) {
         if (range->end_container() == parent && range->end_offset() > index)
-            range->decrease_end_offset({}, 1);
+            range->decrease_end_offset(1);
     }
 }
 
@@ -1259,16 +1274,18 @@ WebIDL::ExceptionOr<void> Node::move_node(Node& new_parent, Node* child)
 
     // 17. If child is non-null:
     if (child) {
-        // 1. For each live range whose start node is newParent and start offset is greater than child’s index, increase its start offset by 1.
+        // 1. For each live range whose start node is newParent and start offset is greater than child’s index, increase
+        //    its start offset by 1.
         for (auto& range : Range::live_ranges()) {
             if (range->start_container() == &new_parent && range->start_offset() > child->index())
-                range->increase_start_offset({}, 1);
+                range->increase_start_offset(1);
         }
 
-        // 2. For each live range whose end node is newParent and end offset is greater than child’s index, increase its end offset by 1.
+        // 2. For each live range whose end node is newParent and end offset is greater than child’s index, increase its
+        //    end offset by 1.
         for (auto& range : Range::live_ranges()) {
             if (range->end_container() == &new_parent && range->end_offset() > child->index())
-                range->increase_end_offset({}, 1);
+                range->increase_end_offset(1);
         }
     }
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -68,6 +68,9 @@ Range::Range(Document& document)
 Range::Range(GC::Ref<Node> start_container, WebIDL::UnsignedLong start_offset, GC::Ref<Node> end_container, WebIDL::UnsignedLong end_offset)
     : AbstractRange(start_container, start_offset, end_container, end_offset)
 {
+    VERIFY(start_offset <= start_container->length());
+    VERIFY(end_offset <= end_container->length());
+
     live_ranges().set(this);
 }
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -39,7 +39,7 @@ HashTable<Range*>& Range::live_ranges()
 
 GC::Ref<Range> Range::create(HTML::Window& window)
 {
-    return Range::create(window.associated_document());
+    return create(window.associated_document());
 }
 
 GC::Ref<Range> Range::create(Document& document)
@@ -57,7 +57,7 @@ GC::Ref<Range> Range::create(GC::Ref<Node> start_container, WebIDL::UnsignedLong
 WebIDL::ExceptionOr<GC::Ref<Range>> Range::construct_impl(JS::Realm& realm)
 {
     auto& window = as<HTML::Window>(realm.global_object());
-    return Range::create(window);
+    return create(window);
 }
 
 Range::Range(Document& document)
@@ -167,6 +167,7 @@ RelativeBoundaryPointPosition position_of_boundary_point_relative_to_other_bound
     return RelativeBoundaryPointPosition::Before;
 }
 
+// https://dom.spec.whatwg.org/#concept-range-bp-set
 WebIDL::ExceptionOr<void> Range::set_start_or_end(GC::Ref<Node> node, u32 offset, StartOrEnd start_or_end)
 {
     // To set the start or end of a range to a boundary point (node, offset), run these steps:
@@ -212,13 +213,14 @@ WebIDL::ExceptionOr<void> Range::set_start_or_end(GC::Ref<Node> node, u32 offset
     return {};
 }
 
-// https://dom.spec.whatwg.org/#concept-range-bp-set
+// https://dom.spec.whatwg.org/#dom-range-setstart
 WebIDL::ExceptionOr<void> Range::set_start(GC::Ref<Node> node, WebIDL::UnsignedLong offset)
 {
     // The setStart(node, offset) method steps are to set the start of this to boundary point (node, offset).
     return set_start_or_end(node, offset, StartOrEnd::Start);
 }
 
+// https://dom.spec.whatwg.org/#dom-range-setend
 WebIDL::ExceptionOr<void> Range::set_end(GC::Ref<Node> node, WebIDL::UnsignedLong offset)
 {
     // The setEnd(node, offset) method steps are to set the end of this to boundary point (node, offset).
@@ -1289,26 +1291,6 @@ WebIDL::ExceptionOr<GC::Ref<DocumentFragment>> Range::create_contextual_fragment
 
     // 5. Return fragment node.
     return fragment_node;
-}
-
-void Range::increase_start_offset(Badge<Node>, WebIDL::UnsignedLong count)
-{
-    m_start_offset += count;
-}
-
-void Range::increase_end_offset(Badge<Node>, WebIDL::UnsignedLong count)
-{
-    m_end_offset += count;
-}
-
-void Range::decrease_start_offset(Badge<Node>, WebIDL::UnsignedLong count)
-{
-    m_start_offset -= count;
-}
-
-void Range::decrease_end_offset(Badge<Node>, WebIDL::UnsignedLong count)
-{
-    m_end_offset -= count;
 }
 
 }

--- a/Libraries/LibWeb/DOM/Range.h
+++ b/Libraries/LibWeb/DOM/Range.h
@@ -47,11 +47,6 @@ public:
     void collapse(bool to_start);
     WebIDL::ExceptionOr<void> select_node_contents(GC::Ref<Node>);
 
-    void increase_start_offset(Badge<Node>, WebIDL::UnsignedLong);
-    void increase_end_offset(Badge<Node>, WebIDL::UnsignedLong);
-    void decrease_start_offset(Badge<Node>, WebIDL::UnsignedLong);
-    void decrease_end_offset(Badge<Node>, WebIDL::UnsignedLong);
-
     // https://dom.spec.whatwg.org/#dom-range-start_to_start
     enum HowToCompareBoundaryPoints : WebIDL::UnsignedShort {
         START_TO_START = 0,
@@ -123,6 +118,10 @@ public:
     }
 
 private:
+    friend class CharacterData;
+    friend class Node;
+    friend class Text;
+
     explicit Range(Document&);
     Range(GC::Ref<Node> start_container, WebIDL::UnsignedLong start_offset, GC::Ref<Node> end_container, WebIDL::UnsignedLong end_offset);
 
@@ -137,6 +136,16 @@ private:
         Start,
         End,
     };
+
+    void set_start_node(GC::Ref<Node> node) { m_start_container = node; }
+    void set_start_offset(WebIDL::UnsignedLong offset) { m_start_offset = offset; }
+    void set_end_node(GC::Ref<Node> node) { m_end_container = node; }
+    void set_end_offset(WebIDL::UnsignedLong offset) { m_end_offset = offset; }
+
+    void increase_start_offset(WebIDL::UnsignedLong count) { m_start_offset += count; }
+    void increase_end_offset(WebIDL::UnsignedLong count) { m_end_offset += count; }
+    void decrease_start_offset(WebIDL::UnsignedLong count) { m_start_offset -= count; }
+    void decrease_end_offset(WebIDL::UnsignedLong count) { m_end_offset -= count; }
 
     WebIDL::ExceptionOr<void> set_start_or_end(GC::Ref<Node> node, u32 offset, StartOrEnd start_or_end);
     WebIDL::ExceptionOr<void> select(GC::Ref<Node> node);

--- a/Libraries/LibWeb/Layout/Viewport.h
+++ b/Libraries/LibWeb/Layout/Viewport.h
@@ -28,6 +28,7 @@ public:
         Vector<TextPosition> positions;
     };
     Vector<TextBlock> const& text_blocks();
+    void invalidate_text_blocks_cache() { m_text_blocks.clear(); }
 
     const DOM::Document& dom_node() const { return static_cast<const DOM::Document&>(*Node::dom_node()); }
 

--- a/Tests/LibWeb/Text/expected/HTML/Window-find-mutations.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-find-mutations.txt
@@ -1,0 +1,3 @@
+Selection: [object Text] 0 - [object Text] 6
+Selection: [object Text] 0 - [object Text] 3
+Expected exception: IndexSizeError: Selection.getRangeAt() on empty Selection or with invalid argument

--- a/Tests/LibWeb/Text/input/HTML/Window-find-mutations.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-find-mutations.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div>foobar</div>
+<script>
+test(() => {
+    function showSelection() {
+        let range = getSelection().getRangeAt(0);
+        println(`Selection: ${range.startContainer} ${range.startOffset} - ${range.endContainer} ${range.endOffset}`);
+    }
+
+    // Select 'foobar'.
+    window.find('foobar');
+    showSelection();
+
+    // Remove 'bar'.
+    document.querySelector('div').childNodes[0].deleteData(3, 3);
+    showSelection();
+
+    // Try to find 'bar'.
+    getSelection().empty();
+    window.find('bar');
+
+    // This should now fail.
+    try {
+        showSelection();
+    } catch (e) {
+        println(`Expected exception: ${e}`);
+    }
+});
+</script>


### PR DESCRIPTION
Fixes 1 crash in WPT's `editing/crashtests` and adds 23 new passes in `editing`. No regressions in `dom/ranges`.