### PR TITLE
LibJS+LibUnicode: Implement retrieval of collator keyword values

### DIFF
--- a/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.resolvedOptions.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.resolvedOptions.js
@@ -54,12 +54,21 @@ describe("correct behavior", () => {
     });
 
     test("collation", () => {
-        // Only "default" collation is parsed for now.
-        const en = new Intl.Collator("en");
-        expect(en.resolvedOptions().collation).toBe("default");
+        const en1 = new Intl.Collator("en");
+        expect(en1.resolvedOptions().locale).toBe("en");
+        expect(en1.resolvedOptions().collation).toBe("default");
+
+        const en2 = new Intl.Collator("en-u-co-phonebk", { collation: "pinyin" });
+        expect(en2.resolvedOptions().locale).toBe("en");
+        expect(en2.resolvedOptions().collation).toBe("default");
 
         const el = new Intl.Collator("el", { collation: "foo" });
+        expect(el.resolvedOptions().locale).toBe("el");
         expect(el.resolvedOptions().collation).toBe("default");
+
+        const de = new Intl.Collator("de-u-co-phonebk", { collation: "pinyin" });
+        expect(de.resolvedOptions().locale).toBe("de-u-co-phonebk");
+        expect(de.resolvedOptions().collation).toBe("phonebk");
     });
 
     test("numeric may be set by locale extension", () => {

--- a/Libraries/LibJS/Tests/builtins/Intl/Intl.supportedValuesOf.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/Intl.supportedValuesOf.js
@@ -26,7 +26,7 @@ describe("normal behavior", () => {
         const values = Intl.supportedValuesOf("collation");
         expect(isSorted(values)).toBeTrue();
 
-        expect(values.indexOf("default")).not.toBe(-1);
+        expect(values.indexOf("emoji")).not.toBe(-1);
     });
 
     test("currency", () => {

--- a/Libraries/LibUnicode/ICU.h
+++ b/Libraries/LibUnicode/ICU.h
@@ -118,7 +118,7 @@ Vector<String> icu_string_enumeration_to_list(OwnPtr<icu::StringEnumeration> enu
         if (icu_failure(status) || value == nullptr)
             break;
 
-        if (!filter(value))
+        if (!filter(value, static_cast<size_t>(length)))
             continue;
 
         if (bcp47_keyword) {
@@ -134,7 +134,7 @@ Vector<String> icu_string_enumeration_to_list(OwnPtr<icu::StringEnumeration> enu
 
 ALWAYS_INLINE Vector<String> icu_string_enumeration_to_list(OwnPtr<icu::StringEnumeration> enumeration, char const* bcp47_keyword)
 {
-    return icu_string_enumeration_to_list(move(enumeration), bcp47_keyword, [](char const*) { return true; });
+    return icu_string_enumeration_to_list(move(enumeration), bcp47_keyword, [](char const*, size_t) { return true; });
 }
 
 }

--- a/Libraries/LibUnicode/TimeZone.cpp
+++ b/Libraries/LibUnicode/TimeZone.cpp
@@ -107,8 +107,8 @@ static Vector<String> icu_available_time_zones(Optional<ByteString> const& regio
     if (icu_failure(status))
         return { "UTC"_string };
 
-    auto time_zones = icu_string_enumeration_to_list(move(time_zone_enumerator), nullptr, [](char const* zone) {
-        return !is_legacy_non_iana_time_zone({ zone, strlen(zone) });
+    auto time_zones = icu_string_enumeration_to_list(move(time_zone_enumerator), nullptr, [](char const* zone, size_t zone_length) {
+        return !is_legacy_non_iana_time_zone({ zone, zone_length });
     });
 
     quick_sort(time_zones);

--- a/Libraries/LibUnicode/TimeZone.cpp
+++ b/Libraries/LibUnicode/TimeZone.cpp
@@ -107,7 +107,7 @@ static Vector<String> icu_available_time_zones(Optional<ByteString> const& regio
     if (icu_failure(status))
         return { "UTC"_string };
 
-    auto time_zones = icu_string_enumeration_to_list(move(time_zone_enumerator), [](char const* zone) {
+    auto time_zones = icu_string_enumeration_to_list(move(time_zone_enumerator), nullptr, [](char const* zone) {
         return !is_legacy_non_iana_time_zone({ zone, strlen(zone) });
     });
 

--- a/Libraries/LibUnicode/UnicodeKeywords.cpp
+++ b/Libraries/LibUnicode/UnicodeKeywords.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -59,16 +59,7 @@ Vector<String> available_calendars(StringView locale)
     if (icu_failure(status))
         return {};
 
-    auto calendars = icu_string_enumeration_to_list(move(keywords));
-
-    for (auto& calendar : calendars) {
-        if (calendar == "gregorian"sv)
-            calendar = "gregory"_string;
-        else if (calendar == "ethiopic-amete-alem"sv)
-            calendar = "ethioaa"_string;
-    }
-
-    return calendars;
+    return icu_string_enumeration_to_list(move(keywords), "ca");
 }
 
 Vector<String> const& available_currencies()
@@ -162,7 +153,7 @@ Vector<String> const& available_number_systems()
         if (icu_failure(status))
             return {};
 
-        auto number_systems = icu_string_enumeration_to_list(move(keywords), [&](char const* keyword) {
+        auto number_systems = icu_string_enumeration_to_list(move(keywords), "nu", [&](char const* keyword) {
             auto system = adopt_own_if_nonnull(icu::NumberingSystem::createInstanceByName(keyword, status));
             if (icu_failure(status))
                 return false;

--- a/Libraries/LibUnicode/UnicodeKeywords.cpp
+++ b/Libraries/LibUnicode/UnicodeKeywords.cpp
@@ -153,7 +153,7 @@ Vector<String> const& available_number_systems()
         if (icu_failure(status))
             return {};
 
-        auto number_systems = icu_string_enumeration_to_list(move(keywords), "nu", [&](char const* keyword) {
+        auto number_systems = icu_string_enumeration_to_list(move(keywords), "nu", [&](char const* keyword, size_t) {
             auto system = adopt_own_if_nonnull(icu::NumberingSystem::createInstanceByName(keyword, status));
             if (icu_failure(status))
                 return false;


### PR DESCRIPTION
Completely missed this when implementing Intl.Collator!

test262 diff (this is a new test, which is probably why I didn't notice before):
```
test/intl402/Collator/prototype/resolvedOptions/resolved-collation-unicode-extensions-and-options.js ❌ -> ✅
```