### PR TITLE
LibJS: Bring `Intl.Locale` up-to-date and implement `Intl.Locale.prototype.variants`

### DIFF
--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -583,6 +583,7 @@ namespace JS {
     P(value)                                 \
     P(valueOf)                               \
     P(values)                                \
+    P(variants)                              \
     P(wait)                                  \
     P(waitAsync)                             \
     P(warn)                                  \

--- a/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -43,6 +43,24 @@ Unicode::LocaleID const& Locale::locale_id() const
     return *m_cached_locale_id;
 }
 
+// 15.5.5 GetLocaleVariants ( locale ), https://tc39.es/ecma402/#sec-getlocalevariants
+Optional<String> get_locale_variants(Unicode::LocaleID const& locale)
+{
+    // 1. Let baseName be GetLocaleBaseName(locale).
+    auto const& base_name = locale.language_id;
+
+    // 2. NOTE: Each subtag in baseName that is preceded by "-" is either a unicode_script_subtag, unicode_region_subtag,
+    //    or unicode_variant_subtag, but any substring matched by unicode_variant_subtag is strictly longer than any
+    //    prefix thereof which could also be matched by one of the other productions.
+
+    // 3. Let variants be the longest suffix of baseName that starts with a "-" followed by a substring that is matched
+    //    by the unicode_variant_subtag Unicode locale nonterminal. If there is no such suffix, return undefined.
+    // 4. Return the substring of variants from 1.
+    if (base_name.variants.is_empty())
+        return {};
+    return MUST(String::join("-"sv, base_name.variants));
+}
+
 // 1.1.1 CreateArrayFromListOrRestricted ( list , restricted )
 static GC::Ref<Array> create_array_from_list_or_restricted(VM& vm, Vector<String> list, Optional<String> restricted)
 {

--- a/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -91,6 +91,8 @@ struct WeekInfo {
     Vector<u8> weekend;    // [[Weekend]]
 };
 
+Optional<String> get_locale_variants(Unicode::LocaleID const&);
+
 GC::Ref<Array> calendars_of_locale(VM&, Locale const&);
 GC::Ref<Array> collations_of_locale(VM&, Locale const& locale);
 GC::Ref<Array> hour_cycles_of_locale(VM&, Locale const& locale);

--- a/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -39,7 +39,7 @@ void LocalePrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.getTextInfo, get_text_info, 0, attr);
     define_native_function(realm, vm.names.getWeekInfo, get_week_info, 0, attr);
 
-    // 15.3.15 Intl.Locale.prototype [ %Symbol.toStringTag% ], https://tc39.es/ecma402/#sec-intl.locale.prototype-%symbol.tostringtag%
+    // 15.3.16 Intl.Locale.prototype [ %Symbol.toStringTag% ], https://tc39.es/ecma402/#sec-intl.locale.prototype-%symbol.tostringtag%
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Intl.Locale"_string), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.baseName, base_name, {}, Attribute::Configurable);
@@ -53,6 +53,7 @@ void LocalePrototype::initialize(Realm& realm)
     define_native_accessor(realm, vm.names.numeric, numeric, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.region, region, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.script, script, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.variants, variants, {}, Attribute::Configurable);
 }
 
 // 15.3.2 get Intl.Locale.prototype.baseName, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.baseName
@@ -180,6 +181,19 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::to_string)
 
     // 3. Return loc.[[Locale]].
     return PrimitiveString::create(vm, locale_object->locale());
+}
+
+// 15.3.15 get Intl.Locale.prototype.variants, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
+JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::variants)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto locale_object = TRY(typed_this_object(vm));
+
+    // 3. Return GetLocaleVariants(loc.[[Locale]]).
+    if (auto variants = get_locale_variants(locale_object->locale_id()); variants.has_value())
+        return PrimitiveString::create(vm, variants.release_value());
+    return js_undefined();
 }
 
 #define JS_ENUMERATE_LOCALE_INFO_PROPERTIES \

--- a/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -37,6 +37,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(numeric);
     JS_DECLARE_NATIVE_FUNCTION(region);
     JS_DECLARE_NATIVE_FUNCTION(script);
+    JS_DECLARE_NATIVE_FUNCTION(variants);
     JS_DECLARE_NATIVE_FUNCTION(get_calendars);
     JS_DECLARE_NATIVE_FUNCTION(get_collations);
     JS_DECLARE_NATIVE_FUNCTION(get_hour_cycles);

--- a/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.variants.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.variants.js
@@ -1,0 +1,44 @@
+describe("errors", () => {
+    test("called on non-Locale object", () => {
+        expect(() => {
+            Intl.Locale.prototype.variants;
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.Locale");
+    });
+
+    test("duplicate variants", () => {
+        expect(() => {
+            new Intl.Locale("en-abcde-abcde");
+        }).toThrowWithMessage(
+            RangeError,
+            "en-abcde-abcde is not a structurally valid language tag"
+        );
+
+        expect(() => {
+            new Intl.Locale("en", { variants: "abcde-abcde" });
+        }).toThrowWithMessage(RangeError, "abcde-abcde is not a valid value for option variants");
+    });
+
+    test("invalid variant", () => {
+        expect(() => {
+            new Intl.Locale("en-a");
+        }).toThrowWithMessage(RangeError, "en-a is not a structurally valid language tag");
+
+        expect(() => {
+            new Intl.Locale("en", { variants: "a" });
+        }).toThrowWithMessage(RangeError, "a is not a valid value for option variants");
+
+        expect(() => {
+            new Intl.Locale("en", { variants: "-" });
+        }).toThrowWithMessage(RangeError, "- is not a valid value for option variants");
+    });
+});
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        expect(new Intl.Locale("en").variants).toBeUndefined();
+        expect(new Intl.Locale("en-abcde").variants).toBe("abcde");
+        expect(new Intl.Locale("en-1234-abcde").variants).toBe("1234-abcde");
+        expect(new Intl.Locale("en", { variants: "abcde" }).variants).toBe("abcde");
+        expect(new Intl.Locale("en", { variants: "1234-abcde" }).variants).toBe("1234-abcde");
+    });
+});


### PR DESCRIPTION
test262 diff:
```
Diff Tests:
+9 ✅    -9 ❌

test/intl402/Locale/constructor-getter-order.js             ❌ -> ✅
test/intl402/Locale/constructor-options-throwing-getters.js ❌ -> ✅
test/intl402/Locale/constructor-options-variants-invalid.js ❌ -> ✅
test/intl402/Locale/constructor-options-variants-valid.js   ❌ -> ✅
test/intl402/Locale/getters-grandfathered.js                ❌ -> ✅
test/intl402/Locale/getters-missing.js                      ❌ -> ✅
test/intl402/Locale/getters.js                              ❌ -> ✅
test/intl402/Locale/prototype/variants/name.js              ❌ -> ✅
test/intl402/Locale/prototype/variants/prop-desc.js         ❌ -> ✅
```

Brings us back to 100% passing `Intl.Locale`:
```
test/intl402/Locale  152/152  (100.00%)  [ ✅ 152 ]
```