### PR TITLE
LibWeb: Use the correct definition of separated-borders mode

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -862,7 +862,7 @@ void TableFormattingContext::compute_table_height()
         cell_state.padding_left = cell.box->computed_values().padding().left().to_px(cell.box, width_of_containing_block);
         cell_state.padding_right = cell.box->computed_values().padding().right().to_px(cell.box, width_of_containing_block);
 
-        if (cell.box->computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
+        if (table_box().computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
             cell_state.border_top = cell.box->computed_values().border_top().width;
             cell_state.border_bottom = cell.box->computed_values().border_bottom().width;
             cell_state.border_left = cell.box->computed_values().border_left().width;
@@ -1286,7 +1286,7 @@ void TableFormattingContext::border_conflict_resolution()
                 .column_index = cell.column_index,
                 .row_span = cell.row_span,
                 .column_span = cell.column_span });
-        if (cell.box->computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
+        if (table_box().computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
             continue;
         }
         Painting::PaintableBox::BordersDataWithElementKind override_borders_data;

--- a/Libraries/LibWeb/Painting/TableBordersPainting.cpp
+++ b/Libraries/LibWeb/Painting/TableBordersPainting.cpp
@@ -377,7 +377,7 @@ void paint_table_borders(PaintContext& context, PaintableBox const& table_painta
     }
     auto cell_coordinates_to_device_rect = snap_cells_to_device_coordinates(cell_coordinates_to_box, row_count, column_count, context);
     for (auto const& cell_box : cell_boxes) {
-        if (cell_box.computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
+        if (table_paintable.computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
             paint_separate_cell_borders(cell_box, cell_coordinates_to_device_rect, context);
             continue;
         }

--- a/Tests/LibWeb/Ref/expected/table-collapse-ignored-in-cells-ref.html
+++ b/Tests/LibWeb/Ref/expected/table-collapse-ignored-in-cells-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+     <link rel="match" href="../expected/table-collapse-ignored-in-cells-ref.html" />
+<style>
+.collapse { border-collapse: collapse; }
+.separate { border-collapse: separate; }
+.border { border: 5px solid black; }
+.border-left { border-left: 5px solid blue; }
+</style>
+</head>
+<body>
+  <table class="collapse border">
+    <td class="border-left">aaaaaaa</td>
+  </table>
+  <table class="separate border-left">
+    <td class="border">aaaaaaa</td>
+  </table>
+</body>

--- a/Tests/LibWeb/Ref/input/table-collapse-ignored-in-cells.html
+++ b/Tests/LibWeb/Ref/input/table-collapse-ignored-in-cells.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+     <link rel="match" href="../expected/table-collapse-ignored-in-cells-ref.html" />
+<style>
+.collapse { border-collapse: collapse; }
+.separate { border-collapse: separate; }
+.border { border: 5px solid black; }
+.border-left { border-left: 5px solid blue; }
+</style>
+</head>
+<body>
+  <table class="collapse border">
+    <td class="separate border-left">aaaaaaa</td>
+  </table>
+  <table class="separate border-left">
+    <td class="collapse border">aaaaaaa</td>
+  </table>
+</body>


### PR DESCRIPTION
We previously checked the cell's computed values for the border-collapse property, but a cell is only in separated-borders mode if the table has border-collapse set to separate. Curiously in some other placed where this mode is checked we already did the correct thing.

For reference: https://www.w3.org/TR/css-tables-3/#border-collapse-property