### PR TITLE
LibWebView: Defer creating services until after application init

### DIFF
--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -47,7 +47,7 @@ public:
 
     static CookieJar& cookie_jar() { return *the().m_cookie_jar; }
 
-    static ProcessManager& process_manager() { return the().m_process_manager; }
+    static ProcessManager& process_manager() { return *the().m_process_manager; }
 
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
 
@@ -142,7 +142,7 @@ private:
     OwnPtr<Core::TimeZoneWatcher> m_time_zone_watcher;
 
     OwnPtr<Core::EventLoop> m_event_loop;
-    ProcessManager m_process_manager;
+    OwnPtr<ProcessManager> m_process_manager;
     bool m_in_shutdown { false };
 
 #if defined(AK_OS_MACOS)

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -59,8 +59,8 @@ void Application::create_platform_options(WebView::BrowserOptions&, WebView::Web
 NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
 {
     if (!browser_options().headless_mode.has_value()) {
-        m_application = make<LadybirdQApplication>(arguments());
         Core::EventLoopManager::install(*new WebView::EventLoopManagerQt);
+        m_application = make<LadybirdQApplication>(arguments());
     }
 
     auto event_loop = WebView::Application::create_platform_event_loop();


### PR DESCRIPTION
In particular, we need to defer creating the process manager until after we have decided whether or not to create a UI-specific event loop. If we create the process manager sooner, its event loop signal registration does not work, and we don't handle child processes exiting.

Fixes #5057