### PR TITLE
LibWeb/HTML: Don't log FIXME messages for location.ancestorOrigins 

### DIFF
--- a/Libraries/LibWeb/HTML/Location.idl
+++ b/Libraries/LibWeb/HTML/Location.idl
@@ -15,5 +15,8 @@ interface Location { // but see also additional creation steps and overridden in
     [LegacyUnforgeable] undefined replace(USVString url);
     [LegacyUnforgeable] undefined reload();
 
-    [FIXME, LegacyUnforgeable, SameObject] readonly attribute DOMStringList ancestorOrigins;
+    // Intentionally not implemented at this stage due to https://github.com/whatwg/html/issues/1918
+    // This is not currently implemented by Firefox due to the above, and only seems to be used by
+    // ad tech on real sites.
+    // [LegacyUnforgeable, SameObject] readonly attribute DOMStringList ancestorOrigins;
 };


### PR DESCRIPTION
This is quite a frequent FIXME log on quite a few sites which
does not serve much value at this stage. So instead of marking it
with a FIXME extended IDL attribute, let's just comment it out.