### PR TITLE
LibWeb: Treat the custom property name "--" as invalid

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1125,6 +1125,8 @@ Optional<Declaration> Parser::consume_a_declaration(TokenStream<T>& input, Neste
 
     // 8. If decl’s name is a custom property name string, then set decl’s original text to the segment
     //    of the original source text string corresponding to the tokens of decl’s value.
+    if (is_invalid_custom_property_name_string(declaration.name))
+        return {};
     if (is_a_custom_property_name_string(declaration.name)) {
         // TODO: If we could reach inside the source string that the TokenStream uses, we could grab this as
         //       a single substring instead of having to reconstruct it.

--- a/Libraries/LibWeb/CSS/PropertyName.h
+++ b/Libraries/LibWeb/CSS/PropertyName.h
@@ -11,11 +11,19 @@
 
 namespace Web::CSS {
 
+static bool is_invalid_custom_property_name_string(StringView string)
+{
+    // https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name
+    // The <custom-property-name> production corresponds to this: it’s defined as any <dashed-ident>
+    // (a valid identifier that starts with two dashes), except -- itself, which is reserved for future use by CSS.
+    return string == "--"sv;
+}
+
 // https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string
 static bool is_a_custom_property_name_string(StringView string)
 {
     // A string is a custom property name string if it starts with two dashes (U+002D HYPHEN-MINUS), like --foo.
-    return string.starts_with("--"sv);
+    return string.starts_with("--"sv) && !is_invalid_custom_property_name_string(string);
 }
 
 }

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-variables/support/color-green-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-variables/support/color-green-ref.html
@@ -1,0 +1,13 @@
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<!DOCTYPE html>
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
+<style>
+p {
+  color: green;
+}
+</style>
+<p>This text must be green.</p>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-variables/variable-supports-58.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-variables/variable-supports-58.html
@@ -1,0 +1,16 @@
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<!DOCTYPE html>
+<title>CSS Test: Test a property declaration in an @supports rule with property name "--".</title>
+<link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au">
+<link rel="help" href="http://www.w3.org/TR/css-variables-1/#defining-variables">
+<link rel="match" href="../../../../expected/wpt-import/css/css-variables/support/color-green-ref.html">
+<style>
+body { color: green; }
+@supports (--: a) {
+  p { color: red; }
+}
+</style>
+<p>This text must be green.</p>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-empty-name-reserved.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-empty-name-reserved.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	-- is a reserved property name

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-empty-name-reserved.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-empty-name-reserved.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/2692">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1467309">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<title>-- is a reserved property name</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  assert_false(CSS.supports("--", "initial"), "-- is a reserved property name");
+});
+</script>


### PR DESCRIPTION
This is reserved for future use by CSS.

Fixes 2 WPT tests.

Split off from #5209.