### PR TITLE
LibJS: Fix arrow function parsing bug

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1065,8 +1065,12 @@ RefPtr<FunctionExpression const> Parser::try_parse_arrow_function_expression(boo
 
             auto const_correct_parameters = parse_formal_parameters(function_length, FunctionNodeParseOptions::IsArrowFunction | (is_async ? FunctionNodeParseOptions::IsAsyncFunction : 0));
             parameters = fixme_launder_const_through_pointer_cast(const_correct_parameters);
-            if (m_state.errors.size() > previous_syntax_errors && m_state.errors[previous_syntax_errors].message.bytes_as_string_view().starts_with("Unexpected token"sv))
-                return nullptr;
+            if (m_state.errors.size() > previous_syntax_errors) {
+                auto error_message = m_state.errors[previous_syntax_errors].message.bytes_as_string_view();
+                if (error_message.starts_with("Unexpected token"sv) || error_message.starts_with("Duplicate parameter names"sv)) {
+                    return nullptr;
+                }
+            }
             if (!match(TokenType::ParenClose))
                 return nullptr;
             consume();

--- a/Libraries/LibJS/Tests/syntax/return-object-with-duplicated-field-names-from-arrow-function.js
+++ b/Libraries/LibJS/Tests/syntax/return-object-with-duplicated-field-names-from-arrow-function.js
@@ -1,0 +1,10 @@
+test("returning object with duplicated member names (i) should not throw exception", () => {
+    expect(`
+const f = (i) => ({
+    obj: { a: { x: i }, b: { x: i } },
+    g: () => {},
+});
+
+f(123);
+    `).toEval();
+});


### PR DESCRIPTION
In the following example:
```js
const f = (i) => ({
    obj: { a: { x: i }, b: { x: i } },
    g: () => {},
});
```

The body of function `f` is initially parsed as an arrow function. As a result, what is actually an object expression is interpreted as a formal parameter with a binding pattern. Since duplicate identifiers are not allowed in this context (`i` in the example), the parser generates an error, causing the entire script to fail parsing.

This change ignores the "Duplicate parameter names in bindings" error during arrow function parameter parsing, allowing the parser to continue and recognize the object expression of the outer arrow function with an implicit return.

Fixes error on https://chat.openai.com/