### PR TITLE
LibWeb: don't place cursor on certain <input> elements

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6306,9 +6306,12 @@ GC::Ptr<DOM::Position> Document::cursor_position() const
         return nullptr;
 
     Optional<HTML::FormAssociatedTextControlElement const&> target {};
-    if (is<HTML::HTMLInputElement>(*focused_element))
-        target = static_cast<HTML::HTMLInputElement const&>(*focused_element);
-    else if (is<HTML::HTMLTextAreaElement>(*focused_element))
+    if (auto const* input_element = as_if<HTML::HTMLInputElement>(*focused_element)) {
+        // Some types of <input> tags shouldn't have a cursor, like buttons
+        if (!input_element->can_have_text_editing_cursor())
+            return nullptr;
+        target = *input_element;
+    } else if (is<HTML::HTMLTextAreaElement>(*focused_element))
         target = static_cast<HTML::HTMLTextAreaElement const&>(*focused_element);
 
     if (target.has_value())

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1594,6 +1594,14 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_type(String const& type)
     return set_attribute(HTML::AttributeNames::type, type);
 }
 
+bool HTMLInputElement::can_have_text_editing_cursor() const
+{
+    if (first_is_one_of(type_state(), TypeAttributeState::SubmitButton, TypeAttributeState::ResetButton, TypeAttributeState::Button))
+        return false;
+
+    return true;
+}
+
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-simple-colour
 static bool is_valid_simple_color(StringView value)
 {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -106,6 +106,8 @@ public:
     bool indeterminate() const { return m_indeterminate; }
     void set_indeterminate(bool);
 
+    bool can_have_text_editing_cursor() const;
+
     GC::Ptr<HTMLDataListElement const> list() const;
 
     void did_pick_color(Optional<Color> picked_color, ColorPickerUpdateState state);


### PR DESCRIPTION
For example, button inputs shouldn't have a cursor displayed in their text since they're not editable, and are not meant to be editable.

Fixes #4140

I've decided to create a method that can tell Document if this element really needs a cursor or not, but I'm open to discussing and implementing alternative approaches.