### PR TITLE
CMake: Set `CMAKE_POSITION_INDEPENDENT_CODE` instead of manual `-fPIC`

### DIFF
--- a/Meta/CMake/lagom_compile_options.cmake
+++ b/Meta/CMake/lagom_compile_options.cmake
@@ -13,8 +13,10 @@ else()
     add_cxx_compile_options(/Z7)
 endif()
 
-if (NOT WIN32)
-    add_cxx_compile_options(-fPIC)
+include(CheckPIESupported)
+check_pie_supported(LANGUAGES CXX)
+if(CMAKE_CXX_LINK_PIE_SUPPORTED)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
 if (LINUX)


### PR DESCRIPTION
If we are doing a statically linked build, there is no need for full `-fPIC`, just `-fpie` is enough (which lets the compiler assume that global variables can be accessed directly without the GOT, etc.). CMake does the right thing already when we set the `POSITION_INDEPENDENT_CODE` property.