### PR TITLE
LibWeb: Explicitly disable ligatures if `font_variant_ligatures` is none

### DIFF
--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -214,7 +214,12 @@ HashMap<StringView, u8> InlineLevelIterator::shape_features_map() const
     if (ligature_or_null.has_value()) {
         auto ligature = ligature_or_null.release_value();
         if (ligature.none) {
-            /* nothing */
+            // Specifies that all types of ligatures and contextual forms covered by this property are explicitly disabled.
+            features.set("liga"sv, 0);
+            features.set("clig"sv, 0);
+            features.set("dlig"sv, 0);
+            features.set("hlig"sv, 0);
+            features.set("calt"sv, 0);
         } else {
             switch (ligature.common) {
             case Gfx::FontVariantLigatures::Common::Common:


### PR DESCRIPTION
Previously ligatures weren't being explicitly disabled in this case

Screenshots taken from: https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures

Before:

![image](https://github.com/user-attachments/assets/6dcce0f9-8e92-4462-bba2-b9db9482ddde)


After:

![image](https://github.com/user-attachments/assets/640e94fc-752d-4f9a-a599-a4b8d3baadf1)


This fixes these WPT tests, but they can't be imported because we don't support any font other than SerenitySans in our tests:
* http://wpt.live/css/css-fonts/font-variant-02.html
* http://wpt.live/css/css-fonts/font-variant-ligatures-02.html
