### PR TITLE
LibWeb+Tests: Continue variable expansion if CSS-wide keyword is parsed

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -4051,6 +4051,9 @@ bool Parser::expand_variables(DOM::Element& element, Optional<PseudoElement> pse
     };
 
     while (source.has_next_token()) {
+        // FIXME: We should properly cascade here instead of doing a basic fallback for CSS-wide keywords.
+        if (auto builtin_value = parse_builtin_value(source))
+            continue;
         auto const& value = source.consume_a_token();
         if (value.is_block()) {
             auto const& source_block = value.block();

--- a/Tests/LibWeb/Ref/expected/css-custom-prop-fallback-ref.html
+++ b/Tests/LibWeb/Ref/expected/css-custom-prop-fallback-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+    body {
+        background-color: crimson;
+    }
+</style>
+<body></body>

--- a/Tests/LibWeb/Ref/input/css-custom-prop-fallback.html
+++ b/Tests/LibWeb/Ref/input/css-custom-prop-fallback.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/css-custom-prop-fallback-ref.html" />
+<style>
+    :root {
+        --a: initial;
+    }
+
+    body {
+        background-color: var(--a, crimson);
+    }
+</style>
+<body></body>


### PR DESCRIPTION
This allows the existing fallback logic in `Parser::expand_variables` to run when a CSS-wide keyword is encountered.

Fixes #1157 