### PR TITLE
LibWeb: Make Environment's top level origin nullable

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -316,7 +316,7 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
             top_level_creation_url = parent_environment.top_level_creation_url;
 
             // 3. Set topLevelOrigin to parentEnvironment's top-level origin.
-            top_level_origin = parent_environment.top_level_origin;
+            top_level_origin = parent_environment.top_level_origin.value();
         }
 
         // 10. Set up a window environment settings object with creationURL, realm execution context,

--- a/Libraries/LibWeb/Fetch/Infrastructure/NetworkPartitionKey.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/NetworkPartitionKey.cpp
@@ -15,8 +15,9 @@ NetworkPartitionKey determine_the_network_partition_key(HTML::Environment const&
     // 1. Let topLevelOrigin be environment’s top-level origin.
     auto top_level_origin = environment.top_level_origin;
 
-    // FIXME: 2. If topLevelOrigin is null, then set topLevelOrigin to environment’s top-level creation URL’s origin
-    // This field is supposed to be nullable
+    // 2. If topLevelOrigin is null, then set topLevelOrigin to environment’s top-level creation URL’s origin
+    if (!top_level_origin.has_value())
+        top_level_origin = environment.top_level_creation_url->origin();
 
     // 3. Assert: topLevelOrigin is an origin.
 
@@ -26,7 +27,7 @@ NetworkPartitionKey determine_the_network_partition_key(HTML::Environment const&
     void* second_key = nullptr;
 
     // 6. Return (topLevelSite, secondKey).
-    return { top_level_origin, second_key };
+    return { top_level_origin.release_value(), second_key };
 }
 
 // https://fetch.spec.whatwg.org/#request-determine-the-network-partition-key

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -254,7 +254,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
         document->set_policy_container(creator->policy_container()->clone(document->heap()));
 
         // 3. If creator's origin is same origin with creator's relevant settings object's top-level origin,
-        if (creator->origin().is_same_origin(creator->relevant_settings_object().top_level_origin)) {
+        if (creator->origin().is_same_origin(creator->relevant_settings_object().top_level_origin.value())) {
             // then set document's opener policy to creator's browsing context's top-level browsing context's active document's opener policy.
             VERIFY(creator->browsing_context());
             VERIFY(creator->browsing_context()->top_level_browsing_context()->active_document());

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1039,7 +1039,7 @@ TokenizedFeature::NoOpener HTMLElement::get_an_elements_noopener(URL::URL const&
         auto const& top_level_origin = relevant_settings_object(*this).top_level_origin;
 
         // 3. If blobOrigin is not same site with topLevelOrigin, then return true.
-        if (!blob_origin.is_same_site(top_level_origin))
+        if (!blob_origin.is_same_site(top_level_origin.value()))
             return TokenizedFeature::NoOpener::Yes;
     }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -420,7 +420,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::show_picker()
     // and this's type attribute is not in the File Upload state or Color state, then throw a "SecurityError" DOMException.
     // NOTE: File and Color inputs are exempted from this check for historical reason: their input activation behavior also shows their pickers,
     //       and has never been guarded by an origin check.
-    if (!relevant_settings_object(*this).origin().is_same_origin(relevant_settings_object(*this).top_level_origin)
+    if (!relevant_settings_object(*this).origin().is_same_origin(relevant_settings_object(*this).top_level_origin.value())
         && m_type != TypeAttributeState::FileUpload && m_type != TypeAttributeState::Color) {
         return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"_string);
     }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -515,8 +515,8 @@ WebIDL::ExceptionOr<void> HTMLSelectElement::show_picker()
         return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"_string);
 
     // 2. If this's relevant settings object's origin is not same origin with this's relevant settings object's top-level origin,
-    // and this is a select element, then throw a "SecurityError" DOMException.
-    if (!relevant_settings_object(*this).origin().is_same_origin(relevant_settings_object(*this).top_level_origin)) {
+    //    and this is a select element, then throw a "SecurityError" DOMException.
+    if (!relevant_settings_object(*this).origin().is_same_origin(relevant_settings_object(*this).top_level_origin.value())) {
         return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"_string);
     }
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -428,7 +428,7 @@ Navigable::ChosenNavigable Navigable::choose_a_navigable(StringView name, Tokeni
             // 4. If currentDocument's opener policy's value is "same-origin" or "same-origin-plus-COEP",
             //    and currentDocument's origin is not same origin with currentDocument's relevant settings object's top-level origin, then:
             if ((current_document->opener_policy().value == OpenerPolicyValue::SameOrigin || current_document->opener_policy().value == OpenerPolicyValue::SameOriginPlusCOEP)
-                && !current_document->origin().is_same_origin(relevant_settings_object(*current_document).top_level_origin)) {
+                && !current_document->origin().is_same_origin(relevant_settings_object(*current_document).top_level_origin.value())) {
 
                 // 1. Set noopener to true.
                 no_opener = TokenizedFeature::NoOpener::Yes;
@@ -936,7 +936,7 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
             Optional<URL::URL> top_level_creation_url = current_url;
 
             // 2. Let topLevelOrigin be null.
-            URL::Origin top_level_origin;
+            Optional<URL::Origin> top_level_origin;
 
             // 3. If navigable is not a top-level traversable, then:
             if (!navigable->is_top_level_traversable()) {

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -37,7 +37,10 @@ public:
     Optional<URL::URL> top_level_creation_url;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin
-    URL::Origin top_level_origin;
+    // A for now implementation-defined value, null, or an origin. For a "top-level" potential execution environment it is null
+    // (i.e., when there is no response yet); otherwise it is the "top-level" environment's origin. For a dedicated worker or worklet
+    // it is the top-level origin of its creator. For a shared or service worker it is an implementation-defined value.
+    Optional<URL::Origin> top_level_origin;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context
     GC::Ptr<BrowsingContext> target_browsing_context;
@@ -52,7 +55,7 @@ public:
 
 protected:
     Environment() = default;
-    Environment(String id, URL::URL creation_url, Optional<URL::URL> top_level_creation_url, URL::Origin top_level_origin, GC::Ptr<BrowsingContext> target_browsing_context)
+    Environment(String id, URL::URL creation_url, Optional<URL::URL> top_level_creation_url, Optional<URL::Origin> top_level_origin, GC::Ptr<BrowsingContext> target_browsing_context)
         : id(move(id))
         , creation_url(move(creation_url))
         , top_level_creation_url(move(top_level_creation_url))

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
@@ -35,7 +35,7 @@ ErrorOr<Web::HTML::SerializedEnvironmentSettingsObject> decode(Decoder& decoder)
     object.id = TRY(decoder.decode<String>());
     object.creation_url = TRY(decoder.decode<URL::URL>());
     object.top_level_creation_url = TRY(decoder.decode<Optional<URL::URL>>());
-    object.top_level_origin = TRY(decoder.decode<URL::Origin>());
+    object.top_level_origin = TRY(decoder.decode<Optional<URL::Origin>>());
     object.api_url_character_encoding = TRY(decoder.decode<String>());
     object.api_base_url = TRY(decoder.decode<URL::URL>());
     object.origin = TRY(decoder.decode<URL::Origin>());

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
@@ -23,7 +23,7 @@ struct SerializedEnvironmentSettingsObject {
     String id;
     URL::URL creation_url;
     Optional<URL::URL> top_level_creation_url;
-    URL::Origin top_level_origin;
+    Optional<URL::Origin> top_level_origin;
 
     String api_url_character_encoding;
     URL::URL api_base_url;

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -171,7 +171,7 @@ static TokenizedFeature::NoOpener get_noopener_for_window_open(DOM::Document con
         auto top_level_origin = source_document.relevant_settings_object().top_level_origin;
 
         // 3. If blobOrigin is not same site with topLevelOrigin, then return true.
-        if (!blob_origin.is_same_site(top_level_origin))
+        if (!blob_origin.is_same_site(top_level_origin.value()))
             return TokenizedFeature::NoOpener::Yes;
     }
 


### PR DESCRIPTION
This matches the definition in the spec, and is also a step towards removing the default constructor of URL::Origin.

Motivated by trying to change URL::Origin to use a nonce for opaque origins.