### PR TITLE
LibGfx: Nearest neighbor scaling for ScalingMode::SmoothPixels

### DIFF
--- a/Libraries/LibGfx/SkiaUtils.h
+++ b/Libraries/LibGfx/SkiaUtils.h
@@ -121,9 +121,9 @@ constexpr SkSamplingOptions to_skia_sampling_options(Gfx::ScalingMode scaling_mo
 {
     switch (scaling_mode) {
     case Gfx::ScalingMode::NearestNeighbor:
+    case Gfx::ScalingMode::SmoothPixels:
         return SkSamplingOptions(SkFilterMode::kNearest);
     case Gfx::ScalingMode::BilinearBlend:
-    case Gfx::ScalingMode::SmoothPixels:
         return SkSamplingOptions(SkFilterMode::kLinear);
     case Gfx::ScalingMode::BoxSampling:
         return SkSamplingOptions(SkCubicResampler::Mitchell());


### PR DESCRIPTION
As #5072 covers, `image-rendering: pixelated` was fixed in #1208 and accidentally reverted in #2876.
#5073 would have fixed it again, but was bested by CRLF line endings.