### PR TITLE
LibWeb/HTML: Handle failure determining mime type fetching module script

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -712,7 +712,7 @@ void fetch_single_module_script(JS::Realm& realm,
 
         // 7. If mimeType is a JavaScript MIME type and moduleType is "javascript", then set moduleScript to the result of creating a JavaScript module script given sourceText, moduleMapRealm, response's URL, and options.
         // FIXME: Pass options.
-        if (mime_type->is_javascript() && module_type == "javascript")
+        if (mime_type.has_value() && mime_type->is_javascript() && module_type == "javascript")
             module_script = JavaScriptModuleScript::create(url.basename(), source_text, module_map_realm, response->url().value_or({})).release_value_but_fixme_should_propagate_errors();
 
         // FIXME: 8. If the MIME type essence of mimeType is "text/css" and moduleType is "css", then set moduleScript to the result of creating a CSS module script given sourceText and settingsObject.


### PR DESCRIPTION
Fixes crash in WPT test:

https://wpt.live/html/semantics/scripting-1/the-script-element/css-module/content-type-checking.html