### PR TITLE
LibWeb: Implement `ReadableStream`, `WritableStream` and `TransformStream` transfer

### DIFF
--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -74,43 +74,15 @@ TransportSocket::TransportSocket(NonnullOwnPtr<Core::LocalSocket> socket)
                 break;
 
             auto [bytes, fds] = send_queue->peek(4096);
-            auto fds_count = fds.size();
-            ReadonlyBytes remaining_to_send_bytes = bytes;
+            ReadonlyBytes remaining_bytes_to_send = bytes;
 
-            Threading::RWLockLocker<Threading::LockMode::Read> lock(m_socket_rw_lock);
-            if (!m_socket->is_open())
+            if (transfer_data(remaining_bytes_to_send, fds) == TransferState::SocketClosed)
                 break;
-            auto result = send_message(*m_socket, remaining_to_send_bytes, fds);
-            if (result.is_error()) {
-                if (result.error().is_errno() && result.error().code() == EPIPE) {
-                    // The socket is closed from the other end, we can stop sending.
-                    break;
-                }
-                dbgln("TransportSocket::send_thread: {}", result.error());
-                VERIFY_NOT_REACHED();
-            }
-
-            auto written_bytes_count = bytes.size() - remaining_to_send_bytes.size();
-            auto written_fds_count = fds_count - fds.size();
-            if (written_bytes_count > 0 || written_fds_count > 0) {
-                send_queue->discard(written_bytes_count, written_fds_count);
-            }
-
-            if (!m_socket->is_open())
-                break;
-
-            {
-                Vector<struct pollfd, 1> pollfds;
-                pollfds.append({ .fd = m_socket->fd().value(), .events = POLLOUT, .revents = 0 });
-
-                ErrorOr<int> result { 0 };
-                do {
-                    result = Core::System::poll(pollfds, -1);
-                } while (result.is_error() && result.error().code() == EINTR);
-            }
         }
+
         return 0;
     });
+
     m_send_thread->start();
 
     (void)Core::System::setsockopt(m_socket->fd().value(), SOL_SOCKET, SO_SNDBUF, &SOCKET_BUFFER_SIZE, sizeof(SOCKET_BUFFER_SIZE));
@@ -119,8 +91,15 @@ TransportSocket::TransportSocket(NonnullOwnPtr<Core::LocalSocket> socket)
 
 TransportSocket::~TransportSocket()
 {
+    stop_send_thread();
+}
+
+void TransportSocket::stop_send_thread()
+{
     m_send_queue->stop();
-    (void)m_send_thread->join();
+
+    if (m_send_thread->needs_to_be_joined())
+        (void)m_send_thread->join();
 }
 
 void TransportSocket::set_up_read_hook(Function<void()> hook)
@@ -140,6 +119,21 @@ void TransportSocket::close()
 {
     Threading::RWLockLocker<Threading::LockMode::Write> lock(m_socket_rw_lock);
     m_socket->close();
+}
+
+void TransportSocket::close_after_sending_all_pending_messages()
+{
+    stop_send_thread();
+
+    auto [bytes, fds] = m_send_queue->peek(NumericLimits<size_t>::max());
+    ReadonlyBytes remaining_bytes_to_send = bytes;
+
+    while (!remaining_bytes_to_send.is_empty() || !fds.is_empty()) {
+        if (transfer_data(remaining_bytes_to_send, fds) == TransferState::SocketClosed)
+            break;
+    }
+
+    close();
 }
 
 void TransportSocket::wait_until_readable()
@@ -215,6 +209,47 @@ ErrorOr<void> TransportSocket::send_message(Core::LocalSocket& socket, ReadonlyB
         unowned_fds.clear();
     }
     return {};
