### PR TITLE
LibJS: Add fast path internal_has_property() for Array

### DIFF
--- a/Libraries/LibJS/Runtime/Array.h
+++ b/Libraries/LibJS/Runtime/Array.h
@@ -50,6 +50,7 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override final;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override final;
+    virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override final;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const override final;
 

--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -48,6 +48,7 @@ void SimpleIndexedPropertyStorage::put(u32 index, Value value, PropertyAttribute
     VERIFY(attributes == default_attributes);
 
     if (index >= m_array_size) {
+        m_number_of_empty_elements += index - m_array_size;
         m_array_size = index + 1;
         grow_storage_if_needed();
     } else {


### PR DESCRIPTION
If array has packed index property storage without holes, we could check
if indexed property is present simple by checking if it's less than
array's length.

Makes the following program go 1.1x faster:
```js
function f() {
    let array = [];
    for (let i = 0; i < 3_000; i++) {
        array.push(i);
    }

    for (let i = 0; i < 10_000; i++) {
        array.map(x => x * 2);
    }
}

f();
```