### PR TITLE
LibWeb: Throw error on insertRule with disallowed @namespace rule

### DIFF
--- a/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -92,7 +92,9 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
 
     // FIXME: 6. If new rule cannot be inserted into list at the zero-index position index due to constraints specified by CSS, then throw a HierarchyRequestError exception. [CSS21]
 
-    // FIXME: 7. If new rule is an @namespace at-rule, and list contains anything other than @import at-rules, and @namespace at-rules, throw an InvalidStateError exception.
+    // 7. If new rule is an @namespace at-rule, and list contains anything other than @import at-rules, and @namespace at-rules, throw an InvalidStateError exception.
+    if (new_rule->type() == CSSRule::Type::Namespace && any_of(m_rules, [](auto existing_rule) { return existing_rule->type() != CSSRule::Type::Import && existing_rule->type() != CSSRule::Type::Namespace; }))
+        return WebIDL::InvalidStateError::create(realm(), "Cannot insert @namespace rule into a stylesheet with non-namespace/import rules"_string);
 
     // 8. Insert new rule into list at the zero-indexed position index.
     m_rules.insert(index, *new_rule);

--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -258,6 +258,9 @@ Optional<Selector::SimpleSelector::QualifiedName> Parser::parse_selector_qualifi
             ? Selector::SimpleSelector::QualifiedName::NamespaceType::Any
             : Selector::SimpleSelector::QualifiedName::NamespaceType::Named;
 
+        // FIXME: https://www.w3.org/TR/selectors-4/#invalid
+        //        - a simple selector containing an undeclared namespace prefix is invalid
+
         transaction.commit();
         return Selector::SimpleSelector::QualifiedName {
             .namespace_type = namespace_type,

--- a/Tests/LibWeb/Text/expected/css/namespace-rules.txt
+++ b/Tests/LibWeb/Text/expected/css/namespace-rules.txt
@@ -1,0 +1,2 @@
+Can insert namespace rule into sheet with only @namespace and @import rules: PASS
+Cannot insert namespace rule into sheet with existing rules: PASS

--- a/Tests/LibWeb/Text/input/css/namespace-rules.html
+++ b/Tests/LibWeb/Text/input/css/namespace-rules.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<style id="a">
+    @namespace my_namespace_1 url("http://www.w3.org/1999/xhtml");
+    @import url("nonexist.css");
+</style>
+<style id="b">
+    div {
+        color: green;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        try {
+            a.sheet.insertRule('@namespace my_namespace_3 url("http://www.w3.org/1999/xhtml")', 0);
+            println("Can insert namespace rule into sheet with only @namespace and @import rules: PASS");
+        } catch {
+            println("Can insert namespace rule into sheet with only @namespace and @import rules: FAIL");
+        }
+
+        try {
+            s.sheet.insertRule('@namespace my_namespace_3 url("http://www.w3.org/1999/xhtml")', 0);
+            println("Cannot insert namespace rule into sheet with existing rules: FAIL");
+        } catch {
+            println("Cannot insert namespace rule into sheet with existing rules: PASS");
+        }
+    });
+</script>


### PR DESCRIPTION
Resolves a FIXME in `CSSRuleList::insert_a_css_rule`. Gets us a bit closer to passing https://wpt.live/css/cssom/at-namespace.html but that requires more work around parsing of selectors with namespaces (namely disallowing use of undeclared selectors), which I have added a FIXME for.