### PR TITLE
Meta: Only run WPT.sh cleanup routines on Linux

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -301,8 +301,11 @@ cleanup_run_dirs() {
         rm -fr "${BUILD_DIR}/wpt"
     }
 cleanup_merge_dirs_and_infra() {
-    cleanup_run_dirs
-    cleanup_run_infra
+    # Cleanup is only needed on Linux
+    if [[ $OSTYPE == 'linux'* ]]; then
+        cleanup_run_dirs
+        cleanup_run_infra
+    fi
 }
 trap cleanup_merge_dirs_and_infra EXIT INT TERM
 


### PR DESCRIPTION
These use the `readarray` command which isn't available in the older version of Bash available on macOS. However, they're also not needed on macOS, so let's skip them entirely.

Fixes #5118

