### PR TITLE
LibWeb: Implement HTML::ImageBitmap creation from HTML::ImageData

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -38,6 +38,9 @@ public:
         // https://w3c.github.io/geolocation/#dfn-geolocation-task-source
         Geolocation,
 
+        // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#bitmap-task-source
+        BitmapTask,
+
         // https://html.spec.whatwg.org/multipage/webappapis.html#navigation-and-traversal-task-source
         NavigationAndTraversal,
 

--- a/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-detached-image-data-buffer.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-detached-image-data-buffer.txt
@@ -1,0 +1,1 @@
+Image data is detached

--- a/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-image-data.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-image-data.txt
@@ -1,0 +1,1 @@
+[Success]: [object ImageBitmap]

--- a/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
@@ -1,7 +1,7 @@
 Blob              [Success]: [object ImageBitmap]
-ImageData         [ Error ]: Error: Not Implemented: createImageBitmap() for non-blob types
+ImageData         [Success]: [object ImageBitmap]
 HTMLImageElement  [ Error ]: InvalidStateError: image argument is not usable
 SVGImageElement   [ Error ]: InvalidStateError: image argument is not usable
-HTMLCanvasElement [ Error ]: Error: Not Implemented: createImageBitmap() for non-blob types
+HTMLCanvasElement [ Error ]: Error: Not Implemented: createImageBitmap() for HTMLCanvasElement
 ImageBitmap       [ Error ]: TypeError: No union types matched
 HTMLVideoElement  [ Error ]: InvalidStateError: image argument is not usable

--- a/Tests/LibWeb/Text/input/HTML/image-bitmap-from-detached-image-data-buffer.html
+++ b/Tests/LibWeb/Text/input/HTML/image-bitmap-from-detached-image-data-buffer.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    let canvas = document.createElement("canvas");
+    canvas.width = 1080;
+    canvas.height = 600;
+
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "rgb(42, 110, 96)";
+    ctx.fillRect(0, 0, 400, 300);
+    let imageData = ctx.getImageData(0, 0, 800, 600);
+    const buffer = imageData.data.buffer;
+    window.postMessage("", "*", [buffer]);
+
+    asyncTest(async done => {
+        try {
+            const result = await createImageBitmap(imageData);
+            println("Failed");
+        } catch (error) {
+            println(error.message);
+        }
+
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/image-bitmap-from-image-data.html
+++ b/Tests/LibWeb/Text/input/HTML/image-bitmap-from-image-data.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<body>
+<script src="../include.js"></script>
+<script>
+    let canvas = document.createElement("canvas");
+
+    canvas.width = 20;
+    canvas.height = 20;
+
+    let ctx = canvas.getContext("2d");
+    ctx.fillStyle = "rgb(42, 110, 96)";
+    ctx.fillRect(0, 0, 10, 10);
+    let imageData = ctx.getImageData(0, 0, 20, 20);
+
+    asyncTest(async done => {
+        try {
+            const bitmap = await createImageBitmap(imageData);
+            println(`[Success]: ${bitmap}`);
+        } catch (err) {
+            println(`[ Error ]: ${err}`);
+        }
+        done();
+    });
+</script>
+</body>


### PR DESCRIPTION
### Specification

See **ImageData** section at https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap


### Demo

#### Happy Path

![imagedata-to-imagebitmap](https://github.com/user-attachments/assets/1a07c35b-3f6d-49f2-ad7c-4145a66751cb)

#### Sad Path


![imagedata-to-imagebitmap-detached](https://github.com/user-attachments/assets/1a128042-9f37-4ab4-9b07-1dac5c557dbb)


### Updated Test Results

![imagebitmap-updated-test-results](https://github.com/user-attachments/assets/88af1a58-dc41-480b-ba51-17788cf1395f)
