### PR TITLE
LibWeb/WebIDL: Bring IDL::construct() up to date with the spec

### DIFF
--- a/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -36,7 +36,7 @@ JS::Completion invoke_callback(CallbackType& callback, Optional<JS::Value> this_
 
 GC::Ref<Promise> invoke_promise_callback(CallbackType& callback, Optional<JS::Value> this_argument, ReadonlySpan<JS::Value> args);
 
-JS::Completion construct(CallbackType& callback, ReadonlySpan<JS::Value> args);
+JS::Completion construct(CallbackType& callable, ReadonlySpan<JS::Value> args);
 
 // https://webidl.spec.whatwg.org/#abstract-opdef-integerpart
 double integer_part(double n);


### PR DESCRIPTION
As with a few other functions in this file, this is a combination of the current spec, and a PR that integrates shadow realms.