### PR TITLE
LibWeb: Don't early return when masking area of StackingContext is empty

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -362,8 +362,6 @@ void StackingContext::paint(PaintContext& context) const
     }
 
     if (auto masking_area = paintable_box().get_masking_area(); masking_area.has_value()) {
-        if (masking_area->is_empty())
-            return;
         auto mask_bitmap = paintable_box().calculate_mask(context, *masking_area);
         if (mask_bitmap) {
             auto masking_area_rect = context.enclosing_device_rect(*masking_area).to_type<int>();

--- a/Tests/LibWeb/Ref/expected/clip-path.html
+++ b/Tests/LibWeb/Ref/expected/clip-path.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <style>
+        * {
+            margin: 0;
+        }
+    </style>
+    <body>
+        <div style="width: 100px; height: 100px; background-color: green"></div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/clip-path.html
+++ b/Tests/LibWeb/Ref/input/clip-path.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/clip-path.html" />
+<html>
+    <style>
+        * {
+            margin: 0;
+        }
+    </style>
+    <body>
+        <div id="container" style="clip-path: rect(0 0 0 0)"></div>
+        <div style="width: 100px; height: 100px; background-color: green"></div>
+    </body>
+</html>


### PR DESCRIPTION
An early return was occurring between the emission of PushStackingContext and PopStackingContext, resulting in a PushStackingContext without a corresponding PopStackingContext in the display list, which caused broken painting.

Fixes black screen on Discord login page.

![CleanShot 2025-06-05 at 23 30 04](https://github.com/user-attachments/assets/57421b2c-bfa2-4b71-9bfd-13faf4a4b957)
