### PR TITLE
LibWeb/IDB: Use operator overloads for key compares

### DIFF
--- a/Libraries/LibWeb/IndexedDB/IDBCursor.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBCursor.cpp
@@ -139,13 +139,11 @@ WebIDL::ExceptionOr<void> IDBCursor::continue_(JS::Value key)
         key_value = r;
 
         // 4. If key is less than or equal to this's position and this's direction is "next" or "nextunique", then throw a "DataError" DOMException.
-        auto is_less_than_or_equal_to = Key::less_than(*key_value, *this->position()) || Key::equals(*key_value, *this->position());
-        if (is_less_than_or_equal_to && (m_direction == Bindings::IDBCursorDirection::Next || m_direction == Bindings::IDBCursorDirection::Nextunique))
+        if (*key_value <= *this->position() && (m_direction == Bindings::IDBCursorDirection::Next || m_direction == Bindings::IDBCursorDirection::Nextunique))
             return WebIDL::DataError::create(realm, "Key is less than or equal to cursor's position"_string);
 
         // 5. If key is greater than or equal to this's position and this's direction is "prev" or "prevunique", then throw a "DataError" DOMException.
-        auto is_greater_than_or_equal_to = Key::greater_than(*key_value, *this->position()) || Key::equals(*key_value, *this->position());
-        if (is_greater_than_or_equal_to && (m_direction == Bindings::IDBCursorDirection::Prev || m_direction == Bindings::IDBCursorDirection::Prevunique))
+        if (*key_value >= *this->position() && (m_direction == Bindings::IDBCursorDirection::Prev || m_direction == Bindings::IDBCursorDirection::Prevunique))
             return WebIDL::DataError::create(realm, "Key is greater than or equal to cursor's position"_string);
     }
 
@@ -287,19 +285,19 @@ WebIDL::ExceptionOr<void> IDBCursor::continue_primary_key(JS::Value key_param, J
     auto primary_key = r;
 
     // 13. If key is less than this’s position and this’s direction is "next", throw a "DataError" DOMException.
-    if (Key::less_than(*key, *this->position()) && m_direction == Bindings::IDBCursorDirection::Next)
+    if (*key < *this->position() && m_direction == Bindings::IDBCursorDirection::Next)
         return WebIDL::DataError::create(realm, "Key is less than cursor's position"_string);
 
     // 14. If key is greater than this’s position and this’s direction is "prev", throw a "DataError" DOMException.
-    if (Key::greater_than(*key, *this->position()) && m_direction == Bindings::IDBCursorDirection::Prev)
+    if (*key > *this->position() && m_direction == Bindings::IDBCursorDirection::Prev)
         return WebIDL::DataError::create(realm, "Key is greater than cursor's position"_string);
 
     // 15. If key is equal to this’s position and primaryKey is less than or equal to this’s object store position and this’s direction is "next", throw a "DataError" DOMException.
-    if (Key::equals(*key, *this->position()) && (Key::less_than(*primary_key, *this->object_store_position()) || Key::equals(*primary_key, *this->object_store_position())) && m_direction == Bindings::IDBCursorDirection::Next)
+    if (*key == *this->position() && *primary_key <= *this->object_store_position() && m_direction == Bindings::IDBCursorDirection::Next)
         return WebIDL::DataError::create(realm, "Key is equal to cursor's position"_string);
 
     // 16. If key is equal to this’s position and primaryKey is greater than or equal to this’s object store position and this’s direction is "prev", throw a "DataError" DOMException.
-    if (Key::equals(*key, *this->position()) && (Key::greater_than(*primary_key, *this->object_store_position()) || Key::equals(*primary_key, *this->object_store_position())) && m_direction == Bindings::IDBCursorDirection::Prev)
+    if (*key == *this->position() && *primary_key >= *this->object_store_position() && m_direction == Bindings::IDBCursorDirection::Prev)
         return WebIDL::DataError::create(realm, "Key is equal to cursor's position"_string);
 
     // 17. Set this’s got value flag to false.
@@ -386,7 +384,7 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBCursor::update(JS::Value value)
         if (kpk_value->is_invalid())
             return WebIDL::DataError::create(realm, "Key path is invalid"_string);
 
-        if (!Key::equals(*kpk_value, *this->effective_key()))
+        if (*kpk_value != *this->effective_key())
             return WebIDL::DataError::create(realm, "Key path is not equal to effective key"_string);
     }
 

--- a/Libraries/LibWeb/IndexedDB/IDBKeyRange.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBKeyRange.cpp
@@ -50,10 +50,10 @@ bool IDBKeyRange::is_in_range(GC::Ref<Key> key) const
     // A key is in a key range range if both of the following conditions are fulfilled:
 
     // The range’s lower bound is null, or it is less than key, or it is both equal to key and the range’s lower open flag is false.
