### PR TITLE
LibWeb: Update m_inline_style when element style attribute is removed

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3637,20 +3637,13 @@ void Element::attribute_changed(FlyString const& local_name, Optional<String> co
         if (m_class_list)
             m_class_list->associated_attribute_changed(value_or_empty);
     } else if (local_name == HTML::AttributeNames::style) {
-        if (!value.has_value()) {
-            if (m_inline_style) {
-                m_inline_style = nullptr;
-                set_needs_style_update(true);
-            }
-        } else {
-            // https://drafts.csswg.org/cssom/#ref-for-cssstyledeclaration-updating-flag
-            if (m_inline_style && m_inline_style->is_updating())
-                return;
-            if (!m_inline_style)
-                m_inline_style = CSS::CSSStyleProperties::create_element_inline_style({ *this }, {}, {});
-            m_inline_style->set_declarations_from_text(*value);
-            set_needs_style_update(true);
-        }
+        // https://drafts.csswg.org/cssom/#ref-for-cssstyledeclaration-updating-flag
+        if (m_inline_style && m_inline_style->is_updating())
+            return;
+        if (!m_inline_style)
+            m_inline_style = CSS::CSSStyleProperties::create_element_inline_style({ *this }, {}, {});
+        m_inline_style->set_declarations_from_text(value.value_or(""_string));
+        set_needs_style_update(true);
     } else if (local_name == HTML::AttributeNames::dir) {
         // https://html.spec.whatwg.org/multipage/dom.html#attr-dir
         if (value_or_empty.equals_ignoring_ascii_case("ltr"sv))

--- a/Tests/LibWeb/Text/expected/DOM/removeAttribute-style.txt
+++ b/Tests/LibWeb/Text/expected/DOM/removeAttribute-style.txt
@@ -1,0 +1,2 @@
+Before: "color: red;"
+After: ""

--- a/Tests/LibWeb/Text/input/DOM/removeAttribute-style.html
+++ b/Tests/LibWeb/Text/input/DOM/removeAttribute-style.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const el = document.createElement("div");
+        const style = el.style;
+        el.setAttribute("style", "color: red;");
+        println(`Before: "${style.cssText}"`);
+        el.removeAttribute("style");
+        println(`After: "${style.cssText}"`);
+    });
+</script>


### PR DESCRIPTION
Previously we would just throw it away and construct a new (empty) one when required. This doesn't work as any existing references to the old instance will contain out of date information. Now we retain and update the existing instance instead.