### PR TITLE
LibWeb: Maintain tree order inside LayoutState

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -205,7 +205,7 @@ struct LayoutState {
     UsedValues& get_mutable(NodeWithStyle const&);
     UsedValues const& get(NodeWithStyle const&) const;
 
-    HashMap<GC::Ref<Layout::Node const>, NonnullOwnPtr<UsedValues>> used_values_per_layout_node;
+    OrderedHashMap<GC::Ref<Layout::Node const>, NonnullOwnPtr<UsedValues>> used_values_per_layout_node;
 
 private:
     void resolve_relative_positions();

--- a/Tests/LibWeb/Layout/expected/inline-fragment-ordering-flakiness.txt
+++ b/Tests/LibWeb/Layout/expected/inline-fragment-ordering-flakiness.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x18 [BFC] children: inline
+    InlineNode <body>
+      frag 0 from BlockContainer start: 0, length: 0, rect: [8,0 36.84375x18] baseline: 13.796875
+      frag 1 from TextNode start: 0, length: 5, rect: [8,0 36.84375x18] baseline: 13.796875
+          "hello"
+      BlockContainer <main> at (8,0) content-size 36.84375x18 inline-block [BFC] children: not-inline
+        BlockContainer <div> at (8,0) content-size 36.84375x18 children: inline
+          TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x18]
+    PaintableWithLines (InlineNode<BODY>)
+      PaintableWithLines (BlockContainer<MAIN>) [8,0 36.84375x18]
+        PaintableWithLines (BlockContainer<DIV>) [8,0 36.84375x18]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/inline-fragment-ordering-flakiness.html
+++ b/Tests/LibWeb/Layout/input/inline-fragment-ordering-flakiness.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><style>
+body {
+    display: inline;
+    position: relative;
+}
+main {
+    display: inline-block;
+}
+</style></head><body><main><div>hello</div></main></body></html>


### PR DESCRIPTION
Before this change, we were at the mercy of hashed pointer addresses when processing fragment relocation in LayoutState::commit(). This made inline fragment order non-deterministic, causing layouts to shift around seemingly randomly on page reload.

By simply using OrderedHashMap, we automatically get tree order processing here. This fixes a bunch of flaky tests on WPT.