### PR TITLE
LibWeb/CSS: Fix some bugs found in the WPT `matchMedia()` test

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -813,7 +813,7 @@ WebIDL::ExceptionOr<GC::RootVector<JS::Object*>> KeyframeEffect::get_keyframes()
             TRY(object->set(vm.names.offset, keyframe.offset.has_value() ? JS::Value(keyframe.offset.value()) : JS::js_null(), ShouldThrowExceptions::Yes));
             TRY(object->set(vm.names.computedOffset, JS::Value(keyframe.computed_offset.value()), ShouldThrowExceptions::Yes));
             auto easing_value = keyframe.easing.get<NonnullRefPtr<CSS::CSSStyleValue const>>();
-            TRY(object->set(vm.names.easing, JS::PrimitiveString::create(vm, easing_value->to_string(CSS::CSSStyleValue::SerializationMode::Normal)), ShouldThrowExceptions::Yes));
+            TRY(object->set(vm.names.easing, JS::PrimitiveString::create(vm, easing_value->to_string(CSS::SerializationMode::Normal)), ShouldThrowExceptions::Yes));
 
             if (keyframe.composite == Bindings::CompositeOperationOrAuto::Replace) {
                 TRY(object->set(vm.names.composite, JS::PrimitiveString::create(vm, "replace"sv), ShouldThrowExceptions::Yes));
@@ -826,7 +826,7 @@ WebIDL::ExceptionOr<GC::RootVector<JS::Object*>> KeyframeEffect::get_keyframes()
             }
 
             for (auto const& [id, value] : keyframe.parsed_properties()) {
-                auto value_string = JS::PrimitiveString::create(vm, value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
+                auto value_string = JS::PrimitiveString::create(vm, value->to_string(CSS::SerializationMode::Normal));
                 TRY(object->set(JS::PropertyKey { CSS::camel_case_string_from_property_id(id), JS::PropertyKey::StringMayBeNumber::No }, value_string, ShouldThrowExceptions::Yes));
             }
 

--- a/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Libraries/LibWeb/CSS/Angle.cpp
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Angle.h"
 #include <AK/Math.h>
+#include <LibWeb/CSS/Angle.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 
@@ -27,8 +27,10 @@ Angle Angle::percentage_of(Percentage const& percentage) const
     return Angle { percentage.as_fraction() * m_value, m_type };
 }
 
-String Angle::to_string() const
+String Angle::to_string(SerializationMode serialization_mode) const
 {
+    if (serialization_mode == SerializationMode::ResolvedValue)
+        return MUST(String::formatted("{}deg", to_degrees()));
     return MUST(String::formatted("{}{}", raw_value(), unit_name()));
 }
 

--- a/Libraries/LibWeb/CSS/Angle.h
+++ b/Libraries/LibWeb/CSS/Angle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,13 +7,14 @@
 #pragma once
 
 #include <AK/String.h>
+#include <LibWeb/CSS/SerializationMode.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
 class Angle {
 public:
-    enum class Type {
+    enum class Type : u8 {
         Deg,
         Grad,
         Rad,
@@ -26,7 +27,7 @@ public:
     static Angle make_degrees(double);
     Angle percentage_of(Percentage const&) const;
 
-    String to_string() const;
+    String to_string(SerializationMode = SerializationMode::Normal) const;
 
     double to_degrees() const;
     double to_radians() const;

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -178,7 +178,7 @@ String CSSDescriptors::get_property_value(StringView property) const
     if (descriptor_id.has_value()) {
         auto match = m_descriptors.first_matching([descriptor_id](auto& entry) { return entry.descriptor_id == *descriptor_id; });
         if (match.has_value())
-            return match->value->to_string(CSSStyleValue::SerializationMode::Normal);
+            return match->value->to_string(SerializationMode::Normal);
     }
 
     // 3. Return the empty string.
@@ -215,7 +215,7 @@ String CSSDescriptors::serialized() const
         // NB: Descriptors can't be shorthands.
 
         // 5. Let value be the result of invoking serialize a CSS value of declaration.
-        auto value = descriptor.value->to_string(CSSStyleValue::SerializationMode::Normal);
+        auto value = descriptor.value->to_string(SerializationMode::Normal);
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value, and the important flag set if declaration has its important flag set.
         auto serialized_declaration = serialize_a_css_declaration(property, value, Important::No);

--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -64,7 +64,7 @@ String CSSFontFaceRule::serialized() const
     builder.append("font-family: "sv);
 
     // 3. The result of performing serialize a string on the rule’s font family name.
-    builder.append(descriptors.descriptor(DescriptorID::FontFamily)->to_string(CSSStyleValue::SerializationMode::Normal));
+    builder.append(descriptors.descriptor(DescriptorID::FontFamily)->to_string(SerializationMode::Normal));
 
     // 4. The string ";", i.e., SEMICOLON (U+003B).
     builder.append(';');
@@ -75,7 +75,7 @@ String CSSFontFaceRule::serialized() const
         builder.append(" src: "sv);
 
         // 2. The result of invoking serialize a comma-separated list on performing serialize a URL or serialize a LOCAL for each source on the source list.
-        builder.append(sources->to_string(CSSStyleValue::SerializationMode::Normal));
+        builder.append(sources->to_string(SerializationMode::Normal));
 
         // 3. The string ";", i.e., SEMICOLON (U+003B).
         builder.append(';');
@@ -84,7 +84,7 @@ String CSSFontFaceRule::serialized() const
     // 6. If rule’s associated unicode-range descriptor is present, a single SPACE (U+0020), followed by the string "unicode-range:", followed by a single SPACE (U+0020), followed by the result of performing serialize a <'unicode-range'>, followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto unicode_range = descriptors.descriptor(DescriptorID::UnicodeRange)) {
         builder.append(" unicode-range: "sv);
-        builder.append(unicode_range->to_string(CSSStyleValue::SerializationMode::Normal));
+        builder.append(unicode_range->to_string(SerializationMode::Normal));
         builder.append(';');
     }
 
@@ -99,7 +99,7 @@ String CSSFontFaceRule::serialized() const
     //    followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto font_feature_settings = descriptors.descriptor(DescriptorID::FontFeatureSettings)) {
         builder.append(" font-feature-settings: "sv);
-        builder.append(font_feature_settings->to_string(CSSStyleValue::SerializationMode::Normal));
+        builder.append(font_feature_settings->to_string(SerializationMode::Normal));
         builder.append(";"sv);
     }
 
@@ -110,7 +110,7 @@ String CSSFontFaceRule::serialized() const
     // NOTE: font-stretch is now an alias for font-width, so we use that instead.
     if (auto font_width = descriptors.descriptor(DescriptorID::FontWidth)) {
         builder.append(" font-stretch: "sv);
-        builder.append(font_width->to_string(CSSStyleValue::SerializationMode::Normal));
+        builder.append(font_width->to_string(SerializationMode::Normal));
         builder.append(";"sv);
     }
 
@@ -120,7 +120,7 @@ String CSSFontFaceRule::serialized() const
     //     followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto font_weight = descriptors.descriptor(DescriptorID::FontWeight)) {
         builder.append(" font-weight: "sv);
-        builder.append(font_weight->to_string(CSSStyleValue::SerializationMode::Normal));
+        builder.append(font_weight->to_string(SerializationMode::Normal));
         builder.append(";"sv);
     }
 
@@ -130,7 +130,7 @@ String CSSFontFaceRule::serialized() const
     //     followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto font_style = descriptors.descriptor(DescriptorID::FontStyle)) {
         builder.append(" font-style: "sv);
-        builder.append(font_style->to_string(CSSStyleValue::SerializationMode::Normal));
+        builder.append(font_style->to_string(SerializationMode::Normal));
         builder.append(";"sv);
     }
 