+}
+
+TransportSocket::TransferState TransportSocket::transfer_data(ReadonlyBytes& bytes, Vector<int>& fds)
+{
+    auto byte_count = bytes.size();
+    auto fd_count = fds.size();
+
+    Threading::RWLockLocker<Threading::LockMode::Read> lock(m_socket_rw_lock);
+
+    if (!m_socket->is_open())
+        return TransferState::SocketClosed;
+
+    if (auto result = send_message(*m_socket, bytes, fds); result.is_error()) {
+        if (result.error().is_errno() && result.error().code() == EPIPE) {
+            // The socket is closed from the other end, we can stop sending.
+            return TransferState::SocketClosed;
+        }
+
+        dbgln("TransportSocket::send_thread: {}", result.error());
+        VERIFY_NOT_REACHED();
+    }
+
+    auto written_byte_count = byte_count - bytes.size();
+    auto written_fd_count = fd_count - fds.size();
+    if (written_byte_count > 0 || written_fd_count > 0)
+        m_send_queue->discard(written_byte_count, written_fd_count);
+
+    if (!m_socket->is_open())
+        return TransferState::SocketClosed;
+
+    {
+        Vector<struct pollfd, 1> pollfds;
+        pollfds.append({ .fd = m_socket->fd().value(), .events = POLLOUT, .revents = 0 });
+
+        ErrorOr<int> result { 0 };
+        do {
+            result = Core::System::poll(pollfds, -1);
+        } while (result.is_error() && result.error().code() == EINTR);
+    }
+
+    return TransferState::Continue;
 }
 
 TransportSocket::ShouldShutdown TransportSocket::read_as_many_messages_as_possible_without_blocking(Function<void(Message&&)>&& callback)

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -8,10 +8,20 @@
 #include <AK/NonnullOwnPtr.h>
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
-#include <LibIPC/File.h>
 #include <LibIPC/TransportSocket.h>
 
 namespace IPC {
+
+AutoCloseFileDescriptor::AutoCloseFileDescriptor(int fd)
+    : m_fd(fd)
+{
+}
+
+AutoCloseFileDescriptor::~AutoCloseFileDescriptor()
+{
+    if (m_fd != -1)
+        (void)Core::System::close(m_fd);
+}
 
 void SendQueue::enqueue_message(Vector<u8>&& bytes, Vector<int>&& fds)
 {

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -10,6 +10,7 @@
 #include <AK/MemoryStream.h>
 #include <AK/Queue.h>
 #include <LibCore/Socket.h>
+#include <LibIPC/File.h>
 #include <LibThreading/ConditionVariable.h>
 #include <LibThreading/MutexProtected.h>
 #include <LibThreading/RWLock.h>
@@ -19,16 +20,8 @@ namespace IPC {
 
 class AutoCloseFileDescriptor : public RefCounted<AutoCloseFileDescriptor> {
 public:
-    AutoCloseFileDescriptor(int fd)
-        : m_fd(fd)
-    {
-    }
-
-    ~AutoCloseFileDescriptor()
-    {
-        if (m_fd != -1)
-            (void)Core::System::close(m_fd);
-    }
+    AutoCloseFileDescriptor(int fd);
+    ~AutoCloseFileDescriptor();
 
     int value() const { return m_fd; }
 

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -73,7 +73,9 @@ public:
 
     void set_up_read_hook(Function<void()>);
     bool is_open() const;
+
     void close();
+    void close_after_sending_all_pending_messages();
 
     void wait_until_readable();
 
@@ -95,7 +97,15 @@ public:
     ErrorOr<IPC::File> clone_for_transfer();
 
 private:
+    enum class TransferState {
+        Continue,
+        SocketClosed,
+    };
+    [[nodiscard]] TransferState transfer_data(ReadonlyBytes& bytes, Vector<int>& fds);
+
     static ErrorOr<void> send_message(Core::LocalSocket&, ReadonlyBytes& bytes, Vector<int>& unowned_fds);
+
+    void stop_send_thread();
 
     NonnullOwnPtr<Core::LocalSocket> m_socket;
     mutable Threading::RWLock m_socket_rw_lock;

--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -37,13 +37,14 @@ static HashTable<GC::RawPtr<MessagePort>>& all_message_ports()
     return ports;
 }
 
-GC::Ref<MessagePort> MessagePort::create(JS::Realm& realm)
+GC::Ref<MessagePort> MessagePort::create(JS::Realm& realm, HTML::TransferType primary_interface)
 {
-    return realm.create<MessagePort>(realm);
+    return realm.create<MessagePort>(realm, primary_interface);
 }
 
-MessagePort::MessagePort(JS::Realm& realm)
+MessagePort::MessagePort(JS::Realm& realm, HTML::TransferType primary_interface)
     : DOM::EventTarget(realm)
+    , m_primary_interface(primary_interface)
 {
     all_message_ports().set(this);
 }

--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -146,11 +146,15 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_receiving_steps(HTML::TransferDa
 
 void MessagePort::disentangle()
 {
-    if (m_remote_port)
+    if (m_remote_port) {
         m_remote_port->m_remote_port = nullptr;
-    m_remote_port = nullptr;
+        m_remote_port = nullptr;
+    }
 
-    m_transport.clear();
+    if (m_transport) {
+        m_transport->close_after_sending_all_pending_messages();
+        m_transport.clear();
+    }
 
     m_worker_event_target = nullptr;
 }

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -20,13 +20,14 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports
-class MessagePort final : public DOM::EventTarget
+class MessagePort final
+    : public DOM::EventTarget
     , public Bindings::Transferable {
     WEB_PLATFORM_OBJECT(MessagePort, DOM::EventTarget);
     GC_DECLARE_ALLOCATOR(MessagePort);
 
 public:
-    [[nodiscard]] static GC::Ref<MessagePort> create(JS::Realm&);
+    [[nodiscard]] static GC::Ref<MessagePort> create(JS::Realm&, HTML::TransferType primary_interface = HTML::TransferType::MessagePort);
 
     static void for_each_message_port(Function<void(MessagePort&)>);
 
@@ -59,14 +60,14 @@ public:
     // ^Transferable
     virtual WebIDL::ExceptionOr<void> transfer_steps(HTML::TransferDataHolder&) override;
     virtual WebIDL::ExceptionOr<void> transfer_receiving_steps(HTML::TransferDataHolder&) override;
-    virtual HTML::TransferType primary_interface() const override { return HTML::TransferType::MessagePort; }
+    virtual HTML::TransferType primary_interface() const override { return m_primary_interface; }
 
     void set_worker_event_target(GC::Ref<DOM::EventTarget>);
 
     WebIDL::ExceptionOr<void> message_port_post_message_steps(GC::Ptr<MessagePort> target_port, JS::Value message, StructuredSerializeOptions const& options);
 
 private:
-    explicit MessagePort(JS::Realm&);
+    explicit MessagePort(JS::Realm&, HTML::TransferType primary_interface);
 
     virtual void initialize(JS::Realm&) override;
     virtual void finalize() override;
@@ -78,6 +79,8 @@ private:
     void post_port_message(SerializedTransferRecord);
     ErrorOr<void> send_message_on_transport(SerializedTransferRecord const&);
     void read_from_transport();
+
+    HTML::TransferType m_primary_interface { HTML::TransferType::MessagePort };
 
     // The HTML spec implies(!) that this is MessagePort.[[RemotePort]]
     GC::Ptr<MessagePort> m_remote_port;

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -50,6 +50,7 @@
 #include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/Streams/ReadableStream.h>
+#include <LibWeb/Streams/TransformStream.h>
 #include <LibWeb/Streams/WritableStream.h>
 #include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -1299,6 +1300,8 @@ static bool is_interface_exposed_on_target_realm(TransferType name, JS::Realm& r
         return intrinsics.is_exposed("ReadableStream"sv);
     case TransferType::WritableStream:
         return intrinsics.is_exposed("WritableStream"sv);
+    case TransferType::TransformStream:
+        return intrinsics.is_exposed("TransformStream"sv);
     case TransferType::Unknown:
         dbgln("Unknown interface type for transfer: {}", to_underlying(name));
         break;
@@ -1325,6 +1328,11 @@ static WebIDL::ExceptionOr<GC::Ref<Bindings::PlatformObject>> create_transferred
         auto writable_stream = target_realm.create<Streams::WritableStream>(target_realm);
         TRY(writable_stream->transfer_receiving_steps(transfer_data_holder));
         return writable_stream;
+    }
+    case TransferType::TransformStream: {
+        auto transform_stream = target_realm.create<Streams::TransformStream>(target_realm);
+        TRY(transform_stream->transfer_receiving_steps(transfer_data_holder));
+        return transform_stream;
     }
     case TransferType::ArrayBuffer:
     case TransferType::ResizableArrayBuffer:

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -49,6 +49,7 @@
 #include <LibWeb/HTML/ImageData.h>
 #include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
+#include <LibWeb/Streams/ReadableStream.h>
 #include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -1293,7 +1294,8 @@ static bool is_interface_exposed_on_target_realm(TransferType name, JS::Realm& r
     switch (name) {
     case TransferType::MessagePort:
         return intrinsics.is_exposed("MessagePort"sv);
-        break;
+    case TransferType::ReadableStream:
+        return intrinsics.is_exposed("ReadableStream"sv);
     case TransferType::Unknown:
         dbgln("Unknown interface type for transfer: {}", to_underlying(name));
         break;
@@ -1310,6 +1312,11 @@ static WebIDL::ExceptionOr<GC::Ref<Bindings::PlatformObject>> create_transferred
         auto message_port = HTML::MessagePort::create(target_realm);
         TRY(message_port->transfer_receiving_steps(transfer_data_holder));
         return message_port;
+    }
+    case TransferType::ReadableStream: {
+        auto readable_stream = target_realm.create<Streams::ReadableStream>(target_realm);
+        TRY(readable_stream->transfer_receiving_steps(transfer_data_holder));
+        return readable_stream;
     }
     case TransferType::ArrayBuffer:
     case TransferType::ResizableArrayBuffer:

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -50,6 +50,7 @@
 #include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/Streams/ReadableStream.h>
+#include <LibWeb/Streams/WritableStream.h>
 #include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -1296,6 +1297,8 @@ static bool is_interface_exposed_on_target_realm(TransferType name, JS::Realm& r
         return intrinsics.is_exposed("MessagePort"sv);
     case TransferType::ReadableStream:
         return intrinsics.is_exposed("ReadableStream"sv);
+    case TransferType::WritableStream:
+        return intrinsics.is_exposed("WritableStream"sv);
     case TransferType::Unknown:
         dbgln("Unknown interface type for transfer: {}", to_underlying(name));
         break;
@@ -1317,6 +1320,11 @@ static WebIDL::ExceptionOr<GC::Ref<Bindings::PlatformObject>> create_transferred
         auto readable_stream = target_realm.create<Streams::ReadableStream>(target_realm);
         TRY(readable_stream->transfer_receiving_steps(transfer_data_holder));
         return readable_stream;
+    }
+    case TransferType::WritableStream: {
+        auto writable_stream = target_realm.create<Streams::WritableStream>(target_realm);
+        TRY(writable_stream->transfer_receiving_steps(transfer_data_holder));
+        return writable_stream;
     }
     case TransferType::ArrayBuffer:
     case TransferType::ResizableArrayBuffer:

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -51,6 +51,7 @@ enum class TransferType : u8 {
     ResizableArrayBuffer = 3,
     ReadableStream = 4,
     WritableStream = 5,
+    TransformStream = 6,
 };
 
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Value);

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -50,6 +50,7 @@ enum class TransferType : u8 {
     ArrayBuffer = 2,
     ResizableArrayBuffer = 3,
     ReadableStream = 4,
+    WritableStream = 5,
 };
 
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Value);

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -49,6 +49,7 @@ enum class TransferType : u8 {
     MessagePort = 1,
     ArrayBuffer = 2,
     ResizableArrayBuffer = 3,
+    ReadableStream = 4,
 };
 
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Value);

