### PR TITLE
LibWeb: Allow `calc()` values in some easing functions

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -75,7 +75,7 @@ EffectTiming AnimationEffect::get_timing() const
         .iterations = m_iteration_count,
         .duration = m_iteration_duration,
         .direction = m_playback_direction,
-        .easing = m_timing_function.to_string(),
+        .easing = m_timing_function.to_string(CSS::SerializationMode::Normal),
     };
 }
 
@@ -110,7 +110,7 @@ ComputedEffectTiming AnimationEffect::get_computed_timing() const
             .iterations = m_iteration_count,
             .duration = duration,
             .direction = m_playback_direction,
-            .easing = m_timing_function.to_string(),
+            .easing = m_timing_function.to_string(CSS::SerializationMode::Normal),
         },
 
         end_time(),

--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <LibWeb/CSS/CSSStyleValue.h>
+#include <LibWeb/CSS/CalculatedOr.h>
 
 namespace Web::CSS {
 
@@ -35,7 +36,7 @@ public:
         bool operator==(Linear const&) const = default;
 
         double evaluate_at(double input_progress, bool before_flag) const;
-        String to_string() const;
+        String to_string(SerializationMode) const;
 
         Linear(Vector<Stop> stops);
     };
@@ -62,7 +63,7 @@ public:
         bool operator==(CubicBezier const&) const;
 
         double evaluate_at(double input_progress, bool before_flag) const;
-        String to_string() const;
+        String to_string(SerializationMode) const;
     };
 
     struct Steps {
@@ -78,20 +79,20 @@ public:
         static Steps step_start();
         static Steps step_end();
 
-        unsigned int number_of_intervals;
+        IntegerOrCalculated number_of_intervals { 0 };
         Position position { Position::End };
 
         bool operator==(Steps const&) const = default;
 
         double evaluate_at(double input_progress, bool before_flag) const;
-        String to_string() const;
+        String to_string(SerializationMode) const;
     };
 
     struct Function : public Variant<Linear, CubicBezier, Steps> {
         using Variant::Variant;
 
         double evaluate_at(double input_progress, bool before_flag) const;
-        String to_string() const;
+        String to_string(SerializationMode) const;
     };
 
     static ValueComparingNonnullRefPtr<EasingStyleValue const> create(Function const& function)
@@ -102,7 +103,7 @@ public:
 
     Function const& function() const { return m_function; }
 
