### PR TITLE
LibWeb: Clean up main thread promise when exiting RenderingThreads

### DIFF
--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -26,8 +26,8 @@ RenderingThread::RenderingThread()
 
 RenderingThread::~RenderingThread()
 {
-    m_exit = true;
-    m_rendering_task_ready_wake_condition.signal();
+    // Note: Promise rejection is expected to signal the thread to exit.
+    m_main_thread_exit_promise->reject(Error::from_errno(ECANCELED));
     (void)m_thread->join();
 }
 


### PR DESCRIPTION
Not cleaning these up by rejecting or resolving the promise causes the main thread to try to reject them at EventLoop::exit() time.

If the RenderThread has already been destroyed by then, we get into use-after-free territory and segfault.