### PR TITLE
LibWeb: Handle format(woff-variations) etc in @font-face src values

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/format-specifiers-variations.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/format-specifiers-variations.txt
@@ -2,16 +2,15 @@ Harness status: OK
 
 Found 48 tests
 
-44 Pass
-4 Fail
+48 Pass
 Pass	Load Ahem with format woff
 Pass	Load Ahem with format truetype
 Pass	Load Ahem with format opentype
 Pass	Load Ahem with format woff2
-Fail	Load Ahem with format woff-variations
-Fail	Load Ahem with format truetype-variations
-Fail	Load Ahem with format opentype-variations
-Fail	Load Ahem with format woff2-variations
+Pass	Load Ahem with format woff-variations
+Pass	Load Ahem with format truetype-variations
+Pass	Load Ahem with format opentype-variations
+Pass	Load Ahem with format woff2-variations
 Pass	Do not load Ahem with format xyzwoff
 Pass	Do not load Ahem with format xyztruetype
 Pass	Do not load Ahem with format xyzopentype

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/format-specifiers-variations.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/format-specifiers-variations.txt
@@ -1,0 +1,54 @@
+Harness status: OK
+
+Found 48 tests
+
+44 Pass
+4 Fail
+Pass	Load Ahem with format woff
+Pass	Load Ahem with format truetype
+Pass	Load Ahem with format opentype
+Pass	Load Ahem with format woff2
+Fail	Load Ahem with format woff-variations
+Fail	Load Ahem with format truetype-variations
+Fail	Load Ahem with format opentype-variations
+Fail	Load Ahem with format woff2-variations
+Pass	Do not load Ahem with format xyzwoff
+Pass	Do not load Ahem with format xyztruetype
+Pass	Do not load Ahem with format xyzopentype
+Pass	Do not load Ahem with format xyzwoff2
+Pass	Do not load Ahem with format xyzwoff-variations
+Pass	Do not load Ahem with format xyztruetype-variations
+Pass	Do not load Ahem with format xyzopentype-variations
+Pass	Do not load Ahem with format xyzwoff2-variations
+Pass	Do not load Ahem with format woffxyz
+Pass	Do not load Ahem with format truetypexyz
+Pass	Do not load Ahem with format opentypexyz
+Pass	Do not load Ahem with format woff2xyz
+Pass	Do not load Ahem with format woff-variationsxyz
+Pass	Do not load Ahem with format truetype-variationsxyz
+Pass	Do not load Ahem with format opentype-variationsxyz
+Pass	Do not load Ahem with format woff2-variationsxyz
+Pass	Do not load Ahem with format wo
+Pass	Do not load Ahem with format truety
+Pass	Do not load Ahem with format openty
+Pass	Do not load Ahem with format wof
+Pass	Do not load Ahem with format woff-variatio
+Pass	Do not load Ahem with format truetype-variatio
+Pass	Do not load Ahem with format opentype-variatio
+Pass	Do not load Ahem with format woff2-variatio
+Pass	Do not load Ahem with format ff
+Pass	Do not load Ahem with format uetype
+Pass	Do not load Ahem with format entype
+Pass	Do not load Ahem with format ff2
+Pass	Do not load Ahem with format ff-variations
+Pass	Do not load Ahem with format uetype-variations
+Pass	Do not load Ahem with format entype-variations
+Pass	Do not load Ahem with format ff2-variations
+Pass	Do not load Ahem with format wff
+Pass	Do not load Ahem with format tretype
+Pass	Do not load Ahem with format opntype
+Pass	Do not load Ahem with format wff2
+Pass	Do not load Ahem with format woff-ariations
+Pass	Do not load Ahem with format truetye-variations
+Pass	Do not load Ahem with format opentye-variations
+Pass	Do not load Ahem with format woff2variations

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/format-specifiers-variations.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/format-specifiers-variations.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>CSS Test: Supported format specifiers should load</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#src-desc"/>
+<meta name="assert" content="Supported format specifiers should load"/>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+setup({
+    explicit_done: true
+});
+
+var formatSpecifiers = [
+    "woff",
+    "truetype",
+    "opentype",
+    "woff2",
+    "woff-variations",
+    "truetype-variations",
+    "opentype-variations",
+    "woff2-variations"
+];
+
+var defaultAhemSrc = 'url("../../fonts/Ahem.ttf") format("INSERT_FORMAT")';
+
+function runTestOnFormatSpecifiers(formats, expectFail) {
+    for (var i = 0; i < formats.length; ++i) {
+        promise_test((testDetails) => {
+            var familyName = "load_ahem_" + i;
+            var ahemSrcFormat = defaultAhemSrc.replace("INSERT_FORMAT", testDetails.properties.format);
+            var fontFace = new FontFace(familyName, ahemSrcFormat);
+            if (!expectFail) {
+                return fontFace.load();
+            } else {
+                return promise_rejects_dom(testDetails, "SyntaxError", fontFace.load());
+            }
+        }, (expectFail ? "Do not load" : "Load") + " Ahem with format " + formats[i], {
+            "format": formats[i]
+        });
+    }
+}
+
+runTestOnFormatSpecifiers(formatSpecifiers, false);
+runTestOnFormatSpecifiers(formatSpecifiers.map(x => "xyz" + x), true);
+runTestOnFormatSpecifiers(formatSpecifiers.map(x => x + "xyz"), true);
+runTestOnFormatSpecifiers(formatSpecifiers.map(x => x.slice(0, -2)), true);
+runTestOnFormatSpecifiers(formatSpecifiers.map(x => x.slice(2)), true);
+runTestOnFormatSpecifiers(formatSpecifiers.map(x => x.slice(0, x.length / 3) + x.slice(x.length / 3 + 1)), true);
+
+done();
+</script>
+</body>
+</html>


### PR DESCRIPTION
"format(woff-variations)" and pals are supposed to expand like so:
"format(woff) tech(variations)".
    
However, since we don't support tech() yet, this patch just adds a small
hack where we still treat "woff-variations" as "woff" so that fonts
load and get used, even if we don't make use of the variations yet.

Makes the monospace font load on https://terminal.shop/

BEFORE:
<img width="1037" alt="Screenshot 2025-05-23 at 14 11 06" src="https://github.com/user-attachments/assets/df1999f5-2125-4db0-a605-629fe48116d2" />

AFTER:
<img width="1037" alt="Screenshot 2025-05-23 at 14 10 54" src="https://github.com/user-attachments/assets/7b3520a3-539e-45de-bb22-d8149e893077" />
