### PR TITLE
LibWeb: Make SVGGradientPaintStyle be atomically ref-counted

### DIFF
--- a/Libraries/LibWeb/Painting/PaintStyle.h
+++ b/Libraries/LibWeb/Painting/PaintStyle.h
@@ -6,8 +6,7 @@
 
 #pragma once
 
-#include <AK/RefCounted.h>
-#include <AK/Variant.h>
+#include <AK/AtomicRefCounted.h>
 #include <LibGfx/PaintStyle.h>
 
 namespace Web::Painting {
@@ -18,7 +17,7 @@ struct ColorStop {
     Optional<float> transition_hint = {};
 };
 
-class SVGGradientPaintStyle : public RefCounted<SVGGradientPaintStyle> {
+class SVGGradientPaintStyle : public AtomicRefCounted<SVGGradientPaintStyle> {
 public:
     enum class SpreadMethod {
         Pad,


### PR DESCRIPTION
This was the only remaining data type used in display lists that wasn't atomically ref-counted.

Now that it is, we no longer crash when scrolling on https://vercel.com/