### PR TITLE
LibWeb: Avoid overwriting resolved values in compute_keyframe_values

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1227,6 +1227,11 @@ void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::
                 continue;
             }
 
+            // If the style value is a PendingSubstitutionStyleValue we should skip it to avoid overwriting any value
+            // already set by resolving the relevant shorthand's value.
+            if (style_value->is_pending_substitution())
+                continue;
+
             if (style_value->is_revert() || style_value->is_revert_layer())
                 style_value = computed_properties.property(property_id);
             if (style_value->is_unresolved())


### PR DESCRIPTION
When we have an unresolved value for a shorthand (e.g. `border-style: var(--border-style)`, `keyframe_values` will contain an `UnresolvedStyleValue` for the shorthand and `PendingSubstitutionStyleValue`s for each of it's longhands.

When we come across the shorthand's `UnresolvedStyleValue` we will resolve the value and set all of the relevant longhands.

If the longhand's `PendingSubstitutionStyleValue` was processed after (which isn't always the case as the iteration order depends on a HashMap) would overwrite the correctly resolved longhand.

To avoid this we just skip any `PendingSubstitutionStyleValue`s we come across and rely on the resolution of the shorthand to set those properties.

Resolves a crash @tcl3 was experiencing when adding a new "border-image-repeat" property.

Not quite sure how to go about writing a test for this as we need to know of a case where a longhand appears after it's shorthand when iterating a HashMap, and this could change when adding new properties so would need to be computed at test run time. Any suggestions around that would be appreciated.

