### PR TITLE
Tests: Disable XMLHttpRequest-override-mimetype-blob.html for now

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -280,3 +280,7 @@ Text/input/WebSocket/echo.html
 
 ; Times out due to us not implementing auto-commit the correct way.
 Text/input/wpt-import/IndexedDB/idbfactory_open.any.html
+
+; Slow on macOS. Takes ~200ms per request to the echo server.
+; https://github.com/LadybirdBrowser/ladybird/issues/4850
+Text/input/XHR/XMLHttpRequest-override-mimetype-blob.html


### PR DESCRIPTION
It is extremely slow on macOS.