### PR TITLE
LibWeb: Fix glitchy CSS transitions

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -91,6 +91,10 @@ void Animation::set_effect(GC::Ptr<AnimationEffect> new_effect)
         m_effect->set_associated_animation({});
     m_effect = new_effect;
 
+    // Once animated properties of the old effect no longer apply, we need to ensure appropriate invalidations are scheduled
+    if (old_effect)
+        old_effect->update_computed_properties();
+
     // 7. Run the procedure to update an animation’s finished state for animation with the did seek flag set to false,
     //    and the synchronously notify flag set to false.
     update_finished_state(DidSeek::No, SynchronouslyNotify::No);

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -941,6 +941,12 @@ void KeyframeEffect::update_computed_properties()
         return;
 
     auto animated_properties_before_update = style->animated_property_values();
+    if (!pseudo_element_type().has_value()) {
+        if (auto computed_properties = target->computed_properties())
+            computed_properties->reset_animated_properties({});
+    } else if (auto computed_properties = target->pseudo_element_computed_properties(pseudo_element_type().value())) {
+        computed_properties->reset_animated_properties({});
+    }
 
     auto& document = target->document();
     document.style_computer().collect_animation_into(*target, pseudo_element_type(), *this, *style, CSS::StyleComputer::AnimationRefresh::Yes);

--- a/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -150,14 +150,4 @@ double CSSTransition::timing_function_output_at_time(double t) const
     return m_keyframe_effect->timing_function().evaluate_at(progress, before_flag);
 }
 
-NonnullRefPtr<CSSStyleValue const> CSSTransition::value_at_time(double t, AllowDiscrete allow_discrete) const
-{
-    // https://drafts.csswg.org/css-transitions/#application
-    auto progress = timing_function_output_at_time(t);
-    auto result = interpolate_property(*m_keyframe_effect->target(), m_transition_property, m_start_value, m_end_value, progress, allow_discrete);
-    if (result)
-        return result.release_nonnull();
-    return m_start_value;
-}
-
 }

--- a/Libraries/LibWeb/CSS/CSSTransition.h
+++ b/Libraries/LibWeb/CSS/CSSTransition.h
@@ -38,7 +38,6 @@ public:
     double reversing_shortening_factor() const { return m_reversing_shortening_factor; }
 
     double timing_function_output_at_time(double t) const;
-    NonnullRefPtr<CSSStyleValue const> value_at_time(double t, AllowDiscrete allow_discrete) const;
 
     // This is designed to be created from AnimationEffect::Phase.
     enum class Phase : u8 {

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -103,7 +103,7 @@ void ComputedProperties::set_animated_property(PropertyID id, NonnullRefPtr<CSSS
     m_animated_property_values.set(id, move(value));
 }
 
-void ComputedProperties::reset_animated_properties()
+void ComputedProperties::reset_animated_properties(Badge<Animations::KeyframeEffect>)
 {
     m_animated_property_values.clear();
 }

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -49,7 +49,7 @@ public:
     };
 
     HashMap<PropertyID, NonnullRefPtr<CSSStyleValue const>> const& animated_property_values() const { return m_animated_property_values; }
-    void reset_animated_properties();
+    void reset_animated_properties(Badge<Animations::KeyframeEffect>);
 
     bool is_property_important(PropertyID property_id) const;
     bool is_property_inherited(PropertyID property_id) const;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1571,8 +1571,6 @@ void Document::update_animated_style_if_needed()
             if (animation->is_idle() || animation->is_finished())
                 continue;
             if (auto effect = animation->effect()) {
-                if (auto* target = effect->target())
-                    target->reset_animated_css_properties();
                 effect->update_computed_properties();
             }
         }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -789,13 +789,6 @@ GC::Ref<CSS::ComputedProperties> Element::resolved_css_values(Optional<CSS::Pseu
     return properties;
 }
 
-void Element::reset_animated_css_properties()
-{
-    if (!m_computed_properties)
-        return;
-    m_computed_properties->reset_animated_properties();
-}
-
 DOMTokenList* Element::class_list()
 {
     if (!m_class_list)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -216,8 +216,6 @@ public:
     void set_pseudo_element_computed_properties(CSS::PseudoElement, GC::Ptr<CSS::ComputedProperties>);
     GC::Ptr<CSS::ComputedProperties> pseudo_element_computed_properties(CSS::PseudoElement);
 
-    void reset_animated_css_properties();
-
     GC::Ptr<CSS::CSSStyleProperties> inline_style() { return m_inline_style; }
     GC::Ptr<CSS::CSSStyleProperties const> inline_style() const { return m_inline_style; }
     void set_inline_style(GC::Ptr<CSS::CSSStyleProperties>);


### PR DESCRIPTION
`start_needed_transitions()` decides which animations need to be started
based on previous and current style property values. Before this change,
we were using the style value without animations applied as the
"current" value. This caused issues such as starting a new transition
from the animation’s end value when an ongoing animation was
interrupted.

Before:
![CleanShot 2025-05-28 at 16 08 32](https://github.com/user-attachments/assets/4d46fc2c-658c-4862-a3d6-e6520e592815)

After:
![CleanShot 2025-05-28 at 16 07 52](https://github.com/user-attachments/assets/2f2f1e23-fe24-4a5c-8b75-afa82c666e1e)

Page I used for testing:
```html
<html>
  <body>
    <div id="sq"></div>
    <style>
      #sq {
        width: 100px;
        height: 100px;
        background: #000;
        transition: transform 2s;
        margin: 200px;
      }
      #sq:hover {
        transform: scale(5);
      }
    </style>
  </body>
</html>
```