### PR TITLE
Documentation: Update Testing.md to reflect changes in CMake presets

### DIFF
--- a/Documentation/Testing.md
+++ b/Documentation/Testing.md
@@ -16,27 +16,25 @@ The easiest way to run tests is to use the `ladybird.py` script. The LibWeb test
 just the LibWeb tests with `Meta/ladybird.py test LibWeb`. The second way is to invoke the `test-web` test runner
 directly with `Meta/ladybird.py run test-web`.
 
-A third way is to invoke `ctest` directly. The simplest method is to use the `default` preset from `CMakePresets.json`:
+A third way is to invoke `ctest` directly. The simplest method is to use the `Release` preset from `CMakePresets.json`:
 
 ```sh
-cmake --preset default
-cmake --build --preset default
-ctest --preset default
+cmake --preset Release
+cmake --build --preset Release
+ctest --preset Release
 ```
 
-If you want to avoid building and running LibWeb tests, you can use a Lagom-only build.
-
-```sh
-cmake -GNinja -S Meta/Lagom -B Build/lagom
-```
-
-The tests can be run via ninja after doing a build. Note that `test-js` requires the `LADYBIRD_SOURCE_DIR` environment
-variable to be set to the root of the ladybird source tree.
+Note that some tests require the `LADYBIRD_SOURCE_DIR` environment variable to be set to the root of the ladybird source tree.
 
 ```sh
 # /path/to/ladybird repository
 export LADYBIRD_SOURCE_DIR=${PWD}
-cd Build/lagom
+```
+
+The tests can be run via ninja after doing a build.
+
+```sh
+cd Build/release
 ninja
 ninja test
 ```


### PR DESCRIPTION
I ran into some issues while working through [Testing Ladybird](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/Testing.md) related to the `default` CMake preset which was removed with #4942. I adjusted the documentation in that respect and separated the instruction about `LADYBIRD_SOURCE_DIR` from those about the targeted ninja run, since it appears to be relevant independently as well.

Due to some helpful advice from @ADKaster I also came to realize that the instructions about the Lagom-only build seem to be invalid. Being unaware of an equivalent valid approach I removed it without replacement from the page.