### PR TITLE
LibWeb: Remove accidentally added test expectation

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Window-find-selection-code-unit-offset.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-find-selection-code-unit-offset.txt
@@ -1,1 +1,0 @@
-selection: 2 - 8


### PR DESCRIPTION
This was added in 4b6489917be3f442fde9103613682abe109eec4b.