### PR TITLE
Meta: Enable UTF-8 process encoding on Windows

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -61,6 +61,7 @@ if (WIN32)
   add_compile_definitions(NAME_MAX=255)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
   add_compile_options(-Wno-deprecated-declarations)
+  add_compile_options(/utf-8)
 endif()
 
 if (MSVC)


### PR DESCRIPTION
See discussion here for context: https://github.com/LadybirdBrowser/ladybird/pull/4707#discussion_r2087208068

And documentation on `/utf-8` is here: https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8

But now we are UTF-8 everywhere and have a consistent process-encoding, which should help prevent Windows-specific issues crop up later in Unicode-related workflows.

As of right now all the libraries required to build the AK testsuite and the AK testsuite itself have no issues with this.