### PR TITLE
CI: Make Windows CI label name consistent with the preset name

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -21,7 +21,7 @@ jobs:
     if: |
       github.repository == 'LadybirdBrowser/ladybird'
       && contains(github.event.pull_request.labels.*.name, 'windows')
-    name: 'Windows, x86_64, Windows_SanitizerCI, ClangCL'
+    name: 'Windows, x86_64, Windows_Sanitizer_CI, ClangCL'
     uses: ./.github/workflows/lagom-template.yml
     with:
       toolchain: 'ClangCL'


### PR DESCRIPTION
A very minor thing, but given all the other CI labels match their respective presets, might as well do the same for Windows CI
![image](https://github.com/user-attachments/assets/619953c1-bb52-4eb7-86ff-538620707cf7)
