### PR TITLE
CI: Changes to make Swift CI Pass

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -107,7 +107,7 @@ runs:
 
         echo "swiftly version: $(swiftly --version)" >&2
 
-        swiftly install --use main-snapshot-2025-04-30
+        swiftly install --use main-snapshot-2025-05-26
         swiftly list
 
     - name: 'Install Dependencies'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -41,7 +41,7 @@ runs:
         sudo apt-get update -y
         sudo apt-get install -y autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 \
             gcc-14 g++-14 libcurl4-openssl-dev libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev \
-            libstdc++-14-dev lld-20 nasm ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
+            libstdc++-14-dev lld-20 llvm-20 nasm ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
 
         if ${{ inputs.toolchain == 'Clang' }} ; then
           sudo apt-get install -y clang-20 clang++-20 clang-tools-20
@@ -49,6 +49,7 @@ runs:
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-20 100
         fi
 
+        sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-20 100
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
 


### PR DESCRIPTION
Swift jobs were failing a test due to the llvm-symbolizer not being
available in the default location next to the clang binary. swift.org
toolchains don't ship this tool, so LSAN suppressions were not being
applied, failing TestWOFF2.

This was hard to reproduce locally, because I have always had a set of
alternatives set up for the full suite of LLVM tools on my machine.

Also bump the snapshot version. No idea why the April snapshot didn't work on macOS. Let's use the latest.