### PR TITLE
CI: Add nightly Windows CI job

### DIFF
--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -42,6 +42,7 @@ runs:
 
     - name: 'Cache Stats'
       shell: bash
+      if: ${{ inputs.ccache_path != '' }}
       run: |
         CCACHE_DIR=${{ inputs.ccache_path }} ccache -s
 

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -1,0 +1,72 @@
+name: Nightly Windows
+
+on:
+  # Automatically run at the end of every day.
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # runner.workspace = /home/runner/work/ladybird
+  # github.workspace = /home/runner/work/ladybird/ladybird
+  LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
+  VCPKG_ROOT:  ${{ github.workspace }}/Build/vcpkg
+
+jobs:
+  CI:
+    if: github.repository == 'LadybirdBrowser/ladybird'
+
+    runs-on: windows-2022
+
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'pull_request' }}
+
+      - uses: actions/checkout@v4
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Set Up Environment
+        uses: ./.github/actions/setup
+        with:
+          os: 'Windows'
+          arch: 'x86_64'
+          toolchain: 'ClangCL'
+
+      - name: Restore Caches
+        uses: ./.github/actions/cache-restore
+        id: 'cache-restore'
+        with:
+          os: Windows
+          arch: x86_64
+          toolchain: ClangCL
+          cache_key_extra: windows_ci_ninja
+          download_cache_path: ${{ github.workspace }}/Build/caches
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+
+      - name: Create Build Environment
+        working-directory: ${{ github.workspace }}
+        run: |
+          cmake --preset windows_ci_ninja
+
+      - name: Build
+        working-directory: ${{ github.workspace }}
+        run: |
+          cmake --build --preset windows_ci_ninja
+
+      - name: Save Caches
+        uses: ./.github/actions/cache-save
+        with:
+          arch: x86_64
+          vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
+          vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}
+
+      - name: Test
+        working-directory: ${{ github.workspace }}
+        run: ctest --preset windows_ci_ninja --timeout 1800
+        env:
+          TESTS_ONLY: 1


### PR DESCRIPTION
This job uses the windows_ci_ninja preset to build just the components and unit tests that are known to work with ClangCL on the amd64-pc-windows-msvc target triple.

As a nightly job, its failures are non-blocking for any PRs, though they should be fixed eventually or the job will get turned off by email-annoyed maintainers.

Hilariously, this job takes 1h10m to build vcpkg dependencies, and less than 5 to build and run AK unit tests. As far as I could tell, windows and ccache are not friends. When we get serious about windows, this will become a build time bottleneck that we'll need a solution for.

Rather than make a gigantic mess of lagom-template.yml, I moved the MVP CI invocations into their own pipeline. 