### PR TITLE
LibWeb: Implement CSS transitions support for pseudo elements

### DIFF
--- a/Libraries/LibWeb/CSS/CSSTransition.h
+++ b/Libraries/LibWeb/CSS/CSSTransition.h
@@ -11,6 +11,7 @@
 #include <LibWeb/CSS/CSSStyleValue.h>
 #include <LibWeb/CSS/Interpolation.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/PseudoElement.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
 #include <LibWeb/CSS/Time.h>
 
@@ -21,9 +22,9 @@ class CSSTransition : public Animations::Animation {
     GC_DECLARE_ALLOCATOR(CSSTransition);
 
 public:
-    static GC::Ref<CSSTransition> start_a_transition(DOM::Element&, PropertyID, size_t transition_generation,
-        double start_time, double end_time, NonnullRefPtr<CSSStyleValue const> start_value, NonnullRefPtr<CSSStyleValue const> end_value,
-        NonnullRefPtr<CSSStyleValue const> reversing_adjusted_start_value, double reversing_shortening_factor);
+    static GC::Ref<CSSTransition> start_a_transition(DOM::Element&, Optional<PseudoElement>, PropertyID,
+        size_t transition_generation, double start_time, double end_time, NonnullRefPtr<CSSStyleValue const> start_value,
+        NonnullRefPtr<CSSStyleValue const> end_value, NonnullRefPtr<CSSStyleValue const> reversing_adjusted_start_value, double reversing_shortening_factor);
 
     StringView transition_property() const { return string_from_property_id(m_transition_property); }
 
@@ -51,7 +52,7 @@ public:
     void set_previous_phase(Phase phase) { m_previous_phase = phase; }
 
 private:
-    CSSTransition(JS::Realm&, DOM::Element&, PropertyID, size_t transition_generation,
+    CSSTransition(JS::Realm&, DOM::Element&, Optional<PseudoElement>, PropertyID, size_t transition_generation,
         double start_time, double end_time, NonnullRefPtr<CSSStyleValue const> start_value, NonnullRefPtr<CSSStyleValue const> end_value,
         NonnullRefPtr<CSSStyleValue const> reversing_adjusted_start_value, double reversing_shortening_factor);
 


### PR DESCRIPTION
We already had all necessary things for pseudo elements support in place except ability to save transition properties in Animatable. This commit adds the missing part.