### PR TITLE
LibWeb: throw NOT_SUPPORTED_ERR when dom create a touchevent

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2236,7 +2236,7 @@ WebIDL::ExceptionOr<GC::Ref<Event>> Document::create_event(StringView interface)
     } else if (interface.equals_ignoring_ascii_case("textevent"sv)) {
         event = UIEvents::TextEvent::create(realm, FlyString {});
     } else if (interface.equals_ignoring_ascii_case("touchevent"sv)) {
-        event = Event::create(realm, FlyString {}); // FIXME: Create TouchEvent
+      return WebIDL::NotSupportedError::create(realm, "expose legacy touch event APIs"_string);
     } else if (interface.equals_ignoring_ascii_case("uievent"sv)
         || interface.equals_ignoring_ascii_case("uievents"sv)) {
         event = UIEvents::UIEvent::create(realm, FlyString {});

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Document-createEvent-touchevent.window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Document-createEvent-touchevent.window.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../dom/nodes/Document-createEvent-touchevent.window.js"></script>


### PR DESCRIPTION
document.createEvent('TouchEvent') should throw if 'expose legacy touch event APIs' is false

This fix three WPT test, also import those test

https://wpt.live/dom/nodes/Document-createEvent-touchevent.window.html