### PR TITLE
LibWeb: Prefer using equals_ignoring_ascii_case

### DIFF
--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -83,7 +83,7 @@ WebIDL::ExceptionOr<void> CSSDescriptors::set_property(StringView property, Stri
     }
 
     // 4. If priority is not the empty string and is not an ASCII case-insensitive match for the string "important", then return.
-    if (!priority.is_empty() && !Infra::is_ascii_case_insensitive_match(priority, "important"sv))
+    if (!priority.is_empty() && !priority.equals_ignoring_ascii_case("important"sv))
         return {};
 
     // 5. Let component value list be the result of parsing value for property property.

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -224,7 +224,7 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(StringView property_n
     }
 
     // 4. If priority is not the empty string and is not an ASCII case-insensitive match for the string "important", then return.
-    if (!priority.is_empty() && !Infra::is_ascii_case_insensitive_match(priority, "important"sv))
+    if (!priority.is_empty() && !priority.equals_ignoring_ascii_case("important"sv))
         return {};
 
     // 5. Let component value list be the result of parsing value for property property.

--- a/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -412,7 +412,7 @@ Token Tokenizer::consume_an_ident_like_token()
 
     // If string’s value is an ASCII case-insensitive match for "url", and the next input code
     // point is U+0028 LEFT PARENTHESIS ((), consume it.
