### PR TITLE
LibCore: Increase `MAX_LOCAL_SOCKET_TRANSFER_FDS`

### DIFF
--- a/Libraries/LibCore/Socket.cpp
+++ b/Libraries/LibCore/Socket.cpp
@@ -10,7 +10,8 @@
 
 namespace Core {
 
-static constexpr size_t MAX_LOCAL_SOCKET_TRANSFER_FDS = 64;
+// FIXME: This limit has been chosen arbitrarily to avoid WPT test flakiness.
+static constexpr size_t MAX_LOCAL_SOCKET_TRANSFER_FDS = 640;
 
 ErrorOr<int> Socket::create_fd(SocketDomain domain, SocketType type)
 {


### PR DESCRIPTION
It is currently possible to hit this limit on pages with large numbers of images. This temporary workaround prevents some WPT tests with large numbers of images from failing.

I'm not exactly sure what to put in the accompanying FIXME, since I'm not sure of the best approach to a longer term fix.