### PR TITLE
LibWeb: Disallow `default` as a keyframe name

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -389,7 +389,7 @@ GC::Ptr<CSSKeyframesRule> Parser::convert_to_keyframes_rule(AtRule const& rule)
         return {};
     }
 
-    if (name_token.is(Token::Type::Ident) && (is_css_wide_keyword(name_token.ident()) || name_token.ident().equals_ignoring_ascii_case("none"sv))) {
+    if (name_token.is(Token::Type::Ident) && (is_css_wide_keyword(name_token.ident()) || name_token.ident().is_one_of_ignoring_ascii_case("none"sv, "default"sv))) {
         dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @keyframes rule name is invalid: {}; discarding.", name_token.ident());
         return {};
     }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/keyframes-name-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/keyframes-name-invalid.txt
@@ -1,0 +1,24 @@
+Harness status: OK
+
+Found 19 tests
+
+19 Pass
+Pass	invalid: @keyframes none { }
+Pass	invalid: @keyframes default { }
+Pass	invalid: @keyframes initial { }
+Pass	invalid: @keyframes inherit { }
+Pass	invalid: @keyframes unset { }
+Pass	invalid: @keyframes revert { }
+Pass	invalid: @keyframes revert-layer { }
+Pass	invalid: @keyframes 12 { }
+Pass	invalid: @keyframes -12 { }
+Pass	invalid: @keyframes 12foo { }
+Pass	invalid: @keyframes foo.bar { }
+Pass	invalid: @keyframes one two { }
+Pass	invalid: @keyframes one, two { }
+Pass	invalid: @keyframes one, initial { }
+Pass	invalid: @keyframes one, inherit { }
+Pass	invalid: @keyframes one, unset { }
+Pass	invalid: @keyframes default, two { }
+Pass	invalid: @keyframes revert, three { }
+Pass	invalid: @keyframes revert-layer, four { }

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/keyframes-name-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/keyframes-name-invalid.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>CSS Animations: parsing @keyframes name with invalid values</title>
+    <link rel="author" title="yisibl(一丝)" href="https://github.com/yisibl"/>
+    <link rel="help" href="https://drafts.csswg.org/css-animations/#typedef-keyframes-name">
+    <meta name="assert" content="@keyframes name supports the full grammar '<custom-ident> | <string>'.">
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+    <div>
+        <main id="main"></main>
+    </div>
+    <script>
+        test_keyframes_name_invalid('none');
+
+        // The CSS-wide keywords are not valid <custom-ident>s. The default keyword is reserved and is also not a valid <custom-ident>.
+        // Spec: https://drafts.csswg.org/css-values-4/#identifier-value
+        test_keyframes_name_invalid('default');
+        test_keyframes_name_invalid('initial');
+        test_keyframes_name_invalid('inherit');
+        test_keyframes_name_invalid('unset');
+        test_keyframes_name_invalid('revert');
+        test_keyframes_name_invalid('revert-layer');
+
+        test_keyframes_name_invalid('12');
+        test_keyframes_name_invalid('-12');
+        test_keyframes_name_invalid('12foo');
+        test_keyframes_name_invalid('foo.bar');
+        test_keyframes_name_invalid('one two');
+        test_keyframes_name_invalid('one, two');
+
+        test_keyframes_name_invalid('one, initial');
+        test_keyframes_name_invalid('one, inherit');
+        test_keyframes_name_invalid('one, unset');
+        test_keyframes_name_invalid('default, two');
+        test_keyframes_name_invalid('revert, three');
+        test_keyframes_name_invalid('revert-layer, four');
+        // TODO: https://bugs.chromium.org/p/chromium/issues/detail?id=1342609
+        // test_keyframes_name_invalid('--foo');
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This fixes 1 WPT subtest :tada::tada::tada: