### PR TITLE
LibWeb/WebAudio: Implement AudioNode::connect()

### DIFF
--- a/Libraries/LibWeb/WebAudio/AudioNode.h
+++ b/Libraries/LibWeb/WebAudio/AudioNode.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2025, Ben Eidson <b.e.eidson@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -26,6 +27,21 @@ struct AudioNodeDefaultOptions {
     WebIDL::UnsignedLong channel_count;
     Bindings::ChannelCountMode channel_count_mode;
     Bindings::ChannelInterpretation channel_interpretation;
+};
+
+struct AudioNodeConnection {
+    GC::Ref<AudioNode> destination_node;
+    WebIDL::UnsignedLong output;
+    WebIDL::UnsignedLong input;
+
+    bool operator==(AudioNodeConnection const& other) const = default;
+};
+
+struct AudioParamConnection {
+    GC::Ref<AudioParam> destination_param;
+    WebIDL::UnsignedLong output;
+
+    bool operator==(AudioParamConnection const& other) const = default;
 };
 
 // https://webaudio.github.io/web-audio-api/#AudioNode
@@ -81,6 +97,12 @@ private:
     WebIDL::UnsignedLong m_channel_count { 2 };
     Bindings::ChannelCountMode m_channel_count_mode { Bindings::ChannelCountMode::Max };
     Bindings::ChannelInterpretation m_channel_interpretation { Bindings::ChannelInterpretation::Speakers };
+    // Connections from other AudioNode outputs into this node's inputs.
+    Vector<AudioNodeConnection> m_input_connections;
+    // Connections from this node's outputs into other AudioNode inputs.
+    Vector<AudioNodeConnection> m_output_connections;
+    // Connections from this node's outputs into AudioParams.
+    Vector<AudioParamConnection> m_param_connections;
 };
 
 }


### PR DESCRIPTION
Sets up the basic infrastructure for the audio node graph and implements the AudioNode `connect()` method with its related overides. AudioNodes store vectors of AudioNodeConnections and AudioParamConnections to represent links between nodes.