### PR TITLE
LibGfx: Add a strict CMake check for the libpng apng patch

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -118,6 +118,20 @@ find_package(harfbuzz REQUIRED)
 target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
             WebP::webpdemux WebP::libwebpmux skia harfbuzz)
 
+set(CMAKE_REQUIRED_LIBRARIES PNG::PNG)
+check_c_source_compiles([=[
+    #include <png.h>
+    #if !defined(PNG_APNG_SUPPORTED) || !defined(PNG_READ_APNG_SUPPORTED) || !defined(PNG_READ_APNG_SUPPORTED)
+    #error "APNG support is required"
+    #endif
+    int main() {}
+]=] LIBPNG_HAS_APNG)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
+if (NOT LIBPNG_HAS_APNG)
+    message(FATAL_ERROR "libpng does not support APNG, which is required by LibGfx.")
+endif()
+
 if (NOT ANDROID)
     pkg_check_modules(Jxl REQUIRED IMPORTED_TARGET libjxl)
     target_link_libraries(LibGfx PRIVATE PkgConfig::Jxl)

--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -41,6 +41,11 @@ serenity_option(ENABLE_SWIFT OFF CACHE BOOL "Enable building Swift files")
 serenity_option(ENABLE_STD_STACKTRACE OFF CACHE BOOL "Force use of std::stacktrace instead of libbacktrace. If it is not supported the build will fail")
 serenity_option(ENABLE_WINDOWS_CI OFF CACHE BOOL "Enable building targets supported on Windows for CI")
 
+if (ENABLE_FUZZERS_LIBFUZZER)
+    # With libfuzzer, we need to avoid a duplicate main() linker error giving false negatives
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY CACHE STRING "Type of target to use for try_compile()" FORCE)
+endif()
+
 if (ENABLE_SWIFT)
     include(${CMAKE_CURRENT_LIST_DIR}/Swift/swift-settings.cmake)
 endif()


### PR DESCRIPTION
This requires a fix for the libfuzzer enabled build to not try to make executables for try_compile, as our try_compiles will get a duplicate main error.