### PR TITLE
LibTLS: Use non-blocking TLS socket in the handshake test

### DIFF
--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -202,7 +202,7 @@ TLSv12::~TLSv12()
 
 ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect_internal(NonnullOwnPtr<Core::TCPSocket> socket, ByteString const& host, Options options)
 {
-    TRY(socket->set_blocking(options.blocking));
+    TRY(socket->set_blocking(false));
 
     auto* ssl_ctx = OPENSSL_TRY_PTR(SSL_CTX_new(TLS_client_method()));
     ArmedScopeGuard free_ssl_ctx = [&] { SSL_CTX_free(ssl_ctx); };

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -14,26 +14,7 @@
 namespace TLS {
 
 struct Options {
-
-#define OPTION_WITH_DEFAULTS(typ, name, ...) \
-    static typ default_##name()              \
-    {                                        \
-        return typ { __VA_ARGS__ };          \
-    }                                        \
-    typ name = default_##name();             \
-    Options& set_##name(typ new_value) &     \
-    {                                        \
-        name = move(new_value);              \
-        return *this;                        \
-    }                                        \
-    Options&& set_##name(typ new_value) &&   \
-    {                                        \
-        name = move(new_value);              \
-        return move(*this);                  \
-    }
-
-    OPTION_WITH_DEFAULTS(Optional<ByteString>, root_certificates_path, )
-    OPTION_WITH_DEFAULTS(bool, blocking, true)
+    Optional<ByteString> root_certificates_path;
 };
 
 class TLSv12 final : public Core::Socket {

--- a/Libraries/LibWebSocket/Impl/WebSocketImplSerenity.cpp
+++ b/Libraries/LibWebSocket/Impl/WebSocketImplSerenity.cpp
@@ -46,8 +46,7 @@ void WebSocketImplSerenity::connect(ConnectionInfo const& connection_info)
         auto host = connection_info.url().serialized_host().to_byte_string();
         if (connection_info.is_secure()) {
             TLS::Options options;
-            options.set_root_certificates_path(connection_info.root_certificates_path());
-            options.set_blocking(false);
+            options.root_certificates_path = connection_info.root_certificates_path();
 
             return TRY(Core::BufferedSocket<TLS::TLSv12>::create(
                 TRY(TLS::TLSv12::connect(host, connection_info.url().port_or_default(), move(options)))));

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -61,10 +61,9 @@ static NonnullRefPtr<Resolver> default_resolver()
 
         if (g_dns_info.use_dns_over_tls) {
             TLS::Options options;
-            options.set_blocking(false);
 
             if (!g_default_certificate_path.is_empty())
-                options.set_root_certificates_path(g_default_certificate_path);
+                options.root_certificates_path = g_default_certificate_path;
 
             return DNS::Resolver::SocketResult {
                 MaybeOwned<Core::Socket>(TRY(TLS::TLSv12::connect(*g_dns_info.server_address, *g_dns_info.server_hostname, move(options)))),

--- a/Tests/LibDNS/TestDNSResolver.cpp
+++ b/Tests/LibDNS/TestDNSResolver.cpp
@@ -94,8 +94,7 @@ TEST_CASE(test_tls)
             Core::SocketAddress addr = { IPv4Address::from_string("1.1.1.1"sv).value(), static_cast<u16>(853) };
 
             TLS::Options options;
-            options.set_root_certificates_path(locate_ca_certs_file());
-            options.set_blocking(false);
+            options.root_certificates_path = locate_ca_certs_file();
 
             return DNS::Resolver::SocketResult {
                 MaybeOwned<Core::Socket>(TRY(TLS::TLSv12::connect(addr, "1.1.1.1", move(options)))),

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -8,6 +8,7 @@
 #include <AK/Base64.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
 #include <LibCrypto/ASN1/ASN1.h>
 #include <LibCrypto/ASN1/PEM.h>
 #include <LibFileSystem/FileSystem.h>
@@ -38,10 +39,13 @@ static Optional<ByteString> locate_ca_certs_file()
 
 TEST_CASE(test_TLS_hello_handshake)
 {
+    Core::EventLoop loop;
+
     TLS::Options options;
+    options.blocking = false;
     options.set_root_certificates_path(locate_ca_certs_file());
 
-    auto tls = TRY_OR_FAIL(TLS::TLSv12::connect(DEFAULT_SERVER, port, move(options)));
+    auto tls = TRY_OR_FAIL(Core::BufferedSocket<TLS::TLSv12>::create(TRY_OR_FAIL(TLS::TLSv12::connect(DEFAULT_SERVER, port, move(options)))));
 
     TRY_OR_FAIL(tls->write_until_depleted("GET /generate_204 HTTP/1.1\r\nHost: "_b));
 
@@ -49,7 +53,26 @@ TEST_CASE(test_TLS_hello_handshake)
     TRY_OR_FAIL(tls->write_until_depleted(the_server.bytes()));
     TRY_OR_FAIL(tls->write_until_depleted("\r\nConnection: close\r\n\r\n"_b));
 
-    auto tmp = TRY_OR_FAIL(ByteBuffer::create_zeroed(128));
-    auto contents = TRY_OR_FAIL(tls->read_some(tmp));
-    EXPECT(contents.starts_with("HTTP/1.1 204 No Content\r\n"_b));
+    tls->on_ready_to_read = [&]() mutable -> void {
+        auto read_buffer = ByteBuffer::create_uninitialized(4096).release_value();
+        auto err = tls->can_read_up_to_delimiter("\r\n"sv.bytes());
+        if (err.is_error() && err.error().code() != EAGAIN) {
+            FAIL("Unexpected socket error during read");
+            loop.quit(1);
+            return;
+        }
+        if (!err.value())
+            return;
+
+        auto line = TRY_OR_FAIL(tls->read_until_any_of(read_buffer, Array { "\r\n"sv }));
+        EXPECT(line.starts_with("HTTP/1.1 204 No Content"_b));
+        loop.quit(0);
+    };
+    tls->set_notifications_enabled(true);
+
+    auto timeout = Core::Timer::create_single_shot(10'000, [&loop] {
+        loop.quit(1);
+    });
+
+    EXPECT_EQ(loop.exec(), 0);
 }

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -42,8 +42,7 @@ TEST_CASE(test_TLS_hello_handshake)
     Core::EventLoop loop;
 
     TLS::Options options;
-    options.blocking = false;
-    options.set_root_certificates_path(locate_ca_certs_file());
+    options.root_certificates_path = locate_ca_certs_file();
 
     auto tls = TRY_OR_FAIL(Core::BufferedSocket<TLS::TLSv12>::create(TRY_OR_FAIL(TLS::TLSv12::connect(DEFAULT_SERVER, port, move(options)))));
 

--- a/Utilities/dns.cpp
+++ b/Utilities/dns.cpp
@@ -78,8 +78,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto make_resolver = [&](Core::SocketAddress const& address) -> ErrorOr<DNS::Resolver::SocketResult> {
                 if (use_tls) {
                     TLS::Options options;
-                    options.set_root_certificates_path(cert_path);
-                    options.set_blocking(false);
+                    options.root_certificates_path = cert_path;
 
                     auto tls = TRY(TLS::TLSv12::connect(address, server_address, move(options)));
                     return DNS::Resolver::SocketResult { move(tls), DNS::Resolver::ConnectionMode::TCP };


### PR DESCRIPTION
None of our real code use cases actually use blocking mode. So we should be testing non-blocking.