### PR TITLE
LibWeb: Disentangle both ends of a MessagePort at once

### DIFF
--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -147,9 +147,13 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_receiving_steps(HTML::TransferDa
 
 void MessagePort::disentangle()
 {
-    if (m_remote_port) {
+    if (auto remote_port = m_remote_port) {
+        // Set the pointers to null before disentangling the remote port to prevent infinite recursion here.
         m_remote_port->m_remote_port = nullptr;
         m_remote_port = nullptr;
+
+        if (remote_port)
+            remote_port->disentangle();
     }
 
     if (m_transport) {

--- a/Tests/LibWeb/Crash/wpt-import/streams/piping/crashtests/cross-piping.html
+++ b/Tests/LibWeb/Crash/wpt-import/streams/piping/crashtests/cross-piping.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script type="module">
+  let a = new ReadableStream();
+  let b = self.open()
+  let f = new b.WritableStream();
+  a.pipeThrough(
+    { "readable": a, "writable": f },
+    { "signal": AbortSignal.abort() }
+  )
+  await new Promise(setTimeout);
+  structuredClone(undefined, { "transfer": [f] })
+</script>


### PR DESCRIPTION
Otherwise, the remote end believes it is still entangled and may try to access its own (now null) remote port. This fixes a crash in WPT.