### PR TITLE
LibCore: MimeType for text/plain has base names with lines folded

### DIFF
--- a/Libraries/LibCore/MimeData.cpp
+++ b/Libraries/LibCore/MimeData.cpp
@@ -61,8 +61,7 @@ static Array constexpr s_plaintext_suffixes = {
 
     // Base names
     ".history"sv,
-    ".shellrc"sv
-    "CMakeLists.txt"sv,
+    ".shellrc"sv,
 };
 
 // See https://www.iana.org/assignments/media-types/<mime-type> for a list of registered MIME types.

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_SOURCES
     TestLibCoreFileWatcher.cpp
     # FIXME: Identify and address the commit that caused this to start failing at runtime
     #TestLibCoreMappedFile.cpp
+    TestLibCoreMimeType.cpp
     TestLibCorePromise.cpp
     TestLibCoreSharedSingleProducerCircularQueue.cpp
     # FIXME: Identify and address the commit that caused this to start failing at runtime

--- a/Tests/LibCore/TestLibCoreMimeType.cpp
+++ b/Tests/LibCore/TestLibCoreMimeType.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Vector.h>
+#include <LibCore/MimeData.h>
+#include <LibTest/TestCase.h>
+
+static void check_filename_mimetype(Vector<StringView> const& filepaths, StringView expected_mime_type)
+{
+    for (auto const& filename : filepaths) {
+        dbgln(filename, "\n");
+        auto const& guessed_mime_type = Core::guess_mime_type_based_on_filename(filename);
+        EXPECT_EQ(guessed_mime_type, expected_mime_type);
+    }
+}
+
+auto text_plain_filenames = Vector {
+    "main.c"sv,
+    "hello.txt"sv,
+    ".history"sv,
+    ".shellrc"sv,
+    "CMakeList.txt"sv,
+};
+// FIXME: fails because .xht extension is in MimeType text/html and application/xhtml+xml
+// auto html_filenames = Vector {"about.html"sv, "send-data-blob.htm"sv, "content.xht"sv, "dir/settings.html"sv,};
+auto xhtml_filenames = Vector {
+    "about.xhtml"sv,
+    "content.xht"sv,
+};
+auto gzip_filenames = Vector {
+    "download.iso.gz"sv,
+    "backup.gzip"sv,
+    "hello.html.gz"sv,
+};
+auto markdown_filenames = Vector {
+    "README.md"sv,
+    "changelog.md"sv,
+};
+auto shell_filenames = Vector {
+    "script.sh"sv,
+};
+
+TEST_CASE(various_types_guessed)
+{
+    check_filename_mimetype(text_plain_filenames, "text/plain"sv);
+    // FIXME: fails because .xht extension is in MimeType text/html and application/xhtml+xml
+    // check_filename_mimetype(html_filenames, "text/html"sv);
+    check_filename_mimetype(xhtml_filenames, "application/xhtml+xml"sv);
+    check_filename_mimetype(gzip_filenames, "application/gzip"sv);
+    check_filename_mimetype(markdown_filenames, "text/markdown"sv);
+    check_filename_mimetype(shell_filenames, "text/x-shellscript"sv);
+}


### PR DESCRIPTION
Fix and tests for text/plain issue on .shellrc and CMakeList.txt lines folded in LibCore/MimeType.cpp

fixes #4859 