### PR TITLE
LibWeb: Don't crash when interpolating single-value repeatable lists

### DIFF
--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -932,7 +932,7 @@ RefPtr<CSSStyleValue const> interpolate_repeatable_list(DOM::Element& element, C
     if (!from.is_value_list() && to.is_value_list())
         from_list = make_single_value_list(from, to.as_value_list().size(), to.as_value_list().separator());
     else if (!to.is_value_list() && from.is_value_list())
-        to_list = make_single_value_list(to, from.as_value_list().size(), to.as_value_list().separator());
+        to_list = make_single_value_list(to, from.as_value_list().size(), from.as_value_list().separator());
     else if (!from.is_value_list() && !to.is_value_list())
         return interpolate_value(element, calculation_context, from, to, delta, allow_discrete);
 

--- a/Tests/LibWeb/Text/expected/css/background-size-animation-crash.txt
+++ b/Tests/LibWeb/Text/expected/css/background-size-animation-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash!)

--- a/Tests/LibWeb/Text/input/css/background-size-animation-crash.html
+++ b/Tests/LibWeb/Text/input/css/background-size-animation-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!-- FIXME: Ideally this would be a crash test, but the test harness doesn't wait long enough for the crash to occur -->
+<script src="../include.js"></script>
+<div></div>
+<script>
+    asyncTest(done => {
+        const element = document.querySelector('div');
+        const animation = element.animate([
+            { backgroundSize: '10% 10%, 20% 20%' },
+            { backgroundSize: 'auto auto' }
+        ], {
+            duration: 1000,
+        });
+        animation.finished.then(() => {
+            println("PASS (didn't crash!)");
+            done();
+        });
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                animation.finish();
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
Previously, when interpolating a repeatable list from a list with multiple values to a single value, we would crash.

Fixes #4951 

We don't currently render the animation on the issue page correctly, but this PR at least fixes the crash.