### PR TITLE
LibWeb: Handle non-numeric `font-weight` values in keyframes

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -386,7 +386,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     //       That's why it has to be set before everything else.
     computed_values.set_font_list(computed_style.computed_font_list());
     computed_values.set_font_size(computed_style.font_size());
-    computed_values.set_font_weight(round_to<int>(computed_style.property(CSS::PropertyID::FontWeight).as_number().number()));
+    computed_values.set_font_weight(computed_style.property(CSS::PropertyID::FontWeight).to_font_weight());
     computed_values.set_font_kerning(computed_style.font_kerning());
     computed_values.set_line_height(computed_style.line_height());
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Fail
+Fail	Initially, the sibling-index() is 3 for #target
+Fail	Removing a preceding sibling of #target reduces the sibling-index()

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: sibling-index() changing font-weight during @keyframes animation</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#tree-counting">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+  @keyframes --anim {
+    from {
+      font-weight: calc(100 * sibling-index());
+    }
+    to {
+      font-weight: 600;
+    }
+  }
+  #target {
+    animation: --anim 1000s step-end;
+  }
+</style>
+<div>
+  <div id="rm"></div>
+  <div></div>
+  <div id="target"></div>
+</div>
+<script>
+  test(() => {
+    assert_equals(getComputedStyle(target).fontWeight, "300");
+  }, "Initially, the sibling-index() is 3 for #target");
+
+  test(() => {
+    rm.remove();
+    assert_equals(getComputedStyle(target).fontWeight, "200");
+  }, "Removing a preceding sibling of #target reduces the sibling-index()");
+
+</script>


### PR DESCRIPTION
Previously, using `font-weight` with a keyword or `calc()` value inside a keyframe rule would cause a crash.

AFAICT, this doesn't get us any more WPT passes, but it does prevent a crash in: http://wpt.live/css/css-values/tree-counting/sibling-index-keyframe-font-weight-dynamic.html, which I've imported.