### PR TITLE
Slim down some things that we're currently doing 60 times/sec

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2232,7 +2232,8 @@ void StyleComputer::compute_font(ComputedProperties& style, DOM::Element const* 
 Gfx::Font const& StyleComputer::initial_font() const
 {
     // FIXME: This is not correct.
-    return ComputedProperties::font_fallback(false, false, 12);
+    static auto font = ComputedProperties::font_fallback(false, false, 12);
+    return font;
 }
 
 void StyleComputer::absolutize_values(ComputedProperties& style, GC::Ptr<DOM::Element const> element) const

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -395,6 +395,7 @@ void ViewportPaintable::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(clip_state);
+    visitor.visit(m_paintable_boxes_with_auto_content_visibility);
 }
 
 }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -40,6 +40,9 @@ public:
 
     ScrollState const& scroll_state() const { return m_scroll_state; }
 
+    void set_paintable_boxes_with_auto_content_visibility(Vector<GC::Ref<PaintableBox>> paintable_boxes) { m_paintable_boxes_with_auto_content_visibility = move(paintable_boxes); }
+    ReadonlySpan<GC::Ref<PaintableBox>> paintable_boxes_with_auto_content_visibility() const { return m_paintable_boxes_with_auto_content_visibility; }
+
 private:
     void build_stacking_context_tree();
 
@@ -49,6 +52,8 @@ private:
 
     ScrollState m_scroll_state;
     bool m_needs_to_refresh_scroll_state { true };
+
+    Vector<GC::Ref<PaintableBox>> m_paintable_boxes_with_auto_content_visibility;
 };
 
 }


### PR DESCRIPTION
See individual commits, but basically do a bit of caching to avoid work in `update_the_rendering`