### PR TITLE
headless-browser: Ensure headless-browser depends on its resource files

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -109,7 +109,7 @@ add_subdirectory(Headless)
 set(ladybird_helper_processes ImageDecoder RequestServer WebContent WebWorker)
 
 add_dependencies(ladybird ${ladybird_helper_processes})
-add_dependencies(headless-browser ${ladybird_helper_processes})
+add_dependencies(headless-browser ${ladybird_helper_processes} ladybird_build_resource_files)
 add_dependencies(WebDriver ladybird headless-browser)
 
 set_helper_process_properties(${ladybird_helper_processes})


### PR DESCRIPTION
In a clean environment, building only headless-browser neglected to install the resource files needed to run the browser. These were only installed by the main Ladybird target.

Fixes #5003