### PR TITLE
LibWeb: Resolve FIXME in `Window::get_computed_style`

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -44,7 +44,7 @@ GC::Ref<CSSStyleProperties> CSSStyleProperties::create(JS::Realm& realm, Vector<
     return realm.create<CSSStyleProperties>(realm, Computed::No, Readonly::No, move(properties), move(custom_properties), OptionalNone {});
 }
 
-GC::Ref<CSSStyleProperties> CSSStyleProperties::create_resolved_style(DOM::ElementReference element_reference)
+GC::Ref<CSSStyleProperties> CSSStyleProperties::create_resolved_style(JS::Realm& realm, Optional<DOM::ElementReference> element_reference)
 {
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
     // 6.  Return a live CSSStyleProperties object with the following properties:
@@ -54,7 +54,6 @@ GC::Ref<CSSStyleProperties> CSSStyleProperties::create_resolved_style(DOM::Eleme
     //     parent CSS rule: Null.
     //     owner node: obj.
     // AD-HOC: Rather than instantiate with a list of decls, they're generated on demand.
-    auto& realm = element_reference.element().realm();
     return realm.create<CSSStyleProperties>(realm, Computed::Yes, Readonly::Yes, Vector<StyleProperty> {}, HashMap<FlyString, StyleProperty> {}, move(element_reference));
 }
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -94,8 +94,11 @@ size_t CSSStyleProperties::length() const
     // The length attribute must return the number of CSS declarations in the declarations.
     // FIXME: Include the number of custom properties.
 
-    if (is_computed())
+    if (is_computed()) {
+        if (!owner_node().has_value())
+            return 0;
         return to_underlying(last_longhand_property_id) - to_underlying(first_longhand_property_id) + 1;
+    }
 
     return m_properties.size();
 }
