### PR TITLE
LibWeb: Do not override whitespace handling for editable elements

### DIFF
--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -339,9 +339,6 @@ void TextNode::compute_text_for_rendering()
         VERIFY_NOT_REACHED();
     }(computed_values().white_space());
 
-    if (dom_node().is_editable() && !dom_node().is_uninteresting_whitespace_node())
-        collapse = false;
-
     auto parent_element = dom_node().parent_element();
     auto const maybe_lang = parent_element ? parent_element->lang() : Optional<String> {};
     auto const lang = maybe_lang.has_value() ? maybe_lang.value() : Optional<StringView> {};

--- a/Tests/LibWeb/Layout/expected/text-collapse-inside-contenteditable.txt
+++ b/Tests/LibWeb/Layout/expected/text-collapse-inside-contenteditable.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x18 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x18 children: inline
+        frag 0 from TextNode start: 0, length: 7, rect: [8,8 62.796875x18] baseline: 13.796875
+            "foo bar"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,26) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x18]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]

--- a/Tests/LibWeb/Layout/input/text-collapse-inside-contenteditable.html
+++ b/Tests/LibWeb/Layout/input/text-collapse-inside-contenteditable.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div contenteditable>foo
+bar</div>

--- a/Tests/LibWeb/Text/expected/selectionchange-event.txt
+++ b/Tests/LibWeb/Text/expected/selectionchange-event.txt
@@ -1,4 +1,4 @@
 Events:
+selectionchange anchorNode=<#text > anchorOffset=0 type=Caret focusNode=<#text > focusOffset=0 isCollapsed=true
 selectionchange anchorNode=<#text > anchorOffset=1 type=Caret focusNode=<#text > focusOffset=1 isCollapsed=true
 selectionchange anchorNode=<#text > anchorOffset=1 type=Caret focusNode=<#text > focusOffset=1 isCollapsed=true
-selectionchange anchorNode=<#text > anchorOffset=2 type=Caret focusNode=<#text > focusOffset=2 isCollapsed=true

--- a/Tests/LibWeb/Text/input/selectionchange-event.html
+++ b/Tests/LibWeb/Text/input/selectionchange-event.html
@@ -31,8 +31,6 @@
             );
         });
 
-        const editable = document.getElementById("editable");
-
         println("Events:");
 
         internals.click(20, 10);


### PR DESCRIPTION
This condition no longer seems to be necessary for anything, and it caused newlines to not render correctly in editable nodes.

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/71014966-f9ad-49d2-a306-38b929c0cda3) | ![image](https://github.com/user-attachments/assets/2a024862-2ac8-45be-a84c-214e294c7c46) |

Screenshots show the result for this snippet:
```html
<!DOCTYPE html>
<div contenteditable>abc
def</div>
```