### PR TITLE
LibWeb: Prevent margin collapsing across <br> in anonymous block containers

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-size.txt
@@ -1,38 +1,38 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x1780 [BFC] children: not-inline
-    BlockContainer <body> at (8,70) content-size 784x1640 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x1640 [BFC] children: not-inline
+    BlockContainer <body> at (8,70) content-size 784x1500 children: not-inline
       BlockContainer <p.min-block-test> at (8,70) content-size 784x700 children: inline
         frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.875x80] baseline: 60.984375
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,840) content-size 784x80 children: inline
+      BlockContainer <(anonymous)> at (8,770) content-size 784x80 children: inline
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <p.max-block-test> at (8,990) content-size 200x100 children: inline
-        frag 0 from TextNode start: 0, length: 2, rect: [8,990 85.875x80] baseline: 60.984375
+      BlockContainer <p.max-block-test> at (8,920) content-size 200x100 children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [8,920 85.875x80] baseline: 60.984375
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,1160) content-size 784x80 children: inline
+      BlockContainer <(anonymous)> at (8,1020) content-size 784x80 children: inline
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <p.block-size-test> at (8,1310) content-size 200x400 children: inline
-        frag 0 from TextNode start: 0, length: 2, rect: [8,1310 85.875x80] baseline: 60.984375
+      BlockContainer <p.block-size-test> at (8,1170) content-size 200x400 children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [8,1170 85.875x80] baseline: 60.984375
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,1780) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,1640) content-size 784x0 children: inline
         TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1780]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1780]
-    PaintableWithLines (BlockContainer<BODY>) [8,70 784x1640]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1640]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1640]
+    PaintableWithLines (BlockContainer<BODY>) [8,70 784x1500]
       PaintableWithLines (BlockContainer<P>.min-block-test) [8,70 784x700]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,840 784x80]
-      PaintableWithLines (BlockContainer<P>.max-block-test) [8,990 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,770 784x80]
+      PaintableWithLines (BlockContainer<P>.max-block-test) [8,920 200x100]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,1160 784x80]
-      PaintableWithLines (BlockContainer<P>.block-size-test) [8,1310 200x400]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1020 784x80]
+      PaintableWithLines (BlockContainer<P>.block-size-test) [8,1170 200x400]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,1780 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1640 784x0]

--- a/Tests/LibWeb/Layout/expected/br-margin-collapse.txt
+++ b/Tests/LibWeb/Layout/expected/br-margin-collapse.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x52 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x36 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (8,8) content-size 784x18 children: inline
+        TextNode <#text>
+        InlineNode <a#target>
+          frag 0 from TextNode start: 0, length: 37, rect: [8,8 295.734375x18] baseline: 13.796875
+              "You should be able to click this link"
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,26) content-size 784x18 children: inline
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x18]
+        PaintableWithLines (InlineNode<A>#target)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x18]

--- a/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
+++ b/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x94 [BFC] children: not-inline
-    BlockContainer <body> at (8,16) content-size 784x70 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x78 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x54 children: not-inline
       BlockContainer <p> at (8,16) content-size 784x18 children: inline
         frag 0 from TextNode start: 0, length: 36, rect: [18.625,16 300x18] baseline: 13.796875
             "P should generate a ::before pseudo."
@@ -9,18 +9,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               "+"
           TextNode <#text>
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,50) content-size 784x36 children: inline
-        frag 0 from TextNode start: 0, length: 14, rect: [8,68 120.578125x18] baseline: 13.796875
+      BlockContainer <(anonymous)> at (8,34) content-size 784x36 children: inline
+        frag 0 from TextNode start: 0, length: 14, rect: [8,52 120.578125x18] baseline: 13.796875
             "BR should not!"
         BreakNode <br>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x94]
