### PR TITLE
LibWeb/CSS: Specify sizes of generated enums

### DIFF
--- a/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Libraries/LibWeb/CSS/MediaQuery.h
@@ -96,7 +96,7 @@ private:
 // https://www.w3.org/TR/mediaqueries-4/#mq-features
 class MediaFeature final : public BooleanExpression {
 public:
-    enum class Comparison {
+    enum class Comparison : u8 {
         Equal,
         LessThan,
         LessThanOrEqual,
@@ -151,7 +151,7 @@ public:
     virtual void dump(StringBuilder&, int indent_levels = 0) const override;
 
 private:
-    enum class Type {
+    enum class Type : u8 {
         IsTrue,
         ExactValue,
         MinValue,

--- a/Libraries/LibWeb/CSS/StyleProperty.h
+++ b/Libraries/LibWeb/CSS/StyleProperty.h
@@ -11,7 +11,7 @@
 
 namespace Web::CSS {
 
-enum class Important {
+enum class Important : u8 {
     No,
     Yes,
 };

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -310,7 +310,7 @@ class URLStyleValue;
 class VisualViewport;
 
 enum class Keyword;
-enum class MediaFeatureID;
+enum class MediaFeatureID : u8;
 enum class PropertyID;
 
 struct BackgroundLayerData;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -309,9 +309,9 @@ class URL;
 class URLStyleValue;
 class VisualViewport;
 
-enum class Keyword;
+enum class Keyword : u16;
 enum class MediaFeatureID : u8;
-enum class PropertyID;
+enum class PropertyID : u16;
 
 struct BackgroundLayerData;
 struct CSSStyleSheetInit;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -61,18 +61,7 @@ enum class Keyword;
         auto enum_generator = generator.fork();
         enum_generator.set("name:titlecase", title_casify(name));
         enum_generator.set("name:snakecase", snake_casify(name));
-
-        // Find the smallest possible type to use.
-        auto member_max_value = members.size() - 1;
-        if (NumericLimits<u8>::max() >= member_max_value) {
-            enum_generator.set("enum_type", "u8"_string);
-        } else if (NumericLimits<u16>::max() >= member_max_value) {
-            enum_generator.set("enum_type", "u16"_string);
-        } else if (NumericLimits<u32>::max() >= member_max_value) {
-            enum_generator.set("enum_type", "u32"_string);
-        } else {
-            enum_generator.set("enum_type", "u64"_string);
-        }
+        enum_generator.set("enum_type", underlying_type_for_enum(members.size()));
 
         enum_generator.appendln("enum class @name:titlecase@ : @enum_type@ {");
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -47,10 +47,9 @@ ErrorOr<void> generate_header_file(JsonObject& enums_data, Core::File& file)
 #pragma once
 
 #include <AK/Optional.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::CSS {
-
-enum class Keyword;
 
 )~~~");
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSKeyword.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSKeyword.cpp
@@ -50,6 +50,7 @@ ErrorOr<void> generate_header_file(JsonArray& keyword_data, Core::File& file)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
+    generator.set("keyword_underlying_type", underlying_type_for_enum(keyword_data.size()));
     generator.append(R"~~~(
 #pragma once
 
@@ -58,7 +59,7 @@ ErrorOr<void> generate_header_file(JsonArray& keyword_data, Core::File& file)
 
 namespace Web::CSS {
 
-enum class Keyword {
+enum class Keyword : @keyword_underlying_type@ {
     Invalid,
 )~~~");
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -42,6 +42,9 @@ ErrorOr<void> generate_header_file(JsonObject& media_feature_data, Core::File& f
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
+
+    generator.set("media_feature_id_underlying_type", underlying_type_for_enum(media_feature_data.size()));
+
     generator.append(R"~~~(#pragma once
 
 #include <AK/StringView.h>
@@ -58,7 +61,7 @@ enum class MediaFeatureValueType {
     Resolution,
 };
 
-enum class MediaFeatureID {)~~~");
+enum class MediaFeatureID : @media_feature_id_underlying_type@ {)~~~");
 
     media_feature_data.for_each_member([&](auto& name, auto&) {
         auto member_generator = generator.fork();

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -126,6 +126,7 @@ ErrorOr<void> generate_header_file(JsonObject& properties, Core::File& file)
 {
     StringBuilder builder;
     SourceGenerator generator { builder };
+    generator.set("property_id_underlying_type", underlying_type_for_enum(properties.size()));
     generator.append(R"~~~(
 #pragma once
 
@@ -137,7 +138,7 @@ ErrorOr<void> generate_header_file(JsonObject& properties, Core::File& file)
 
 namespace Web::CSS {
 
-enum class PropertyID {
+enum class PropertyID : @property_id_underlying_type@ {
     Invalid,
     Custom,
     All,


### PR DESCRIPTION
This has a noticeable effect on `MediaFeature`. The others I haven't observed a difference for but it also doesn't hurt.