### PR TITLE
CI: Use Blacksmith cache action only on Blacksmith runners

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -3,6 +3,9 @@ description: 'Restores caches of downloaded files and build artifacts.'
 author: 'Andrew Kaster <akaster@serenityos.org>'
 
 inputs:
+  runner_label:
+    description: 'Name of runner instance'
+    required: true
   os:
     description: 'Operating System to restore caches for'
     required: true
@@ -39,10 +42,10 @@ inputs:
 outputs:
   ccache_primary_key:
     description: 'Primary ccache key'
-    value: ${{ steps.ccache.outputs.cache-primary-key }}
+    value: ${{ steps.cache-outputs.outputs.ccache_primary_key }}
   vcpkg_cache_primary_key:
     description: 'Primary vcpkg binary cache key'
-    value: ${{ steps.vcpkg.outputs.cache-primary-key }}
+    value: ${{ steps.cache-outputs.outputs.vcpkg_cache_primary_key }}
 
 runs:
   using: "composite"
@@ -53,15 +56,25 @@ runs:
       run: |
         echo "timestamp=$(date -u "+%Y%m%d%H%M_%S")" >> "$GITHUB_OUTPUT"
 
-    - name: 'Compiler Cache'
+    - name: 'Compiler Cache (blacksmith)'
       uses: useblacksmith/cache/restore@v5
-      id: 'ccache'
-      if: ${{ inputs.ccache_path != '' }}
+      id: 'ccache-blacksmith'
+      if: ${{ inputs.ccache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
       with:
           path: ${{ inputs.ccache_path }}
           key: '"ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
           restore-keys: |
               "ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
+
+    - name: 'Compiler Cache (GitHub runner)'
+      uses: actions/cache/restore@v4
+      id: 'ccache-gh'
+      if: ${{ inputs.ccache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
+      with:
+        path: ${{ inputs.ccache_path }}
+        key: '"ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
+        restore-keys: |
+          "ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
 
     - name: 'Configure Compiler Cache'
       if: ${{ inputs.ccache_path != '' }}
@@ -75,12 +88,34 @@ runs:
           CCACHE_DIR=${{ inputs.ccache_path }} ccache -s
           CCACHE_DIR=${{ inputs.ccache_path }} ccache -z
 
-    - name: 'Restore vcpkg cache'
+    - name: 'Restore vcpkg cache (blacksmith)'
       uses: useblacksmith/cache/restore@v5
-      if: ${{ inputs.vcpkg_cache_path != '' }}
-      id: 'vcpkg'
+      if: ${{ inputs.vcpkg_cache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
+      id: 'vcpkg-blacksmith'
       with:
         path: ${{ inputs.vcpkg_cache_path }}
         key: '"vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
         restore-keys: |
           "vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
+
+    - name: 'Compiler Cache (GitHub runner)'
+      uses: actions/cache/restore@v4
+      if: ${{ inputs.ccache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
+      id: 'vcpkg-gh'
+      with:
+        path: ${{ inputs.vcpkg_cache_path }}
+        key: '"vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
+        restore-keys: |
+          "vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
+
+    - name: 'Cache Outputs'
+      id: 'cache-outputs'
+      shell: bash
+      run: |
+        if ${{ startsWith(inputs.runner_label, 'blacksmith') }} ; then
+          echo "ccache_primary_key=${{ steps.ccache-blacksmith.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
+          echo "vcpkg_cache_primary_key=${{ steps.vcpkg-blacksmith.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "ccache_primary_key=${{ steps.ccache-gh.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
+          echo "vcpkg_cache_primary_key=${{ steps.vcpkg-gh.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -3,6 +3,9 @@ description: 'Saves caches of build artifacts.'
 author: 'Andrew Kaster <akaster@serenityos.org>'
 
 inputs:
+  runner_label:
+    description: 'Name of runner instance'
+    required: true
   arch:
     description: 'Target Architecture to restore caches for'
     required: false
@@ -33,9 +36,16 @@ runs:
       run: |
         CCACHE_DIR=${{ inputs.ccache_path }} ccache --evict-older-than=1d
 
-    - name: 'Compiler Cache'
+    - name: 'Compiler Cache (blacksmith)'
       uses: useblacksmith/cache/save@v5
-      if: ${{ inputs.ccache_path != '' }}
+      if: ${{ inputs.ccache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
+      with:
+        path: ${{ inputs.ccache_path }}
+        key: ${{ inputs.ccache_primary_key }}
+
+    - name: 'Compiler Cache (GitHub runner)'
+      uses: actions/cache/save@v4
+      if: ${{ inputs.ccache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
       with:
         path: ${{ inputs.ccache_path }}
         key: ${{ inputs.ccache_primary_key }}
@@ -46,9 +56,16 @@ runs:
       run: |
         CCACHE_DIR=${{ inputs.ccache_path }} ccache -s
 
-    - name: 'vcpkg binary cache'
+    - name: 'vcpkg binary cache (blacksmith)'
       uses: useblacksmith/cache/save@v5
-      if: ${{ inputs.vcpkg_cache_path != '' }}
+      if: ${{ inputs.vcpkg_cache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
+      with:
+        path: ${{ inputs.vcpkg_cache_path }}
+        key: ${{ inputs.vcpkg_cache_primary_key }}
+
+    - name: 'vcpkg binary cache (GitHub runner)'
+      uses: actions/cache/save@v4
+      if: ${{ inputs.vcpkg_cache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
       with:
         path: ${{ inputs.vcpkg_cache_path }}
         key: ${{ inputs.vcpkg_cache_primary_key }}

--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -41,6 +41,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         id: 'cache-restore'
         with:
+          runner_label: ${{ matrix.runner }}
           os: ${{ matrix.os_name }}
           arch: ${{ matrix.arch }}
           cache_key_extra: 'LibJS Artifacts'
@@ -76,6 +77,7 @@ jobs:
       - name: Save Caches
         uses: ./.github/actions/cache-save
         with:
+          runner_label: ${{ matrix.runner }}
           arch: 'Lagom'
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -103,6 +103,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         id: 'cache-restore'
         with:
+          runner_label: ${{ inputs.runner }}
           os: ${{ inputs.os_name }}
           arch: ${{ inputs.arch }}
           toolchain: ${{ inputs.toolchain }}
@@ -175,6 +176,7 @@ jobs:
       - name: Save Caches
         uses: ./.github/actions/cache-save
         with:
+          runner_label: ${{ inputs.runner }}
           arch: ${{ inputs.arch }}
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Restore Caches
         uses: ./.github/actions/cache-restore
         with:
+          runner_label: test262-runner
           os: 'Linux'
           arch: 'Lagom'
           download_cache_path: ${{ github.workspace }}/libjs-test262/Build/caches

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -41,6 +41,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         id: 'cache-restore'
         with:
+          runner_label: windows-2022
           os: Windows
           arch: x86_64
           toolchain: ClangCL
@@ -61,6 +62,7 @@ jobs:
       - name: Save Caches
         uses: ./.github/actions/cache-save
         with:
+          runner_label: windows-2022
           arch: x86_64
           vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
           vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}


### PR DESCRIPTION
Their cache action only works on their runners. For jobs that run on other runners, we have use the default cache action. At least until they update their cache product to work or fallback on other runners.