### PR TITLE
LibJS: Skip caching get_by_id() if object's shape is changed by a getter

### DIFF
--- a/Libraries/LibJS/Tests/regress/add-property-with-the-same-from-getter-in-prototype.js
+++ b/Libraries/LibJS/Tests/regress/add-property-with-the-same-from-getter-in-prototype.js
@@ -1,0 +1,30 @@
+test("Mutation of object in getter should result in skipping of collecting inline cache data", () => {
+    class Color {
+        get rgb() {
+            const value = [];
+            Object.defineProperty(this, "rgb", { value });
+            return value;
+        }
+
+        set rgb(value) {
+            Object.defineProperty(this, "rgb", { value });
+        }
+    }
+
+    function testGetting() {
+        const c = new Color();
+        for (let i = 0; i < 2; i++) {
+            c.rgb;
+        }
+    }
+
+    function testSetting() {
+        const c = new Color();
+        for (let i = 0; i < 2; i++) {
+            c.rgb = i;
+        }
+    }
+
+    expect(testGetting).not.toThrow();
+    expect(testSetting).not.toThrow();
+});


### PR DESCRIPTION
Fixes a bug that reproduces with the following steps:
1. Create an object with a getter for property "a" in its prototype, where the getter adds an "a" property to the object itself.
2. Call the "a" getter in a loop for the first time. This triggers caching of metadata indicating that the "a" property is located in the prototype chain.
3. Call the "a" getter in a loop for the second time. Oops, the cache says the getter is in the prototype chain, but the object now also has its own "a" property that was added by the first getter call.