### PR TITLE
LibWeb+WebWorker: Create SharedWorkerGlobalScope for Shared Workers 

### DIFF
--- a/Libraries/LibWeb/Bindings/AgentType.h
+++ b/Libraries/LibWeb/Bindings/AgentType.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Web::Bindings {
+
+enum class AgentType : u8 {
+    SimilarOriginWindow,
+    DedicatedWorker,
+    SharedWorker,
+    ServiceWorker,
+    Worklet,
+};
+
+}

--- a/Libraries/LibWeb/Bindings/MainThreadVM.h
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.h
@@ -10,6 +10,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/JobCallback.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/AgentType.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/MutationObserver.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
@@ -31,14 +32,6 @@ struct WebEngineCustomJobCallbackData final : public JS::JobCallback::CustomData
 };
 
 HTML::Script* active_script();
-
-enum class AgentType : u8 {
-    SimilarOriginWindow,
-    DedicatedWorker,
-    SharedWorker,
-    ServiceWorker,
-    Worklet,
-};
 
 void initialize_main_thread_vm(AgentType);
 JS::VM& main_thread_vm();

--- a/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.h
@@ -28,9 +28,6 @@ public:
     WebIDL::ExceptionOr<void> post_message(JS::Value message, StructuredSerializeOptions const&);
     WebIDL::ExceptionOr<void> post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer);
 
-    void set_name(String name) { m_name = move(name); }
-    String name() const { return m_name; }
-
     void close();
 
 #undef __ENUMERATE
@@ -46,8 +43,6 @@ private:
     DedicatedWorkerGlobalScope(JS::Realm&, GC::Ref<Web::Page>);
 
     virtual void initialize_web_interfaces_impl() override;
-
-    String m_name;
 };
 
 }

