### PR TITLE
LibWeb: Ensure audio tracks are set to the correct volume before playing

### DIFF
--- a/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -41,6 +41,8 @@ AudioTrack::AudioTrack(JS::Realm& realm, GC::Ref<HTMLMediaElement> media_element
     m_audio_plugin->on_decoder_error = [this](String error_message) {
         m_media_element->set_decoder_error(move(error_message));
     };
+
+    update_volume();
 }
 
 AudioTrack::~AudioTrack()


### PR DESCRIPTION
Previously, a video or audio element with the `autoplay` and `muted` attributes set, would not mute the audio before playing.

This ensures the video is initially muted on: https://isle.pizza

I'm not sure how to test this change, since I don't think the bug is observable in JS.