### PR TITLE
LibWeb: Don't play initially-paused animations

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1281,7 +1281,7 @@ static void apply_animation_properties(DOM::Document& document, CascadedProperti
     effect.set_playback_direction(Animations::css_animation_direction_to_bindings_playback_direction(direction));
 
     if (play_state != effect.last_css_animation_play_state()) {
-        if (play_state == CSS::AnimationPlayState::Running && animation.play_state() == Bindings::AnimationPlayState::Paused) {
+        if (play_state == CSS::AnimationPlayState::Running && animation.play_state() != Bindings::AnimationPlayState::Running) {
             HTML::TemporaryExecutionContext context(document.realm());
             animation.play().release_value_but_fixme_should_propagate_errors();
         } else if (play_state == CSS::AnimationPlayState::Paused && animation.play_state() != Bindings::AnimationPlayState::Paused) {
@@ -2655,11 +2655,6 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
 
                 effect->set_target(&element);
                 element.set_cached_animation_name_animation(animation, pseudo_element);
-
-                if (!element.has_inclusive_ancestor_with_display_none()) {
-                    HTML::TemporaryExecutionContext context(realm);
-                    animation->play().release_value_but_fixme_should_propagate_errors();
-                }
             } else {
                 // The animation hasn't changed, but some properties of the animation may have
                 if (auto animation = element.cached_animation_name_animation(pseudo_element); animation)

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3968,9 +3968,6 @@ void Element::play_or_cancel_animations_after_display_property_change()
     auto play_or_cancel_depending_on_display = [&](Animations::Animation& animation) {
         if (has_display_none_inclusive_ancestor) {
             animation.cancel();
-        } else {
-            HTML::TemporaryExecutionContext context(realm());
-            animation.play().release_value_but_fixme_should_propagate_errors();
         }
     };
 

--- a/Tests/LibWeb/Text/expected/css/initially-paused-animation.txt
+++ b/Tests/LibWeb/Text/expected/css/initially-paused-animation.txt
@@ -1,0 +1,2 @@
+paused
+running

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/animations/background-image-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/animations/background-image-interpolation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 288 tests
 
-192 Pass
-96 Fail
+198 Pass
+90 Fail
 Fail	CSS Transitions: property <background-image> from neutral to [url(../resources/green-100.png)] at (-0.3) should be [url(../resources/blue-100.png)]
 Fail	CSS Transitions: property <background-image> from neutral to [url(../resources/green-100.png)] at (0) should be [url(../resources/blue-100.png)]
 Fail	CSS Transitions: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.3) should be [url(../resources/blue-100.png)]
@@ -16,15 +16,15 @@ Fail	CSS Transitions with transition: all: property <background-image> from neut
 Pass	CSS Transitions with transition: all: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.6) should be [url(../resources/green-100.png)]
 Pass	CSS Transitions with transition: all: property <background-image> from neutral to [url(../resources/green-100.png)] at (1) should be [url(../resources/green-100.png)]
 Pass	CSS Transitions with transition: all: property <background-image> from neutral to [url(../resources/green-100.png)] at (1.5) should be [url(../resources/green-100.png)]
-Fail	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (-0.3) should be [url(../resources/blue-100.png)]
-Fail	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0) should be [url(../resources/blue-100.png)]
-Fail	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.3) should be [url(../resources/blue-100.png)]
+Pass	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (-0.3) should be [url(../resources/blue-100.png)]
+Pass	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0) should be [url(../resources/blue-100.png)]
+Pass	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.3) should be [url(../resources/blue-100.png)]
 Pass	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.6) should be [url(../resources/green-100.png)]
 Pass	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (1) should be [url(../resources/green-100.png)]
 Pass	CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (1.5) should be [url(../resources/green-100.png)]
-Fail	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (-0.3) should be [url(../resources/blue-100.png)]
-Fail	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0) should be [url(../resources/blue-100.png)]
-Fail	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.3) should be [url(../resources/blue-100.png)]
+Pass	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (-0.3) should be [url(../resources/blue-100.png)]
+Pass	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0) should be [url(../resources/blue-100.png)]
+Pass	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.3) should be [url(../resources/blue-100.png)]
 Pass	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (0.6) should be [url(../resources/green-100.png)]
 Pass	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (1) should be [url(../resources/green-100.png)]
 Pass	Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)] at (1.5) should be [url(../resources/green-100.png)]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/animations/border-radius-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/animations/border-radius-interpolation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 196 tests
 
