### PR TITLE
LibWeb: Fix font-style to slope conversion

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -457,7 +457,21 @@ int CSSStyleValue::to_font_slope() const
             return oblique_slope;
         case Keyword::Normal:
         default:
-            break;
+            static int normal_slope = Gfx::name_to_slope("Normal"sv);
+            return normal_slope;
+        }
+    } else if (is_font_style()) {
+        switch (as_font_style().font_style()) {
+        case FontStyle::Italic:
+            static int italic_slope = Gfx::name_to_slope("Italic"sv);
+            return italic_slope;
+        case FontStyle::Oblique:
+            static int oblique_slope = Gfx::name_to_slope("Oblique"sv);
+            return oblique_slope;
+        case FontStyle::Normal:
+        default:
+            static int normal_slope = Gfx::name_to_slope("Normal"sv);
+            return normal_slope;
         }
     }
     static int normal_slope = Gfx::name_to_slope("Normal"sv);

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -446,21 +446,7 @@ int CSSStyleValue::to_font_weight() const
 int CSSStyleValue::to_font_slope() const
 {
     // FIXME: Implement oblique <angle>
-    if (is_keyword()) {
-        switch (as_keyword().keyword()) {
-        case Keyword::Italic: {
-            static int italic_slope = Gfx::name_to_slope("Italic"sv);
-            return italic_slope;
-        }
-        case Keyword::Oblique:
-            static int oblique_slope = Gfx::name_to_slope("Oblique"sv);
-            return oblique_slope;
-        case Keyword::Normal:
-        default:
-            static int normal_slope = Gfx::name_to_slope("Normal"sv);
-            return normal_slope;
-        }
-    } else if (is_font_style()) {
+    if (is_font_style()) {
         switch (as_font_style().font_style()) {
         case FontStyle::Italic:
             static int italic_slope = Gfx::name_to_slope("Italic"sv);


### PR DESCRIPTION
In a recent refactor of font styles (#4552), the new FontStyleStyleValue was introduced; however, the `to_font_slope()` function was not changed to understand this new type. When it tries to convert such a font style to a keyword, it fails. We then rendered the wrong font-style.

This bug caused text to render with the wrong font style, for example `font-style: italic` simply didn't render italic unless the font itself was italic.

*also* Fixes #4808