### PR TITLE
Implement persistence of localStorage using sqlite

### DIFF
--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -917,13 +917,13 @@ struct UnderlyingSource;
 namespace Web::StorageAPI {
 
 class NavigatorStorage;
+class StorageBottle;
+class StorageBucket;
 class StorageManager;
 class StorageShed;
+class StorageShelf;
 
-struct StorageBottle;
-struct StorageBucket;
 struct StorageEndpoint;
-struct StorageShelf;
 
 }
 

--- a/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Libraries/LibWeb/HTML/Storage.cpp
@@ -46,9 +46,6 @@ Storage::Storage(JS::Realm& realm, Type type, GC::Ref<StorageAPI::StorageBottle>
         .named_property_deleter_has_identifier = true,
     };
 
-    for (auto const& item : map())
-        m_stored_bytes += item.key.byte_count() + item.value.byte_count();
-
     all_storages().set(*this);
 }
 
@@ -75,74 +72,46 @@ void Storage::visit_edges(GC::Cell::Visitor& visitor)
 size_t Storage::length() const
 {
     // The length getter steps are to return this's map's size.
-    return map().size();
+    return m_storage_bottle->size();
 }
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-key
 Optional<String> Storage::key(size_t index)
 {
     // 1. If index is greater than or equal to this's map's size, then return null.
-    if (index >= map().size())
+    if (index >= m_storage_bottle->size())
         return {};
 
     // 2. Let keys be the result of running get the keys on this's map.
-    auto keys = map().keys();
+    auto keys = m_storage_bottle->keys();
 
     // 3. Return keys[index].
     return keys[index];
 }
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-getitem
-Optional<String> Storage::get_item(StringView key) const
+Optional<String> Storage::get_item(String const& key) const
 {
     // 1. If this's map[key] does not exist, then return null.
-    auto it = map().find(key);
-    if (it == map().end())
-        return {};
-
     // 2. Return this's map[key].
-    return it->value;
+    return m_storage_bottle->get(key);
 }
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-setitem
 WebIDL::ExceptionOr<void> Storage::set_item(String const& key, String const& value)
 {
-    auto& realm = this->realm();
-
     // 1. Let oldValue be null.
     Optional<String> old_value;
 
     // 2. Let reorder be true.
-    bool reorder = true;
-
     // 3. If this's map[key] exists:
-    auto new_size = m_stored_bytes;
-    if (auto it = map().find(key); it != map().end()) {
-        // 1. Set oldValue to this's map[key].
-        old_value = it->value;
-
-        // 2. If oldValue is value, then return.
-        if (old_value == value)
-            return {};
-
-        // 3. Set reorder to false.
-        reorder = false;
-    } else {
-        new_size += key.bytes().size();
-    }
 
     // 4. If value cannot be stored, then throw a "QuotaExceededError" DOMException exception.
-    new_size += value.bytes().size() - old_value.value_or(String {}).bytes().size();
-    if (m_storage_bottle->quota.has_value() && new_size > *m_storage_bottle->quota)
-        return WebIDL::QuotaExceededError::create(realm, MUST(String::formatted("Unable to store more than {} bytes in storage", *m_storage_bottle->quota)));
-
     // 5. Set this's map[key] to value.
-    map().set(key, value);
-    m_stored_bytes = new_size;
-
-    // 6. If reorder is true, then reorder this.
-    if (reorder)
-        this->reorder();
+    auto error = m_storage_bottle->set(key, value);
+    if (error == WebView::StorageOperationError::QuotaExceededError) {
+        return WebIDL::QuotaExceededError::create(realm(), MUST(String::formatted("Unable to store more than {} bytes in storage", *m_storage_bottle->quota())));
+    }
 
     // 7. Broadcast this with key, oldValue, and value.
     broadcast(key, old_value, value);
@@ -154,16 +123,13 @@ WebIDL::ExceptionOr<void> Storage::set_item(String const& key, String const& val
 void Storage::remove_item(String const& key)
 {
     // 1. If this's map[key] does not exist, then return.
-    auto it = map().find(key);
-    if (it == map().end())
+    // 2. Set oldValue to this's map[key].
+    auto old_value = m_storage_bottle->get(key);
+    if (!old_value.has_value())
         return;
 
-    // 2. Set oldValue to this's map[key].
-    auto old_value = it->value;
-
     // 3. Remove this's map[key].
-    map().remove(it);
-    m_stored_bytes = m_stored_bytes - key.bytes().size() - old_value.bytes().size();
+    m_storage_bottle->remove(key);
 
     // 4. Reorder this.
     reorder();
@@ -176,7 +142,7 @@ void Storage::remove_item(String const& key)
 void Storage::clear()
 {
     // 1. Clear this's map.
-    map().clear();
+    m_storage_bottle->clear();
 
     // 2. Broadcast this with null, null, and null.
     broadcast({}, {}, {});
@@ -253,8 +219,9 @@ Vector<FlyString> Storage::supported_property_names() const
 {
     // The supported property names on a Storage object storage are the result of running get the keys on storage's map.
     Vector<FlyString> names;
-    names.ensure_capacity(map().size());
-    for (auto const& key : map().keys())
+    auto keys = m_storage_bottle->keys();
+    names.ensure_capacity(keys.size());
+    for (auto const& key : keys)
         names.unchecked_append(key);
     return names;
 }
@@ -271,7 +238,7 @@ Optional<JS::Value> Storage::item_value(size_t index) const
 
 JS::Value Storage::named_item_value(FlyString const& name) const
 {
-    auto value = get_item(name);
+    auto value = get_item(String(name));
     if (!value.has_value())
         // AD-HOC: Spec leaves open to a description at: https://html.spec.whatwg.org/multipage/webstorage.html#the-storage-interface
         // However correct behavior expected here: https://github.com/whatwg/html/issues/8684
@@ -302,10 +269,12 @@ WebIDL::ExceptionOr<void> Storage::set_value_of_named_property(String const& key
 
 void Storage::dump() const
 {
-    dbgln("Storage ({} key(s))", map().size());
+    auto keys = m_storage_bottle->keys();
+    dbgln("Storage ({} key(s))", keys.size());
     size_t i = 0;
-    for (auto const& it : map()) {
-        dbgln("[{}] \"{}\": \"{}\"", i, it.key, it.value);
+    for (auto const& key : keys) {
+        auto value = m_storage_bottle->get(key);
+        dbgln("[{}] \"{}\": \"{}\"", i, key, value.value());
         ++i;
     }
 }

--- a/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Libraries/LibWeb/HTML/Storage.cpp
@@ -25,12 +25,12 @@ static HashTable<GC::RawRef<Storage>>& all_storages()
     return storages;
 }
 
-GC::Ref<Storage> Storage::create(JS::Realm& realm, Type type, NonnullRefPtr<StorageAPI::StorageBottle> storage_bottle)
+GC::Ref<Storage> Storage::create(JS::Realm& realm, Type type, GC::Ref<StorageAPI::StorageBottle> storage_bottle)
 {
     return realm.create<Storage>(realm, type, move(storage_bottle));
 }
 
-Storage::Storage(JS::Realm& realm, Type type, NonnullRefPtr<StorageAPI::StorageBottle> storage_bottle)
+Storage::Storage(JS::Realm& realm, Type type, GC::Ref<StorageAPI::StorageBottle> storage_bottle)
     : Bindings::PlatformObject(realm)
     , m_type(type)
     , m_storage_bottle(move(storage_bottle))
@@ -63,6 +63,12 @@ void Storage::initialize(JS::Realm& realm)
 void Storage::finalize()
 {
     all_storages().remove(*this);
+}
+
+void Storage::visit_edges(GC::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_storage_bottle);
 }
 
 // https://html.spec.whatwg.org/multipage/webstorage.html#dom-storage-length

--- a/Libraries/LibWeb/HTML/Storage.h
+++ b/Libraries/LibWeb/HTML/Storage.h
@@ -27,7 +27,7 @@ public:
         Session,
     };
 
-    [[nodiscard]] static GC::Ref<Storage> create(JS::Realm&, Type, NonnullRefPtr<StorageAPI::StorageBottle>);
+    [[nodiscard]] static GC::Ref<Storage> create(JS::Realm&, Type, GC::Ref<StorageAPI::StorageBottle>);
 
     ~Storage();
 
@@ -44,10 +44,11 @@ public:
     void dump() const;
 
 private:
-    Storage(JS::Realm&, Type, NonnullRefPtr<StorageAPI::StorageBottle>);
+    Storage(JS::Realm&, Type, GC::Ref<StorageAPI::StorageBottle>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void finalize() override;
+    virtual void visit_edges(GC::Cell::Visitor&) override;
 
     // ^PlatformObject
     virtual Optional<JS::Value> item_value(size_t index) const override;
@@ -61,7 +62,7 @@ private:
     void broadcast(Optional<String> const& key, Optional<String> const& old_value, Optional<String> const& new_value);
 
     Type m_type {};
-    NonnullRefPtr<StorageAPI::StorageBottle> m_storage_bottle;
+    GC::Ref<StorageAPI::StorageBottle> m_storage_bottle;
     u64 m_stored_bytes { 0 };
 };
 

--- a/Libraries/LibWeb/HTML/Storage.h
+++ b/Libraries/LibWeb/HTML/Storage.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AK/HashMap.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/StorageAPI/StorageBottle.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -33,12 +32,10 @@ public:
 
     size_t length() const;
     Optional<String> key(size_t index);
-    Optional<String> get_item(StringView key) const;
+    Optional<String> get_item(String const& key) const;
     WebIDL::ExceptionOr<void> set_item(String const& key, String const& value);
     void remove_item(String const& key);
     void clear();
-    auto const& map() const { return m_storage_bottle->map; }
-    auto& map() { return m_storage_bottle->map; }
     Type type() const { return m_type; }
 
     void dump() const;
@@ -63,7 +60,6 @@ private:
 
     Type m_type {};
     GC::Ref<StorageAPI::StorageBottle> m_storage_bottle;
-    u64 m_stored_bytes { 0 };
 };
 
 }

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -50,6 +50,7 @@ static RefPtr<Gfx::SkiaBackendContext> get_skia_backend_context()
 
 TraversableNavigable::TraversableNavigable(GC::Ref<Page> page)
     : Navigable(page)
+    , m_storage_shed(StorageAPI::StorageShed::create(page->heap()))
     , m_session_history_traversal_queue(vm().heap().allocate<SessionHistoryTraversalQueue>())
 {
     if (!page->client().is_svg_page_client()) {
@@ -75,6 +76,7 @@ void TraversableNavigable::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_session_history_entries);
     visitor.visit(m_session_history_traversal_queue);
+    visitor.visit(m_storage_shed);
 }
 
 static OrderedHashTable<TraversableNavigable*>& user_agent_top_level_traversable_set()

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -164,7 +164,7 @@ private:
 
     // https://storage.spec.whatwg.org/#traversable-navigable-storage-shed
     // A traversable navigable holds a storage shed, which is a storage shed. A traversable navigable’s storage shed holds all session storage data.
-    StorageAPI::StorageShed m_storage_shed;
+    GC::Ref<StorageAPI::StorageShed> m_storage_shed;
 
     GC::Ref<SessionHistoryTraversalQueue> m_session_history_traversal_queue;
 

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -471,7 +471,7 @@ WebIDL::ExceptionOr<GC::Ref<Storage>> Window::local_storage()
         return WebIDL::SecurityError::create(realm, "localStorage is not available"_string);
 
     // 4. Let storage be a new Storage object whose map is map.
-    auto storage = Storage::create(realm, Storage::Type::Session, map.release_nonnull());
+    auto storage = Storage::create(realm, Storage::Type::Session, *map);
 
     // 5. Set this's associated Document's local storage holder to storage.
     associated_document.set_local_storage_holder(storage);
@@ -498,7 +498,7 @@ WebIDL::ExceptionOr<GC::Ref<Storage>> Window::session_storage()
         return WebIDL::SecurityError::create(realm, "sessionStorage is not available"_string);
 
     // 4. Let storage be a new Storage object whose map is map.
-    auto storage = Storage::create(realm, Storage::Type::Session, map.release_nonnull());
+    auto storage = Storage::create(realm, Storage::Type::Session, *map);
 
     // 5. Set this's associated Document's session storage holder to storage.
     associated_document.set_session_storage_holder(storage);

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -66,6 +66,7 @@
 #include <LibWeb/RequestIdleCallback/IdleDeadline.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/StorageAPI/StorageBottle.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 
 namespace Web::HTML {
@@ -464,7 +465,11 @@ WebIDL::ExceptionOr<GC::Ref<Storage>> Window::local_storage()
         return GC::Ref { *storage };
 
     // 2. Let map be the result of running obtain a local storage bottle map with this's relevant settings object and "localStorage".
-    auto map = StorageAPI::obtain_a_local_storage_bottle_map(relevant_settings_object(*this), "localStorage"sv);
+    GC::Ptr<StorageAPI::LocalStorageBottle> map;
+    auto storage_key = StorageAPI::obtain_a_storage_key(relevant_settings_object(*this));
+    if (storage_key.has_value()) {
+        map = StorageAPI::LocalStorageBottle::create(heap(), page(), storage_key.value(), StorageAPI::StorageEndpoint::LOCAL_STORAGE_QUOTA);
+    }
 
     // 3. If map is failure, then throw a "SecurityError" DOMException.
     if (!map)
@@ -491,7 +496,7 @@ WebIDL::ExceptionOr<GC::Ref<Storage>> Window::session_storage()
         return GC::Ref { *storage };
 
     // 2. Let map be the result of running obtain a session storage bottle map with this's relevant settings object and "sessionStorage".
-    auto map = StorageAPI::obtain_a_session_storage_bottle_map(relevant_settings_object(*this), "sessionStorage"sv);
+    auto map = StorageAPI::obtain_a_session_storage_bottle_map(relevant_settings_object(*this), StorageAPI::StorageEndpointType::SessionStorage);
 
     // 3. If map is failure, then throw a "SecurityError" DOMException.
     if (!map)

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -37,7 +37,9 @@
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWeb/UIEvents/KeyCode.h>
+#include <LibWebView/StorageOperationError.h>
 
 namespace Web {
 
@@ -375,6 +377,11 @@ public:
     virtual void page_did_set_cookie(URL::URL const&, Cookie::ParsedCookie const&, Cookie::Source) { }
     virtual void page_did_update_cookie(Web::Cookie::Cookie const&) { }
     virtual void page_did_expire_cookies_with_time_offset(AK::Duration) { }
+    virtual Optional<String> page_did_request_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key) { return {}; }
+    virtual WebView::StorageOperationError page_did_set_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key, [[maybe_unused]] String const& value) { return WebView::StorageOperationError::None; }
+    virtual void page_did_remove_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key) { }
+    virtual Vector<String> page_did_request_storage_keys([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { return {}; }
+    virtual void page_did_clear_storage([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key) { }
     virtual void page_did_update_resource_count(i32) { }
     struct NewWebViewResult {
         GC::Ptr<Page> page;

--- a/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024-2025, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,16 +14,18 @@
 
 namespace Web::StorageAPI {
 
-GC_DEFINE_ALLOCATOR(StorageBottle);
+GC_DEFINE_ALLOCATOR(LocalStorageBottle);
+GC_DEFINE_ALLOCATOR(SessionStorageBottle);
 GC_DEFINE_ALLOCATOR(StorageBucket);
 
 void StorageBucket::visit_edges(GC::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_bottle_map);
+    for (auto& entry : m_bottle_map)
+        visitor.visit(entry);
 }
 
-StorageBucket::StorageBucket(StorageType type)
+StorageBucket::StorageBucket(GC::Ref<Page> page, StorageKey key, StorageType type)
 {
     // 1. Let bucket be null.
     // 2. If type is "local", then set bucket to a new local storage bucket.
@@ -33,21 +36,23 @@ StorageBucket::StorageBucket(StorageType type)
     // 4. For each endpoint of registered storage endpoints whose types contain type, set bucket’s bottle map[endpoint’s identifier] to a new storage bottle whose quota is endpoint’s quota.
     for (auto const& endpoint : StorageEndpoint::registered_endpoints()) {
         if (endpoint.type == type)
-            m_bottle_map.set(endpoint.identifier, StorageBottle::create(heap(), endpoint.quota));
+            m_bottle_map[to_underlying(endpoint.identifier)] = StorageBottle::create(heap(), page, type, key, endpoint.quota);
     }
 
     // 5. Return bucket.
 }
 
 // https://storage.spec.whatwg.org/#obtain-a-storage-bottle-map
-GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType type, HTML::EnvironmentSettingsObject& environment, StringView identifier)
+GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType type, HTML::EnvironmentSettingsObject& environment, StorageEndpointType endpoint_type)
 {
     // 1. Let shed be null.
-    GC::Ptr<StorageShed> shed = nullptr;
+    GC::Ptr<StorageShed> shed;
 
     // 2. If type is "local", then set shed to the user agent’s storage shed.
     if (type == StorageType::Local) {
-        shed = user_agent_storage_shed(environment.heap());
+        // NOTE: Bottle for local storage is constructed directly, bypassing this function, because
+        //       in that case StorageJar located on browser process side is used as a shed.
+        VERIFY_NOT_REACHED();
     }
     // 3. Otherwise:
     else {
@@ -67,10 +72,10 @@ GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType type, HTML::Envir
         return {};
 
     // 6. Let bucket be shelf’s bucket map["default"].
-    auto& bucket = shelf->bucket_map().get("default"sv).value();
+    auto bucket = shelf->bucket_map().get("default"sv).value();
 
     // 7. Let bottle be bucket’s bottle map[identifier].
-    auto bottle = bucket->bottle_map().get(identifier).value();
+    auto bottle = bucket->bottle_map()[to_underlying(endpoint_type)];
 
     // 8. Let proxyMap be a new storage proxy map whose backing map is bottle’s map.
     // 9. Append proxyMap to bottle’s proxy map reference set.
@@ -79,19 +84,100 @@ GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType type, HTML::Envir
 }
 
 // https://storage.spec.whatwg.org/#obtain-a-session-storage-bottle-map
-GC::Ptr<StorageBottle> obtain_a_session_storage_bottle_map(HTML::EnvironmentSettingsObject& environment, StringView identifier)
+GC::Ptr<StorageBottle> obtain_a_session_storage_bottle_map(HTML::EnvironmentSettingsObject& environment, StorageEndpointType identifier)
 {
     // To obtain a session storage bottle map, given an environment settings object environment and storage identifier identifier,
     // return the result of running obtain a storage bottle map with "session", environment, and identifier.
     return obtain_a_storage_bottle_map(StorageType::Session, environment, identifier);
 }
 
-// https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map
-GC::Ptr<StorageBottle> obtain_a_local_storage_bottle_map(HTML::EnvironmentSettingsObject& environment, StringView identifier)
+GC::Ref<StorageBottle> StorageBottle::create(GC::Heap& heap, GC::Ref<Page> page, StorageType type, StorageKey key, Optional<u64> quota)
 {
-    // To obtain a local storage bottle map, given an environment settings object environment and storage identifier identifier,
-    // return the result of running obtain a storage bottle map with "local", environment, and identifier.
-    return obtain_a_storage_bottle_map(StorageType::Local, environment, identifier);
+    if (type == StorageType::Local)
+        return LocalStorageBottle::create(heap, page, key, quota);
+    return SessionStorageBottle::create(heap, quota);
+}
+
+void LocalStorageBottle::visit_edges(GC::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_page);
+}
+
+size_t LocalStorageBottle::size() const
+{
+    return m_page->client().page_did_request_storage_keys(Web::StorageAPI::StorageEndpointType::LocalStorage, m_storage_key.to_string()).size();
+}
+
+Vector<String> LocalStorageBottle::keys() const
+{
+    return m_page->client().page_did_request_storage_keys(Web::StorageAPI::StorageEndpointType::LocalStorage, m_storage_key.to_string());
+}
+
+Optional<String> LocalStorageBottle::get(String const& key) const
+{
+    return m_page->client().page_did_request_storage_item(Web::StorageAPI::StorageEndpointType::LocalStorage, m_storage_key.to_string(), key);
+}
+
+WebView::StorageOperationError LocalStorageBottle::set(String const& key, String const& value)
+{
+    return m_page->client().page_did_set_storage_item(Web::StorageAPI::StorageEndpointType::LocalStorage, m_storage_key.to_string(), key, value);
+}
+
+void LocalStorageBottle::clear()
+{
+    m_page->client().page_did_clear_storage(Web::StorageAPI::StorageEndpointType::LocalStorage, m_storage_key.to_string());
+}
+
+void LocalStorageBottle::remove(String const& key)
+{
+    m_page->client().page_did_remove_storage_item(Web::StorageAPI::StorageEndpointType::LocalStorage, m_storage_key.to_string(), key);
+}
+
+size_t SessionStorageBottle::size() const
+{
+    return m_map.size();
+}
+
+Vector<String> SessionStorageBottle::keys() const
+{
+    return m_map.keys();
+}
+
+Optional<String> SessionStorageBottle::get(String const& key) const
+{
+    if (auto value = m_map.get(key); value.has_value())
+        return value.value();
+    return OptionalNone {};
+}
+
+WebView::StorageOperationError SessionStorageBottle::set(String const& key, String const& value)
+{
+    if (m_quota.has_value()) {
+        size_t current_size = 0;
+        for (auto const& [existing_key, existing_value] : m_map) {
+            if (existing_key != key) {
+                current_size += existing_key.bytes().size();
+                current_size += existing_value.bytes().size();
+            }
+        }
+        size_t new_size = key.bytes().size() + value.bytes().size();
+        if (current_size + new_size > m_quota.value())
+            return WebView::StorageOperationError::QuotaExceededError;
+    }
+
+    m_map.set(key, value);
+    return WebView::StorageOperationError::None;
+}
+
+void SessionStorageBottle::clear()
+{
+    m_map.clear();
+}
+
+void SessionStorageBottle::remove(String const& key)
+{
+    m_map.remove(key);
 }
 
 }

--- a/Libraries/LibWeb/StorageAPI/StorageBottle.h
+++ b/Libraries/LibWeb/StorageAPI/StorageBottle.h
@@ -14,14 +14,17 @@
 namespace Web::StorageAPI {
 
 // https://storage.spec.whatwg.org/#storage-bottle
-struct StorageBottle : public RefCounted<StorageBottle> {
-    static NonnullRefPtr<StorageBottle> create(Optional<u64> quota) { return adopt_ref(*new StorageBottle(quota)); }
+class StorageBottle : public GC::Cell {
+    GC_CELL(StorageBottle, GC::Cell);
+    GC_DECLARE_ALLOCATOR(StorageBottle);
+
+    static GC::Ref<StorageBottle> create(GC::Heap& heap, Optional<u64> quota) { return heap.allocate<StorageBottle>(quota); }
 
     // A storage bottle has a map, which is initially an empty map
     OrderedHashMap<String, String> map;
 
     // A storage bottle also has a proxy map reference set, which is initially an empty set
-    NonnullRefPtr<StorageBottle> proxy() { return *this; }
+    GC::Ref<StorageBottle> proxy() { return *this; }
 
     // A storage bottle also has a quota, which is null or a number representing a conservative estimate of
     // the total amount of bytes it can hold. Null indicates the lack of a limit.
@@ -34,19 +37,31 @@ private:
     }
 };
 
-using BottleMap = OrderedHashMap<String, NonnullRefPtr<StorageBottle>>;
+using BottleMap = OrderedHashMap<String, GC::Ref<StorageBottle>>;
 
 // https://storage.spec.whatwg.org/#storage-bucket
 // A storage bucket is a place for storage endpoints to store data.
-struct StorageBucket {
+class StorageBucket : public GC::Cell {
+    GC_CELL(StorageBucket, GC::Cell);
+    GC_DECLARE_ALLOCATOR(StorageBucket);
+
+public:
+    static GC::Ref<StorageBucket> create(GC::Heap& heap, StorageType type) { return heap.allocate<StorageBucket>(type); }
+
+    BottleMap& bottle_map() { return m_bottle_map; }
+    BottleMap const& bottle_map() const { return m_bottle_map; }
+
+    virtual void visit_edges(GC::Cell::Visitor& visitor) override;
+
+private:
     explicit StorageBucket(StorageType);
 
     // A storage bucket has a bottle map of storage identifiers to storage bottles.
-    BottleMap bottle_map;
+    BottleMap m_bottle_map;
 };
 
-RefPtr<StorageBottle> obtain_a_session_storage_bottle_map(HTML::EnvironmentSettingsObject&, StringView storage_identifier);
-RefPtr<StorageBottle> obtain_a_local_storage_bottle_map(HTML::EnvironmentSettingsObject&, StringView storage_identifier);
-RefPtr<StorageBottle> obtain_a_storage_bottle_map(StorageType, HTML::EnvironmentSettingsObject&, StringView storage_identifier);
+GC::Ptr<StorageBottle> obtain_a_session_storage_bottle_map(HTML::EnvironmentSettingsObject&, StringView storage_identifier);
+GC::Ptr<StorageBottle> obtain_a_local_storage_bottle_map(HTML::EnvironmentSettingsObject&, StringView storage_identifier);
+GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType, HTML::EnvironmentSettingsObject&, StringView storage_identifier);
 
 }

--- a/Libraries/LibWeb/StorageAPI/StorageBottle.h
+++ b/Libraries/LibWeb/StorageAPI/StorageBottle.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024-2025, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,36 +9,105 @@
 
 #include <AK/HashMap.h>
 #include <AK/String.h>
+#include <LibGC/Ptr.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Page/Page.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
+#include <LibWeb/StorageAPI/StorageKey.h>
 #include <LibWeb/StorageAPI/StorageType.h>
+#include <LibWebView/StorageOperationError.h>
 
 namespace Web::StorageAPI {
 
 // https://storage.spec.whatwg.org/#storage-bottle
 class StorageBottle : public GC::Cell {
     GC_CELL(StorageBottle, GC::Cell);
-    GC_DECLARE_ALLOCATOR(StorageBottle);
 
-    static GC::Ref<StorageBottle> create(GC::Heap& heap, Optional<u64> quota) { return heap.allocate<StorageBottle>(quota); }
+public:
+    static GC::Ref<StorageBottle> create(GC::Heap& heap, GC::Ref<Page> page, StorageType type, StorageKey key, Optional<u64> quota);
 
-    // A storage bottle has a map, which is initially an empty map
-    OrderedHashMap<String, String> map;
+    virtual ~StorageBottle() = default;
 
     // A storage bottle also has a proxy map reference set, which is initially an empty set
     GC::Ref<StorageBottle> proxy() { return *this; }
 
-    // A storage bottle also has a quota, which is null or a number representing a conservative estimate of
-    // the total amount of bytes it can hold. Null indicates the lack of a limit.
-    Optional<u64> quota;
+    virtual size_t size() const = 0;
+    virtual Vector<String> keys() const = 0;
+    virtual Optional<String> get(String const&) const = 0;
+    virtual WebView::StorageOperationError set(String const& key, String const& value) = 0;
+    virtual void clear() = 0;
+    virtual void remove(String const&) = 0;
 
-private:
-    explicit StorageBottle(Optional<u64> quota_)
-        : quota(quota_)
+    Optional<u64> quota() const { return m_quota; }
+
+protected:
+    explicit StorageBottle(Optional<u64> quota)
+        : m_quota(quota)
     {
     }
+
+    Optional<u64> m_quota;
 };
 
-using BottleMap = OrderedHashMap<String, GC::Ref<StorageBottle>>;
+class LocalStorageBottle final : public StorageBottle {
+    GC_CELL(LocalStorageBottle, StorageBottle);
+    GC_DECLARE_ALLOCATOR(LocalStorageBottle);
+
+public:
+    static GC::Ref<LocalStorageBottle> create(GC::Heap& heap, GC::Ref<Page> page, StorageKey key, Optional<u64> quota)
+    {
+        return heap.allocate<LocalStorageBottle>(page, key, quota);
+    }
+
+    virtual size_t size() const override;
+    virtual Vector<String> keys() const override;
+    virtual Optional<String> get(String const&) const override;
+    virtual WebView::StorageOperationError set(String const& key, String const& value) override;
+    virtual void clear() override;
+    virtual void remove(String const&) override;
+
+    virtual void visit_edges(GC::Cell::Visitor& visitor) override;
+
+private:
+    explicit LocalStorageBottle(GC::Ref<Page> page, StorageKey key, Optional<u64> quota)
+        : StorageBottle(quota)
+        , m_page(move(page))
+        , m_storage_key(move(key))
+    {
+    }
+
+    GC::Ref<Page> m_page;
+    StorageKey m_storage_key;
+};
+
+class SessionStorageBottle final : public StorageBottle {
+    GC_CELL(SessionStorageBottle, StorageBottle);
+    GC_DECLARE_ALLOCATOR(SessionStorageBottle);
+
+public:
+    static GC::Ref<SessionStorageBottle> create(GC::Heap& heap, Optional<u64> quota)
+    {
+        return heap.allocate<SessionStorageBottle>(quota);
+    }
+
+    virtual size_t size() const override;
+    virtual Vector<String> keys() const override;
+    virtual Optional<String> get(String const&) const override;
+    virtual WebView::StorageOperationError set(String const& key, String const& value) override;
+    virtual void clear() override;
+    virtual void remove(String const&) override;
+
+private:
+    explicit SessionStorageBottle(Optional<u64> quota)
+        : StorageBottle(quota)
+    {
+    }
+
+    // A storage bottle has a map, which is initially an empty map
+    OrderedHashMap<String, String> m_map;
+};
+
+using BottleMap = Array<GC::Ptr<StorageBottle>, to_underlying(StorageEndpointType::Count)>;
 
 // https://storage.spec.whatwg.org/#storage-bucket
 // A storage bucket is a place for storage endpoints to store data.
@@ -46,7 +116,7 @@ class StorageBucket : public GC::Cell {
     GC_DECLARE_ALLOCATOR(StorageBucket);
 
 public:
-    static GC::Ref<StorageBucket> create(GC::Heap& heap, StorageType type) { return heap.allocate<StorageBucket>(type); }
+    static GC::Ref<StorageBucket> create(GC::Heap& heap, GC::Ref<Page> page, StorageKey key, StorageType type) { return heap.allocate<StorageBucket>(page, key, type); }
 
     BottleMap& bottle_map() { return m_bottle_map; }
     BottleMap const& bottle_map() const { return m_bottle_map; }
@@ -54,14 +124,13 @@ public:
     virtual void visit_edges(GC::Cell::Visitor& visitor) override;
 
 private:
-    explicit StorageBucket(StorageType);
+    explicit StorageBucket(GC::Ref<Page> page, StorageKey key, StorageType type);
 
     // A storage bucket has a bottle map of storage identifiers to storage bottles.
     BottleMap m_bottle_map;
 };
 
-GC::Ptr<StorageBottle> obtain_a_session_storage_bottle_map(HTML::EnvironmentSettingsObject&, StringView storage_identifier);
-GC::Ptr<StorageBottle> obtain_a_local_storage_bottle_map(HTML::EnvironmentSettingsObject&, StringView storage_identifier);
-GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType, HTML::EnvironmentSettingsObject&, StringView storage_identifier);
+GC::Ptr<StorageBottle> obtain_a_session_storage_bottle_map(HTML::EnvironmentSettingsObject&, StorageEndpointType endpoint_type);
+GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType, HTML::EnvironmentSettingsObject&, StorageEndpointType endpoint_type);
 
 }

