### PR TITLE
AK: Avoid a copy in StringBuilder's default constructor

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -41,8 +41,9 @@ ErrorOr<StringBuilder> StringBuilder::create(size_t initial_capacity)
 }
 
 StringBuilder::StringBuilder()
-    : StringBuilder(inline_capacity)
 {
+    static_assert(inline_capacity > STRING_BASE_PREFIX_SIZE);
+    m_buffer.resize(STRING_BASE_PREFIX_SIZE);
 }
 
 StringBuilder::StringBuilder(size_t initial_capacity)


### PR DESCRIPTION
Found this while looking at a valgrind profile of `js` where the execution time is widely dominated by the parser. This commit reduces the number of instruction spent in `StringBuilder::StringBuilder()` from 1.85%  to 0.08%.