### PR TITLE
LibWeb: Handle non-OK network responses in `<object>` elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -297,7 +297,7 @@ void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
                 auto& realm = this->realm();
                 auto& global = document().realm().global_object();
 
-                if (response->is_network_error()) {
+                if (response->is_network_error() || !Fetch::Infrastructure::is_ok_status(response->status())) {
                     resource_did_fail();
                     return;
                 }

--- a/Tests/LibWeb/Layout/expected/object-fallback.txt
+++ b/Tests/LibWeb/Layout/expected/object-fallback.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x34 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x18 children: inline
+      InlineNode <object>
+        frag 0 from TextNode start: 1, length: 23, rect: [8,8 181.5x18] baseline: 13.796875
+            "This should be visible!"
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      PaintableWithLines (InlineNode<OBJECT>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/object-fallback.html
+++ b/Tests/LibWeb/Layout/input/object-fallback.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<!-- For testing purposes, this must be a domain name that resolves and results in a non-200 HTTP response -->
+<object data="https://ladybird.org/does-not-exist.html" type="text/html">
+    This should be visible!
+</object>


### PR DESCRIPTION
We were previously only testing for network errors, which includes e.g. DNS resolution and connection errors. It does not include e.g. HTTP 404 responses, which is exercised by Acid 2.

Acid 2 before this change (on macOS):
<img width="793" alt="Screenshot 2025-05-21 at 12 05 42 PM" src="https://github.com/user-attachments/assets/f6245538-5922-4397-8744-e62384ddb3c7" />

After this change:
<img width="793" alt="Screenshot 2025-05-21 at 12 05 33 PM" src="https://github.com/user-attachments/assets/3bb0ceda-59a7-4f33-96f2-38a952bb531d" />

