### PR TITLE
Revert "Meta: Update skia to version 134"

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -199,7 +199,7 @@
     },
     {
       "name": "skia",
-      "version": "134#2"
+      "version": "129#0"
     },
     {
       "name": "sqlite3",


### PR DESCRIPTION
This reverts commit 51d189198d3fc61141fc367dc315c7f50492a57e.

This neglected to update the overlay port, thus had no effect.

I won't be getting to the overlay port update today, so let's just revert this for now for correctness.