--- a/Libraries/LibWeb/HTML/StructuredSerializeTypes.h
+++ b/Libraries/LibWeb/HTML/StructuredSerializeTypes.h
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGC/Forward.h>
-
 #pragma once
+
+#include <AK/HashMap.h>
+#include <AK/Vector.h>
+#include <LibGC/Forward.h>
+#include <LibJS/Forward.h>
 
 namespace Web::HTML {
 

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -9,12 +9,27 @@
  */
 
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibWeb/Bindings/ExceptionOrUtils.h>
+#include <LibWeb/DOM/IDLEventListener.h>
+#include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
+#include <LibWeb/HTML/StructuredSerializeOptions.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/QueuingStrategy.h>
+#include <LibWeb/Streams/ReadableStream.h>
+#include <LibWeb/Streams/ReadableStreamDefaultController.h>
+#include <LibWeb/Streams/ReadableStreamOperations.h>
+#include <LibWeb/Streams/WritableStream.h>
+#include <LibWeb/Streams/WritableStreamDefaultController.h>
+#include <LibWeb/Streams/WritableStreamOperations.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/Buffers.h>
+#include <LibWeb/WebIDL/CallbackType.h>
+#include <LibWeb/WebIDL/DOMException.h>
 
 namespace Web::Streams {
 
@@ -48,6 +63,359 @@ GC::Ref<SizeAlgorithm> extract_size_algorithm(JS::VM& vm, QueuingStrategy const&
         // 1. Return the result of invoking strategy["size"] with argument list « chunk ».
         return WebIDL::invoke_callback(*size, {}, { { chunk } });
     });
+}
+
+struct PromiseHolder : public JS::Cell {
+    GC_CELL(PromiseHolder, JS::Cell);
+    GC_DECLARE_ALLOCATOR(PromiseHolder);
+
+    explicit PromiseHolder(GC::Ptr<WebIDL::Promise> promise)
+        : promise(promise)
+    {
+    }
+
+    virtual void visit_edges(JS::Cell::Visitor& visitor) override
+    {
+        Base::visit_edges(visitor);
+        visitor.visit(promise);
+    }
+
+    GC::Ptr<WebIDL::Promise> promise;
+};
+
+GC_DEFINE_ALLOCATOR(PromiseHolder);
+
+static void add_message_event_listener(JS::Realm& realm, HTML::MessagePort& port, FlyString const& name, Function<void(JS::VM&, HTML::MessageEvent const&)> handler)
+{
+    auto behavior = [handler = GC::create_function(realm.heap(), move(handler))](JS::VM& vm) {
+        auto event = vm.argument(0);
+        VERIFY(event.is_object());
+
+        auto& message_event = as<HTML::MessageEvent>(event.as_object());
+        handler->function()(vm, message_event);
+
+        return JS::js_undefined();
+    };
+
+    auto function = JS::NativeFunction::create(realm, move(behavior), 1, FlyString {}, &realm);
+    auto callback = realm.heap().allocate<WebIDL::CallbackType>(function, realm);
+    auto listener = DOM::IDLEventListener::create(realm, callback);
+
+    port.add_event_listener_without_options(name, listener);
+}
+
+// https://streams.spec.whatwg.org/#abstract-opdef-crossrealmtransformsenderror
+void cross_realm_transform_send_error(JS::Realm& realm, HTML::MessagePort& port, JS::Value error)
+{
+    // 1. Perform PackAndPostMessage(port, "error", error), discarding the result.
+    (void)pack_and_post_message(realm, port, "error"sv, error);
+}
+
+// https://streams.spec.whatwg.org/#abstract-opdef-packandpostmessagehandlingerror
+WebIDL::ExceptionOr<void> pack_and_post_message(JS::Realm& realm, HTML::MessagePort& port, StringView type, JS::Value value)
+{
+    auto& vm = realm.vm();
+
+    // 1. Let message be OrdinaryObjectCreate(null).
+    auto message = JS::Object::create(realm, nullptr);
+
+    // 2. Perform ! CreateDataProperty(message, "type", type).
+    MUST(message->create_data_property(vm.names.type, JS::PrimitiveString::create(vm, type)));
+
+    // 3. Perform ! CreateDataProperty(message, "value", value).
+    MUST(message->create_data_property(vm.names.value, value));
+
+    // 4. Let targetPort be the port with which port is entangled, if any; otherwise let it be null.
+    auto target_port = port.entangled_port();
+
+    // 5. Let options be «[ "transfer" → « » ]».
+    HTML::StructuredSerializeOptions options { .transfer = {} };
+
+    // 6. Run the message port post message steps providing targetPort, message, and options.
+    return port.message_port_post_message_steps(target_port, message, options);
+}
+
+// https://streams.spec.whatwg.org/#abstract-opdef-packandpostmessagehandlingerror
+WebIDL::ExceptionOr<void> pack_and_post_message_handling_error(JS::Realm& realm, HTML::MessagePort& port, StringView type, JS::Value value)
+{
+    // 1. Let result be PackAndPostMessage(port, type, value).
+    auto result = pack_and_post_message(realm, port, type, value);
+
+    // 2. If result is an abrupt completion,
+    if (result.is_exception()) {
+        auto error = Bindings::exception_to_throw_completion(realm.vm(), result.release_error());
+
+        // 1. Perform ! CrossRealmTransformSendError(port, result.[[Value]]).
+        cross_realm_transform_send_error(realm, port, error.value());
+    }
+
+    // 3. Return result as a completion record.
+    return result;
+}
+
+// https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
+void set_up_cross_realm_transform_readable(JS::Realm& realm, ReadableStream& stream, HTML::MessagePort& port)
+{
+    // 1. Perform ! InitializeReadableStream(stream).
+    initialize_readable_stream(stream);
+
+    // 2. Let controller be a new ReadableStreamDefaultController.
+    auto controller = realm.create<ReadableStreamDefaultController>(realm);
+
+    // 3. Add a handler for port’s message event with the following steps:
+    add_message_event_listener(realm, port, HTML::EventNames::message,
+        [&port, controller](JS::VM& vm, HTML::MessageEvent const& message) {
+            // 1. Let data be the data of the message.
+            auto data = message.data();
+
+            // 2. Assert: data is an Object.
+            VERIFY(data.is_object());
+
+            // 3. Let type be ! Get(data, "type").
+            auto type = MUST(data.get(vm, vm.names.type));
+
+            // 4. Let value be ! Get(data, "value").
+            auto value = MUST(data.get(vm, vm.names.value));
+
+            // 5. Assert: type is a String.
+            auto type_string = type.as_string().utf8_string_view();
+
+            // 6. If type is "chunk",
+            if (type_string == "chunk"sv) {
+                // 1. Perform ! ReadableStreamDefaultControllerEnqueue(controller, value).
+                MUST(readable_stream_default_controller_enqueue(controller, value));
+            }
+            // 7. Otherwise, if type is "close",
+            else if (type_string == "close"sv) {
+                // 1. Perform ! ReadableStreamDefaultControllerClose(controller).
+                readable_stream_default_controller_close(controller);
+
+                // 2. Disentangle port.
+                port.disentangle();
+            }
+            // 8. Otherwise, if type is "error",
+            else if (type_string == "error"sv) {
+                // 1. Perform ! ReadableStreamDefaultControllerError(controller, value).
+                readable_stream_default_controller_error(controller, value);
+
+                // 2. Disentangle port.
+                port.disentangle();
+            }
+        });
+
+    // 4. Add a handler for port’s messageerror event with the following steps:
+    add_message_event_listener(realm, port, HTML::EventNames::messageerror,
+        [&realm, &port, controller](JS::VM&, HTML::MessageEvent const&) {
+            // 1. Let error be a new "DataCloneError" DOMException.
+            auto error = WebIDL::DataCloneError::create(realm, "Unable to transfer stream"_string);
+
+            // 2. Perform ! CrossRealmTransformSendError(port, error).
+            cross_realm_transform_send_error(realm, port, error);
+
+            // 3. Perform ! ReadableStreamDefaultControllerError(controller, error).
+            readable_stream_default_controller_error(controller, error);
+
+            // 4. Disentangle port.
+            port.disentangle();
+        });
+
+    // FIXME: 5. Enable port’s port message queue.
+
+    // 6. Let startAlgorithm be an algorithm that returns undefined.
+    auto start_algorithm = GC::create_function(realm.heap(), []() -> WebIDL::ExceptionOr<JS::Value> {
+        return JS::js_undefined();
+    });
+
+    // 7. Let pullAlgorithm be the following steps:
+    auto pull_algorithm = GC::create_function(realm.heap(), [&realm, &port]() -> GC::Ref<WebIDL::Promise> {
+        // 1. Perform ! PackAndPostMessage(port, "pull", undefined).
+        MUST(pack_and_post_message(realm, port, "pull"sv, JS::js_undefined()));
+
+        // 2. Return a promise resolved with undefined.
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    });
+
+    // 8. Let cancelAlgorithm be the following steps, taking a reason argument:
+    auto cancel_algorithm = GC::create_function(realm.heap(), [&realm, &port](JS::Value reason) -> GC::Ref<WebIDL::Promise> {
+        // 1. Let result be PackAndPostMessageHandlingError(port, "error", reason).
+        auto result = pack_and_post_message_handling_error(realm, port, "error"sv, reason);
+
+        // 2. Disentangle port.
+        port.disentangle();
+
+        // 3. If result is an abrupt completion, return a promise rejected with result.[[Value]].
+        if (result.is_error())
+            return WebIDL::create_rejected_promise_from_exception(realm, result.release_error());
+
+        // 4. Otherwise, return a promise resolved with undefined.
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    });
+
+    // 9. Let sizeAlgorithm be an algorithm that returns 1.
+    auto size_algorithm = GC::create_function(realm.heap(), [](JS::Value) -> JS::Completion {
+        return JS::Value { 1 };
+    });
+
+    // 10. Perform ! SetUpReadableStreamDefaultController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, 0, sizeAlgorithm).
+    MUST(set_up_readable_stream_default_controller(stream, controller, start_algorithm, pull_algorithm, cancel_algorithm, 0, size_algorithm));
+}
+
+// https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable
+void set_up_cross_realm_transform_writable(JS::Realm& realm, WritableStream& stream, HTML::MessagePort& port)
+{
+    // 1. Perform ! InitializeWritableStream(stream).
+    initialize_writable_stream(stream);
+
+    // 2. Let controller be a new WritableStreamDefaultController.
+    auto controller = realm.create<WritableStreamDefaultController>(realm);
+
+    // 3. Let backpressurePromise be a new promise.
+    auto backpressure_promise = realm.heap().allocate<PromiseHolder>(WebIDL::create_promise(realm));
+
+    // 4. Add a handler for port’s message event with the following steps:
+    add_message_event_listener(realm, port, HTML::EventNames::message,
+        [&realm, controller, backpressure_promise](JS::VM& vm, HTML::MessageEvent const& message) {
+            // 1. Let data be the data of the message.
+            auto data = message.data();
+
+            // 2. Assert: data is an Object.
+            VERIFY(data.is_object());
+
+            // 3. Let type be ! Get(data, "type").
+            auto type = MUST(data.get(vm, vm.names.type));
+
+            // 4. Let value be ! Get(data, "value").
+            auto value = MUST(data.get(vm, vm.names.value));
+
+            // 5. Assert: type is a String.
+            auto type_string = type.as_string().utf8_string_view();
+
+            // 6. If type is "pull",
+            if (type_string == "pull"sv) {
+                // 1. If backpressurePromise is not undefined,
+                if (backpressure_promise->promise) {
+                    // 1. Resolve backpressurePromise with undefined.
+                    WebIDL::resolve_promise(realm, *backpressure_promise->promise, JS::js_undefined());
+
+                    // 2. Set backpressurePromise to undefined.
+                    backpressure_promise->promise = nullptr;
+                }
+            }
+            // 7. Otherwise, if type is "error",
+            else if (type_string == "error"sv) {
+                // 1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(controller, value).
+                writable_stream_default_controller_error_if_needed(controller, value);
+
+                // 2. If backpressurePromise is not undefined,
+                if (backpressure_promise->promise) {
+                    // 1. Resolve backpressurePromise with undefined.
+                    WebIDL::resolve_promise(realm, *backpressure_promise->promise, JS::js_undefined());
+
+                    // 2. Set backpressurePromise to undefined.
+                    backpressure_promise->promise = nullptr;
+                }
+            }
+        });
+
+    // 5. Add a handler for port’s messageerror event with the following steps:
+    add_message_event_listener(realm, port, HTML::EventNames::messageerror,
+        [&realm, &port, controller](JS::VM&, HTML::MessageEvent const&) {
+            // 1. Let error be a new "DataCloneError" DOMException
+            auto error = WebIDL::DataCloneError::create(realm, "Unable to transfer stream"_string);
+
+            // 2. Perform ! CrossRealmTransformSendError(port, error).
+            cross_realm_transform_send_error(realm, port, error);
+
+            // 3. Perform ! WritableStreamDefaultControllerErrorIfNeeded(controller, error).
+            writable_stream_default_controller_error_if_needed(controller, error);
+
+            // 4. Disentangle port.
+            port.disentangle();
+        });
+
+    // FIXME: 6. Enable port’s port message queue.
+
+    // 7. Let startAlgorithm be an algorithm that returns undefined.
+    auto start_algorithm = GC::create_function(realm.heap(), []() -> WebIDL::ExceptionOr<JS::Value> {
+        return JS::js_undefined();
+    });
+
+    // 8. Let writeAlgorithm be the following steps, taking a chunk argument:
+    auto write_algorithm = GC::create_function(realm.heap(), [&realm, &port, backpressure_promise](JS::Value chunk) -> GC::Ref<WebIDL::Promise> {
+        // 1. If backpressurePromise is undefined, set backpressurePromise to a promise resolved with undefined.
+        if (!backpressure_promise->promise)
+            backpressure_promise->promise = WebIDL::create_resolved_promise(realm, JS::js_undefined());
+
+        // FIXME: The steps below ("Return a promise rejected/resolved with ...") seem to indicate we should be creating
+        //        a promise on-the-fly. But in order for the error from PackAndPostMessageHandlingError to be propagated
+        //        back to the original ReadableStream, we must actually fulfill the promise created from reacting to the
+        //        backpressure promise. This is explicitly tested by WPT.
+        auto reaction_promise = realm.heap().allocate<PromiseHolder>(nullptr);
+
+        // 2. Return the result of reacting to backpressurePromise with the following fulfillment steps:
+        reaction_promise->promise = WebIDL::upon_fulfillment(*backpressure_promise->promise,
+            GC::create_function(realm.heap(), [&realm, &port, backpressure_promise, reaction_promise, chunk](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+                // 1. Set backpressurePromise to a new promise.
+                backpressure_promise->promise = WebIDL::create_promise(realm);
+
+                // 2. Let result be PackAndPostMessageHandlingError(port, "chunk", chunk).
+                auto result = pack_and_post_message_handling_error(realm, port, "chunk"sv, chunk);
+
+                // 3. If result is an abrupt completion,
+                if (result.is_error()) {
+                    // 1. Disentangle port.
+                    port.disentangle();
+
+                    // 2. Return a promise rejected with result.[[Value]].
+                    auto error = Bindings::exception_to_throw_completion(realm.vm(), result.release_error());
+                    WebIDL::reject_promise(realm, *reaction_promise->promise, error.value());
+                }
+                // 4. Otherwise, return a promise resolved with undefined.
+                else {
+                    WebIDL::resolve_promise(realm, *reaction_promise->promise, JS::js_undefined());
+                }
+
+                return reaction_promise->promise;
+            }));
+
+        return *reaction_promise->promise;
+    });
+
+    // 9. Let closeAlgorithm be the folowing steps:
+    auto close_algorithm = GC::create_function(realm.heap(), [&realm, &port]() -> GC::Ref<WebIDL::Promise> {
+        // 1. Perform ! PackAndPostMessage(port, "close", undefined).
+        MUST(pack_and_post_message(realm, port, "close"sv, JS::js_undefined()));
+
+        // 2. Disentangle port.
+        port.disentangle();
+
+        // 3. Return a promise resolved with undefined.
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    });
+
+    // 10. Let abortAlgorithm be the following steps, taking a reason argument:
+    auto abort_algorithm = GC::create_function(realm.heap(), [&realm, &port](JS::Value reason) -> GC::Ref<WebIDL::Promise> {
+        // 1. Let result be PackAndPostMessageHandlingError(port, "error", reason).
+        auto result = pack_and_post_message_handling_error(realm, port, "error"sv, reason);
+
+        // 2. Disentangle port.
+        port.disentangle();
+
+        // 3. If result is an abrupt completion, return a promise rejected with result.[[Value]].
+        if (result.is_error())
+            return WebIDL::create_rejected_promise_from_exception(realm, result.release_error());
+
+        // 4. Otherwise, return a promise resolved with undefined.
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    });
+
+    // 11. Let sizeAlgorithm be an algorithm that returns 1.
+    auto size_algorithm = GC::create_function(realm.heap(), [](JS::Value) -> JS::Completion {
+        return JS::Value { 1 };
+    });
+
+    // 12. Perform ! SetUpWritableStreamDefaultController(stream, controller, startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm, 1, sizeAlgorithm).
+    MUST(set_up_writable_stream_default_controller(stream, controller, start_algorithm, write_algorithm, close_algorithm, abort_algorithm, 1, size_algorithm));
 }
 
 // https://streams.spec.whatwg.org/#can-transfer-array-buffer

