### PR TITLE
LibWeb: Fix grid item placement when only grid-column-end is specified

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -351,6 +351,14 @@ GridFormattingContext::PlacementPosition GridFormattingContext::resolve_grid_pos
         }
     }
 
+    if (!placement_start.is_positioned() && placement_end.is_positioned() && !placement_end.is_span()) {
+        if (result.span == 0)
+            result.span = 1;
+        result.start = result.end - result.span;
+        if (result.start < 0)
+            result.start = 0;
+    }
+
     if (placement_start.is_positioned() && placement_end.is_positioned()) {
         if (result.start > result.end)
             swap(result.start, result.end);

--- a/Tests/LibWeb/Layout/expected/grid/placement-auto-negative.txt
+++ b/Tests/LibWeb/Layout/expected/grid/placement-auto-negative.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x64 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x48 children: not-inline
+      Box <div.a> at (8,8) content-size 784x48 [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.b> at (8,8) content-size 48x48 [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.c> at (56,8) content-size 48x48 [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,56) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x64]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x48]
+      PaintableBox (Box<DIV>.a) [8,8 784x48]
+        PaintableWithLines (BlockContainer<DIV>.b) [8,8 48x48]
+        PaintableWithLines (BlockContainer<DIV>.c) [56,8 48x48]
+      PaintableWithLines (BlockContainer(anonymous)) [8,56 784x0]

--- a/Tests/LibWeb/Layout/input/grid/placement-auto-negative.html
+++ b/Tests/LibWeb/Layout/input/grid/placement-auto-negative.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+  .a {
+    display: grid;
+    grid-template-columns: auto 1fr;
+  }
+
+  .b {
+    width: 48px;
+    height: 48px;
+    background-color: red;
+  }
+
+  .c {
+    width: 48px;
+    height: 48px;
+    background-color: blue;
+    grid-column-end: -1;
+  }
+</style>
+<div class="a">
+  <div class="b"></div>
+  <div class="c"></div>
+</div>


### PR DESCRIPTION
Fixes #4928.

This fixes an incorrect layout when placement start is auto positioned, but grid-column-end is specified. The fix is a bit hackish, but [kalenikaliaksandr](https://github.com/kalenikaliaksandr) mentioned that it's acceptable for now in the issue I mentioned above.