### PR TITLE
LibWeb: Cancel previous animation if new animation-name is "none"

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2678,6 +2678,8 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
         auto const animation_name = computed_style->maybe_null_property(PropertyID::AnimationName);
         if (!animation_name)
             return OptionalNone {};
+        if (animation_name->is_keyword() && animation_name->to_keyword() == Keyword::None)
+            return OptionalNone {};
         if (animation_name->is_string())
             return animation_name->as_string().string_value().to_string();
         return animation_name->to_string(SerializationMode::Normal);

--- a/Tests/LibWeb/Text/expected/WebAnimations/cancel-animation.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/cancel-animation.txt
@@ -1,0 +1,1 @@
+Animation cancelled

--- a/Tests/LibWeb/Text/input/WebAnimations/cancel-animation.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/cancel-animation.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <div id="box"></div>
+        <style>
+            #box {
+                width: 100px;
+                height: 100px;
+                background: #000;
+                margin: 200px;
+            }
+            @keyframes enlarge {
+                from {
+                    transform: scale(1);
+                }
+                to {
+                    transform: scale(5);
+                }
+            }
+        </style>
+    </body>
+    <script src="../include.js"></script>
+    <script>
+        asyncTest(done => {
+            const box = document.getElementById("box");
+
+            box.addEventListener("animationcancel", () => {
+                println("Animation cancelled");
+                done();
+            });
+
+            box.addEventListener("animationstart", () => {
+                requestAnimationFrame(() => (box.style.animation = "none"));
+            });
+
+            box.style.animation = "enlarge 2s forwards";
+        });
+    </script>
+</html>


### PR DESCRIPTION
"none" value should be interpreted as "no animation" to trigger the path that cancels previous animation if it exists.