### PR TITLE
LibDevTools: Set target type for frame actors

### DIFF
--- a/Libraries/LibDevTools/Actors/DeviceActor.cpp
+++ b/Libraries/LibDevTools/Actors/DeviceActor.cpp
@@ -42,7 +42,7 @@ void DeviceActor::handle_message(Message const& message)
         value.set("version"sv, browser_version);
         value.set("appbuildid"sv, build_id);
         value.set("platformbuildid"sv, build_id);
-        value.set("platformversion"sv, "135.0"sv);
+        value.set("platformversion"sv, "139.0"sv);
         value.set("useragent"sv, Web::default_user_agent);
         value.set("os"sv, platform_name);
         value.set("arch"sv, arch);

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -115,6 +115,7 @@ JsonObject FrameActor::serialize_target() const
 
     JsonObject target;
     target.set("actor"sv, name());
+    target.set("targetType"sv, "frame"sv);
 
     if (auto tab_actor = m_tab.strong_ref()) {
         target.set("title"sv, tab_actor->description().title);


### PR DESCRIPTION
Required for Firefox 139.