--- a/Libraries/LibWeb/StorageAPI/StorageEndpoint.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageEndpoint.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024-2025, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,11 +13,11 @@ ReadonlySpan<StorageEndpoint> StorageEndpoint::registered_endpoints()
 {
     // https://storage.spec.whatwg.org/#registered-storage-endpoints
     static auto const endpoints = to_array<StorageEndpoint>({
-        { "caches"_string, StorageType::Local, {} },
-        { "indexedDB"_string, StorageType::Local, {} },
-        { "localStorage"_string, StorageType::Local, 5 * MiB },
-        { "serviceWorkerRegistrations"_string, StorageType::Local, {} },
-        { "sessionStorage"_string, StorageType::Session, 5 * MiB },
+        { StorageEndpointType::Caches, StorageType::Local, {} },
+        { StorageEndpointType::IndexedDB, StorageType::Local, {} },
+        { StorageEndpointType::LocalStorage, StorageType::Local, LOCAL_STORAGE_QUOTA },
+        { StorageEndpointType::ServiceWorkerRegistrations, StorageType::Local, {} },
+        { StorageEndpointType::SessionStorage, StorageType::Session, SESSION_STORAGE_QUOTA },
     });
     return endpoints;
 }

--- a/Libraries/LibWeb/StorageAPI/StorageEndpoint.h
+++ b/Libraries/LibWeb/StorageAPI/StorageEndpoint.h
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2024-2025, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Array.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Types.h>
@@ -14,14 +14,27 @@
 
 namespace Web::StorageAPI {
 
+enum class StorageEndpointType : u8 {
+    Caches = 0,
+    IndexedDB = 1,
+    LocalStorage = 2,
+    ServiceWorkerRegistrations = 3,
+    SessionStorage = 4,
+
+    Count = 5 // This should always be the last value in the enum.
+};
+
 // https://storage.spec.whatwg.org/#storage-endpoint
 //
 // A storage endpoint is a local or session storage API that uses the infrastructure defined by this
 // standard, most notably storage bottles, to keep track of its storage needs.
 struct StorageEndpoint {
+    static constexpr u64 LOCAL_STORAGE_QUOTA = 5 * MiB;
+    static constexpr u64 SESSION_STORAGE_QUOTA = 5 * MiB;
+
     // https://storage.spec.whatwg.org/#storage-endpoint-identifier
     // A storage endpoint has an identifier, which is a storage identifier.
-    String identifier;
+    StorageEndpointType identifier;
 
     // https://storage.spec.whatwg.org/#storage-endpoint-types
     // A storage endpoint also has types, which is a set of storage types.

--- a/Libraries/LibWeb/StorageAPI/StorageKey.h
+++ b/Libraries/LibWeb/StorageAPI/StorageKey.h
@@ -20,6 +20,11 @@ struct StorageKey {
     // NOTE: This is expected to change; see Client-Side Storage Partitioning https://privacycg.github.io/storage-partitioning/.
     URL::Origin origin;
 
+    String to_string() const
+    {
+        return origin.serialize();
+    }
+
     friend bool operator==(StorageKey const& a, StorageKey const& b)
     {
         // To determine whether a storage key A equals storage key B, run these steps:

--- a/Libraries/LibWeb/StorageAPI/StorageShed.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageShed.cpp
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/Heap.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/StorageAPI/StorageShed.h>
 
 namespace Web::StorageAPI {
 
+GC_DEFINE_ALLOCATOR(StorageShed);
+
+void StorageShed::visit_edges(GC::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_data);
+}
+
 // https://storage.spec.whatwg.org/#obtain-a-storage-shelf
-Optional<StorageShelf&> StorageShed::obtain_a_storage_shelf(HTML::EnvironmentSettingsObject const& environment, StorageType type)
+GC::Ptr<StorageShelf> StorageShed::obtain_a_storage_shelf(HTML::EnvironmentSettingsObject const& environment, StorageType type)
 {
     // 1. Let key be the result of running obtain a storage key with environment.
     auto key = obtain_a_storage_key(environment);
@@ -21,18 +30,18 @@ Optional<StorageShelf&> StorageShed::obtain_a_storage_shelf(HTML::EnvironmentSet
 
     // 3. If shed[key] does not exist, then set shed[key] to the result of running create a storage shelf with type.
     // 4. Return shed[key].
-    return m_data.ensure(key.value(), [type] {
-        return StorageShelf { type };
+    return m_data.ensure(key.value(), [type, &heap = this->heap()] {
+        return StorageShelf::create(heap, type);
     });
 }
 
 // https://storage.spec.whatwg.org/#user-agent-storage-shed
-StorageShed& user_agent_storage_shed()
+GC::Ref<StorageShed> user_agent_storage_shed(GC::Heap& heap)
 {
     // A user agent holds a storage shed, which is a storage shed. A user agent’s storage shed holds all local storage data.
     // FIXME: Storing this statically in memory is not the correct place or way of doing this!
-    static StorageShed storage_shed;
-    return storage_shed;
+    static GC::Root<StorageShed> storage_shed = GC::make_root(StorageShed::create(heap));
+    return *storage_shed;
 }
 
 }

--- a/Libraries/LibWeb/StorageAPI/StorageShed.h
+++ b/Libraries/LibWeb/StorageAPI/StorageShed.h
@@ -24,7 +24,7 @@ class StorageShed : public GC::Cell {
 public:
     static GC::Ref<StorageShed> create(GC::Heap& heap) { return heap.allocate<StorageShed>(); }
 
-    GC::Ptr<StorageShelf> obtain_a_storage_shelf(HTML::EnvironmentSettingsObject const&, StorageType);
+    GC::Ptr<StorageShelf> obtain_a_storage_shelf(HTML::EnvironmentSettingsObject&, StorageType);
 
     virtual void visit_edges(GC::Cell::Visitor& visitor) override;
 
@@ -33,7 +33,5 @@ private:
 
     OrderedHashMap<StorageKey, GC::Ref<StorageShelf>> m_data;
 };
-
-GC::Ref<StorageShed> user_agent_storage_shed(GC::Heap&);
 
 }

--- a/Libraries/LibWeb/StorageAPI/StorageShed.h
+++ b/Libraries/LibWeb/StorageAPI/StorageShed.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
+#include <LibGC/Ptr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/StorageAPI/StorageKey.h>
 #include <LibWeb/StorageAPI/StorageShelf.h>
@@ -16,14 +17,23 @@ namespace Web::StorageAPI {
 
 // https://storage.spec.whatwg.org/#storage-shed
 // A storage shed is a map of storage keys to storage shelves. It is initially empty.
-class StorageShed {
+class StorageShed : public GC::Cell {
+    GC_CELL(StorageShed, GC::Cell);
+    GC_DECLARE_ALLOCATOR(StorageShed);
+
 public:
-    Optional<StorageShelf&> obtain_a_storage_shelf(HTML::EnvironmentSettingsObject const&, StorageType);
+    static GC::Ref<StorageShed> create(GC::Heap& heap) { return heap.allocate<StorageShed>(); }
+
+    GC::Ptr<StorageShelf> obtain_a_storage_shelf(HTML::EnvironmentSettingsObject const&, StorageType);
+
+    virtual void visit_edges(GC::Cell::Visitor& visitor) override;
 
 private:
-    OrderedHashMap<StorageKey, StorageShelf> m_data;
+    StorageShed() = default;
+
+    OrderedHashMap<StorageKey, GC::Ref<StorageShelf>> m_data;
 };
 
-StorageShed& user_agent_storage_shed();
+GC::Ref<StorageShed> user_agent_storage_shed(GC::Heap&);
 
 }

--- a/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
@@ -4,16 +4,25 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/Heap.h>
 #include <LibWeb/StorageAPI/StorageShelf.h>
 
 namespace Web::StorageAPI {
+
+GC_DEFINE_ALLOCATOR(StorageShelf);
+
+void StorageShelf::visit_edges(GC::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_bucket_map);
+}
 
 // https://storage.spec.whatwg.org/#create-a-storage-shelf
 StorageShelf::StorageShelf(StorageType type)
 {
     // 1. Let shelf be a new storage shelf.
     // 2. Set shelf’s bucket map["default"] to the result of running create a storage bucket with type.
-    bucket_map.set("default"_string, StorageBucket { type });
+    m_bucket_map.set("default"_string, StorageBucket::create(heap(), type));
     // 3. Return shelf.
 }
 

--- a/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageShelf.cpp
@@ -18,11 +18,11 @@ void StorageShelf::visit_edges(GC::Cell::Visitor& visitor)
 }
 
 // https://storage.spec.whatwg.org/#create-a-storage-shelf
-StorageShelf::StorageShelf(StorageType type)
+StorageShelf::StorageShelf(GC::Ref<Page> page, StorageKey key, StorageType type)
 {
     // 1. Let shelf be a new storage shelf.
     // 2. Set shelf’s bucket map["default"] to the result of running create a storage bucket with type.
-    m_bucket_map.set("default"_string, StorageBucket::create(heap(), type));
+    m_bucket_map.set("default"_string, StorageBucket::create(heap(), page, key, type));
     // 3. Return shelf.
 }
 

--- a/Libraries/LibWeb/StorageAPI/StorageShelf.h
+++ b/Libraries/LibWeb/StorageAPI/StorageShelf.h
@@ -23,7 +23,7 @@ class StorageShelf : public GC::Cell {
     GC_DECLARE_ALLOCATOR(StorageShelf);
 
 public:
-    static GC::Ref<StorageShelf> create(GC::Heap& heap, StorageType type) { return heap.allocate<StorageShelf>(type); }
+    static GC::Ref<StorageShelf> create(GC::Heap& heap, GC::Ref<Page> page, StorageKey key, StorageType type) { return heap.allocate<StorageShelf>(page, key, type); }
 
     BucketMap& bucket_map() { return m_bucket_map; }
     BucketMap const& bucket_map() const { return m_bucket_map; }
@@ -31,7 +31,7 @@ public:
     virtual void visit_edges(GC::Cell::Visitor& visitor) override;
 
 private:
-    explicit StorageShelf(StorageType);
+    explicit StorageShelf(GC::Ref<Page>, StorageKey, StorageType);
 
     BucketMap m_bucket_map;
 };

--- a/Libraries/LibWeb/StorageAPI/StorageShelf.h
+++ b/Libraries/LibWeb/StorageAPI/StorageShelf.h
@@ -8,7 +8,7 @@
 
 #include <AK/HashMap.h>
 #include <AK/String.h>
-#include <LibWeb/Forward.h>
+#include <LibGC/Ptr.h>
 #include <LibWeb/StorageAPI/StorageBottle.h>
 #include <LibWeb/StorageAPI/StorageType.h>
 
@@ -16,12 +16,24 @@ namespace Web::StorageAPI {
 
 // https://storage.spec.whatwg.org/#storage-shelf
 // A storage shelf exists for each storage key within a storage shed. It holds a bucket map, which is a map of strings to storage buckets.
-using BucketMap = OrderedHashMap<String, StorageBucket>;
+using BucketMap = OrderedHashMap<String, GC::Ref<StorageBucket>>;
 
-struct StorageShelf {
+class StorageShelf : public GC::Cell {
+    GC_CELL(StorageShelf, GC::Cell);
+    GC_DECLARE_ALLOCATOR(StorageShelf);
+
+public:
+    static GC::Ref<StorageShelf> create(GC::Heap& heap, StorageType type) { return heap.allocate<StorageShelf>(type); }
+
+    BucketMap& bucket_map() { return m_bucket_map; }
+    BucketMap const& bucket_map() const { return m_bucket_map; }
+
+    virtual void visit_edges(GC::Cell::Visitor& visitor) override;
+
+private:
     explicit StorageShelf(StorageType);
 
-    BucketMap bucket_map;
+    BucketMap m_bucket_map;
 };
 
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -326,8 +326,10 @@ ErrorOr<void> Application::launch_services()
     if (m_browser_options.disable_sql_database == DisableSQLDatabase::No) {
         m_database = Database::create().release_value_but_fixme_should_propagate_errors();
         m_cookie_jar = CookieJar::create(*m_database).release_value_but_fixme_should_propagate_errors();
+        m_storage_jar = StorageJar::create(*m_database).release_value_but_fixme_should_propagate_errors();
     } else {
         m_cookie_jar = CookieJar::create();
+        m_storage_jar = StorageJar::create();
     }
 
     // No need to monitor the system time zone if the TZ environment variable is set, as it overrides system preferences.

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -22,6 +22,7 @@
 #include <LibWebView/Process.h>
 #include <LibWebView/ProcessManager.h>
 #include <LibWebView/Settings.h>
+#include <LibWebView/StorageJar.h>
 
 namespace WebView {
 
@@ -46,6 +47,7 @@ public:
     static ImageDecoderClient::Client& image_decoder_client() { return *the().m_image_decoder_client; }
 
     static CookieJar& cookie_jar() { return *the().m_cookie_jar; }
+    static StorageJar& storage_jar() { return *the().m_storage_jar; }
 
     static ProcessManager& process_manager() { return *the().m_process_manager; }
 
@@ -138,6 +140,7 @@ private:
 
     RefPtr<Database> m_database;
     OwnPtr<CookieJar> m_cookie_jar;
+    OwnPtr<StorageJar> m_storage_jar;
 
     OwnPtr<Core::TimeZoneWatcher> m_time_zone_watcher;
 

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     Settings.cpp
     SiteIsolation.cpp
     SourceHighlighter.cpp
+    StorageJar.cpp
     URL.cpp
     UserAgent.cpp
     Utilities.cpp

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NonnullOwnPtr.h>
+#include <AK/StdLibExtras.h>
+#include <LibWebView/StorageJar.h>
+
+namespace WebView {
+
+// Quota size is specified in https://storage.spec.whatwg.org/#registered-storage-endpoints
+static constexpr size_t LOCAL_STORAGE_QUOTA = 5 * MiB;
+
+ErrorOr<NonnullOwnPtr<StorageJar>> StorageJar::create(Database& database)
+{
+    Statements statements {};
+
+    auto create_table = TRY(database.prepare_statement(R"#(
+        CREATE TABLE IF NOT EXISTS WebStorage (
+            storage_endpoint INTEGER,
+            storage_key TEXT,
+            bottle_key TEXT,
+            bottle_value TEXT,
+            PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
+        );)#"sv));
+    database.execute_statement(create_table, {});
+
+    statements.set_item = TRY(database.prepare_statement("INSERT OR REPLACE INTO WebStorage VALUES (?, ?, ?, ?);"sv));
+    statements.delete_item = TRY(database.prepare_statement("DELETE FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key = ?;"sv));
+    statements.get_item = TRY(database.prepare_statement("SELECT bottle_value FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key = ?;"sv));
+    statements.clear = TRY(database.prepare_statement("DELETE FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ?;"sv));
+    statements.get_keys = TRY(database.prepare_statement("SELECT bottle_key FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ?;"sv));
+    statements.calculate_size_excluding_key = TRY(database.prepare_statement("SELECT SUM(LENGTH(bottle_key) + LENGTH(bottle_value)) FROM WebStorage WHERE storage_endpoint = ? AND storage_key = ? AND bottle_key != ?;"sv));
+
+    return adopt_own(*new StorageJar { PersistedStorage { database, statements } });
+}
+
+NonnullOwnPtr<StorageJar> StorageJar::create()
+{
+    return adopt_own(*new StorageJar { OptionalNone {} });
+}
+
+StorageJar::StorageJar(Optional<PersistedStorage> persisted_storage)
+    : m_persisted_storage(move(persisted_storage))
+{
+}
+
+StorageJar::~StorageJar() = default;
+
+Optional<String> StorageJar::get_item(StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key)
+{
+    StorageLocation storage_location { storage_endpoint, storage_key, bottle_key };
+    if (m_persisted_storage.has_value())
+        return m_persisted_storage->get_item(storage_location);
+    return m_transient_storage.get_item(storage_location);
+}
+
+StorageOperationError StorageJar::set_item(StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key, String const& bottle_value)
+{
+    StorageLocation storage_location { storage_endpoint, storage_key, bottle_key };
+    if (m_persisted_storage.has_value())
+        return m_persisted_storage->set_item(storage_location, bottle_value);
+    return m_transient_storage.set_item(storage_location, bottle_value);
+}
+
+void StorageJar::remove_item(StorageEndpointType storage_endpoint, String const& storage_key, String const& key)
+{
+    StorageLocation storage_location { storage_endpoint, storage_key, key };
+    if (m_persisted_storage.has_value()) {
+        m_persisted_storage->delete_item(storage_location);
+    } else {
+        m_transient_storage.delete_item(storage_location);
+    }
+}
+
+void StorageJar::clear_storage_key(StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    if (m_persisted_storage.has_value()) {
+        m_persisted_storage->clear(storage_endpoint, storage_key);
+    } else {
+        m_transient_storage.clear(storage_endpoint, storage_key);
+    }
+}
+
+Vector<String> StorageJar::get_all_keys(StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    if (m_persisted_storage.has_value())
+        return m_persisted_storage->get_keys(storage_endpoint, storage_key);
+    return m_transient_storage.get_keys(storage_endpoint, storage_key);
+}
+
+StorageOperationError StorageJar::PersistedStorage::set_item(StorageLocation const& key, String const& value)
+{
+    size_t current_size = 0;
+    database.execute_statement(
+        statements.calculate_size_excluding_key,
+        [&](auto statement_id) {
+            current_size = database.result_column<int>(statement_id, 0);
+        },
+        static_cast<int>(to_underlying(key.storage_endpoint)),
+        key.storage_key,
+        key.bottle_key);
+
+    auto new_size = key.bottle_key.bytes().size() + value.bytes().size();
+    if (current_size + new_size > LOCAL_STORAGE_QUOTA) {
+        return StorageOperationError::QuotaExceededError;
+    }
+
+    database.execute_statement(
+        statements.set_item,
+        {},
+        static_cast<int>(to_underlying(key.storage_endpoint)),
+        key.storage_key,
+        key.bottle_key,
+        value);
+
+    return StorageOperationError::None;
+}
+
+void StorageJar::PersistedStorage::delete_item(StorageLocation const& key)
+{
+    database.execute_statement(
+        statements.delete_item,
+        {},
+        static_cast<int>(to_underlying(key.storage_endpoint)),
+        key.storage_key,
+        key.bottle_key);
+}
+
+Optional<String> StorageJar::PersistedStorage::get_item(StorageLocation const& key)
+{
+    Optional<String> result;
+    database.execute_statement(
+        statements.get_item,
+        [&](auto statement_id) {
+            result = database.result_column<String>(statement_id, 0);
+        },
+        static_cast<int>(to_underlying(key.storage_endpoint)),
+        key.storage_key,
+        key.bottle_key);
+    return result;
+}
+
+void StorageJar::PersistedStorage::clear(StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    database.execute_statement(
+        statements.clear,
+        {},
+        static_cast<int>(to_underlying(storage_endpoint)),
+        storage_key);
+}
+
+Vector<String> StorageJar::PersistedStorage::get_keys(StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    Vector<String> keys;
+    database.execute_statement(
+        statements.get_keys,
+        [&](auto statement_id) {
+            keys.append(database.result_column<String>(statement_id, 0));
+        },
+        static_cast<int>(to_underlying(storage_endpoint)),
+        storage_key);
+    return keys;
+}
+
+StorageOperationError StorageJar::TransientStorage::set_item(StorageLocation const& key, String const& value)
+{
+    u64 current_size = 0;
+    for (auto const& [existing_key, existing_value] : m_storage_items) {
+        if (existing_key.storage_endpoint == key.storage_endpoint && existing_key.storage_key == key.storage_key && existing_key.bottle_key != key.bottle_key) {
+            current_size += existing_key.bottle_key.bytes().size();
+            current_size += existing_value.bytes().size();
+        }
+    }
+
+    auto new_size = key.bottle_key.bytes().size() + value.bytes().size();
+    if (current_size + new_size > LOCAL_STORAGE_QUOTA) {
+        return StorageOperationError::QuotaExceededError;
+    }
+
+    m_storage_items.set(key, value);
+    return StorageOperationError::None;
+}
+
+Optional<String> StorageJar::TransientStorage::get_item(StorageLocation const& key)
+{
+    if (auto value = m_storage_items.get(key); value.has_value())
+        return value.value();
+    return OptionalNone {};
+}
+
+void StorageJar::TransientStorage::delete_item(StorageLocation const& key)
+{
+    m_storage_items.remove(key);
+}
+
+void StorageJar::TransientStorage::clear(StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    Vector<StorageLocation> keys_to_remove;
+    for (auto const& [key, value] : m_storage_items) {
+        if (key.storage_endpoint == storage_endpoint && key.storage_key == storage_key)
+            keys_to_remove.append(key);
+    }
+
+    for (auto const& key : keys_to_remove) {
+        m_storage_items.remove(key);
+    }
+}
+
+Vector<String> StorageJar::TransientStorage::get_keys(StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    Vector<String> keys;
+    for (auto const& [key, value] : m_storage_items) {
+        if (key.storage_endpoint == storage_endpoint && key.storage_key == storage_key)
+            keys.append(key.bottle_key);
+    }
+    return keys;
+}
+
+}

--- a/Libraries/LibWebView/StorageJar.h
+++ b/Libraries/LibWebView/StorageJar.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <AK/Traits.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
+#include <LibWebView/Database.h>
+#include <LibWebView/Forward.h>
+#include <LibWebView/StorageOperationError.h>
+
+namespace WebView {
+
+using StorageEndpointType = Web::StorageAPI::StorageEndpointType;
+
+struct StorageLocation {
+    bool operator==(StorageLocation const&) const = default;
+
+    StorageEndpointType storage_endpoint;
+    String storage_key;
+    String bottle_key;
+};
+
+class StorageJar {
+    AK_MAKE_NONCOPYABLE(StorageJar);
+    AK_MAKE_NONMOVABLE(StorageJar);
+
+public:
+    static ErrorOr<NonnullOwnPtr<StorageJar>> create(Database&);
+    static NonnullOwnPtr<StorageJar> create();
+
+    ~StorageJar();
+
+    Optional<String> get_item(StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key);
+    StorageOperationError set_item(StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key, String const& bottle_value);
+    void remove_item(StorageEndpointType storage_endpoint, String const& storage_key, String const& key);
+    void clear_storage_key(StorageEndpointType storage_endpoint, String const& storage_key);
+    Vector<String> get_all_keys(StorageEndpointType storage_endpoint, String const& storage_key);
+
+private:
+    struct Statements {
+        Database::StatementID set_item { 0 };
+        Database::StatementID delete_item { 0 };
+        Database::StatementID get_item { 0 };
+        Database::StatementID clear { 0 };
+        Database::StatementID get_keys { 0 };
+        Database::StatementID calculate_size_excluding_key { 0 };
+    };
+
+    class TransientStorage {
+    public:
+        StorageOperationError set_item(StorageLocation const& key, String const& value);
+        Optional<String> get_item(StorageLocation const& key);
+        void delete_item(StorageLocation const& key);
+        void clear(StorageEndpointType storage_endpoint, String const& storage_key);
+        Vector<String> get_keys(StorageEndpointType storage_endpoint, String const& storage_key);
+
+    private:
+        HashMap<StorageLocation, String> m_storage_items;
+    };
+
+    struct PersistedStorage {
+        StorageOperationError set_item(StorageLocation const& key, String const& value);
+        Optional<String> get_item(StorageLocation const& key);
+        void delete_item(StorageLocation const& key);
+        void clear(StorageEndpointType storage_endpoint, String const& storage_key);
+        Vector<String> get_keys(StorageEndpointType storage_endpoint, String const& storage_key);
+
+        Database& database;
+        Statements statements;
+    };
+
+    explicit StorageJar(Optional<PersistedStorage>);
+
+    Optional<PersistedStorage> m_persisted_storage;
+    TransientStorage m_transient_storage;
+};
+
+}
+
+template<>
+struct AK::Traits<WebView::StorageLocation> : public AK::DefaultTraits<WebView::StorageLocation> {
+    static unsigned hash(WebView::StorageLocation const& key)
+    {
+        unsigned hash = 0;
+        hash = pair_int_hash(hash, to_underlying(key.storage_endpoint));
+        hash = pair_int_hash(hash, key.storage_key.hash());
+        hash = pair_int_hash(hash, key.bottle_key.hash());
+        return hash;
+    }
+};

--- a/Libraries/LibWebView/StorageOperationError.h
+++ b/Libraries/LibWebView/StorageOperationError.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace WebView {
+
+enum class StorageOperationError : u8 {
+    None,
+    QuotaExceededError,
+};
+
+}

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -505,6 +505,31 @@ void WebContentClient::did_expire_cookies_with_time_offset(AK::Duration offset)
     Application::cookie_jar().expire_cookies_with_time_offset(offset);
 }
 
+Messages::WebContentClient::DidRequestStorageItemResponse WebContentClient::did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key)
+{
+    return Application::storage_jar().get_item(storage_endpoint, storage_key, bottle_key);
+}
+
+Messages::WebContentClient::DidSetStorageItemResponse WebContentClient::did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value)
+{
+    return Application::storage_jar().set_item(storage_endpoint, storage_key, bottle_key, value);
+}
+
+void WebContentClient::did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key)
+{
+    Application::storage_jar().remove_item(storage_endpoint, storage_key, bottle_key);
+}
+
+Messages::WebContentClient::DidRequestStorageKeysResponse WebContentClient::did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key)
+{
+    return Application::storage_jar().get_all_keys(storage_endpoint, storage_key);
+}
+
+void WebContentClient::did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key)
+{
+    Application::storage_jar().clear_storage_key(storage_endpoint, storage_key);
+}
+
 Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -17,6 +17,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/Page/EventResult.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
@@ -106,6 +107,11 @@ private:
     virtual void did_set_cookie(URL::URL, Web::Cookie::ParsedCookie, Web::Cookie::Source) override;
     virtual void did_update_cookie(Web::Cookie::Cookie) override;
     virtual void did_expire_cookies_with_time_offset(AK::Duration) override;
+    virtual Messages::WebContentClient::DidRequestStorageItemResponse did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) override;
+    virtual Messages::WebContentClient::DidSetStorageItemResponse did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value) override;
+    virtual void did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) override;
+    virtual Messages::WebContentClient::DidRequestStorageKeysResponse did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
+    virtual void did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) override;
     virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<u64> page_index) override;
     virtual void did_request_activate_tab(u64 page_id) override;
     virtual void did_close_browsing_context(u64 page_id) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1152,28 +1152,6 @@ void ConnectionFromClient::did_update_window_rect(u64 page_id)
         page->page().did_update_window_rect();
 }
 
