### PR TITLE
LibWeb/CSS: Treat repeated `text-decoration-line` values as invalid

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -3537,7 +3537,7 @@ RefPtr<CSSStyleValue const> Parser::parse_text_decoration_line_value(TokenStream
                 includes_spelling_or_grammar_error_value = true;
             }
             if (style_values.contains_slow(value))
-                break;
+                return nullptr;
             style_values.append(move(value));
             continue;
         }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-text-decor/parsing/text-decoration-line-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-text-decor/parsing/text-decoration-line-invalid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 14 tests
 
-12 Pass
-2 Fail
+14 Pass
 Pass	e.style['text-decoration-line'] = "auto" should not set the property value
 Pass	e.style['text-decoration-line'] = "null" should not set the property value
 Pass	e.style['text-decoration-line'] = "noone" should not set the property value
@@ -12,9 +11,9 @@ Pass	e.style['text-decoration-line'] = "over-line" should not set the property v
 Pass	e.style['text-decoration-line'] = "linethrough" should not set the property value
 Pass	e.style['text-decoration-line'] = "none underline" should not set the property value
 Pass	e.style['text-decoration-line'] = "none spelling-error" should not set the property value
-Fail	e.style['text-decoration-line'] = "underline underline" should not set the property value
+Pass	e.style['text-decoration-line'] = "underline underline" should not set the property value
 Pass	e.style['text-decoration-line'] = "underline none overline" should not set the property value
-Fail	e.style['text-decoration-line'] = "blink line-through blink" should not set the property value
+Pass	e.style['text-decoration-line'] = "blink line-through blink" should not set the property value
 Pass	e.style['text-decoration-line'] = "spelling-error overline" should not set the property value
 Pass	e.style['text-decoration-line'] = "spelling-error grammar-error" should not set the property value
 Pass	e.style['text-decoration-line'] = "blink underline line-through grammar-error" should not set the property value


### PR DESCRIPTION
Fixes all subtests in `css-text-decor/parsing/text-decoration-line-invalid.html`.