### PR TITLE
LibMedia: Add support for YUVJ pixel formats in FFmpegVideoDecoder

### DIFF
--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
@@ -25,6 +25,9 @@ static AVPixelFormat negotiate_output_format(AVCodecContext*, AVPixelFormat cons
         case AV_PIX_FMT_YUV444P:
         case AV_PIX_FMT_YUV444P10:
         case AV_PIX_FMT_YUV444P12:
+        case AV_PIX_FMT_YUVJ420P:
+        case AV_PIX_FMT_YUVJ422P:
+        case AV_PIX_FMT_YUVJ444P:
             return *formats;
         default:
             break;
@@ -137,6 +140,15 @@ DecoderErrorOr<NonnullOwnPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
         auto transfer_characteristics = static_cast<TransferCharacteristics>(m_frame->color_trc);
         auto matrix_coefficients = static_cast<MatrixCoefficients>(m_frame->colorspace);
         auto color_range = [&] {
+            switch (m_frame->format) {
+            case AV_PIX_FMT_YUVJ420P:
+            case AV_PIX_FMT_YUVJ422P:
+            case AV_PIX_FMT_YUVJ444P:
+                return VideoFullRangeFlag::Full;
+            default:
+                break;
+            }
+
             switch (m_frame->color_range) {
             case AVColorRange::AVCOL_RANGE_MPEG:
                 return VideoFullRangeFlag::Studio;
@@ -153,6 +165,9 @@ DecoderErrorOr<NonnullOwnPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
             case AV_PIX_FMT_YUV420P:
             case AV_PIX_FMT_YUV422P:
             case AV_PIX_FMT_YUV444P:
+            case AV_PIX_FMT_YUVJ420P:
+            case AV_PIX_FMT_YUVJ422P:
+            case AV_PIX_FMT_YUVJ444P:
                 return 8;
             case AV_PIX_FMT_YUV420P10:
             case AV_PIX_FMT_YUV422P10:
@@ -172,14 +187,17 @@ DecoderErrorOr<NonnullOwnPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame(
             case AV_PIX_FMT_YUV420P:
             case AV_PIX_FMT_YUV420P10:
             case AV_PIX_FMT_YUV420P12:
+            case AV_PIX_FMT_YUVJ420P:
                 return { true, true };
             case AV_PIX_FMT_YUV422P:
             case AV_PIX_FMT_YUV422P10:
             case AV_PIX_FMT_YUV422P12:
+            case AV_PIX_FMT_YUVJ422P:
                 return { true, false };
             case AV_PIX_FMT_YUV444P:
             case AV_PIX_FMT_YUV444P10:
             case AV_PIX_FMT_YUV444P12:
+            case AV_PIX_FMT_YUVJ444P:
                 return { false, false };
 
             default:


### PR DESCRIPTION
Fixes playback of videos that use YUVJ pixel format. Before we weren't able to load them at all. For example, this video from NASA: [https://sdo.gsfc.nasa.gov/assets/img/latest/mpeg/latest_1024_0304.mp4](https://sdo.gsfc.nasa.gov/assets/img/latest/mpeg/latest_1024_0304.mp4)

![image](https://github.com/user-attachments/assets/48453a09-f517-48e0-8390-7093591971e3)