-48 Pass
-148 Fail
+50 Pass
+146 Fail
 Fail	CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px] to [30px 50px 70px 90px / 130px 150px 170px 190px] at (-0.3) should be [17px 37px 57px 77px / 117px 137px 157px 177px]
 Fail	CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px] to [30px 50px 70px 90px / 130px 150px 170px 190px] at (0) should be [20px 40px 60px 80px / 120px 140px 160px 180px]
 Fail	CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px] to [30px 50px 70px 90px / 130px 150px 170px 190px] at (0.3) should be [23px 43px 63px 83px / 123px 143px 163px 183px]
@@ -41,13 +41,13 @@ Fail	CSS Transitions with transition: all: property <border-top-left-radius> fro
 Pass	CSS Transitions with transition: all: property <border-top-left-radius> from neutral to [20px] at (1) should be [20px]
 Fail	CSS Transitions with transition: all: property <border-top-left-radius> from neutral to [20px] at (1.5) should be [25px]
 Fail	CSS Animations: property <border-top-left-radius> from neutral to [20px] at (-0.3) should be [7px]
-Fail	CSS Animations: property <border-top-left-radius> from neutral to [20px] at (0) should be [10px]
+Pass	CSS Animations: property <border-top-left-radius> from neutral to [20px] at (0) should be [10px]
 Fail	CSS Animations: property <border-top-left-radius> from neutral to [20px] at (0.3) should be [13px]
 Fail	CSS Animations: property <border-top-left-radius> from neutral to [20px] at (0.6) should be [16px]
 Pass	CSS Animations: property <border-top-left-radius> from neutral to [20px] at (1) should be [20px]
 Fail	CSS Animations: property <border-top-left-radius> from neutral to [20px] at (1.5) should be [25px]
 Fail	Web Animations: property <border-top-left-radius> from neutral to [20px] at (-0.3) should be [7px]
-Fail	Web Animations: property <border-top-left-radius> from neutral to [20px] at (0) should be [10px]
+Pass	Web Animations: property <border-top-left-radius> from neutral to [20px] at (0) should be [10px]
 Fail	Web Animations: property <border-top-left-radius> from neutral to [20px] at (0.3) should be [13px]
 Fail	Web Animations: property <border-top-left-radius> from neutral to [20px] at (0.6) should be [16px]
 Pass	Web Animations: property <border-top-left-radius> from neutral to [20px] at (1) should be [20px]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-masking/animations/clip-path-interpolation-002.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-masking/animations/clip-path-interpolation-002.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 720 tests
 
-542 Pass
-178 Fail
+544 Pass
+176 Fail
 Fail	CSS Transitions: property <clip-path> from neutral to [inset(20px)] at (-0.3) should be [inset(7px)]
 Fail	CSS Transitions: property <clip-path> from neutral to [inset(20px)] at (0) should be [inset(10px)]
 Fail	CSS Transitions: property <clip-path> from neutral to [inset(20px)] at (0.3) should be [inset(13px)]
@@ -17,13 +17,13 @@ Fail	CSS Transitions with transition: all: property <clip-path> from neutral to 
 Pass	CSS Transitions with transition: all: property <clip-path> from neutral to [inset(20px)] at (1) should be [inset(20px)]
 Fail	CSS Transitions with transition: all: property <clip-path> from neutral to [inset(20px)] at (1.5) should be [inset(25px)]
 Fail	CSS Animations: property <clip-path> from neutral to [inset(20px)] at (-0.3) should be [inset(7px)]
-Fail	CSS Animations: property <clip-path> from neutral to [inset(20px)] at (0) should be [inset(10px)]
+Pass	CSS Animations: property <clip-path> from neutral to [inset(20px)] at (0) should be [inset(10px)]
 Fail	CSS Animations: property <clip-path> from neutral to [inset(20px)] at (0.3) should be [inset(13px)]
 Fail	CSS Animations: property <clip-path> from neutral to [inset(20px)] at (0.6) should be [inset(16px)]
 Pass	CSS Animations: property <clip-path> from neutral to [inset(20px)] at (1) should be [inset(20px)]
 Fail	CSS Animations: property <clip-path> from neutral to [inset(20px)] at (1.5) should be [inset(25px)]
 Fail	Web Animations: property <clip-path> from neutral to [inset(20px)] at (-0.3) should be [inset(7px)]
