### PR TITLE
AK: Update simdutf and remove some now-unnecessary workarounds for base64

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -45,9 +45,7 @@ static ErrorOr<size_t, InvalidBase64> decode_base64_into_impl(StringView input, 
         to_simdutf_last_chunk_handling(last_chunk_handling),
         decode_up_to_bad_character);
 
-    if (result.error == simdutf::BASE64_INPUT_REMAINDER && last_chunk_handling == LastChunkHandling::StopBeforePartial) {
-        result.error = simdutf::SUCCESS;
-    } else if (result.error != simdutf::SUCCESS && result.error != simdutf::OUTPUT_BUFFER_TOO_SMALL) {
+    if (result.error != simdutf::SUCCESS && result.error != simdutf::OUTPUT_BUFFER_TOO_SMALL) {
         output.resize((result.count / 4) * 3);
 
         auto error = [&]() {
@@ -69,10 +67,7 @@ static ErrorOr<size_t, InvalidBase64> decode_base64_into_impl(StringView input, 
     VERIFY(output_length <= output.size());
     output.resize(output_length);
 
-    if (last_chunk_handling == LastChunkHandling::StopBeforePartial)
-        return input.length() - (input.length() % 4);
-
-    return result.error == simdutf::SUCCESS ? input.length() : result.count;
+    return result.count;
 }
 
 static ErrorOr<ByteBuffer> decode_base64_impl(StringView input, LastChunkHandling last_chunk_handling, simdutf::base64_options options)

--- a/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
+++ b/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
@@ -40,7 +40,7 @@ describe("errors", () => {
     test("invalid padding", () => {
         expect(() => {
             Uint8Array.fromBase64("Zm9v=", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
 
         expect(() => {
             Uint8Array.fromBase64("Zm9vaa=", { lastChunkHandling: "strict" });

--- a/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromBase64.js
+++ b/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromBase64.js
@@ -79,7 +79,7 @@ describe("errors", () => {
     test("invalid padding", () => {
         expect(() => {
             new Uint8Array(10).setFromBase64("Zm9v=", { lastChunkHandling: "strict" });
-        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
+        }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
 
         expect(() => {
             new Uint8Array(10).setFromBase64("Zm9vaa=", { lastChunkHandling: "strict" });

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "8f54ef5453e7e76ff01e15988bf243e7247c5eb5",
+  "builtin-baseline": "89dc8be6dbcf18482a5a1bf86a2f4615c939b0fb",
   "dependencies": [
     {
       "name": "angle",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -195,7 +195,7 @@
     },
     {
       "name": "simdutf",
-      "version": "7.0.0#0"
+      "version": "7.3.0#0"
     },
     {
       "name": "skia",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -139,7 +139,7 @@
     },
     {
       "name": "curl",
-      "version": "8.13.0#0"
+      "version": "8.14.0#0"
     },
     {
       "name": "dirent",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -163,7 +163,7 @@
     },
     {
       "name": "libjxl",
-      "version": "0.11.1"
+      "version": "0.11.1#1"
     },
     {
       "name": "libpng",


### PR DESCRIPTION
This PR includes a couple of package updates since updating simdutf busts our vcpkg cache anyways. The libjxl update was missed last time I updated packages, it includes a fix made by us.

No test262 diff.