### PR TITLE
CI: Switch over some workflows to Blacksmith.sh runners

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -7,7 +7,7 @@ on: [pull_request_target]
 
 jobs:
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
 
     steps:

--- a/.github/workflows/merge-conflict-labeler.yml
+++ b/.github/workflows/merge-conflict-labeler.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   auto-labeler:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/notes-push.yml
+++ b/.github/workflows/notes-push.yml
@@ -5,10 +5,11 @@ on:
       - master
 permissions:
   contents: write
+
 jobs:
   build:
     if: github.repository == 'LadybirdBrowser/ladybird'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       actions: write  # required for cache management (see https://github.com/actions/stale/issues/1133)
       pull-requests: write


### PR DESCRIPTION
The people over at Blacksmith.sh have generously offered usage of their runners for our organization, so let's try to switch over some simple workflows. The runners should be drop-in replacements.