### PR TITLE
LibWeb: Absolutize CSS image URLs for computed style resolution

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -53,6 +53,7 @@ private:
     ImageStyleValue(URL const&);
 
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
+    virtual ValueComparingNonnullRefPtr<CSSStyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     void animate();
     Gfx::ImmutableBitmap const* bitmap(size_t frame_index, Gfx::IntSize = {}) const;

--- a/Libraries/LibWeb/CSS/URL.h
+++ b/Libraries/LibWeb/CSS/URL.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibGC/Ptr.h>
@@ -35,6 +36,7 @@ public:
 private:
     using Value = Variant<CrossOriginModifierValue, ReferrerPolicyModifierValue, FlyString>;
     RequestURLModifier(Type, Value);
+
     Type m_type;
     Value m_value;
 };

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-base.sub.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-base.sub.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	base-relative URL: relative-image-url
+1 Pass
+1 Fail
+Pass	base-relative URL: relative-image-url
 Fail	base-relative URL: relative-image-variable-url

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-stylesheet.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/urls/resolve-relative-to-stylesheet.txt
@@ -2,7 +2,8 @@ Harness status: OK
 
 Found 3 tests
 
-3 Fail
-Fail	stylesheet-relative URL: stylesheet-relative-image
+1 Pass
+2 Fail
+Pass	stylesheet-relative URL: stylesheet-relative-image
 Fail	stylesheet-relative URL: stylesheet-relative-variable-image
 Fail	stylesheet-relative URL: stylesheet-relative-document-variable-image


### PR DESCRIPTION
For `getComputedStyle()`, we must return an absolute URL for image style values. We currently return the raw parsed URL.

This fixes loading the marker icons on https://usermap.serenityos.org/.

Fixes #4972