### PR TITLE
LibWeb: Don't crash when handling invalid HTTP status codes

### DIFF
--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -443,8 +443,12 @@ void ResourceLoader::load(LoadRequest& request, GC::Root<SuccessCallback> succes
                 else
                     error_builder.append("Load failed"sv);
 
-                if (status_code.has_value() && *status_code > 0)
-                    error_builder.appendff(" (status: {} {})", *status_code, HTTP::HttpResponse::reason_phrase_for_code(*status_code));
+                if (status_code.has_value()) {
+                    if (*status_code >= 100 && *status_code <= 599)
+                        error_builder.appendff(" (status: {} {})", *status_code, HTTP::HttpResponse::reason_phrase_for_code(*status_code));
+                    else
+                        error_builder.appendff(" (status: {})", *status_code);
+                }
 
                 log_failure(request, error_builder.string_view());
                 if (error_callback)


### PR DESCRIPTION
Example crash: https://wpt.live/fetch/h1-parsing/status-code.window.html

~~There is still work to make the above tests pass but we are limited by CURL on that: https://github.com/curl/curl/issues/17446~~

Edit: As discussed in the above curl issue it seems as though some of the subtests in the above WPT test rely on behavior counter to the HTTP spec (supporting HTTP status codes <100)