### PR TITLE
LibGfx: Destroy FontConfig string iterator after use

### DIFF
--- a/Libraries/LibGfx/Font/FontDatabase.cpp
+++ b/Libraries/LibGfx/Font/FontDatabase.cpp
@@ -63,6 +63,7 @@ ErrorOr<Vector<String>> FontDatabase::font_directories()
         char const* dir_cstring = reinterpret_cast<char const*>(dir);
         paths.append(TRY(String::from_utf8(StringView { dir_cstring, strlen(dir_cstring) })));
     }
+    FcStrListDone(dirs);
     return paths;
 
 #elif defined(AK_OS_HAIKU)


### PR DESCRIPTION
This avoids a memory leak in `FontDatabase::font_directories()`.

Found by running the following command: `BUILD_PRESET=Sanitizer Meta/ladybird.py run test-web -f Text/input/selection-over-multiple-code-units.html`

