### PR TITLE
LibRegex: Fix handling of + quantifier with zero-width matches

### DIFF
--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -1121,9 +1121,8 @@ ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const& inp
         }
     }
 
-    if (state.string_position < input.view.length()) {
+    if (form() == OpCodeId::Jump && state.string_position < input.view.length())
         return ExecutionResult::Failed_ExecuteLowPrioForks;
-    }
 
     return ExecutionResult::Continue;
 }

--- a/Tests/LibRegex/TestRegex.cpp
+++ b/Tests/LibRegex/TestRegex.cpp
@@ -1298,3 +1298,17 @@ TEST_CASE(optimizer_repeat_offset)
         Regex<ECMA262> re("\\/?\\??#?([\\/?#]|[\\uD800-\\uDBFF]|%[c-f][0-9a-f](%[89ab][0-9a-f]){0,2}(%[89ab]?)?|%[0-9a-f]?)$"sv);
     }
 }
+
+TEST_CASE(zero_width_backreference)
+{
+    {
+        // Ensure that a zero-width backreference will match correctly.
+        Regex<ECMA262> re("(a*)b\\1+", ECMAScriptFlags::Global);
+        auto result = re.match("baaac"sv);
+
+        EXPECT_EQ(result.success, true);
+        EXPECT_EQ(result.matches.size(), 1u);
+        EXPECT_EQ(result.matches.first().view.to_byte_string(), "b"sv);
+        EXPECT_EQ(result.capture_group_matches.first()[0].view.to_byte_string(), ""sv);
+    }
+}


### PR DESCRIPTION
Fixes an issue where + quantifiers failed on zero-width matches, such as empty backreferences.

Diff Tests:
    test/annexB/language/literals/regexp/quantifiable-assertion-followed-by.js ❌ -> ✅
    test/built-ins/RegExp/S15.10.2.5_A1_T5.js                                  ❌ -> ✅
    test/built-ins/RegExp/S15.10.2.9_A1_T5.js                                  ❌ -> ✅
