### PR TITLE
LibGfx: CMake build fixes

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -116,7 +116,7 @@ find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(LIBAVIF REQUIRED)
 find_package(WebP REQUIRED)
-find_package(harfbuzz REQUIRED)
+pkg_check_modules(harfbuzz REQUIRED IMPORTED_TARGET harfbuzz)
 
 target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
             WebP::webpdemux WebP::libwebpmux skia harfbuzz)

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -118,8 +118,17 @@ find_package(LIBAVIF REQUIRED)
 find_package(WebP REQUIRED)
 pkg_check_modules(harfbuzz REQUIRED IMPORTED_TARGET harfbuzz)
 
-target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
+if (HAS_FONTCONFIG)
+    pkg_check_modules(fontconfig REQUIRED IMPORTED_TARGET fontconfig)
+endif()
+
+if (HAS_FONTCONFIG)
+    target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
+            WebP::webpdemux WebP::libwebpmux skia harfbuzz fontconfig)
+else()
+    target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
             WebP::webpdemux WebP::libwebpmux skia harfbuzz)
+endif()
 
 set(CMAKE_REQUIRED_LIBRARIES PNG::PNG)
 check_c_source_compiles([=[


### PR DESCRIPTION
Fixes `Libraries/LibGfx` configuration and build issues on OpenMandrivaLx relating to CMake detcection of `harfbuzz` and `fontconfig` and `LibGfx` build time linker issues with `fontconfig`.

Resolves https://github.com/LadybirdBrowser/ladybird/issues/5023