### PR TITLE
Documentation: Small precision regarding LSP setup on Neovim

### DIFF
--- a/Documentation/EditorConfiguration/NvimConfiguration.md
+++ b/Documentation/EditorConfiguration/NvimConfiguration.md
@@ -8,6 +8,7 @@ project:
 
 For both setups, make sure you ran `./Meta/ladybird.py run ladybird` at least
 once.
+Building the project generates a `compile_commands.json` file, which tells clangd where the header files are located. Without this file, clangd will not be able to find them, and will therefore give you a lot of errors.
 
 ## With nvim-lspconfig
 
@@ -16,6 +17,7 @@ once.
 
 If you have an [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), setup
 already, registering clangd is similar to other LSPs:
+
 ```lua
 require('lspconfig').clangd.setup {
   -- If you have an on_attach function, this is where you'd put it. If not,
@@ -26,14 +28,14 @@ require('lspconfig').clangd.setup {
   -- capabilities = ...,
 
   -- If you have another clangd installation, put it here. Note that we use
-  -- clangd version 18 for the Ladybird project.
+  -- clangd version 20 for the Ladybird project.
   -- cmd = { '/path/to/clangd' },
 }
 ```
 
 A base `setup` call should be enough to register the LSP, but if false-negative
 LSP errors occur upon opening Neovim, make sure your clangd installation is at
-least version 18.
+least version 20.
 
 ## With coc.nvim
 
@@ -80,7 +82,7 @@ This will install a separate version of clangd just for neovim.
 Use the following settings to ensure that coc-clangd works out of the box.
 
 > **Note**: You might want to adjust the `clangd.fallbackFlags` depending on your build
-system and customize the `inlayHints.sep` based on your preference.
+> system and customize the `inlayHints.sep` based on your preference.
 
 ```json
 {
@@ -96,22 +98,27 @@ To change the coc-settings.json go to the file `~/.config/nvim/coc-settings.json
 or type `:CocConfig` in the command line.
 
 > **Note**: In case you already had another c++ language server configured in the
-`coc-settings.json` you might want to nuke it first and
-work towards your desired config by adding the other parts back in to avoid
-conflicts.
+> `coc-settings.json` you might want to nuke it first and
+> work towards your desired config by adding the other parts back in to avoid
+> conflicts.
 
 > **Note**: If you have configured `clangd` as a languageServer in
-`coc-settings.json`, you should remove it to avoid running clangd twice!
+> `coc-settings.json`, you should remove it to avoid running clangd twice!
 
 > **Note**: `clangd.inlayHints.sep` breaks on `clangd 15.0.6`.
 
 ### Formatting
+
 For code formatting the formatter plugin can be used.
+
 ```vim
 Plug 'mhartington/formatter.nvim'
 ```
+
 #### Configuration
+
 To use the formatter plugin one needs to opt-in to specific formatters. An example lua configuration which uses clang-format for cpp files:
+
 ```lua
 require("formatter").setup{
     filetype = {


### PR DESCRIPTION
This PR adds a precision about how the editor setup for Neovim, as well as bumping up the needed clang version from 18 to 20.