-Messages::WebContentServer::GetLocalStorageEntriesResponse ConnectionFromClient::get_local_storage_entries(u64 page_id)
-{
-    auto page = this->page(page_id);
-    if (!page.has_value())
-        return OrderedHashMap<String, String> {};
-
-    auto* document = page->page().top_level_browsing_context().active_document();
-    auto local_storage = document->window()->local_storage().release_value_but_fixme_should_propagate_errors();
-    return local_storage->map();
-}
-
-Messages::WebContentServer::GetSessionStorageEntriesResponse ConnectionFromClient::get_session_storage_entries(u64 page_id)
-{
-    auto page = this->page(page_id);
-    if (!page.has_value())
-        return OrderedHashMap<String, String> {};
-
-    auto* document = page->page().top_level_browsing_context().active_document();
-    auto session_storage = document->window()->session_storage().release_value_but_fixme_should_propagate_errors();
-    return session_storage->map();
-}
-
 void ConnectionFromClient::handle_file_return(u64, i32 error, Optional<IPC::File> file, i32 request_id)
 {
     auto file_request = m_requested_files.take(request_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -145,9 +145,6 @@ private:
 
     virtual void request_internal_page_info(u64 page_id, WebView::PageInfoType) override;
 
-    virtual Messages::WebContentServer::GetLocalStorageEntriesResponse get_local_storage_entries(u64 page_id) override;
-    virtual Messages::WebContentServer::GetSessionStorageEntriesResponse get_session_storage_entries(u64 page_id) override;
-
     virtual Messages::WebContentServer::GetSelectedTextResponse get_selected_text(u64 page_id) override;
     virtual void select_all(u64 page_id) override;
 

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -578,6 +578,54 @@ void PageClient::page_did_expire_cookies_with_time_offset(AK::Duration offset)
     client().async_did_expire_cookies_with_time_offset(offset);
 }
 
+Optional<String> PageClient::page_did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key)
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestStorageItem>(storage_endpoint, storage_key, bottle_key);
+    if (!response) {
+        dbgln("WebContent client disconnected during DidRequestStorageItem. Exiting peacefully.");
+        exit(0);
+    }
+    return response->take_value();
+}
+
+WebView::StorageOperationError PageClient::page_did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key, String const& value)
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidSetStorageItem>(storage_endpoint, storage_key, bottle_key, value);
+    if (!response) {
+        dbgln("WebContent client disconnected during DidSetStorageItem. Exiting peacefully.");
+        exit(0);
+    }
+    return response->error();
+}
+
+void PageClient::page_did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key)
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRemoveStorageItem>(storage_endpoint, storage_key, bottle_key);
+    if (!response) {
+        dbgln("WebContent client disconnected during DidRemoveStorageItem. Exiting peacefully.");
+        exit(0);
+    }
+}
+
+Vector<String> PageClient::page_did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestStorageKeys>(storage_endpoint, storage_key);
+    if (!response) {
+        dbgln("WebContent client disconnected during DidRequestStorageKeys. Exiting peacefully.");
+        exit(0);
+    }
+    return response->take_keys();
+}
+
+void PageClient::page_did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key)
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidClearStorage>(storage_endpoint, storage_key);
+    if (!response) {
+        dbgln("WebContent client disconnected during DidClearStorage. Exiting peacefully.");
+        exit(0);
+    }
+}
+
 void PageClient::page_did_update_resource_count(i32 count_waiting)
 {
     client().async_did_update_resource_count(m_id, count_waiting);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -14,7 +14,9 @@
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWebView/Forward.h>
+#include <LibWebView/StorageOperationError.h>
 #include <WebContent/BackingStoreManager.h>
 #include <WebContent/Forward.h>
 
@@ -156,6 +158,11 @@ private:
     virtual void page_did_set_cookie(URL::URL const&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override;
     virtual void page_did_update_cookie(Web::Cookie::Cookie const&) override;
     virtual void page_did_expire_cookies_with_time_offset(AK::Duration) override;
+    virtual Optional<String> page_did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key) override;
+    virtual WebView::StorageOperationError page_did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key, String const& value) override;
+    virtual void page_did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key) override;
+    virtual Vector<String> page_did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
+    virtual void page_did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key) override;
     virtual void page_did_update_resource_count(i32) override;
     virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Web::HTML::TokenizedFeature::NoOpener) override;
     virtual void page_did_request_activate_tab() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -20,6 +20,8 @@
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ConsoleOutput.h>
 #include <LibWebView/DOMNodeProperties.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
