### PR TITLE
LibWeb: Fix visual regression in ACID3 test

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -817,9 +817,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed) {
             m_margin_state.reset();
         }
-        auto box_height = box_state.offset.y() + box_state.content_height() + box_state.border_box_bottom();
-        if (!m_y_offset_of_current_block_container.has_value() || box_height > m_y_offset_of_current_block_container.value())
-            m_y_offset_of_current_block_container = box_height;
+        m_y_offset_of_current_block_container = box_state.offset.y() + box_state.content_height() + box_state.border_box_bottom();
     }
     m_margin_state.box_last_in_flow_child_margin_bottom_collapsed = false;
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/negative-margin-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/negative-margin-with-padding.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x56 [BFC] children: not-inline
+    BlockContainer <body> at (18,18) content-size 764x20 children: not-inline
+      BlockContainer <div#a> at (18,18) content-size 764x0 children: not-inline
+      BlockContainer <(anonymous)> at (18,168) content-size 764x0 children: inline
+        TextNode <#text>
+      BlockContainer <div#b> at (18,-72) content-size 764x92 children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [18,-72 135.78125x92] baseline: 69.984375
+            "foo"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (18,20) content-size 764x18 children: inline
+        frag 0 from TextNode start: 1, length: 3, rect: [18,20 27.640625x18] baseline: 13.796875
+            "bar"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,-72 800x672]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x56] overflow: [0,-72 800x240]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x40] overflow: [18,-72 764x240]
+      PaintableWithLines (BlockContainer<DIV>#a) [18,18 764x150]
+      PaintableWithLines (BlockContainer(anonymous)) [18,168 764x0]
+      PaintableWithLines (BlockContainer<DIV>#b) [18,-72 764x92]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [18,20 764x18]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/negative-margin-with-padding.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/negative-margin-with-padding.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+body {
+    border: 10px solid red;
+}
+#a {
+    padding-bottom: 150px;
+}
+#b {
+    font-size: 5em;
+    margin: -240px 0 0;
+}
+</style>
+<div id="a"></div>
+<div id="b">foo</div>
+bar


### PR DESCRIPTION
Originally part of a fix in 15103d172c2a4279c611d8a9d6262e15d3a3351e, it appears that this is no longer necessary and received a better fix in a more recent commit. Resolves a visual regression with the ACID3 test.

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/0c4ca378-a32d-4890-b614-5d3604b717a4) | ![image](https://github.com/user-attachments/assets/63081f8f-cddb-4d39-bb97-04b3823fd383) |