### PR TITLE
Meta: Don't assume all build commands have a target

### DIFF
--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -120,10 +120,11 @@ def main():
         print("ladybird.py must be run from a Visual Studio enabled environment", file=sys.stderr)
         sys.exit(1)
 
-    if args.target == "ladybird":
-        args.target = "Ladybird"
-    if not args.target and args.command not in ("build", "rebuild"):
-        args.target = "Ladybird"
+    if "target" in args:
+        if args.target == "ladybird":
+            args.target = "Ladybird"
+        if not args.target and args.command not in ("build", "rebuild"):
+            args.target = "Ladybird"
 
     (cc, cxx) = pick_host_compiler(platform, args.cc, args.cxx)
 

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -60,7 +60,7 @@ def main():
         "test", help="Runs the unit tests on the build host", parents=[preset_parser, compiler_parser]
     )
     test_parser.add_argument(
-        "--pattern", required=False, help="Limits the tests that are ran to those that match the regex pattern"
+        "pattern", nargs=argparse.OPTIONAL, help="Limits the tests that are run to those that match the regex pattern"
     )
 
     run_parser = subparsers.add_parser(


### PR DESCRIPTION
For example, the "test" and "vcpkg" build commands do not.

Fixes #4913