### PR TITLE
CMake: Exclude GlobalFontConfig.h from autogenerated clang module

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SOURCES
 )
 
 set(SWIFT_EXCLUDE_HEADERS
+    GlobalFontConfig.h
     MetalContext.h
     VulkanContext.h
     SkiaUtils.h


### PR DESCRIPTION
This header file is never included by any other headers, and including it would require adding the fontconfig include paths to the swift interop header generation, which is not desirable.