### PR TITLE
CI: Use GitHub's actions cache instead of Blacksmith's for now

### DIFF
--- a/.github/actions/cache-restore/action.yml
+++ b/.github/actions/cache-restore/action.yml
@@ -42,10 +42,10 @@ inputs:
 outputs:
   ccache_primary_key:
     description: 'Primary ccache key'
-    value: ${{ steps.cache-outputs.outputs.ccache_primary_key }}
+    value: ${{ steps.ccache.outputs.cache-primary-key }}
   vcpkg_cache_primary_key:
     description: 'Primary vcpkg binary cache key'
-    value: ${{ steps.cache-outputs.outputs.vcpkg_cache_primary_key }}
+    value: ${{ steps.vcpkg.outputs.cache-primary-key }}
 
 runs:
   using: "composite"
@@ -56,26 +56,13 @@ runs:
       run: |
         echo "timestamp=$(date -u "+%Y%m%d%H%M_%S")" >> "$GITHUB_OUTPUT"
 
-    - name: 'Compiler Cache (blacksmith)'
-      uses: useblacksmith/cache/restore@v5
-      id: 'ccache-blacksmith'
-      if: ${{ inputs.ccache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
-      with:
-        path: ${{ inputs.ccache_path }}
-        key: '"ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
-        restore-keys: |
-          ccache | ${{ inputs.os }} | ${{ inputs.arch }} | ${{ inputs.toolchain }} | ${{ inputs.cache_key_extra }} | ${{ inputs.ccache_version }}
-          "ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
-
-    - name: 'Compiler Cache (GitHub runner)'
+    - name: 'Compiler Cache'
       uses: actions/cache/restore@v4
-      id: 'ccache-gh'
-      if: ${{ inputs.ccache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
+      id: 'ccache'
       with:
         path: ${{ inputs.ccache_path }}
         key: '"ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
         restore-keys: |
-          ccache | ${{ inputs.os }} | ${{ inputs.arch }} | ${{ inputs.toolchain }} | ${{ inputs.cache_key_extra }} | ${{ inputs.ccache_version }}
           "ccache" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
 
     - name: 'Configure Compiler Cache'
@@ -90,38 +77,11 @@ runs:
           CCACHE_DIR=${{ inputs.ccache_path }} ccache -s
           CCACHE_DIR=${{ inputs.ccache_path }} ccache -z
 
-    - name: 'Restore vcpkg cache (blacksmith)'
-      uses: useblacksmith/cache/restore@v5
-      if: ${{ inputs.vcpkg_cache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
-      id: 'vcpkg-blacksmith'
-      with:
-        path: ${{ inputs.vcpkg_cache_path }}
-        key: '"vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
-        restore-keys: |
-          vcpkg | ${{ inputs.os }} | ${{ inputs.arch }} | ${{ inputs.toolchain }} | ${{ inputs.cache_key_extra }} | ${{ inputs.ccache_version }}
-          "vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
-
-    - name: 'Restore vcpkg cache (GitHub runner)'
+    - name: 'Restore vcpkg cache'
       uses: actions/cache/restore@v4
-      if: ${{ inputs.ccache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
-      id: 'vcpkg-gh'
+      id: 'vcpkg'
       with:
         path: ${{ inputs.vcpkg_cache_path }}
         key: '"vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}" | ${{ steps.date-stamp.outputs.timestamp }}'
         restore-keys: |
-          vcpkg | ${{ inputs.os }} | ${{ inputs.arch }} | ${{ inputs.toolchain }} | ${{ inputs.cache_key_extra }} | ${{ inputs.ccache_version }}
           "vcpkg" | "${{ inputs.os }}" | "${{ inputs.arch }}" | "${{ inputs.toolchain }}" | "${{ inputs.cache_key_extra }}" | "${{ inputs.ccache_version }}"
-
-    # FIXME: When all runners are using the useblacksmith/cache action and this step is removed, we should also be able
-    #        to remove the quoteless cache restore keys in the cache actions above.
-    - name: 'Cache Outputs'
-      id: 'cache-outputs'
-      shell: bash
-      run: |
-        if ${{ contains(inputs.runner_labels, 'blacksmith') }} ; then
-          echo "ccache_primary_key=${{ steps.ccache-blacksmith.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
-          echo "vcpkg_cache_primary_key=${{ steps.vcpkg-blacksmith.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "ccache_primary_key=${{ steps.ccache-gh.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
-          echo "vcpkg_cache_primary_key=${{ steps.vcpkg-gh.outputs.cache-primary-key }}" >> "$GITHUB_OUTPUT"
-        fi

--- a/.github/actions/cache-save/action.yml
+++ b/.github/actions/cache-save/action.yml
@@ -36,16 +36,8 @@ runs:
       run: |
         CCACHE_DIR=${{ inputs.ccache_path }} ccache --evict-older-than=1d
 
-    - name: 'Compiler Cache (blacksmith)'
-      uses: useblacksmith/cache/save@v5
-      if: ${{ inputs.ccache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
-      with:
-        path: ${{ inputs.ccache_path }}
-        key: ${{ inputs.ccache_primary_key }}
-
-    - name: 'Compiler Cache (GitHub runner)'
+    - name: 'Compiler Cache'
       uses: actions/cache/save@v4
-      if: ${{ inputs.ccache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.ccache_path }}
         key: ${{ inputs.ccache_primary_key }}
@@ -56,16 +48,8 @@ runs:
       run: |
         CCACHE_DIR=${{ inputs.ccache_path }} ccache -s
 
-    - name: 'vcpkg binary cache (blacksmith)'
-      uses: useblacksmith/cache/save@v5
-      if: ${{ inputs.vcpkg_cache_path != '' && contains(inputs.runner_labels, 'blacksmith') }}
-      with:
-        path: ${{ inputs.vcpkg_cache_path }}
-        key: ${{ inputs.vcpkg_cache_primary_key }}
-
-    - name: 'vcpkg binary cache (GitHub runner)'
+    - name: 'vcpkg binary cache'
       uses: actions/cache/save@v4
-      if: ${{ inputs.vcpkg_cache_path != '' && !contains(inputs.runner_labels, 'blacksmith') }}
       with:
         path: ${{ inputs.vcpkg_cache_path }}
         key: ${{ inputs.vcpkg_cache_primary_key }}


### PR DESCRIPTION
We were seeing lower ccache hitrates using Blacksmith's cache, and after some investigation it turned out that actions running on our `master` branch were pulling the caches from PRs. Blacksmith is looking into this - for now revert to GitHub's cache until the issue is resolved.