### PR TITLE
CI: Do not install clang in the JS benchmarks workflow

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -36,10 +36,8 @@ jobs:
         if: ${{ matrix.os_name == 'Linux' }}
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang++-20 python3-venv
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-20 100
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
+          sudo apt-get update -y
+          sudo apt-get install -y python3-venv
 
       - name: 'Download JS repl artifact'
         id: download-artifact


### PR DESCRIPTION
It's not needed. This is primarily to reduce the number of places needed to be updated on the next clang rollout.

Benchmarks ran fine on my fork (up until the webhooks ofc):
https://github.com/trflynn89/ladybird/actions/runs/15049233245/job/42299552137