### PR TITLE
LibJS: Fuse Not and JumpIf into inverted JumpIf, avoid exception check for Not/Typeof

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1268,6 +1268,15 @@ bool Generator::fuse_compare_and_jump(ScopedOperand const& condition, Label true
     JS_ENUMERATE_COMPARISON_OPS(HANDLE_COMPARISON_OP);
 #undef HANDLE_COMPARISON_OP
 
+    if (last_instruction.type() == Instruction::Type::Not) {
+        auto& not_ = static_cast<Op::Not const&>(last_instruction);
+        VERIFY(not_.dst() == condition);
+        m_current_basic_block->rewind();
+        // NOTE: Inverted true and false targets to handle the negation.
+        emit<Op::JumpIf>(not_.src(), false_target, true_target);
+        return true;
+    }
+
     return false;
 }
 

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -170,9 +170,11 @@ JS_ENUMERATE_COMMON_BINARY_OPS_WITH_FAST_PATH(JS_DECLARE_COMMON_BINARY_OP)
 
 #define JS_ENUMERATE_COMMON_UNARY_OPS(O) \
     O(BitwiseNot, bitwise_not)           \
-    O(Not, not_)                         \
     O(UnaryPlus, unary_plus)             \
-    O(UnaryMinus, unary_minus)           \
+    O(UnaryMinus, unary_minus)
+
+#define JS_ENUMERATE_COMMON_UNARY_OPS_WITHOUT_EXCEPTION_CHECK(O) \
+    O(Not, not_)                                                 \
     O(Typeof, typeof_)
 
 #define JS_DECLARE_COMMON_UNARY_OP(OpTitleCase, op_snake_case)              \
@@ -203,6 +205,35 @@ JS_ENUMERATE_COMMON_BINARY_OPS_WITH_FAST_PATH(JS_DECLARE_COMMON_BINARY_OP)
 
 JS_ENUMERATE_COMMON_UNARY_OPS(JS_DECLARE_COMMON_UNARY_OP)
 #undef JS_DECLARE_COMMON_UNARY_OP
+
+#define JS_DECLARE_COMMON_UNARY_OP_WITHOUT_EXCEPTION_CHECK(OpTitleCase, op_snake_case) \
+    class OpTitleCase final : public Instruction {                                     \
+    public:                                                                            \
+        OpTitleCase(Operand dst, Operand src)                                          \
+            : Instruction(Type::OpTitleCase)                                           \
+            , m_dst(dst)                                                               \
+            , m_src(src)                                                               \
+        {                                                                              \
+        }                                                                              \
+                                                                                       \
+        void execute_impl(Bytecode::Interpreter&) const;                               \
+        ByteString to_byte_string_impl(Bytecode::Executable const&) const;             \
+        void visit_operands_impl(Function<void(Operand&)> visitor)                     \
+        {                                                                              \
+            visitor(m_dst);                                                            \
+            visitor(m_src);                                                            \
+        }                                                                              \
+                                                                                       \
+        Operand dst() const { return m_dst; }                                          \
+        Operand src() const { return m_src; }                                          \
+                                                                                       \
+    private:                                                                           \
+        Operand m_dst;                                                                 \
+        Operand m_src;                                                                 \
+    };
+
+JS_ENUMERATE_COMMON_UNARY_OPS_WITHOUT_EXCEPTION_CHECK(JS_DECLARE_COMMON_UNARY_OP_WITHOUT_EXCEPTION_CHECK)
+#undef JS_DECLARE_COMMON_UNARY_OP_WITHOUT_EXCEPTION_CHECK
 
 class NewObject final : public Instruction {
 public:


### PR DESCRIPTION
Ends up being relatively even across the board, but does (surprisingly to me) give a 20% speedup in `access-fannkuch.js` tested on distribution build since the not is in the critical path.

With latest push:
```
Suite       Test                           Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  ---------------------------  ---------  ------------------------  ------------------------
LongSpider  3d-cube.js                       1.005  3.287 ± 3.280 … 3.290     3.270 ± 3.260 … 3.290
LongSpider  3d-morph.js                      0.998  2.000 ± 2.000 … 2.000     2.003 ± 2.000 … 2.010
LongSpider  3d-raytrace.js                   1.009  3.563 ± 3.540 … 3.580     3.530 ± 3.520 … 3.540
LongSpider  access-binary-trees.js           1.006  27.517 ± 27.370 … 27.750  27.357 ± 27.280 … 27.400
LongSpider  access-fannkuch.js               1.238  2.390 ± 2.390 … 2.390     1.930 ± 1.930 … 1.930
LongSpider  access-nbody.js                  1.01   6.277 ± 6.230 … 6.300     6.217 ± 6.190 … 6.250
LongSpider  access-nsieve.js                 1.014  11.693 ± 11.670 … 11.730  11.530 ± 11.520 … 11.540
LongSpider  bitops-3bit-bits-in-byte.js      1.006  0.580 ± 0.570 … 0.590     0.577 ± 0.560 … 0.590
LongSpider  bitops-bits-in-byte.js           1.057  0.923 ± 0.910 … 0.940     0.873 ± 0.870 … 0.880
LongSpider  bitops-nsieve-bits.js            1.005  1.940 ± 1.930 … 1.950     1.930 ± 1.930 … 1.930
LongSpider  crypto-aes.js                    0.996  8.203 ± 8.200 … 8.210     8.233 ± 8.200 … 8.250
LongSpider  crypto-md5.js                    1      8.173 ± 8.090 … 8.280     8.173 ± 8.090 … 8.220
LongSpider  crypto-sha1.js                   1.026  16.320 ± 16.100 … 16.510  15.913 ± 15.830 … 16.000
LongSpider  date-format-tofte.js             1.031  3.813 ± 3.760 … 3.860     3.700 ± 3.690 … 3.710
LongSpider  date-format-xparb.js             0.998  3.467 ± 3.460 … 3.480     3.473 ± 3.430 … 3.530
LongSpider  hash-map.js                      1.006  1.557 ± 1.550 … 1.560     1.547 ± 1.540 … 1.550
LongSpider  math-cordic.js                   0.991  5.967 ± 5.880 … 6.020     6.020 ± 5.990 … 6.050
LongSpider  math-partial-sums.js             1.008  0.887 ± 0.880 … 0.890     0.880 ± 0.880 … 0.880
LongSpider  math-spectral-norm.js            1.006  7.403 ± 7.310 … 7.470     7.357 ± 7.340 … 7.370
LongSpider  string-base64.js                 1.025  1.660 ± 1.650 … 1.670     1.620 ± 1.620 … 1.620
LongSpider  string-fasta.js                  1.001  8.817 ± 8.760 … 8.850     8.810 ± 8.800 … 8.820
LongSpider  string-tagcloud.js               1.002  1.867 ± 1.860 … 1.870     1.863 ± 1.860 … 1.870
LongSpider  Total                            1.012  128.303                   126.807
All Suites  Total                            1.012  128.303                   126.807
```