### PR TITLE
LibWeb: Treat `font-variant` values with unknown keywords as invalid

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -2976,7 +2976,7 @@ RefPtr<CSSStyleValue const> Parser::parse_font_variant(TokenStream<ComponentValu
                 position_value = value.ptr();
                 break;
             default:
-                break;
+                return nullptr;
             }
         }
     }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-variant-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-variant-invalid.txt
@@ -2,14 +2,13 @@ Harness status: OK
 
 Found 21 tests
 
-15 Pass
-6 Fail
-Fail	e.style['font-variant'] = "normal none" should not set the property value
-Fail	e.style['font-variant'] = "none normal" should not set the property value
-Fail	e.style['font-variant'] = "small-caps normal" should not set the property value
-Fail	e.style['font-variant'] = "normal small-caps" should not set the property value
-Fail	e.style['font-variant'] = "small-caps none" should not set the property value
-Fail	e.style['font-variant'] = "none small-caps" should not set the property value
+21 Pass
+Pass	e.style['font-variant'] = "normal none" should not set the property value
+Pass	e.style['font-variant'] = "none normal" should not set the property value
+Pass	e.style['font-variant'] = "small-caps normal" should not set the property value
+Pass	e.style['font-variant'] = "normal small-caps" should not set the property value
+Pass	e.style['font-variant'] = "small-caps none" should not set the property value
+Pass	e.style['font-variant'] = "none small-caps" should not set the property value
 Pass	e.style['font-variant'] = "common-ligatures no-common-ligatures" should not set the property value
 Pass	e.style['font-variant'] = "discretionary-ligatures no-discretionary-ligatures" should not set the property value
 Pass	e.style['font-variant'] = "historical-ligatures no-historical-ligatures" should not set the property value


### PR DESCRIPTION
Fixes 6 WPT subtests.