### PR TITLE
LibWeb: Be less aggressive in marking elements as not being named

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5440,7 +5440,7 @@ void Document::element_id_changed(Badge<DOM::Element>, GC::Ref<DOM::Element> ele
 
     if (element->id().has_value())
         insert_in_tree_order(m_potentially_named_elements, element);
-    else
+    else if (!element->name().has_value())
         (void)m_potentially_named_elements.remove_first_matching([element](auto& e) { return e == element; });
 
     auto new_id = element->id();

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/documents/dom-tree-accessors/nameditem-01.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/documents/dom-tree-accessors/nameditem-01.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 7 tests
+
+7 Pass
+Pass	img elements that have a name and id attribute, should be accessible by both values.
+Pass	img elements that have a name and id attribute with same value.
+Pass	Dynamically removing the name attribute from img elements, should not be accessible.
+Pass	Dynamically removing the id attribute from img elements, should still be accessible by name value.
+Pass	Dynamically updating the name attribute from img elements, should be accessible by values.
+Pass	Dynamically updating the id attribute from img elements, should be accessible by values.
+Pass	img elements that is removed, should not be accessible.

--- a/Tests/LibWeb/Text/input/wpt-import/html/dom/documents/dom-tree-accessors/nameditem-01.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/dom/documents/dom-tree-accessors/nameditem-01.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Named items: img id &amp; name</title>
+<link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-nameditem">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<div id="test">
+<img id="a" name="b">
+<img id="test" name="test">
+<img id="test2a" name="test2b">
+<img id="test3a" name="test3b">
+<img id="test4a" name="test4b">
+<img id="test5a" name="test5b">
+<img id="test6a" name="test6b">
+</div>
+<script>
+test(function() {
+  let img = document.getElementsByTagName("img")[0];
+  assert_equals(document.a, img);
+  assert_equals(document['a'], img);
+  assert_equals(document.b, img);
+  assert_equals(document['b'], img);
+}, "img elements that have a name and id attribute, should be accessible by both values.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[1];
+  assert_equals(document.test, img);
+  assert_equals(document['test'], img);
+}, "img elements that have a name and id attribute with same value.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[2];
+  assert_equals(document.test2a, img);
+  assert_equals(document['test2a'], img);
+  assert_equals(document.test2b, img);
+  assert_equals(document['test2b'], img);
+
+  img.removeAttribute("name");
+  assert_equals(document.test2a, undefined);
+  assert_equals(document['test2a'], undefined);
+  assert_equals(document.test2b, undefined);
+  assert_equals(document['test2b'], undefined);
+}, "Dynamically removing the name attribute from img elements, should not be accessible.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[3];
+  assert_equals(document.test3a, img);
+  assert_equals(document['test3a'], img);
+  assert_equals(document.test3b, img);
+  assert_equals(document['test3b'], img);
+
+  img.removeAttribute("id");
+  assert_equals(document.test3a, undefined);
+  assert_equals(document['test3a'], undefined);
+  assert_equals(document.test3b, img);
+  assert_equals(document['test3b'], img);
+}, "Dynamically removing the id attribute from img elements, should still be accessible by name value.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[4];
+  assert_equals(document.test4a, img);
+  assert_equals(document['test4a'], img);
+  assert_equals(document.test4b, img);
+  assert_equals(document['test4b'], img);
+
+  img.name = 'test4a';
+  assert_equals(document.test4a, img);
+  assert_equals(document['test4a'], img);
+  assert_equals(document.test4b, undefined);
+  assert_equals(document['test4b'], undefined);
+
+  img.name = 'test4c';
+  assert_equals(document.test4a, img);
+  assert_equals(document['test4a'], img);
+  assert_equals(document.test4b, undefined);
+  assert_equals(document['test4b'], undefined);
+  assert_equals(document.test4c, img);
+  assert_equals(document['test4c'], img);
+}, "Dynamically updating the name attribute from img elements, should be accessible by values.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[5];
+  assert_equals(document.test5a, img);
+  assert_equals(document['test5a'], img);
+  assert_equals(document.test5b, img);
+  assert_equals(document['test5b'], img);
+
+  img.id = 'test5b';
+  assert_equals(document.test5a, undefined);
+  assert_equals(document['test5a'], undefined);
+  assert_equals(document.test5b, img);
+  assert_equals(document['test5b'], img);
+
+  img.id = 'test5c';
+  assert_equals(document.test5a, undefined);
+  assert_equals(document['test5a'], undefined);
+  assert_equals(document.test5b, img);
+  assert_equals(document['test5b'], img);
+  assert_equals(document.test5c, img);
+  assert_equals(document['test5c'], img);
+}, "Dynamically updating the id attribute from img elements, should be accessible by values.");
+
+test(function() {
+  let img = document.getElementsByTagName("img")[6];
+  assert_equals(document.test6a, img);
+  assert_equals(document['test6a'], img);
+  assert_equals(document.test6b, img);
+  assert_equals(document['test6b'], img);
+
+  img.remove();
+  assert_equals(document.test6a, undefined);
+  assert_equals(document['test6a'], undefined);
+  assert_equals(document.test6b, undefined);
+  assert_equals(document['test6b'], undefined);
+}, "img elements that is removed, should not be accessible.");
+</script>


### PR DESCRIPTION
When an element's ID is removed we only want to remove it from `m_potentially_named_elements` if it is not also considered a potentially named element due to it's name content attribute.

Gains us atleast [one extra pass in WPT](http://wpt.live/html/dom/documents/dom-tree-accessors/nameditem-01.html)