### PR TITLE
CI: Use explicit run IDs to download JS binary and call webhook

### DIFF
--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -4,8 +4,7 @@ on:
   workflow_run:
     workflows: ['Package the js repl as a binary artifact']
     branches: [master]
-    types:
-      - completed
+    types: [completed]
 
 jobs:
   js-benchmarks:
@@ -25,6 +24,10 @@ jobs:
             arch: 'arm64'
             package_type: 'macOS-universal2'
 
+    permissions:
+      actions: read
+      contents: read
+
     steps:
       - name: 'Checkout LadybirdBrowser/js-benchmarks'
         uses: actions/checkout@v4
@@ -43,8 +46,7 @@ jobs:
         id: download-artifact
         uses: dawidd6/action-download-artifact@v9
         with:
-          workflow: js-artifacts.yml
-          commit: ${{ github.event.workflow_run.head_sha }}
+          run_id: ${{ github.event.workflow_run.id }}
           name: ladybird-js-${{ matrix.package_type }}
           path: js-repl
 
@@ -77,7 +79,8 @@ jobs:
               "commit": "${{ github.event.workflow_run.head_sha }}",
               "os": "${{ matrix.os_name }}",
               "arch": "${{ matrix.arch }}",
-              "artifact": "js-benchmarks-results-${{ matrix.os_name }}-${{ matrix.arch }}"
+              "artifact": "js-benchmarks-results-${{ matrix.os_name }}-${{ matrix.arch }}",
+              "artifact_run_id": "${{ github.run_id }}"
           }' > request.json
           curl \
               --fail \


### PR DESCRIPTION
When we try to retrieve benchmark results in the webhook call, we cannot use the `head_sha` parameter since the workflow run might have a different `head_sha` associated with it than the upstream workflow run. This can happen when the JS repl binary workflow runs, a new commit is pushed to master, followed by a JS benchmarks workflow run causing this latter run to be associated with a different commit ID.

This extends the webhook payload to include the current run ID, which can eventually be used by the webhook script to specifically download the benchmark results associated with the current run.

Additionally, this changes the JS artifact download to use the upstream run ID which seems nicer to do anyway.