### PR TITLE
LibWeb: Invalidate layout tree at nearest non-anonymous ancestor

### DIFF
--- a/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x79.875 [BFC] children: not-inline
+    BlockContainer <body> at (8,21.4375) content-size 784x37 children: not-inline
+      BlockContainer <(anonymous)> at (8,21.4375) content-size 784x0 children: inline
+        InlineNode <a>
+          InlineNode <span#foo>
+      BlockContainer <(anonymous)> at (8,21.4375) content-size 784x37 children: not-inline continuation
+        BlockContainer <h1> at (8,21.4375) content-size 784x37 children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [8,21.4375 63.5625x37] baseline: 28.09375
+              "test"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,79.875) content-size 784x0 children: inline
+        InlineNode <a> continuation
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x79.875]
+    PaintableWithLines (BlockContainer<BODY>) [8,21.4375 784x37]
+      PaintableWithLines (BlockContainer(anonymous)) [8,21.4375 784x0]
+        PaintableWithLines (InlineNode<A>)
+          PaintableWithLines (InlineNode<SPAN>#foo)
+      PaintableWithLines (BlockContainer(anonymous)) [8,21.4375 784x37]
+        PaintableWithLines (BlockContainer<H1>) [8,21.4375 784x37]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,79.875 784x0]
+        PaintableWithLines (InlineNode<A>)

--- a/Tests/LibWeb/Layout/input/layout-tree-update/inline-element-position-change.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/inline-element-position-change.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<script>
+    function flipFlop() {
+        foo.style.position = 'relative';
+        foo.offsetWidth;
+        foo.style.position = '';
+        foo.offsetWidth;
+    }
+    onload = function() {
+        flipFlop();
+        flipFlop();
+        flipFlop();
+    };
+</script><body><a><span id="foo"></span><h1>test</h1>


### PR DESCRIPTION
When marking a part of the layout tree for rebuild, if the subtree root that we're marking has an anonymous parent, we now mark from the nearest
non-anonymous ancestor instead.

This ensures that subtrees inside anonymous wrappers don't just get duplicated (i.e recreated but inserted instead of replaced).

Fixes this very wonky visual issue when resizing on https://patricia.no/2025/05/30/why_lean_software_dev_is_wrong.html


https://github.com/user-attachments/assets/bdeb278b-e4f3-4ccb-aac2-dd9e967e7856