--- a/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
@@ -30,7 +30,7 @@ CSSPropertyRule::CSSPropertyRule(JS::Realm& realm, FlyString name, FlyString syn
 Optional<String> CSSPropertyRule::initial_value() const
 {
     if (m_initial_value)
-        return m_initial_value->to_string(CSSStyleValue::SerializationMode::Normal);
+        return m_initial_value->to_string(SerializationMode::Normal);
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -392,8 +392,8 @@ String CSSStyleProperties::get_property_value(StringView property_name) const
         auto maybe_custom_property = custom_property(FlyString::from_utf8_without_validation(property_name.bytes()));
         if (maybe_custom_property.has_value()) {
             return maybe_custom_property.value().value->to_string(
-                is_computed() ? CSSStyleValue::SerializationMode::ResolvedValue
-                              : CSSStyleValue::SerializationMode::Normal);
+                is_computed() ? SerializationMode::ResolvedValue
+                              : SerializationMode::Normal);
         }
         return {};
     }
@@ -402,8 +402,8 @@ String CSSStyleProperties::get_property_value(StringView property_name) const
     if (!maybe_property.has_value())
         return {};
     return maybe_property->value->to_string(
-        is_computed() ? CSSStyleValue::SerializationMode::ResolvedValue
-                      : CSSStyleValue::SerializationMode::Normal);
+        is_computed() ? SerializationMode::ResolvedValue
+                      : SerializationMode::Normal);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
@@ -1109,7 +1109,7 @@ String CSSStyleProperties::serialized() const
         // NB: There are no shorthands for custom properties.
 
         // 5. Let value be the result of invoking serialize a CSS value of declaration.
-        auto value = declaration.value.value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
+        auto value = declaration.value.value->to_string(Web::CSS::SerializationMode::Normal);
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.
@@ -1137,7 +1137,7 @@ String CSSStyleProperties::serialized() const
         // FIXME: 4. Shorthand loop: For each shorthand in shorthands, follow these substeps: ...
 
         // 5. Let value be the result of invoking serialize a CSS value of declaration.
-        auto value = declaration.value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
+        auto value = declaration.value->to_string(Web::CSS::SerializationMode::Normal);
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -22,6 +22,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/CSS/Keyword.h>
 #include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/SerializationMode.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -385,10 +386,6 @@ public:
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const { return {}; }
     Keyword to_keyword() const;
 
-    enum class SerializationMode {
-        Normal,
-        ResolvedValue,
-    };
     virtual String to_string(SerializationMode) const = 0;
 
     [[nodiscard]] int to_font_weight() const;
@@ -432,6 +429,6 @@ template<>
 struct AK::Formatter<Web::CSS::CSSStyleValue> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::CSSStyleValue const& style_value)
     {
-        return Formatter<StringView>::format(builder, style_value.to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
+        return Formatter<StringView>::format(builder, style_value.to_string(Web::CSS::SerializationMode::Normal));
     }
 };

--- a/Libraries/LibWeb/CSS/CalculatedOr.h
+++ b/Libraries/LibWeb/CSS/CalculatedOr.h
@@ -74,7 +74,7 @@ public:
                 }
             },
             [](NonnullRefPtr<CalculatedStyleValue const> const& calculated) {
-                return calculated->to_string(CSSStyleValue::SerializationMode::Normal);
+                return calculated->to_string(SerializationMode::Normal);
             });
     }
 

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -182,7 +182,7 @@ Size ComputedProperties::size_value(PropertyID id) const
     }
 
     // FIXME: Support `fit-content(<length>)`
-    dbgln("FIXME: Unsupported size value: `{}`, treating as `auto`", value.to_string(CSSStyleValue::SerializationMode::Normal));
+    dbgln("FIXME: Unsupported size value: `{}`, treating as `auto`", value.to_string(SerializationMode::Normal));
     return Size::make_auto();
 }
 
@@ -310,7 +310,7 @@ CSSPixels ComputedProperties::compute_line_height(CSSPixelRect const& viewport_r
         if (line_height.as_calculated().resolves_to_number()) {
             auto resolved = line_height.as_calculated().resolve_number(context);
             if (!resolved.has_value()) {
-                dbgln("FIXME: Failed to resolve calc() line-height (number): {}", line_height.as_calculated().to_string(CSSStyleValue::SerializationMode::Normal));
+                dbgln("FIXME: Failed to resolve calc() line-height (number): {}", line_height.as_calculated().to_string(SerializationMode::Normal));
                 return CSSPixels::nearest_value_for(m_font_list->first().pixel_metrics().line_spacing());
             }
             return Length(resolved.value(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
@@ -318,7 +318,7 @@ CSSPixels ComputedProperties::compute_line_height(CSSPixelRect const& viewport_r
 
         auto resolved = line_height.as_calculated().resolve_length(context);
         if (!resolved.has_value()) {
-            dbgln("FIXME: Failed to resolve calc() line-height: {}", line_height.as_calculated().to_string(CSSStyleValue::SerializationMode::Normal));
+            dbgln("FIXME: Failed to resolve calc() line-height: {}", line_height.as_calculated().to_string(SerializationMode::Normal));
             return CSSPixels::nearest_value_for(m_font_list->first().pixel_metrics().line_spacing());
         }
         return resolved->to_px(viewport_rect, font_metrics, root_font_metrics);
@@ -358,13 +358,13 @@ float ComputedProperties::resolve_opacity_value(CSSStyleValue const& value)
             if (maybe_percentage.has_value())
                 unclamped_opacity = maybe_percentage->as_fraction();
             else
-                dbgln("Unable to resolve calc() as opacity (percentage): {}", value.to_string(CSSStyleValue::SerializationMode::Normal));
+                dbgln("Unable to resolve calc() as opacity (percentage): {}", value.to_string(SerializationMode::Normal));
         } else if (calculated.resolves_to_number()) {
             auto maybe_number = value.as_calculated().resolve_number(context);
             if (maybe_number.has_value())
                 unclamped_opacity = maybe_number.value();
             else
-                dbgln("Unable to resolve calc() as opacity (number): {}", value.to_string(CSSStyleValue::SerializationMode::Normal));
+                dbgln("Unable to resolve calc() as opacity (number): {}", value.to_string(SerializationMode::Normal));
         }
     } else if (value.is_percentage()) {
         unclamped_opacity = value.as_percentage().percentage().as_fraction();
@@ -938,14 +938,14 @@ ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(
                         quote_nesting_level--;
                     break;
                 default:
-                    dbgln("`{}` is not supported in `content` (yet?)", item->to_string(CSSStyleValue::SerializationMode::Normal));
+                    dbgln("`{}` is not supported in `content` (yet?)", item->to_string(SerializationMode::Normal));
                     break;
                 }
             } else if (item->is_counter()) {
                 builder.append(item->as_counter().resolve(element));
             } else {
                 // TODO: Implement images, and other things.
-                dbgln("`{}` is not supported in `content` (yet?)", item->to_string(CSSStyleValue::SerializationMode::Normal));
+                dbgln("`{}` is not supported in `content` (yet?)", item->to_string(SerializationMode::Normal));
             }
         }
         content_data.type = ContentData::Type::String;
@@ -959,7 +959,7 @@ ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(
                 } else if (item->is_counter()) {
                     alt_text_builder.append(item->as_counter().resolve(element));
                 } else {
-                    dbgln("`{}` is not supported in `content` alt-text (yet?)", item->to_string(CSSStyleValue::SerializationMode::Normal));
+                    dbgln("`{}` is not supported in `content` alt-text (yet?)", item->to_string(SerializationMode::Normal));
                 }
             }
             content_data.alt_text = MUST(alt_text_builder.to_string());
@@ -1048,7 +1048,7 @@ Vector<TextDecorationLine> ComputedProperties::text_decoration_line() const
         return { keyword_to_text_decoration_line(value.to_keyword()).release_value() };
     }
 
-    dbgln("FIXME: Unsupported value for text-decoration-line: {}", value.to_string(CSSStyleValue::SerializationMode::Normal));
+    dbgln("FIXME: Unsupported value for text-decoration-line: {}", value.to_string(SerializationMode::Normal));
     return {};
 }
 
@@ -1686,7 +1686,7 @@ Containment ComputedProperties::contain() const
                     containment.paint_containment = true;
                     break;
                 default:
-                    dbgln("`{}` is not supported in `contain` (yet?)", item->to_string(CSSStyleValue::SerializationMode::Normal));
+                    dbgln("`{}` is not supported in `contain` (yet?)", item->to_string(SerializationMode::Normal));
                     break;
                 }
             }
