### PR TITLE
LibWeb: Set readyState to complete for DOMParser documents

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -324,6 +324,15 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
             (void)parser->m_stack_of_open_elements.pop();
     }
 
+    // AD-HOC: Skip remaining steps when there's no browsing context.
+    // This happens when parsing HTML via DOMParser or similar mechanisms.
+    // Note: This diverges from the spec, which expects more steps to follow.
+    if (!document->browsing_context()) {
+        // Parsed via DOMParser, no need to wait for load events.
+        document->update_readiness(HTML::DocumentReadyState::Complete);
+        return;
+    }
+
     // 5. While the list of scripts that will execute when the document has finished parsing is not empty:
     while (!document->scripts_to_execute_when_parsing_has_finished().is_empty()) {
         // 1. Spin the event loop until the first script in the list of scripts that will execute when the document has finished parsing

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -275,6 +275,12 @@ void XMLDocumentBuilder::document_end()
     // Pop all the nodes off the stack of open elements.
     // NOTE: Noop.
 
+    if (!m_document->browsing_context()) {
+        // Parsed via DOMParser, no need to wait for load events.
+        m_document->update_readiness(HTML::DocumentReadyState::Complete);
+        return;
+    }
+
     // While the list of scripts that will execute when the document has finished parsing is not empty:
     while (!m_document->scripts_to_execute_when_parsing_has_finished().is_empty()) {
         // Spin the event loop until the first script in the list of scripts that will execute when the document has finished parsing has its "ready to be parser-executed" flag set

--- a/Tests/LibWeb/Text/expected/HTML/document-readyState-is-initially-complete.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-readyState-is-initially-complete.txt
@@ -1,5 +1,5 @@
 readyState of 'new Document()' should be 'complete': 'complete'
 readyState of 'document.implementation.createHTMLDocument()' should be 'complete': 'complete'
 readyState of 'document.implementation.createDocument()' should be 'complete': 'complete'
-FIXME: readyState of 'new DOMParser().parseFromString('', 'text/html')' should be 'complete': 'interactive'
+readyState of 'new DOMParser().parseFromString('', 'text/html')' should be 'complete': 'complete'
 readyState of 'iframe.contentDocument' of initial about:blank iframe should be 'complete': 'complete'

--- a/Tests/LibWeb/Text/expected/wpt-import/domparsing/xmldomparser.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domparsing/xmldomparser.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	XML Dom Parse readyState Test

--- a/Tests/LibWeb/Text/input/HTML/document-readyState-is-initially-complete.html
+++ b/Tests/LibWeb/Text/input/HTML/document-readyState-is-initially-complete.html
@@ -5,7 +5,7 @@
         println(`readyState of 'new Document()' should be 'complete': '${new Document().readyState}'`);
         println(`readyState of 'document.implementation.createHTMLDocument()' should be 'complete': '${document.implementation.createHTMLDocument().readyState}'`);
         println(`readyState of 'document.implementation.createDocument()' should be 'complete': '${document.implementation.createDocument('http://www.w3.org/1999/xhtml', '').readyState}'`);
-        println(`FIXME: readyState of 'new DOMParser().parseFromString('', 'text/html')' should be 'complete': '${new DOMParser().parseFromString('', 'text/html').readyState}'`);
+        println(`readyState of 'new DOMParser().parseFromString('', 'text/html')' should be 'complete': '${new DOMParser().parseFromString('', 'text/html').readyState}'`);
 
         const iframe = document.createElement("iframe");
         document.body.appendChild(iframe);

--- a/Tests/LibWeb/Text/input/wpt-import/domparsing/xmldomparser.html
+++ b/Tests/LibWeb/Text/input/wpt-import/domparsing/xmldomparser.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>XML Dom Parse readyState Test</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script>
+    test(function () {
+        assert_equals(
+            (new DOMParser()).parseFromString("<html></html>", "text/xml").readyState,
+            "complete"
+        );
+    });
+</script>


### PR DESCRIPTION
Documents created via DOMParser.parseFromString()
are parsed synchronously and do not participate in the browsing context's loading pipeline.

This patch ensures that if the document has no browsing context (i.e. was parsed via DOMParser),
its readiness is set to "complete" synchronously.

Fixes WPT:
domparsing/xmldomparser.html