### PR TITLE
LibWeb: Add flow relative values for the clear property

### DIFF
--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -101,7 +101,9 @@
     "none",
     "left",
     "right",
-    "both"
+    "both",
+    "inline-start",
+    "inline-end"
   ],
   "column-span": [
     "none",

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -975,19 +975,6 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
         return;
     }
 
-    if (property_id == CSS::PropertyID::Float) {
-        auto keyword = value.to_keyword();
-
-        // FIXME: Honor writing-mode, direction and text-orientation.
-        if (keyword == Keyword::InlineStart) {
-            set_longhand_property(CSS::PropertyID::Float, CSSKeywordValue::create(Keyword::Left));
-            return;
-        } else if (keyword == Keyword::InlineEnd) {
-            set_longhand_property(CSS::PropertyID::Float, CSSKeywordValue::create(Keyword::Right));
-            return;
-        }
-    }
-
     if (property_is_shorthand(property_id)) {
         // ShorthandStyleValue was handled already, as were unresolved shorthands.
         // That means the only values we should see are the CSS-wide keywords, or the guaranteed-invalid value.

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1164,9 +1164,10 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     };
 
     // Next, float to the left and/or right
-    if (box.computed_values().float_() == CSS::Float::Left) {
+    // FIXME: Honor writing-mode, direction and text-orientation.
+    if (box.computed_values().float_() == CSS::Float::Left || box.computed_values().float_() == CSS::Float::InlineStart) {
         float_box(FloatSide::Left, m_left_floats);
-    } else if (box.computed_values().float_() == CSS::Float::Right) {
+    } else if (box.computed_values().float_() == CSS::Float::Right || box.computed_values().float_() == CSS::Float::InlineEnd) {
         float_box(FloatSide::Right, m_right_floats);
     }
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -939,9 +939,10 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
             float_side.clear();
     };
 
-    if (computed_values.clear() == CSS::Clear::Left || computed_values.clear() == CSS::Clear::Both)
+    // FIXME: Honor writing-mode, direction and text-orientation.
+    if (first_is_one_of(computed_values.clear(), CSS::Clear::Left, CSS::Clear::Both, CSS::Clear::InlineStart))
         clear_floating_boxes(m_left_floats);
-    if (computed_values.clear() == CSS::Clear::Right || computed_values.clear() == CSS::Clear::Both)
+    if (first_is_one_of(computed_values.clear(), CSS::Clear::Right, CSS::Clear::Both, CSS::Clear::InlineEnd))
         clear_floating_boxes(m_right_floats);
 
     return result;

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-box/parsing/clear-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-box/parsing/clear-computed.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	Property clear value 'none'
+Pass	Property clear value 'left'
+Pass	Property clear value 'right'
+Pass	Property clear value 'both'
+Pass	Property clear value 'inline-start'
+Pass	Property clear value 'inline-end'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-box/parsing/clear-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-box/parsing/clear-valid.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	e.style['clear'] = "none" should set the property value
+Pass	e.style['clear'] = "left" should set the property value
+Pass	e.style['clear'] = "right" should set the property value
+Pass	e.style['clear'] = "both" should set the property value
+Pass	e.style['clear'] = "inline-start" should set the property value
+Pass	e.style['clear'] = "inline-end" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-box/parsing/float-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-box/parsing/float-computed.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	Property float value 'none'
+Pass	Property float value 'left'
+Pass	Property float value 'right'
+Pass	Property float value 'inline-start'
+Pass	Property float value 'inline-end'

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-box/parsing/clear-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-box/parsing/clear-computed.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: getComputedStyle().clear</title>
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-clear">
+<link rel="help" href="https://drafts.csswg.org/css-logical/#float-clear">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("clear", "none");
+test_computed_value("clear", "left");
+test_computed_value("clear", "right");
+test_computed_value("clear", "both");
+
+test_computed_value("clear", "inline-start");
+test_computed_value("clear", "inline-end");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-box/parsing/clear-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-box/parsing/clear-valid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing clear with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-clear">
+<link rel="help" href="https://drafts.csswg.org/css-logical/#float-clear">
+<meta name="assert" content="clear supports the full grammar 'none | left | right | both'.">
+<meta name="assert" content="clear also supports inline-start and inline-end.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("clear", "none");
+test_valid_value("clear", "left");
+test_valid_value("clear", "right");
+test_valid_value("clear", "both");
+
+test_valid_value("clear", "inline-start");
+test_valid_value("clear", "inline-end");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-box/parsing/float-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-box/parsing/float-computed.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: getComputedStyle().float</title>
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-float">
+<link rel="help" href="https://drafts.csswg.org/css-logical/#float-clear">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("float", "none");
+test_computed_value("float", "left");
+test_computed_value("float", "right");
+
+test_computed_value("float", "inline-start");
+test_computed_value("float", "inline-end");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Currently `inline-start` and `inline-end` are always treated as `left` and `right` respectively. This is the same behavior that we currently have for the float property.

Fixes at least 6 WPT subtests.