-    virtual String to_string(SerializationMode) const override { return m_function.to_string(); }
+    virtual String to_string(SerializationMode mode) const override { return m_function.to_string(mode); }
 
     bool properties_equal(EasingStyleValue const& other) const { return m_function == other.m_function; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
@@ -47,10 +47,10 @@ public:
         static CubicBezier ease_out();
         static CubicBezier ease_in_out();
 
-        double x1;
-        double y1;
-        double x2;
-        double y2;
+        NumberOrCalculated x1 { 0 };
+        NumberOrCalculated y1 { 0 };
+        NumberOrCalculated x2 { 0 };
+        NumberOrCalculated y2 { 0 };
 
         struct CachedSample {
             double x;
@@ -79,7 +79,7 @@ public:
         static Steps step_start();
         static Steps step_end();
 
-        IntegerOrCalculated number_of_intervals { 0 };
+        IntegerOrCalculated number_of_intervals { 1 };
         Position position { Position::End };
 
         bool operator==(Steps const&) const = default;

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-computed.txt
@@ -1,0 +1,27 @@
+Harness status: OK
+
+Found 21 tests
+
+18 Pass
+3 Fail
+Pass	Property animation-timing-function value 'linear'
+Pass	Property animation-timing-function value 'ease'
+Pass	Property animation-timing-function value 'ease-in'
+Pass	Property animation-timing-function value 'ease-out'
+Pass	Property animation-timing-function value 'ease-in-out'
+Pass	Property animation-timing-function value 'cubic-bezier(0.1, 0.2, 0.8, 0.9)'
+Pass	Property animation-timing-function value 'cubic-bezier(0, -2, 1, 3)'
+Pass	Property animation-timing-function value 'cubic-bezier(0, 0.7, 1, 1.3)'
+Fail	Property animation-timing-function value 'cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))'
+Pass	Property animation-timing-function value 'steps(4, start)'
+Pass	Property animation-timing-function value 'steps(2, end)'
+Pass	Property animation-timing-function value 'steps( 2, end )'
+Pass	Property animation-timing-function value 'steps(2, jump-start)'
+Pass	Property animation-timing-function value 'steps(2, jump-end)'
+Pass	Property animation-timing-function value 'steps(2, jump-both)'
+Pass	Property animation-timing-function value 'steps(2, jump-none)'
+Pass	Property animation-timing-function value 'steps(calc(-10), start)'
+Pass	Property animation-timing-function value 'steps(calc(5 / 2), start)'
+Pass	Property animation-timing-function value 'steps(calc(1), jump-none)'
+Fail	Property animation-timing-function value 'linear, ease, linear'
+Fail	Property animation-timing-function value 'steps(calc(2 + sign(100em - 1px)), end)'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 21 tests
 
-18 Pass
-3 Fail
+19 Pass
+2 Fail
 Pass	Property animation-timing-function value 'linear'
 Pass	Property animation-timing-function value 'ease'
 Pass	Property animation-timing-function value 'ease-in'
@@ -12,7 +12,7 @@ Pass	Property animation-timing-function value 'ease-in-out'
 Pass	Property animation-timing-function value 'cubic-bezier(0.1, 0.2, 0.8, 0.9)'
 Pass	Property animation-timing-function value 'cubic-bezier(0, -2, 1, 3)'
 Pass	Property animation-timing-function value 'cubic-bezier(0, 0.7, 1, 1.3)'
-Fail	Property animation-timing-function value 'cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))'
+Pass	Property animation-timing-function value 'cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))'
 Pass	Property animation-timing-function value 'steps(4, start)'
 Pass	Property animation-timing-function value 'steps(2, end)'
 Pass	Property animation-timing-function value 'steps( 2, end )'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-valid.txt
@@ -1,0 +1,28 @@
+Harness status: OK
+
+Found 22 tests
+
+19 Pass
+3 Fail
+Pass	e.style['animation-timing-function'] = "linear" should set the property value
+Pass	e.style['animation-timing-function'] = "ease" should set the property value
+Pass	e.style['animation-timing-function'] = "ease-in" should set the property value
+Pass	e.style['animation-timing-function'] = "ease-out" should set the property value
+Pass	e.style['animation-timing-function'] = "ease-in-out" should set the property value
+Pass	e.style['animation-timing-function'] = "cubic-bezier(0.1, 0.2, 0.8, 0.9)" should set the property value
+Pass	e.style['animation-timing-function'] = "cubic-bezier(0, -2, 1, 3)" should set the property value
+Pass	e.style['animation-timing-function'] = "cubic-bezier(0, 0.7, 1, 1.3)" should set the property value
+Fail	e.style['animation-timing-function'] = "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))" should set the property value
+Fail	e.style['animation-timing-function'] = "cubic-bezier(0, sibling-index(), 1, sign(2em - 20px))" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(4, start)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(2, end)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps( 2, end )" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(2, jump-start)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(2, jump-end)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(2, jump-both)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(2, jump-none)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(calc(-10), start)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(calc(5 / 2), start)" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(calc(1), jump-none)" should set the property value
+Fail	e.style['animation-timing-function'] = "linear, ease, linear" should set the property value
+Pass	e.style['animation-timing-function'] = "steps(calc(2 + sign(100em - 1px)))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 22 tests
 
-19 Pass
-3 Fail
+20 Pass
+2 Fail
 Pass	e.style['animation-timing-function'] = "linear" should set the property value
 Pass	e.style['animation-timing-function'] = "ease" should set the property value
 Pass	e.style['animation-timing-function'] = "ease-in" should set the property value
@@ -12,7 +12,7 @@ Pass	e.style['animation-timing-function'] = "ease-in-out" should set the propert
 Pass	e.style['animation-timing-function'] = "cubic-bezier(0.1, 0.2, 0.8, 0.9)" should set the property value
 Pass	e.style['animation-timing-function'] = "cubic-bezier(0, -2, 1, 3)" should set the property value
 Pass	e.style['animation-timing-function'] = "cubic-bezier(0, 0.7, 1, 1.3)" should set the property value
-Fail	e.style['animation-timing-function'] = "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))" should set the property value
+Pass	e.style['animation-timing-function'] = "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))" should set the property value
 Fail	e.style['animation-timing-function'] = "cubic-bezier(0, sibling-index(), 1, sign(2em - 20px))" should set the property value
 Pass	e.style['animation-timing-function'] = "steps(4, start)" should set the property value
 Pass	e.style['animation-timing-function'] = "steps(2, end)" should set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-easing/timing-functions-syntax-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-easing/timing-functions-syntax-computed.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Easing: getComputedStyle().animationTimingFunction</title>
+<link rel="help" href="https://drafts.csswg.org/css-easing/#timing-functions">
+<meta name="assert" content="animation-timing-function computed value is a computed <easing-function> list.">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("animation-timing-function", "linear");
+
+test_computed_value("animation-timing-function", "ease");
+test_computed_value("animation-timing-function", "ease-in");
+test_computed_value("animation-timing-function", "ease-out");
+test_computed_value("animation-timing-function", "ease-in-out");
+test_computed_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
+test_computed_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
+test_computed_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
+test_computed_value("animation-timing-function", "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))", "cubic-bezier(0, 0.35, 1, 0)",);
+
+test_computed_value("animation-timing-function", "steps(4, start)");
+test_computed_value("animation-timing-function", "steps(2, end)", "steps(2)");
+test_computed_value("animation-timing-function", "steps( 2, end )", "steps(2)");
+test_computed_value("animation-timing-function", "steps(2, jump-start)");
+test_computed_value("animation-timing-function", "steps(2, jump-end)", "steps(2)");
+test_computed_value("animation-timing-function", "steps(2, jump-both)");
+test_computed_value("animation-timing-function", "steps(2, jump-none)");
+test_computed_value("animation-timing-function", "steps(calc(-10), start)", "steps(1, start)");
+test_computed_value("animation-timing-function", "steps(calc(5 / 2), start)", "steps(3, start)");
+test_computed_value("animation-timing-function", "steps(calc(1), jump-none)", "steps(2, jump-none)");
+
+test_computed_value("animation-timing-function", "linear, ease, linear");
+
+test_computed_value("animation-timing-function", "steps(calc(2 + sign(100em - 1px)), end)", "steps(3)");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-easing/timing-functions-syntax-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-easing/timing-functions-syntax-valid.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Easing: parsing animation-timing-function with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-easing/#timing-functions">
+<meta name="assert" content="animation-timing-function supports the full grammar '<timing-function> #'.">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-timing-function", "linear");
+
+test_valid_value("animation-timing-function", "ease");
+test_valid_value("animation-timing-function", "ease-in");
+test_valid_value("animation-timing-function", "ease-out");
+test_valid_value("animation-timing-function", "ease-in-out");
+test_valid_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
+test_valid_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
+test_valid_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
+test_valid_value("animation-timing-function", "cubic-bezier(calc(-2), calc(0.7 / 2), calc(1.5), calc(0))", "cubic-bezier(calc(-2), calc(0.35), calc(1.5), calc(0))");
+test_valid_value("animation-timing-function", "cubic-bezier(0, sibling-index(), 1, sign(2em - 20px))");
+
+test_valid_value("animation-timing-function", "steps(4, start)");
+test_valid_value("animation-timing-function", "steps(2, end)", "steps(2)");
+test_valid_value("animation-timing-function", "steps( 2, end )", "steps(2)");
+test_valid_value("animation-timing-function", "steps(2, jump-start)");
+test_valid_value("animation-timing-function", "steps(2, jump-end)", "steps(2)");
+test_valid_value("animation-timing-function", "steps(2, jump-both)");
+test_valid_value("animation-timing-function", "steps(2, jump-none)");
+test_valid_value("animation-timing-function", "steps(calc(-10), start)");
+test_valid_value("animation-timing-function", "steps(calc(5 / 2), start)", "steps(calc(2.5), start)");
+test_valid_value("animation-timing-function", "steps(calc(1), jump-none)");
+
+test_valid_value("animation-timing-function", "linear, ease, linear");
+
+test_valid_value("animation-timing-function", "steps(calc(2 + sign(100em - 1px)))");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This PR allows `calc()` values in `steps()` and `cubic-bezier()` easing functions.

This fixes at least 9 WPT subtests.