### PR TITLE
CI: Run all macOS jobs on self-hosted runner

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -3,8 +3,8 @@ description: 'Restores caches of downloaded files and build artifacts.'
 author: 'Andrew Kaster <akaster@serenityos.org>'
 
 inputs:
-  runner_label:
-    description: 'Name of runner instance'
+  runner_labels:
+    description: 'Runner selection labels'
     required: true
   os:
     description: 'Operating System to restore caches for'
@@ -59,7 +59,7 @@ runs:
     - name: 'Compiler Cache (blacksmith)'
       uses: useblacksmith/cache/restore@v5
       id: 'ccache-blacksmith'
-      if: ${{ inputs.ccache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.ccache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.ccache_path }}
         key: '"ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
@@ -70,7 +70,7 @@ runs:
     - name: 'Compiler Cache (GitHub runner)'
       uses: actions/cache/restore@v4
       id: 'ccache-gh'
-      if: ${{ inputs.ccache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.ccache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.ccache_path }}
         key: '"ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
@@ -92,7 +92,7 @@ runs:
 
     - name: 'Restore vcpkg cache (blacksmith)'
       uses: useblacksmith/cache/restore@v5
-      if: ${{ inputs.vcpkg_cache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.vcpkg_cache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
       id: 'vcpkg-blacksmith'
       with:
         path: ${{ inputs.vcpkg_cache_path }}
@@ -103,7 +103,7 @@ runs:
 
     - name: 'Restore vcpkg cache (GitHub runner)'
       uses: actions/cache/restore@v4
-      if: ${{ inputs.ccache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.ccache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
       id: 'vcpkg-gh'
       with:
         path: ${{ inputs.vcpkg_cache_path }}
@@ -118,7 +118,7 @@ runs:
       id: 'cache-outputs'
       shell: bash
       run: |
-        if ${{ startsWith(inputs.runner_label, 'blacksmith') }} ; then
+        if ${{ contains(inputs.runner_labels, 'blacksmith') }} ; then
           echo "ccache_primary_key=${{ steps.ccache-blacksmith.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
           echo "vcpkg_cache_primary_key=${{ steps.vcpkg-blacksmith.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
         else

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -3,8 +3,8 @@ description: 'Saves caches of build artifacts.'
 author: 'Andrew Kaster <akaster@serenityos.org>'
 
 inputs:
-  runner_label:
-    description: 'Name of runner instance'
+  runner_labels:
+    description: 'Runner selection labels'
     required: true
   arch:
     description: 'Target Architecture to restore caches for'
@@ -28,7 +28,7 @@ inputs:
     default: ''
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: 'Prune obsolete ccache files'
       shell: bash
@@ -38,14 +38,14 @@ runs:
 
     - name: 'Compiler Cache (blacksmith)'
       uses: useblacksmith/cache/save@v5
-      if: ${{ inputs.ccache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.ccache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.ccache_path }}
         key: ${{ inputs.ccache_primary_key }}
 
     - name: 'Compiler Cache (GitHub runner)'
       uses: actions/cache/save@v4
-      if: ${{ inputs.ccache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.ccache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.ccache_path }}
         key: ${{ inputs.ccache_primary_key }}
@@ -58,14 +58,14 @@ runs:
 
     - name: 'vcpkg binary cache (blacksmith)'
       uses: useblacksmith/cache/save@v5
-      if: ${{ inputs.vcpkg_cache_path != '' && startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.vcpkg_cache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.vcpkg_cache_path }}
         key: ${{ inputs.vcpkg_cache_primary_key }}
 
     - name: 'vcpkg binary cache (GitHub runner)'
       uses: actions/cache/save@v4
-      if: ${{ inputs.vcpkg_cache_path != '' && !startsWith(inputs.runner_label, 'blacksmith') }}
+      if: ${{ inputs.vcpkg_cache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.vcpkg_cache_path }}
         key: ${{ inputs.vcpkg_cache_primary_key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   # CI matrix - runs the job in lagom-template.yml with different configurations.
   Lagom:
     if: github.repository == 'LadybirdBrowser/ladybird'
+    name: ${{ matrix.os_name }}, ${{ matrix.arch }}, ${{ matrix.build_preset }}, ${{ matrix.toolchain }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             build_preset: 'Sanitizer_CI'
             toolchain: 'Clang'
             clang_plugins: false
-            runner_labels: '["macos-15"]'
+            runner_labels: '["macos-15", "self-hosted"]'
 
           - os_name: 'Linux'
             arch: 'x86_64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         build_preset: ['Sanitizer_CI']
         toolchain: ['GNU']
         clang_plugins: [false]
-        runner: ['blacksmith-16vcpu-ubuntu-2404']
+        runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
 
         include:
           - os_name: 'Linux'
@@ -27,27 +27,27 @@ jobs:
             build_preset: 'Sanitizer_CI'
             toolchain: 'Clang'
             clang_plugins: true
-            runner: 'blacksmith-16vcpu-ubuntu-2404'
+            runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
 
           - os_name: 'macOS'
             arch: 'arm64'
             build_preset: 'Sanitizer_CI'
             toolchain: 'Clang'
             clang_plugins: false
-            runner: 'macos-15'
+            runner_labels: '["macos-15"]'
 
           - os_name: 'Linux'
             arch: 'x86_64'
             build_preset: 'Fuzzers_CI'
             toolchain: 'Clang'
             clang_plugins: false
-            runner: 'blacksmith-16vcpu-ubuntu-2404'
+            runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
 
     uses: ./.github/workflows/lagom-template.yml
     with:
       toolchain: ${{ matrix.toolchain }}
       os_name: ${{ matrix.os_name }}
-      runner: ${{ matrix.runner }}
+      runner_labels: ${{ matrix.runner_labels }}
       arch: ${{ matrix.arch }}
       build_preset: ${{ matrix.build_preset }}
       clang_plugins: ${{ matrix.clang_plugins }}

--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -13,6 +13,8 @@ jobs:
   build-and-package:
     runs-on: ${{ fromJSON(matrix.runner_labels) }}
     if: github.repository == 'LadybirdBrowser/ladybird'
+    name: ${{ matrix.os_name }}, ${{ matrix.arch }}
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -25,7 +25,7 @@ jobs:
           - os_name: 'macOS'
             arch: 'arm64'
             package_type: 'macOS-arm64'
-            runner_labels: '["macos-15"]'
+            runner_labels: '["macos-15", "self-hosted"]'
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird

--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-package:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ fromJSON(matrix.runner_labels) }}
     if: github.repository == 'LadybirdBrowser/ladybird'
     strategy:
       fail-fast: false
@@ -19,13 +19,13 @@ jobs:
         os_name: ['Linux']
         arch: ['x86_64']
         package_type: ['Linux-x86_64']
-        runner: ['blacksmith-8vcpu-ubuntu-2404']
+        runner_labels: ['["blacksmith-8vcpu-ubuntu-2404"]']
 
         include:
           - os_name: 'macOS'
             arch: 'arm64'
             package_type: 'macOS-arm64'
-            runner: 'macos-15'
+            runner_labels: '["macos-15"]'
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         id: 'cache-restore'
         with:
-          runner_label: ${{ matrix.runner }}
+          runner_labels: ${{ matrix.runner_labels }}
           os: ${{ matrix.os_name }}
           arch: ${{ matrix.arch }}
           cache_key_extra: 'LibJS Artifacts'
@@ -77,7 +77,7 @@ jobs:
       - name: Save Caches
         uses: ./.github/actions/cache-save
         with:
-          runner_label: ${{ matrix.runner }}
+          runner_labels: ${{ matrix.runner_labels }}
           arch: 'Lagom'
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}

--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -10,6 +10,8 @@ jobs:
   js-benchmarks:
     runs-on: ${{ fromJSON(matrix.runner_labels) }}
     if: ${{ github.repository == 'LadybirdBrowser/ladybird' && github.event.workflow_run.conclusion == 'success' }}
+    name: ${{ matrix.os_name }}, ${{ matrix.arch }}
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js-benchmarks.yml
+++ b/.github/workflows/js-benchmarks.yml
@@ -8,21 +8,21 @@ on:
 
 jobs:
   js-benchmarks:
-    runs-on: ['js-benchmarks', 'self-hosted', '${{ matrix.runner }}']
+    runs-on: ${{ fromJSON(matrix.runner_labels) }}
     if: ${{ github.repository == 'LadybirdBrowser/ladybird' && github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
         os_name: ['Linux']
-        runner: ['ubuntu-24.04-internal']
         arch: ['x86_64']
         package_type: ['Linux-x86_64']
+        runner_labels: ['["ubuntu-24.04-internal", "js-benchmarks", "self-hosted"]']
 
         include:
           - os_name: 'macOS'
-            runner: 'macos-15'
             arch: 'arm64'
             package_type: 'macOS-arm64'
+            runner_labels: '["macos-15", "js-benchmarks", "self-hosted"]'
 
     permissions:
       actions: read

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -9,7 +9,7 @@ on:
       os_name:
         required: true
         type: string
-      runner:
+      runner_labels:
         required: true
         type: string
       arch:
@@ -38,7 +38,7 @@ env:
 
 jobs:
   CI:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
 
     steps:
       # Pull requests can trail behind `master` and can cause breakage if merging before running the CI checks on an updated branch.
@@ -103,7 +103,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         id: 'cache-restore'
         with:
-          runner_label: ${{ inputs.runner }}
+          runner_labels: ${{ inputs.runner_labels }}
           os: ${{ inputs.os_name }}
           arch: ${{ inputs.arch }}
           toolchain: ${{ inputs.toolchain }}
@@ -176,7 +176,7 @@ jobs:
       - name: Save Caches
         uses: ./.github/actions/cache-save
         with:
-          runner_label: ${{ inputs.runner }}
+          runner_labels: ${{ inputs.runner_labels }}
           arch: ${{ inputs.arch }}
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Restore Caches
         uses: ./.github/actions/cache-restore
         with:
-          runner_label: test262-runner
+          runner_labels: '["test262-runner"]'
           os: 'Linux'
           arch: 'Lagom'
           download_cache_path: ${{ github.workspace }}/libjs-test262/Build/caches

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -13,6 +13,7 @@ jobs:
   # CI matrix - runs the job in lagom-template.yml with different configurations.
   Lagom:
     if: github.repository == 'LadybirdBrowser/ladybird'
+    name: ${{ matrix.os_name }}, ${{ matrix.arch }}, ${{ matrix.build_preset }}, ${{ matrix.toolchain }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -22,7 +22,7 @@ jobs:
         build_preset: ['Sanitizer_CI']
         toolchain: ['Clang']
         clang_plugins: [false]
-        runner: ['blacksmith-8vcpu-ubuntu-2404-arm']
+        runner_labels: ['["blacksmith-8vcpu-ubuntu-2404-arm"]']
 
         include:
           - os_name: 'Linux'
@@ -30,41 +30,41 @@ jobs:
             build_preset: 'Distribution_CI'
             toolchain: 'GNU'
             clang_plugins: false
-            runner: 'blacksmith-8vcpu-ubuntu-2404'
+            runner_labels: '["blacksmith-8vcpu-ubuntu-2404"]'
 
           - os_name: 'macOS'
             arch: 'arm64'
             build_preset: 'Distribution_CI'
             toolchain: 'Clang'
             clang_plugins: false
-            runner: 'macos-15'
+            runner_labels: '["macos-15"]'
 
           - os_name: 'Linux'
             arch: 'arm64'
             build_preset: 'Distribution_CI'
             toolchain: 'Clang'
             clang_plugins: false
-            runner: 'blacksmith-8vcpu-ubuntu-2404-arm'
+            runner_labels: '["blacksmith-8vcpu-ubuntu-2404-arm"]'
 
           - os_name: 'Linux'
             arch: 'x86_64'
             build_preset: 'Sanitizer_CI'
             toolchain: 'Swift'
             clang_plugins: false
-            runner: 'blacksmith-8vcpu-ubuntu-2404'
+            runner_labels: '["blacksmith-8vcpu-ubuntu-2404"]'
 
           - os_name: 'macOS'
             arch: 'arm64'
             build_preset: 'Sanitizer_CI'
             toolchain: 'Swift'
             clang_plugins: false
-            runner: 'macos-15'
+            runner_labels: '["macos-15"]'
 
     uses: ./.github/workflows/lagom-template.yml
     with:
       toolchain: ${{ matrix.toolchain }}
       os_name: ${{ matrix.os_name }}
-      runner: ${{ matrix.runner }}
+      runner_labels: ${{ matrix.runner_labels }}
       arch: ${{ matrix.arch }}
       build_preset: ${{ matrix.build_preset }}
       clang_plugins: ${{ matrix.clang_plugins }}

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/cache-restore
         id: 'cache-restore'
         with:
-          runner_label: windows-2022
+          runner_labels: '["windows-2022"]'
           os: Windows
           arch: x86_64
           toolchain: ClangCL
@@ -62,7 +62,7 @@ jobs:
       - name: Save Caches
         uses: ./.github/actions/cache-save
         with:
-          runner_label: windows-2022
+          runner_labels: '["windows-2022"]'
           arch: x86_64
           vcpkg_cache_path: ${{ github.workspace }}/Build/caches/vcpkg-binary-cache
           vcpkg_cache_primary_key: ${{ steps.cache-restore.outputs.vcpkg_cache_primary_key }}


### PR DESCRIPTION
The GitHub-provided runner frequently times out and is plain slow most of the time. And since Blacksmith does not yet offer macOS runners, let's use our self-hosted runner that is currently idle most of the time (when it's not running JS benchmarks).

**Note:** this cannot be auto-merged and after merging, the required checks for the `master` branch need updating.