-    PaintableWithLines (BlockContainer<BODY>) [8,16 784x70]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x78]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x54]
       PaintableWithLines (BlockContainer<P>) [8,16 784x18]
         PaintableWithLines (InlineNode(anonymous))
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x36]
+      PaintableWithLines (BlockContainer(anonymous)) [8,34 784x36]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -1,38 +1,38 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x1060 [BFC] children: not-inline
-    BlockContainer <body> at (8,70) content-size 784x920 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x920 [BFC] children: not-inline
+    BlockContainer <body> at (8,70) content-size 784x780 children: not-inline
       BlockContainer <p.min-inline-test> at (8,70) content-size 784x200 children: inline
         frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.875x80] baseline: 60.984375
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,340) content-size 784x80 children: inline
+      BlockContainer <(anonymous)> at (8,270) content-size 784x80 children: inline
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <p.max-inline-test> at (8,490) content-size 100x80 children: inline
-        frag 0 from TextNode start: 0, length: 2, rect: [8,490 85.875x80] baseline: 60.984375
+      BlockContainer <p.max-inline-test> at (8,420) content-size 100x80 children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [8,420 85.875x80] baseline: 60.984375
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,640) content-size 784x80 children: inline
+      BlockContainer <(anonymous)> at (8,500) content-size 784x80 children: inline
         TextNode <#text>
         BreakNode <br>
         TextNode <#text>
-      BlockContainer <p.inline-size-test> at (8,790) content-size 400x200 children: inline
-        frag 0 from TextNode start: 0, length: 2, rect: [8,790 85.875x80] baseline: 60.984375
+      BlockContainer <p.inline-size-test> at (8,650) content-size 400x200 children: inline
+        frag 0 from TextNode start: 0, length: 2, rect: [8,650 85.875x80] baseline: 60.984375
             "KK"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,1060) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,920) content-size 784x0 children: inline
         TextNode <#text>
 
-ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1060]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1060]
-    PaintableWithLines (BlockContainer<BODY>) [8,70 784x920]
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x920]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x920]
+    PaintableWithLines (BlockContainer<BODY>) [8,70 784x780]
       PaintableWithLines (BlockContainer<P>.min-inline-test) [8,70 784x200]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,340 784x80]
-      PaintableWithLines (BlockContainer<P>.max-inline-test) [8,490 100x80]
+      PaintableWithLines (BlockContainer(anonymous)) [8,270 784x80]
+      PaintableWithLines (BlockContainer<P>.max-inline-test) [8,420 100x80]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,640 784x80]
-      PaintableWithLines (BlockContainer<P>.inline-size-test) [8,790 400x200]
+      PaintableWithLines (BlockContainer(anonymous)) [8,500 784x80]
+      PaintableWithLines (BlockContainer<P>.inline-size-test) [8,650 400x200]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,1060 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,920 784x0]

--- a/Tests/LibWeb/Layout/input/br-margin-collapse.html
+++ b/Tests/LibWeb/Layout/input/br-margin-collapse.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+
+<body>
+    <div style="margin-bottom:-25px;">
+        <a href="#" id="target">You should be able to click this link</a>
+    </div>
+    <br>
+</body>


### PR DESCRIPTION
`<br>` creates a line box and per CSS 2.2 §8.3.1 line boxes prevent vertical margins from collapsing.

This change fixes a margin collapse happening incorrectly over `<br>` inside an anonymous block container. Now, we reset the margin state when such a container includes a `<br>`.

Before this fix, the following HTML would render the link unclickable due to the collapsed negative margin. You can also see this in the screen recording. After, the layout is corrected and the link is clickable.

```
<!DOCTYPE html>

<body>
    <div style="margin-bottom:-25px;">
        <a href="#" id="target">You should be able to click this link</a>
    </div>
    <br>
</body>
```


### Before:

https://github.com/user-attachments/assets/a6abf227-a117-456e-ba31-ce0dfa55f1ee

### After:

https://github.com/user-attachments/assets/a4e55f17-6bb2-409b-bed7-20ec08fd5d21

