### PR TITLE
LibCore: Remove .xht from common_extensions in MimeType text/html

### DIFF
--- a/Libraries/LibCore/MimeData.cpp
+++ b/Libraries/LibCore/MimeData.cpp
@@ -138,7 +138,7 @@ static Array const s_registered_mime_type = {
 
     MimeType { .name = "text/css"sv, .common_extensions = { ".css"sv }, .description = "Cascading Style Sheet"sv },
     MimeType { .name = "text/csv"sv, .common_extensions = { ".csv"sv }, .description = "CSV text"sv },
-    MimeType { .name = "text/html"sv, .common_extensions = { ".html"sv, ".htm"sv, ".xht"sv, "/"sv }, .description = "HTML document"sv }, // FIXME: The "/" seems dubious
+    MimeType { .name = "text/html"sv, .common_extensions = { ".html"sv, ".htm"sv, "/"sv }, .description = "HTML document"sv }, // FIXME: The "/" seems dubious
     MimeType { .name = "text/xml"sv, .common_extensions = { ".xml"sv }, .description = "XML document"sv },
     MimeType { .name = "text/markdown"sv, .common_extensions = { ".md"sv }, .description = "Markdown document"sv },
     MimeType { .name = "text/plain"sv, .common_extensions = Vector(s_plaintext_suffixes.span()), .description = "plain text"sv },

--- a/Tests/LibCore/TestLibCoreMimeType.cpp
+++ b/Tests/LibCore/TestLibCoreMimeType.cpp
@@ -24,8 +24,11 @@ auto text_plain_filenames = Vector {
     ".shellrc"sv,
     "CMakeList.txt"sv,
 };
-// FIXME: fails because .xht extension is in MimeType text/html and application/xhtml+xml
-// auto html_filenames = Vector {"about.html"sv, "send-data-blob.htm"sv, "content.xht"sv, "dir/settings.html"sv,};
+auto html_filenames = Vector {
+    "about.html"sv,
+    "send-data-blob.htm"sv,
+    "dir/settings.html"sv,
+};
 auto xhtml_filenames = Vector {
     "about.xhtml"sv,
     "content.xht"sv,
@@ -46,8 +49,7 @@ auto shell_filenames = Vector {
 TEST_CASE(various_types_guessed)
 {
     check_filename_mimetype(text_plain_filenames, "text/plain"sv);
-    // FIXME: fails because .xht extension is in MimeType text/html and application/xhtml+xml
-    // check_filename_mimetype(html_filenames, "text/html"sv);
+    check_filename_mimetype(html_filenames, "text/html"sv);
     check_filename_mimetype(xhtml_filenames, "application/xhtml+xml"sv);
     check_filename_mimetype(gzip_filenames, "application/gzip"sv);
     check_filename_mimetype(markdown_filenames, "text/markdown"sv);


### PR DESCRIPTION
Extension .xht was part of common_extensions for two MimeType array entries: application/xhtml+xml and text/html. Should only be part of one.

Duplicate .xht extension removed from text/html mime type and is now only part of application/xhtml+xml mime type.


Pull request as a follow-up to #4860.


As Andrew Kaster mentions [here](https://github.com/LadybirdBrowser/ladybird/pull/4860#discussion_r2104979619), an authoritative reference for .xht file is not easy to find.


Some mention of the extension and these MimeTypes, at the IANA mime type registry.

https://www.iana.org/assignments/media-types/application/xhtml+xml
https://www.iana.org/assignments/media-types/text/html


This Mozilla guide does not include the .xht extension in this table, only makes reference to .xhtml, html, htm

https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types


![xhtml](https://github.com/user-attachments/assets/d81856ac-4b08-46e7-909d-15ddb40afc42)
![html](https://github.com/user-attachments/assets/6ab2c433-1de9-4956-8a75-ecf7a7f23553)

Looking further online we have lots of discussion about html vs xhtml

https://www.w3.org/TR/2010/WD-html-markup-20101019/documents.html#mime-types
https://www.sitepoint.com/community/t/html-or-xhtml/24939
https://www.w3schools.com/html/html_xhtml.asp
https://stackoverflow.com/questions/1969290/what-is-the-difference-between-html-and-xhtml-extension-xhtml-is-a-markup-lan

I'm sure more can be found. I didn't look hard for these.