-    if (Infra::is_ascii_case_insensitive_match(string, "url"sv) && is_left_paren(peek_code_point())) {
+    if (string.equals_ignoring_ascii_case("url"sv) && is_left_paren(peek_code_point())) {
         (void)next_code_point();
 
         // While the next two input code points are whitespace, consume the next input code point.

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -66,7 +66,7 @@ static bool language_range_matches_tag(StringView language_range, StringView lan
     //    is the wildcard '*'.
     auto subtags_match = [](StringView language_range_subtag, StringView language_subtag) {
         return language_range_subtag == "*"sv
-            || Infra::is_ascii_case_insensitive_match(language_range_subtag, language_subtag);
+            || language_range_subtag.equals_ignoring_ascii_case(language_subtag);
     };
 
     // 2. Begin with the first subtag in each list. If the first subtag in the range does not match the first
@@ -271,7 +271,7 @@ static inline void for_each_matching_attribute(CSS::Selector::SimpleSelector::At
         for (auto i = 0u; i < element.attributes()->length(); ++i) {
             auto const* attr = element.attributes()->item(i);
             bool matches = case_insensitive
-                ? Infra::is_ascii_case_insensitive_match(attr->local_name(), attribute_name)
+                ? attr->local_name().equals_ignoring_ascii_case(attribute_name)
                 : attr->local_name() == attribute_name;
             if (matches) {
                 if (process_attribute(*attr) == IterationDecision::Break)
@@ -301,7 +301,7 @@ static bool matches_single_attribute(CSS::Selector::SimpleSelector::Attribute co
     switch (attribute_selector.match_type) {
     case CSS::Selector::SimpleSelector::Attribute::MatchType::ExactValueMatch:
         return case_insensitive_match
-            ? Infra::is_ascii_case_insensitive_match(attribute.value(), attribute_selector.value)
+            ? attribute.value().equals_ignoring_ascii_case(attribute_selector.value)
             : attribute.value() == attribute_selector.value;
     case CSS::Selector::SimpleSelector::Attribute::MatchType::ContainsWord: {
         if (attribute_selector.value.is_empty()) {
@@ -314,7 +314,7 @@ static bool matches_single_attribute(CSS::Selector::SimpleSelector::Attribute co
         for (size_t i = 0; i < size; ++i) {
             auto const value = view.at(i);
             if (case_insensitive_match
-                    ? Infra::is_ascii_case_insensitive_match(value, attribute_selector.value)
+                    ? value.equals_ignoring_ascii_case(attribute_selector.value)
                     : value == attribute_selector.value) {
                 return true;
             }
@@ -346,7 +346,7 @@ static bool matches_single_attribute(CSS::Selector::SimpleSelector::Attribute co
 
         if (attribute_length == element_attribute_length) {
             return case_insensitive_match
-                ? Infra::is_ascii_case_insensitive_match(element_attr_value, attribute_selector.value)
+                ? element_attr_value.equals_ignoring_ascii_case(attribute_selector.value)
                 : element_attr_value == attribute_selector.value;
         }
 
@@ -1040,7 +1040,7 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, DOM::
             if (element.document().document_type() == DOM::Document::Type::HTML && element.namespace_uri() == Namespace::HTML) {
                 if (qualified_name.name.lowercase_name != element.local_name())
                     return false;
-            } else if (!Infra::is_ascii_case_insensitive_match(qualified_name.name.name, element.local_name())) {
+            } else if (!qualified_name.name.name.equals_ignoring_ascii_case(element.local_name())) {
                 return false;
             }
         }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2201,44 +2201,44 @@ WebIDL::ExceptionOr<GC::Ref<Event>> Document::create_event(StringView interface)
 
     // 2. If interface is an ASCII case-insensitive match for any of the strings in the first column in the following table,
     //      then set constructor to the interface in the second column on the same row as the matching string:
-    if (Infra::is_ascii_case_insensitive_match(interface, "beforeunloadevent"sv)) {
+    if (interface.equals_ignoring_ascii_case("beforeunloadevent"sv)) {
         event = HTML::BeforeUnloadEvent::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "compositionevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("compositionevent"sv)) {
         event = UIEvents::CompositionEvent::create(realm, String {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "customevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("customevent"sv)) {
         event = CustomEvent::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "devicemotionevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("devicemotionevent"sv)) {
         event = Event::create(realm, FlyString {}); // FIXME: Create DeviceMotionEvent
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "deviceorientationevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("deviceorientationevent"sv)) {
         event = Event::create(realm, FlyString {}); // FIXME: Create DeviceOrientationEvent
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "dragevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("dragevent"sv)) {
         event = Event::create(realm, FlyString {}); // FIXME: Create DragEvent
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "event"sv)
-        || Infra::is_ascii_case_insensitive_match(interface, "events"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("event"sv)
+        || interface.equals_ignoring_ascii_case("events"sv)) {
         event = Event::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "focusevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("focusevent"sv)) {
         event = UIEvents::FocusEvent::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "hashchangeevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("hashchangeevent"sv)) {
         event = HTML::HashChangeEvent::create(realm, FlyString {}, {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "htmlevents"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("htmlevents"sv)) {
         event = Event::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "keyboardevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("keyboardevent"sv)) {
         event = UIEvents::KeyboardEvent::create(realm, String {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "messageevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("messageevent"sv)) {
         event = HTML::MessageEvent::create(realm, String {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "mouseevent"sv)
-        || Infra::is_ascii_case_insensitive_match(interface, "mouseevents"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("mouseevent"sv)
+        || interface.equals_ignoring_ascii_case("mouseevents"sv)) {
         event = UIEvents::MouseEvent::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "storageevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("storageevent"sv)) {
         event = Event::create(realm, FlyString {}); // FIXME: Create StorageEvent
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "svgevents"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("svgevents"sv)) {
         event = Event::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "textevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("textevent"sv)) {
         event = UIEvents::TextEvent::create(realm, FlyString {});
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "touchevent"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("touchevent"sv)) {
         event = Event::create(realm, FlyString {}); // FIXME: Create TouchEvent
-    } else if (Infra::is_ascii_case_insensitive_match(interface, "uievent"sv)
-        || Infra::is_ascii_case_insensitive_match(interface, "uievents"sv)) {
+    } else if (interface.equals_ignoring_ascii_case("uievent"sv)
+        || interface.equals_ignoring_ascii_case("uievents"sv)) {
         event = UIEvents::UIEvent::create(realm, FlyString {});
     }
 
@@ -2620,7 +2620,7 @@ Document::IndicatedPart Document::determine_the_indicated_part() const
         return potential_indicated_element;
 
     // 9. If decodedFragment is an ASCII case-insensitive match for the string top, then return the top of the document.
-    if (Infra::is_ascii_case_insensitive_match(decoded_fragment, "top"sv))
+    if (decoded_fragment.equals_ignoring_ascii_case("top"sv))
         return Document::TopOfTheDocument {};
 
     // 10. Return null.

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1971,8 +1971,8 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
     // 2. Use the first matching item from this list:
     // - If position is an ASCII case-insensitive match for the string "beforebegin"
     // - If position is an ASCII case-insensitive match for the string "afterend"
-    if (Infra::is_ascii_case_insensitive_match(position, "beforebegin"sv)
-        || Infra::is_ascii_case_insensitive_match(position, "afterend"sv)) {
+    if (position.equals_ignoring_ascii_case("beforebegin"sv)
+        || position.equals_ignoring_ascii_case("afterend"sv)) {
         // 1. Set context to this's parent.
         context = this->parent();
 
@@ -1982,8 +1982,8 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
     }
     // - If position is an ASCII case-insensitive match for the string "afterbegin"
     // - If position is an ASCII case-insensitive match for the string "beforeend"
-    else if (Infra::is_ascii_case_insensitive_match(position, "afterbegin"sv)
-        || Infra::is_ascii_case_insensitive_match(position, "beforeend"sv)) {
+    else if (position.equals_ignoring_ascii_case("afterbegin"sv)
+        || position.equals_ignoring_ascii_case("beforeend"sv)) {
         // Set context to this.
         context = this;
     }
@@ -2010,25 +2010,25 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
     // 5. Use the first matching item from this list:
 
     // - If position is an ASCII case-insensitive match for the string "beforebegin"
-    if (Infra::is_ascii_case_insensitive_match(position, "beforebegin"sv)) {
+    if (position.equals_ignoring_ascii_case("beforebegin"sv)) {
         // Insert fragment into this's parent before this.
         parent()->insert_before(fragment, this);
     }
 
     // - If position is an ASCII case-insensitive match for the string "afterbegin"
-    else if (Infra::is_ascii_case_insensitive_match(position, "afterbegin"sv)) {
+    else if (position.equals_ignoring_ascii_case("afterbegin"sv)) {
         // Insert fragment into this before its first child.
         insert_before(fragment, first_child());
     }
 
     // - If position is an ASCII case-insensitive match for the string "beforeend"
-    else if (Infra::is_ascii_case_insensitive_match(position, "beforeend"sv)) {
+    else if (position.equals_ignoring_ascii_case("beforeend"sv)) {
         // Append fragment to this.
         TRY(append_child(fragment));
     }
 
     // - If position is an ASCII case-insensitive match for the string "afterend"
-    else if (Infra::is_ascii_case_insensitive_match(position, "afterend"sv)) {
+    else if (position.equals_ignoring_ascii_case("afterend"sv)) {
         // Insert fragment into this's parent before this's next sibling.
         parent()->insert_before(fragment, next_sibling());
     }
@@ -2039,7 +2039,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
 WebIDL::ExceptionOr<GC::Ptr<Node>> Element::insert_adjacent(StringView where, GC::Ref<Node> node)
 {
     // To insert adjacent, given an element element, string where, and a node node, run the steps associated with the first ASCII case-insensitive match for where:
-    if (Infra::is_ascii_case_insensitive_match(where, "beforebegin"sv)) {
+    if (where.equals_ignoring_ascii_case("beforebegin"sv)) {
         // -> "beforebegin"
         // If element’s parent is null, return null.
         if (!parent())
@@ -2049,19 +2049,19 @@ WebIDL::ExceptionOr<GC::Ptr<Node>> Element::insert_adjacent(StringView where, GC
         return GC::Ptr<Node> { TRY(parent()->pre_insert(move(node), this)) };
     }
 
-    if (Infra::is_ascii_case_insensitive_match(where, "afterbegin"sv)) {
+    if (where.equals_ignoring_ascii_case("afterbegin"sv)) {
         // -> "afterbegin"
         // Return the result of pre-inserting node into element before element’s first child.
         return GC::Ptr<Node> { TRY(pre_insert(move(node), first_child())) };
     }
 
-    if (Infra::is_ascii_case_insensitive_match(where, "beforeend"sv)) {
+    if (where.equals_ignoring_ascii_case("beforeend"sv)) {
         // -> "beforeend"
         // Return the result of pre-inserting node into element before null.
         return GC::Ptr<Node> { TRY(pre_insert(move(node), nullptr)) };
     }
 
-    if (Infra::is_ascii_case_insensitive_match(where, "afterend"sv)) {
+    if (where.equals_ignoring_ascii_case("afterend"sv)) {
         // -> "afterend"
         // If element’s parent is null, return null.
         if (!parent())

--- a/Libraries/LibWeb/DOM/StyleElementUtils.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementUtils.cpp
@@ -47,7 +47,7 @@ void StyleElementUtils::update_a_style_block(DOM::Element& style_element)
 
     // 4. If element's type attribute is present and its value is neither the empty string nor an ASCII case-insensitive match for "text/css", then return.
     auto type_attribute = style_element.attribute(HTML::AttributeNames::type);
-    if (type_attribute.has_value() && !type_attribute->is_empty() && !Infra::is_ascii_case_insensitive_match(type_attribute->bytes_as_string_view(), "text/css"sv))
+    if (type_attribute.has_value() && !type_attribute->is_empty() && !type_attribute->bytes_as_string_view().equals_ignoring_ascii_case("text/css"sv))
         return;
 
     // FIXME: 5. If the Should element's inline behavior be blocked by Content Security Policy? algorithm returns "Blocked" when executed upon the style element, "style", and the style element's child text content, then return. [CSP]

--- a/Libraries/LibWeb/Fetch/Infrastructure/NoSniffBlocking.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/NoSniffBlocking.cpp
@@ -23,7 +23,7 @@ bool determine_nosniff(HeaderList const& list)
         return false;
 
     // 3. If values[0] is an ASCII case-insensitive match for "nosniff", then return true.
-    if (!values->is_empty() && Infra::is_ascii_case_insensitive_match(values->at(0), "nosniff"sv))
+    if (!values->is_empty() && values->at(0).equals_ignoring_ascii_case("nosniff"sv))
         return true;
 
     // 4. Return false.

--- a/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -176,7 +176,7 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
             }
         }
         // 9. Otherwise, if the field element is an input element whose type attribute is in the Hidden state and name is an ASCII case-insensitive match for "_charset_":
-        else if (auto* hidden_input = dynamic_cast<HTML::HTMLInputElement*>(control.ptr()); hidden_input && hidden_input->type_state() == HTMLInputElement::TypeAttributeState::Hidden && Infra::is_ascii_case_insensitive_match(name, "_charset_"sv)) {
+        else if (auto* hidden_input = dynamic_cast<HTML::HTMLInputElement*>(control.ptr()); hidden_input && hidden_input->type_state() == HTMLInputElement::TypeAttributeState::Hidden && name.equals_ignoring_ascii_case("_charset_"sv)) {
             // 1. Let charset be the name of encoding if encoding is given, and "UTF-8" otherwise.
             auto charset = encoding.has_value() ? encoding.value() : "UTF-8"_string;
 

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -999,7 +999,7 @@ TokenizedFeature::NoOpener HTMLElement::get_an_elements_noopener(URL::URL const&
 
     // 2. If element's link types do not include the opener keyword and
     //    target is an ASCII case-insensitive match for "_blank", then return true.
-    if (!link_types.contains_slow("opener"sv) && Infra::is_ascii_case_insensitive_match(target, "_blank"sv))
+    if (!link_types.contains_slow("opener"sv) && target.equals_ignoring_ascii_case("_blank"sv))
         return TokenizedFeature::NoOpener::Yes;
 
     // 3. If url's blob URL entry is not null:

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -432,8 +432,8 @@ String HTMLFormElement::action_from_form_element(GC::Ref<HTMLElement> element) c
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-attributes:attr-fs-method-2
 static HTMLFormElement::MethodAttributeState method_attribute_to_method_state(StringView method)
 {
-#define __ENUMERATE_FORM_METHOD_ATTRIBUTE(keyword, state)             \
-    if (Infra::is_ascii_case_insensitive_match(#keyword##sv, method)) \
+#define __ENUMERATE_FORM_METHOD_ATTRIBUTE(keyword, state) \
+    if (#keyword##sv.equals_ignoring_ascii_case(method))  \
         return HTMLFormElement::MethodAttributeState::state;
     ENUMERATE_FORM_METHOD_ATTRIBUTES
 #undef __ENUMERATE_FORM_METHOD_ATTRIBUTE
@@ -467,8 +467,8 @@ HTMLFormElement::MethodAttributeState HTMLFormElement::method_state_from_form_el
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-attributes:attr-fs-enctype-2
 static HTMLFormElement::EncodingTypeAttributeState encoding_type_attribute_to_encoding_type_state(StringView encoding_type)
 {
-#define __ENUMERATE_FORM_METHOD_ENCODING_TYPE(keyword, state)               \
-    if (Infra::is_ascii_case_insensitive_match(keyword##sv, encoding_type)) \
+#define __ENUMERATE_FORM_METHOD_ENCODING_TYPE(keyword, state)  \
+    if (keyword##sv.equals_ignoring_ascii_case(encoding_type)) \
         return HTMLFormElement::EncodingTypeAttributeState::state;
     ENUMERATE_FORM_METHOD_ENCODING_TYPES
 #undef __ENUMERATE_FORM_METHOD_ENCODING_TYPE

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2559,7 +2559,7 @@ Optional<double> HTMLInputElement::allowed_value_step() const
     auto step_string = *maybe_step_string;
 
     // 3. Otherwise, if the attribute's value is an ASCII case-insensitive match for the string "any", then there is no allowed value step.
-    if (Infra::is_ascii_case_insensitive_match(step_string, "any"_string))
+    if (step_string.equals_ignoring_ascii_case("any"sv))
         return {};
 
     // 4. Otherwise, if the rules for parsing floating-point number values, when they are applied to the attribute's value, return an error,

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -229,12 +229,12 @@ void HTMLScriptElement::prepare_script()
         m_script_type = ScriptType::Classic;
     }
     // 10. Otherwise, if the script block's type string is an ASCII case-insensitive match for the string "module",
-    else if (Infra::is_ascii_case_insensitive_match(script_block_type, "module"sv)) {
+    else if (script_block_type.equals_ignoring_ascii_case("module"sv)) {
         // then set el's type to "module".
         m_script_type = ScriptType::Module;
     }
     // 11. Otherwise, if the script block's type string is an ASCII case-insensitive match for the string "importmap",
-    else if (Infra::is_ascii_case_insensitive_match(script_block_type, "importmap"sv)) {
+    else if (script_block_type.equals_ignoring_ascii_case("importmap"sv)) {
         // then set el's type to "importmap".
         m_script_type = ScriptType::ImportMap;
     }
@@ -290,14 +290,14 @@ void HTMLScriptElement::prepare_script()
         event = MUST(event.trim(Infra::ASCII_WHITESPACE));
 
         // 4. If for is not an ASCII case-insensitive match for the string "window", then return.
-        if (!Infra::is_ascii_case_insensitive_match(for_, "window"sv)) {
+        if (!for_.equals_ignoring_ascii_case("window"sv)) {
             dbgln("HTMLScriptElement: Refusing to run classic script because the provided 'for' attribute is not equal to 'window'");
             return;
         }
 
         // 5. If event is not an ASCII case-insensitive match for either the string "onload" or the string "onload()", then return.
-        if (!Infra::is_ascii_case_insensitive_match(event, "onload"sv)
-            && !Infra::is_ascii_case_insensitive_match(event, "onload()"sv)) {
+        if (!event.equals_ignoring_ascii_case("onload"sv)
+            && !event.equals_ignoring_ascii_case("onload()"sv)) {
             dbgln("HTMLScriptElement: Refusing to run classic script because the provided 'event' attribute is not equal to 'onload' or 'onload()'");
             return;
         }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -372,13 +372,13 @@ Navigable::ChosenNavigable Navigable::choose_a_navigable(StringView name, Tokeni
     auto sandboxing_flag_set = active_document()->active_sandboxing_flag_set();
 
     // 4. If name is the empty string or an ASCII case-insensitive match for "_self", then set chosen to currentNavigable.
-    if (name.is_empty() || Infra::is_ascii_case_insensitive_match(name, "_self"sv)) {
+    if (name.is_empty() || name.equals_ignoring_ascii_case("_self"sv)) {
         chosen = this;
     }
 
     // 5. Otherwise, if name is an ASCII case-insensitive match for "_parent",
     //    set chosen to currentNavigable's parent, if any, and currentNavigable otherwise.
-    else if (Infra::is_ascii_case_insensitive_match(name, "_parent"sv)) {
+    else if (name.equals_ignoring_ascii_case("_parent"sv)) {
         if (auto parent = this->parent())
             chosen = parent;
         else
@@ -387,13 +387,13 @@ Navigable::ChosenNavigable Navigable::choose_a_navigable(StringView name, Tokeni
 
     // 6. Otherwise, if name is an ASCII case-insensitive match for "_top",
     //    set chosen to currentNavigable's traversable navigable.
-    else if (Infra::is_ascii_case_insensitive_match(name, "_top"sv)) {
+    else if (name.equals_ignoring_ascii_case("_top"sv)) {
         chosen = traversable_navigable();
     }
 
     // 7. Otherwise, if name is not an ASCII case-insensitive match for "_blank" and noopener is false, then set chosen
     //    to the result of finding a navigable by target name given name and currentNavigable.
-    else if (!Infra::is_ascii_case_insensitive_match(name, "_blank"sv) && no_opener == TokenizedFeature::NoOpener::No) {
+    else if (!name.equals_ignoring_ascii_case("_blank"sv) && no_opener == TokenizedFeature::NoOpener::No) {
         chosen = find_a_navigable_by_target_name(name);
     }
 
@@ -446,7 +446,7 @@ Navigable::ChosenNavigable Navigable::choose_a_navigable(StringView name, Tokeni
             String target_name;
 
             // 6. If name is not an ASCII case-insensitive match for "_blank", then set targetName to name.
-            if (!Infra::is_ascii_case_insensitive_match(name, "_blank"sv))
+            if (!name.equals_ignoring_ascii_case("_blank"sv))
                 target_name = MUST(String::from_utf8(name));
 
             auto create_new_traversable_closure = [this, no_opener, target_name, activate_tab, window_features](GC::Ptr<BrowsingContext> opener) -> GC::Ref<Navigable> {

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -5071,7 +5071,7 @@ Optional<Color> parse_legacy_color_value(StringView string_view)
     input = input.trim(Infra::ASCII_WHITESPACE);
 
     // 3. If input is an ASCII case-insensitive match for "transparent", then return failure.
-    if (Infra::is_ascii_case_insensitive_match(input, "transparent"sv))
+    if (input.equals_ignoring_ascii_case("transparent"sv))
         return {};
 
     // 4. If input is an ASCII case-insensitive match for one of the named colors, then return the CSS color corresponding to that keyword. [CSSCOLOR]

--- a/Libraries/LibWeb/HTML/XMLSerializer.cpp
+++ b/Libraries/LibWeb/HTML/XMLSerializer.cpp
@@ -892,7 +892,7 @@ static WebIDL::ExceptionOr<String> serialize_processing_instruction(DOM::Process
         if (processing_instruction.target().contains(':'))
             return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target contains a colon"_string);
 
-        if (Infra::is_ascii_case_insensitive_match(processing_instruction.target(), "xml"sv))
+        if (processing_instruction.target().equals_ignoring_ascii_case("xml"sv))
             return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target is equal to 'xml'"_string);
 
         // 2. If the require well-formed flag is set (its value is true), and node's data contains characters that are not matched by the XML Char production or contains

--- a/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Libraries/LibWeb/Infra/Strings.cpp
@@ -19,14 +19,6 @@
 
 namespace Web::Infra {
 
-// https://infra.spec.whatwg.org/#ascii-case-insensitive
-bool is_ascii_case_insensitive_match(StringView a, StringView b)
-{
-    // A string A is an ASCII case-insensitive match for a string B,
-    // if the ASCII lowercase of A is the ASCII lowercase of B.
-    return AK::StringUtils::equals_ignoring_ascii_case(a, b);
-}
-
 // https://infra.spec.whatwg.org/#normalize-newlines
 String normalize_newlines(String const& string)
 {

--- a/Libraries/LibWeb/Infra/Strings.h
+++ b/Libraries/LibWeb/Infra/Strings.h
@@ -13,7 +13,6 @@
 
 namespace Web::Infra {
 
-bool is_ascii_case_insensitive_match(StringView a, StringView b);
 String normalize_newlines(String const&);
 ErrorOr<String> strip_and_collapse_whitespace(StringView string);
 bool is_code_unit_prefix(StringView potential_prefix, StringView input);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
@@ -168,12 +168,12 @@ JS::Object* WebGL2RenderingContext::get_extension(String const& name)
     // been enabled.
     auto supported_extensions = get_supported_extensions();
     auto supported_extension_iterator = supported_extensions->find_if([&name](String const& supported_extension) {
-        return Infra::is_ascii_case_insensitive_match(supported_extension, name);
+        return supported_extension.equals_ignoring_ascii_case(name);
     });
     if (supported_extension_iterator == supported_extensions->end())
         return nullptr;
 
-    if (Infra::is_ascii_case_insensitive_match(name, "WEBGL_compressed_texture_s3tc"sv)) {
+    if (name.equals_ignoring_ascii_case("WEBGL_compressed_texture_s3tc"sv)) {
         if (!m_webgl_compressed_texture_s3tc_extension) {
             m_webgl_compressed_texture_s3tc_extension = MUST(Extensions::WebGLCompressedTextureS3tc::create(realm(), this));
         }
@@ -182,7 +182,7 @@ JS::Object* WebGL2RenderingContext::get_extension(String const& name)
         return m_webgl_compressed_texture_s3tc_extension;
     }
 
-    if (Infra::is_ascii_case_insensitive_match(name, "EXT_color_buffer_float"sv)) {
+    if (name.equals_ignoring_ascii_case("EXT_color_buffer_float"sv)) {
         if (!m_ext_color_buffer_float_extension) {
             m_ext_color_buffer_float_extension = MUST(Extensions::EXTColorBufferFloat::create(realm(), *this));
         }

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -190,12 +190,12 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
     // been enabled.
     auto supported_extensions = get_supported_extensions();
     auto supported_extension_iterator = supported_extensions->find_if([&name](String const& supported_extension) {
-        return Infra::is_ascii_case_insensitive_match(supported_extension, name);
+        return supported_extension.equals_ignoring_ascii_case(name);
     });
     if (supported_extension_iterator == supported_extensions->end())
         return nullptr;
 
-    if (Infra::is_ascii_case_insensitive_match(name, "ANGLE_instanced_arrays"sv)) {
+    if (name.equals_ignoring_ascii_case("ANGLE_instanced_arrays"sv)) {
         if (!m_angle_instanced_arrays_extension) {
             m_angle_instanced_arrays_extension = MUST(Extensions::ANGLEInstancedArrays::create(realm(), *this));
         }
@@ -204,7 +204,7 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
         return m_angle_instanced_arrays_extension;
     }
 
-    if (Infra::is_ascii_case_insensitive_match(name, "EXT_blend_minmax"sv)) {
+    if (name.equals_ignoring_ascii_case("EXT_blend_minmax"sv)) {
         if (!m_ext_blend_min_max_extension) {
             m_ext_blend_min_max_extension = MUST(Extensions::EXTBlendMinMax::create(realm(), *this));
         }
@@ -213,7 +213,7 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
         return m_ext_blend_min_max_extension;
     }
 
-    if (Infra::is_ascii_case_insensitive_match(name, "OES_vertex_array_object"sv)) {
+    if (name.equals_ignoring_ascii_case("OES_vertex_array_object"sv)) {
         if (!m_oes_vertex_array_object_extension) {
             m_oes_vertex_array_object_extension = MUST(Extensions::OESVertexArrayObject::create(realm(), *this));
         }
@@ -222,7 +222,7 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
         return m_oes_vertex_array_object_extension;
     }
 
-    if (Infra::is_ascii_case_insensitive_match(name, "WEBGL_compressed_texture_s3tc"sv)) {
+    if (name.equals_ignoring_ascii_case("WEBGL_compressed_texture_s3tc"sv)) {
         if (!m_webgl_compressed_texture_s3tc_extension) {
             m_webgl_compressed_texture_s3tc_extension = MUST(Extensions::WebGLCompressedTextureS3tc::create(realm(), this));
         }
@@ -231,7 +231,7 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
         return m_webgl_compressed_texture_s3tc_extension;
     }
 
-    if (Infra::is_ascii_case_insensitive_match(name, "WEBGL_draw_buffers"sv)) {
+    if (name.equals_ignoring_ascii_case("WEBGL_draw_buffers"sv)) {
         if (!m_webgl_draw_buffers_extension) {
             m_webgl_draw_buffers_extension = MUST(Extensions::WebGLDrawBuffers::create(realm(), *this));
         }

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -601,7 +601,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
                 // 2. If contentTypeRecord is not failure, contentTypeRecord’s parameters["charset"] exists, and parameters["charset"] is not an ASCII case-insensitive match for "UTF-8", then:
                 if (content_type_record.has_value()) {
                     auto charset_parameter_iterator = content_type_record->parameters().find("charset"sv);
-                    if (charset_parameter_iterator != content_type_record->parameters().end() && !Infra::is_ascii_case_insensitive_match(charset_parameter_iterator->value, "UTF-8"sv)) {
+                    if (charset_parameter_iterator != content_type_record->parameters().end() && !charset_parameter_iterator->value.equals_ignoring_ascii_case("UTF-8"sv)) {
                         // 1. Set contentTypeRecord’s parameters["charset"] to "UTF-8".
                         content_type_record->set_parameter("charset"_string, "UTF-8"_string);
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -102,7 +102,7 @@ Optional<MediaFeatureID> media_feature_id_from_string(StringView string)
         member_generator.set("name", name);
         member_generator.set("name:titlecase", title_casify(name));
         member_generator.append(R"~~~(
-    if (Infra::is_ascii_case_insensitive_match(string, "@name@"sv))
+    if (string.equals_ignoring_ascii_case("@name@"sv))
         return MediaFeatureID::@name:titlecase@;
 )~~~");
     });

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -443,7 +443,7 @@ Optional<PropertyID> property_id_from_string(StringView string)
     if (is_a_custom_property_name_string(string))
         return PropertyID::Custom;
 
-    if (Infra::is_ascii_case_insensitive_match(string, "all"sv))
+    if (string.equals_ignoring_ascii_case("all"sv))
         return PropertyID::All;
 )~~~");
 
@@ -458,7 +458,7 @@ Optional<PropertyID> property_id_from_string(StringView string)
             member_generator.set("name:titlecase", title_casify(name));
         }
         member_generator.append(R"~~~(
-    if (Infra::is_ascii_case_insensitive_match(string, "@name@"sv))
+    if (string.equals_ignoring_ascii_case("@name@"sv))
         return PropertyID::@name:titlecase@;
 )~~~");
     });

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -778,7 +778,7 @@ void ConnectionFromClient::replace_dom_node_attribute(u64 page_id, Web::UniqueNo
     bool should_remove_attribute = true;
 
     for (auto const& attribute : replacement_attributes) {
-        if (should_remove_attribute && Web::Infra::is_ascii_case_insensitive_match(name, attribute.name))
+        if (should_remove_attribute && name.equals_ignoring_ascii_case(attribute.name))
             should_remove_attribute = false;
 
         // NOTE: We ignore invalid attributes for now, but we may want to send feedback to the user that this failed.


### PR DESCRIPTION
Which has an optmization if both size of the string being passed through are FlyStrings, which actually ends up being the case in some places during selector matching comparing attribute names. Instead of maintaining more overloads of
Infra::is_ascii_case_insensitive_match, switch everything over to equals_ignoring_ascii_case instead.