### PR TITLE
LibWeb/CSS: Implement CSSPageRule.setSelectorText()

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -116,6 +116,7 @@ set(SOURCES
     CSS/MediaQueryList.cpp
     CSS/MediaQueryListEvent.cpp
     CSS/Number.cpp
+    CSS/PageSelector.cpp
     CSS/ParsedFontFace.cpp
     CSS/Parser/ComponentValue.cpp
     CSS/Parser/DescriptorParsing.cpp

--- a/Libraries/LibWeb/CSS/CSSPageRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSPageRule.cpp
@@ -15,50 +15,6 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSPageRule);
 
-Optional<PagePseudoClass> page_pseudo_class_from_string(StringView input)
-{
-    if (input.equals_ignoring_ascii_case("blank"sv))
-        return PagePseudoClass::Blank;
-    if (input.equals_ignoring_ascii_case("first"sv))
-        return PagePseudoClass::First;
-    if (input.equals_ignoring_ascii_case("left"sv))
-        return PagePseudoClass::Left;
-    if (input.equals_ignoring_ascii_case("right"sv))
-        return PagePseudoClass::Right;
-    return {};
-}
-
-StringView to_string(PagePseudoClass pseudo_class)
-{
-    switch (pseudo_class) {
-    case PagePseudoClass::Blank:
-        return "blank"sv;
-    case PagePseudoClass::First:
-        return "first"sv;
-    case PagePseudoClass::Left:
-        return "left"sv;
-    case PagePseudoClass::Right:
-        return "right"sv;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-PageSelector::PageSelector(Optional<FlyString> name, Vector<PagePseudoClass> pseudo_classes)
-    : m_name(move(name))
-    , m_pseudo_classes(move(pseudo_classes))
-{
-}
-
-String PageSelector::serialize() const
-{
-    StringBuilder builder;
-    if (m_name.has_value())
-        builder.append(m_name.value());
-    for (auto pseudo_class : m_pseudo_classes)
-        builder.appendff(":{}", to_string(pseudo_class));
-    return builder.to_string_without_validation();
-}
-
 GC::Ref<CSSPageRule> CSSPageRule::create(JS::Realm& realm, PageSelectorList&& selectors, GC::Ref<CSSPageDescriptors> style, CSSRuleList& rules)
 {
     return realm.create<CSSPageRule>(realm, move(selectors), style, rules);

--- a/Libraries/LibWeb/CSS/CSSPageRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSPageRule.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSPageRule.h>
 #include <LibWeb/CSS/DescriptorID.h>
+#include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -45,12 +46,17 @@ String CSSPageRule::selector_text() const
 }
 
 // https://drafts.csswg.org/cssom/#dom-csspagerule-selectortext
-void CSSPageRule::set_selector_text(StringView)
+void CSSPageRule::set_selector_text(StringView text)
 {
-    // FIXME: On setting the selectorText attribute these steps must be run:
-    //  1. Run the parse a list of CSS page selectors algorithm on the given value.
-    //  2. If the algorithm returns a non-null value replace the associated selector list with the returned value.
-    //  3. Otherwise, if the algorithm returns a null value, do nothing.
+    // On setting the selectorText attribute these steps must be run:
+    // 1. Run the parse a list of CSS page selectors algorithm on the given value.
+    auto page_selector_list = parse_page_selector_list(Parser::ParsingParams {}, text);
+
+    // 2. If the algorithm returns a non-null value replace the associated selector list with the returned value.
+    if (page_selector_list.has_value())
+        m_selectors = page_selector_list.release_value();
+
+    // 3. Otherwise, if the algorithm returns a null value, do nothing.
 }
 
 // https://drafts.csswg.org/cssom/#ref-for-csspagerule

--- a/Libraries/LibWeb/CSS/CSSPageRule.h
+++ b/Libraries/LibWeb/CSS/CSSPageRule.h
@@ -8,31 +8,9 @@
 
 #include <LibWeb/CSS/CSSGroupingRule.h>
 #include <LibWeb/CSS/CSSPageDescriptors.h>
+#include <LibWeb/CSS/PageSelector.h>
 
 namespace Web::CSS {
-
-enum class PagePseudoClass : u8 {
-    Left,
-    Right,
-    First,
-    Blank,
-};
-Optional<PagePseudoClass> page_pseudo_class_from_string(StringView);
-StringView to_string(PagePseudoClass);
-
-class PageSelector {
-public:
-    PageSelector(Optional<FlyString> name, Vector<PagePseudoClass>);
-
-    Optional<FlyString> name() const { return m_name; }
-    Vector<PagePseudoClass> const& pseudo_classes() const { return m_pseudo_classes; }
-    String serialize() const;
-
-private:
-    Optional<FlyString> m_name;
-    Vector<PagePseudoClass> m_pseudo_classes;
-};
-using PageSelectorList = Vector<PageSelector>;
 
 // https://drafts.csswg.org/css-page-3/#at-ruledef-page
 class CSSPageRule final : public CSSGroupingRule {

--- a/Libraries/LibWeb/CSS/PageSelector.cpp
+++ b/Libraries/LibWeb/CSS/PageSelector.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/PageSelector.h>
+
+namespace Web::CSS {
+
+Optional<PagePseudoClass> page_pseudo_class_from_string(StringView input)
+{
+    if (input.equals_ignoring_ascii_case("blank"sv))
+        return PagePseudoClass::Blank;
+    if (input.equals_ignoring_ascii_case("first"sv))
+        return PagePseudoClass::First;
+    if (input.equals_ignoring_ascii_case("left"sv))
+        return PagePseudoClass::Left;
+    if (input.equals_ignoring_ascii_case("right"sv))
+        return PagePseudoClass::Right;
+    return {};
+}
+
+StringView to_string(PagePseudoClass pseudo_class)
+{
+    switch (pseudo_class) {
+    case PagePseudoClass::Blank:
+        return "blank"sv;
+    case PagePseudoClass::First:
+        return "first"sv;
+    case PagePseudoClass::Left:
+        return "left"sv;
+    case PagePseudoClass::Right:
+        return "right"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+PageSelector::PageSelector(Optional<FlyString> name, Vector<PagePseudoClass> pseudo_classes)
+    : m_name(move(name))
+    , m_pseudo_classes(move(pseudo_classes))
+{
+}
+
+String PageSelector::serialize() const
+{
+    StringBuilder builder;
+    if (m_name.has_value())
+        builder.append(m_name.value());
+    for (auto pseudo_class : m_pseudo_classes)
+        builder.appendff(":{}", to_string(pseudo_class));
+    return builder.to_string_without_validation();
+}
+
+}

--- a/Libraries/LibWeb/CSS/PageSelector.h
+++ b/Libraries/LibWeb/CSS/PageSelector.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <AK/Optional.h>
+#include <AK/Vector.h>
+
+namespace Web::CSS {
+
+enum class PagePseudoClass : u8 {
+    Left,
+    Right,
+    First,
+    Blank,
+};
+Optional<PagePseudoClass> page_pseudo_class_from_string(StringView);
+StringView to_string(PagePseudoClass);
+
+class PageSelector {
+public:
+    PageSelector(Optional<FlyString> name, Vector<PagePseudoClass>);
+
+    Optional<FlyString> name() const { return m_name; }
+    Vector<PagePseudoClass> const& pseudo_classes() const { return m_pseudo_classes; }
+    String serialize() const;
+
+private:
+    Optional<FlyString> m_name;
+    Vector<PagePseudoClass> m_pseudo_classes;
+};
+using PageSelectorList = Vector<PageSelector>;
+
+}

--- a/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -106,6 +106,11 @@ Optional<CSS::SelectorList> parse_selector_for_nested_style_rule(CSS::Parser::Pa
     return adapt_nested_relative_selector_list(*maybe_selectors);
 }
 
+Optional<CSS::PageSelectorList> parse_page_selector_list(CSS::Parser::ParsingParams const& params, StringView selector_text)
+{
+    return CSS::Parser::Parser::create(params, selector_text).parse_as_page_selector_list();
+}
+
 Optional<CSS::Selector::PseudoElementSelector> parse_pseudo_element_selector(CSS::Parser::ParsingParams const& context, StringView selector_text)
 {
     return CSS::Parser::Parser::create(context, selector_text).parse_as_pseudo_element_selector();

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -19,6 +19,7 @@
 #include <LibWeb/CSS/Descriptor.h>
 #include <LibWeb/CSS/DescriptorID.h>
 #include <LibWeb/CSS/MediaQuery.h>
+#include <LibWeb/CSS/PageSelector.h>
 #include <LibWeb/CSS/ParsedFontFace.h>
 #include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/Dimension.h>
@@ -117,6 +118,8 @@ public:
 
     Optional<Selector::PseudoElementSelector> parse_as_pseudo_element_selector();
 
+    Optional<PageSelectorList> parse_as_page_selector_list();
+
     Vector<NonnullRefPtr<MediaQuery>> parse_as_media_query_list();
     RefPtr<MediaQuery> parse_as_media_query();
 
@@ -187,6 +190,9 @@ private:
     };
     template<typename T>
     ParseErrorOr<SelectorList> parse_a_selector_list(TokenStream<T>&, SelectorType, SelectorParsingMode = SelectorParsingMode::Standard);
+
+    template<typename T>
+    ParseErrorOr<PageSelectorList> parse_a_page_selector_list(TokenStream<T>&);
 
     template<typename T>
     Vector<NonnullRefPtr<MediaQuery>> parse_a_media_query_list(TokenStream<T>&);
@@ -523,6 +529,7 @@ RefPtr<CSS::CSSStyleValue const> parse_css_value(CSS::Parser::ParsingParams cons
 RefPtr<CSS::CSSStyleValue const> parse_css_descriptor(CSS::Parser::ParsingParams const&, CSS::AtRuleID, CSS::DescriptorID, StringView);
 Optional<CSS::SelectorList> parse_selector(CSS::Parser::ParsingParams const&, StringView);
 Optional<CSS::SelectorList> parse_selector_for_nested_style_rule(CSS::Parser::ParsingParams const&, StringView);
+Optional<CSS::PageSelectorList> parse_page_selector_list(CSS::Parser::ParsingParams const&, StringView);
 Optional<CSS::Selector::PseudoElementSelector> parse_pseudo_element_selector(CSS::Parser::ParsingParams const&, StringView);
 CSS::CSSRule* parse_css_rule(CSS::Parser::ParsingParams const&, StringView);
 RefPtr<CSS::MediaQuery> parse_media_query(CSS::Parser::ParsingParams const&, StringView);

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -639,74 +639,13 @@ GC::Ptr<CSSFontFaceRule> Parser::convert_to_font_face_rule(AtRule const& rule)
     return CSSFontFaceRule::create(realm(), CSSFontFaceDescriptors::create(realm(), descriptors.release_descriptors()));
 }
 
-static Optional<PageSelectorList> parse_page_selector_list(Vector<ComponentValue> const& component_values)
-{
-    // https://drafts.csswg.org/css-page-3/#syntax-page-selector
-    // <page-selector-list> = <page-selector>#
-    // <page-selector> = [ <ident-token>? <pseudo-page>* ]!
-    // <pseudo-page> = : [ left | right | first | blank ]
-
-    PageSelectorList selector_list;
-
-    TokenStream tokens { component_values };
-    tokens.discard_whitespace();
-
-    while (tokens.has_next_token()) {
-        // First optional ident
-        Optional<FlyString> maybe_ident;
-        if (tokens.next_token().is(Token::Type::Ident))
-            maybe_ident = tokens.consume_a_token().token().ident();
-
-        // Then an optional series of pseudo-classes
-        Vector<PagePseudoClass> pseudo_classes;
-        while (tokens.next_token().is(Token::Type::Colon)) {
-            tokens.discard_a_token(); // :
-            if (!tokens.next_token().is(Token::Type::Ident)) {
-                dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: pseudo-class is not an ident: `{}`", tokens.next_token().to_debug_string());
-                return {};
-            }
-            auto pseudo_class_name = tokens.consume_a_token().token().ident();
-            if (auto pseudo_class = page_pseudo_class_from_string(pseudo_class_name); pseudo_class.has_value()) {
-                pseudo_classes.append(*pseudo_class);
-            } else {
-                dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: unrecognized pseudo-class `:{}`", pseudo_class_name);
-                return {};
-            }
-        }
-
-        if (!maybe_ident.has_value() && pseudo_classes.is_empty()) {
-            // Nothing parsed
-            dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: is empty");
-            return {};
-        }
-
-        selector_list.empend(move(maybe_ident), move(pseudo_classes));
-
-        tokens.discard_whitespace();
-
-        if (tokens.next_token().is(Token::Type::Comma)) {
-            tokens.discard_a_token(); // ,
-            tokens.discard_whitespace();
-            if (!tokens.has_next_token()) {
-                dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: trailing comma");
-                return {};
-            }
-
-        } else if (tokens.has_next_token()) {
-            dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: trailing token `{}`", tokens.next_token().to_debug_string());
-            return {};
-        }
-    }
-
-    return selector_list;
-}
-
 GC::Ptr<CSSPageRule> Parser::convert_to_page_rule(AtRule const& page_rule)
 {
     // https://drafts.csswg.org/css-page-3/#syntax-page-selector
     // @page = @page <page-selector-list>? { <declaration-rule-list> }
-    auto page_selectors = parse_page_selector_list(page_rule.prelude);
-    if (!page_selectors.has_value())
+    TokenStream tokens { page_rule.prelude };
+    auto page_selectors = parse_a_page_selector_list(tokens);
+    if (page_selectors.is_error())
         return nullptr;
 
     GC::RootVector<GC::Ref<CSSRule>> child_rules { realm().heap() };

--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -1145,4 +1145,76 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     return syntax_error();
 }
 
+Optional<PageSelectorList> Parser::parse_as_page_selector_list()
+{
+    auto selector_list = parse_a_page_selector_list(m_token_stream);
+    if (!selector_list.is_error())
+        return selector_list.release_value();
+    return {};
+}
+
+template<typename T>
+Parser::ParseErrorOr<PageSelectorList> Parser::parse_a_page_selector_list(TokenStream<T>& tokens)
+{
+    // https://drafts.csswg.org/css-page-3/#syntax-page-selector
+    // <page-selector-list> = <page-selector>#
+    // <page-selector> = [ <ident-token>? <pseudo-page>* ]!
+    // <pseudo-page> = : [ left | right | first | blank ]
+
+    PageSelectorList selector_list;
+
+    tokens.discard_whitespace();
+
+    while (tokens.has_next_token()) {
+        // First optional ident
+        Optional<FlyString> maybe_ident;
+        if (tokens.next_token().is(Token::Type::Ident))
+            maybe_ident = static_cast<Token>(tokens.consume_a_token()).ident();
+
+        // Then an optional series of pseudo-classes
+        Vector<PagePseudoClass> pseudo_classes;
+        while (tokens.next_token().is(Token::Type::Colon)) {
+            tokens.discard_a_token(); // :
+            if (!tokens.next_token().is(Token::Type::Ident)) {
+                dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: pseudo-class is not an ident: `{}`", tokens.next_token().to_debug_string());
+                return ParseError::SyntaxError;
+            }
+            auto pseudo_class_name = static_cast<Token>(tokens.consume_a_token()).ident();
+            if (auto pseudo_class = page_pseudo_class_from_string(pseudo_class_name); pseudo_class.has_value()) {
+                pseudo_classes.append(*pseudo_class);
+            } else {
+                dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: unrecognized pseudo-class `:{}`", pseudo_class_name);
+                return ParseError::SyntaxError;
+            }
+        }
+
+        if (!maybe_ident.has_value() && pseudo_classes.is_empty()) {
+            // Nothing parsed
+            dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: is empty");
+            return ParseError::SyntaxError;
+        }
+
+        selector_list.empend(move(maybe_ident), move(pseudo_classes));
+
+        tokens.discard_whitespace();
+
+        if (tokens.next_token().is(Token::Type::Comma)) {
+            tokens.discard_a_token(); // ,
+            tokens.discard_whitespace();
+            if (!tokens.has_next_token()) {
+                dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: trailing comma");
+                return ParseError::SyntaxError;
+            }
+
+        } else if (tokens.has_next_token()) {
+            dbgln_if(CSS_PARSER_DEBUG, "Invalid @page selector: trailing token `{}`", tokens.next_token().to_debug_string());
+            return ParseError::SyntaxError;
+        }
+    }
+
+    return selector_list;
+}
+template Parser::ParseErrorOr<PageSelectorList> Parser::parse_a_page_selector_list(TokenStream<ComponentValue>&);
+template Parser::ParseErrorOr<PageSelectorList> Parser::parse_a_page_selector_list(TokenStream<Token>&);
+
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssom-pagerule.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/cssom-pagerule.txt
@@ -1,0 +1,27 @@
+Harness status: OK
+
+Found 22 tests
+
+22 Pass
+Pass	Sanity checks
+Pass	Page selector is initially the empty string
+Pass	Page selector 'cssText' is initially the @page { }
+Pass	Set selectorText to :left pseudo page
+Pass	Set cssText to :left pseudo page
+Pass	Set selectorText to named page
+Pass	Set cssText to named page
+Pass	Set selectorText to named page with :first pseudo page
+Pass	Set cssText to named page with :first pseudo page
+Pass	Set selectorText to named page with case insensitive :first pseudo page
+Pass	Set cssText to named page with case insensitive :first pseudo page
+Pass	Set selectorText to named page with two :first pseudo page
+Pass	Set cssText to named page with two :first pseudo page
+Pass	Set selectorText to named page with pseudo pages of :first, :left, :right, :first in order.
+Pass	Set cssText to named page with pseudo pages of :first, :left, :right, :first in order.
+Pass	Cannot set selectorText to named page with pseudo, whitespace between
+Pass	Cannot set cssText to named page with pseudo, whitespace between - return default @page { }
+Pass	Cannot set selectorText to two pseudos, whitespace between
+Pass	Cannot set cssText to two pseudos, whitespace between - return default @page { }
+Pass	Cannot set selectorText to invalid pseudo page
+Pass	Cannot set cssText to invalid pseudo page - return default @page { }
+Pass	Set selectorText to named page after rule was removed

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/cssom-pagerule.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/cssom-pagerule.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<title>CSSOM: CSSPageRule tests</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#the-csspagerule-interface" />
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  @page {}
+</style>
+<script>
+  const sheet = document.styleSheets[0];
+  const rule = sheet.cssRules[0];
+
+  test(() => {
+    assert_true(!!rule);
+    assert_equals(rule.type, CSSRule.PAGE_RULE);
+  }, "Sanity checks");
+
+  test(() => {
+    assert_equals(rule.selectorText, "");
+  }, "Page selector is initially the empty string");
+
+  test(() => {
+    assert_equals(rule.cssText, "@page { }");
+  }, "Page selector 'cssText' is initially the @page { }");
+
+  test(() => {
+    rule.selectorText = ":left";
+    assert_equals(rule.selectorText, ":left");
+  }, "Set selectorText to :left pseudo page");
+
+  test(() => {
+    rule.selectorText = ":left";
+    assert_equals(rule.cssText, "@page :left { }");
+  }, "Set cssText to :left pseudo page");
+
+  test(() => {
+    rule.selectorText = "named";
+    assert_equals(rule.selectorText, "named");
+  }, "Set selectorText to named page");
+
+  test(() => {
+    rule.selectorText = "named";
+    assert_equals(rule.cssText, "@page named { }");
+  }, "Set cssText to named page");
+
+  test(() => {
+    rule.selectorText = "named:first";
+    assert_equals(rule.selectorText, "named:first");
+  }, "Set selectorText to named page with :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:first";
+    assert_equals(rule.cssText, "@page named:first { }");
+  }, "Set cssText to named page with :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:First";
+    assert_equals(rule.selectorText, "named:first");
+  }, "Set selectorText to named page with case insensitive :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:First";
+    assert_equals(rule.cssText, "@page named:first { }");
+  }, "Set cssText to named page with case insensitive :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:first:first";
+    assert_equals(rule.selectorText, "named:first:first");
+  }, "Set selectorText to named page with two :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:first:first";
+    assert_equals(rule.cssText, "@page named:first:first { }");
+  }, "Set cssText to named page with two :first pseudo page");
+
+  test(() => {
+    rule.selectorText = "named:first:left:right:first";
+    assert_equals(rule.selectorText, "named:first:left:right:first");
+  }, "Set selectorText to named page with pseudo pages of " +
+    ":first, :left, :right, :first in order.");
+
+    test(() => {
+    rule.selectorText = "named:first:left:right:first";
+    assert_equals(rule.cssText, "@page named:first:left:right:first { }");
+  }, "Set cssText to named page with pseudo pages of " +
+    ":first, :left, :right, :first in order.");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = "named :first";
+    assert_equals(rule.selectorText, "");
+  }, "Cannot set selectorText to named page with pseudo, whitespace between");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = "named :first";
+    assert_equals(rule.cssText, "@page { }");
+  }, "Cannot set cssText to named page with pseudo, whitespace between - return default @page { }");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = ":first :left";
+    assert_equals(rule.selectorText, "");
+  }, "Cannot set selectorText to two pseudos, whitespace between");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = ":first :left";
+    assert_equals(rule.cssText, "@page { }");
+  }, "Cannot set cssText to two pseudos, whitespace between - return default @page { }");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = ":notapagepseudo";
+    assert_equals(rule.selectorText, "");
+  }, "Cannot set selectorText to invalid pseudo page");
+
+  test(() => {
+    rule.selectorText = "";
+    rule.selectorText = ":notapagepseudo";
+    assert_equals(rule.cssText, "@page { }");
+  }, "Cannot set cssText to invalid pseudo page - return default @page { }");
+
+  test(() => {
+    assert_equals(rule.parentStyleSheet, sheet);
+    sheet.deleteRule(0);
+    assert_equals(rule.parentStyleSheet, null);
+    rule.selectorText = "pagename";
+  }, "Set selectorText to named page after rule was removed");
+</script>


### PR DESCRIPTION
Most of the diff here is moving code around. I managed to forget about the FIXME when I first implemented `@page`, otherwise I would have put things in the right place to begin with. :sweat_smile: 