-    auto lower_bound_in_range = this->lower_key() == nullptr || Key::less_than(*this->lower_key(), key) || (Key::equals(key, *this->lower_key()) && !this->lower_open());
+    auto lower_bound_in_range = this->lower_key() == nullptr || *this->lower_key() < *key || (*key == *this->lower_key() && !this->lower_open());
 
     // The range’s upper bound is null, or it is greater than key, or it is both equal to key and the range’s upper open flag is false.
-    auto upper_bound_in_range = this->upper_key() == nullptr || Key::greater_than(*this->upper_key(), key) || (Key::equals(key, *this->upper_key()) && !this->upper_open());
+    auto upper_bound_in_range = this->upper_key() == nullptr || *this->upper_key() > *key || (*key == *this->upper_key() && !this->upper_open());
 
     return lower_bound_in_range && upper_bound_in_range;
 }
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<GC::Ref<IDBKeyRange>> IDBKeyRange::bound(JS::VM& vm, JS::Val
         return WebIDL::DataError::create(realm, "Value is invalid"_string);
 
     // 5. If lowerKey is greater than upperKey, throw a "DataError" DOMException.
-    if (Key::less_than(upper_key, lower_key))
+    if (*lower_key > *upper_key)
         return WebIDL::DataError::create(realm, "Lower key is greater than upper key"_string);
 
     // 6. Create and return a new key range with lower bound set to lowerKey, lower open flag set to lowerOpen, upper bound set to upperKey and upper open flag set to upperOpen.

--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -1546,7 +1546,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto is_greater_than_or_equal = record.visit(
                 [](Empty) { VERIFY_NOT_REACHED(); },
                 [key](auto const& inner_record) {
-                    return Key::greater_than(inner_record.key, *key) || Key::equals(inner_record.key, *key);
+                    return *inner_record.key >= *key;
                 });
 
             if (!is_greater_than_or_equal)
@@ -1558,11 +1558,11 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto const& inner_record = record.get<IndexRecord>();
 
             // * the record’s key is equal to key and the record’s value is greater than or equal to primaryKey,
-            if (!(Key::equals(inner_record.key, *key) && (Key::greater_than(inner_record.value, *primary_key) || Key::equals(inner_record.value, *primary_key))))
+            if (!(*inner_record.key == *key && *inner_record.value >= *primary_key))
                 return false;
 
             // * or the record’s key is greater than key.
-            if (!Key::greater_than(inner_record.key, *key))
+            if (!(*inner_record.key > *key))
                 return false;
         }
 
@@ -1571,7 +1571,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto const& inner_record = record.get<Record>();
 
             // * the record’s key is greater than position.
-            if (!Key::greater_than(inner_record.key, *position))
+            if (!(*inner_record.key > *position))
                 return false;
         }
 
@@ -1580,11 +1580,11 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto const& inner_record = record.get<IndexRecord>();
 
             // * the record’s key is equal to position and the record’s value is greater than object store position
-            if (!(Key::equals(inner_record.key, *position) && (Key::greater_than(inner_record.value, *object_store_position))))
+            if (!(*inner_record.key == *position || *inner_record.value <= *object_store_position))
                 return false;
 
             // * or the record’s key is greater than position.
-            if (!Key::greater_than(inner_record.key, *position))
+            if (!(*inner_record.key > *position))
                 return false;
         }
 
@@ -1605,7 +1605,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto is_greater_than_or_equal = record.visit(
                 [](Empty) { VERIFY_NOT_REACHED(); },
                 [key](auto const& inner_record) {
-                    return Key::greater_than(inner_record.key, *key) || Key::equals(inner_record.key, *key);
+                    return *inner_record.key >= *key;
                 });
 
             if (!is_greater_than_or_equal)
@@ -1618,7 +1618,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto is_greater_than_position = record.visit(
                 [](Empty) { VERIFY_NOT_REACHED(); },
                 [position](auto const& inner_record) {
-                    return Key::greater_than(inner_record.key, *position) || Key::equals(inner_record.key, *position);
+                    return *inner_record.key > *position;
                 });
 
             if (!is_greater_than_position)
@@ -1642,7 +1642,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto is_less_than_or_equal = record.visit(
                 [](Empty) { VERIFY_NOT_REACHED(); },
                 [key](auto const& inner_record) {
-                    return Key::less_than(inner_record.key, *key) || Key::equals(inner_record.key, *key);
+                    return *inner_record.key <= *key;
                 });
 
             if (!is_less_than_or_equal)
@@ -1654,11 +1654,11 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto const& inner_record = record.get<IndexRecord>();
 
             // * the record’s key is equal to key and the record’s value is less than or equal to primaryKey,
-            if (!(Key::equals(inner_record.key, *key) && (Key::less_than(inner_record.value, *primary_key) || Key::equals(inner_record.value, *primary_key))))
+            if (!(*inner_record.key == *key && *inner_record.value <= *primary_key))
                 return false;
 
             // * or the record’s key is less than key.
-            if (!Key::less_than(inner_record.key, *key))
+            if (!(*inner_record.key < *key))
                 return false;
         }
 
@@ -1667,7 +1667,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto const& inner_record = record.get<Record>();
 
             // * the record’s key is less than position.