--- a/Libraries/LibWeb/HTML/EmbedderPolicy.h
+++ b/Libraries/LibWeb/HTML/EmbedderPolicy.h
@@ -15,7 +15,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value
-enum class EmbedderPolicyValue {
+enum class EmbedderPolicyValue : u8 {
     UnsafeNone,
     RequireCorp,
     Credentialless,
@@ -30,13 +30,13 @@ struct EmbedderPolicy {
     // A value, which is an embedder policy value, initially "unsafe-none".
     EmbedderPolicyValue value { EmbedderPolicyValue::UnsafeNone };
 
-    // https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-reporting-endpoint
-    // A reporting endpoint string, initially the empty string.
-    String reporting_endpoint;
-
     // https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-value
     // A report only value, which is an embedder policy value, initially "unsafe-none".
     EmbedderPolicyValue report_only_value { EmbedderPolicyValue::UnsafeNone };
+
+    // https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-reporting-endpoint
+    // A reporting endpoint string, initially the empty string.
+    String reporting_endpoint;
 
     // https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-reporting-endpoint
     // A report only reporting endpoint string, initially the empty string.

--- a/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
@@ -6,10 +6,10 @@
  */
 
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
+#include <LibWeb/HTML/DedicatedWorkerGlobalScope.h>
 #include <LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
-#include <WebWorker/DedicatedWorkerHost.h>
 
 namespace Web::HTML {
 
@@ -36,7 +36,7 @@ GC::Ref<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObject::setup(
 
     // FIXME: 5. Set settings object's id to a new unique opaque string, creation URL to worker global scope's url, top-level creation URL to null, target browsing context to null, and active service worker to null.
     // 6. If worker global scope is a DedicatedWorkerGlobalScope object, then set settings object's top-level origin to outside settings's top-level origin.
-    if (is<WebWorker::DedicatedWorkerHost>(worker)) {
+    if (is<DedicatedWorkerGlobalScope>(worker)) {
         settings_object->top_level_origin = outside_settings.top_level_origin;
     }
     // FIXME: 7. Otherwise, set settings object's top-level origin to an implementation-defined value.

--- a/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.cpp
@@ -18,9 +18,8 @@ HashTable<GC::RawRef<SharedWorkerGlobalScope>>& all_shared_worker_global_scopes(
     return set;
 }
 
-SharedWorkerGlobalScope::SharedWorkerGlobalScope(JS::Realm& realm, GC::Ref<Web::Page> page, String name)
+SharedWorkerGlobalScope::SharedWorkerGlobalScope(JS::Realm& realm, GC::Ref<Web::Page> page)
     : WorkerGlobalScope(realm, page)
-    , m_name(move(name))
 {
     all_shared_worker_global_scopes().set(*this);
 }

--- a/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.h
@@ -25,6 +25,15 @@ class SharedWorkerGlobalScope
 public:
     virtual ~SharedWorkerGlobalScope() override;
 
+    void set_constructor_origin(URL::Origin origin) { m_constructor_origin = move(origin); }
+    URL::Origin const& constructor_origin() const { return m_constructor_origin; }
+
+    void set_constructor_url(URL::URL url) { m_constructor_url = move(url); }
+    URL::URL const& constructor_url() const { return m_constructor_url; }
+
+    Fetch::Infrastructure::Request::CredentialsMode credentials() const { return m_credentials; }
+    void set_credentials(Fetch::Infrastructure::Request::CredentialsMode credentials) { m_credentials = credentials; }
+
     void close();
 
 #define __ENUMERATE(attribute_name, event_name)       \
@@ -38,6 +47,10 @@ private:
 
     virtual void initialize_web_interfaces_impl() override;
     virtual void finalize() override;
+
+    URL::Origin m_constructor_origin;
+    URL::URL m_constructor_url;
+    Fetch::Infrastructure::Request::CredentialsMode m_credentials;
 };
 
 HashTable<GC::RawRef<SharedWorkerGlobalScope>>& all_shared_worker_global_scopes();

--- a/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.h
@@ -25,8 +25,6 @@ class SharedWorkerGlobalScope
 public:
     virtual ~SharedWorkerGlobalScope() override;
 
-    String const& name() const { return m_name; }
-
     void close();
 
 #define __ENUMERATE(attribute_name, event_name)       \
@@ -36,12 +34,10 @@ public:
 #undef __ENUMERATE
 
 private:
-    SharedWorkerGlobalScope(JS::Realm&, GC::Ref<Web::Page>, String name);
+    SharedWorkerGlobalScope(JS::Realm&, GC::Ref<Web::Page>);
 
     virtual void initialize_web_interfaces_impl() override;
     virtual void finalize() override;
-
-    String m_name;
 };
 
 HashTable<GC::RawRef<SharedWorkerGlobalScope>>& all_shared_worker_global_scopes();

--- a/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Libraries/LibWeb/HTML/Worker.cpp
@@ -93,7 +93,7 @@ WebIDL::ExceptionOr<GC::Ref<Worker>> Worker::create(String const& script_url, Wo
 void run_a_worker(Variant<GC::Ref<Worker>, GC::Ref<SharedWorker>> worker, URL::URL& url, EnvironmentSettingsObject& outside_settings, GC::Ptr<MessagePort> port, WorkerOptions const& options)
 {
     // 1. Let is shared be true if worker is a SharedWorker object, and false otherwise.
-    // FIXME: SharedWorker support
+    Bindings::AgentType agent_type = worker.has<GC::Ref<SharedWorker>>() ? Bindings::AgentType::SharedWorker : Bindings::AgentType::DedicatedWorker;
 
     // 2. Let owner be the relevant owner to add given outside settings.
     // FIXME: Support WorkerGlobalScope options
@@ -111,7 +111,7 @@ void run_a_worker(Variant<GC::Ref<Worker>, GC::Ref<SharedWorker>> worker, URL::U
     //    and is shared. Run the rest of these steps in that agent.
 
     // Note: This spawns a new process to act as the 'agent' for the worker.
-    auto agent = outside_settings.realm().create<WorkerAgentParent>(url, options, port, outside_settings);
+    auto agent = outside_settings.realm().create<WorkerAgentParent>(url, options, port, outside_settings, agent_type);
     worker.visit([&](auto worker) { worker->set_agent(agent); });
 }
 

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/Bindings/AgentType.h>
 #include <LibWeb/Bindings/RequestPrototype.h>
 #include <LibWeb/Bindings/WorkerPrototype.h>
 #include <LibWeb/Forward.h>
@@ -25,12 +26,13 @@ class WorkerAgentParent : public JS::Cell {
     GC_DECLARE_ALLOCATOR(WorkerAgentParent);
 
 protected:
-    WorkerAgentParent(URL::URL url, WorkerOptions const& options, GC::Ptr<MessagePort> outside_port, GC::Ref<EnvironmentSettingsObject> outside_settings);
+    WorkerAgentParent(URL::URL url, WorkerOptions const& options, GC::Ptr<MessagePort> outside_port, GC::Ref<EnvironmentSettingsObject> outside_settings, Bindings::AgentType);
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
     WorkerOptions m_worker_options;
+    Bindings::AgentType m_agent_type { Bindings::AgentType::DedicatedWorker };
     URL::URL m_url;
 
     GC::Ptr<MessagePort> m_message_port;

--- a/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -83,6 +83,12 @@ public:
     URL::URL const& url() const { return m_url.value(); }
     void set_url(URL::URL const& url) { m_url = url; }
 
+    String const& name() const { return m_name; }
+    void set_name(String name) { m_name = move(name); }
+
+    Bindings::WorkerType type() const { return m_type; }
+    void set_type(Bindings::WorkerType type) { m_type = type; }
+
     // Spec note: While the WorkerLocation object is created after the WorkerGlobalScope object,
     //            this is not problematic as it cannot be observed from script.
     void set_location(GC::Ref<WorkerLocation> loc) { m_location = move(loc); }
@@ -121,14 +127,13 @@ private:
 
     GC::Ref<Web::Page> m_page;
 
-    // FIXME: Add all these internal slots
-
     // https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set
-    // A WorkerGlobalScope object has an associated owner set (a set of Document and WorkerGlobalScope objects). It is initially empty and populated when the worker is created or obtained.
+    // FIXME: A WorkerGlobalScope object has an associated owner set (a set of Document and WorkerGlobalScope objects). It is initially empty and populated when the worker is created or obtained.
     //     Note: It is a set, instead of a single owner, to accommodate SharedWorkerGlobalScope objects.
 
     // https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type
     // A WorkerGlobalScope object has an associated type ("classic" or "module"). It is set during creation.
+    Bindings::WorkerType m_type { Bindings::WorkerType::Classic };
 
     // https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url
     // A WorkerGlobalScope object has an associated url (null or a URL). It is initially null.
@@ -140,6 +145,7 @@ private:
     //        For DedicatedWorkerGlobalScope instances, it is simply a developer-supplied name, useful mostly for debugging purposes.
     //        For SharedWorkerGlobalScope instances, it allows obtaining a reference to a common shared worker via the SharedWorker() constructor.
     //        For ServiceWorkerGlobalScope objects, it doesn't make sense (and as such isn't exposed through the JavaScript API at all).
+    String m_name;
 
     // https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-policy-container
     // A WorkerGlobalScope object has an associated policy container (a policy container). It is initially a new policy container.
@@ -147,10 +153,10 @@ private:
 
     // https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-embedder-policy
     // A WorkerGlobalScope object has an associated embedder policy (an embedder policy).
-    EmbedderPolicy m_embedder_policy;
+    // FIXME: Should be removed, https://github.com/whatwg/html/issues/11316
 
     // https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-module-map
-    // A WorkerGlobalScope object has an associated module map. It is a module map, initially empty.
+    // FIXME: A WorkerGlobalScope object has an associated module map. It is a module map, initially empty.
 
     // https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-cross-origin-isolated-capability
     bool m_cross_origin_isolated_capability { false };

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -20,7 +20,7 @@
 #include <LibGfx/Size.h>
 #include <LibIPC/Forward.h>
 #include <LibURL/URL.h>
-#include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Bindings/AgentType.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -1,12 +1,19 @@
 #include <LibURL/URL.h>
 #include <LibIPC/File.h>
+#include <LibWeb/Bindings/AgentType.h>
+#include <LibWeb/Bindings/WorkerPrototype.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h>
-#include <LibWeb/Bindings/WorkerPrototype.h>
 
 endpoint WebWorkerServer {
 
-    start_dedicated_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataHolder message_port, Web::HTML::SerializedEnvironmentSettingsObject outside_settings) =|
+    start_worker(URL::URL url,
+                 Web::Bindings::WorkerType type,
+                 Web::Bindings::RequestCredentials credentials,
+                 String name,
+                 Web::HTML::TransferDataHolder message_port,
+                 Web::HTML::SerializedEnvironmentSettingsObject outside_settings,
+                 Web::Bindings::AgentType agent_type) =|
 
     close_worker() =|
 

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(WEBWORKER_SOURCES
     ConnectionFromClient.cpp
-    DedicatedWorkerHost.cpp
     PageHost.cpp
+    WorkerHost.cpp
 )
 
 # FIXME: Add Android service

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -6,8 +6,8 @@
 
 #include <LibCore/EventLoop.h>
 #include <WebWorker/ConnectionFromClient.h>
-#include <WebWorker/DedicatedWorkerHost.h>
 #include <WebWorker/PageHost.h>
+#include <WebWorker/WorkerHost.h>
 
 namespace WebWorker {
 
@@ -63,10 +63,16 @@ Web::Page const& ConnectionFromClient::page() const
     return m_page_host->page();
 }
 
-void ConnectionFromClient::start_dedicated_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials, String name, Web::HTML::TransferDataHolder implicit_port, Web::HTML::SerializedEnvironmentSettingsObject outside_settings)
+void ConnectionFromClient::start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataHolder implicit_port, Web::HTML::SerializedEnvironmentSettingsObject outside_settings, Web::Bindings::AgentType agent_type)
 {
-    m_worker_host = make_ref_counted<DedicatedWorkerHost>(move(url), type, move(name));
-    m_worker_host->run(page(), move(implicit_port), outside_settings);
+    m_worker_host = make_ref_counted<WorkerHost>(move(url), type, move(name));
+
+    bool const is_shared = agent_type == Web::Bindings::AgentType::SharedWorker;
+    VERIFY(is_shared || agent_type == Web::Bindings::AgentType::DedicatedWorker);
+
+    // FIXME: Add an assertion that the agent_type passed here is the same that was passed at process creation to initialize_main_thread_vm()
+
+    m_worker_host->run(page(), move(implicit_port), outside_settings, credentials, is_shared);
 }
 
 void ConnectionFromClient::handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id)

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -41,7 +41,7 @@ private:
     Web::Page& page();
     Web::Page const& page() const;
 
-    virtual void start_dedicated_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataHolder, Web::HTML::SerializedEnvironmentSettingsObject) override;
+    virtual void start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataHolder, Web::HTML::SerializedEnvironmentSettingsObject, Web::Bindings::AgentType) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) override;
 
     GC::Root<PageHost> m_page_host;
@@ -51,7 +51,7 @@ private:
     HashMap<int, Web::FileRequest> m_requested_files {};
     int last_id { 0 };
 
-    RefPtr<DedicatedWorkerHost> m_worker_host;
+    RefPtr<WorkerHost> m_worker_host;
 };
 
 }

