### PR TITLE
Meta: Switch to different source for pre-commit feature in dev-container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     // Features to add to the dev container. More info: https://containers.dev/implementors/features.
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
+        "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
         "./features/ladybird": {
             "llvm_version": 20
         },


### PR DESCRIPTION
I ran into an issue while setting up a dev-container as configured. The given source for the pre-commit feature doesn't exist anymore. This change switches to a different source for the same feature: https://github.com/devcontainers-extra/features/pkgs/container/features%2Fpre-commit

While this works (for now), it should be considered, that this new source is equally prone to the same supply chain risk as the one before.