### PR TITLE
LibCore: Ensure we don't replace an already-installed event loop manager

### DIFF
--- a/Libraries/LibCore/EventLoopImplementation.cpp
+++ b/Libraries/LibCore/EventLoopImplementation.cpp
@@ -23,7 +23,7 @@ EventLoopImplementation::EventLoopImplementation()
 
 EventLoopImplementation::~EventLoopImplementation() = default;
 
-static EventLoopManager* s_event_loop_manager;
+static EventLoopManager* s_event_loop_manager = nullptr;
 EventLoopManager& EventLoopManager::the()
 {
     if (!s_event_loop_manager)
@@ -33,6 +33,7 @@ EventLoopManager& EventLoopManager::the()
 
 void EventLoopManager::install(Core::EventLoopManager& manager)
 {
+    VERIFY(!s_event_loop_manager);
     s_event_loop_manager = &manager;
 }
 


### PR DESCRIPTION
Once an event loop manager is installed, we want to be sure we only use that manager in the current process going forward. Mixing event loop implementations can only cause problems.

More to the point, this ensures that we have installed the AppKit or Qt event loop managers before the first time `EventLoopManager::the()` is invoked. Now that we defer this installation until we know whether we are running headlessly, we want to be extra sure that we have done so before any services using the event loop have started.

Meant to make this change in #5061. This assertion would have caught #5057.