### PR TITLE
Meta: Add ladybird.py project helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ Meta/CMake/vcpkg/user-variables.cmake
 
 # Keep last to ensure .DS_Store is never tracked, even if otherwise allowed by any exception above.
 .DS_Store
+
+__pycache__

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,14 +55,18 @@
     {
       "hidden": true,
       "name": "windows_ci",
+      "binaryDir": "${fileDir}/Build/release",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "ENABLE_WINDOWS_CI": "ON"
       }
     },
     {
       "hidden": true,
       "name": "windows_dev",
+      "binaryDir": "${fileDir}/Build/debug",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_WINDOWS_CI": "OFF"
       }
     },

--- a/Meta/__init__.py
+++ b/Meta/__init__.py
@@ -1,0 +1,1 @@
+# NOTE: Provided so ladybird.py can import the BuildVcpkg script as a module

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -96,6 +96,9 @@ def main(platform):
     run_parser.add_argument('args', nargs=argparse.REMAINDER,
                             help='Additional arguments passed through to the application')
 
+    subparsers.add_parser('install', help='Installs the target binary',
+                          parents=[preset_parser, compiler_parser, target_parser])
+
     args = parser.parse_args()
     kwargs = vars(args)
     command = kwargs.pop('command', None)
@@ -133,6 +136,11 @@ def main(platform):
         build_dir = _configure_main(platform, **kwargs)
         _build_main(build_dir, **kwargs)
         _run_main(platform.host_system, build_dir, **kwargs)
+    elif command == 'install':
+        build_dir = _configure_main(platform, **kwargs)
+        _build_main(build_dir, **kwargs)
+        kwargs['target'] = 'install'
+        _build_main(build_dir, **kwargs)
 
 
 def _configure_main(platform, **kwargs):

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -113,6 +113,8 @@ def main(platform):
     subparsers.add_parser('vcpkg', help='Ensure that dependencies are available',
                           parents=[preset_parser, compiler_parser])
 
+    subparsers.add_parser('clean', help='Cleans the build environment', parents=[preset_parser, compiler_parser])
+
     args = parser.parse_args()
     kwargs = vars(args)
     command = kwargs.pop('command', None)
@@ -162,6 +164,8 @@ def main(platform):
     elif command == 'vcpkg':
         _configure_build_env(**kwargs)
         _build_vcpkg()
+    elif command == 'clean':
+        _clean_main(**kwargs)
 
 
 def _configure_main(platform, **kwargs):
@@ -422,6 +426,14 @@ def _debug_main(host_system, build_dir, **kwargs):
     except subprocess.CalledProcessError as e:
         _print_process_stderr(e, f'Unable to run ladybird target "{app_target}" with "{debugger}" debugger')
         sys.exit(1)
+
+
+def _clean_main(**kwargs):
+    lb_source_dir, build_preset_dir, _ = _configure_build_env(**kwargs)
+    shutil.rmtree(str(build_preset_dir), ignore_errors=True)
+
+    user_vars_cmake_module = lb_source_dir.joinpath('Meta', 'CMake', 'vcpkg', 'user-variables.cmake')
+    user_vars_cmake_module.unlink(missing_ok=True)
 
 
 def _print_process_stderr(e, msg):

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -115,6 +115,12 @@ def main(platform):
 
     subparsers.add_parser('clean', help='Cleans the build environment', parents=[preset_parser, compiler_parser])
 
+    rebuild_parser = subparsers.add_parser('rebuild',
+                                           help='Cleans the build environment and compiles the target binaries',
+                                           parents=[preset_parser, compiler_parser, target_parser])
+    rebuild_parser.add_argument('args', nargs=argparse.REMAINDER,
+                                help='Additional arguments passed through to the build system')
+
     args = parser.parse_args()
     kwargs = vars(args)
     command = kwargs.pop('command', None)
@@ -166,6 +172,10 @@ def main(platform):
         _build_vcpkg()
     elif command == 'clean':
         _clean_main(**kwargs)
+    elif command == 'rebuild':
+        _clean_main(**kwargs)
+        build_dir = _configure_main(platform, **kwargs)
+        _build_main(build_dir, **kwargs)
 
 
 def _configure_main(platform, **kwargs):

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -110,6 +110,9 @@ def main(platform):
     subparsers.add_parser('install', help='Installs the target binary',
                           parents=[preset_parser, compiler_parser, target_parser])
 
