### PR TITLE
LibWeb: Support counters on pseudo-elements

### DIFF
--- a/Documentation/CSSGeneratedFiles.md
+++ b/Documentation/CSSGeneratedFiles.md
@@ -169,7 +169,6 @@ Each entry has the following properties:
 |----------------------|----------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `alias-for`          | No       | Nothing        | Use to specify that this should be treated as an alias for the named pseudo-element.                                                                                   |
 | `function-syntax`    | No       | Nothing        | Syntax for the function arguments if this is a function-type pseudo-element. Copied directly from the spec.                                                            |
-| `is-generated`       | No       | `false`        | Whether this is a [generated pseudo-element](https://drafts.csswg.org/css-pseudo-4/#generated-content).                                                                |
 | `is-allowed-in-has`  | No       | `false`        | Whether this is a [`:has`-allowed pseudo-element](https://drafts.csswg.org/selectors/#has-allowed-pseudo-element).                                                     |
 | `is-pseudo-root`     | No       | `false` | Whether this is a [pseudo-element root](https://drafts.csswg.org/css-view-transitions/#pseudo-element-root).                                                                  |
 | `property-whitelist` | No       | Nothing        | Some pseudo-elements only permit certain properties. If so, name them in an array here. Some special values are allowed here for categories of properties - see below. |
@@ -184,9 +183,6 @@ The generated code provides:
 - `bool is_has_allowed_pseudo_element(PseudoElement)` returns whether the pseudo-element is valid inside `:has()`
 - `bool is_pseudo_element_root(PseudoElement)` returns whether the pseudo-element is a [pseudo-element root](https://drafts.csswg.org/css-view-transitions/#pseudo-element-root)
 - `bool pseudo_element_supports_property(PseudoElement, PropertyID)` returns whether the property can be applied to this pseudo-element
-- A `GeneratedPseudoElement` enum listing only the pseudo-elements that are [generated content](https://drafts.csswg.org/css-pseudo-4/#generated-content)
-- `Optional<GeneratedPseudoElement> to_generated_pseudo_element(PseudoElement)` for converting from `PseudoElement` to `GeneratedPseudoElement`. Returns nothing if it's not a generated pseudo-element
-- `PseudoElement to_pseudo_element(GeneratedPseudoElement)` does the opposite conversion
 
 ### `property-whitelist`
 

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -211,6 +211,7 @@ set(SOURCES
     CSS/VisualViewport.cpp
     DOM/AbortController.cpp
     DOM/AbortSignal.cpp
+    DOM/AbstractElement.cpp
     DOM/AbstractRange.cpp
     DOM/AccessibilityTreeNode.cpp
     DOM/AdoptedStyleSheets.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -250,6 +250,7 @@ set(SOURCES
     DOM/ParentNode.cpp
     DOM/Position.cpp
     DOM/ProcessingInstruction.cpp
+    DOM/PseudoElement.cpp
     DOM/QualifiedName.cpp
     DOM/Range.cpp
     DOM/ShadowRoot.cpp

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
@@ -5,7 +5,9 @@
  */
 
 #include <LibWeb/Bindings/CSSFontFaceDescriptorsPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSFontFaceDescriptors.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
@@ -5,7 +5,9 @@
  */
 
 #include <LibWeb/Bindings/CSSPageDescriptorsPrototype.h>
+#include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/CSSPageDescriptors.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -11,7 +11,7 @@
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CSS/CSSStyleValue.h>
 #include <LibWeb/CSS/StyleProperty.h>
-#include <LibWeb/DOM/ElementReference.h>
+#include <LibWeb/DOM/AbstractElement.h>
 
 namespace Web::CSS {
 
@@ -50,8 +50,8 @@ public:
     void set_parent_rule(GC::Ptr<CSSRule> parent) { m_parent_rule = parent; }
 
     // https://drafts.csswg.org/cssom/#cssstyledeclaration-owner-node
-    Optional<DOM::ElementReference> owner_node() const { return m_owner_node; }
-    void set_owner_node(Optional<DOM::ElementReference> owner_node) { m_owner_node = move(owner_node); }
+    Optional<DOM::AbstractElement> owner_node() const { return m_owner_node; }
+    void set_owner_node(Optional<DOM::AbstractElement> owner_node) { m_owner_node = move(owner_node); }
 
     // https://drafts.csswg.org/cssom/#cssstyledeclaration-updating-flag
     [[nodiscard]] bool is_updating() const { return m_updating; }
@@ -80,7 +80,7 @@ private:
     GC::Ptr<CSSRule> m_parent_rule { nullptr };
 
     // https://drafts.csswg.org/cssom/#cssstyledeclaration-owner-node
-    Optional<DOM::ElementReference> m_owner_node {};
+    Optional<DOM::AbstractElement> m_owner_node {};
 
     // https://drafts.csswg.org/cssom/#cssstyledeclaration-computed-flag
     bool m_computed { false };

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -44,7 +44,7 @@ GC::Ref<CSSStyleProperties> CSSStyleProperties::create(JS::Realm& realm, Vector<
     return realm.create<CSSStyleProperties>(realm, Computed::No, Readonly::No, convert_declarations_to_specified_order(properties), move(custom_properties), OptionalNone {});
 }
 
-GC::Ref<CSSStyleProperties> CSSStyleProperties::create_resolved_style(JS::Realm& realm, Optional<DOM::ElementReference> element_reference)
+GC::Ref<CSSStyleProperties> CSSStyleProperties::create_resolved_style(JS::Realm& realm, Optional<DOM::AbstractElement> element_reference)
 {
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
     // 6.  Return a live CSSStyleProperties object with the following properties:
@@ -57,7 +57,7 @@ GC::Ref<CSSStyleProperties> CSSStyleProperties::create_resolved_style(JS::Realm&
     return realm.create<CSSStyleProperties>(realm, Computed::Yes, Readonly::Yes, Vector<StyleProperty> {}, HashMap<FlyString, StyleProperty> {}, move(element_reference));
 }
 
-GC::Ref<CSSStyleProperties> CSSStyleProperties::create_element_inline_style(DOM::ElementReference element_reference, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties)
+GC::Ref<CSSStyleProperties> CSSStyleProperties::create_element_inline_style(DOM::AbstractElement element_reference, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties)
 {
     // https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style
     // The style attribute must return a CSS declaration block object whose readonly flag is unset, whose parent CSS
@@ -66,7 +66,7 @@ GC::Ref<CSSStyleProperties> CSSStyleProperties::create_element_inline_style(DOM:
     return realm.create<CSSStyleProperties>(realm, Computed::No, Readonly::No, convert_declarations_to_specified_order(properties), move(custom_properties), move(element_reference));
 }
 
-CSSStyleProperties::CSSStyleProperties(JS::Realm& realm, Computed computed, Readonly readonly, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties, Optional<DOM::ElementReference> owner_node)
+CSSStyleProperties::CSSStyleProperties(JS::Realm& realm, Computed computed, Readonly readonly, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties, Optional<DOM::AbstractElement> owner_node)
     : CSSStyleDeclaration(realm, computed, readonly)
     , m_properties(move(properties))
     , m_custom_properties(move(custom_properties))

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -22,8 +22,8 @@ class CSSStyleProperties
 public:
     [[nodiscard]] static GC::Ref<CSSStyleProperties> create(JS::Realm&, Vector<StyleProperty>, HashMap<FlyString, StyleProperty> custom_properties);
 
-    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_resolved_style(JS::Realm&, Optional<DOM::ElementReference>);
-    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_element_inline_style(DOM::ElementReference, Vector<StyleProperty>, HashMap<FlyString, StyleProperty> custom_properties);
+    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_resolved_style(JS::Realm&, Optional<DOM::AbstractElement>);
+    [[nodiscard]] static GC::Ref<CSSStyleProperties> create_element_inline_style(DOM::AbstractElement, Vector<StyleProperty>, HashMap<FlyString, StyleProperty> custom_properties);
 
     virtual ~CSSStyleProperties() override = default;
     virtual void initialize(JS::Realm&) override;
@@ -62,7 +62,7 @@ public:
     virtual CSSStyleProperties& generated_style_properties_to_css_style_properties() override { return *this; }
 
 private:
-    CSSStyleProperties(JS::Realm&, Computed, Readonly, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties, Optional<DOM::ElementReference>);
+    CSSStyleProperties(JS::Realm&, Computed, Readonly, Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties, Optional<DOM::AbstractElement>);
     static Vector<StyleProperty> convert_declarations_to_specified_order(Vector<StyleProperty>&);
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/GeneratedCSSStyleProperties.h>
+#include <LibWeb/DOM/Node.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -937,7 +937,7 @@ ColumnSpan ComputedProperties::column_span() const
     return keyword_to_column_span(value.to_keyword()).release_value();
 }
 
-ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(DOM::Element& element, u32 initial_quote_nesting_level) const
+ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(DOM::AbstractElement& element_reference, u32 initial_quote_nesting_level) const
 {
     auto const& value = property(PropertyID::Content);
     auto quotes_data = quotes();
@@ -1001,7 +1001,7 @@ ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(
                     break;
                 }
             } else if (item->is_counter()) {
-                builder.append(item->as_counter().resolve(element));
+                builder.append(item->as_counter().resolve(element_reference));
             } else {
                 // TODO: Implement images, and other things.
                 dbgln("`{}` is not supported in `content` (yet?)", item->to_string(SerializationMode::Normal));
@@ -1016,7 +1016,7 @@ ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(
                 if (item->is_string()) {
                     alt_text_builder.append(item->as_string().string_value());
                 } else if (item->is_counter()) {
-                    alt_text_builder.append(item->as_counter().resolve(element));
+                    alt_text_builder.append(item->as_counter().resolve(element_reference));
                 } else {
                     dbgln("`{}` is not supported in `content` alt-text (yet?)", item->to_string(SerializationMode::Normal));
                 }

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -96,7 +96,7 @@ public:
         ContentData content_data;
         u32 final_quote_nesting_level { 0 };
     };
-    ContentDataAndQuoteNestingLevel content(DOM::Element&, u32 initial_quote_nesting_level) const;
+    ContentDataAndQuoteNestingLevel content(DOM::AbstractElement&, u32 initial_quote_nesting_level) const;
     ContentVisibility content_visibility() const;
     Vector<CursorData> cursor() const;
     Variant<LengthOrCalculated, NumberOrCalculated> tab_size() const;

--- a/Libraries/LibWeb/CSS/CountersSet.h
+++ b/Libraries/LibWeb/CSS/CountersSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2024-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -47,5 +47,8 @@ public:
 private:
     Vector<Counter> m_counters;
 };
+
+void resolve_counters(DOM::AbstractElement&);
+void inherit_counters(DOM::AbstractElement&);
 
 }

--- a/Libraries/LibWeb/CSS/CountersSet.h
+++ b/Libraries/LibWeb/CSS/CountersSet.h
@@ -9,6 +9,7 @@
 #include <AK/Checked.h>
 #include <AK/FlyString.h>
 #include <AK/Optional.h>
+#include <LibWeb/DOM/AbstractElement.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {
@@ -22,7 +23,7 @@ using CounterValue = Checked<i32>;
 // https://drafts.csswg.org/css-lists-3/#counter
 struct Counter {
     FlyString name;
-    UniqueNodeID originating_element_id; // "creator"
+    DOM::AbstractElement originating_element; // "creator"
     bool reversed { false };
     Optional<CounterValue> value;
 };
@@ -33,16 +34,20 @@ public:
     CountersSet() = default;
     ~CountersSet() = default;
 
-    Counter& instantiate_a_counter(FlyString name, UniqueNodeID originating_element_id, bool reversed, Optional<CounterValue>);
-    void set_a_counter(FlyString name, UniqueNodeID originating_element_id, CounterValue value);
-    void increment_a_counter(FlyString name, UniqueNodeID originating_element_id, CounterValue amount);
+    Counter& instantiate_a_counter(FlyString name, DOM::AbstractElement const&, bool reversed, Optional<CounterValue>);
+    void set_a_counter(FlyString name, DOM::AbstractElement const&, CounterValue value);
+    void increment_a_counter(FlyString name, DOM::AbstractElement const&, CounterValue amount);
     void append_copy(Counter const&);
 
     Optional<Counter&> last_counter_with_name(FlyString const& name);
-    Optional<Counter&> counter_with_same_name_and_creator(FlyString const& name, UniqueNodeID originating_element_id);
+    Optional<Counter&> counter_with_same_name_and_creator(FlyString const& name, DOM::AbstractElement const&);
 
     Vector<Counter> const& counters() const { return m_counters; }
     bool is_empty() const { return m_counters.is_empty(); }
+
+    void visit_edges(GC::Cell::Visitor&);
+
+    String dump() const;
 
 private:
     Vector<Counter> m_counters;

--- a/Libraries/LibWeb/CSS/PseudoElements.json
+++ b/Libraries/LibWeb/CSS/PseudoElements.json
@@ -30,16 +30,13 @@
     "alias-for": "slider-thumb"
   },
   "after": {
-    "spec": "https://drafts.csswg.org/css-pseudo-4/#selectordef-after",
-    "is-generated": true
+    "spec": "https://drafts.csswg.org/css-pseudo-4/#selectordef-after"
   },
   "backdrop": {
-    "spec": "https://drafts.csswg.org/css-position-4/#selectordef-backdrop",
-    "is-generated": true
+    "spec": "https://drafts.csswg.org/css-position-4/#selectordef-backdrop"
   },
   "before": {
-    "spec": "https://drafts.csswg.org/css-pseudo-4/#selectordef-before",
-    "is-generated": true
+    "spec": "https://drafts.csswg.org/css-pseudo-4/#selectordef-before"
   },
   "details-content": {
     "spec": "https://drafts.csswg.org/css-pseudo-4/#selectordef-details-content"

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -1,15 +1,16 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
- * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2024-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "CounterStyleValue.h"
+#include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Keyword.h>
 #include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/StyleValues/CounterStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
 #include <LibWeb/DOM/Element.h>
@@ -94,13 +95,13 @@ static String generate_a_counter_representation(CSSStyleValue const& counter_sty
     return MUST(String::formatted("{}", value));
 }
 
-String CounterStyleValue::resolve(DOM::Element& element) const
+String CounterStyleValue::resolve(DOM::AbstractElement& element_reference) const
 {
     // "If no counter named <counter-name> exists on an element where counter() or counters() is used,
     // one is first instantiated with a starting value of 0."
-    auto& counters_set = element.ensure_counters_set();
+    auto& counters_set = element_reference.ensure_counters_set();
     if (!counters_set.last_counter_with_name(m_properties.counter_name).has_value())
-        counters_set.instantiate_a_counter(m_properties.counter_name, element.unique_id(), false, 0);
+        counters_set.instantiate_a_counter(m_properties.counter_name, element_reference, false, 0);
 
     // counter( <counter-name>, <counter-style>? )
     // "Represents the value of the innermost counter in the element’s CSS counters set named <counter-name>

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.h
@@ -34,7 +34,7 @@ public:
     auto counter_style() const { return m_properties.counter_style; }
     auto join_string() const { return m_properties.join_string; }
 
-    String resolve(DOM::Element&) const;
+    String resolve(DOM::AbstractElement&) const;
 
     virtual String to_string(SerializationMode) const override;
 

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024-2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/AbstractElement.h>
+
+namespace Web::DOM {
+
+AbstractElement::AbstractElement(GC::Ref<Element> element, Optional<CSS::PseudoElement> pseudo_element)
+    : m_element(element)
+    , m_pseudo_element(move(pseudo_element))
+{
+}
+
+void AbstractElement::visit(GC::Cell::Visitor& visitor) const
+{
+    visitor.visit(m_element);
+}
+
+GC::Ptr<Element const> AbstractElement::parent_element() const
+{
+    if (m_pseudo_element.has_value())
+        return m_element;
+    return m_element->parent_element();
+}
+
+GC::Ptr<CSS::ComputedProperties const> AbstractElement::computed_properties() const
+{
+    if (m_pseudo_element.has_value())
+        return m_element->pseudo_element_computed_properties(*m_pseudo_element);
+    return m_element->computed_properties();
+}
+
+CSS::CountersSet& AbstractElement::ensure_counters_set()
+{
+    // FIXME: Handle pseudo-elements
+    return m_element->ensure_counters_set();
+}
+
+void AbstractElement::set_counters_set(OwnPtr<CSS::CountersSet>&& counters_set)
+{
+    // FIXME: Handle pseudo-elements
+    m_element->set_counters_set(move(counters_set));
+}
+
+}

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/DOM/AbstractElement.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/Layout/Node.h>
 
 namespace Web::DOM {
 
@@ -20,11 +21,51 @@ void AbstractElement::visit(GC::Cell::Visitor& visitor) const
     visitor.visit(m_element);
 }
 
+GC::Ptr<Layout::NodeWithStyle> AbstractElement::layout_node()
+{
+    if (m_pseudo_element.has_value())
+        return m_element->get_pseudo_element_node(*m_pseudo_element);
+    return m_element->layout_node();
+}
+
 GC::Ptr<Element const> AbstractElement::parent_element() const
 {
     if (m_pseudo_element.has_value())
         return m_element;
     return m_element->parent_element();
+}
+
+Optional<AbstractElement> AbstractElement::walk_layout_tree(WalkMethod walk_method)
+{
+    GC::Ptr<Layout::Node> node = layout_node();
+    if (!node)
+        return OptionalNone {};
+
+    while (true) {
+        switch (walk_method) {
+        case WalkMethod::Previous:
+            node = node->previous_in_pre_order();
+            break;
+        case WalkMethod::PreviousSibling:
+            node = node->previous_sibling();
+            break;
+        }
+        if (!node)
+            return OptionalNone {};
+
+        if (auto* previous_element = as_if<Element>(node->dom_node()))
+            return AbstractElement { *previous_element };
+
+        if (node->is_generated())
+            return AbstractElement { *node->pseudo_element_generator(), node->generated_for_pseudo_element() };
+    }
+}
+
+bool AbstractElement::is_before(AbstractElement const& other) const
+{
+    auto this_node = layout_node();
+    auto other_node = other.layout_node();
+    return this_node && other_node && this_node->is_before(*other_node);
 }
 
 GC::Ptr<CSS::ComputedProperties const> AbstractElement::computed_properties() const
@@ -34,16 +75,46 @@ GC::Ptr<CSS::ComputedProperties const> AbstractElement::computed_properties() co
     return m_element->computed_properties();
 }
 
+bool AbstractElement::has_non_empty_counters_set() const
+{
+    if (m_pseudo_element.has_value())
+        return m_element->get_pseudo_element(*m_pseudo_element)->has_non_empty_counters_set();
+    return m_element->has_non_empty_counters_set();
+}
+
+Optional<CSS::CountersSet const&> AbstractElement::counters_set() const
+{
+    if (m_pseudo_element.has_value())
+        return m_element->get_pseudo_element(*m_pseudo_element)->counters_set();
+    return m_element->counters_set();
+}
+
 CSS::CountersSet& AbstractElement::ensure_counters_set()
 {
-    // FIXME: Handle pseudo-elements
+    if (m_pseudo_element.has_value())
+        return m_element->get_pseudo_element(*m_pseudo_element)->ensure_counters_set();
     return m_element->ensure_counters_set();
 }
 
 void AbstractElement::set_counters_set(OwnPtr<CSS::CountersSet>&& counters_set)
 {
-    // FIXME: Handle pseudo-elements
-    m_element->set_counters_set(move(counters_set));
+    if (m_pseudo_element.has_value()) {
+        m_element->get_pseudo_element(*m_pseudo_element)->set_counters_set(move(counters_set));
+    } else {
+        m_element->set_counters_set(move(counters_set));
+    }
+}
+
+String AbstractElement::debug_description() const
+{
+    if (m_pseudo_element.has_value()) {
+        StringBuilder builder;
+        builder.append(m_element->debug_description());
+        builder.append("::"sv);
+        builder.append(CSS::pseudo_element_name(*m_pseudo_element));
+        return builder.to_string_without_validation();
+    }
+    return m_element->debug_description();
 }
 
 }

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/DOM/AbstractElement.h>
+#include <LibWeb/DOM/Element.h>
 
 namespace Web::DOM {
 

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -21,15 +21,33 @@ public:
     Element const& element() const { return m_element; }
     Optional<CSS::PseudoElement> pseudo_element() const { return m_pseudo_element; }
 
+    GC::Ptr<Layout::NodeWithStyle> layout_node();
+    GC::Ptr<Layout::NodeWithStyle const> layout_node() const { return const_cast<AbstractElement*>(this)->layout_node(); }
+
     GC::Ptr<Element const> parent_element() const;
+    Optional<AbstractElement> previous_in_tree_order() { return walk_layout_tree(WalkMethod::Previous); }
+    Optional<AbstractElement> previous_sibling_in_tree_order() { return walk_layout_tree(WalkMethod::PreviousSibling); }
+    bool is_before(AbstractElement const&) const;
+
     GC::Ptr<CSS::ComputedProperties const> computed_properties() const;
 
+    bool has_non_empty_counters_set() const;
+    Optional<CSS::CountersSet const&> counters_set() const;
     CSS::CountersSet& ensure_counters_set();
     void set_counters_set(OwnPtr<CSS::CountersSet>&&);
 
     void visit(GC::Cell::Visitor& visitor) const;
 
+    String debug_description() const;
+    bool operator==(AbstractElement const&) const = default;
+
 private:
+    enum class WalkMethod : u8 {
+        Previous,
+        PreviousSibling,
+    };
+    Optional<AbstractElement> walk_layout_tree(WalkMethod);
+
     GC::Ref<Element> m_element;
     Optional<CSS::PseudoElement> m_pseudo_element;
 };

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -12,22 +12,22 @@
 
 namespace Web::DOM {
 
-class ElementReference {
+// Either an Element or a PseudoElement
+class AbstractElement {
 public:
-    ElementReference(GC::Ref<Element> element, Optional<CSS::PseudoElement> pseudo_element = {})
-        : m_element(element)
-        , m_pseudo_element(move(pseudo_element))
-    {
-    }
+    AbstractElement(GC::Ref<Element>, Optional<CSS::PseudoElement> = {});
 
     Element& element() { return m_element; }
     Element const& element() const { return m_element; }
     Optional<CSS::PseudoElement> pseudo_element() const { return m_pseudo_element; }
 
-    void visit(GC::Cell::Visitor& visitor) const
-    {
-        visitor.visit(m_element);
-    }
+    GC::Ptr<Element const> parent_element() const;
+    GC::Ptr<CSS::ComputedProperties const> computed_properties() const;
+
+    CSS::CountersSet& ensure_counters_set();
+    void set_counters_set(OwnPtr<CSS::CountersSet>&&);
+
+    void visit(GC::Cell::Visitor& visitor) const;
 
 private:
     GC::Ref<Element> m_element;

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -8,7 +8,7 @@
 
 #include <LibGC/Cell.h>
 #include <LibWeb/CSS/Selector.h>
-#include <LibWeb/DOM/Element.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::DOM {
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2966,7 +2966,7 @@ void Element::scroll(double x, double y)
     //               as the element is not eligible to be the Document.scrollingElement.
     if (x == 0
         && y == 0
-        && scroll_offset(ScrollOffsetFor::Self).is_zero()
+        && scroll_offset({}).is_zero()
         && this != document.body()
         && this != document.document_element()) {
         return;
@@ -3330,6 +3330,25 @@ IntersectionObserver::IntersectionObserverRegistration& Element::get_intersectio
     });
     VERIFY(!registration_iterator.is_end());
     return *registration_iterator;
+}
+
+CSSPixelPoint Element::scroll_offset(Optional<CSS::PseudoElement> pseudo_element_type) const
+{
+    if (pseudo_element_type.has_value()) {
+        if (auto pseudo_element = get_pseudo_element(*pseudo_element_type); pseudo_element.has_value())
+            return pseudo_element->scroll_offset();
+        return {};
+    }
+    return m_scroll_offset;
+}
+
+void Element::set_scroll_offset(Optional<CSS::PseudoElement> pseudo_element_type, CSSPixelPoint offset)
+{
+    if (pseudo_element_type.has_value()) {
+        if (auto pseudo_element = get_pseudo_element(*pseudo_element_type); pseudo_element.has_value())
+            pseudo_element->set_scroll_offset(offset);
+    }
+    m_scroll_offset = offset;
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#translation-mode

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/CSSStyleProperties.h>
 #include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/SelectorEngine.h>
@@ -128,6 +129,8 @@ void Element::visit_edges(Cell::Visitor& visitor)
         for (auto& registered_intersection_observers : *m_registered_intersection_observers)
             visitor.visit(registered_intersection_observers.observer);
     }
+    if (m_counters_set)
+        m_counters_set->visit_edges(visitor);
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattribute

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3737,7 +3737,7 @@ WebIDL::ExceptionOr<void> Element::set_html_unsafe(StringView html)
     return {};
 }
 
-Optional<CSS::CountersSet const&> Element::counters_set()
+Optional<CSS::CountersSet const&> Element::counters_set() const
 {
     if (!m_counters_set)
         return {};
@@ -3751,102 +3751,9 @@ CSS::CountersSet& Element::ensure_counters_set()
     return *m_counters_set;
 }
 
-// https://drafts.csswg.org/css-lists-3/#auto-numbering
-void Element::resolve_counters(CSS::ComputedProperties& style)
+void Element::set_counters_set(OwnPtr<CSS::CountersSet>&& counters_set)
 {
-    // Resolving counter values on a given element is a multi-step process:
-
-    // 1. Existing counters are inherited from previous elements.
-    inherit_counters();
-
-    // https://drafts.csswg.org/css-lists-3/#counters-without-boxes
-    // An element that does not generate a box (for example, an element with display set to none,
-    // or a pseudo-element with content set to none) cannot set, reset, or increment a counter.
-    // The counter properties are still valid on such an element, but they must have no effect.
-    if (style.display().is_none())
-        return;
-
-    // 2. New counters are instantiated (counter-reset).
-    auto counter_reset = style.counter_data(CSS::PropertyID::CounterReset);
-    for (auto const& counter : counter_reset)
-        ensure_counters_set().instantiate_a_counter(counter.name, unique_id(), counter.is_reversed, counter.value);
-
-    // FIXME: Take style containment into account
-    // https://drafts.csswg.org/css-contain-2/#containment-style
-    // Giving an element style containment has the following effects:
-    // 1. The 'counter-increment' and 'counter-set' properties must be scoped to the element’s sub-tree and create a
-    //    new counter.
-
-    // 3. Counter values are incremented (counter-increment).
-    auto counter_increment = style.counter_data(CSS::PropertyID::CounterIncrement);
-    for (auto const& counter : counter_increment)
-        ensure_counters_set().increment_a_counter(counter.name, unique_id(), *counter.value);
-
-    // 4. Counter values are explicitly set (counter-set).
-    auto counter_set = style.counter_data(CSS::PropertyID::CounterSet);
-    for (auto const& counter : counter_set)
-        ensure_counters_set().set_a_counter(counter.name, unique_id(), *counter.value);
-
-    // 5. Counter values are used (counter()/counters()).
-    // NOTE: This happens when we process the `content` property.
-}
-
-// https://drafts.csswg.org/css-lists-3/#inherit-counters
-void Element::inherit_counters()
-{
-    // 1. If element is the root of its document tree, the element has an initially-empty CSS counters set.
-    //    Return.
-    auto parent = parent_element();
-    if (parent == nullptr) {
-        // NOTE: We represent an empty counters set with `m_counters_set = nullptr`.
-        m_counters_set = nullptr;
-        return;
-    }
-
-    // 2. Let element counters, representing element’s own CSS counters set, be a copy of the CSS counters
-    //    set of element’s parent element.
-    OwnPtr<CSS::CountersSet> element_counters;
-    // OPTIMIZATION: If parent has a set, we create a copy. Otherwise, we avoid allocating one until we need
-    // to add something to it.
-    auto ensure_element_counters = [&]() {
-        if (!element_counters)
-            element_counters = make<CSS::CountersSet>();
-    };
-    if (parent->has_non_empty_counters_set()) {
-        element_counters = make<CSS::CountersSet>();
-        *element_counters = *parent_element()->counters_set();
-    }
-
-    // 3. Let sibling counters be the CSS counters set of element’s preceding sibling (if it has one),
-    //    or an empty CSS counters set otherwise.
-    //    For each counter of sibling counters, if element counters does not already contain a counter with
-    //    the same name, append a copy of counter to element counters.
-    if (auto* const sibling = previous_sibling_of_type<Element>(); sibling && sibling->has_non_empty_counters_set()) {
-        auto& sibling_counters = sibling->counters_set().release_value();
-        ensure_element_counters();
-        for (auto const& counter : sibling_counters.counters()) {
-            if (!element_counters->last_counter_with_name(counter.name).has_value())
-                element_counters->append_copy(counter);
-        }
-    }
-
-    // 4. Let value source be the CSS counters set of the element immediately preceding element in tree order.
-    //    For each source counter of value source, if element counters contains a counter with the same name
-    //    and creator, then set the value of that counter to source counter’s value.
-    if (auto* const previous = previous_element_in_pre_order(); previous && previous->has_non_empty_counters_set()) {
-        // NOTE: If element_counters is empty (AKA null) then we can skip this since nothing will match.
-        if (element_counters) {
-            auto& value_source = previous->counters_set().release_value();
-            for (auto const& source_counter : value_source.counters()) {
-                auto maybe_existing_counter = element_counters->counter_with_same_name_and_creator(source_counter.name, source_counter.originating_element_id);
-                if (maybe_existing_counter.has_value())
-                    maybe_existing_counter->value = source_counter.value;
-            }
-        }
-    }
-
-    VERIFY(!element_counters || !element_counters->is_empty());
-    m_counters_set = move(element_counters);
+    m_counters_set = move(counters_set);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -767,7 +767,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
 
 GC::Ref<CSS::ComputedProperties> Element::resolved_css_values(Optional<CSS::PseudoElement> type)
 {
-    auto element_computed_style = CSS::CSSStyleProperties::create_resolved_style(realm(), ElementReference { *this, type });
+    auto element_computed_style = CSS::CSSStyleProperties::create_resolved_style(realm(), AbstractElement { *this, type });
     auto properties = heap().allocate<CSS::ComputedProperties>();
 
     for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -219,6 +219,8 @@ public:
     void set_pseudo_element_computed_properties(CSS::PseudoElement, GC::Ptr<CSS::ComputedProperties>);
     GC::Ptr<CSS::ComputedProperties> pseudo_element_computed_properties(CSS::PseudoElement);
 
+    Optional<PseudoElement&> get_pseudo_element(CSS::PseudoElement) const;
+
     GC::Ptr<CSS::CSSStyleProperties> inline_style() { return m_inline_style; }
     GC::Ptr<CSS::CSSStyleProperties const> inline_style() const { return m_inline_style; }
     void set_inline_style(GC::Ptr<CSS::CSSStyleProperties>);
@@ -566,7 +568,6 @@ private:
 
     using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;
     mutable OwnPtr<PseudoElementData> m_pseudo_element_data;
-    Optional<PseudoElement&> get_pseudo_element(CSS::PseudoElement) const;
     PseudoElement& ensure_pseudo_element(CSS::PseudoElement) const;
 
     Optional<CSS::PseudoElement> m_use_pseudo_element;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -418,10 +418,9 @@ public:
     bool rendered_in_top_layer() const { return m_rendered_in_top_layer; }
 
     bool has_non_empty_counters_set() const { return m_counters_set; }
-    Optional<CSS::CountersSet const&> counters_set();
+    Optional<CSS::CountersSet const&> counters_set() const;
     CSS::CountersSet& ensure_counters_set();
-    void resolve_counters(CSS::ComputedProperties&);
-    void inherit_counters();
+    void set_counters_set(OwnPtr<CSS::CountersSet>&&);
 
     ProximityToTheViewport proximity_to_the_viewport() const { return m_proximity_to_the_viewport; }
     void determine_proximity_to_the_viewport();

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -23,6 +23,7 @@
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
 #include <LibWeb/DOM/ParentNode.h>
+#include <LibWeb/DOM/PseudoElement.h>
 #include <LibWeb/DOM/QualifiedName.h>
 #include <LibWeb/DOM/Slottable.h>
 #include <LibWeb/HTML/AttributeNames.h>
@@ -564,25 +565,6 @@ private:
     GC::Ptr<CSS::ComputedProperties> m_computed_properties;
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
 
-    struct PseudoElement : public JS::Cell {
-        GC_CELL(PseudoElement, JS::Cell);
-        GC_DECLARE_ALLOCATOR(PseudoElement);
-
-        GC::Ptr<Layout::NodeWithStyle> layout_node;
-        GC::Ptr<CSS::CascadedProperties> cascaded_properties;
-        GC::Ptr<CSS::ComputedProperties> computed_properties;
-        HashMap<FlyString, CSS::StyleProperty> custom_properties;
-
-    private:
-        virtual void visit_edges(JS::Cell::Visitor&) override;
-    };
-    // https://drafts.csswg.org/css-view-transitions/#pseudo-element-tree
-    struct PseudoElementTreeNode
-        : public PseudoElement
-        , TreeNode<PseudoElementTreeNode> {
-        GC_CELL(PseudoElementTreeNode, PseudoElement);
-        GC_DECLARE_ALLOCATOR(PseudoElementTreeNode);
-    };
     using PseudoElementData = HashMap<CSS::PseudoElement, GC::Ref<PseudoElement>>;
     mutable OwnPtr<PseudoElementData> m_pseudo_element_data;
     Optional<PseudoElement&> get_pseudo_element(CSS::PseudoElement) const;
@@ -673,7 +655,7 @@ inline bool Element::has_pseudo_element(CSS::PseudoElement type) const
     auto pseudo_element = m_pseudo_element_data->get(type);
     if (!pseudo_element.has_value())
         return false;
-    return pseudo_element.value()->layout_node;
+    return pseudo_element.value()->layout_node();
 }
 
 WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, FlyString const& qualified_name);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -16,7 +16,6 @@
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/ComputedProperties.h>
-#include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
 #include <LibWeb/CSS/StyleProperty.h>

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -373,13 +373,8 @@ public:
     void unregister_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, GC::Ref<IntersectionObserver::IntersectionObserver>);
     IntersectionObserver::IntersectionObserverRegistration& get_intersection_observer_registration(Badge<DOM::Document>, IntersectionObserver::IntersectionObserver const&);
 
-    enum class ScrollOffsetFor {
-        Self,
-        PseudoBefore,
-        PseudoAfter
-    };
-    CSSPixelPoint scroll_offset(ScrollOffsetFor type) const { return m_scroll_offset[to_underlying(type)]; }
-    void set_scroll_offset(ScrollOffsetFor type, CSSPixelPoint offset) { m_scroll_offset[to_underlying(type)] = offset; }
+    CSSPixelPoint scroll_offset(Optional<CSS::PseudoElement> type) const;
+    void set_scroll_offset(Optional<CSS::PseudoElement> type, CSSPixelPoint offset);
 
     enum class TranslationMode {
         TranslateEnabled,
@@ -595,7 +590,7 @@ private:
     // Element objects have an internal [[RegisteredIntersectionObservers]] slot, which is initialized to an empty list.
     OwnPtr<Vector<IntersectionObserver::IntersectionObserverRegistration>> m_registered_intersection_observers;
 
-    Array<CSSPixelPoint, 3> m_scroll_offset;
+    CSSPixelPoint m_scroll_offset;
 
     bool m_in_top_layer : 1 { false };
     bool m_rendered_in_top_layer : 1 { false };

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/CascadedProperties.h>
+#include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/DOM/PseudoElement.h>
+#include <LibWeb/Layout/Node.h>
+
+namespace Web::DOM {
+
+GC_DEFINE_ALLOCATOR(PseudoElement);
+GC_DEFINE_ALLOCATOR(PseudoElementTreeNode);
+
+void PseudoElement::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+
+    visitor.visit(m_cascaded_properties);
+    visitor.visit(m_computed_properties);
+    visitor.visit(m_layout_node);
+}
+
+}

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -23,4 +23,23 @@ void PseudoElement::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_layout_node);
 }
 
+Optional<CSS::CountersSet const&> PseudoElement::counters_set() const
+{
+    if (!m_counters_set)
+        return {};
+    return *m_counters_set;
+}
+
+CSS::CountersSet& PseudoElement::ensure_counters_set()
+{
+    if (!m_counters_set)
+        m_counters_set = make<CSS::CountersSet>();
+    return *m_counters_set;
+}
+
+void PseudoElement::set_counters_set(OwnPtr<CSS::CountersSet>&& counters_set)
+{
+    m_counters_set = move(counters_set);
+}
+
 }

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -21,6 +21,8 @@ void PseudoElement::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_cascaded_properties);
     visitor.visit(m_computed_properties);
     visitor.visit(m_layout_node);
+    if (m_counters_set)
+        m_counters_set->visit_edges(visitor);
 }
 
 Optional<CSS::CountersSet const&> PseudoElement::counters_set() const

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -30,6 +30,11 @@ class PseudoElement : public JS::Cell {
     HashMap<FlyString, CSS::StyleProperty> const& custom_properties() const { return m_custom_properties; }
     void set_custom_properties(HashMap<FlyString, CSS::StyleProperty> value) { m_custom_properties = move(value); }
 
+    bool has_non_empty_counters_set() const { return m_counters_set; }
+    Optional<CSS::CountersSet const&> counters_set() const;
+    CSS::CountersSet& ensure_counters_set();
+    void set_counters_set(OwnPtr<CSS::CountersSet>&&);
+
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
 private:
@@ -37,6 +42,7 @@ private:
     GC::Ptr<CSS::CascadedProperties> m_cascaded_properties;
     GC::Ptr<CSS::ComputedProperties> m_computed_properties;
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
+    OwnPtr<CSS::CountersSet> m_counters_set;
 };
 
 // https://drafts.csswg.org/css-view-transitions/#pseudo-element-tree

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGC/CellAllocator.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibWeb/CSS/StyleProperty.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/TreeNode.h>
+
+namespace Web::DOM {
+
+class PseudoElement : public JS::Cell {
+    GC_CELL(PseudoElement, JS::Cell);
+    GC_DECLARE_ALLOCATOR(PseudoElement);
+
+    GC::Ptr<Layout::NodeWithStyle> layout_node() const { return m_layout_node; }
+    void set_layout_node(GC::Ptr<Layout::NodeWithStyle> value) { m_layout_node = value; }
+
+    GC::Ptr<CSS::CascadedProperties> cascaded_properties() const { return m_cascaded_properties; }
+    void set_cascaded_properties(GC::Ptr<CSS::CascadedProperties> value) { m_cascaded_properties = value; }
+
+    GC::Ptr<CSS::ComputedProperties> computed_properties() const { return m_computed_properties; }
+    void set_computed_properties(GC::Ptr<CSS::ComputedProperties> value) { m_computed_properties = value; }
+
+    HashMap<FlyString, CSS::StyleProperty> const& custom_properties() const { return m_custom_properties; }
+    void set_custom_properties(HashMap<FlyString, CSS::StyleProperty> value) { m_custom_properties = move(value); }
+
+    virtual void visit_edges(JS::Cell::Visitor&) override;
+
+private:
+    GC::Ptr<Layout::NodeWithStyle> m_layout_node;
+    GC::Ptr<CSS::CascadedProperties> m_cascaded_properties;
+    GC::Ptr<CSS::ComputedProperties> m_computed_properties;
+    HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
+};
+
+// https://drafts.csswg.org/css-view-transitions/#pseudo-element-tree
+class PseudoElementTreeNode final
+    : public PseudoElement
+    , TreeNode<PseudoElementTreeNode> {
+    GC_CELL(PseudoElementTreeNode, PseudoElement);
+    GC_DECLARE_ALLOCATOR(PseudoElementTreeNode);
+};
+
+}

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -35,6 +35,9 @@ class PseudoElement : public JS::Cell {
     CSS::CountersSet& ensure_counters_set();
     void set_counters_set(OwnPtr<CSS::CountersSet>&&);
 
+    CSSPixelPoint scroll_offset() const { return m_scroll_offset; }
+    void set_scroll_offset(CSSPixelPoint value) { m_scroll_offset = value; }
+
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
 private:
@@ -43,6 +46,7 @@ private:
     GC::Ptr<CSS::ComputedProperties> m_computed_properties;
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
     OwnPtr<CSS::CountersSet> m_counters_set;
+    CSSPixelPoint m_scroll_offset {};
 };
 
 // https://drafts.csswg.org/css-view-transitions/#pseudo-element-tree

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -4741,7 +4741,7 @@ Optional<NonnullRefPtr<CSS::CSSStyleValue const>> resolved_value(GC::Ref<DOM::No
         return {};
 
     // Retrieve resolved style value
-    auto resolved_css_style_declaration = CSS::CSSStyleProperties::create_resolved_style(element->realm(), DOM::ElementReference { static_cast<DOM::Element&>(*element) });
+    auto resolved_css_style_declaration = CSS::CSSStyleProperties::create_resolved_style(element->realm(), DOM::AbstractElement { static_cast<DOM::Element&>(*element) });
     auto optional_style_property = resolved_css_style_declaration->property(property_id);
     if (!optional_style_property.has_value())
         return {};

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -339,6 +339,7 @@ namespace Web::DOM {
 
 class AbortController;
 class AbortSignal;
+class AbstractElement;
 class AbstractRange;
 class AccessibilityTreeNode;
 class Attr;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -185,6 +185,7 @@ class ConicGradientStyleValue;
 class ContentStyleValue;
 class CounterDefinitionsStyleValue;
 class CounterStyleValue;
+class CountersSet;
 class CSSAnimation;
 class CSSColorValue;
 class CSSConditionRule;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -373,6 +373,7 @@ class NodeList;
 class ParentNode;
 class Position;
 class ProcessingInstruction;
+class PseudoElement;
 class Range;
 class RegisteredObserver;
 class ShadowRoot;

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1278,7 +1278,7 @@ GC::Ref<CSS::CSSStyleDeclaration> Window::get_computed_style(DOM::Element& eleme
     // 1. Let doc be elt’s node document.
 
     // 2. Let obj be elt.
-    Optional<DOM::ElementReference> object { element };
+    Optional<DOM::AbstractElement> object { element };
 
     // 3. If pseudoElt is provided, is not the empty string, and starts with a colon, then:
     if (pseudo_element.has_value() && pseudo_element.value().starts_with(':')) {

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -50,10 +50,10 @@ public:
     void reset_needs_layout_update() { m_needs_layout_update = false; }
 
     bool is_generated() const { return m_generated_for.has_value(); }
-    bool is_generated_for_before_pseudo_element() const { return m_generated_for == CSS::GeneratedPseudoElement::Before; }
-    bool is_generated_for_after_pseudo_element() const { return m_generated_for == CSS::GeneratedPseudoElement::After; }
-    bool is_generated_for_backdrop_pseudo_element() const { return m_generated_for == CSS::GeneratedPseudoElement::Backdrop; }
-    void set_generated_for(CSS::GeneratedPseudoElement type, DOM::Element& element)
+    bool is_generated_for_before_pseudo_element() const { return m_generated_for == CSS::PseudoElement::Before; }
+    bool is_generated_for_after_pseudo_element() const { return m_generated_for == CSS::PseudoElement::After; }
+    bool is_generated_for_backdrop_pseudo_element() const { return m_generated_for == CSS::PseudoElement::Backdrop; }
+    void set_generated_for(CSS::PseudoElement type, DOM::Element& element)
     {
         m_generated_for = type;
         m_pseudo_element_generator = &element;
@@ -224,7 +224,7 @@ private:
 
     bool m_needs_layout_update { false };
 
-    Optional<CSS::GeneratedPseudoElement> m_generated_for {};
+    Optional<CSS::PseudoElement> m_generated_for {};
 
     u32 m_initial_quote_nesting_level { 0 };
 };

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -50,6 +50,7 @@ public:
     void reset_needs_layout_update() { m_needs_layout_update = false; }
 
     bool is_generated() const { return m_generated_for.has_value(); }
+    Optional<CSS::PseudoElement> generated_for_pseudo_element() const { return m_generated_for; }
     bool is_generated_for_before_pseudo_element() const { return m_generated_for == CSS::PseudoElement::Before; }
     bool is_generated_for_after_pseudo_element() const { return m_generated_for == CSS::PseudoElement::After; }
     bool is_generated_for_backdrop_pseudo_element() const { return m_generated_for == CSS::PseudoElement::Backdrop; }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -219,15 +219,14 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Ps
         pseudo_element_node->prepend_child(*list_item_marker);
     }
 
-    auto generated_for = CSS::to_generated_pseudo_element(pseudo_element).release_value();
-    pseudo_element_node->set_generated_for(generated_for, element);
+    pseudo_element_node->set_generated_for(pseudo_element, element);
     pseudo_element_node->set_initial_quote_nesting_level(initial_quote_nesting_level);
 
     // FIXME: Handle images, and multiple values
     if (pseudo_element_content.type == CSS::ContentData::Type::String) {
         auto text = document.realm().create<DOM::Text>(document, pseudo_element_content.data);
         auto text_node = document.heap().allocate<Layout::TextNode>(document, *text);
-        text_node->set_generated_for(generated_for, element);
+        text_node->set_generated_for(pseudo_element, element);
 
         push_parent(*pseudo_element_node);
         insert_node_into_inline_or_block_ancestor(*text_node, text_node->display(), AppendOrPrepend::Append);
@@ -583,7 +582,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                                 return;
 
                             top_layer_element->set_pseudo_element_node({}, CSS::PseudoElement::Backdrop, pseudo_element_node);
-                            pseudo_element_node->set_generated_for(CSS::GeneratedPseudoElement::Backdrop, top_layer_element);
+                            pseudo_element_node->set_generated_for(CSS::PseudoElement::Backdrop, top_layer_element);
                             insert_node_into_inline_or_block_ancestor(*pseudo_element_node, pseudo_element_display, AppendOrPrepend::Append);
                         }();
                         update_layout_tree(top_layer_element, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -195,9 +195,10 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Ps
     auto pseudo_element_display = pseudo_element_style->display();
     // ::before and ::after only exist if they have content. `content: normal` computes to `none` for them.
     // We also don't create them if they are `display: none`.
-    if (pseudo_element_display.is_none()
-        || pseudo_element_content.type == CSS::ContentData::Type::Normal
-        || pseudo_element_content.type == CSS::ContentData::Type::None)
+    if (first_is_one_of(pseudo_element, CSS::PseudoElement::Before, CSS::PseudoElement::After)
+        && (pseudo_element_display.is_none()
+            || pseudo_element_content.type == CSS::ContentData::Type::Normal
+            || pseudo_element_content.type == CSS::ContentData::Type::None))
         return;
 
     auto pseudo_element_node = DOM::Element::create_layout_node_for_display_type(document, pseudo_element_display, *pseudo_element_style, nullptr);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -723,6 +723,7 @@ void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, GC::Ref
         auto marker_style = style_computer.compute_style(element, CSS::PseudoElement::Marker);
         auto list_item_marker = document.heap().allocate<ListItemMarkerBox>(document, layout_node->computed_values().list_style_type(), layout_node->computed_values().list_style_position(), element, marker_style);
         static_cast<ListItemBox&>(*layout_node).set_marker(list_item_marker);
+        element.set_pseudo_element_computed_properties(CSS::PseudoElement::Marker, marker_style);
         element.set_pseudo_element_node({}, CSS::PseudoElement::Marker, list_item_marker);
         layout_node->prepend_child(*list_item_marker);
     }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -480,7 +480,8 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
             element.clear_pseudo_element_nodes({});
             VERIFY(!element.needs_style_update());
             style = element.computed_properties();
-            element.resolve_counters(*style);
+            DOM::AbstractElement element_reference { element };
+            CSS::resolve_counters(element_reference);
             display = style->display();
             if (display.is_none())
                 return;

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -96,15 +96,13 @@ CSSPixelPoint PaintableBox::scroll_offset() const
     }
 
     auto const& node = layout_node();
-    if (node.is_generated_for_before_pseudo_element())
-        return node.pseudo_element_generator()->scroll_offset(DOM::Element::ScrollOffsetFor::PseudoBefore);
-    if (node.is_generated_for_after_pseudo_element())
-        return node.pseudo_element_generator()->scroll_offset(DOM::Element::ScrollOffsetFor::PseudoAfter);
+    if (auto pseudo_element = node.generated_for_pseudo_element(); pseudo_element.has_value())
+        return node.pseudo_element_generator()->scroll_offset(*pseudo_element);
 
     if (!(dom_node() && is<DOM::Element>(*dom_node())))
         return {};
 
-    return static_cast<DOM::Element const*>(dom_node())->scroll_offset(DOM::Element::ScrollOffsetFor::Self);
+    return static_cast<DOM::Element const*>(dom_node())->scroll_offset({});
 }
 
 void PaintableBox::set_scroll_offset(CSSPixelPoint offset)
@@ -127,12 +125,10 @@ void PaintableBox::set_scroll_offset(CSSPixelPoint offset)
         return;
 
     auto& node = layout_node();
-    if (node.is_generated_for_before_pseudo_element()) {
-        node.pseudo_element_generator()->set_scroll_offset(DOM::Element::ScrollOffsetFor::PseudoBefore, offset);
-    } else if (node.is_generated_for_after_pseudo_element()) {
-        node.pseudo_element_generator()->set_scroll_offset(DOM::Element::ScrollOffsetFor::PseudoAfter, offset);
+    if (auto pseudo_element = node.generated_for_pseudo_element(); pseudo_element.has_value()) {
+        node.pseudo_element_generator()->set_scroll_offset(*pseudo_element, offset);
     } else if (is<DOM::Element>(*dom_node())) {
-        static_cast<DOM::Element*>(dom_node())->set_scroll_offset(DOM::Element::ScrollOffsetFor::Self, offset);
+        static_cast<DOM::Element*>(dom_node())->set_scroll_offset({}, offset);
     } else {
         return;
     }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoElement.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoElement.cpp
@@ -99,23 +99,6 @@ struct PseudoElementMetadata {
 };
 PseudoElementMetadata pseudo_element_metadata(PseudoElement);
 
-enum class GeneratedPseudoElement : @generated_pseudo_element_underlying_type@ {
-)~~~");
-    pseudo_elements_data.for_each_member([&](auto& name, JsonValue const& value) {
-        auto& pseudo_element = value.as_object();
-        if (!pseudo_element.get_bool("is-generated"sv).value_or(false))
-            return;
-
-        auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
-        member_generator.appendln("    @name:titlecase@,");
-    });
-    generator.append(R"~~~(
-};
-
-Optional<GeneratedPseudoElement> to_generated_pseudo_element(PseudoElement);
-PseudoElement to_pseudo_element(GeneratedPseudoElement);
-
 }
 )~~~");
 
@@ -561,57 +544,6 @@ PseudoElementMetadata pseudo_element_metadata(PseudoElement pseudo_element)
         };
     case PseudoElement::KnownPseudoElementCount:
         break;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-Optional<GeneratedPseudoElement> to_generated_pseudo_element(PseudoElement pseudo_element)
