### PR TITLE
LibJS: Add more fast paths for arrays with simple storage

### DIFF
--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -14,8 +14,7 @@ constexpr size_t const SPARSE_ARRAY_HOLE_THRESHOLD = 200;
 constexpr size_t const LENGTH_SETTER_GENERIC_STORAGE_THRESHOLD = 4 * MiB;
 
 SimpleIndexedPropertyStorage::SimpleIndexedPropertyStorage(Vector<Value>&& initial_values)
-    : IndexedPropertyStorage(IsSimpleStorage::Yes)
-    , m_array_size(initial_values.size())
+    : IndexedPropertyStorage(IsSimpleStorage::Yes, initial_values.size())
     , m_packed_elements(move(initial_values))
 {
 }
@@ -112,9 +111,8 @@ bool SimpleIndexedPropertyStorage::set_array_like_size(size_t new_size)
 }
 
 GenericIndexedPropertyStorage::GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&& storage)
-    : IndexedPropertyStorage(IsSimpleStorage::No)
+    : IndexedPropertyStorage(IsSimpleStorage::No, storage.array_like_size())
 {
-    m_array_size = storage.array_like_size();
     for (size_t i = 0; i < storage.m_packed_elements.size(); ++i) {
         auto value = storage.m_packed_elements[i];
         if (!value.is_special_empty_value())

--- a/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -41,16 +41,19 @@ public:
     virtual ValueAndAttributes take_last() = 0;
 
     virtual size_t size() const = 0;
-    virtual size_t array_like_size() const = 0;
+    size_t array_like_size() const { return m_array_size; }
     virtual bool set_array_like_size(size_t new_size) = 0;
 
     bool is_simple_storage() const { return m_is_simple_storage; }
 
 protected:
-    explicit IndexedPropertyStorage(IsSimpleStorage is_simple_storage)
-        : m_is_simple_storage(is_simple_storage == IsSimpleStorage::Yes)
+    explicit IndexedPropertyStorage(IsSimpleStorage is_simple_storage, size_t array_size = 0)
+        : m_array_size(array_size)
+        , m_is_simple_storage(is_simple_storage == IsSimpleStorage::Yes)
     {
     }
+
+    size_t m_array_size { 0 };
 
 private:
     bool m_is_simple_storage { false };
@@ -73,7 +76,6 @@ public:
     virtual ValueAndAttributes take_last() override;
 
     virtual size_t size() const override { return m_packed_elements.size(); }
-    virtual size_t array_like_size() const override { return m_array_size; }
     virtual bool set_array_like_size(size_t new_size) override;
 
     Vector<Value> const& elements() const { return m_packed_elements; }
@@ -97,7 +99,6 @@ private:
 
     void grow_storage_if_needed();
 
-    size_t m_array_size { 0 };
     Checked<size_t> m_number_of_empty_elements { 0 };
     Vector<Value> m_packed_elements;
 };
@@ -119,13 +120,11 @@ public:
     virtual ValueAndAttributes take_last() override;
 
     virtual size_t size() const override { return m_sparse_elements.size(); }
-    virtual size_t array_like_size() const override { return m_array_size; }
     virtual bool set_array_like_size(size_t new_size) override;
 
     HashMap<u32, ValueAndAttributes> const& sparse_elements() const { return m_sparse_elements; }
 
 private:
-    size_t m_array_size { 0 };
     HashMap<u32, ValueAndAttributes> m_sparse_elements;
 };
 


### PR DESCRIPTION
Makes MicroBench/array-prototype-map.js go 1.2x faster