### PR TITLE
Meta: Default chosen compilers to the CC and CXX environment variables

### DIFF
--- a/Meta/host_platform.py
+++ b/Meta/host_platform.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import enum
+import os
 import platform
 import sys
 
@@ -45,6 +46,11 @@ class Platform:
             sys.exit(1)
 
     def default_compiler(self) -> tuple[str, str]:
+        cc = os.environ.get("CC", None)
+        cxx = os.environ.get("CXX", None)
+
+        if cc and cxx:
+            return (cc, cxx)
         if self.host_system == HostSystem.Windows:
             return ("clang-cl", "clang-cl")
         return ("cc", "c++")


### PR DESCRIPTION
This regressed when porting find_compiler.sh to python.

Fixes #4959