-{
-    switch (pseudo_element) {
-)~~~");
-
-    pseudo_elements_data.for_each_member([&](auto& name, JsonValue const& value) {
-        auto& pseudo_element = value.as_object();
-        if (pseudo_element.has("alias-for"sv))
-            return;
-        if (!pseudo_element.get_bool("is-generated"sv).value_or(false))
-            return;
-
-        auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
-        member_generator.append(R"~~~(
-    case PseudoElement::@name:titlecase@:
-        return GeneratedPseudoElement::@name:titlecase@;
-)~~~");
-    });
-
-    generator.append(R"~~~(
-    default:
-        return {};
-    }
-}
-
-PseudoElement to_pseudo_element(GeneratedPseudoElement generated_pseudo_element)
-{
-    switch (generated_pseudo_element) {
-)~~~");
-
-    pseudo_elements_data.for_each_member([&](auto& name, JsonValue const& value) {
-        auto& pseudo_element = value.as_object();
-        if (pseudo_element.has("alias-for"sv))
-            return;
-        if (!pseudo_element.get_bool("is-generated"sv).value_or(false))
-            return;
-
-        auto member_generator = generator.fork();
-        member_generator.set("name:titlecase", title_casify(name));
-        member_generator.append(R"~~~(
-    case GeneratedPseudoElement::@name:titlecase@:
-        return PseudoElement::@name:titlecase@;
-)~~~");
-    });
-
-    generator.append(R"~~~(
     }
     VERIFY_NOT_REACHED();
 }