+    subparsers.add_parser('vcpkg', help='Ensure that dependencies are available',
+                          parents=[preset_parser, compiler_parser])
+
     args = parser.parse_args()
     kwargs = vars(args)
     command = kwargs.pop('command', None)
@@ -156,6 +159,9 @@ def main(platform):
         _build_main(build_dir, **kwargs)
         kwargs['target'] = 'install'
         _build_main(build_dir, **kwargs)
+    elif command == 'vcpkg':
+        _configure_build_env(**kwargs)
+        _build_vcpkg()
 
 
 def _configure_main(platform, **kwargs):

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import sys
+import shutil
+import multiprocessing
+from pathlib import Path
+import subprocess
+from enum import IntEnum
+
+
+class HostArchitecture(IntEnum):
+    Unsupported = 0
+    x86_64 = 1
+    AArch64 = 2
+
+
+class HostSystem(IntEnum):
+    Unsupported = 0
+    Linux = 1
+    macOS = 2
+    Windows = 3
+
+
+class Platform:
+    def __init__(self):
+        import platform
+        self.system = platform.system()
+        if self.system == 'Windows':
+            self.host_system = HostSystem.Windows
+        elif self.system == 'Darwin':
+            self.host_system = HostSystem.macOS
+        elif self.system == 'Linux':
+            self.host_system = HostSystem.Linux
+        else:
+            self.host_system = HostSystem.Unsupported
+
+        self.architecture = platform.machine().lower()
+        if self.architecture in ('x86_64', 'amd64'):
+            self.host_architecture = HostArchitecture.x86_64
+        elif self.architecture in ('aarch64', 'arm64'):
+            self.host_architecture = HostArchitecture.AArch64
+        else:
+            self.host_architecture = HostArchitecture.Unsupported
+
+
+def main(platform):
+    if platform.host_system == HostSystem.Unsupported:
+        print(f'Unsupported host system {platform.system}', file=sys.stderr)
+        sys.exit(1)
+    if platform.host_architecture == HostArchitecture.Unsupported:
+        print(f'Unsupported host architecture {platform.architecture}', file=sys.stderr)
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description='Ladybird')
+    subparsers = parser.add_subparsers(dest='command')
+
+    preset_parser = argparse.ArgumentParser(add_help=False)
+    preset_parser.add_argument(
+        '--preset',
+        required=False,
+        default=os.environ.get('BUILD_PRESET',
+                               'windows_dev_ninja' if platform.host_system == HostSystem.Windows else 'default'),
+    )
+
+    # FIXME: Validate that the cc/cxx combination is compatible (e.g. don't allow CC=gcc and CXX=clang++)
+    # FIXME: Migrate find_compiler.sh for more explicit compiler validation
+    compiler_parser = argparse.ArgumentParser(add_help=False)
+    compiler_parser.add_argument(
+        '--cc',
+        required=False,
+        default=os.environ.get('CC', 'clang-cl' if platform.host_system == HostSystem.Windows else 'cc'))
+    compiler_parser.add_argument(
+        '--cxx',
+        required=False,
+        default=os.environ.get('CXX', 'clang-cl' if platform.host_system == HostSystem.Windows else 'c++')
+    )
+
+    target_parser = argparse.ArgumentParser(add_help=False)
+    target_parser.add_argument('--target', required=False, default='Ladybird')
+
+    build_parser = subparsers.add_parser('build', help='Compiles the target binaries',
+                                         parents=[preset_parser, compiler_parser, target_parser])
+    build_parser.add_argument('args', nargs=argparse.REMAINDER,
+                              help='Additional arguments passed through to the build system')
+
+    args = parser.parse_args()
+    kwargs = vars(args)
+    command = kwargs.pop('command', None)
+
+    if not command:
+        parser.print_help()
+        sys.exit(1)
+
+    if platform.host_system != HostSystem.Windows and os.geteuid() == 0:
+        print('Do not run ladybird.py as root, your Build directory will become root-owned', file=sys.stderr)
+        sys.exit(1)
+    elif platform.host_system == HostSystem.Windows and 'VCINSTALLDIR' not in os.environ:
+        print('ladybird.py must be run from a Visual Studio enabled environment', file=sys.stderr)
+        sys.exit(1)
+
+    if command == 'build':
+        build_dir = _configure_main(platform, **kwargs)
+        _build_main(build_dir, **kwargs)
+
+
+def _configure_main(platform, **kwargs):
+    cmake_args = []
+
+    host_system = platform.host_system
+    if host_system == HostSystem.Linux and platform.host_architecture == HostArchitecture.AArch64:
+        cmake_args.extend(_configure_skia_jemalloc())
+
+    lb_source_dir, build_preset_dir, build_env_cmake_args = _configure_build_env(**kwargs)
+    if build_preset_dir.joinpath('build.ninja').exists() or build_preset_dir.joinpath('ladybird.sln').exists():
+        return build_preset_dir
+
+    _build_vcpkg()
+    _validate_cmake_version()
+
+    cmake_args.extend(build_env_cmake_args)
+    config_args = [
+        'cmake',
+        '--preset',
+        kwargs.get('preset'),
+        '-S',
+        lb_source_dir,
+        '-B',
+        build_preset_dir,
+    ]
+    config_args.extend(cmake_args)
+
+    # FIXME: Improve error reporting for vcpkg install failures
+    # https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/BuildInstructionsLadybird.md#unable-to-find-a-build-program-corresponding-to-ninja
+    try:
+        subprocess.check_call(config_args)
+    except subprocess.CalledProcessError as e:
+        _print_process_stderr(e, 'Unable to configure ladybird project')
+        sys.exit(1)
+    return build_preset_dir
+
+
+def _configure_skia_jemalloc():
+    import resource
+    page_size = resource.getpagesize()
+    gn = shutil.which('gn') or None
+    # https://github.com/LadybirdBrowser/ladybird/issues/261
+    if page_size != 4096 and gn is None:
+        print('GN not found! Please build GN from source and put it in $PATH', file=sys.stderr)
+        sys.exit(1)
+    pkg_config = shutil.which('pkg-config') or None
+    cmake_args = []
+    if pkg_config:
+        cmake_args.append(f'-DPKG_CONFIG_EXECUTABLE={pkg_config}')
+
+    user_vars_cmake_module = Path('Meta/CMake/vcpkg/user-variables.cmake')
+    user_vars_cmake_module.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(user_vars_cmake_module, 'w') as f:
+        f.writelines([
+            f'set(PKGCONFIG {pkg_config})',
+            f'set(GN {gn})',
+            '',
+        ])
+
+    return cmake_args
+
+
+def _configure_build_env(**kwargs):
+    preset = kwargs.get('preset')
+    cc = kwargs.get('cc')
+    cxx = kwargs.get('cxx')
+    cmake_args = []
+    cmake_args.extend([
+        f'-DCMAKE_C_COMPILER={cc}',
+        f'-DCMAKE_CXX_COMPILER={cxx}',
+    ])
+    _ensure_ladybird_source_dir()
+    lb_source_dir = Path(os.environ.get('LADYBIRD_SOURCE_DIR'))
+
+    build_root_dir = lb_source_dir / 'Build'
+
+    known_presets = {
+        'default': build_root_dir / 'release',
+        'windows_ci_ninja': build_root_dir / 'release',
+        'windows_dev_ninja': build_root_dir / 'debug',
+        'windows_dev_msbuild': build_root_dir / 'debug',
+        'Debug': build_root_dir / 'debug',
+        'Sanitizer': build_root_dir / 'sanitizers',
+        'Distribution': build_root_dir / 'distribution',
+    }
+    if preset not in known_presets:
+        print(f'Unknown build preset "{preset}"', file=sys.stderr)
+        sys.exit(1)
+
+    build_preset_dir = known_presets.get(preset)
+    vcpkg_root = str(build_root_dir / 'vcpkg')
+    os.environ['VCPKG_ROOT'] = vcpkg_root
+    os.environ['PATH'] += os.pathsep + str(lb_source_dir.joinpath('Toolchain', 'Local', 'cmake', 'bin'))
+    os.environ['PATH'] += os.pathsep + str(vcpkg_root)
+    return lb_source_dir, build_preset_dir, cmake_args
+
+
+def _build_vcpkg():
+    sys.path.append(str(Path(__file__).parent.joinpath('..', 'Toolchain')))
+    # FIXME: Rename main() in BuildVcpkg.py to build_vcpkg() and call that from the scripts __main__
+    from BuildVcpkg import main as build_vcpkg
+    build_vcpkg()
+
+
+def _validate_cmake_version():
+    # FIXME: This 3.25+ CMake version check may not be needed anymore due to vcpkg downloading a newer version
+    cmake_pls_install_msg = 'Please install CMake version 3.25 or newer.'
+
+    try:
+        cmake_version_output = subprocess.check_output(
+            [
+                'cmake',
+                '--version',
+            ],
+            text=True
+        ).strip()
+
+        version_match = re.search(r'version\s+(\d+)\.(\d+)\.(\d+)?', cmake_version_output)
+        if version_match:
+            major = int(version_match.group(1))
+            minor = int(version_match.group(2))
+            patch = int(version_match.group(3))
+            if major < 3 or (major == 3 and minor < 25):
+                print(f'CMake version {major}.{minor}.{patch} is too old. {cmake_pls_install_msg}', file=sys.stderr)
+                sys.exit(1)
+        else:
+            print(f'Unable to determine CMake version. {cmake_pls_install_msg}', file=sys.stderr)
+            sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        _print_process_stderr(e, f'CMake not found. {cmake_pls_install_msg}\n')
+        sys.exit(1)
+
+
+def _ensure_ladybird_source_dir():
+    ladybird_source_dir = os.environ.get('LADYBIRD_SOURCE_DIR', None)
+    ladybird_source_dir = Path(ladybird_source_dir) if ladybird_source_dir else None
+
+    if not ladybird_source_dir or not ladybird_source_dir.is_dir():
+        try:
+            top_dir = subprocess.check_output(
+                [
+                    'git',
+                    'rev-parse',
+                    '--show-toplevel',
+                ],
+                text=True
+            ).strip()
+
+            ladybird_source_dir = Path(top_dir)
+            os.environ['LADYBIRD_SOURCE_DIR'] = str(ladybird_source_dir)
+        except subprocess.CalledProcessError as e:
+            _print_process_stderr(e, 'Unable to determine LADYBIRD_SOURCE_DIR:')
+            sys.exit(1)
+    return ladybird_source_dir
+
+
+def _build_main(build_dir, **kwargs):
+    build_args = [
+        'cmake',
+        '--build',
+        str(build_dir),
+        '--parallel',
+        os.environ.get('MAKEJOBS', str(multiprocessing.cpu_count())),
+    ]
+    build_target = kwargs.get('target', '')
+    if build_target:
+        build_args.extend([
+            '--target',
+            build_target,
+        ])
+    build_system_args = kwargs.get('args', [])
+    if build_system_args:
+        build_args.append('--')
+        build_args.extend(build_system_args)
+    try:
+        subprocess.check_call(build_args)
+    except subprocess.CalledProcessError as e:
+        msg = 'Unable to build ladybird '
+        if build_target:
+            msg += f'target "{build_target}"'
+        else:
+            msg += 'project'
+        _print_process_stderr(e, msg)
+        sys.exit(1)
+
+
+def _print_process_stderr(e, msg):
+    err_details = f': {e.stderr}' if e.stderr else ''
+    print(f'{msg}{err_details}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main(Platform())

--- a/Toolchain/__init__.py
+++ b/Toolchain/__init__.py
@@ -1,0 +1,1 @@
+# NOTE: Provided so ladybird.py can import the BuildVcpkg script as a module


### PR DESCRIPTION
WIP draft of the python script that can eventually replace `ladybird.sh`. There is Windows support, although there won't be a preset that will actually build successfully until https://github.com/LadybirdBrowser/ladybird/pull/4707 is sorted out.

To start there is just the `build`, but I will add the rest in subsequent commits, just putting up now so others can see it and give early feedback.

I also haven't fully tested configure yet on all platforms. So far, I've only done a full clean build and then ran `ctest` on my Mac Book as it is the fastest of my machines to build everything. A few JS/Wasm failures, so I'm probably missing something during config. For Linux/Windows so I just built with presets that were already configured.

So I'll still need to fix the JS/Wasm stuff and do full clean builds on Linux and Windows to completely test what I have so far, but I'll wait for initial thoughts/feedback about my first pass before doing that in case this implementation isn't what we want.

Test log from running `ctest` after the macOS clean build, All but JS/Wasm have passed so far:

[LastTest.log](https://github.com/user-attachments/files/20223485/LastTest.log)

[LastTestsFailed.log](https://github.com/user-attachments/files/20223489/LastTestsFailed.log)


Addresses https://github.com/LadybirdBrowser/ladybird/issues/4755


FYI @ADKaster 