### PR TITLE
CI: Fix path to test-dumps folder of LibWeb tests for artifact upload

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -231,7 +231,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: libweb-test-artifacts-${{ inputs.os_name }}-${{ inputs.build_preset }}-${{ inputs.toolchain }}-${{ inputs.clang-plugins }}
-          path: ${{ github.workspace }}/Build/UI/Headless/test-dumps
+          path: ${{ github.workspace }}/Build/Lagom/Tests/LibWeb/test-web/test-dumps/
           retention-days: 0
           if-no-files-found: ignore
 


### PR DESCRIPTION
The CI runs are supposed to upload test dumps for failed LibWeb tests as artifacts. However, the path for the artifact upload was wrong, it likely regressed in #5026.

Verified to work in https://github.com/LadybirdBrowser/ladybird/actions/runs/15828383994?pr=5180#artifacts