--- a/Tests/LibWeb/Layout/expected/css/counters-on-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/css/counters-on-pseudo-elements.txt
@@ -1,0 +1,46 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x70 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x54 children: not-inline
+      BlockContainer <div#a> at (8,8) content-size 784x18 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [26.6875,8 9.34375x18] baseline: 13.796875
+            "a"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,8 18.6875x18] baseline: 13.796875
+              "1. "
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div#b> at (8,26) content-size 784x18 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [29.15625,26 9.46875x18] baseline: 13.796875
+            "b"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,26 21.15625x18] baseline: 13.796875
+              "2. "
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div#c> at (8,44) content-size 784x18 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [29.4375,44 8.890625x18] baseline: 13.796875
+            "c"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,44 21.4375x18] baseline: 13.796875
+              "3. "
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,62) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x54]
+      PaintableWithLines (BlockContainer<DIV>#a) [8,8 784x18]
+        PaintableWithLines (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#b) [8,26 784x18]
+        PaintableWithLines (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>#c) [8,44 784x18]
+        PaintableWithLines (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,62 784x0]

--- a/Tests/LibWeb/Layout/input/css/counters-on-pseudo-elements.html
+++ b/Tests/LibWeb/Layout/input/css/counters-on-pseudo-elements.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    body {
+      counter-reset: section;
+    }
+    div::before {
+      counter-increment: section;
+      content: counter(section) ". ";
+    }
+</style><div id=a>a</div><div id=b>b</div><div id=c>c</div>


### PR DESCRIPTION
The CSS-Lists spec, where [counters](https://drafts.csswg.org/css-lists-3/#counter) are defined, generally just talks about "elements" having a counters set, but actually includes pseudo-elements in that. This PR gives them a CountersSet and greatly extends AbstractElement (previously known as ElementReference) so that the counters algorithms don't have to care whether they're dealing with a "real" element or not. There are also some related pseudo-element changes.

## Before
![image](https://github.com/user-attachments/assets/32f4fd95-b3ba-4d55-b422-5ca9d12c1527)


## After
![image](https://github.com/user-attachments/assets/e1b49249-346a-4cf4-aad0-c70f711b5f0a)