### PR TITLE
LibWeb: Don't claim that inline layout nodes can contain abspos elements

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -76,6 +76,9 @@ bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
 
 bool Node::can_contain_boxes_with_position_absolute() const
 {
+    if (!is<Box>(*this))
+        return false;
+
     if (computed_values().position() != CSS::Positioning::Static)
         return true;
 

--- a/Tests/LibWeb/Layout/expected/abspos-static-position-containing-block-inline-situation.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-static-position-containing-block-inline-situation.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x18 [BFC] children: inline
+    InlineNode <body>
+      frag 0 from TextNode start: 0, length: 5, rect: [8,0 36.84375x18] baseline: 13.796875
+          "hello"
+      frag 1 from BlockContainer start: 0, length: 0, rect: [8,13 0x0] baseline: 0
+      BlockContainer <main> at (8,13) content-size 0x0 inline-block [BFC] children: not-inline
+        BlockContainer <div> at (8,0) content-size 36.84375x18 positioned [BFC] children: inline
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x18]
+    PaintableWithLines (InlineNode<BODY>)
+      PaintableWithLines (BlockContainer<MAIN>) [8,13 0x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,0 36.84375x18]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/abspos-static-position-containing-block-inline-situation.html
+++ b/Tests/LibWeb/Layout/input/abspos-static-position-containing-block-inline-situation.html
@@ -1,0 +1,12 @@
+<!doctype html><style>
+body {
+    display: inline;
+    position: relative;
+}
+main {
+    display: inline-block;
+}
+div {
+    position: absolute;
+}
+</style><body><main><div>hello


### PR DESCRIPTION
We assume elsewhere that any abspos element's containing block must be some kind of Layout::Box, so let's enforce that when deciding if a box can be such a container.

This fixes a bad downcast on https://serpapi.com/