### PR TITLE
LibWeb: Remove `Document::validate_qualified_name()`

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -567,12 +567,6 @@ public:
 
     static bool is_valid_name(String const&);
 
-    struct PrefixAndTagName {
-        FlyString prefix;
-        FlyString tag_name;
-    };
-    static WebIDL::ExceptionOr<PrefixAndTagName> validate_qualified_name(JS::Realm&, FlyString const& qualified_name);
-
     GC::Ref<NodeIterator> create_node_iterator(Node& root, unsigned what_to_show, GC::Ptr<NodeFilter>);
     GC::Ref<TreeWalker> create_tree_walker(Node& root, unsigned what_to_show, GC::Ptr<NodeFilter>);
 


### PR DESCRIPTION
This is no longer used and appears to have been removed from the specification.

No functional changes.