### PR TITLE
LibWeb: Start integrating the editing API with user input

### DIFF
--- a/Libraries/LibWeb/DOM/EditingHostManager.h
+++ b/Libraries/LibWeb/DOM/EditingHostManager.h
@@ -25,7 +25,7 @@ public:
 
     virtual void handle_insert(String const&) override;
     virtual void handle_delete(DeleteDirection) override;
-    virtual EventResult handle_return_key() override;
+    virtual EventResult handle_return_key(FlyString const& ui_input_type) override;
     virtual void select_all() override;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) override;
     virtual void set_selection_focus(GC::Ref<DOM::Node>, size_t offset) override;

--- a/Libraries/LibWeb/DOM/InputEventsTarget.h
+++ b/Libraries/LibWeb/DOM/InputEventsTarget.h
@@ -19,7 +19,7 @@ public:
     virtual GC::Ref<JS::Cell> as_cell() = 0;
 
     virtual void handle_insert(String const&) = 0;
-    virtual EventResult handle_return_key() = 0;
+    virtual EventResult handle_return_key(FlyString const& ui_input_type) = 0;
 
     enum class DeleteDirection {
         Backward,

--- a/Libraries/LibWeb/Editing/CommandNames.h
+++ b/Libraries/LibWeb/Editing/CommandNames.h
@@ -40,6 +40,7 @@ namespace Web::Editing::CommandNames {
     __ENUMERATE_COMMAND_NAME(justifyRight, "justifyRight")                           \
     __ENUMERATE_COMMAND_NAME(outdent, "outdent")                                     \
     __ENUMERATE_COMMAND_NAME(paste, "paste")                                         \
+    __ENUMERATE_COMMAND_NAME(preserveWhitespace, "preserveWhitespace")               \
     __ENUMERATE_COMMAND_NAME(redo, "redo")                                           \
     __ENUMERATE_COMMAND_NAME(removeFormat, "removeFormat")                           \
     __ENUMERATE_COMMAND_NAME(selectAll, "selectAll")                                 \

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -2657,6 +2657,15 @@ static Array const commands {
         .preserves_overrides = true,
         .mapped_value = "formatOutdent"_fly_string,
     },
+    // AD-HOC: This is a Ladybird-specific formatting command that is not part of the spec. It has no action and as
+    //         such, it's not supported in userland (yet). The relevant CSS property `white-space` is used to indicate
+    //         that if this style value is found during editing commands, it is recorded and restored where necessary.
+    //         This is used to keep things like <div style="white-space: pre">..</div> intact when a selection is
+    //         deleted, for example.
+    CommandDefinition {
+        .command = CommandNames::preserveWhitespace,
+        .relevant_css_property = CSS::PropertyID::WhiteSpace,
+    },
     // https://w3c.github.io/editing/docs/execCommand/#the-removeformat-command
     CommandDefinition {
         .command = CommandNames::removeFormat,

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/TemporaryChange.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Range.h>
@@ -25,8 +26,7 @@ WebIDL::ExceptionOr<bool> Document::exec_command(FlyString const& command, [[may
     // AD-HOC: All major browsers refuse to recursively execute execCommand() (e.g. inside input event handlers).
     if (m_inside_exec_command)
         return false;
-    ScopeGuard guard_recursion = [&] { m_inside_exec_command = false; };
-    m_inside_exec_command = true;
+    TemporaryChange guard_recursion { m_inside_exec_command, true };
 
     // 1. If only one argument was provided, let show UI be false.
     // 2. If only one or two arguments were provided, let value be the empty string.

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -360,10 +360,11 @@ WebIDL::ExceptionOr<bool> Document::query_command_supported(FlyString const& com
     if (!is_html_document())
         return WebIDL::InvalidStateError::create(realm(), "queryCommandSupported is only supported on HTML documents"_string);
 
-    // When the queryCommandSupported(command) method on the Document interface is invoked, the
-    // user agent must return true if command is supported and available within the current script
-    // on the current site, and false otherwise.
-    return Editing::find_command_definition(command).has_value();
+    // When the queryCommandSupported(command) method on the Document interface is invoked, the user agent must return
+    // true if command is supported and available within the current script on the current site, and false otherwise.
+    // AD-HOC: Supported commands should have an action defined. Currently, ::preserveWhitespace does not have one.
+    auto command_definition = Editing::find_command_definition(command);
+    return command_definition.has_value() && command_definition->action;
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#querycommandvalue()

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -122,6 +122,11 @@ WebIDL::ExceptionOr<bool> Document::exec_command(FlyString const& command, [[may
         UIEvents::InputEventInit event_init {};
         event_init.bubbles = true;
         event_init.input_type = command_definition.mapped_value;
+
+        // AD-HOC: For insertText, we do what other browsers do and set data to value.
+        if (command == Editing::CommandNames::insertText)
+            event_init.data = value;
+
         auto event = realm().create<UIEvents::InputEvent>(realm(), HTML::EventNames::input, event_init);
         event->set_is_trusted(true);
         affected_editing_host->dispatch_event(event);

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -3333,9 +3333,10 @@ Vector<RecordedNodeValue> record_the_values_of_nodes(Vector<GC::Ref<DOM::Node>> 
     // 2. For each node in node list, for each command in the list "subscript", "bold", "fontName",
     //    "fontSize", "foreColor", "hiliteColor", "italic", "strikethrough", and "underline" in that
     //    order:
+    // AD-HOC: We include "preserveWhitespace" as well.
     Array const commands = { CommandNames::subscript, CommandNames::bold, CommandNames::fontName,
         CommandNames::fontSize, CommandNames::foreColor, CommandNames::hiliteColor, CommandNames::italic,
-        CommandNames::strikethrough, CommandNames::underline };
+        CommandNames::strikethrough, CommandNames::underline, CommandNames::preserveWhitespace };
     for (auto node : node_list) {
         for (auto command : commands) {
             // 1. Let ancestor equal node.

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -820,7 +820,7 @@ void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
     MUST(set_range_text(String {}, selection_start, selection_end, Bindings::SelectionMode::End));
 }
 
-EventResult FormAssociatedTextControlElement::handle_return_key()
+EventResult FormAssociatedTextControlElement::handle_return_key(FlyString const&)
 {
     auto* input_element = as_if<HTMLInputElement>(form_associated_element_to_html_element());
     if (!input_element)

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -226,7 +226,7 @@ public:
 
     virtual void handle_insert(String const&) override;
     virtual void handle_delete(DeleteDirection) override;
-    virtual EventResult handle_return_key() override;
+    virtual EventResult handle_return_key(FlyString const& ui_input_type) override;
     virtual void select_all() override;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) override;
     virtual void set_selection_focus(GC::Ref<DOM::Node>, size_t offset) override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1320,6 +1320,7 @@ void HTMLInputElement::user_interaction_did_change_input_value()
     // then when the user changes the element's value, the user agent must queue an element task on the user interaction task source
     // given the input element to fire an event named input at the input element, with the bubbles and composed attributes initialized to true
     queue_an_element_task(HTML::Task::Source::UserInteraction, [this] {
+        // FIXME: If a string was added to this input, this input event's .data should be set to it.
         auto input_event = DOM::Event::create(realm(), HTML::EventNames::input);
         input_event->set_bubbles(true);
         input_event->set_composed(true);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -471,6 +471,7 @@ void HTMLTextAreaElement::did_edit_text_node()
 void HTMLTextAreaElement::queue_firing_input_event()
 {
     queue_an_element_task(HTML::Task::Source::UserInteraction, [this]() {
+        // FIXME: If a string was added to this textarea, this input event's .data should be set to it.
         auto change_event = DOM::Event::create(realm(), HTML::EventNames::input, { .bubbles = true, .composed = true });
         dispatch_event(change_event);
     });

--- a/Libraries/LibWeb/UIEvents/InputTypes.h
+++ b/Libraries/LibWeb/UIEvents/InputTypes.h
@@ -12,10 +12,11 @@ namespace Web::UIEvents::InputTypes {
 
 // https://w3c.github.io/input-events/#interface-InputEvent-Attributes
 #define ENUMERATE_INPUT_TYPES                     \
-    __ENUMERATE_INPUT_TYPE(insertText)            \
-    __ENUMERATE_INPUT_TYPE(insertParagraph)       \
     __ENUMERATE_INPUT_TYPE(deleteContentBackward) \
-    __ENUMERATE_INPUT_TYPE(deleteContentForward)
+    __ENUMERATE_INPUT_TYPE(deleteContentForward)  \
+    __ENUMERATE_INPUT_TYPE(insertLineBreak)       \
+    __ENUMERATE_INPUT_TYPE(insertParagraph)       \
+    __ENUMERATE_INPUT_TYPE(insertText)
 
 #define __ENUMERATE_INPUT_TYPE(name) extern FlyString name;
 ENUMERATE_INPUT_TYPES

--- a/Libraries/LibWeb/UIEvents/KeyCode.h
+++ b/Libraries/LibWeb/UIEvents/KeyCode.h
@@ -229,6 +229,10 @@ inline KeyCode code_point_to_key_code(u32 code_point)
 #define MATCH_KEY(name, character) \
     case character:                \
         return KeyCode::Key_##name;
+        MATCH_KEY(Backspace, '\b')
+        MATCH_KEY(Tab, '\t')
+        MATCH_KEY(Return, '\n')
+        MATCH_KEY(Space, ' ')
         MATCH_KEY(ExclamationPoint, '!')
         MATCH_KEY(DoubleQuote, '"')
         MATCH_KEY(Hashtag, '#')
@@ -271,9 +275,6 @@ inline KeyCode code_point_to_key_code(u32 code_point)
         MATCH_KEY(Pipe, '|')
         MATCH_KEY(Tilde, '~')
         MATCH_KEY(Backtick, '`')
-        MATCH_KEY(Space, ' ')
-        MATCH_KEY(Tab, '\t')
-        MATCH_KEY(Backspace, '\b')
 #undef MATCH_KEY
 
     default:

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-preserveWhitespace.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-preserveWhitespace.txt
@@ -1,0 +1,2 @@
+Before: foo<div style="white-space: pre">bar</div>
+After: foo<span style="white-space: pre;">bar</span>

--- a/Tests/LibWeb/Text/input/Editing/execCommand-preserveWhitespace.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-preserveWhitespace.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div contenteditable>foo<div style="white-space: pre">bar</div></div>
+<script>
+test(() => {
+    var divElm = document.querySelector('div');
+    println(`Before: ${divElm.innerHTML}`);
+
+    // Put cursor before 'bar'
+    var range = document.createRange();
+    range.setStart(divElm.childNodes[1].childNodes[0], 0);
+    getSelection().addRange(range);
+
+    // Press backspace
+    document.execCommand('delete');
+
+    println(`After: ${divElm.innerHTML}`);
+});
+</script>


### PR DESCRIPTION
+2053 WPT subtest passes. Some regressions in `editing/plaintext-only` that I'm going to look at in a new PR.

**WPT changes compared to master**

| Suite | Results |
|--|--|
| `editing/other` | +1163 passes, -4 crashes |
| `editing/plaintext-only` | -61 passes |
| `editing/run` | +10 passes |
| `editing/whitespaces` | +28 passes |
| `input-events` | +913 passes |