### PR TITLE
LibWeb: Ensure scroll offset is applied to mask-images

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -310,12 +310,10 @@ void DisplayListRecorder::push_stacking_context(PushStackingContextParams params
             .matrix = params.transform.matrix,
         },
         .clip_path = params.clip_path });
-    m_scroll_frame_id_stack.append({});
 }
 
 void DisplayListRecorder::pop_stacking_context()
 {
-    (void)m_scroll_frame_id_stack.take_last();
     append(PopStackingContext {});
 }
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -371,7 +371,9 @@ void StackingContext::paint(PaintContext& context) const
         }
     }
 
+    context.display_list_recorder().push_scroll_frame_id({});
     paint_internal(context);
+    context.display_list_recorder().pop_scroll_frame_id();
 
     if (!filter.is_empty()) {
         context.display_list_recorder().restore();

--- a/Tests/LibWeb/Ref/expected/mask-image-with-scroll-offset-ref.html
+++ b/Tests/LibWeb/Ref/expected/mask-image-with-scroll-offset-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+* { scrollbar-width: none; }
+body { height: 200vh; }
+div {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/mask-image-with-scroll-offset.html
+++ b/Tests/LibWeb/Ref/input/mask-image-with-scroll-offset.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/mask-image-with-scroll-offset-ref.html" />
+<style>
+* { scrollbar-width: none; }
+body { height: 200vh; }
+#spacer { height: 100px; }
+#mask-image-box {
+  background-color: green;
+  width: 100px;
+  height: 200px;
+  mask-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAADIAQMAAAAk8taCAAAABlBMVEUAAAAAAAClZ7nPAAAAAXRSTlMAQObYZgAAACJJREFUSMftxyEBAAAIA7D3T0sDsBQAtbmll4qZmV0PgFcD8QgJXHxT3vkAAAAASUVORK5CYII=");
+}
+</style>
+<div id="spacer"></div>
+<div id="mask-image-box"></div>
+<script>
+    window.scrollTo(0, 100);
+</script>


### PR DESCRIPTION
This fixes rendering bugs on https://www.fangamer.com/, https://null.com/games/bleakwood and https://t-shaped.nl/, among others. For details on the approach see the commit message. For a demonstration of the change, see the videos in #3646.

This is the third attempt at fixing this problem, the prior ones are in the stale PRs #3646 and #4312. However, this PR does not built on top of those changes. The approach used there was not correct. The original approach was to apply the scroll-offset of the mask-images while recording the display list. This does not work because a single display list may be rendered multiple times with different scroll offsets if the page does not cause any invalidation during scrolling.

As it turns out, applying of scroll-offsets to mask-images during display list replay is already present. It simply did not work because the scroll-frame ids were not set up correctly. For more details on the new approach see the commit message.