@@ -1789,7 +1789,7 @@ Vector<CounterData> ComputedProperties::counter_data(PropertyID property_id) con
                     if (maybe_int.has_value())
                         data.value = AK::clamp_to<i32>(*maybe_int);
                 } else {
-                    dbgln("Unimplemented type for {} integer value: '{}'", string_from_property_id(property_id), counter.value->to_string(CSSStyleValue::SerializationMode::Normal));
+                    dbgln("Unimplemented type for {} integer value: '{}'", string_from_property_id(property_id), counter.value->to_string(SerializationMode::Normal));
                 }
             }
             result.append(move(data));
@@ -1800,7 +1800,7 @@ Vector<CounterData> ComputedProperties::counter_data(PropertyID property_id) con
     if (value.to_keyword() == Keyword::None)
         return {};
 
-    dbgln("Unhandled type for {} value: '{}'", string_from_property_id(property_id), value.to_string(CSSStyleValue::SerializationMode::Normal));
+    dbgln("Unhandled type for {} value: '{}'", string_from_property_id(property_id), value.to_string(SerializationMode::Normal));
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/Flex.cpp
+++ b/Libraries/LibWeb/CSS/Flex.cpp
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Flex.h"
+#include <LibWeb/CSS/Flex.h>
 #include <LibWeb/CSS/Percentage.h>
 
 namespace Web::CSS {
@@ -25,9 +25,11 @@ Flex Flex::percentage_of(Percentage const& percentage) const
     return Flex { percentage.as_fraction() * m_value, m_type };
 }
 
-String Flex::to_string() const
+String Flex::to_string(SerializationMode serialization_mode) const
 {
-    return MUST(String::formatted("{}fr", to_fr()));
+    if (serialization_mode == SerializationMode::ResolvedValue)
+        return MUST(String::formatted("{}fr", to_fr()));
+    return MUST(String::formatted("{}{}", raw_value(), unit_name()));
 }
 
 double Flex::to_fr() const