--- a/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -21,6 +21,13 @@ namespace Web::Streams {
 WebIDL::ExceptionOr<double> extract_high_water_mark(QueuingStrategy const&, double default_hwm);
 GC::Ref<SizeAlgorithm> extract_size_algorithm(JS::VM&, QueuingStrategy const&);
 
+// 8.2. Transferable streams, https://streams.spec.whatwg.org/#transferrable-streams
+void cross_realm_transform_send_error(JS::Realm&, HTML::MessagePort&, JS::Value error);
+WebIDL::ExceptionOr<void> pack_and_post_message(JS::Realm&, HTML::MessagePort&, StringView type, JS::Value value);
+WebIDL::ExceptionOr<void> pack_and_post_message_handling_error(JS::Realm&, HTML::MessagePort&, StringView type, JS::Value value);
+void set_up_cross_realm_transform_readable(JS::Realm&, ReadableStream&, HTML::MessagePort&);
+void set_up_cross_realm_transform_writable(JS::Realm&, WritableStream&, HTML::MessagePort&);
+
 // 8.3. Miscellaneous, https://streams.spec.whatwg.org/#misc-abstract-ops
 bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer);
 bool is_non_negative_number(JS::Value);

--- a/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Libraries/LibWeb/Streams/ReadableStream.h
@@ -11,6 +11,7 @@
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Bindings/ReadableStreamPrototype.h>
+#include <LibWeb/Bindings/Transferable.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Streams/Algorithms.h>
 #include <LibWeb/Streams/QueuingStrategy.h>
