### PR TITLE
LibIPC: Transfer extra fds in empty payload messages

### DIFF
--- a/Libraries/LibCore/Socket.h
+++ b/Libraries/LibCore/Socket.h
@@ -352,6 +352,8 @@ public:
 
     virtual ~LocalSocket() { close(); }
 
+    static size_t const MAX_TRANSFER_FDS;
+
 private:
     explicit LocalSocket(PreventSIGPIPE prevent_sigpipe = PreventSIGPIPE::Yes)
         : Socket(prevent_sigpipe)


### PR DESCRIPTION
This seems to work on both linux and macOS.

With this we can stop trying to transfer 640 fds per message, and just rely on TransferSocket's send thread to keep sending fds 64 at a time in `sendmsg` calls with empty iov entries.