### PR TITLE
Meta: Remove msbuild presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -116,26 +116,6 @@
       ]
     },
     {
-      "hidden": true,
-      "name": "windows_msbuild",
-      "inherits": [
-        "default_base",
-        "windows"
-      ],
-      "generator": "Visual Studio 17 2022",
-      "toolset": "ClangCL"
-    },
-    {
-      "hidden": false,
-      "name": "windows_dev_msbuild",
-      "displayName": "Windows Development (ClangCL and MSBuild)",
-      "description": "Windows development build using MSBuild (experimental)",
-      "inherits": [
-        "windows_msbuild",
-        "windows_dev"
-      ]
-    },
-    {
       "name": "Distribution",
       "inherits": "default",
       "displayName": "Distribution Config",
@@ -254,16 +234,6 @@
       ]
     },
     {
-      "name": "windows_dev_msbuild",
-      "inherits": "windows",
-      "configurePreset": "windows_dev_msbuild",
-      "displayName": "Build",
-      "description": "Build the project",
-      "targets": [
-        "ALL_BUILD"
-      ]
-    },
-    {
       "name": "windows_dev_ninja",
       "inherits": "windows",
       "configurePreset": "windows_dev_ninja",
@@ -377,11 +347,6 @@
       "name": "windows_ci_ninja",
       "inherits": "default_windows",
       "configurePreset": "windows_ci_ninja"
-    },
-    {
-      "name": "windows_dev_msbuild",
-      "inherits": "default_windows",
-      "configurePreset": "windows_dev_msbuild"
     }
   ]
 }

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -241,12 +241,11 @@ def configure_build_env(preset: str) -> tuple[Path, Path]:
 
     known_presets = {
         "default": build_root_dir / "release",
+        "Debug": build_root_dir / "debug",
+        "Distribution": build_root_dir / "distribution",
+        "Sanitizer": build_root_dir / "sanitizers",
         "windows_ci_ninja": build_root_dir / "release",
         "windows_dev_ninja": build_root_dir / "debug",
-        "windows_dev_msbuild": build_root_dir / "debug",
-        "Debug": build_root_dir / "debug",
-        "Sanitizer": build_root_dir / "sanitizers",
-        "Distribution": build_root_dir / "distribution",
     }
 
     build_preset_dir = known_presets.get(preset, None)


### PR DESCRIPTION
Let's just support `ninja `for simplicity. The `msbuild `presets are significantly slower anyhow.