### PR TITLE
LibJS: Cache string constants in Generator::add_constant

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1344,6 +1344,12 @@ ScopedOperand Generator::add_constant(Value value)
             return append_new_constant();
         });
     }
+    if (value.is_string()) {
+        auto as_string = value.as_string().utf8_string();
+        return m_string_constants.ensure(as_string, [&] {
+            return append_new_constant();
+        });
+    }
     return append_new_constant();
 }
 

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -397,6 +397,7 @@ private:
     mutable Optional<ScopedOperand> m_undefined_constant;
     mutable Optional<ScopedOperand> m_empty_constant;
     mutable HashMap<i32, ScopedOperand> m_int32_constants;
+    mutable HashMap<String, ScopedOperand> m_string_constants;
 
     ScopedOperand m_accumulator;
     ScopedOperand m_this_value;


### PR DESCRIPTION
This mirrors the existing caching logic for int32 constants. Avoids duplication of string constants in m_constants which could result in stack overflows for large scripts with a lot of similar strings.