--- a/Libraries/LibWeb/CSS/Flex.h
+++ b/Libraries/LibWeb/CSS/Flex.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2023-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <LibWeb/CSS/SerializationMode.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -15,7 +16,7 @@ namespace Web::CSS {
 // https://drafts.csswg.org/css-grid-2/#typedef-flex
 class Flex {
 public:
-    enum class Type {
+    enum class Type : u8 {
         Fr,
     };
 
@@ -25,7 +26,7 @@ public:
     static Flex make_fr(double);
     Flex percentage_of(Percentage const&) const;
 
-    String to_string() const;
+    String to_string(SerializationMode = SerializationMode::Normal) const;
     double to_fr() const;
 
     Type type() const { return m_type; }

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -82,7 +82,7 @@ GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, Font
             font_face->reject_status_promise(WebIDL::SyntaxError::create(realm, MUST(String::formatted("FontFace constructor: Invalid {}", to_string(descriptor_id)))));
             return {};
         }
-        return result->to_string(CSSStyleValue::SerializationMode::Normal);
+        return result->to_string(SerializationMode::Normal);
     };
     font_face->m_family = try_parse_descriptor(DescriptorID::FontFamily, family);
     font_face->m_style = try_parse_descriptor(DescriptorID::FontStyle, descriptors.style);
@@ -224,7 +224,7 @@ WebIDL::ExceptionOr<void> FontFace::set_family(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-family property
     }
 
-    m_family = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_family = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -244,7 +244,7 @@ WebIDL::ExceptionOr<void> FontFace::set_style(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-style property
     }
 
-    m_style = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_style = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -264,7 +264,7 @@ WebIDL::ExceptionOr<void> FontFace::set_weight(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-weight property
     }
 
-    m_weight = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_weight = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -285,7 +285,7 @@ WebIDL::ExceptionOr<void> FontFace::set_stretch(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_stretch = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_stretch = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -305,7 +305,7 @@ WebIDL::ExceptionOr<void> FontFace::set_unicode_range(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_unicode_range = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_unicode_range = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -325,7 +325,7 @@ WebIDL::ExceptionOr<void> FontFace::set_feature_settings(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_feature_settings = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_feature_settings = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -345,7 +345,7 @@ WebIDL::ExceptionOr<void> FontFace::set_variation_settings(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_variation_settings = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_variation_settings = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -365,7 +365,7 @@ WebIDL::ExceptionOr<void> FontFace::set_display(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_display = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_display = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -385,7 +385,7 @@ WebIDL::ExceptionOr<void> FontFace::set_ascent_override(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_ascent_override = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_ascent_override = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -405,7 +405,7 @@ WebIDL::ExceptionOr<void> FontFace::set_descent_override(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_descent_override = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_descent_override = property->to_string(SerializationMode::Normal);
 
     return {};
 }
@@ -425,7 +425,7 @@ WebIDL::ExceptionOr<void> FontFace::set_line_gap_override(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_line_gap_override = property->to_string(CSSStyleValue::SerializationMode::Normal);
+    m_line_gap_override = property->to_string(SerializationMode::Normal);
 
     return {};
 }

--- a/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Libraries/LibWeb/CSS/Frequency.cpp
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Frequency.h"
+#include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 
@@ -26,9 +26,11 @@ Frequency Frequency::percentage_of(Percentage const& percentage) const
     return Frequency { percentage.as_fraction() * m_value, m_type };
 }
 
-String Frequency::to_string() const
+String Frequency::to_string(SerializationMode serialization_mode) const
 {
-    return MUST(String::formatted("{}hz", to_hertz()));
+    if (serialization_mode == SerializationMode::ResolvedValue)
+        return MUST(String::formatted("{}hz", to_hertz()));
+    return MUST(String::formatted("{}{}", raw_value(), unit_name()));
 }
 
 double Frequency::to_hertz() const

--- a/Libraries/LibWeb/CSS/Frequency.h
+++ b/Libraries/LibWeb/CSS/Frequency.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,13 +7,14 @@
 #pragma once
 
 #include <AK/String.h>
+#include <LibWeb/CSS/SerializationMode.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
 class Frequency {
 public:
-    enum class Type {
+    enum class Type : u8 {
         Hz,
         kHz
     };
@@ -24,7 +25,7 @@ public:
     static Frequency make_hertz(double);
     Frequency percentage_of(Percentage const&) const;
 
-    String to_string() const;
+    String to_string(SerializationMode = SerializationMode::Normal) const;
     double to_hertz() const;
 
     Type type() const { return m_type; }

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -270,7 +270,7 @@ RefPtr<CSSStyleValue const> interpolate_transform(DOM::Element& element, CSSStyl
                 } else if (calculated.resolves_to_number()) {
                     values.append(NumberPercentage { calculated });
                 } else {
-                    dbgln("Calculation `{}` inside {} transform-function is not a recognized type", calculated.to_string(CSSStyleValue::SerializationMode::Normal), to_string(transformation.transform_function()));
+                    dbgln("Calculation `{}` inside {} transform-function is not a recognized type", calculated.to_string(SerializationMode::Normal), to_string(transformation.transform_function()));
                     return {};
                 }
                 break;

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020-2024, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -198,10 +198,14 @@ CSSPixels Length::to_px_slow_case(Layout::Node const& layout_node) const
     return viewport_relative_length_to_px(viewport_rect);
 }
 
-String Length::to_string() const
+String Length::to_string(SerializationMode serialization_mode) const
 {
     if (is_auto())
         return "auto"_string;
+    // FIXME: Manually skip this for px so we avoid rounding errors in absolute_length_to_px.
+    //        Maybe provide alternative functions that don't produce CSSPixels?
+    if (serialization_mode == SerializationMode::ResolvedValue && is_absolute() && m_type != Type::Px)
+        return MUST(String::formatted("{:.5}px", absolute_length_to_px()));
     return MUST(String::formatted("{:.5}{}", m_value, unit_name()));
 }
 

--- a/Libraries/LibWeb/CSS/Length.h
+++ b/Libraries/LibWeb/CSS/Length.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
+#include <LibWeb/CSS/SerializationMode.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -17,7 +18,7 @@ namespace Web::CSS {
 
 class Length {
 public:
-    enum class Type {
+    enum class Type : u8 {
         // Font-relative
         Em,
         Rem,
@@ -218,7 +219,7 @@ public:
         }
     }
 
-    String to_string() const;
+    String to_string(SerializationMode = SerializationMode::Normal) const;
 
     bool operator==(Length const& other) const
     {

--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -31,7 +31,7 @@ String MediaFeatureValue::to_string() const
         [](ResolutionOrCalculated const& resolution) { return resolution.to_string(); },
         [](IntegerOrCalculated const& integer) {
             if (integer.is_calculated())
-                return integer.calculated()->to_string(CSSStyleValue::SerializationMode::Normal);
+                return integer.calculated()->to_string(SerializationMode::Normal);
             return String::number(integer.value());
         });
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1309,14 +1309,20 @@ Vector<Vector<ComponentValue>> Parser::parse_a_comma_separated_list_of_component
     Vector<Vector<ComponentValue>> groups;
 
     // 3. While input is not empty:
+    bool just_consumed_comma = false;
     while (!input.is_empty()) {
 
         // 1. Consume a list of component values from input, with <comma-token> as the stop token, and append the result to groups.
         groups.append(consume_a_list_of_component_values(input, Token::Type::Comma));
 
         // 2. Discard a token from input.
-        input.discard_a_token();
+        just_consumed_comma = input.consume_a_token().is(Token::Type::Comma);
     }
+
+    // AD-HOC: Also append an empty group if there was a trailing comma.
+    // Some related spec discussion: https://github.com/w3c/csswg-drafts/issues/11254
+    if (just_consumed_comma)
+        groups.append({});
 
     // 4. Return groups.
     return groups;

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -1086,7 +1086,7 @@ RefPtr<CSSStyleValue const> Parser::parse_rect_value(TokenStream<ComponentValue>
             if (!maybe_length.has_value())
                 return nullptr;
             if (maybe_length.value().is_calculated()) {
-                dbgln("FIXME: Support calculated lengths in rect(): {}", maybe_length.value().calculated()->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
+                dbgln("FIXME: Support calculated lengths in rect(): {}", maybe_length.value().calculated()->to_string(CSS::SerializationMode::Normal));
                 return nullptr;
             }
             params.append(maybe_length.value().value());

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -122,7 +122,7 @@ public:
     String to_string() const
     {
         if (is_calculated())
-            return m_value.template get<NonnullRefPtr<CalculatedStyleValue const>>()->to_string(CSSStyleValue::SerializationMode::Normal);
+            return m_value.template get<NonnullRefPtr<CalculatedStyleValue const>>()->to_string(SerializationMode::Normal);
         if (is_percentage())
             return m_value.template get<Percentage>().to_string();
         return m_value.template get<T>().to_string();

--- a/Libraries/LibWeb/CSS/Resolution.cpp
+++ b/Libraries/LibWeb/CSS/Resolution.cpp
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2024, Glenn Skrzypczak <glenn.skrzypczak@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Resolution.h"
+#include <LibWeb/CSS/Resolution.h>
 
 namespace Web::CSS {
 
@@ -20,9 +20,11 @@ Resolution Resolution::make_dots_per_pixel(double value)
     return { value, Type::Dppx };
 }
 
-String Resolution::to_string() const
+String Resolution::to_string(SerializationMode serialization_mode) const
 {
-    return MUST(String::formatted("{}dppx", to_dots_per_pixel()));
+    if (serialization_mode == SerializationMode::ResolvedValue)
+        return MUST(String::formatted("{}dppx", to_dots_per_pixel()));
+    return MUST(String::formatted("{}{}", raw_value(), unit_name()));
 }
 
 double Resolution::to_dots_per_pixel() const

--- a/Libraries/LibWeb/CSS/Resolution.cpp
+++ b/Libraries/LibWeb/CSS/Resolution.cpp
@@ -35,6 +35,7 @@ double Resolution::to_dots_per_pixel() const
     case Type::Dpcm:
         return m_value / (96.0 / 2.54); // 1cm = 96px/2.54
     case Type::Dppx:
+    case Type::X:
         return m_value;
     }
     VERIFY_NOT_REACHED();
@@ -49,19 +50,22 @@ StringView Resolution::unit_name() const
         return "dpcm"sv;
     case Type::Dppx:
         return "dppx"sv;
+    case Type::X:
+        return "x"sv;
     }
     VERIFY_NOT_REACHED();
 }
 
 Optional<Resolution::Type> Resolution::unit_from_name(StringView name)
 {
-    if (name.equals_ignoring_ascii_case("dpi"sv)) {
+    if (name.equals_ignoring_ascii_case("dpi"sv))
         return Type::Dpi;
-    } else if (name.equals_ignoring_ascii_case("dpcm"sv)) {
+    if (name.equals_ignoring_ascii_case("dpcm"sv))
         return Type::Dpcm;
-    } else if (name.equals_ignoring_ascii_case("dppx"sv) || name.equals_ignoring_ascii_case("x"sv)) {
+    if (name.equals_ignoring_ascii_case("dppx"sv))
         return Type::Dppx;
-    }
+    if (name.equals_ignoring_ascii_case("x"sv))
+        return Type::X;
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/Resolution.h
+++ b/Libraries/LibWeb/CSS/Resolution.h
@@ -17,6 +17,7 @@ public:
         Dpi,
         Dpcm,
         Dppx,
+        X,
     };
 
     static Optional<Type> unit_from_name(StringView);

--- a/Libraries/LibWeb/CSS/Resolution.h
+++ b/Libraries/LibWeb/CSS/Resolution.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,13 +7,13 @@
 #pragma once
 
 #include <AK/String.h>
-#include <LibWeb/Forward.h>
+#include <LibWeb/CSS/SerializationMode.h>
 
 namespace Web::CSS {
 
 class Resolution {
 public:
-    enum class Type {
+    enum class Type : u8 {
         Dpi,
         Dpcm,
         Dppx,
@@ -24,7 +24,7 @@ public:
     Resolution(double value, Type type);
     static Resolution make_dots_per_pixel(double);
 
-    String to_string() const;
+    String to_string(SerializationMode = SerializationMode::Normal) const;
     double to_dots_per_pixel() const;
 
     Type type() const { return m_type; }

--- a/Libraries/LibWeb/CSS/SerializationMode.h
+++ b/Libraries/LibWeb/CSS/SerializationMode.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::CSS {
+
+enum class SerializationMode : u8 {
+    Normal,
+    ResolvedValue,
+};
+
+}

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1248,7 +1248,7 @@ void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::
         if (!resolved_end_property) {
             if (resolved_start_property) {
                 computed_properties.set_animated_property(it.key, *resolved_start_property);
-                dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "No end property for property {}, using {}", string_from_property_id(it.key), resolved_start_property->to_string(CSSStyleValue::SerializationMode::Normal));
+                dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "No end property for property {}, using {}", string_from_property_id(it.key), resolved_start_property->to_string(SerializationMode::Normal));
             }
             continue;
         }
@@ -1267,11 +1267,11 @@ void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::
         }
 
         if (auto next_value = interpolate_property(*effect->target(), it.key, *start, *end, progress_in_keyframe)) {
-            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} = {}", string_from_property_id(it.key), progress_in_keyframe, start->to_string(CSSStyleValue::SerializationMode::Normal), end->to_string(CSSStyleValue::SerializationMode::Normal), next_value->to_string(CSSStyleValue::SerializationMode::Normal));
+            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} = {}", string_from_property_id(it.key), progress_in_keyframe, start->to_string(SerializationMode::Normal), end->to_string(SerializationMode::Normal), next_value->to_string(SerializationMode::Normal));
             computed_properties.set_animated_property(it.key, *next_value);
         } else {
             // If interpolate_property() fails, the element should not be rendered
-            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} is invalid", string_from_property_id(it.key), progress_in_keyframe, start->to_string(CSSStyleValue::SerializationMode::Normal), end->to_string(CSSStyleValue::SerializationMode::Normal));
+            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} is invalid", string_from_property_id(it.key), progress_in_keyframe, start->to_string(SerializationMode::Normal), end->to_string(SerializationMode::Normal));
             computed_properties.set_animated_property(PropertyID::Visibility, CSSKeywordValue::create(Keyword::Hidden));
         }
     }
@@ -1556,7 +1556,7 @@ void StyleComputer::start_needed_transitions(ComputedProperties const& previous_
         //    there is a matching transition-property value,
         //    and the end value of the running transition is not equal to the value of the property in the after-change style, then:
         if (has_running_transition && matching_transition_properties.has_value() && !existing_transition->transition_end_value()->equals(after_change_value)) {
-            dbgln_if(CSS_TRANSITIONS_DEBUG, "Transition step 4. existing end value = {}, after change value = {}", existing_transition->transition_end_value()->to_string(CSSStyleValue::SerializationMode::Normal), after_change_value.to_string(CSSStyleValue::SerializationMode::Normal));
+            dbgln_if(CSS_TRANSITIONS_DEBUG, "Transition step 4. existing end value = {}, after change value = {}", existing_transition->transition_end_value()->to_string(SerializationMode::Normal), after_change_value.to_string(SerializationMode::Normal));
             // 1. If the current value of the property in the running transition is equal to the value of the property in the after-change style,
             //    or if these two values are not transitionable,
             //    then implementations must cancel the running transition.
@@ -2686,7 +2686,7 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
             return OptionalNone {};
         if (animation_name->is_string())
             return animation_name->as_string().string_value().to_string();
-        return animation_name->to_string(CSSStyleValue::SerializationMode::Normal);
+        return animation_name->to_string(SerializationMode::Normal);
     }();
 
     if (animation_name.has_value()) {

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -177,7 +177,7 @@ struct ColorStopListElement {
 using LinearColorStopListElement = ColorStopListElement<LengthPercentage>;
 using AngularColorStopListElement = ColorStopListElement<AnglePercentage>;
 
-static void serialize_color_stop_list(StringBuilder& builder, auto const& color_stop_list, CSSStyleValue::SerializationMode mode)
+static void serialize_color_stop_list(StringBuilder& builder, auto const& color_stop_list, SerializationMode mode)
 {
     bool first = true;
     for (auto const& element : color_stop_list) {

--- a/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.cpp
@@ -21,9 +21,7 @@ AngleStyleValue::~AngleStyleValue() = default;
 
 String AngleStyleValue::to_string(SerializationMode serialization_mode) const
 {
-    if (serialization_mode == SerializationMode::ResolvedValue)
-        return MUST(String::formatted("{}deg", m_angle.to_degrees()));
-    return m_angle.to_string();
+    return m_angle.to_string(serialization_mode);
 }
 
 bool AngleStyleValue::equals(CSSStyleValue const& other) const

--- a/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.cpp
@@ -34,7 +34,7 @@ Gfx::Path Inset::to_path(CSSPixelRect reference_box, Layout::Node const& node) c
     return path_from_resolved_rect(top, right, bottom, left);
 }
 
-String Inset::to_string(CSSStyleValue::SerializationMode) const
+String Inset::to_string(SerializationMode) const
 {
     return MUST(String::formatted("inset({} {} {} {})", inset_box.top(), inset_box.right(), inset_box.bottom(), inset_box.left()));
 }
@@ -49,7 +49,7 @@ Gfx::Path Xywh::to_path(CSSPixelRect reference_box, Layout::Node const& node) co
     return path_from_resolved_rect(top, right, bottom, left);
 }
 
-String Xywh::to_string(CSSStyleValue::SerializationMode) const
+String Xywh::to_string(SerializationMode) const
 {
     return MUST(String::formatted("xywh({} {} {} {})", x, y, width, height));
 }
@@ -68,7 +68,7 @@ Gfx::Path Rect::to_path(CSSPixelRect reference_box, Layout::Node const& node) co
     return path_from_resolved_rect(top, max(right, left), max(bottom, top), left);
 }
 
-String Rect::to_string(CSSStyleValue::SerializationMode) const
+String Rect::to_string(SerializationMode) const
 {
     return MUST(String::formatted("rect({} {} {} {})", box.top(), box.right(), box.bottom(), box.left()));
 }
@@ -123,7 +123,7 @@ Gfx::Path Circle::to_path(CSSPixelRect reference_box, Layout::Node const& node) 
     return path;
 }
 
-String Circle::to_string(CSSStyleValue::SerializationMode mode) const
+String Circle::to_string(SerializationMode mode) const
 {
     return MUST(String::formatted("circle({} at {})", radius_to_string(radius), position->to_string(mode)));
 }
@@ -168,7 +168,7 @@ Gfx::Path Ellipse::to_path(CSSPixelRect reference_box, Layout::Node const& node)
     return path;
 }
 
-String Ellipse::to_string(CSSStyleValue::SerializationMode mode) const
+String Ellipse::to_string(SerializationMode mode) const
 {
     return MUST(String::formatted("ellipse({} {} at {})", radius_to_string(radius_x), radius_to_string(radius_y), position->to_string(mode)));
 }
@@ -193,7 +193,7 @@ Gfx::Path Polygon::to_path(CSSPixelRect reference_box, Layout::Node const& node)
     return path;
 }
 
-String Polygon::to_string(CSSStyleValue::SerializationMode) const
+String Polygon::to_string(SerializationMode) const
 {
     StringBuilder builder;
     builder.append("polygon("sv);

--- a/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
@@ -17,7 +17,7 @@ namespace Web::CSS {
 
 struct Inset {
     Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
-    String to_string(CSSStyleValue::SerializationMode) const;
+    String to_string(SerializationMode) const;
 
     bool operator==(Inset const&) const = default;
 
@@ -26,7 +26,7 @@ struct Inset {
 
 struct Xywh {
     Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
-    String to_string(CSSStyleValue::SerializationMode) const;
+    String to_string(SerializationMode) const;
 
     bool operator==(Xywh const&) const = default;
 
@@ -38,7 +38,7 @@ struct Xywh {
 
 struct Rect {
     Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
-    String to_string(CSSStyleValue::SerializationMode) const;
+    String to_string(SerializationMode) const;
 
     bool operator==(Rect const&) const = default;
 
@@ -54,7 +54,7 @@ using ShapeRadius = Variant<LengthPercentage, FitSide>;
 
 struct Circle {
     Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
-    String to_string(CSSStyleValue::SerializationMode) const;
+    String to_string(SerializationMode) const;
 
     bool operator==(Circle const&) const = default;
 
@@ -64,7 +64,7 @@ struct Circle {
 
 struct Ellipse {
     Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
-    String to_string(CSSStyleValue::SerializationMode) const;
+    String to_string(SerializationMode) const;
 
     bool operator==(Ellipse const&) const = default;
 
@@ -81,7 +81,7 @@ struct Polygon {
     };
 
     Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
-    String to_string(CSSStyleValue::SerializationMode) const;
+    String to_string(SerializationMode) const;
 
     bool operator==(Polygon const&) const = default;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -130,17 +130,17 @@ static NonnullRefPtr<CalculationNode const> simplify_2_children(T const& origina
     return original;
 }
 
-static String serialize_a_calculation_tree(CalculationNode const&, CalculationContext const&, CSSStyleValue::SerializationMode);
+static String serialize_a_calculation_tree(CalculationNode const&, CalculationContext const&, SerializationMode);
 
 // https://drafts.csswg.org/css-values-4/#serialize-a-math-function
-static String serialize_a_math_function(CalculationNode const& fn, CalculationContext const& context, CSSStyleValue::SerializationMode serialization_mode)
+static String serialize_a_math_function(CalculationNode const& fn, CalculationContext const& context, SerializationMode serialization_mode)
 {
     // To serialize a math function fn:
 
     // 1. If the root of the calculation tree fn represents is a numeric value (number, percentage, or dimension), and
     //    the serialization being produced is of a computed value or later, then clamp the value to the range allowed
     //    for its context (if necessary), then serialize the value as normal and return the result.
-    if (fn.type() == CalculationNode::Type::Numeric && serialization_mode == CSSStyleValue::SerializationMode::ResolvedValue) {
+    if (fn.type() == CalculationNode::Type::Numeric && serialization_mode == SerializationMode::ResolvedValue) {
         // FIXME: Clamp the value. Note that we might have an infinite/nan value here.
         return static_cast<NumericCalculationNode const&>(fn).value_to_string();
     }
@@ -311,7 +311,7 @@ static Vector<NonnullRefPtr<CalculationNode const>> sort_a_calculations_children
 }
 
 // https://drafts.csswg.org/css-values-4/#serialize-a-calculation-tree
-static String serialize_a_calculation_tree(CalculationNode const& root, CalculationContext const& context, CSSStyleValue::SerializationMode serialization_mode)
+static String serialize_a_calculation_tree(CalculationNode const& root, CalculationContext const& context, SerializationMode serialization_mode)
 {
     // 1. Let root be the root node of the calculation tree.
     // NOTE: Already the case.

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -90,7 +90,7 @@ static String generate_a_counter_representation(CSSStyleValue const& counter_sty
     }
     // FIXME: Handle `symbols()` function for counter_style.
 
-    dbgln("FIXME: Unsupported counter style '{}'", counter_style.to_string(CSSStyleValue::SerializationMode::Normal));
+    dbgln("FIXME: Unsupported counter style '{}'", counter_style.to_string(SerializationMode::Normal));
     return MUST(String::formatted("{}", value));
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
@@ -10,7 +10,7 @@ namespace Web::CSS {
 
 String EdgeStyleValue::to_string(SerializationMode mode) const
 {
-    if (mode == CSSStyleValue::SerializationMode::ResolvedValue) {
+    if (mode == SerializationMode::ResolvedValue) {
         // FIXME: Figure out how to get the proper calculation context here
         CalculationContext context {};
         return resolved_value(context)->offset().to_string();

--- a/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
@@ -23,7 +23,7 @@ public:
     virtual double value() const override { return m_flex.raw_value(); }
     virtual StringView unit() const override { return m_flex.unit_name(); }
 
-    virtual String to_string(SerializationMode) const override { return m_flex.to_string(); }
+    virtual String to_string(SerializationMode serialization_mode) const override { return m_flex.to_string(serialization_mode); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/FrequencyStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FrequencyStyleValue.h
@@ -26,7 +26,7 @@ public:
     virtual double value() const override { return m_frequency.raw_value(); }
     virtual StringView unit() const override { return m_frequency.unit_name(); }
 
-    virtual String to_string(SerializationMode) const override { return m_frequency.to_string(); }
+    virtual String to_string(SerializationMode serialization_mode) const override { return m_frequency.to_string(serialization_mode); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -23,7 +23,7 @@ public:
     virtual double value() const override { return m_length.raw_value(); }
     virtual StringView unit() const override { return m_length.unit_name(); }
 
-    virtual String to_string(SerializationMode) const override { return m_length.to_string(); }
+    virtual String to_string(SerializationMode serialization_mode) const override { return m_length.to_string(serialization_mode); }
     virtual ValueComparingNonnullRefPtr<CSSStyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     bool equals(CSSStyleValue const& other) const override;

--- a/Libraries/LibWeb/CSS/StyleValues/ResolutionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ResolutionStyleValue.h
@@ -23,7 +23,7 @@ public:
     virtual double value() const override { return m_resolution.raw_value(); }
     virtual StringView unit() const override { return m_resolution.unit_name(); }
 
-    virtual String to_string(SerializationMode) const override { return m_resolution.to_string(); }
+    virtual String to_string(SerializationMode serialization_mode) const override { return m_resolution.to_string(serialization_mode); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/TimeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TimeStyleValue.h
@@ -26,12 +26,7 @@ public:
     virtual double value() const override { return m_time.raw_value(); }
     virtual StringView unit() const override { return m_time.unit_name(); }
 
-    virtual String to_string(SerializationMode serialization_mode) const override
-    {
-        if (serialization_mode == SerializationMode::ResolvedValue)
-            return MUST(String::formatted("{}s", m_time.to_seconds()));
-        return m_time.to_string();
-    }
+    virtual String to_string(SerializationMode serialization_mode) const override { return m_time.to_string(serialization_mode); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/Time.cpp
+++ b/Libraries/LibWeb/CSS/Time.cpp
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Time.h"
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
+#include <LibWeb/CSS/Time.h>
 
 namespace Web::CSS {
 
@@ -26,8 +26,10 @@ Time Time::percentage_of(Percentage const& percentage) const
     return Time { percentage.as_fraction() * m_value, m_type };
 }
 
-String Time::to_string() const
+String Time::to_string(SerializationMode serialization_mode) const
 {
+    if (serialization_mode == SerializationMode::ResolvedValue)
+        return MUST(String::formatted("{}s", to_seconds()));
     return MUST(String::formatted("{}{}", raw_value(), unit_name()));
 }
 

--- a/Libraries/LibWeb/CSS/Time.h
+++ b/Libraries/LibWeb/CSS/Time.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,13 +7,14 @@
 #pragma once
 
 #include <AK/String.h>
+#include <LibWeb/CSS/SerializationMode.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
 class Time {
 public:
-    enum class Type {
+    enum class Type : u8 {
         S,
         Ms,
     };
@@ -24,7 +25,7 @@ public:
     static Time make_seconds(double);
     Time percentage_of(Percentage const&) const;
 
-    String to_string() const;
+    String to_string(SerializationMode = SerializationMode::Normal) const;
     double to_milliseconds() const;
     double to_seconds() const;
 

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -426,7 +426,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         };
         Vector<NameAndValue> properties;
         as<DOM::Element>(*layout_node.dom_node()).computed_properties()->for_each_property([&](auto property_id, auto& value) {
-            properties.append({ CSS::string_from_property_id(property_id), value.to_string(CSS::CSSStyleValue::SerializationMode::Normal) });
+            properties.append({ CSS::string_from_property_id(property_id), value.to_string(CSS::SerializationMode::Normal) });
         });
         quick_sort(properties, [](auto& a, auto& b) { return a.name < b.name; });
 
@@ -827,14 +827,14 @@ void dump_style_properties(StringBuilder& builder, CSS::CSSStyleProperties const
     builder.appendff("Declarations ({}):\n", declaration.length());
     for (auto& property : declaration.properties()) {
         indent(builder, indent_levels);
-        builder.appendff("  {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
+        builder.appendff("  {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_string(CSS::SerializationMode::Normal));
         if (property.important == CSS::Important::Yes)
             builder.append(" \033[31;1m!important\033[0m"sv);
         builder.append('\n');
     }
     for (auto& property : declaration.custom_properties()) {
         indent(builder, indent_levels);
-        builder.appendff("  {}: '{}'", property.key, property.value.value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
+        builder.appendff("  {}: '{}'", property.key, property.value.value->to_string(CSS::SerializationMode::Normal));
         if (property.value.important == CSS::Important::Yes)
             builder.append(" \033[31;1m!important\033[0m"sv);
         builder.append('\n');
@@ -847,7 +847,7 @@ void dump_descriptors(StringBuilder& builder, CSS::CSSDescriptors const& descrip
     builder.appendff("Declarations ({}):\n", descriptors.length());
     for (auto const& descriptor : descriptors.descriptors()) {
         indent(builder, indent_levels);
-        builder.appendff("  {}: '{}'", CSS::to_string(descriptor.descriptor_id), descriptor.value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
+        builder.appendff("  {}: '{}'", CSS::to_string(descriptor.descriptor_id), descriptor.value->to_string(CSS::SerializationMode::Normal));
         builder.append('\n');
     }
 }

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -646,7 +646,7 @@ Vector<GC::Ref<DOM::Node>> clear_the_value(FlyString const& command, GC::Ref<DOM
         auto new_style_value = CSS::StyleValueList::create(move(new_values), value_list.separator());
         MUST(inline_style->set_property(
             string_from_property_id(CSS::PropertyID::TextDecoration),
-            new_style_value->to_string(CSS::CSSStyleValue::SerializationMode::Normal),
+            new_style_value->to_string(CSS::SerializationMode::Normal),
             {}));
     };
     if (command == CommandNames::strikethrough)
@@ -1184,7 +1184,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
         auto resolved_value = resolved_background_color();
         if (!resolved_value.has_value())
             return {};
-        return resolved_value.value()->to_string(CSS::CSSStyleValue::SerializationMode::ResolvedValue);
+        return resolved_value.value()->to_string(CSS::SerializationMode::ResolvedValue);
     }
 
     // 5. If command is "subscript" or "superscript":
@@ -1264,7 +1264,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
     auto optional_value = resolved_value(*node, command_definition.relevant_css_property.value());
     if (!optional_value.has_value())
         return {};
-    return optional_value.value()->to_string(CSS::CSSStyleValue::SerializationMode::ResolvedValue);
+    return optional_value.value()->to_string(CSS::SerializationMode::ResolvedValue);
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#first-equivalent-point
@@ -2741,7 +2741,7 @@ void justify_the_selection(DOM::Document& document, JustifyAlignment alignment)
                     && element->inline_style()->length() == 1) {
                     auto text_align = element->inline_style()->property(CSS::PropertyID::TextAlign);
                     if (text_align.has_value()) {
-                        auto align_value = text_align.value().value->to_string(CSS::CSSStyleValue::SerializationMode::Normal);
+                        auto align_value = text_align.value().value->to_string(CSS::SerializationMode::Normal);
                         if (align_value.equals_ignoring_ascii_case(alignment_keyword))
                             ++number_of_matching_attributes;
                     }
@@ -3926,7 +3926,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
     //     that it sets property to.
     auto style_value = property_in_style_attribute(element, property.value());
     if (style_value.has_value())
-        return style_value.value()->to_string(CSS::CSSStyleValue::SerializationMode::Normal);
+        return style_value.value()->to_string(CSS::SerializationMode::Normal);
 
     // 11. If element is a font element that has an attribute whose effect is to create a presentational hint for
     //     property, return the value that the hint sets property to. (For a size of 7, this will be the non-CSS value
@@ -3937,7 +3937,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
         font_element.apply_presentational_hints(cascaded_properties);
         auto property_value = cascaded_properties->property(property.value());
         if (property_value)
-            return property_value->to_string(CSS::CSSStyleValue::SerializationMode::Normal);
+            return property_value->to_string(CSS::SerializationMode::Normal);
     }
 
     // 12. If element is in the following list, and property is equal to the CSS property name listed for it, return the

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -34,10 +34,10 @@ public:
         auto font_size = font_style_value.longhand(CSS::PropertyID::FontSize);
         auto font_family = font_style_value.longhand(CSS::PropertyID::FontFamily);
         return ByteString::formatted("{} {} {} {}",
-            font_style->to_string(CSS::CSSStyleValue::SerializationMode::Normal),
-            font_weight->to_string(CSS::CSSStyleValue::SerializationMode::Normal),
-            font_size->to_string(CSS::CSSStyleValue::SerializationMode::Normal),
-            font_family->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
+            font_style->to_string(CSS::SerializationMode::Normal),
+            font_weight->to_string(CSS::SerializationMode::Normal),
+            font_size->to_string(CSS::SerializationMode::Normal),
+            font_family->to_string(CSS::SerializationMode::Normal));
     }
 
     void set_font(StringView font)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -315,7 +315,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
                     dbgln("+ Element {}", element->debug_description());
                     for (size_t i = 0; i < Web::CSS::ComputedProperties::number_of_properties; ++i) {
                         auto property = styles->maybe_null_property(static_cast<Web::CSS::PropertyID>(i));
-                        dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), property ? property->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal) : ""_string);
+                        dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), property ? property->to_string(Web::CSS::SerializationMode::Normal) : ""_string);
                     }
                     dbgln("---");
                 }
@@ -483,7 +483,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
         properties->for_each_property([&](auto property_id, auto& value) {
             serialized.set(
                 Web::CSS::string_from_property_id(property_id),
-                value.to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
+                value.to_string(Web::CSS::SerializationMode::Normal));
         });
 
         return serialized;
@@ -517,12 +517,12 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
         serialized.set("border-bottom-width"sv, box_model.border.bottom.to_double());
         serialized.set("border-left-width"sv, box_model.border.left.to_double());
 
-        serialized.set("box-sizing"sv, properties->property(Web::CSS::PropertyID::BoxSizing).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
-        serialized.set("display"sv, properties->property(Web::CSS::PropertyID::Display).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
-        serialized.set("float"sv, properties->property(Web::CSS::PropertyID::Float).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
-        serialized.set("line-height"sv, properties->property(Web::CSS::PropertyID::LineHeight).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
-        serialized.set("position"sv, properties->property(Web::CSS::PropertyID::Position).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
-        serialized.set("z-index"sv, properties->property(Web::CSS::PropertyID::ZIndex).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
+        serialized.set("box-sizing"sv, properties->property(Web::CSS::PropertyID::BoxSizing).to_string(Web::CSS::SerializationMode::Normal));
+        serialized.set("display"sv, properties->property(Web::CSS::PropertyID::Display).to_string(Web::CSS::SerializationMode::Normal));
+        serialized.set("float"sv, properties->property(Web::CSS::PropertyID::Float).to_string(Web::CSS::SerializationMode::Normal));
+        serialized.set("line-height"sv, properties->property(Web::CSS::PropertyID::LineHeight).to_string(Web::CSS::SerializationMode::Normal));
+        serialized.set("position"sv, properties->property(Web::CSS::PropertyID::Position).to_string(Web::CSS::SerializationMode::Normal));
+        serialized.set("z-index"sv, properties->property(Web::CSS::PropertyID::ZIndex).to_string(Web::CSS::SerializationMode::Normal));
 
         return serialized;
     };

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -1378,7 +1378,7 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
             // computed value of parameter URL variables["property name"] from element's style declarations.
             if (auto property = Web::CSS::property_id_from_string(name); property.has_value()) {
                 if (auto computed_properties = element->computed_properties())
-                    computed_value = computed_properties->property(property.value()).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
+                    computed_value = computed_properties->property(property.value()).to_string(Web::CSS::SerializationMode::Normal);
             }
         }
         // -> Otherwise

--- a/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
+++ b/Tests/LibWeb/Text/expected/css/media-query-serialization-basic.txt
@@ -2,9 +2,9 @@
 }
 @media screen and (min-width: 20px) and (max-width: 40px) {
 }
-@media screen and (min-resolution: 1dppx) {
+@media screen and (min-resolution: 96dpi) {
 }
 @media screen and (min-resolution: 2dppx) {
 }
-@media screen and (min-resolution: 2.54dppx) {
+@media screen and (min-resolution: 96dpcm) {
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-variation-settings-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-variation-settings-invalid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 18 tests
 
-17 Pass
-1 Fail
+18 Pass
 Pass	e.style['font-variation-settings'] = "700" should not set the property value
 Pass	e.style['font-variation-settings'] = "\"XHGT\"" should not set the property value
 Pass	e.style['font-variation-settings'] = "wght 700" should not set the property value
@@ -16,7 +15,7 @@ Pass	e.style['font-variation-settings'] = "\"abcA9\" 0.5" should not set the pro
 Pass	e.style['font-variation-settings'] = "'wght' 200 'abcd' 400" should not set the property value
 Pass	e.style['font-variation-settings'] = "'a' 1234" should not set the property value
 Pass	e.style['font-variation-settings'] = "'abcde' 1234" should not set the property value
-Fail	e.style['font-variation-settings'] = "'wght' 200, " should not set the property value
+Pass	e.style['font-variation-settings'] = "'wght' 200, " should not set the property value
 Pass	e.style['font-variation-settings'] = "'abcd\" 123" should not set the property value
 Pass	e.style['font-variation-settings'] = "'wght' 100px" should not set the property value
 Pass	e.style['font-variation-settings'] = "'wght' calc(100px + 200px)" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 34 tests
 
-30 Pass
-4 Fail
+32 Pass
+2 Fail
 Pass	Test parsing '' with matchMedia
 Pass	Test parsing ' ' with matchMedia
 Pass	Test parsing 'all' with matchMedia
@@ -20,9 +20,9 @@ Pass	Test parsing 'color)' with matchMedia
 Pass	Test parsing '  color)' with matchMedia
 Pass	Test parsing '  color ), ( color' with matchMedia
 Fail	Test parsing ' foo ' with matchMedia
-Fail	Test parsing ',' with matchMedia
+Pass	Test parsing ',' with matchMedia
 Pass	Test parsing ' , ' with matchMedia
-Fail	Test parsing ',,' with matchMedia
+Pass	Test parsing ',,' with matchMedia
 Pass	Test parsing '  ,  ,  ' with matchMedia
 Fail	Test parsing ' foo,' with matchMedia
 Pass	Test parsing '(min-resolution: 1x)' with matchMedia

--- a/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
@@ -1,0 +1,40 @@
+Harness status: OK
+
+Found 34 tests
+
+25 Pass
+9 Fail
+Pass	Test parsing '' with matchMedia
+Pass	Test parsing ' ' with matchMedia
+Pass	Test parsing 'all' with matchMedia
+Pass	Test parsing ' all' with matchMedia
+Pass	Test parsing '   all   ' with matchMedia
+Pass	Test parsing 'all,all' with matchMedia
+Pass	Test parsing ' all , all ' with matchMedia
+Pass	Test parsing '(color)' with matchMedia
+Pass	Test parsing '(color' with matchMedia
+Pass	Test parsing ' (color)' with matchMedia
+Pass	Test parsing ' ( color  )  ' with matchMedia
+Pass	Test parsing ' ( color   ' with matchMedia
+Pass	Test parsing 'color)' with matchMedia
+Pass	Test parsing '  color)' with matchMedia
+Pass	Test parsing '  color ), ( color' with matchMedia
+Fail	Test parsing ' foo ' with matchMedia
+Fail	Test parsing ',' with matchMedia
+Pass	Test parsing ' , ' with matchMedia
+Fail	Test parsing ',,' with matchMedia
+Pass	Test parsing '  ,  ,  ' with matchMedia
+Fail	Test parsing ' foo,' with matchMedia
+Fail	Test parsing '(min-resolution: 1x)' with matchMedia
+Pass	Test parsing '(min-resolution: calc(1x))' with matchMedia
+Fail	Test parsing '(resolution: 2x)' with matchMedia
+Pass	Test parsing '(resolution: calc(2x))' with matchMedia
+Fail	Test parsing '(max-resolution: 7x)' with matchMedia
+Pass	Test parsing '(max-resolution: calc(7x))' with matchMedia
+Pass	Test parsing '(resolution: 2dppx)' with matchMedia
+Fail	Test parsing '(resolution: 600dpi)' with matchMedia
+Fail	Test parsing '(resolution: 77dpcm)' with matchMedia
+Pass	Test parsing '(resolution: calc(1x + 2x))' with matchMedia
+Pass	Test parsing '(resolution: calc(5x - 2x))' with matchMedia
+Pass	Test parsing '(resolution: calc(1x * 3))' with matchMedia
+Pass	Test parsing '(resolution: calc(6x / 2))' with matchMedia

--- a/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 34 tests
 
-25 Pass
-9 Fail
+27 Pass
+7 Fail
 Pass	Test parsing '' with matchMedia
 Pass	Test parsing ' ' with matchMedia
 Pass	Test parsing 'all' with matchMedia
@@ -32,8 +32,8 @@ Pass	Test parsing '(resolution: calc(2x))' with matchMedia
 Fail	Test parsing '(max-resolution: 7x)' with matchMedia
 Pass	Test parsing '(max-resolution: calc(7x))' with matchMedia
 Pass	Test parsing '(resolution: 2dppx)' with matchMedia
-Fail	Test parsing '(resolution: 600dpi)' with matchMedia
-Fail	Test parsing '(resolution: 77dpcm)' with matchMedia
+Pass	Test parsing '(resolution: 600dpi)' with matchMedia
+Pass	Test parsing '(resolution: 77dpcm)' with matchMedia
 Pass	Test parsing '(resolution: calc(1x + 2x))' with matchMedia
 Pass	Test parsing '(resolution: calc(5x - 2x))' with matchMedia
 Pass	Test parsing '(resolution: calc(1x * 3))' with matchMedia

--- a/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/match-media-parsing.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 34 tests
 
-27 Pass
-7 Fail
+30 Pass
+4 Fail
 Pass	Test parsing '' with matchMedia
 Pass	Test parsing ' ' with matchMedia
 Pass	Test parsing 'all' with matchMedia
@@ -25,11 +25,11 @@ Pass	Test parsing ' , ' with matchMedia
 Fail	Test parsing ',,' with matchMedia
 Pass	Test parsing '  ,  ,  ' with matchMedia
 Fail	Test parsing ' foo,' with matchMedia
-Fail	Test parsing '(min-resolution: 1x)' with matchMedia
+Pass	Test parsing '(min-resolution: 1x)' with matchMedia
 Pass	Test parsing '(min-resolution: calc(1x))' with matchMedia
-Fail	Test parsing '(resolution: 2x)' with matchMedia
+Pass	Test parsing '(resolution: 2x)' with matchMedia
 Pass	Test parsing '(resolution: calc(2x))' with matchMedia
-Fail	Test parsing '(max-resolution: 7x)' with matchMedia
+Pass	Test parsing '(max-resolution: 7x)' with matchMedia
 Pass	Test parsing '(max-resolution: calc(7x))' with matchMedia
 Pass	Test parsing '(resolution: 2dppx)' with matchMedia
 Pass	Test parsing '(resolution: 600dpi)' with matchMedia

--- a/Tests/LibWeb/Text/input/wpt-import/css/mediaqueries/match-media-parsing.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/mediaqueries/match-media-parsing.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-syntax-3/#parse-comma-separated-list-of-component-values">
+<script type="text/javascript" src="../../resources/testharness.js"></script>
+<script type="text/javascript" src="../../resources/testharnessreport.js"></script>
+
+<script>
+function test_parsing(query, expected) {
+    if(expected === undefined)
+        expected = query;
+
+    test(() => {
+        const match = window.matchMedia(query);
+        assert_equals(match.media, expected)
+    }, "Test parsing '" + query + "' with matchMedia");
+}
+
+function test_resolution_parsing() {
+    test_parsing("(min-resolution: 1x)");
+    test_parsing("(min-resolution: calc(1x))", "(min-resolution: calc(1dppx))");
+    test_parsing("(resolution: 2x)");
+    test_parsing("(resolution: calc(2x))", "(resolution: calc(2dppx))");
+    test_parsing("(max-resolution: 7x)");
+    test_parsing("(max-resolution: calc(7x))", "(max-resolution: calc(7dppx))");
+
+    test_parsing("(resolution: 2dppx)");
+    test_parsing("(resolution: 600dpi)");
+    test_parsing("(resolution: 77dpcm)");
+
+    test_parsing("(resolution: calc(1x + 2x))", "(resolution: calc(3dppx))");
+    test_parsing("(resolution: calc(5x - 2x))", "(resolution: calc(3dppx))");
+    test_parsing("(resolution: calc(1x * 3))", "(resolution: calc(3dppx))");
+    test_parsing("(resolution: calc(6x / 2))", "(resolution: calc(3dppx))");
+}
+
+test_parsing("", "");
+test_parsing(" ", "");
+test_parsing("all", "all");
+test_parsing(" all", "all");
+test_parsing("   all   ", "all");
+test_parsing("all,all", "all, all");
+test_parsing(" all , all ", "all, all");
+test_parsing("(color)", "(color)");
+test_parsing("(color", "(color)");
+test_parsing(" (color)", "(color)");
+test_parsing(" ( color  )  ", "(color)");
+test_parsing(" ( color   ", "(color)");
+test_parsing("color)", "not all");
+test_parsing("  color)", "not all");
+test_parsing("  color ), ( color", "not all, (color)");
+test_parsing(" foo ", "foo");
+test_parsing(",", "not all, not all");
+test_parsing(" , ", "not all, not all");
+test_parsing(",,", "not all, not all, not all");
+test_parsing("  ,  ,  ", "not all, not all, not all");
+test_parsing(" foo,", "foo, not all");
+
+test_resolution_parsing();
+</script>


### PR DESCRIPTION
8 WPT passes, that I know of.

There are a couple more, but those require allowing arbitrary `<ident>`s as the `<media-type>` and I'm done for today. :^)