### PR TITLE
LibWeb: Match paragraph align attribute keywords case-insensitively

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -61,17 +61,17 @@ bool HTMLBodyElement::is_presentational_hint(FlyString const& name) const
 void HTMLBodyElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
 {
     for_each_attribute([&](auto& name, auto& value) {
-        if (name.equals_ignoring_ascii_case("bgcolor"sv)) {
+        if (name == HTML::AttributeNames::bgcolor) {
             // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BackgroundColor, CSS::CSSColorValue::create_from_color(color.value(), CSS::ColorSyntax::Legacy));
-        } else if (name.equals_ignoring_ascii_case("text"sv)) {
+        } else if (name == HTML::AttributeNames::text) {
             // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-2
             auto color = parse_legacy_color_value(value);
             if (color.has_value())
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Color, CSS::CSSColorValue::create_from_color(color.value(), CSS::ColorSyntax::Legacy));
-        } else if (name.equals_ignoring_ascii_case("background"sv)) {
+        } else if (name == HTML::AttributeNames::background) {
             VERIFY(m_background_style_value);
             cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BackgroundImage, *m_background_style_value);
         }
@@ -114,22 +114,22 @@ void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> 
 {
     Base::attribute_changed(name, old_value, value, namespace_);
 
-    if (name.equals_ignoring_ascii_case("link"sv)) {
+    if (name == HTML::AttributeNames::link) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-3
         auto color = parse_legacy_color_value(value.value_or(String {}));
         if (color.has_value())
             document().set_normal_link_color(color.value());
-    } else if (name.equals_ignoring_ascii_case("alink"sv)) {
+    } else if (name == HTML::AttributeNames::alink) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-5
         auto color = parse_legacy_color_value(value.value_or(String {}));
         if (color.has_value())
             document().set_active_link_color(color.value());
-    } else if (name.equals_ignoring_ascii_case("vlink"sv)) {
+    } else if (name == HTML::AttributeNames::vlink) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-4
         auto color = parse_legacy_color_value(value.value_or(String {}));
         if (color.has_value())
             document().set_visited_link_color(color.value());
-    } else if (name.equals_ignoring_ascii_case("background"sv)) {
+    } else if (name == HTML::AttributeNames::background) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:attr-background
         if (auto maybe_background_url = document().encoding_parse_url(value.value_or(String {})); maybe_background_url.has_value()) {
             m_background_style_value = CSS::ImageStyleValue::create(maybe_background_url.value());

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -190,7 +190,7 @@ void HTMLCanvasElement::attribute_changed(FlyString const& local_name, Optional<
 {
     Base::attribute_changed(local_name, old_value, value, namespace_);
 
-    if (local_name.equals_ignoring_ascii_case(HTML::AttributeNames::width) || local_name.equals_ignoring_ascii_case(HTML::AttributeNames::height)) {
+    if (local_name.is_one_of(HTML::AttributeNames::width, HTML::AttributeNames::height)) {
         notify_context_about_canvas_size_change();
         reset_context_to_default_state();
         if (auto layout_node = this->layout_node())

--- a/Libraries/LibWeb/HTML/HTMLDivElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDivElement.cpp
@@ -33,7 +33,7 @@ bool HTMLDivElement::is_presentational_hint(FlyString const& name) const
 void HTMLDivElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
 {
     for_each_attribute([&](auto& name, auto& value) {
-        if (name.equals_ignoring_ascii_case("align"sv)) {
+        if (name == HTML::AttributeNames::align) {
             if (value.equals_ignoring_ascii_case("left"sv))
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::LibwebLeft));
             else if (value.equals_ignoring_ascii_case("right"sv))

--- a/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHeadingElement.cpp
@@ -40,7 +40,7 @@ void HTMLHeadingElement::apply_presentational_hints(GC::Ref<CSS::CascadedPropert
 {
     HTMLElement::apply_presentational_hints(cascaded_properties);
     for_each_attribute([&](auto& name, auto& value) {
-        if (name.equals_ignoring_ascii_case("align"sv)) {
+        if (name == HTML::AttributeNames::align) {
             if (value == "left"sv)
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Left));
             else if (value == "right"sv)

--- a/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -41,13 +41,13 @@ void HTMLParagraphElement::apply_presentational_hints(GC::Ref<CSS::CascadedPrope
     HTMLElement::apply_presentational_hints(cascaded_properties);
     for_each_attribute([&](auto& name, auto& value) {
         if (name == HTML::AttributeNames::align) {
-            if (value == "left"sv)
+            if (value.equals_ignoring_ascii_case("left"sv))
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Left));
-            else if (value == "right"sv)
+            else if (value.equals_ignoring_ascii_case("right"sv))
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Right));
-            else if (value == "center"sv)
+            else if (value.equals_ignoring_ascii_case("center"sv))
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Center));
-            else if (value == "justify"sv)
+            else if (value.equals_ignoring_ascii_case("justify"sv))
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Justify));
         }
     });

--- a/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLParagraphElement.cpp
@@ -40,7 +40,7 @@ void HTMLParagraphElement::apply_presentational_hints(GC::Ref<CSS::CascadedPrope
 {
     HTMLElement::apply_presentational_hints(cascaded_properties);
     for_each_attribute([&](auto& name, auto& value) {
-        if (name.equals_ignoring_ascii_case("align"sv)) {
+        if (name == HTML::AttributeNames::align) {
             if (value == "left"sv)
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Left));
             else if (value == "right"sv)

--- a/Libraries/LibWeb/HTML/HTMLPreElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLPreElement.cpp
@@ -41,7 +41,7 @@ void HTMLPreElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties>
     HTMLElement::apply_presentational_hints(cascaded_properties);
 
     for_each_attribute([&](auto const& name, auto const&) {
-        if (name.equals_ignoring_ascii_case(HTML::AttributeNames::wrap)) {
+        if (name == HTML::AttributeNames::wrap) {
             cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::TextWrapMode, CSS::CSSKeywordValue::create(CSS::Keyword::Wrap));
         }
     });

--- a/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableCaptionElement.cpp
@@ -40,7 +40,7 @@ void HTMLTableCaptionElement::apply_presentational_hints(GC::Ref<CSS::CascadedPr
 {
     HTMLElement::apply_presentational_hints(cascaded_properties);
     for_each_attribute([&](auto& name, auto& value) {
-        if (name.equals_ignoring_ascii_case("align"sv)) {
+        if (name == HTML::AttributeNames::align) {
             if (value == "bottom"sv)
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::CaptionSide, CSS::CSSKeywordValue::create(CSS::Keyword::Bottom));
         }

--- a/Libraries/LibWeb/SVG/AttributeNames.h
+++ b/Libraries/LibWeb/SVG/AttributeNames.h
@@ -76,6 +76,8 @@ namespace Web::SVG::AttributeNames {
     __ENUMERATE_SVG_ATTRIBUTE(startOffset, "startOffset")                 \
     __ENUMERATE_SVG_ATTRIBUTE(stdDeviation, "stdDeviation")               \
     __ENUMERATE_SVG_ATTRIBUTE(stitchTiles, "stitchTiles")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(stopColor, "stop-color")                    \
+    __ENUMERATE_SVG_ATTRIBUTE(stopOpacity, "stop-opacity")                \
     __ENUMERATE_SVG_ATTRIBUTE(surfaceScale, "surfaceScale")               \
     __ENUMERATE_SVG_ATTRIBUTE(systemLanguage, "systemLanguage")           \
     __ENUMERATE_SVG_ATTRIBUTE(tableValues, "tableValues")                 \

--- a/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -35,9 +35,7 @@ bool SVGStopElement::is_presentational_hint(FlyString const& name) const
     if (Base::is_presentational_hint(name))
         return true;
 
-    return first_is_one_of(name,
-        "stop-color"sv,
-        "stop-opacity"sv);
+    return first_is_one_of(name, SVG::AttributeNames::stopColor, SVG::AttributeNames::stopOpacity);
 }
 
 void SVGStopElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
@@ -45,11 +43,11 @@ void SVGStopElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties>
     CSS::Parser::ParsingParams parsing_context { document() };
     for_each_attribute([&](auto& name, auto& value) {
         CSS::Parser::ParsingParams parsing_context { document() };
-        if (name.equals_ignoring_ascii_case("stop-color"sv)) {
+        if (name == SVG::AttributeNames::stopColor) {
             if (auto stop_color = parse_css_value(parsing_context, value, CSS::PropertyID::StopColor)) {
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::StopColor, stop_color.release_nonnull());
             }
-        } else if (name.equals_ignoring_ascii_case("stop-opacity"sv)) {
+        } else if (name == SVG::AttributeNames::stopOpacity) {
             if (auto stop_opacity = parse_css_value(parsing_context, value, CSS::PropertyID::StopOpacity)) {
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::StopOpacity, stop_opacity.release_nonnull());
             }


### PR DESCRIPTION
A reimplementation of #4957, with some extra fixes.