-            if (!Key::less_than(inner_record.key, *position))
+            if (!(*inner_record.key < *position))
                 return false;
         }
 
@@ -1676,11 +1676,11 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto const& inner_record = record.get<IndexRecord>();
 
             // * the record’s key is equal to position and the record’s value is less than object store position
-            if (!(Key::equals(inner_record.key, *position) && Key::less_than(inner_record.value, *object_store_position)))
+            if (!(*inner_record.key == *position && *inner_record.value < *object_store_position))
                 return false;
 
             // * or the record’s key is less than position.
-            if (!Key::less_than(inner_record.key, *position))
+            if (!(*inner_record.key < *position))
                 return false;
         }
 
@@ -1701,7 +1701,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto is_less_than_or_equal = record.visit(
                 [](Empty) { VERIFY_NOT_REACHED(); },
                 [key](auto const& inner_record) {
-                    return Key::less_than(inner_record.key, *key) || Key::equals(inner_record.key, *key);
+                    return *inner_record.key <= *key;
                 });
 
             if (!is_less_than_or_equal)
@@ -1714,7 +1714,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
             auto is_less_than_position = record.visit(
                 [](Empty) { VERIFY_NOT_REACHED(); },
                 [position](auto const& inner_record) {
-                    return Key::less_than(inner_record.key, *position) || Key::equals(inner_record.key, *position);
+                    return *inner_record.key < *position;
                 });
 
             if (!is_less_than_position)
@@ -1788,7 +1788,7 @@ GC::Ptr<IDBCursor> iterate_a_cursor(JS::Realm& realm, GC::Ref<IDBCursor> cursor,
 
                 found_record = records.visit([&](auto content) -> Variant<Empty, Record, IndexRecord> {
                     auto value = content.first_matching([&](auto const& content_record) {
-                        return Key::equals(content_record.key, temp_record_key);
+                        return *content_record.key == *temp_record_key;
                     });
                     if (value.has_value())
                         return *value;

--- a/Libraries/LibWeb/IndexedDB/Internal/Index.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Index.cpp
@@ -52,7 +52,7 @@ void Index::set_name(String name)
 bool Index::has_record_with_key(GC::Ref<Key> key)
 {
     auto index = m_records.find_if([&key](auto const& record) {
-        return Key::equals(record.key, key);
+        return *record.key == *key;
     });
 
     return index != m_records.end();
@@ -66,7 +66,7 @@ HTML::SerializationRecord Index::referenced_value(IndexRecord const& index_recor
     return m_object_store
         ->records()
         .first_matching([&](auto const& store_record) {
-            return Key::equals(store_record.key, index_record.value);
+            return *store_record.key == *index_record.value;
         })
         .value()
         .value;

--- a/Libraries/LibWeb/IndexedDB/Internal/Key.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Key.h
@@ -14,6 +14,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <compare>
 
 namespace Web::IndexedDB {
 
@@ -66,9 +67,21 @@ public:
     [[nodiscard]] static GC::Ref<Key> create_invalid(JS::Realm& realm, AK::String const& value) { return create(realm, Invalid, value); }
 
     [[nodiscard]] static i8 compare_two_keys(GC::Ref<Key> a, GC::Ref<Key> b);
-    [[nodiscard]] static bool equals(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) == 0; }
-    [[nodiscard]] static bool less_than(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) < 0; }
-    [[nodiscard]] static bool greater_than(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) > 0; }
+
+    bool operator==(Key& other)
+    {
+        return compare_two_keys(*this, other) == 0;
+    }
+
+    std::strong_ordering operator<=>(Key& other)
+    {
+        auto value = compare_two_keys(*this, other);
+        if (value == 0)
+            return std::strong_ordering::equal;
+        if (value < 0)
+            return std::strong_ordering::less;
+        return std::strong_ordering::greater;
+    }
 
 private:
     Key(KeyType type, KeyValue value)

--- a/Libraries/LibWeb/IndexedDB/Internal/ObjectStore.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/ObjectStore.cpp
@@ -51,7 +51,7 @@ void ObjectStore::remove_records_in_range(GC::Ref<IDBKeyRange> range)
 bool ObjectStore::has_record_with_key(GC::Ref<Key> key)
 {
     auto index = m_records.find_if([&key](auto const& record) {
-        return Key::equals(key, record.key);
+        return *key == *record.key;
     });
 
     return index != m_records.end();
@@ -63,7 +63,7 @@ void ObjectStore::store_a_record(Record const& record)
 
     // NOTE: The record is stored in the object store’s list of records such that the list is sorted according to the key of the records in ascending order.
     AK::quick_sort(m_records, [](auto const& a, auto const& b) {
-        return Key::compare_two_keys(a.key, b.key) < 0;
+        return *a.key < *b.key;
     });
 }
 


### PR DESCRIPTION
Makes the code read a lot better imo.

A slight foot-gun that `Ref<T> < Ref<T>` doesnt pass the compare onto `T < T`. (so its important to do work on the `ptr()`)