--- a/Services/WebWorker/Forward.h
+++ b/Services/WebWorker/Forward.h
@@ -9,7 +9,7 @@
 namespace WebWorker {
 
 class ConnectionFromClient;
-class DedicatedWorkerHost;
 class PageHost;
+class WorkerHost;
 
 }

--- a/Services/WebWorker/WorkerHost.h
+++ b/Services/WebWorker/WorkerHost.h
@@ -16,12 +16,12 @@
 
 namespace WebWorker {
 
-class DedicatedWorkerHost : public RefCounted<DedicatedWorkerHost> {
+class WorkerHost : public RefCounted<WorkerHost> {
 public:
-    explicit DedicatedWorkerHost(URL::URL url, Web::Bindings::WorkerType type, String name);
-    ~DedicatedWorkerHost();
+    explicit WorkerHost(URL::URL url, Web::Bindings::WorkerType type, String name);
+    ~WorkerHost();
 
-    void run(GC::Ref<Web::Page>, Web::HTML::TransferDataHolder message_port_data, Web::HTML::SerializedEnvironmentSettingsObject const&);
+    void run(GC::Ref<Web::Page>, Web::HTML::TransferDataHolder message_port_data, Web::HTML::SerializedEnvironmentSettingsObject const&, Web::Bindings::RequestCredentials, bool is_shared);
 
 private:
     GC::Root<Web::HTML::WorkerDebugConsoleClient> m_console;


### PR DESCRIPTION
Also push the onconnect event for the inital connection.

This still doesn't properly handle sending an onconnect event to a
pre-existing SharedWorkerGlobalScope with the same name for the same
origin, but it does give us a lot of WPT passes in the SharedWorker
category.

Running a full WPT run in parallel with `./Meta/WPT.sh run --parallel-instances 0 --log-wptreport expectations.json --log-wptscreenshot expectations.db` on master and this branch gave me the following:

master:

```
Total tests run: 59328
Ran as expected: 24648
Skipped: 0
Errored unexpectedly: 3635
Unexpected subtest results: 0
Longest run time: 6105.6s
```

this branch:

```
Total tests run: 59328
Ran as expected: 24852
Skipped: 0
Errored unexpectedly: 3633
Unexpected subtest results: 0
Longest run time: 5864.3s
```

@tcl3 is there an easier way to check the impact of this on `.sharedworker` tests?