### PR TITLE
js: Improvements for eshost

### DIFF
--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -1038,18 +1038,18 @@ ErrorOr<void> print_value(JS::PrintContext& print_context, JS::Value value, Hash
     else if (value.is_undefined())
         TRY(js_out(print_context, "\033[34;1m"));
 
-    if (value.is_string() && !print_context.disable_string_quotes)
+    if (value.is_string() && !print_context.raw_strings)
         TRY(js_out(print_context, "\""));
     else if (value.is_negative_zero())
         TRY(js_out(print_context, "-"));
 
     auto contents = value.to_string_without_side_effects();
-    if (value.is_string() && !print_context.disable_string_quotes)
+    if (value.is_string() && !print_context.raw_strings)
         TRY(js_out(print_context, "{}", TRY(escape_for_string_literal(contents))));
     else
         TRY(js_out(print_context, "{}", contents));
 
-    if (value.is_string() && !print_context.disable_string_quotes)
+    if (value.is_string() && !print_context.raw_strings)
         TRY(js_out(print_context, "\""));
     TRY(js_out(print_context, "\033[0m"));
     return {};

--- a/Libraries/LibJS/Print.h
+++ b/Libraries/LibJS/Print.h
@@ -17,7 +17,7 @@ struct PrintContext {
     JS::VM& vm;
     Stream& stream;
     bool strip_ansi { false };
-    bool disable_string_quotes { false };
+    bool raw_strings { false };
 };
 
 JS_API ErrorOr<void> print(JS::Value value, PrintContext&);

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -95,7 +95,7 @@ static String s_history_path = String {};
 static bool s_keep_running_repl = true;
 static int s_exit_code = 0;
 
-static ErrorOr<void> print(JS::Value value, Stream& stream)
+static ErrorOr<void> print_inline(JS::Value value, Stream& stream)
 {
     JS::PrintContext print_context { .vm = *g_vm, .stream = stream, .strip_ansi = s_strip_ansi, .disable_string_quotes = s_disable_string_quotes };
     return JS::print(value, print_context);
@@ -106,23 +106,48 @@ enum class PrintTarget {
     StandardOutput,
 };
 
-static ErrorOr<void> print(JS::Value value, PrintTarget target = PrintTarget::StandardOutput)
+static ErrorOr<NonnullOwnPtr<Stream>> flushed_print_stream(PrintTarget target)
 {
-    auto stream = TRY(target == PrintTarget::StandardError ? Core::File::standard_error() : Core::File::standard_output());
-    return print(value, *stream);
+    if (target == PrintTarget::StandardOutput) {
+        (void)fflush(stdout);
+        return Core::File::standard_output();
+    }
+
+    (void)fflush(stderr);
+    return Core::File::standard_error();
 }
 
-static ErrorOr<void> print_all_arguments(JS::VM const& vm, PrintTarget target = PrintTarget::StandardOutput)
+enum class PrintEnd {
+    Newline,
+    None
+};
+
+static ErrorOr<void> print(JS::Value value, PrintTarget target = PrintTarget::StandardOutput, PrintEnd end = PrintEnd::Newline)
 {
-    auto stream = TRY(target == PrintTarget::StandardError ? Core::File::standard_error() : Core::File::standard_output());
+    auto stream = TRY(flushed_print_stream(target));
+
+    TRY(print_inline(value, *stream));
+
+    if (end == PrintEnd::Newline)
+        TRY(stream->write_until_depleted("\n"sv));
+
+    return {};
+}
+
+static ErrorOr<void> print_all_arguments(JS::VM const& vm, PrintTarget target = PrintTarget::StandardOutput, PrintEnd end = PrintEnd::Newline)
+{
+    auto stream = TRY(flushed_print_stream(target));
 
     for (size_t i = 0; i < vm.argument_count(); i++) {
-        TRY(print(vm.argument(i), *stream));
+        TRY(print_inline(vm.argument(i), *stream));
 
         if (i < vm.argument_count() - 1) {
             TRY(stream->write_until_depleted(" "sv));
         }
     }
+
+    if (end == PrintEnd::Newline)
+        TRY(stream->write_until_depleted("\n"sv));
 
     return {};
 }
@@ -204,7 +229,6 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
     auto handle_exception = [&](JS::Value thrown_value) -> ErrorOr<void> {
         warnln("Uncaught exception: ");
         TRY(print(thrown_value, PrintTarget::StandardError));
-        warnln();
 
         if (!thrown_value.is_object() || !is<JS::Error>(thrown_value.as_object()))
             return {};
@@ -222,7 +246,6 @@ static ErrorOr<bool> parse_and_run(JS::Realm& realm, StringView source, StringVi
 
     if (s_print_last_result) {
         TRY(print(result.value()));
-        warnln();
     }
 
     return true;
@@ -350,8 +373,6 @@ JS_DEFINE_NATIVE_FUNCTION(ReplObject::print)
     if (result.is_error())
         return g_vm->throw_completion<JS::InternalError>(TRY_OR_THROW_OOM(*g_vm, String::formatted("Failed to print value(s): {}", result.error())));
 
-    outln();
-
     return JS::js_undefined();
 }
 
@@ -381,8 +402,6 @@ JS_DEFINE_NATIVE_FUNCTION(ScriptObject::print)
     auto result = print_all_arguments(vm);
     if (result.is_error())
         return g_vm->throw_completion<JS::InternalError>(TRY_OR_THROW_OOM(*g_vm, String::formatted("Failed to print value(s): {}", result.error())));
-
-    outln();
 
     return JS::js_undefined();
 }
@@ -828,13 +847,13 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         g_vm->on_promise_unhandled_rejection = [](auto& promise) {
             warn("WARNING: A promise was rejected without any handlers");
             warn(" (result: ");
-            (void)print(promise.result(), PrintTarget::StandardError);
+            (void)print(promise.result(), PrintTarget::StandardError, PrintEnd::None);
             warnln(")");
         };
         g_vm->on_promise_rejection_handled = [](auto& promise) {
             warn("WARNING: A handler was added to an already rejected promise");
             warn(" (result: ");
-            (void)print(promise.result(), PrintTarget::StandardError);
+            (void)print(promise.result(), PrintTarget::StandardError, PrintEnd::None);
             warnln(")");
         };
     }

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -85,7 +85,7 @@ static bool s_dump_ast = false;
 static bool s_as_module = false;
 static bool s_print_last_result = false;
 static bool s_strip_ansi = false;
-static bool s_disable_string_quotes = false;
+static bool s_raw_strings = false;
 static bool s_disable_source_location_hints = false;
 #if !defined(AK_OS_WINDOWS)
 static RefPtr<Line::Editor> s_editor;
@@ -97,7 +97,7 @@ static int s_exit_code = 0;
 
 static ErrorOr<void> print_inline(JS::Value value, Stream& stream)
 {
-    JS::PrintContext print_context { .vm = *g_vm, .stream = stream, .strip_ansi = s_strip_ansi, .disable_string_quotes = s_disable_string_quotes };
+    JS::PrintContext print_context { .vm = *g_vm, .stream = stream, .strip_ansi = s_strip_ansi, .raw_strings = s_raw_strings };
     return JS::print(value, print_context);
 }
 
@@ -822,8 +822,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(s_strip_ansi, "Disable ANSI colors", "disable-ansi-colors", 'i');
     args_parser.add_option(s_disable_source_location_hints, "Disable source location hints", "disable-source-location-hints", 'h');
     args_parser.add_option(gc_on_every_allocation, "GC on every allocation", "gc-on-every-allocation", 'g');
+    args_parser.add_option(s_raw_strings, "Display strings without quotes or escape sequences", "--raw-strings", 'r');
     args_parser.add_option(disable_syntax_highlight, "Disable live syntax highlighting", "no-syntax-highlight", 's');
-    args_parser.add_option(s_disable_string_quotes, "Disable quotes around strings", "disable-string-quotes", {});
     args_parser.add_option(disable_debug_printing, "Disable debug output", "disable-debug-output", {});
     args_parser.add_option(evaluate_script, "Evaluate argument as a script", "evaluate", 'c', "script");
     args_parser.add_option(use_test262_global, "Use test262 global ($262)", "use-test262-global", {});


### PR DESCRIPTION
Fixes https://github.com/LadybirdBrowser/ladybird/issues/4947 by flushing stdout/sterr before using an unbuffered `AK::Stream` on them.

```sh
❯ bin/js -c 'print("foo"); print("bar");' | cat 
"foo"
"bar"
```

Adds a better name for the flag that disables the string quotes and escaping as discussed in https://github.com/LadybirdBrowser/ladybird/pull/4946. If this gets merged, https://github.com/devsnek/esvu/pull/69 and https://github.com/CanadaHonk/esvu/pull/7 will need to be modified.