### PR TITLE
LibWeb: Remove Unicode Cyrillic e char (04+35) in variable name

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -62,10 +62,10 @@ JS::Object* Internals::hit_test(double x, double y)
     active_document.update_layout(DOM::UpdateLayoutReason::InternalsHitTest);
     auto result = active_document.paintable_box()->hit_test({ x, y }, Painting::HitTestType::Exact);
     if (result.has_value()) {
-        auto hit_tеsting_result = JS::Object::create(realm(), nullptr);
-        hit_tеsting_result->define_direct_property("node"_fly_string, result->dom_node(), JS::default_attributes);
-        hit_tеsting_result->define_direct_property("indexInNode"_fly_string, JS::Value(result->index_in_node), JS::default_attributes);
-        return hit_tеsting_result;
+        auto hit_testing_result = JS::Object::create(realm(), nullptr);
+        hit_testing_result->define_direct_property("node"_fly_string, result->dom_node(), JS::default_attributes);
+        hit_testing_result->define_direct_property("indexInNode"_fly_string, JS::Value(result->index_in_node), JS::default_attributes);
+        return hit_testing_result;
     }
     return nullptr;
 }


### PR DESCRIPTION
Using cppcheck static analysis tool, got this "syntaxError":

`Libraries/LibWeb/Internals/Internals.cpp:65:19: error: The code contains unhandled character(s) (character code=208). Neither unicode nor extended ascii is supported. [syntaxError]
`

Line 65 looks like this:

        auto hit_tеsting_result = JS::Object::create(realm(), nullptr);


Using uniname (from the uniutils apt package on Ubuntu) I inspected the line to see what is going on.  With it I see that the first letter e from the name hit_testing_result is not the expected ascii e (00+65), but a cyrillic e (04+35).  This is probably not what was intended


```
$ head -65 Libraries/LibWeb/Internals/Internals.cpp | tail -1 | uniname
character  byte       UTF-32   encoded as     glyph   name
        0          0  000020   20                     SPACE
        1          1  000020   20                     SPACE
        2          2  000020   20                     SPACE
        3          3  000020   20                     SPACE
        4          4  000020   20                     SPACE
        5          5  000020   20                     SPACE
        6          6  000020   20                     SPACE
        7          7  000020   20                     SPACE
        8          8  000061   61             a      LATIN SMALL LETTER A
        9          9  000075   75             u      LATIN SMALL LETTER U
       10         10  000074   74             t      LATIN SMALL LETTER T
       11         11  00006F   6F             o      LATIN SMALL LETTER O
       12         12  000020   20                     SPACE
       13         13  000068   68             h      LATIN SMALL LETTER H
       14         14  000069   69             i      LATIN SMALL LETTER I
       15         15  000074   74             t      LATIN SMALL LETTER T
       16         16  00005F   5F             _      LOW LINE
       17         17  000074   74             t      LATIN SMALL LETTER T
       18         18  000435   D0 B5          е      CYRILLIC SMALL LETTER IE            <--- ISSUE IS HERE
       19         20  000073   73             s      LATIN SMALL LETTER S
       20         21  000074   74             t      LATIN SMALL LETTER T
       21         22  000069   69             i      LATIN SMALL LETTER I
character  byte       UTF-32   encoded as     glyph   name
       22         23  00006E   6E             n      LATIN SMALL LETTER N
       23         24  000067   67             g      LATIN SMALL LETTER G
       24         25  00005F   5F             _      LOW LINE
       25         26  000072   72             r      LATIN SMALL LETTER R
       26         27  000065   65             e      LATIN SMALL LETTER E
       27         28  000073   73             s      LATIN SMALL LETTER S
       28         29  000075   75             u      LATIN SMALL LETTER U
       29         30  00006C   6C             l      LATIN SMALL LETTER L
       30         31  000074   74             t      LATIN SMALL LETTER T
       31         32  000020   20                     SPACE
       32         33  00003D   3D             =      EQUALS SIGN
       33         34  000020   20                     SPACE
       34         35  00004A   4A             J      LATIN CAPITAL LETTER J
       35         36  000053   53             S      LATIN CAPITAL LETTER S
       36         37  00003A   3A             :      COLON
       37         38  00003A   3A             :      COLON
       38         39  00004F   4F             O      LATIN CAPITAL LETTER O
       39         40  000062   62             b      LATIN SMALL LETTER B
       40         41  00006A   6A             j      LATIN SMALL LETTER J
       41         42  000065   65             e      LATIN SMALL LETTER E
       42         43  000063   63             c      LATIN SMALL LETTER C
       43         44  000074   74             t      LATIN SMALL LETTER T
```

Unix command 'file' shows the file as having Unicode text:

`Libraries/LibWeb/Internals/Internals.cpp: C source, Unicode text, UTF-8 text`

After renaming the variable name with ASCII e, then the file command shows the file as plain ASCII:

`Libraries/LibWeb/Internals/Internals.cpp: C source, ASCII text`


Even Github shows the variable name hit_testing_result as two-toned. First starting in blue and then changing to white at the point of the first letter e.

![gihub_hit_testing_result_colors](https://github.com/user-attachments/assets/a3a02b4e-5d0c-4408-853e-4d35b14aaad2)


Here is a portion of the Unicode Cyrillic characters.

https://en.wikipedia.org/wiki/Cyrillic_(Unicode_block)

![cyrillic_e_table](https://github.com/user-attachments/assets/ab2e4fde-e942-40a8-8c39-4e57e6835710)


No other use of Unicode characters for identifiers in the Ladybird code base was flagged by cppcheck, so assuming that this is unintended use.

From my understanding, the project's CodingStyle.md file does not cover this situation, so not sure if that document needs updating or not.