### PR TITLE
CI: Rename macOS js REPL artifact to match name of tgz

### DIFF
--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - os_name: 'macOS'
             arch: 'arm64'
-            package_type: 'macOS-universal2'
+            package_type: 'macOS-arm64'
             runner: 'macos-15'
 
     steps:


### PR DESCRIPTION
We haven't built a universal binary in over 11 months. The name is confusing, and actually breaks esvu on macOS. The fact that nobody has complained suggests that this is not a common use case..