### PR TITLE
AK: Use `__is_trivially_destructible` built-in with new enough GCC

### DIFF
--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -521,7 +521,7 @@ template<typename T>
 inline constexpr bool IsDestructible = requires { declval<T>().~T(); };
 
 template<typename T>
-#if defined(AK_COMPILER_CLANG)
+#if __has_builtin(__is_trivially_destructible)
 inline constexpr bool IsTriviallyDestructible = __is_trivially_destructible(T);
 #else
 inline constexpr bool IsTriviallyDestructible = __has_trivial_destructor(T) && IsDestructible<T>;


### PR DESCRIPTION
GCC 16 trunk has started diagnosing calls to `__has_trivial_destructor` if the destructor is inaccessible. At the same time, they added a Clang-compatible `__is_trivially_destructible` built-in trait, so let's just use that.