### PR TITLE
LibGfx: Disable `tech(variations)` font support for now

### DIFF
--- a/Libraries/LibGfx/Font/FontSupport.cpp
+++ b/Libraries/LibGfx/Font/FontSupport.cpp
@@ -53,7 +53,8 @@ bool font_tech_is_supported(FontTech const font_tech)
 #endif
     case FontTech::Variations:
         // avar, cvar, fvar, gvar, HVAR, MVAR, STAT, and VVAR, supported by HarfBuzz
-        return true;
+        // FIXME: This does not actually seem to work and causes issues with the font weight on https://ladybird.org
+        return false;
     case FontTech::ColorColrv0:
     case FontTech::ColorColrv1:
         // COLR, supported by HarfBuzz

--- a/Tests/LibWeb/Text/expected/HTML/Window-find-selection-code-unit-offset.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-find-selection-code-unit-offset.txt
@@ -1,0 +1,1 @@
+selection: 2 - 8

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-tech.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-face-src-tech.txt
@@ -2,7 +2,8 @@ Harness status: OK
 
 Found 39 tests
 
-39 Pass
+36 Pass
+3 Fail
 Pass	Check that src: url("foo.ttf") is valid
 Pass	Check that src: url("foo.ttf") tech() is invalid
 Pass	Check that src: url("foo.ttf") tech(features-opentype) is valid
@@ -11,12 +12,12 @@ Pass	Check that src: url("foo.ttf") tech(color-COLRv0) is valid
 Pass	Check that src: url("foo.ttf") tech(color-COLRv1) is valid
 Pass	Check that src: url("foo.ttf") tech(color-sbix) is valid
 Pass	Check that src: url("foo.ttf") tech(color-CBDT) is valid
-Pass	Check that src: url("foo.ttf") tech(variations) is valid
+Fail	Check that src: url("foo.ttf") tech(variations) is valid
 Pass	Check that src: url("foo.ttf") tech(palettes) is valid
 Pass	Check that src: url("foo.ttf") tech("features-opentype") is invalid
 Pass	Check that src: url("foo.ttf") tech("color-COLRv0") is invalid
 Pass	Check that src: url("foo.ttf") tech("variations") is invalid
-Pass	Check that src: url("foo.ttf") tech(features-opentype, color-COLRv0, variations, palettes) is valid
+Fail	Check that src: url("foo.ttf") tech(features-opentype, color-COLRv0, variations, palettes) is valid
 Pass	Check that src: url("foo.ttf") tech(features-opentype color-COLRv0 variations palettes) is invalid
 Pass	Check that src: url("foo.ttf") tech(feature-opentype) is invalid
 Pass	Check that src: url("foo.ttf") tech(feature-aat) is invalid
@@ -40,5 +41,5 @@ Pass	Check that src: url("foo.ttf") tech(features-graphite), url("bar.html") is 
 Pass	Check that src: url("foo.ttf") dummy("opentype") tech(variations) is invalid
 Pass	Check that src: url("foo.ttf") dummy("opentype") dummy(variations) is invalid
 Pass	Check that src: url("foo.ttf") format(opentype) tech(features-opentype) dummy(something) is invalid
-Pass	Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid
+Fail	Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid
 Pass	Check that src: url("foo.ttf") tech(color), url("bar.html") is valid


### PR DESCRIPTION
We apparently don't support it in the right way, since it causes the wrong font to display on https://ladybird.org.