@@ -119,6 +122,9 @@ String CSSStyleProperties::item(size_t index) const
 Optional<StyleProperty> CSSStyleProperties::property(PropertyID property_id) const
 {
     if (is_computed()) {
+        if (!owner_node().has_value())
+            return {};
+
         auto& element = owner_node()->element();
         auto pseudo_element = owner_node()->pseudo_element();
 
@@ -180,6 +186,9 @@ Optional<StyleProperty> CSSStyleProperties::property(PropertyID property_id) con
 Optional<StyleProperty const&> CSSStyleProperties::custom_property(FlyString const& custom_property_name) const
 {
     if (is_computed()) {
+        if (!owner_node().has_value())
+            return {};
+
         auto& element = owner_node()->element();
         auto pseudo_element = owner_node()->pseudo_element();
 
@@ -645,6 +654,11 @@ static RefPtr<CSSStyleValue const> resolve_color_style_value(CSSStyleValue const
 
 RefPtr<CSSStyleValue const> CSSStyleProperties::style_value_for_computed_property(Layout::NodeWithStyle const& layout_node, PropertyID property_id) const
 {
+    if (!owner_node().has_value()) {
+        dbgln_if(LIBWEB_CSS_DEBUG, "Computed style for CSSStyleProperties without owner node was requested");
+        return nullptr;
+    }
+
     auto used_value_for_property = [&layout_node, property_id](Function<CSSPixels(Painting::PaintableBox const&)>&& used_value_getter) -> Optional<CSSPixels> {
         auto const& display = layout_node.computed_values().display();
         if (!display.is_none() && !display.is_contents() && layout_node.first_paintable()) {

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -22,7 +22,7 @@ class CSSStyleProperties
 public:
     [[nodiscard]] static GC::Ref<CSSStyleProperties> create(JS::Realm&, Vector<StyleProperty>, HashMap<FlyString, StyleProperty> custom_properties);
 
-    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_resolved_style(DOM::ElementReference);
+    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_resolved_style(JS::Realm&, Optional<DOM::ElementReference>);
     [[nodiscard]] static GC::Ref<CSSStyleProperties> create_element_inline_style(DOM::ElementReference, Vector<StyleProperty>, HashMap<FlyString, StyleProperty> custom_properties);
 
     virtual ~CSSStyleProperties() override = default;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -775,7 +775,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
 
 GC::Ref<CSS::ComputedProperties> Element::resolved_css_values(Optional<CSS::PseudoElement> type)
 {
-    auto element_computed_style = CSS::CSSStyleProperties::create_resolved_style({ *this, type });
+    auto element_computed_style = CSS::CSSStyleProperties::create_resolved_style(realm(), ElementReference { *this, type });
     auto properties = heap().allocate<CSS::ComputedProperties>();
 
     for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -4741,7 +4741,7 @@ Optional<NonnullRefPtr<CSS::CSSStyleValue const>> resolved_value(GC::Ref<DOM::No
         return {};
 
     // Retrieve resolved style value
-    auto resolved_css_style_declaration = CSS::CSSStyleProperties::create_resolved_style({ static_cast<DOM::Element&>(*element) });
+    auto resolved_css_style_declaration = CSS::CSSStyleProperties::create_resolved_style(element->realm(), DOM::ElementReference { static_cast<DOM::Element&>(*element) });
     auto optional_style_property = resolved_css_style_declaration->property(property_id);
     if (!optional_style_property.has_value())
         return {};

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1273,7 +1273,7 @@ GC::Ref<CSS::CSSStyleDeclaration> Window::get_computed_style(DOM::Element& eleme
     // 1. Let doc be elt’s node document.
 
     // 2. Let obj be elt.
-    DOM::ElementReference object { element };
+    Optional<DOM::ElementReference> object { element };
 
     // 3. If pseudoElt is provided, is not the empty string, and starts with a colon, then:
     if (pseudo_element.has_value() && pseudo_element.value().starts_with(':')) {
@@ -1281,8 +1281,8 @@ GC::Ref<CSS::CSSStyleDeclaration> Window::get_computed_style(DOM::Element& eleme
         auto type = parse_pseudo_element_selector(CSS::Parser::ParsingParams(associated_document()), pseudo_element.value());
 
         // 2. If type is failure, or is a ::slotted() or ::part() pseudo-element, let obj be null.
-        // FIXME: We can't pass a null element to CSSStyleProperties::create_resolved_style()
         if (!type.has_value()) {
+            object = {};
         }
         // 3. Otherwise let obj be the given pseudo-element of elt.
         else {
@@ -1311,7 +1311,7 @@ GC::Ref<CSS::CSSStyleDeclaration> Window::get_computed_style(DOM::Element& eleme
     //        Null.
     //    owner node
     //        obj.
-    return CSS::CSSStyleProperties::create_resolved_style(move(object));
+    return CSS::CSSStyleProperties::create_resolved_style(element.realm(), move(object));
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-view/#dom-window-matchmedia

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-pseudo.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-pseudo.txt
@@ -1,0 +1,33 @@
+Harness status: OK
+
+Found 26 tests
+
+22 Pass
+1 Fail
+3 Optional Feature Unsupported
+Pass	Resolution of width is correct when pseudo-element argument is ignored (due to no colon)
+Fail	Resolution of width is correct when pseudo-element argument is invalid (due to a trailing token)
+Pass	Resolution of width is correct for ::before and ::after pseudo-elements (single-colon)
+Pass	Resolution of width is correct for ::before and ::after pseudo-elements (double-colon)
+Pass	Pseudo-elements can use the full range of CSS syntax
+Pass	Resolution of width is correct for ::before and ::after pseudo-elements of display: contents elements
+Pass	Resolution of nonexistent pseudo-element styles
+Pass	Resolution of pseudo-element styles in display: none elements
+Pass	Item-based blockification of pseudo-elements
+Pass	Item-based blockification of nonexistent pseudo-elements
+Pass	display: contents on pseudo-elements
+Pass	Dynamically change to display: contents on pseudo-elements
+Pass	Unknown pseudo-elements
+Pass	CSSStyleDeclaration is immutable
+Pass	Unknown pseudo-element with a known identifier: backdrop
+Pass	Unknown pseudo-element with a known identifier: file-selector-button
+Optional Feature Unsupported	Unknown pseudo-element with a known identifier: grammar-error
+Optional Feature Unsupported	Unknown pseudo-element with a known identifier: highlight(name)
+Pass	Unknown pseudo-element with a known identifier: marker
+Pass	Unknown pseudo-element with a known identifier: placeholder
+Optional Feature Unsupported	Unknown pseudo-element with a known identifier: spelling-error
+Pass	Unknown pseudo-element with a known identifier: view-transition
+Pass	Unknown pseudo-element with a known identifier: view-transition-image-pair(name)
+Pass	Unknown pseudo-element with a known identifier: view-transition-group(name)
+Pass	Unknown pseudo-element with a known identifier: view-transition-old(name)
+Pass	Unknown pseudo-element with a known identifier: view-transition-new(name)

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/getComputedStyle-pseudo.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/getComputedStyle-pseudo.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: Correct resolution of resolved value for display-affected pseudo-elements</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle">
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-values">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Karl Dubost" href="https://github.com/karlcow">
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<style>
+#test { width: 100px; }
+
+#contents {
+  display: contents;
+  border: 10px solid red;
+}
+
+#test::before,
+#test::after,
+#contents::before,
+#contents::after,
+#flex::before,
+#flex::after {
+  content: " ";
+  width: 50%;
+  height: 10px;
+  display: block;
+}
+#none {
+  display: none;
+}
+#none::before,
+#none::after {
+  content: "Foo";
+}
+#flex {
+  display: flex;
+}
+#flex-no-pseudo {
+  display: flex;
+}
+#contents-pseudos::before,
+#contents-pseudos::after {
+  display: contents;
+  content: "foo";
+  position: absolute;
+}
+#contents-pseudos-dynamic::before,
+#contents-pseudos-dynamic::after {
+  display: block;
+  content: "foo";
+  position: absolute;
+}
+#contents-pseudos-dynamic.contents::before,
+#contents-pseudos-dynamic.contents::after {
+  display: contents;
+}
+#pseudo-invalid::backdrop {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::file-selector-button {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::grammar-error {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::highlight(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::marker {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::placeholder {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::spelling-error {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-image-pair(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-group(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-old(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid::view-transition-new(name) {
+  color: rgb(0, 128, 0);
+}
+#pseudo-invalid {
+  color: rgb(255, 0, 0)
+}
+</style>
+<div id="test">
+  <div id="contents"></div>
+  <div id="none"></div>
+  <div id="flex"></div>
+  <div id="flex-no-pseudo"></div>
+  <div id="contents-pseudos"></div>
+  <div id="contents-pseudos-dynamic"></div>
+  <ul><li id="pseudo-invalid">Item</li></ul>
+</div>
+<script>
+test(() => {
+  const div = document.getElementById('test');
+  ["before", "after"].forEach(pseudo => {
+    assert_equals(getComputedStyle(div, pseudo).width, "100px");
+  });
+}, "Resolution of width is correct when pseudo-element argument is ignored (due to no colon)");
+
+test(() => {
+  const div = document.getElementById('test');
+  [
+    ":before ",
+    "::before ",
+    "::before\t",
+    "::before\f",
+    "::before\n",
+    "::before,",
+    "::before,::after",
+    "::before@after",
+    "::before#after",
+    "::\"before\"",
+    "::before\u0000",
+    "::before-->",
+    "::before0",
+  ].forEach(pseudo => {
+    assert_equals(getComputedStyle(div, pseudo).width, "", pseudo);
+  });
+}, "Resolution of width is correct when pseudo-element argument is invalid (due to a trailing token)");
+
+test(() => {
+  const div = document.getElementById('test');
+  [":before", ":after"].forEach(pseudo => {
+    assert_equals(getComputedStyle(div, pseudo).width, "50px");
+  });
+}, "Resolution of width is correct for ::before and ::after pseudo-elements (single-colon)");
+
+test(() => {
+  const div = document.getElementById('test');
+  ["::before", "::after"].forEach(pseudo => {
+    assert_equals(getComputedStyle(div, pseudo).width, "50px");
+  });
+}, "Resolution of width is correct for ::before and ::after pseudo-elements (double-colon)");
+
+test(function() {
+  const div = document.getElementById('test');
+  [":bef\\oRE", "::\\000041fter"].forEach(pseudo => {
+    assert_equals(getComputedStyle(div, pseudo).width, "50px");
+  });
+}, "Pseudo-elements can use the full range of CSS syntax");
+
+test(function() {
+  var contents = document.getElementById('contents');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(contents, pseudo).width, "50px");
+  });
+}, "Resolution of width is correct for ::before and ::after pseudo-elements of display: contents elements");
+
+test(function() {
+  var has_no_pseudos = document.body;
+  has_no_pseudos.style.position = "relative";
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(has_no_pseudos, pseudo).position, "static",
+                  "Nonexistent " + pseudo + " pseudo-element shouldn't claim to have " +
+                  "the same style as the originating element");
+    assert_equals(getComputedStyle(has_no_pseudos, pseudo).width, "auto",
+                  "Nonexistent " + pseudo + " pseudo-element shouldn't claim to have " +
+                  "definite size");
+  });
+}, "Resolution of nonexistent pseudo-element styles");
+
+test(function() {
+  var none = document.getElementById('none');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(none, pseudo).content, "\"Foo\"",
+                  "Pseudo-styles of display: none elements should be correct");
+  });
+}, "Resolution of pseudo-element styles in display: none elements");
+
+test(function() {
+  var flex = document.getElementById('flex');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(flex, pseudo).display, "block",
+                  "Pseudo-styles of display: flex elements should get blockified");
+  });
+}, "Item-based blockification of pseudo-elements");
+
+test(function() {
+  var flexNoPseudo = document.getElementById('flex-no-pseudo');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(flexNoPseudo, pseudo).display, "block",
+                  "Pseudo-styles of display: flex elements should get blockified");
+  });
+}, "Item-based blockification of nonexistent pseudo-elements");
+
+test(function() {
+  var contentsPseudos = document.getElementById('contents-pseudos');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(contentsPseudos, pseudo).display, "contents",
+                  "display: contents in " + pseudo + " should get reflected on CSSOM");
+    assert_equals(getComputedStyle(contentsPseudos, pseudo).width, "auto",
+                  pseudo + " with display: contents should have no box");
+    assert_equals(getComputedStyle(contentsPseudos, pseudo).position, "absolute",
+                  "display: contents in " + pseudo + " should reflect other non-inherited properties in CSSOM");
+  });
+}, "display: contents on pseudo-elements");
+
+test(function() {
+  var contentsPseudosDynamic = document.getElementById('contents-pseudos-dynamic');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(contentsPseudosDynamic, pseudo).display, "block",
+                  "Check that display for " + pseudo + " is block before change");
+  });
+  contentsPseudosDynamic.className = "contents";
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(contentsPseudosDynamic, pseudo).display, "contents",
+                  "display: contents in " + pseudo + " should get reflected on CSSOM");
+    assert_equals(getComputedStyle(contentsPseudosDynamic, pseudo).width, "auto",
+                  pseudo + " with display: contents should have no box");
+    assert_equals(getComputedStyle(contentsPseudosDynamic, pseudo).position, "absolute",
+                  "display: contents in " + pseudo + " should reflect other non-inherited properties in CSSOM");
+  });
+}, "Dynamically change to display: contents on pseudo-elements");
+
+test(() => {
+  const div = document.getElementById('test');
+  // Note that these assertions deliberately avoid assert_[not_]equals to
+  // avoid gCS().length in the failure output.
+  assert_true(
+    getComputedStyle(div, "totallynotapseudo").length != 0,
+    "Should return the element's style for unknown pseudo-elements that don't start with a colon");
+  assert_true(
+    getComputedStyle(div, "::totallynotapseudo").length == 0,
+    "Should return an empty style for unknown pseudo-elements starting with double-colon");
+  assert_true(
+    getComputedStyle(div, ":totallynotapseudo").length == 0,
+    "Should return an empty style for unknown pseudo-elements starting with colon");
+}, "Unknown pseudo-elements");
+
+test(() => {
+  const div = document.getElementById('test');
+
+  const style1 = getComputedStyle(div, "totallynotapseudo");
+  assert_throws_dom("NoModificationAllowedError", () => style1.color = "1");
+  assert_throws_dom("NoModificationAllowedError", () => style1.margin = "10px");
+
+  const style2 = getComputedStyle(div, "::totallynotapseudo");
+  assert_throws_dom("NoModificationAllowedError", () => style2.color = "1");
+  assert_throws_dom("NoModificationAllowedError", () => style2.margin = "10px");
+
+  const style3 = getComputedStyle(div, ":totallynotapseudo");
+  assert_throws_dom("NoModificationAllowedError", () => style3.color = "1");
+  assert_throws_dom("NoModificationAllowedError", () => style3.margin = "10px");
+}, "CSSStyleDeclaration is immutable");
+
+// If you add a pseudo-element identifier here, don't forget to add the corresponding style rule in
+// <style> above.
+[
+  "backdrop",
+  "file-selector-button",
+  "grammar-error",
+  "highlight(name)",
+  "marker",
+  "placeholder",
+  "spelling-error",
+  "view-transition",
+  "view-transition-image-pair(name)",
+  "view-transition-group(name)",
+  "view-transition-old(name)",
+  "view-transition-new(name)"
+].forEach(pseudoIdentifier => {
+  test(() => {
+    assert_implements_optional(CSS.supports(`selector(::${pseudoIdentifier})`), `::${pseudoIdentifier}`);
+    const li = document.querySelector('li');
+    assert_true(
+      getComputedStyle(li, `:${pseudoIdentifier}`).length == 0,
+      `Should return an empty style for :${pseudoIdentifier}`);
+    assert_true(
+      getComputedStyle(li, pseudoIdentifier).length != 0,
+      `Should return the element style for ${pseudoIdentifier}`);
+    assert_equals(
+      getComputedStyle(li, pseudoIdentifier).color, "rgb(255, 0, 0)",
+      `Should return the element style for ${pseudoIdentifier}`);
+    assert_equals(
+    getComputedStyle(li, `::${pseudoIdentifier}`).color, "rgb(0, 128, 0)",
+    `Should return the ::${pseudoIdentifier} style`);
+  }, `Unknown pseudo-element with a known identifier: ${pseudoIdentifier}`);
+});
+</script>


### PR DESCRIPTION
This PR adds support for `CSSStyleProperties` having no owner node, and takes advantage of that functionality when calling `getComputedStyle` with an invalid pseudo-element.

Gains us a few more WPT passes, https://wpt.live/css/cssom/getComputedStyle-pseudo.html