@@ -58,7 +59,9 @@ struct ReadableStreamPair {
 };
 
 // https://streams.spec.whatwg.org/#readablestream
-class ReadableStream final : public Bindings::PlatformObject {
+class ReadableStream final
+    : public Bindings::PlatformObject
+    , public Bindings::Transferable {
     WEB_PLATFORM_OBJECT(ReadableStream, Bindings::PlatformObject);
     GC_DECLARE_ALLOCATOR(ReadableStream);
 
@@ -113,6 +116,11 @@ public:
 
     GC::Ptr<WebIDL::ArrayBufferView> current_byob_request_view();
 
+    // ^Transferable
+    virtual WebIDL::ExceptionOr<void> transfer_steps(HTML::TransferDataHolder&) override;
+    virtual WebIDL::ExceptionOr<void> transfer_receiving_steps(HTML::TransferDataHolder&) override;
+    virtual HTML::TransferType primary_interface() const override { return HTML::TransferType::ReadableStream; }
+
 private:
     explicit ReadableStream(JS::Realm&);
 
@@ -122,10 +130,6 @@ private:
     // https://streams.spec.whatwg.org/#readablestream-controller
     // A ReadableStreamDefaultController or ReadableByteStreamController created with the ability to control the state and queue of this stream
     Optional<ReadableStreamController> m_controller;
-
-    // https://streams.spec.whatwg.org/#readablestream-detached
-    // A boolean flag set to true when the stream is transferred
-    bool m_detached { false };
 
     // https://streams.spec.whatwg.org/#readablestream-disturbed
     // A boolean flag set to true when the stream has been read from or canceled

--- a/Libraries/LibWeb/Streams/TransformStream.h
+++ b/Libraries/LibWeb/Streams/TransformStream.h
@@ -8,6 +8,7 @@
 
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/Bindings/Transferable.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Streams/Algorithms.h>
 #include <LibWeb/Streams/QueuingStrategy.h>
@@ -15,7 +16,9 @@
 
 namespace Web::Streams {
 
-class TransformStream final : public Bindings::PlatformObject {
+class TransformStream final
+    : public Bindings::PlatformObject
+    , public Bindings::Transferable {
     WEB_PLATFORM_OBJECT(TransformStream, Bindings::PlatformObject);
     GC_DECLARE_ALLOCATOR(TransformStream);
 
@@ -44,6 +47,11 @@ public:
     void set_up(GC::Ref<TransformAlgorithm>, GC::Ptr<FlushAlgorithm> = {}, GC::Ptr<CancelAlgorithm> = {});
     void enqueue(JS::Value chunk);
 
+    // ^Transferable
+    virtual WebIDL::ExceptionOr<void> transfer_steps(HTML::TransferDataHolder&) override;
+    virtual WebIDL::ExceptionOr<void> transfer_receiving_steps(HTML::TransferDataHolder&) override;
+    virtual HTML::TransferType primary_interface() const override { return HTML::TransferType::TransformStream; }
+
 private:
     explicit TransformStream(JS::Realm& realm);
 
@@ -62,10 +70,6 @@ private:
     // https://streams.spec.whatwg.org/#transformstream-controller
     // A TransformStreamDefaultController created with the ability to control [[readable]] and [[writable]]
     GC::Ptr<TransformStreamDefaultController> m_controller;
-
-    // https://streams.spec.whatwg.org/#transformstream-detached
-    // A boolean flag set to true when the stream is transferred
-    bool m_detached { false };
 
     // https://streams.spec.whatwg.org/#transformstream-readable
     // The ReadableStream instance controlled by this object

--- a/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 150 tests
 
-140 Pass
+141 Pass
 9 Fail
-1 Optional Feature Unsupported
 Pass	primitive undefined
 Pass	primitive null
 Pass	primitive true
@@ -149,7 +148,7 @@ Pass	A detached ArrayBuffer cannot be transferred
 Pass	A detached platform object cannot be transferred
 Pass	Transferring a non-transferable platform object fails
 Pass	An object whose interface is deleted from the global object must still be received
-Optional Feature Unsupported	A subclass instance will be received as its closest transferable superclass
+Pass	A subclass instance will be received as its closest transferable superclass
 Pass	Resizable ArrayBuffer is transferable
 Fail	Length-tracking TypedArray is transferable
 Fail	Length-tracking DataView is transferable

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/structured-clone/structured-clone.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/structured-clone/structured-clone.any.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 150 tests
 
-140 Pass
+141 Pass
 9 Fail
-1 Optional Feature Unsupported
 Pass	primitive undefined
 Pass	primitive null
 Pass	primitive true
@@ -149,7 +148,7 @@ Pass	A detached ArrayBuffer cannot be transferred
 Pass	A detached platform object cannot be transferred
 Pass	Transferring a non-transferable platform object fails
 Pass	An object whose interface is deleted from the global object must still be received
-Optional Feature Unsupported	A subclass instance will be received as its closest transferable superclass
+Pass	A subclass instance will be received as its closest transferable superclass
 Pass	Resizable ArrayBuffer is transferable
 Fail	Length-tracking TypedArray is transferable
 Fail	Length-tracking DataView is transferable

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/transferable/readable-stream.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/transferable/readable-stream.txt
@@ -1,0 +1,21 @@
+Harness status: OK
+
+Found 16 tests
+
+16 Pass
+Pass	sending one chunk through a transferred stream should work
+Pass	sending ten chunks through a transferred stream should work
+Pass	sending ten chunks one at a time should work
+Pass	sending ten chunks on demand should work
+Pass	transferring a stream should relieve backpressure
+Pass	transferring a stream should add one chunk to the queue size
+Pass	the extra queue from transferring is counted in chunks
+Pass	cancel should be propagated to the original
+Pass	cancel should abort a pending read()
+Pass	stream cancel should not wait for underlying source cancel
+Pass	serialization should not happen until the value is read
+Pass	transferring a non-serializable chunk should error both sides
+Pass	errors should be passed through
+Pass	race between cancel() and error() should leave sides in different states
+Pass	race between cancel() and close() should be benign
+Pass	race between cancel() and enqueue() should be benign

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/transferable/transform-stream.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/transferable/transform-stream.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	window.postMessage should be able to transfer a TransformStream
+Pass	a TransformStream with a locked writable should not be transferable
+Pass	a TransformStream with a locked readable should not be transferable
+Pass	a TransformStream with both sides locked should not be transferable
+Pass	piping through transferred transforms should work

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/transferable/writable-stream.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/transferable/writable-stream.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	window.postMessage should be able to transfer a WritableStream
+Pass	a locked WritableStream should not be transferable
+Pass	window.postMessage should be able to transfer a {readable, writable} pair
+Pass	desiredSize for a newly-transferred stream should be 1
+Pass	effective queue size of a transferred writable should be 2
+Pass	second write should wait for first underlying write to complete
+Pass	abort() should work
+Pass	writing a unclonable object should error the stream

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transferable/readable-stream.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transferable/readable-stream.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script>
+'use strict';
+
+promise_test(async () => {
+  const rs = await createTransferredReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.close();
+    }
+  });
+  const reader = rs.getReader();
+  {
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, 'a', 'first chunk should be a');
+  }
+  {
+    const {done} = await reader.read();
+    assert_true(done, 'should be done now');
+  }
+}, 'sending one chunk through a transferred stream should work');
+
+promise_test(async () => {
+  let controller;
+  const rs = await createTransferredReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  for (let i = 0; i < 10; ++i) {
+    controller.enqueue(i);
+  }
+  controller.close();
+  const reader = rs.getReader();
+  for (let i = 0; i < 10; ++i) {
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, i, 'chunk content should match index');
+  }
+  const {done} = await reader.read();
+  assert_true(done, 'should be done now');
+}, 'sending ten chunks through a transferred stream should work');
+
+promise_test(async () => {
+  let controller;
+  const rs = await createTransferredReadableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const reader = rs.getReader();
+  for (let i = 0; i < 10; ++i) {
+    controller.enqueue(i);
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, i, 'chunk content should match index');
+  }
+  controller.close();
+  const {done} = await reader.read();
+  assert_true(done, 'should be done now');
+}, 'sending ten chunks one at a time should work');
+
+promise_test(async () => {
+  let controller;
+  const rs = await createTransferredReadableStream({
+    start() {
+      this.counter = 0;
+    },
+    pull(controller) {
+      controller.enqueue(this.counter);
+      ++this.counter;
+      if (this.counter === 10)
+        controller.close();
+    }
+  });
+  const reader = rs.getReader();
+  for (let i = 0; i < 10; ++i) {
+    const {value, done} = await reader.read();
+    assert_false(done, 'should not be done yet');
+    assert_equals(value, i, 'chunk content should match index');
+  }
+  const {done} = await reader.read();
+  assert_true(done, 'should be done now');
+}, 'sending ten chunks on demand should work');
+
+promise_test(async () => {
+  const rs = recordingReadableStream({}, { highWaterMark: 0 });
+  await delay(0);
+  assert_array_equals(rs.events, [], 'pull() should not have been called');
+  // Eat the message so it can't interfere with other tests.
+  addEventListener('message', () => {}, {once: true});
+  // The transfer is done manually to verify that it is posting the stream that
+  // relieves backpressure, not receiving it.
+  postMessage(rs, '*', [rs]);
+  await delay(0);
+  assert_array_equals(rs.events, ['pull'], 'pull() should have been called');
+}, 'transferring a stream should relieve backpressure');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream({
+    pull(controller) {
+      controller.enqueue('a');
+    }
+  }, { highWaterMark: 2 });
+  await delay(0);
+  assert_array_equals(rs.events, ['pull', 'pull', 'pull'],
+                      'pull() should have been called three times');
+}, 'transferring a stream should add one chunk to the queue size');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array(1024));
+      controller.enqueue(new Uint8Array(1024));
+    }
+  }, new ByteLengthQueuingStrategy({highWaterMark: 512}));
+  await delay(0);
+  // At this point the queue contains 1024/512 bytes and 1/1 chunk, so it's full
+  // and pull() is not called.
+  assert_array_equals(rs.events, [], 'pull() should not have been called');
+  const reader = rs.getReader();
+  const {value, done} = await reader.read();
+  assert_false(done, 'we should not be done');
+  assert_equals(value.byteLength, 1024, 'expected chunk should be returned');
+  // Now the queue contains 0/512 bytes and 1/1 chunk, so pull() is called. If
+  // the implementation erroneously counted the extra queue space in bytes, then
+  // the queue would contain 1024/513 bytes and pull() wouldn't be called.
+  assert_array_equals(rs.events, ['pull'], 'pull() should have been called');
+}, 'the extra queue from transferring is counted in chunks');
+
+async function transferredReadableStreamWithCancelPromise() {
+  let resolveCancelCalled;
+  const cancelCalled = new Promise(resolve => {
+    resolveCancelCalled = resolve;
+  });
+  const rs = await recordingTransferredReadableStream({
+    cancel() {
+      resolveCancelCalled();
+    }
+  });
+  return { rs, cancelCalled };
+}
+
+promise_test(async () => {
+  const { rs, cancelCalled } = await transferredReadableStreamWithCancelPromise();
+  rs.cancel('message');
+  await cancelCalled;
+  assert_array_equals(rs.events, ['pull', 'cancel', 'message'],
+                      'cancel() should have been called');
+  const reader = rs.getReader();
+  // Check the stream really got closed.
+  await reader.closed;
+}, 'cancel should be propagated to the original');
+
+promise_test(async () => {
+  const { rs, cancelCalled } = await transferredReadableStreamWithCancelPromise();
+  const reader = rs.getReader();
+  const readPromise = reader.read();
+  reader.cancel('done');
+  const { done } = await readPromise;
+  assert_true(done, 'should be done');
+  await cancelCalled;
+  assert_array_equals(rs.events, ['pull', 'cancel', 'done'],
+                      'events should match');
+}, 'cancel should abort a pending read()');
+
+promise_test(async () => {
+  let cancelComplete = false;
+  const rs = await createTransferredReadableStream({
+    async cancel() {
+      await flushAsyncEvents();
+      cancelComplete = true;
+    }
+  });
+  await rs.cancel();
+  assert_false(cancelComplete,
+               'cancel() on the underlying sink should not have completed');
+}, 'stream cancel should not wait for underlying source cancel');
+
+promise_test(async t => {
+  const rs = await recordingTransferredReadableStream();
+  const reader = rs.getReader();
+  let serializationHappened = false;
+  rs.controller.enqueue({
+    get getter() {
+      serializationHappened = true;
+      return 'a';
+    }
+  });
+  await flushAsyncEvents();
+  assert_false(serializationHappened,
+               'serialization should not have happened yet');
+  const {value, done} = await reader.read();
+  assert_false(done, 'should not be done');
+  assert_equals(value.getter, 'a', 'getter should be a');
+  assert_true(serializationHappened,
+              'serialization should have happened');
+}, 'serialization should not happen until the value is read');
+
+promise_test(async t => {
+  const rs = await recordingTransferredReadableStream();
+  const reader = rs.getReader();
+  rs.controller.enqueue(new ReadableStream());
+  await promise_rejects_dom(t, 'DataCloneError', reader.read(),
+                            'closed promise should reject');
+  assert_throws_js(TypeError, () => rs.controller.enqueue(),
+                   'original stream should be errored');
+}, 'transferring a non-serializable chunk should error both sides');
+
+promise_test(async t => {
+  const rs = await createTransferredReadableStream({
+    start(controller) {
+      controller.error('foo');
+    }
+  });
+  const reader = rs.getReader();
+  return promise_rejects_exactly(t, 'foo', reader.read(),
+                                 'error should be passed through');
+}, 'errors should be passed through');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream();
+  await delay(0);
+  const reader = rs.getReader();
+  reader.cancel();
+  rs.controller.error();
+  const {done} = await reader.read();
+  assert_true(done, 'should be done');
+  assert_throws_js(TypeError, () => rs.controller.enqueue(),
+                   'enqueue should throw');
+}, 'race between cancel() and error() should leave sides in different states');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream();
+  await delay(0);
+  const reader = rs.getReader();
+  reader.cancel();
+  rs.controller.close();
+  const {done} = await reader.read();
+  assert_true(done, 'should be done');
+}, 'race between cancel() and close() should be benign');
+
+promise_test(async () => {
+  const rs = await recordingTransferredReadableStream();
+  await delay(0);
+  const reader = rs.getReader();
+  reader.cancel();
+  rs.controller.enqueue('a');
+  const {done} = await reader.read();
+  assert_true(done, 'should be done');
+}, 'race between cancel() and enqueue() should be benign');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transferable/resources/helpers.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transferable/resources/helpers.js
@@ -1,0 +1,132 @@
+'use strict';
+
+(() => {
+  // Create a ReadableStream that will pass the tests in
+  // testTransferredReadableStream(), below.
+  function createOriginalReadableStream() {
+    return new ReadableStream({
+      start(controller) {
+        controller.enqueue('a');
+        controller.close();
+      }
+    });
+  }
+
+  // Common tests to roughly determine that |rs| is a correctly transferred
+  // version of a stream created by createOriginalReadableStream().
+  function testTransferredReadableStream(rs) {
+    assert_equals(rs.constructor, ReadableStream,
+                  'rs should be a ReadableStream in this realm');
+    assert_true(rs instanceof ReadableStream,
+                'instanceof check should pass');
+
+    // Perform a brand-check on |rs| in the process of calling getReader().
+    const reader = ReadableStream.prototype.getReader.call(rs);
+
+    return reader.read().then(({value, done}) => {
+      assert_false(done, 'done should be false');
+      assert_equals(value, 'a', 'value should be "a"');
+      return reader.read();
+    }).then(({done}) => {
+      assert_true(done, 'done should be true');
+    });
+  }
+
+  function testMessage(msg) {
+    assert_array_equals(msg.ports, [], 'there should be no ports in the event');
+    return testTransferredReadableStream(msg.data);
+  }
+
+  function testMessageEvent(target) {
+    return new Promise((resolve, reject) => {
+      target.addEventListener('message', ev => {
+        try {
+          resolve(testMessage(ev));
+        } catch (e) {
+          reject(e);
+        }
+      }, {once: true});
+    });
+  }
+
+  function testMessageEventOrErrorMessage(target) {
+    return new Promise((resolve, reject) => {
+      target.addEventListener('message', ev => {
+        if (typeof ev.data === 'string') {
+          // Assume it's an error message and reject with it.
+          reject(ev.data);
+          return;
+        }
+
+        try {
+          resolve(testMessage(ev));
+        } catch (e) {
+          reject(e);
+        }
+      }, {once: true});
+    });
+  }
+
+  function checkTestResults(target) {
+    return new Promise((resolve, reject) => {
+      target.onmessage = msg => {
+        // testharness.js sends us objects which we need to ignore.
+        if (typeof msg.data !== 'string')
+        return;
+
+        if (msg.data === 'OK') {
+          resolve();
+        } else {
+          reject(msg.data);
+        }
+      };
+    });
+  }
+
+  // These tests assume that a transferred ReadableStream will behave the same
+  // regardless of how it was transferred. This enables us to simply transfer the
+  // stream to ourselves.
+  function createTransferredReadableStream(underlyingSource) {
+    const original = new ReadableStream(underlyingSource);
+    const promise = new Promise((resolve, reject) => {
+      addEventListener('message', msg => {
+        const rs = msg.data;
+        if (rs instanceof ReadableStream) {
+          resolve(rs);
+        } else {
+          reject(new Error(`what is this thing: "${rs}"?`));
+        }
+      }, {once: true});
+    });
+    postMessage(original, '*', [original]);
+    return promise;
+  }
+
+  function recordingTransferredReadableStream(underlyingSource, strategy) {
+    const original = recordingReadableStream(underlyingSource, strategy);
+    const promise = new Promise((resolve, reject) => {
+      addEventListener('message', msg => {
+        const rs = msg.data;
+        if (rs instanceof ReadableStream) {
+          rs.events = original.events;
+          rs.eventsWithoutPulls = original.eventsWithoutPulls;
+          rs.controller = original.controller;
+          resolve(rs);
+        } else {
+          reject(new Error(`what is this thing: "${rs}"?`));
+        }
+      }, {once: true});
+    });
+    postMessage(original, '*', [original]);
+    return promise;
+  }
+
+  self.createOriginalReadableStream = createOriginalReadableStream;
+  self.testMessage = testMessage;
+  self.testMessageEvent = testMessageEvent;
+  self.testMessageEventOrErrorMessage = testMessageEventOrErrorMessage;
+  self.checkTestResults = checkTestResults;
+  self.createTransferredReadableStream = createTransferredReadableStream;
+  self.recordingTransferredReadableStream = recordingTransferredReadableStream;
+
+})();

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transferable/transform-stream.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transferable/transform-stream.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  const orig = new TransformStream();
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(evt => {
+      const transferred = evt.data;
+      assert_equals(transferred.constructor, TransformStream,
+                    'transferred should be a TransformStream in this realm');
+      assert_true(transferred instanceof TransformStream,
+                  'instanceof check should pass');
+
+      // Perform a brand-check on |transferred|.
+      const readableGetter = Object.getOwnPropertyDescriptor(
+        TransformStream.prototype, 'readable').get;
+      assert_true(readableGetter.call(transferred) instanceof ReadableStream,
+                 'brand check should pass and readable stream should result');
+      const writableGetter = Object.getOwnPropertyDescriptor(
+        TransformStream.prototype, 'writable').get;
+      assert_true(writableGetter.call(transferred) instanceof WritableStream,
+                 'brand check should pass and writable stream should result');
+      resolve();
+    }), {once: true});
+  });
+  postMessage(orig, '*', [orig]);
+  assert_true(orig.readable.locked, 'the readable side should be locked');
+  assert_true(orig.writable.locked, 'the writable side should be locked');
+  return promise;
+}, 'window.postMessage should be able to transfer a TransformStream');
+
+test(() => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
+                    'postMessage should throw');
+  assert_false(ts.readable.locked, 'readable side should not get locked');
+}, 'a TransformStream with a locked writable should not be transferable');
+
+test(() => {
+  const ts = new TransformStream();
+  const reader = ts.readable.getReader();
+  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
+                    'postMessage should throw');
+  assert_false(ts.writable.locked, 'writable side should not get locked');
+}, 'a TransformStream with a locked readable should not be transferable');
+
+test(() => {
+  const ts = new TransformStream();
+  const reader = ts.readable.getReader();
+  const writer = ts.writable.getWriter();
+  assert_throws_dom('DataCloneError', () => postMessage(ts, '*', [ts]),
+                    'postMessage should throw');
+}, 'a TransformStream with both sides locked should not be transferable');
+
+promise_test(t => {
+  const source = new ReadableStream({
+    start(controller) {
+      controller.enqueue('hello ');
+      controller.enqueue('there ');
+      controller.close();
+    }
+  });
+  let resolve;
+  const ready = new Promise(r => resolve = r);
+  let result = '';
+  const sink = new WritableStream({
+    write(chunk) {
+      if (result) {
+        resolve();
+      }
+      result += chunk;
+    }
+  });
+  const transform1 = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk.toUpperCase());
+    }
+  });
+  const transform2 = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk + chunk);
+    }
+  });
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(evt => {
+      const data = evt.data;
+      resolve(data.source
+                .pipeThrough(data.transform1)
+                .pipeThrough(data.transform2)
+                .pipeTo(data.sink));
+    }));
+  });
+  postMessage({source, sink, transform1, transform2}, '*',
+              [source, transform1, sink, transform2]);
+  return ready
+    .then(() => {
+      assert_equals(result, 'HELLO HELLO THERE THERE ',
+                    'transforms should have been applied');
+    });
+}, 'piping through transferred transforms should work');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/transferable/writable-stream.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/transferable/writable-stream.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  const orig = new WritableStream();
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(evt => {
+      const transferred = evt.data;
+      assert_equals(transferred.constructor, WritableStream,
+                    'transferred should be a WritableStream in this realm');
+      assert_true(transferred instanceof WritableStream,
+                  'instanceof check should pass');
+
+      // Perform a brand-check on |transferred|.
+      const writer = WritableStream.prototype.getWriter.call(transferred);
+      resolve();
+    }), {once: true});
+  });
+  postMessage(orig, '*', [orig]);
+  assert_true(orig.locked, 'the original stream should be locked');
+  return promise;
+}, 'window.postMessage should be able to transfer a WritableStream');
+
+test(() => {
+  const ws = new WritableStream();
+  const writer = ws.getWriter();
+  assert_throws_dom('DataCloneError', () => postMessage(ws, '*', [ws]),
+                    'postMessage should throw');
+}, 'a locked WritableStream should not be transferable');
+
+promise_test(t => {
+  const {writable, readable} = new TransformStream();
+  const promise = new Promise(resolve => {
+    addEventListener('message', t.step_func(async evt => {
+      const {writable, readable} = evt.data;
+      const reader = readable.getReader();
+      const writer = writable.getWriter();
+      const writerPromises = Promise.all([
+        writer.write('hi'),
+        writer.close(),
+      ]);
+      const {value, done} = await reader.read();
+      assert_false(done, 'we should not be done');
+      assert_equals(value, 'hi', 'chunk should have been delivered');
+      const readResult = await reader.read();
+      assert_true(readResult.done, 'readable should be closed');
+      await writerPromises;
+      resolve();
+    }), {once: true});
+  });
+  postMessage({writable, readable}, '*', [writable, readable]);
+  return promise;
+}, 'window.postMessage should be able to transfer a {readable, writable} pair');
+
+function transfer(stream) {
+  return new Promise(resolve => {
+    addEventListener('message', evt => resolve(evt.data), { once: true });
+    postMessage(stream, '*', [stream]);
+  });
+}
+
+promise_test(async () => {
+  const orig = new WritableStream(
+    {}, new ByteLengthQueuingStrategy({ highWaterMark: 65536 }));
+  const transferred = await transfer(orig);
+  const writer = transferred.getWriter();
+  assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+}, 'desiredSize for a newly-transferred stream should be 1');
+
+promise_test(async () => {
+  const orig = new WritableStream({
+    write() {
+      return new Promise(() => {});
+    }
+  });
+  const transferred = await transfer(orig);
+  const writer = transferred.getWriter();
+  await writer.write('a');
+  assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+}, 'effective queue size of a transferred writable should be 2');
+
+promise_test(async () => {
+  const [writeCalled, resolveWriteCalled] = makePromiseAndResolveFunc();
+  let resolveWrite;
+  const orig = new WritableStream({
+    write() {
+      resolveWriteCalled();
+      return new Promise(resolve => {
+        resolveWrite = resolve;
+      });
+    }
+  });
+  const transferred = await transfer(orig);
+  const writer = transferred.getWriter();
+  await writer.write('a');
+  let writeDone = false;
+  const writePromise = writer.write('b').then(() => {
+    writeDone = true;
+  });
+  await writeCalled;
+  assert_false(writeDone, 'second write should not have resolved yet');
+  resolveWrite();
+  await writePromise; // (makes sure this resolves)
+}, 'second write should wait for first underlying write to complete');
+
+async function transferredWritableStreamWithAbortPromise() {
+  const [abortCalled, resolveAbortCalled] = makePromiseAndResolveFunc();
+  const orig = recordingWritableStream({
+    abort() {
+      resolveAbortCalled();
+    }
+  });
+  const transferred = await transfer(orig);
+  return { orig, transferred, abortCalled };
+}
+
+promise_test(async t => {
+  const { orig, transferred, abortCalled } = await transferredWritableStreamWithAbortPromise();
+  transferred.abort('p');
+  await abortCalled;
+  assert_array_equals(orig.events, ['abort', 'p'],
+                      'abort() should have been called');
+}, 'abort() should work');
+
+promise_test(async t => {
+  const { orig, transferred, abortCalled } = await transferredWritableStreamWithAbortPromise();
+  const writer = transferred.getWriter();
+  // A WritableStream object cannot be cloned.
+  await promise_rejects_dom(t, 'DataCloneError', writer.write(new WritableStream()),
+                            'the write should reject');
+  await promise_rejects_dom(t, 'DataCloneError', writer.closed,
+                            'the stream should be errored');
+  await abortCalled;
+  assert_equals(orig.events.length, 2, 'abort should have been called');
+  assert_equals(orig.events[0], 'abort', 'first event should be abort');
+  assert_equals(orig.events[1].name, 'DataCloneError',
+                'reason should be a DataCloneError');
+}, 'writing a unclonable object should error the stream');
+</script>


### PR DESCRIPTION
For stream transfer to work, this requires `MessagePort::disentangle` to flush pending messages before the transport socket is closed.

Fixes #3294 
