### PR TITLE
LibWeb: Correctly handle serialization of PseudoElements

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -475,7 +475,8 @@ String Selector::SimpleSelector::serialize() const
         break;
     }
     case Selector::SimpleSelector::Type::PseudoElement:
-        // Note: Pseudo-elements are dealt with in Selector::serialize()
+        // AD-HOC: Spec issue: https://github.com/w3c/csswg-drafts/issues/11997
+        s.append(this->pseudo_element().serialize());
         break;
     case Type::Nesting:
         // AD-HOC: Not in spec yet.
@@ -572,9 +573,8 @@ String Selector::serialize() const
         } else {
             // 4. If this is the last part of the chain of the selector and there is a pseudo-element,
             // append "::" followed by the name of the pseudo-element, to s.
-            if (compound_selector.simple_selectors.last().type == Selector::SimpleSelector::Type::PseudoElement) {
-                s.append(compound_selector.simple_selectors.last().pseudo_element().serialize());
-            }
+            // This algorithm has a problem, see https://github.com/w3c/csswg-drafts/issues/11997
+            //      serialization of pseudoElements was moved to SimpleSelector::serialize()
         }
     }
 

--- a/Tests/LibWeb/Text/expected/css/CSSStyleRule-pseudoElement-selectorText.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleRule-pseudoElement-selectorText.txt
@@ -1,0 +1,2 @@
+::-webkit-scrollbar-thumb
+::-webkit-scrollbar-thumb:hover

--- a/Tests/LibWeb/Text/input/css/CSSStyleRule-pseudoElement-selectorText.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleRule-pseudoElement-selectorText.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+::-webkit-scrollbar-thumb {
+  background: #28bea5;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #28bea5;
+}
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        for (let rule of document.styleSheets[0].cssRules) {
+            println(rule.selectorText);
+        }
+    });
+</script>


### PR DESCRIPTION
I was testing ladybird when I found a weird problem in a website where opening it the background was colored, while accessing it on another browser it wasn't.

I decided to take a look and was able to reduce its code to this:

```html
<!DOCTYPE html>
<head>
    <style>
::-webkit-scrollbar-thumb:hover {
  background: #28bea5;
}
    </style>
</head>
<html lang="pt" style="zoom: 100%">
  <script>
    !(function () {
      var e = {
          755: function (e, t) {
            var n;
            !(function (t, n) {
              n(t);
            })(window, function (r, i) {
              var s = Object.getPrototypeOf,
                v = function (e) {
                  return true;
                },
                b = r.document;

              var S = function (e, t) {
                return new S.fn.init(e, t);
              };
              (S.fn = S.prototype = {}),
                (S.extend = S.fn.extend =
                  function () {
                    return s;
                  });

              S.fn.extend({
                filter: function (e) {
                  return this.pushStack(N(this, e || [], !1));
                },
              });
              var D;
              ((S.fn.init = function (e, t, n) {
                if (((n = n || D), "string" == typeof e)) {
                  return this;
                }
                return e.nodeType
                  ? ((this[0] = e), (this.length = 1), this)
                  : v(e)
                    ? void 0 !== n.ready
                      ? n.ready(e)
                      : e(S)
                    : S.makeArray(e, this);
              }).prototype = S.fn),
                (D = S(b));
            (S.trim = function (e) {
                return "";
              }),
                void 0 ===
                  (n = function () {
                    return S;
                  }.apply(t, [])) || (e.exports = n);
              return S;
            });
          },
        },
        t = {};
      function n(r) {
        var a = (t[r] = { exports: {} });
        return e[r].call(a.exports, a, a.exports, n), a.exports;
      }
      (n.n = function (e) {
        var t = () => e;
        return n.d(t, { a: t }), t;
      }),
        (n.d = function (e, t) {}),
        (function () {
          var e = n(755),
            t = n.n(e);
          function _(e, t) {
            ([].forEach.call(e.styleSheets, o), t.mustPolyfill)
            function o(e) {
                [].forEach.call(e.cssRules || [], function (r, i) {
                    r.selectorText = r.selectorText.replace(
                      /\.js-has-pseudo\s/g,
                      ""
                    );
                });
            }
          }
          t()(() => {
            _(document);
          });
        })();
    })();
  </script>
  <body>
    <h1>this is a test</h1>
  </body>
</html>
```

If you try to run this on Ladybird, and hover the mouse over the text, the background will turn green, while this doesn't happen on other browsers.

![Pasted image 20250622212318](https://github.com/user-attachments/assets/707c4598-0655-4b4f-9d28-ade2c5cf8070)

For what I investigated this happens because the site uses JQuery, and at the same time has a colored scrollbar, which is referred on the CSS with the PseudoElement `::-webkit-scrollbar-thumb`, but the problem specifically happens when it has the PseudoClass `:hover` .

The reason is because the code from JQuery apparently tries to apply some kind of polyfill rules on the CSS (honestly I don't know exactly what it is doing with it), but in doing this it rewrites the `cssRule`s from the document's stylesheets, probably only changing what it needs. 

But this hits a problem on Ladybird, where we are not serializing PseudoElements correctly to put on `CssRule::selectorText` attributes, and because of this, when the script does this rewrite on the stylesheet the selector `::-webkit-scrollbar-thumb:hover` breaks and becomes only `:hover`.

(You can see this by inspecting document.stylesheets)

![Pasted image 20250622213235](https://github.com/user-attachments/assets/fe43fa63-42e3-48ed-b2bd-a7e0eef014c1)

In the first render everything works OK, you can try this by removing the javascript code, and the bug won't happen, the browser parses the stylesheet correctly, and correctly ignores the `::-webkit-*` PseudoElement at the time to apply the styles, as is described on the spec, the only problem is when javascript accesses the `selectorText`.

I tracked the problem to the `Selector::SimpleSelector::Type::PseudoElement` case of `SimpleSelector::serialize()`, it assumes that in `Selector::serialize()` the serialization of PseudoElements is dealt with, but here:

![Pasted image 20250622204206](https://github.com/user-attachments/assets/4ddb24df-7ed7-4a30-80ce-6dde7f5761f7)

the code only works if the PseudoElement is the last SimpleSelector from the CompoundSelector. This explains why if you remove the `:hover` PseudoClass from my example code the error does not happen.

The thing I found weird on this is that the comment is not actually wrong, the spec does not mention the serialization of PseudoElements in the section where it describes the serializations of other SimpleSelectors.

Am I just confused or could this be an issue with the spec?

Anyway, the code I provided fixes the problem, serializing the PseudoElement wherever it is in the selector. I also had to remove the code from `Selector::serialize()`, otherwise it would duplicate the PseudoElement in the case in which it was the last element.

This is my first PR, so I don't know if the approach I used to solve this is the correct one and if there's something I'm missing, the code is a proof-of-concept of the solution, I ask for your help on what should be the best way to fix this the right way.