### PR TITLE
LibWeb: Limit scroll bar thumb movement based on grab point

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -279,7 +279,7 @@ private:
     virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers) override;
 
     bool scrollbar_contains_mouse_position(ScrollDirection, CSSPixelPoint);
-    void scroll_to_mouse_postion(CSSPixelPoint);
+    void scroll_to_mouse_position(CSSPixelPoint);
 
     OwnPtr<StackingContext> m_stacking_context;
 
@@ -305,7 +305,7 @@ private:
     Optional<BordersData> m_outline_data;
     CSSPixels m_outline_offset { 0 };
 
-    Optional<CSSPixelPoint> m_last_mouse_tracking_position;
+    Optional<CSSPixels> m_scroll_thumb_grab_position;
     Optional<ScrollDirection> m_scroll_thumb_dragging_direction;
     bool m_draw_enlarged_horizontal_scrollbar { false };
     bool m_draw_enlarged_vertical_scrollbar { false };


### PR DESCRIPTION
Let this before/after speak for itself:

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/596ab0f7-53fa-4444-82ed-70ba58e49674"></video> | <video src="https://github.com/user-attachments/assets/5eb94141-bde6-4917-bfa8-fd2e9c0b043d"></video> |