### PR TITLE
Meta: Use human readable timestamp in WPT run folder name

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -486,6 +486,8 @@ run_wpt_chunked() {
     echo "Launching $procs chunked instances (concurrency=$concurrency each)"
     export LADYBIRD_GIT_VERSION
     local logs=()
+    local run_start_time
+    run_start_time=$(date +"%Y%m%d%H%M%S")
 
     for i in $(seq 0 $((procs - 1))); do
         local rundir runpath logpath
@@ -513,7 +515,7 @@ run_wpt_chunked() {
     show_files "${logs[@]}"
     wait
 
-    copy_results_to "${BUILD_DIR}/wpt-run-$(date +%s)" "$procs"
+    copy_results_to "${BUILD_DIR}/wpt-run-${run_start_time}" "$procs"
     show_summary "${logs[@]}"
 }
 


### PR DESCRIPTION
This makes it easier to figure out when a given run started.

Outputs timestamps like `20250515105535` instead of `1747302935`. Not sure how useful this is to anyone other than me, but I do find it occasionally useful to be able to tell at a glance what date a given WPT run is from.