### PR TITLE
LibWeb/Editing: Fix two crashes in queryCommandState 

### DIFF
--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -329,7 +329,7 @@ WebIDL::ExceptionOr<bool> Document::query_command_state(FlyString const& command
         if (inline_values.is_empty())
             return false;
         auto range = Editing::active_range(*this);
-        Vector<GC::Ref<Node>> formattable_nodes;
+        GC::RootVector<GC::Ref<Node>> formattable_nodes(heap());
         Editing::for_each_node_effectively_contained_in_range(range, [&](GC::Ref<Node> descendant) {
             if (Editing::is_formattable_node(descendant))
                 formattable_nodes.append(descendant);

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -329,6 +329,8 @@ WebIDL::ExceptionOr<bool> Document::query_command_state(FlyString const& command
         if (inline_values.is_empty())
             return false;
         auto range = Editing::active_range(*this);
+        if (!range)
+            return false;
         GC::RootVector<GC::Ref<Node>> formattable_nodes(heap());
         Editing::for_each_node_effectively_contained_in_range(range, [&](GC::Ref<Node> descendant) {
             if (Editing::is_formattable_node(descendant))

--- a/Tests/LibWeb/Text/expected/Editing/case-insensitive-strikethrough-command.txt
+++ b/Tests/LibWeb/Text/expected/Editing/case-insensitive-strikethrough-command.txt
@@ -1,0 +1,1 @@
+strikeThrough active?: true

--- a/Tests/LibWeb/Text/expected/Editing/case-insensitive-strikethrough-command.txt
+++ b/Tests/LibWeb/Text/expected/Editing/case-insensitive-strikethrough-command.txt
@@ -1,1 +1,2 @@
+strikeThrough active?: false
 strikeThrough active?: true

--- a/Tests/LibWeb/Text/input/Editing/case-insensitive-strikethrough-command.html
+++ b/Tests/LibWeb/Text/input/Editing/case-insensitive-strikethrough-command.html
@@ -9,7 +9,7 @@
     const range = document.createRange();
     const selection = window.getSelection();
 
-    // println(`strikeThrough active?: ${document.queryCommandState("strikeThrough")}`);
+    println(`strikeThrough active?: ${document.queryCommandState("strikeThrough")}`);
     range.selectNodeContents(target);
     selection.removeAllRanges();
     selection.addRange(range);

--- a/Tests/LibWeb/Text/input/Editing/case-insensitive-strikethrough-command.html
+++ b/Tests/LibWeb/Text/input/Editing/case-insensitive-strikethrough-command.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="editor" contenteditable="true">
+  This is <span id="target">some text</span> to test.
+</div>
+<script>
+  test(() => {
+    const target = document.getElementById("target");
+    const range = document.createRange();
+    const selection = window.getSelection();
+
+    // println(`strikeThrough active?: ${document.queryCommandState("strikeThrough")}`);
+    range.selectNodeContents(target);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.execCommand("strikeThrough");
+
+    println(`strikeThrough active?: ${document.queryCommandState("strikeThrough")}`);
+  });
+</script>


### PR DESCRIPTION
The first crash fix was seen on gmail.com, the second while writing a test for it.