-Fail	Web Animations: property <clip-path> from neutral to [inset(20px)] at (0) should be [inset(10px)]
+Pass	Web Animations: property <clip-path> from neutral to [inset(20px)] at (0) should be [inset(10px)]
 Fail	Web Animations: property <clip-path> from neutral to [inset(20px)] at (0.3) should be [inset(13px)]
 Fail	Web Animations: property <clip-path> from neutral to [inset(20px)] at (0.6) should be [inset(16px)]
 Pass	Web Animations: property <clip-path> from neutral to [inset(20px)] at (1) should be [inset(20px)]

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/animations/z-index-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/animations/z-index-interpolation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 250 tests
 
-204 Pass
-46 Fail
+212 Pass
+38 Fail
 Pass	CSS Transitions: property <z-index> from neutral to [5] at (-0.3) should be [-4]
 Pass	CSS Transitions: property <z-index> from neutral to [5] at (0) should be [-2]
 Pass	CSS Transitions: property <z-index> from neutral to [5] at (0.3) should be [0]
@@ -16,16 +16,16 @@ Fail	CSS Transitions with transition: all: property <z-index> from neutral to [5
 Fail	CSS Transitions with transition: all: property <z-index> from neutral to [5] at (0.6) should be [2]
 Pass	CSS Transitions with transition: all: property <z-index> from neutral to [5] at (1) should be [5]
 Fail	CSS Transitions with transition: all: property <z-index> from neutral to [5] at (1.5) should be [9]
-Fail	CSS Animations: property <z-index> from neutral to [5] at (-0.3) should be [-4]
-Fail	CSS Animations: property <z-index> from neutral to [5] at (0) should be [-2]
-Fail	CSS Animations: property <z-index> from neutral to [5] at (0.3) should be [0]
-Fail	CSS Animations: property <z-index> from neutral to [5] at (0.6) should be [2]
+Pass	CSS Animations: property <z-index> from neutral to [5] at (-0.3) should be [-4]
+Pass	CSS Animations: property <z-index> from neutral to [5] at (0) should be [-2]
+Pass	CSS Animations: property <z-index> from neutral to [5] at (0.3) should be [0]
+Pass	CSS Animations: property <z-index> from neutral to [5] at (0.6) should be [2]
 Pass	CSS Animations: property <z-index> from neutral to [5] at (1) should be [5]
 Fail	CSS Animations: property <z-index> from neutral to [5] at (1.5) should be [9]
-Fail	Web Animations: property <z-index> from neutral to [5] at (-0.3) should be [-4]
-Fail	Web Animations: property <z-index> from neutral to [5] at (0) should be [-2]
-Fail	Web Animations: property <z-index> from neutral to [5] at (0.3) should be [0]
-Fail	Web Animations: property <z-index> from neutral to [5] at (0.6) should be [2]
+Pass	Web Animations: property <z-index> from neutral to [5] at (-0.3) should be [-4]
+Pass	Web Animations: property <z-index> from neutral to [5] at (0) should be [-2]
+Pass	Web Animations: property <z-index> from neutral to [5] at (0.3) should be [0]
+Pass	Web Animations: property <z-index> from neutral to [5] at (0.6) should be [2]
 Pass	Web Animations: property <z-index> from neutral to [5] at (1) should be [5]
 Fail	Web Animations: property <z-index> from neutral to [5] at (1.5) should be [9]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <z-index> from [initial] to [5] at (-0.3) should be [initial]

--- a/Tests/LibWeb/Text/input/WebAnimations/misc/animation-events-basic.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/misc/animation-events-basic.html
@@ -41,6 +41,7 @@
             div.style.display = "none";
             done();
         });
+        div.style.animationPlayState = "running";
     });
 </script>
 </body>

--- a/Tests/LibWeb/Text/input/css/initially-paused-animation.html
+++ b/Tests/LibWeb/Text/input/css/initially-paused-animation.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        background-color: #f0f0f0;
+    }
+
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: #3498db;
+        position: relative;
+        animation: moveRight 0.1s linear;
+        animation-play-state: paused;
+    }
+
+    @keyframes moveRight {
+        0% {
+            left: 0;
+        }
+
+        100% {
+            left: 100px;
+        }
+    }
+</style>
+<body>
+<script src="../include.js"></script>
+<div id="d"></div>
+<script>
+    test(() => {
+        let animation = document.getElementById("d").getAnimations()[0];
+        println(animation.playState);
+        animation.play();
+        println(animation.playState);
+    });
+</script>


### PR DESCRIPTION
also appears to gain a few passing subtests, yippee.

I changed `Tests/LibWeb/Text/input/WebAnimations/misc/animation-events-basic.html` to play the animation before waiting because the previously expected behaviour (running despite being paused) was incorrect.