### PR TITLE
Meta: Enforce symbol annotation for EXPLICIT_SYMBOL_EXPORT on Windows

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -184,6 +184,8 @@ function(lagom_generate_export_header name fs_name)
     # to gradually slowly migrate instead of an all-or-nothing approach.
     if (NOT WIN32)
         target_compile_options(${name} PRIVATE -fvisibility=hidden)
+    else()
+        set_target_properties(${name} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS OFF)
     endif()
     include(GenerateExportHeader)
     string(TOUPPER ${fs_name} fs_name_upper)


### PR DESCRIPTION
### Before

As shown below, before it didn't actually matter on Windows if you annotated or not as `set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)` makes all targets export by default.

#### Forgot to annotate
![image](https://github.com/user-attachments/assets/0d76327f-48ac-4372-aad7-60d9ec47e742)

#### Remembered to annotate
![image](https://github.com/user-attachments/assets/4db4dc83-3475-4e11-a6ec-b806c4317d7f)


### After

Now that we explicitly turn off `WINDOWS_EXPORT_ALL_SYMBOLS` for targets that set the `EXPLICIT_SYMBOL_EXPORT` flag, forgetting to annotate will cause link-time errors, which is what already happens on Unix.

#### Forgot to annotate
![image](https://github.com/user-attachments/assets/55147cb1-a1c5-4dab-b573-e44558597ab8)

#### Remembered to annotate

![image](https://github.com/user-attachments/assets/2065db42-f98a-492b-9201-b706c33c9ed0)


So now all platforms have consistent explicit export symbol behaviour wrt annotation requirements.