+#include <LibWebView/StorageOperationError.h>
 #include <LibWebView/Mutation.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/ProcessHandle.h>
@@ -76,6 +78,11 @@ endpoint WebContentClient
     did_set_cookie(URL::URL url, Web::Cookie::ParsedCookie cookie, Web::Cookie::Source source) => ()
     did_update_cookie(Web::Cookie::Cookie cookie) =|
     did_expire_cookies_with_time_offset(AK::Duration offset) =|
+    did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) => (Optional<String> value)
+    did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value) => (WebView::StorageOperationError error)
+    did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) => ()
+    did_request_storage_keys(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => (Vector<String> keys)
+    did_clear_storage(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key) => ()
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
     did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) => (String handle)
     did_request_activate_tab(u64 page_id) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -104,9 +104,6 @@ endpoint WebContentServer
     set_window_size(u64 page_id, Web::DevicePixelSize size) =|
     did_update_window_rect(u64 page_id) =|
 
-    get_local_storage_entries(u64 page_id) => (OrderedHashMap<String, String> entries)
-    get_session_storage_entries(u64 page_id) => (OrderedHashMap<String, String> entries)
-
     handle_file_return(u64 page_id, i32 error, Optional<IPC::File> file, i32 request_id) =|
 
     set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state) =|

--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -59,6 +59,8 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
 void Application::create_platform_options(WebView::BrowserOptions& browser_options, WebView::WebContentOptions& web_content_options)
 {
     browser_options.headless_mode = WebView::HeadlessMode::Test;
+    browser_options.disable_sql_database = WebView::DisableSQLDatabase::Yes;
+
     web_content_options.is_layout_test_mode = WebView::IsLayoutTestMode::Yes;
 
     // Allow window.open() to succeed for tests.


### PR DESCRIPTION
This change follows the pattern of our cookies persistence
implementation: the "browser" process is responsible for interacting
with the sqlite database, and WebContent communicates all storage
operations via IPC.

The new database table uses (storage_endpoint, storage_key, bottle_key)
as the primary key. This design follows concepts from the
https://storage.spec.whatwg.org/ and is intended to support reuse of the
persistence layer for other APIs (e.g., CacheStorage, IndexedDB). For
now, `storage_endpoint` is always "localStorage", `storage_key` is the
website's origin, and `bottle_key` is the name of the localStorage key.