### PR TITLE
LibWeb/CSS: Improve serialization of the `contain` property

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -1060,6 +1060,17 @@ RefPtr<CSSStyleValue const> CSSStyleProperties::style_value_for_computed_propert
         auto border_top_width = layout_node.computed_values().border_top().width;
         return LengthStyleValue::create(Length::make_px(border_top_width));
     }
+    case PropertyID::Contain: {
+        auto const& contain = layout_node.computed_values().contain();
+        if (contain.layout_containment && contain.style_containment && contain.paint_containment) {
+            if (contain.size_containment)
+                return CSSKeywordValue::create(Keyword::Strict);
+            if (!contain.inline_size_containment)
+                return CSSKeywordValue::create(Keyword::Content);
+        }
+
+        return get_computed_value(property_id);
+    }
     case PropertyID::OutlineWidth: {
         auto outline_width = layout_node.computed_values().outline_width();
         return LengthStyleValue::create(outline_width);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -4839,47 +4839,56 @@ RefPtr<CSSStyleValue const> Parser::parse_contain_value(TokenStream<ComponentVal
     if (!tokens.has_next_token())
         return {};
 
-    bool has_size = false;
-    bool has_layout = false;
-    bool has_style = false;
-    bool has_paint = false;
+    RefPtr<CSSStyleValue const> size_value;
+    RefPtr<CSSStyleValue const> layout_value;
+    RefPtr<CSSStyleValue const> style_value;
+    RefPtr<CSSStyleValue const> paint_value;
 
-    StyleValueVector containments;
     while (tokens.has_next_token()) {
         tokens.discard_whitespace();
-        auto keyword = parse_keyword_value(tokens);
-        if (!keyword)
+        auto keyword_value = parse_keyword_value(tokens);
+        if (!keyword_value)
             return {};
-        switch (keyword->to_keyword()) {
+        switch (keyword_value->to_keyword()) {
         case Keyword::Size:
         case Keyword::InlineSize:
-            if (has_size)
+            if (size_value)
                 return {};
-            has_size = true;
+            size_value = move(keyword_value);
             break;
         case Keyword::Layout:
-            if (has_layout)
+            if (layout_value)
                 return {};
-            has_layout = true;
+            layout_value = move(keyword_value);
             break;
         case Keyword::Style:
-            if (has_style)
+            if (style_value)
                 return {};
-            has_style = true;
+            style_value = move(keyword_value);
             break;
         case Keyword::Paint:
-            if (has_paint)
+            if (paint_value)
                 return {};
-            has_paint = true;
+            paint_value = move(keyword_value);
             break;
         default:
             return {};
         }
-        containments.append(*keyword);
     }
+
+    StyleValueVector containment_values;
+    if (size_value)
+        containment_values.append(size_value.release_nonnull());
+    if (layout_value)
+        containment_values.append(layout_value.release_nonnull());
+    if (style_value)
+        containment_values.append(style_value.release_nonnull());
+    if (paint_value)
+        containment_values.append(paint_value.release_nonnull());
+
     transaction.commit();
 
-    return StyleValueList::create(move(containments), StyleValueList::Separator::Space);
+    return StyleValueList::create(move(containment_values), StyleValueList::Separator::Space);
 }
 
 // https://www.w3.org/TR/css-text-4/#white-space-trim

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-computed.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 15 tests
 
-13 Pass
-2 Fail
+15 Pass
 Pass	Property contain value 'none'
 Pass	Property contain value 'strict'
 Pass	Property contain value 'content'
@@ -13,8 +12,8 @@ Pass	Property contain value 'style'
 Pass	Property contain value 'paint'
 Pass	Property contain value 'size layout'
 Pass	Property contain value 'style paint'
-Fail	Property contain value 'style layout paint'
-Fail	Property contain value 'size style layout paint'
+Pass	Property contain value 'style layout paint'
+Pass	Property contain value 'size style layout paint'
 Pass	Property contain value 'size layout paint'
 Pass	Property contain value 'layout paint'
 Pass	Property contain value 'inline-size'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-contain/parsing/contain-valid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 13 tests
 
-9 Pass
-4 Fail
+13 Pass
 Pass	e.style['contain'] = "none" should set the property value
 Pass	e.style['contain'] = "strict" should set the property value
 Pass	e.style['contain'] = "content" should set the property value
@@ -11,9 +10,9 @@ Pass	e.style['contain'] = "size" should set the property value
 Pass	e.style['contain'] = "layout" should set the property value
 Pass	e.style['contain'] = "style" should set the property value
 Pass	e.style['contain'] = "paint" should set the property value
-Fail	e.style['contain'] = "layout size" should set the property value
-Fail	e.style['contain'] = "paint style" should set the property value
+Pass	e.style['contain'] = "layout size" should set the property value
+Pass	e.style['contain'] = "paint style" should set the property value
 Pass	e.style['contain'] = "layout style paint" should set the property value
-Fail	e.style['contain'] = "layout paint style size" should set the property value
+Pass	e.style['contain'] = "layout paint style size" should set the property value
 Pass	e.style['contain'] = "inline-size" should set the property value
-Fail	e.style['contain'] = "layout inline-size" should set the property value
+Pass	e.style['contain'] = "layout inline-size" should set the property value


### PR DESCRIPTION
See individual commits for details.

Fixes at least 6 WPT subtests.