### PR TITLE
LibWeb: Merge consecutive grid lines in GridTrackSizeList

### DIFF
--- a/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -209,6 +209,11 @@ bool GridTrackSizeList::operator==(GridTrackSizeList const& other) const = defau
 
 void GridTrackSizeList::append(GridLineNames&& line_names)
 {
+    if (!m_list.is_empty() && m_list.last().has<GridLineNames>()) {
+        auto& last_line_names = m_list.last().get<GridLineNames>();
+        last_line_names.names.extend(move(line_names.names));
+        return;
+    }
     m_list.append(move(line_names));
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-shorthand.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 63 tests
 
-34 Pass
-29 Fail
+35 Pass
+28 Fail
 Fail	e.style['grid'] = "none" should set grid-auto-columns
 Fail	e.style['grid'] = "none" should set grid-auto-flow
 Fail	e.style['grid'] = "none" should set grid-auto-rows
@@ -37,7 +37,7 @@ Fail	e.style['grid'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \
 Fail	e.style['grid'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-auto-rows
 Pass	e.style['grid'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-areas
 Pass	e.style['grid'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-columns
-Fail	e.style['grid'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-rows
+Pass	e.style['grid'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-rows
 Pass	e.style['grid'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should not set unrelated longhands
 Fail	e.style['grid'] = "  \"a a a\"  \"b b b\" 1fr/ auto 1fr auto" should set grid-auto-columns
 Fail	e.style['grid'] = "  \"a a a\"  \"b b b\" 1fr/ auto 1fr auto" should set grid-auto-flow

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-template-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-template-shorthand.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 24 tests
 
-23 Pass
-1 Fail
+24 Pass
 Pass	e.style['grid-template'] = "none" should set grid-template-areas
 Pass	e.style['grid-template'] = "none" should set grid-template-columns
 Pass	e.style['grid-template'] = "none" should set grid-template-rows
@@ -18,7 +17,7 @@ Pass	e.style['grid-template'] = "fit-content(calc(-0.5em + 10px)) / fit-content(
 Pass	e.style['grid-template'] = "fit-content(calc(-0.5em + 10px)) / fit-content(calc(0.5em + 10px))" should not set unrelated longhands
 Pass	e.style['grid-template'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-areas
 Pass	e.style['grid-template'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-columns
-Fail	e.style['grid-template'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-rows
+Pass	e.style['grid-template'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should set grid-template-rows
 Pass	e.style['grid-template'] = "[header-top] \"a a a\"     [header-bottom]  [main-top] \"b b b\" 1fr [main-bottom]           / auto 1fr auto" should not set unrelated longhands
 Pass	e.style['grid-template'] = "  \"a a a\"  \"b b b\" 1fr/ auto 1fr auto" should set grid-template-areas
 Pass	e.style['grid-template'] = "  \"a a a\"  \"b b b\" 1fr/ auto 1fr auto" should set grid-template-columns


### PR DESCRIPTION
Fixes a bug where consecutively defined grid lines were not merged during serialization.