### PR TITLE
LibWeb+LibURL: Remove the default constructor for URL::Origin

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 
 serenity_lib(LibGfx gfx)
 
-target_link_libraries(LibGfx PRIVATE LibCompress LibCore LibCrypto LibFileSystem LibRIFF LibTextCodec LibIPC LibUnicode LibURL)
+target_link_libraries(LibGfx PRIVATE LibCompress LibCore LibCrypto LibFileSystem LibRIFF LibTextCodec LibIPC LibUnicode)
 
 set(generated_sources TIFFMetadata.h TIFFTagHandler.cpp)
 list(TRANSFORM generated_sources PREPEND "ImageFormats/")

--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -106,7 +106,7 @@ ErrorOr<URL::Origin> decode(Decoder& decoder)
 {
     auto is_opaque = TRY(decoder.decode<bool>());
     if (is_opaque)
-        return URL::Origin {};
+        return URL::Origin::create_opaque();
 
     auto scheme = TRY(decoder.decode<Optional<String>>());
     auto host = TRY(decoder.decode<URL::Host>());

--- a/Libraries/LibURL/Origin.cpp
+++ b/Libraries/LibURL/Origin.cpp
@@ -10,6 +10,12 @@
 
 namespace URL {
 
+// FIXME: This should be generating a unique origin identifer that can be used for equality checks.
+Origin Origin::create_opaque()
+{
+    return Origin {};
+}
+
 // https://html.spec.whatwg.org/multipage/browsers.html#same-site
 bool Origin::is_same_site(Origin const& other) const
 {

--- a/Libraries/LibURL/Origin.h
+++ b/Libraries/LibURL/Origin.h
@@ -15,10 +15,6 @@ namespace URL {
 
 class Origin {
 public:
-    // FIXME: This should be generating a unique origin identifer that can be used for equality checks.
-    //        Probably we should remove the default constructor, and instead expose this as a factory method.
-    Origin() = default;
-
     Origin(Optional<String> const& scheme, Host const& host, Optional<u16> port)
         : m_state(State {
               .scheme = scheme,
@@ -27,6 +23,8 @@ public:
           })
     {
     }
+
+    static Origin create_opaque();
 
     // https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque
     bool is_opaque() const { return !m_state.has_value(); }
@@ -102,6 +100,8 @@ public:
     bool operator==(Origin const& other) const { return is_same_origin(other); }
 
 private:
+    Origin() = default;
+
     struct State {
         Optional<String> scheme;
         Host host;

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -345,14 +345,14 @@ Origin URL::origin() const
 
         // 3. If pathURL is failure, then return a new opaque origin.
         if (!path_url.has_value())
-            return Origin {};
+            return Origin::create_opaque();
 
         // 4. If pathURL’s scheme is "http", "https", or "file", then return pathURL’s origin.
         if (path_url->scheme().is_one_of("http"sv, "https"sv, "file"sv))
             return path_url->origin();
 
         // 5. Return a new opaque origin.
-        return Origin {};
+        return Origin::create_opaque();
     }
 
     // -> "ftp"
@@ -375,7 +375,7 @@ Origin URL::origin() const
 
     // -> Otherwise
     // Return a new opaque origin.
-    return Origin {};
+    return Origin::create_opaque();
 }
 
 bool URL::equals(URL const& other, ExcludeFragment exclude_fragments) const

--- a/Libraries/LibWeb/ContentSecurityPolicy/Policy.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Policy.cpp
@@ -201,7 +201,7 @@ SerializedPolicy Policy::serialize() const
         .directives = move(serialized_directives),
         .disposition = m_disposition,
         .source = m_source,
-        .self_origin = m_self_origin,
+        .self_origin = m_self_origin.value(),
         .pre_parsed_policy_string = m_pre_parsed_policy_string,
     };
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Policy.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Policy.h
@@ -45,7 +45,7 @@ public:
     [[nodiscard]] Vector<GC::Ref<Directives::Directive>> const& directives() const { return m_directives; }
     [[nodiscard]] Disposition disposition() const { return m_disposition; }
     [[nodiscard]] Source source() const { return m_source; }
-    [[nodiscard]] URL::Origin const& self_origin() const { return m_self_origin; }
+    [[nodiscard]] URL::Origin const& self_origin() const { return m_self_origin.value(); }
     [[nodiscard]] String const& pre_parsed_policy_string(Badge<Violation>) const { return m_pre_parsed_policy_string; }
 
     [[nodiscard]] bool contains_directive_with_name(StringView name) const;
@@ -81,7 +81,7 @@ private:
     // Spec Note: This is needed to facilitate the 'self' checks of local scheme documents/workers that have inherited
     //            their policy but have an opaque origin. Most of the time this will simply be the environment settings
     //            object’s origin.
-    URL::Origin m_self_origin;
+    Optional<URL::Origin> m_self_origin;
 
     // This is used for reporting which policy was violated. It's not exactly specified, only linking to an ABNF grammar
     // definition. WebKit and Blink return the original string that was parsed, whereas Firefox seems to try and return

--- a/Libraries/LibWeb/ContentSecurityPolicy/SerializedPolicy.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/SerializedPolicy.cpp
@@ -25,15 +25,13 @@ ErrorOr<void> encode(Encoder& encoder, Web::ContentSecurityPolicy::SerializedPol
 template<>
 ErrorOr<Web::ContentSecurityPolicy::SerializedPolicy> decode(Decoder& decoder)
 {
-    Web::ContentSecurityPolicy::SerializedPolicy serialized_policy {};
-
-    serialized_policy.directives = TRY(decoder.decode<Vector<Web::ContentSecurityPolicy::Directives::SerializedDirective>>());
-    serialized_policy.disposition = TRY(decoder.decode<Web::ContentSecurityPolicy::Policy::Disposition>());
-    serialized_policy.source = TRY(decoder.decode<Web::ContentSecurityPolicy::Policy::Source>());
-    serialized_policy.self_origin = TRY(decoder.decode<URL::Origin>());
-    serialized_policy.pre_parsed_policy_string = TRY(decoder.decode<String>());
-
-    return serialized_policy;
+    return Web::ContentSecurityPolicy::SerializedPolicy {
+        .directives = TRY(decoder.decode<Vector<Web::ContentSecurityPolicy::Directives::SerializedDirective>>()),
+        .disposition = TRY(decoder.decode<Web::ContentSecurityPolicy::Policy::Disposition>()),
+        .source = TRY(decoder.decode<Web::ContentSecurityPolicy::Policy::Source>()),
+        .self_origin = TRY(decoder.decode<URL::Origin>()),
+        .pre_parsed_policy_string = TRY(decoder.decode<String>()),
+    };
 }
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -840,7 +840,7 @@ GC::Ptr<HTML::WindowProxy const> Document::default_view() const
 
 URL::Origin const& Document::origin() const
 {
-    return m_origin;
+    return m_origin.value();
 }
 
 void Document::set_origin(URL::Origin const& origin)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1103,7 +1103,7 @@ private:
     String m_referrer;
 
     // https://dom.spec.whatwg.org/#concept-document-origin
-    URL::Origin m_origin;
+    Optional<URL::Origin> m_origin;
 
     GC::Ptr<HTMLCollection> m_applets;
     GC::Ptr<HTMLCollection> m_anchors;

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -57,21 +57,21 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     //    user involvement: userInvolvement
     auto response = Fetch::Infrastructure::Response::create(vm);
     response->url_list().append(URL::about_error()); // AD-HOC: https://github.com/whatwg/html/issues/9122
-    auto navigation_params = vm.heap().allocate<HTML::NavigationParams>();
-    navigation_params->id = move(navigation_id);
-    navigation_params->navigable = navigable;
-    navigation_params->request = nullptr;
-    navigation_params->response = response;
-    navigation_params->fetch_controller = nullptr;
-    navigation_params->commit_early_hints = nullptr;
-    navigation_params->coop_enforcement_result = move(coop_enforcement_result);
-    navigation_params->reserved_environment = {};
-    navigation_params->origin = move(origin);
-    navigation_params->policy_container = vm.heap().allocate<HTML::PolicyContainer>(vm.heap());
-    navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
-    navigation_params->opener_policy = move(coop);
-    navigation_params->about_base_url = {};
-    navigation_params->user_involvement = user_involvement;
+    auto navigation_params = vm.heap().allocate<HTML::NavigationParams>(
+        move(navigation_id),
+        navigable,
+        nullptr,
+        response,
+        nullptr,
+        nullptr,
+        move(coop_enforcement_result),
+        nullptr,
+        move(origin),
+        vm.heap().allocate<HTML::PolicyContainer>(vm.heap()),
+        HTML::SandboxingFlagSet {},
+        move(coop),
+        OptionalNone {},
+        user_involvement);
 
     // 5. Let document be the result of creating and initializing a Document object given "html", "text/html", and navigationParams.
     auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params).release_value_but_fixme_should_propagate_errors();

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -24,7 +24,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     VERIFY(navigable->active_document());
 
     // 1. Let origin be a new opaque origin.
-    URL::Origin origin {};
+    auto origin = URL::Origin::create_opaque();
 
     // 2. Let coop be a new opener policy.
     auto coop = HTML::OpenerPolicy {};

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -56,12 +56,12 @@ URL::Origin determine_the_origin(Optional<URL::URL const&> url, SandboxingFlagSe
 {
     // 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
     if (has_flag(sandbox_flags, SandboxingFlagSet::SandboxedOrigin)) {
-        return URL::Origin {};
+        return URL::Origin::create_opaque();
     }
 
     // 2. If url is null, then return a new opaque origin.
     if (!url.has_value()) {
-        return URL::Origin {};
+        return URL::Origin::create_opaque();
     }
 
     // 3. If url is about:srcdoc, then:

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -263,26 +263,27 @@ HTMLLinkElement::LinkProcessingOptions HTMLLinkElement::create_link_options()
     auto& document = this->document();
 
     // 2. Let options be a new link processing options with
-    LinkProcessingOptions options;
-    // FIXME: destination                      the result of translating the state of el's as attribute
-    // crossorigin                      the state of el's crossorigin content attribute
-    options.crossorigin = cors_setting_attribute_from_keyword(get_attribute(AttributeNames::crossorigin));
-    // referrer policy                  the state of el's referrerpolicy content attribute
-    options.referrer_policy = ReferrerPolicy::from_string(get_attribute(AttributeNames::referrerpolicy).value_or(""_string)).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
-    // FIXME: source set                       el's source set
-    // base URL                         document's document base URL
-    options.base_url = document.base_url();
-    // origin                           document's origin
-    options.origin = document.origin();
-    // environment                      document's relevant settings object
-    options.environment = &document.relevant_settings_object();
-    // policy container                 document's policy container
-    options.policy_container = document.policy_container();
-    // document                         document
-    options.document = &document;
-    // FIXME: cryptographic nonce metadata     the current value of el's [[CryptographicNonce]] internal slot
-    // fetch priority                   the state of el's fetchpriority content attribute
-    options.fetch_priority = Fetch::Infrastructure::request_priority_from_string(get_attribute_value(HTML::AttributeNames::fetchpriority)).value_or(Fetch::Infrastructure::Request::Priority::Auto);
+    LinkProcessingOptions options {
+        // FIXME: destination                      the result of translating the state of el's as attribute
+        // crossorigin                      the state of el's crossorigin content attribute
+        .crossorigin = cors_setting_attribute_from_keyword(get_attribute(AttributeNames::crossorigin)),
+        // referrer policy                  the state of el's referrerpolicy content attribute
+        .referrer_policy = ReferrerPolicy::from_string(get_attribute(AttributeNames::referrerpolicy).value_or(""_string)).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString),
+        // FIXME: source set                       el's source set
+        // base URL                         document's document base URL
+        .base_url = document.base_url(),
+        // origin                           document's origin
+        .origin = document.origin(),
+        // environment                      document's relevant settings object
+        .environment = &document.relevant_settings_object(),
+        // policy container                 document's policy container
+        .policy_container = document.policy_container(),
+        // document                         document
+        .document = &document,
+        // FIXME: cryptographic nonce metadata     the current value of el's [[CryptographicNonce]] internal slot
+        // fetch priority                   the state of el's fetchpriority content attribute
+        .fetch_priority = Fetch::Infrastructure::request_priority_from_string(get_attribute_value(HTML::AttributeNames::fetchpriority)).value_or(Fetch::Infrastructure::Request::Priority::Auto),
+    };
 
     // 3. If el has an href attribute, then set options's href to the value of el's href attribute.
     if (auto maybe_href = get_attribute(AttributeNames::href); maybe_href.has_value())

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -751,19 +751,21 @@ static GC::Ref<NavigationParams> create_navigation_params_from_a_srcdoc_resource
     //    FIXME: navigation timing type: navTimingType
     //    about base URL: entry's document state's about base URL
     //    user involvement: userInvolvement
-    auto navigation_params = vm.heap().allocate<NavigationParams>();
-    navigation_params->id = move(navigation_id);
-    navigation_params->navigable = navigable;
-    navigation_params->response = response;
-    navigation_params->coop_enforcement_result = move(coop_enforcement_result);
-    navigation_params->origin = move(response_origin);
-    navigation_params->policy_container = *policy_container;
-    navigation_params->final_sandboxing_flag_set = target_snapshot_params.sandboxing_flags;
-    navigation_params->opener_policy = move(coop);
-    navigation_params->about_base_url = entry->document_state()->about_base_url();
-    navigation_params->user_involvement = user_involvement;
-
-    return navigation_params;
+    return vm.heap().allocate<NavigationParams>(
+        move(navigation_id),
+        navigable,
+        nullptr,
+        response,
+        nullptr,
+        nullptr,
+        move(coop_enforcement_result),
+        nullptr,
+        move(response_origin),
+        *policy_container,
+        target_snapshot_params.sandboxing_flags,
+        move(coop),
+        entry->document_state()->about_base_url(),
+        user_involvement);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching
@@ -1165,22 +1167,21 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
     //     FIXME: navigation timing type: navTimingType
     //     about base URL: entry's document state's about base URL
     //     user involvement: userInvolvement
-    auto navigation_params = vm.heap().allocate<NavigationParams>();
-    navigation_params->id = navigation_id;
-    navigation_params->navigable = navigable;
-    navigation_params->request = request;
-    navigation_params->response = *response_holder->response();
-    navigation_params->fetch_controller = fetch_controller;
-    navigation_params->commit_early_hints = move(commit_early_hints);
-    navigation_params->coop_enforcement_result = coop_enforcement_result;
-    navigation_params->reserved_environment = request->reserved_client();
-    navigation_params->origin = *response_origin;
-    navigation_params->policy_container = result_policy_container;
-    navigation_params->final_sandboxing_flag_set = final_sandbox_flags;
-    navigation_params->opener_policy = response_coop;
-    navigation_params->about_base_url = entry->document_state()->about_base_url();
-    navigation_params->user_involvement = user_involvement;
-    return navigation_params;
+    return vm.heap().allocate<NavigationParams>(
+        navigation_id,
+        navigable,
+        request,
+        *response_holder->response(),
+        fetch_controller,
+        move(commit_early_hints),
+        coop_enforcement_result,
+        request->reserved_client(),
+        *response_origin,
+        result_policy_container,
+        final_sandbox_flags,
+        response_coop,
+        entry->document_state()->about_base_url(),
+        user_involvement);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#attempt-to-populate-the-history-entry's-document
@@ -1891,21 +1892,21 @@ GC::Ptr<DOM::Document> Navigable::evaluate_javascript_url(URL::URL const& url, U
     //     FIXME: navigation timing type: "navigate"
     //     about base URL: targetNavigable's active document's about base URL
     //     user involvement: userInvolvement
-    auto navigation_params = vm.heap().allocate<NavigationParams>();
-    navigation_params->id = navigation_id;
-    navigation_params->navigable = this;
-    navigation_params->request = {};
-    navigation_params->response = response;
-    navigation_params->fetch_controller = nullptr;
-    navigation_params->commit_early_hints = nullptr;
-    navigation_params->coop_enforcement_result = move(coop_enforcement_result);
-    navigation_params->reserved_environment = {};
-    navigation_params->origin = new_document_origin;
-    navigation_params->policy_container = policy_container;
-    navigation_params->final_sandboxing_flag_set = final_sandbox_flags;
-    navigation_params->opener_policy = coop;
-    navigation_params->about_base_url = active_document()->about_base_url();
-    navigation_params->user_involvement = user_involvement;
+    auto navigation_params = vm.heap().allocate<NavigationParams>(
+        navigation_id,
+        this,
+        nullptr,
+        response,
+        nullptr,
+        nullptr,
+        move(coop_enforcement_result),
+        nullptr,
+        new_document_origin,
+        policy_container,
+        final_sandbox_flags,
+        coop,
+        active_document()->about_base_url(),
+        user_involvement);
 
     // 17. Return the result of loading an HTML document given navigationParams.
     return load_document(navigation_params);

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1111,15 +1111,14 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
         // - initiator origin: responseOrigin
         // FIXME: - navigation timing type: navTimingType
         // - user involvement: userInvolvement
-        auto navigation_params = vm.heap().allocate<NonFetchSchemeNavigationParams>();
-        navigation_params->id = navigation_id;
-        navigation_params->navigable = navigable;
-        navigation_params->url = location_url.release_value().value();
-        navigation_params->target_snapshot_sandboxing_flags = target_snapshot_params.sandboxing_flags;
-        navigation_params->source_snapshot_has_transient_activation = source_snapshot_params.has_transient_activation;
-        navigation_params->initiator_origin = move(*response_origin);
-        navigation_params->user_involvement = user_involvement;
-        return navigation_params;
+        return vm.heap().allocate<NonFetchSchemeNavigationParams>(
+            navigation_id,
+            navigable,
+            location_url.release_value().value(),
+            target_snapshot_params.sandboxing_flags,
+            source_snapshot_params.has_transient_activation,
+            move(*response_origin),
+            user_involvement);
     }
 
     // 21. If any of the following are true:
@@ -1234,15 +1233,14 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
             // - initiator origin: entry's document state's initiator origin
             // FIXME: - navigation timing type: navTimingType
             // - user involvement: userInvolvement
-            auto non_fetching_scheme_navigation_params = vm().heap().allocate<NonFetchSchemeNavigationParams>();
-            non_fetching_scheme_navigation_params->id = navigation_id;
-            non_fetching_scheme_navigation_params->navigable = this;
-            non_fetching_scheme_navigation_params->url = entry->url();
-            non_fetching_scheme_navigation_params->target_snapshot_sandboxing_flags = target_snapshot_params.sandboxing_flags;
-            non_fetching_scheme_navigation_params->source_snapshot_has_transient_activation = source_snapshot_params.has_transient_activation;
-            non_fetching_scheme_navigation_params->initiator_origin = *entry->document_state()->initiator_origin();
-            non_fetching_scheme_navigation_params->user_involvement = user_involvement;
-            navigation_params = non_fetching_scheme_navigation_params;
+            navigation_params = vm().heap().allocate<NonFetchSchemeNavigationParams>(
+                navigation_id,
+                this,
+                entry->url(),
+                target_snapshot_params.sandboxing_flags,
+                source_snapshot_params.has_transient_activation,
+                *entry->document_state()->initiator_origin(),
+                user_involvement);
         }
     }
 

--- a/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Libraries/LibWeb/HTML/NavigationParams.h
@@ -140,6 +140,25 @@ struct NonFetchSchemeNavigationParams : JS::Cell {
     // a user navigation involvement used when obtaining a browsing context for the new Document (if one is created)
     UserNavigationInvolvement user_involvement;
 
+protected:
+    NonFetchSchemeNavigationParams(
+        Optional<String> id,
+        GC::Ptr<Navigable> navigable,
+        URL::URL url,
+        SandboxingFlagSet target_snapshot_sandboxing_flags,
+        bool source_snapshot_has_transient_activation,
+        URL::Origin initiator_origin,
+        UserNavigationInvolvement user_involvement)
+        : id(move(id))
+        , navigable(navigable)
+        , url(move(url))
+        , target_snapshot_sandboxing_flags(target_snapshot_sandboxing_flags)
+        , source_snapshot_has_transient_activation(source_snapshot_has_transient_activation)
+        , initiator_origin(move(initiator_origin))
+        , user_involvement(user_involvement)
+    {
+    }
+
     void visit_edges(Visitor& visitor) override;
 };
 

--- a/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Libraries/LibWeb/HTML/NavigationParams.h
@@ -76,7 +76,40 @@ struct NavigationParams : GC::Cell {
     // a user navigation involvement used when obtaining a browsing context for the new Document
     UserNavigationInvolvement user_involvement;
 
+protected:
     void visit_edges(Visitor& visitor) override;
+
+    NavigationParams(
+        Optional<String> id,
+        GC::Ptr<Navigable> navigable,
+        GC::Ptr<Fetch::Infrastructure::Request> request,
+        GC::Ptr<Fetch::Infrastructure::Response> response,
+        GC::Ptr<Fetch::Infrastructure::FetchController> fetch_controller,
+        Function<void(DOM::Document&)> commit_early_hints,
+        OpenerPolicyEnforcementResult coop_enforcement_result,
+        Fetch::Infrastructure::Request::ReservedClientType reserved_environment,
+        URL::Origin origin,
+        GC::Ptr<PolicyContainer> policy_container,
+        SandboxingFlagSet final_sandboxing_flag_set,
+        OpenerPolicy opener_policy,
+        Optional<URL::URL> about_base_url,
+        UserNavigationInvolvement user_involvement)
+        : id(move(id))
+        , navigable(navigable)
+        , request(request)
+        , response(response)
+        , fetch_controller(fetch_controller)
+        , commit_early_hints(move(commit_early_hints))
+        , coop_enforcement_result(move(coop_enforcement_result))
+        , reserved_environment(reserved_environment)
+        , origin(move(origin))
+        , policy_container(policy_container)
+        , final_sandboxing_flag_set(final_sandboxing_flag_set)
+        , opener_policy(opener_policy)
+        , about_base_url(move(about_base_url))
+        , user_involvement(user_involvement)
+    {
+    }
 };
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#non-fetch-scheme-navigation-params

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -4570,6 +4570,11 @@ Vector<GC::Root<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& contex
     //         This is required for Document::parse_url() to work inside iframe srcdoc documents.
     temp_document->set_about_base_url(context_element.document().about_base_url());
 
+    // AD-HOC: The origin is not otherwise set for the document, but it may be accessed during parsing
+    //         script. For now, let's just use an opaque origin, but it is likely that the spec is
+    //         missing setting this origin.
+    temp_document->set_origin(URL::Origin {});
+
     // 2. If context's node document is in quirks mode, then set document's mode to "quirks".
     if (context_element.document().in_quirks_mode())
         temp_document->set_quirks_mode(DOM::QuirksMode::Yes);

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -4573,7 +4573,7 @@ Vector<GC::Root<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& contex
     // AD-HOC: The origin is not otherwise set for the document, but it may be accessed during parsing
     //         script. For now, let's just use an opaque origin, but it is likely that the spec is
     //         missing setting this origin.
-    temp_document->set_origin(URL::Origin {});
+    temp_document->set_origin(URL::Origin::create_opaque());
 
     // 2. If context's node document is in quirks mode, then set document's mode to "quirks".
     if (context_element.document().in_quirks_mode())

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -564,20 +564,18 @@ bool is_non_secure_context(Environment const& environment)
 
 SerializedEnvironmentSettingsObject EnvironmentSettingsObject::serialize()
 {
-    SerializedEnvironmentSettingsObject object;
-
-    object.id = this->id;
-    object.creation_url = this->creation_url;
-    object.top_level_creation_url = this->top_level_creation_url;
-    object.top_level_origin = this->top_level_origin;
-
-    object.api_url_character_encoding = api_url_character_encoding();
-    object.api_base_url = api_base_url();
-    object.origin = origin();
-    object.policy_container = policy_container()->serialize();
-    object.cross_origin_isolated_capability = cross_origin_isolated_capability();
-
-    return object;
+    return SerializedEnvironmentSettingsObject {
+        .id = this->id,
+        .creation_url = this->creation_url,
+        .top_level_creation_url = this->top_level_creation_url,
+        .top_level_origin = this->top_level_origin,
+        .api_url_character_encoding = api_url_character_encoding(),
+        .api_base_url = api_base_url(),
+        .origin = origin(),
+        .policy_container = policy_container()->serialize(),
+        .cross_origin_isolated_capability = cross_origin_isolated_capability(),
+        .time_origin = this->time_origin(),
+    };
 }
 
 GC::Ref<StorageAPI::StorageManager> EnvironmentSettingsObject::storage_manager()

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
@@ -30,20 +30,18 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::SerializedEnvironmentSettingsO
 template<>
 ErrorOr<Web::HTML::SerializedEnvironmentSettingsObject> decode(Decoder& decoder)
 {
-    Web::HTML::SerializedEnvironmentSettingsObject object {};
-
-    object.id = TRY(decoder.decode<String>());
-    object.creation_url = TRY(decoder.decode<URL::URL>());
-    object.top_level_creation_url = TRY(decoder.decode<Optional<URL::URL>>());
-    object.top_level_origin = TRY(decoder.decode<Optional<URL::Origin>>());
-    object.api_url_character_encoding = TRY(decoder.decode<String>());
-    object.api_base_url = TRY(decoder.decode<URL::URL>());
-    object.origin = TRY(decoder.decode<URL::Origin>());
-    object.policy_container = TRY(decoder.decode<Web::HTML::SerializedPolicyContainer>());
-    object.cross_origin_isolated_capability = TRY(decoder.decode<Web::HTML::CanUseCrossOriginIsolatedAPIs>());
-    object.time_origin = TRY(decoder.decode<double>());
-
-    return object;
+    return Web::HTML::SerializedEnvironmentSettingsObject {
+        .id = TRY(decoder.decode<String>()),
+        .creation_url = TRY(decoder.decode<URL::URL>()),
+        .top_level_creation_url = TRY(decoder.decode<Optional<URL::URL>>()),
+        .top_level_origin = TRY(decoder.decode<Optional<URL::Origin>>()),
+        .api_url_character_encoding = TRY(decoder.decode<String>()),
+        .api_base_url = TRY(decoder.decode<URL::URL>()),
+        .origin = TRY(decoder.decode<URL::Origin>()),
+        .policy_container = TRY(decoder.decode<Web::HTML::SerializedPolicyContainer>()),
+        .cross_origin_isolated_capability = TRY(decoder.decode<Web::HTML::CanUseCrossOriginIsolatedAPIs>()),
+        .time_origin = TRY(decoder.decode<double>()),
+    };
 }
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
@@ -30,9 +30,8 @@ GC::Ref<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObject::setup(
 
     // 4. Let settings object be a new environment settings object whose algorithms are defined as follows:
     // NOTE: See the functions defined for this class.
-    auto settings_object = realm->create<WorkerEnvironmentSettingsObject>(move(execution_context), worker, unsafe_worker_creation_time);
+    auto settings_object = realm->create<WorkerEnvironmentSettingsObject>(move(execution_context), worker, move(inherited_origin), unsafe_worker_creation_time);
     settings_object->target_browsing_context = nullptr;
-    settings_object->m_origin = move(inherited_origin);
 
     // FIXME: 5. Set settings object's id to a new unique opaque string, creation URL to worker global scope's url, top-level creation URL to null, target browsing context to null, and active service worker to null.
     // 6. If worker global scope is a DedicatedWorkerGlobalScope object, then set settings object's top-level origin to outside settings's top-level origin.
@@ -64,7 +63,7 @@ URL::Origin WorkerEnvironmentSettingsObject::origin() const
 {
     // Return a unique opaque origin if worker global scope's url's scheme is "data", and inherited origin otherwise.
     if (m_global_scope->url().scheme() == "data")
-        return URL::Origin {};
+        return URL::Origin::create_opaque();
     return m_origin;
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
+++ b/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
@@ -18,8 +18,9 @@ class WorkerEnvironmentSettingsObject final
     GC_DECLARE_ALLOCATOR(WorkerEnvironmentSettingsObject);
 
 public:
-    WorkerEnvironmentSettingsObject(NonnullOwnPtr<JS::ExecutionContext> execution_context, GC::Ref<WorkerGlobalScope> global_scope, HighResolutionTime::DOMHighResTimeStamp unsafe_worker_creation_time)
+    WorkerEnvironmentSettingsObject(NonnullOwnPtr<JS::ExecutionContext> execution_context, GC::Ref<WorkerGlobalScope> global_scope, URL::Origin origin, HighResolutionTime::DOMHighResTimeStamp unsafe_worker_creation_time)
         : EnvironmentSettingsObject(move(execution_context))
+        , m_origin(move(origin))
         , m_global_scope(global_scope)
         , m_unsafe_worker_creation_time(unsafe_worker_creation_time)
     {

--- a/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/SharedWorkerGlobalScope.h
@@ -26,7 +26,7 @@ public:
     virtual ~SharedWorkerGlobalScope() override;
 
     void set_constructor_origin(URL::Origin origin) { m_constructor_origin = move(origin); }
-    URL::Origin const& constructor_origin() const { return m_constructor_origin; }
+    URL::Origin const& constructor_origin() const { return m_constructor_origin.value(); }
 
     void set_constructor_url(URL::URL url) { m_constructor_url = move(url); }
     URL::URL const& constructor_url() const { return m_constructor_url; }
@@ -48,7 +48,7 @@ private:
     virtual void initialize_web_interfaces_impl() override;
     virtual void finalize() override;
 
-    URL::Origin m_constructor_origin;
+    Optional<URL::Origin> m_constructor_origin;
     URL::URL m_constructor_url;
     Fetch::Infrastructure::Request::CredentialsMode m_credentials;
 };

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -37,13 +37,20 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& rea
     GC::Ref<HTML::Navigable> navigable = page->top_level_traversable();
     auto response = Fetch::Infrastructure::Response::create(navigable->vm());
     response->url_list().append(url);
-    auto navigation_params = navigable->heap().allocate<HTML::NavigationParams>();
-    navigation_params->navigable = navigable;
-    navigation_params->response = response;
-    navigation_params->origin = URL::Origin {};
-    navigation_params->policy_container = navigable->heap().allocate<HTML::PolicyContainer>(realm.heap());
-    navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
-    navigation_params->opener_policy = HTML::OpenerPolicy {};
+    auto navigation_params = navigable->heap().allocate<HTML::NavigationParams>(OptionalNone {},
+        navigable,
+        nullptr,
+        response,
+        nullptr,
+        nullptr,
+        HTML::OpenerPolicyEnforcementResult {},
+        nullptr,
+        URL::Origin {},
+        navigable->heap().allocate<HTML::PolicyContainer>(realm.heap()),
+        HTML::SandboxingFlagSet {},
+        HTML::OpenerPolicy {},
+        OptionalNone {},
+        HTML::UserNavigationInvolvement::None);
 
     // FIXME: Use Navigable::navigate() instead of manually replacing the navigable's document.
     auto document = MUST(DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params));

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -37,15 +37,16 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& rea
     GC::Ref<HTML::Navigable> navigable = page->top_level_traversable();
     auto response = Fetch::Infrastructure::Response::create(navigable->vm());
     response->url_list().append(url);
+    auto origin = URL::Origin::create_opaque();
     auto navigation_params = navigable->heap().allocate<HTML::NavigationParams>(OptionalNone {},
         navigable,
         nullptr,
         response,
         nullptr,
         nullptr,
-        HTML::OpenerPolicyEnforcementResult {},
+        HTML::OpenerPolicyEnforcementResult { .url = url, .origin = origin, .opener_policy = HTML::OpenerPolicy {} },
         nullptr,
-        URL::Origin {},
+        origin,
         navigable->heap().allocate<HTML::PolicyContainer>(realm.heap()),
         HTML::SandboxingFlagSet {},
         HTML::OpenerPolicy {},


### PR DESCRIPTION
Precursor to changing URL::Origin to use a nonce for opaque origins.