### PR TITLE
LibWeb: Replace usages of `Document::parse_url()`

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1199,16 +1199,6 @@ URL::URL Document::base_url() const
     return base_element->frozen_base_url();
 }
 
-// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
-Optional<URL::URL> Document::parse_url(StringView url) const
-{
-    // 1. Let baseURL be environment's base URL, if environment is a Document object; otherwise environment's API base URL.
-    auto base_url = this->base_url();
-
-    // 2. Return the result of applying the URL parser to url, with baseURL.
-    return DOMURL::parse(url, base_url);
-}
-
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-a-url
 Optional<URL::URL> Document::encoding_parse_url(StringView url) const
 {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4975,9 +4975,8 @@ void Document::shared_declarative_refresh_steps(StringView input, GC::Ptr<HTML::
     }
 
     parse:
-        // 11. Parse: Parse urlString relative to document. If that fails, return. Otherwise, set urlRecord to the
-        //     resulting URL record.
-        auto maybe_url_record = parse_url(url_string);
+        // 11. Set urlRecord to the result of encoding-parsing a URL given urlString, relative to document.
+        auto maybe_url_record = encoding_parse_url(url_string);
         if (!maybe_url_record.has_value())
             return;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -235,7 +235,6 @@ public:
     HTML::OpenerPolicy const& opener_policy() const { return m_opener_policy; }
     void set_opener_policy(HTML::OpenerPolicy policy) { m_opener_policy = move(policy); }
 
-    Optional<URL::URL> parse_url(StringView) const;
     Optional<URL::URL> encoding_parse_url(StringView) const;
     Optional<String> encoding_parse_and_serialize_url(StringView) const;
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -136,7 +136,7 @@ private:
 
     void handle_successful_fetch(URL::URL const&, StringView mime_type, ImageRequest&, ByteBuffer, bool maybe_omit_events, URL::URL const& previous_url);
     void handle_failed_fetch();
-    void add_callbacks_to_image_request(GC::Ref<ImageRequest>, bool maybe_omit_events, URL::URL const& url_string, String const& previous_url);
+    void add_callbacks_to_image_request(GC::Ref<ImageRequest>, bool maybe_omit_events, String const& url_string, String const& previous_url);
 
     void animate();
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -642,7 +642,7 @@ WebIDL::ExceptionOr<void> HTMLLinkElement::load_fallback_favicon_if_needed(GC::R
     //    synchronous flag is set, credentials mode is "include", and whose use-URL-credentials flag is set.
     // NOTE: Fetch requests no longer have a synchronous flag, see https://github.com/whatwg/fetch/pull/1165
     auto request = Fetch::Infrastructure::Request::create(vm);
-    request->set_url(*document->parse_url("/favicon.ico"sv));
+    request->set_url(*document->encoding_parse_url("/favicon.ico"sv));
     request->set_client(&document->relevant_settings_object());
     request->set_destination(Fetch::Infrastructure::Request::Destination::Image);
     request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::Include);

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -387,10 +387,10 @@ void HTMLScriptElement::prepare_script()
         // 4. Set el's from an external file to true.
         m_from_an_external_file = true;
 
-        // 5. Parse src relative to el's node document.
-        auto url = document().parse_url(src);
+        // 5. Let url be the result of encoding-parsing a URL given src, relative to el's node document.
+        auto url = document().encoding_parse_url(src);
 
-        // 6. If the previous step failed, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return. Otherwise, let url be the resulting URL record.
+        // 6. If url is failure, then queue an element task on the DOM manipulation task source given el to fire an event named error at el, and return.
         if (!url.has_value()) {
             dbgln("HTMLScriptElement: Refusing to run script because the src URL '{}' is invalid.", url);
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this] {

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -183,13 +183,14 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
     if (!poster.has_value() || poster->is_empty())
         return {};
 
-    // 3. Parse the poster attribute's value relative to the element's node document. If this fails, then there is no
-    //    poster frame; return.
-    auto url_record = document().parse_url(*poster);
+    // 3. Let url be the result of encoding-parsing a URL given the poster attribute's value, relative to the element's node document.
+    auto url_record = document().encoding_parse_url(*poster);
+
+    // 4. If url is failure, then return.
     if (!url_record.has_value())
         return {};
 
-    // 4. Let request be a new request whose URL is the resulting URL record, client is the element's node document's
+    // 5. Let request be a new request whose URL is the resulting URL record, client is the element's node document's
     //    relevant settings object, destination is "image", initiator type is "video", credentials mode is "include",
     //    and whose use-URL-credentials flag is set.
     auto request = Fetch::Infrastructure::Request::create(vm);
@@ -200,10 +201,11 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
     request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::Include);
     request->set_use_url_credentials(true);
 
-    // 5. Fetch request. This must delay the load event of the element's node document.
+    // 6. Fetch request. This must delay the load event of the element's node document.
     Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
     m_load_event_delayer.emplace(document());
 
+    // 7. If an image is thus obtained, the poster frame is that image. Otherwise, there is no poster frame.
     fetch_algorithms_input.process_response = [this](auto response) mutable {
         ScopeGuard guard { [&] { m_load_event_delayer.clear(); } };
 

--- a/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
+++ b/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
@@ -22,7 +22,7 @@ bool ListOfAvailableImages::Key::operator==(Key const& other) const
 u32 ListOfAvailableImages::Key::hash() const
 {
     if (!cached_hash.has_value()) {
-        u32 url_hash = Traits<URL::URL>::hash(url);
+        u32 url_hash = url.hash();
         u32 mode_hash = static_cast<u32>(mode);
         u32 origin_hash = 0;
         if (origin.has_value())

--- a/Libraries/LibWeb/HTML/ListOfAvailableImages.h
+++ b/Libraries/LibWeb/HTML/ListOfAvailableImages.h
@@ -22,7 +22,7 @@ class ListOfAvailableImages : public JS::Cell {
 
 public:
     struct Key {
-        URL::URL url;
+        String url;
         HTML::CORSSettingAttribute mode;
         Optional<URL::Origin> origin;
 

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -209,14 +209,15 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
     // 1. Let url be the URL record about:blank.
     auto url = URL::about_blank();
 
-    // 2. If element has a src attribute specified, and its value is not the empty string,
-    //    then parse the value of that attribute relative to element's node document.
-    //    If this is successful, then set url to the resulting URL record.
+    // 2. If element has a src attribute specified, and its value is not the empty string, then:
     auto src_attribute_value = get_attribute_value(HTML::AttributeNames::src);
     if (!src_attribute_value.is_empty()) {
-        auto parsed_src = document().parse_url(src_attribute_value);
-        if (parsed_src.has_value())
-            url = parsed_src.release_value();
+        // 1. Let maybeURL be the result of encoding-parsing a URL given that attribute's value, relative to element's node document.
+        auto maybe_url = document().encoding_parse_url(src_attribute_value);
+
+        // 2. If maybeURL is not failure, then set url to maybeURL.
+        if (maybe_url.has_value())
+            url = maybe_url.release_value();
     }
 
     // 3. If the inclusive ancestor navigables of element's node navigable contains a navigable

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -146,7 +146,7 @@ void SVGImageElement::process_the_url(Optional<String> const& href)
         return;
     }
 
-    m_href = document().parse_url(*href);
+    m_href = document().encoding_parse_url(*href);
     if (!m_href.has_value())
         return;
 

--- a/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -92,7 +92,7 @@ void SVGScriptElement::process_the_script_element()
     if (has_attribute(SVG::AttributeNames::href) || has_attribute_ns(Namespace::XLink.to_string(), SVG::AttributeNames::href)) {
         auto href_value = href()->base_val();
 
-        auto maybe_script_url = document().parse_url(href_value);
+        auto maybe_script_url = document().encoding_parse_url(href_value);
         if (!maybe_script_url.has_value()) {
             dbgln("Invalid script URL: {}", href_value);
             return;


### PR DESCRIPTION
The spec has been updated to use `encoding_parse_url()` and `encoding_parse_and_serialize_url()` instead.