### PR TITLE
LibWeb/HTML: Add accessors for "multiple" attribute of HTMLSelectElement

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -574,6 +574,16 @@ void HTMLSelectElement::form_associated_element_was_inserted()
     create_shadow_tree_if_needed();
 }
 
+void HTMLSelectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
+{
+    if (name == HTML::AttributeNames::multiple) {
+        // If the multiple attribute is absent then update the selectedness of the option elements.
+        if (!value.has_value()) {
+            update_selectedness();
+        }
+    }
+}
+
 void HTMLSelectElement::computed_properties_changed()
 {
     // Hide chevron icon when appearance is none

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -98,6 +98,7 @@ public:
     virtual void activation_behavior(DOM::Event const&) override;
 
     virtual void form_associated_element_was_inserted() override;
+    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
 
     void did_select_item(Optional<u32> const& id);
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-multiple.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-multiple.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	multiple selected options exist, both set from markup
 Pass	multiple selected options exist, one set from script
-Fail	Removing multiple attribute reduces the number of selected OPTIONs to 1
+Pass	Removing multiple attribute reduces the number of selected OPTIONs to 1


### PR DESCRIPTION
This change adds getter and setter support for the "multiple" attribute on HTMLSelectElement. It ensures correct behavior when the attribute is removed, reducing the number of selected <option> elements to one.

Fixes a failing WPT test in:
https://wpt.live/html/semantics/forms/the-select-element/select-multiple.html