### PR TITLE
LibCore+LibGfx: Rely on fontconfig(if enabled) for font directory resolution

### DIFF
--- a/Libraries/LibCore/StandardPaths.h
+++ b/Libraries/LibCore/StandardPaths.h
@@ -26,7 +26,6 @@ public:
     static ByteString user_data_directory();
     static Vector<ByteString> system_data_directories();
     static ErrorOr<ByteString> runtime_directory();
-    static ErrorOr<Vector<String>> font_directories();
 };
 
 }

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -72,6 +72,10 @@ if (HAS_VULKAN)
     list(APPEND SOURCES VulkanContext.cpp)
 endif()
 
+if (HAS_FONTCONFIG)
+    list(APPEND SOURCES Font/GlobalFontConfig.cpp)
+endif()
+
 serenity_lib(LibGfx gfx)
 
 target_link_libraries(LibGfx PRIVATE LibCompress LibCore LibCrypto LibFileSystem LibRIFF LibTextCodec LibIPC LibUnicode LibURL)

--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -5,8 +5,13 @@
  */
 
 #include <AK/FlyString.h>
+#include <LibCore/StandardPaths.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
+
+#if defined(AK_OS_HAIKU)
+#    include <FindDirectory.h>
+#endif
 
 namespace Gfx {
 
@@ -42,6 +47,51 @@ RefPtr<Gfx::Font> FontDatabase::get(FlyString const& family, float point_size, u
 void FontDatabase::for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)> callback)
 {
     m_system_font_provider->for_each_typeface_with_family_name(family_name, move(callback));
+}
+
+ErrorOr<Vector<String>> FontDatabase::font_directories()
+{
+#if defined(AK_OS_HAIKU)
+    Vector<String> paths_vector;
+    char** paths;
+    size_t paths_count;
+    if (find_paths(B_FIND_PATH_FONTS_DIRECTORY, NULL, &paths, &paths_count) == B_OK) {
+        for (size_t i = 0; i < paths_count; ++i) {
+            StringBuilder builder;
+            builder.append(paths[i], strlen(paths[i]));
+            paths_vector.append(TRY(builder.to_string()));
+        }
+    }
+    return paths_vector;
+#else
+    auto paths = Vector { {
+#    if defined(AK_OS_SERENITY)
+        "/res/fonts"_string,
+#    elif defined(AK_OS_MACOS)
+        "/System/Library/Fonts"_string,
+        "/Library/Fonts"_string,
+        TRY(String::formatted("{}/Library/Fonts"sv, Core::StandardPaths::home_directory())),
+#    elif defined(AK_OS_ANDROID)
+        // FIXME: We should be using the ASystemFontIterator NDK API here.
+        // There is no guarantee that this will continue to exist on future versions of Android.
+        "/system/fonts"_string,
+#    elif defined(AK_OS_WINDOWS)
+        TRY(String::formatted(R"({}\Fonts)"sv, getenv("WINDIR"))),
+        TRY(String::formatted(R"({}\Microsoft\Windows\Fonts)"sv, getenv("LOCALAPPDATA"))),
+#    else
+        TRY(String::formatted("{}/fonts", Core::StandardPaths::user_data_directory())),
+        TRY(String::formatted("{}/X11/fonts", Core::StandardPaths::user_data_directory())),
+#    endif
+    } };
+#    if !(defined(AK_OS_SERENITY) || defined(AK_OS_MACOS) || defined(AK_OS_WINDOWS))
+    auto data_directories = Core::StandardPaths::system_data_directories();
+    for (auto& data_directory : data_directories) {
+        paths.append(TRY(String::formatted("{}/fonts", data_directory)));
+        paths.append(TRY(String::formatted("{}/X11/fonts", data_directory)));
+    }
+#    endif
+    return paths;
+#endif
 }
 
 }

--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -13,6 +13,10 @@
 #    include <FindDirectory.h>
 #endif
 
+#ifdef USE_FONTCONFIG
+#    include <LibGfx/Font/GlobalFontConfig.h>
+#endif
+
 namespace Gfx {
 
 // Key function for SystemFontProvider to emit the vtable here
@@ -51,7 +55,16 @@ void FontDatabase::for_each_typeface_with_family_name(FlyString const& family_na
 
 ErrorOr<Vector<String>> FontDatabase::font_directories()
 {
-#if defined(AK_OS_HAIKU)
+#if defined(USE_FONTCONFIG)
+    Vector<String> paths;
+    FcConfig* config = Gfx::GlobalFontConfig::the().get();
+    FcStrList* dirs = FcConfigGetFontDirs(config);
+    while (FcChar8* dir = FcStrListNext(dirs)) {
+        char const* dir_cstring = reinterpret_cast<char const*>(dir);
+        paths.append(TRY(String::from_utf8(StringView { dir_cstring, strlen(dir_cstring) })));
+    }
+    return paths;
+#elif defined(AK_OS_HAIKU)
     Vector<String> paths_vector;
     char** paths;
     size_t paths_count;

--- a/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Libraries/LibGfx/Font/FontDatabase.h
@@ -32,6 +32,8 @@ public:
     void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>);
     [[nodiscard]] StringView system_font_provider_name() const;
 
+    static ErrorOr<Vector<String>> font_directories();
+
 private:
     FontDatabase();
     ~FontDatabase() = default;

--- a/Libraries/LibGfx/Font/GlobalFontConfig.cpp
+++ b/Libraries/LibGfx/Font/GlobalFontConfig.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, blukai <init1@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <LibGfx/Font/GlobalFontConfig.h>
+#include <fontconfig/fontconfig.h>
+
+namespace Gfx {
+
+GlobalFontConfig::GlobalFontConfig()
+{
+    FcBool inited = FcInit();
+    VERIFY(inited);
+
+    m_config = FcConfigGetCurrent();
+    FcConfigReference(m_config);
+}
+
+GlobalFontConfig::~GlobalFontConfig()
+{
+    FcConfigDestroy(m_config);
+}
+
+GlobalFontConfig& GlobalFontConfig::the()
+{
+    static GlobalFontConfig s_the;
+    return s_the;
+}
+
+FcConfig* GlobalFontConfig::get()
+{
+    return m_config;
+}
+
+}

--- a/Libraries/LibGfx/Font/GlobalFontConfig.h
+++ b/Libraries/LibGfx/Font/GlobalFontConfig.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, blukai <init1@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <fontconfig/fontconfig.h>
+
+namespace Gfx {
+
+class GlobalFontConfig {
+public:
+    static GlobalFontConfig& the();
+    FcConfig* get();
+
+private:
+    GlobalFontConfig();
+    ~GlobalFontConfig();
+
+    GlobalFontConfig(GlobalFontConfig const&) = delete;
+    GlobalFontConfig& operator=(GlobalFontConfig const&) = delete;
+
+    FcConfig* m_config;
+};
+
+}

--- a/Libraries/LibGfx/Font/PathFontProvider.cpp
+++ b/Libraries/LibGfx/Font/PathFontProvider.cpp
@@ -31,8 +31,7 @@ void PathFontProvider::load_all_fonts_from_uri(StringView uri)
     root->for_each_descendant_file([this](Core::Resource const& resource) -> IterationDecision {
         auto uri = resource.uri();
         auto path = LexicalPath(uri.bytes_as_string_view());
-        if (path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv)) {
-            // FIXME: What about .otf
+        if (path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv) || path.has_extension(".otf"sv)) {
             if (auto font_or_error = Typeface::try_load_from_resource(resource); !font_or_error.is_error()) {
                 auto font = font_or_error.release_value();
                 auto& family = m_typeface_by_family.ensure(font->family(), [] {

--- a/Libraries/LibWebView/Plugins/FontPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/FontPlugin.cpp
@@ -16,7 +16,7 @@
 #include <LibWebView/Plugins/FontPlugin.h>
 
 #ifdef USE_FONTCONFIG
-#    include <fontconfig/fontconfig.h>
+#    include <LibGfx/Font/GlobalFontConfig.h>
 #endif
 
 namespace WebView {
@@ -24,13 +24,6 @@ namespace WebView {
 FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_provider)
     : m_is_layout_test_mode(is_layout_test_mode)
 {
-#ifdef USE_FONTCONFIG
-    {
-        auto fontconfig_initialized = FcInit();
-        VERIFY(fontconfig_initialized);
-    }
-#endif
-
     if (!font_provider)
         font_provider = &static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
     if (is<Gfx::PathFontProvider>(*font_provider)) {
@@ -114,7 +107,7 @@ static Optional<String> query_fontconfig_for_generic_family(Web::Platform::Gener
         VERIFY_NOT_REACHED();
     }
 
-    auto* config = FcConfigGetCurrent();
+    auto* config = Gfx::GlobalFontConfig::the().get();
     VERIFY(config);
 
     FcPattern* pattern = FcNameParse(reinterpret_cast<FcChar8 const*>(pattern_string));

--- a/Libraries/LibWebView/Plugins/FontPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/FontPlugin.cpp
@@ -36,7 +36,7 @@ FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_p
     if (is<Gfx::PathFontProvider>(*font_provider)) {
         auto& path_font_provider = static_cast<Gfx::PathFontProvider&>(*font_provider);
         // Load anything we can find in the system's font directories
-        for (auto const& path : Core::StandardPaths::font_directories().release_value_but_fixme_should_propagate_errors())
+        for (auto const& path : Gfx::FontDatabase::font_directories().release_value_but_fixme_should_propagate_errors())
             path_font_provider.load_all_fonts_from_uri(MUST(String::formatted("file://{}", path)));
     }
 


### PR DESCRIPTION
first timer here.

i run a rather obscure linux and none of the fallback fonts that are listed in update_generic_fonts are present on my system. my initial clue was to try to enable fontconfig, but result was fruitless. eventually after a bunch of printf (or in this case outln) debugging i figured out that the issues was that ladybird was not able to load the fonts that fontconfig was resolving because ladybird was not trying look into directories in which fontconfig has found fonts.

this might be related to #4601

i moved font_directories from StandardPaths to FontDatabase because it didn't seem like it would be appropriate to call to fontconfig funcs from within the LibCore (based on my brief observations of how everything is structured).
i'm not 100% confident that FontDatabase is the correct place.. but seems okay?

besides issue with fonts it was a rather straightforward sailing, getting to build the whole thing. thanks for your efforts.