### PR TITLE
LibWeb/SVG: Disallow negative values for SVG radius properties

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -2677,8 +2677,8 @@
     "inherited": false,
     "initial": "0",
     "valid-types": [
-      "length [-∞,∞]",
-      "percentage [-∞,∞]"
+      "length [0,∞]",
+      "percentage [0,∞]"
     ],
     "percentages-resolve-to": "length",
     "quirks": [
@@ -2727,8 +2727,8 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
-      "length [-∞,∞]",
-      "percentage [-∞,∞]"
+      "length [0,∞]",
+      "percentage [0,∞]"
     ],
     "valid-identifiers": [
       "auto"
@@ -2744,8 +2744,8 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
-      "length [-∞,∞]",
-      "percentage [-∞,∞]"
+      "length [0,∞]",
+      "percentage [0,∞]"
     ],
     "valid-identifiers": [
       "auto"

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/geometry/parsing/r-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/geometry/parsing/r-invalid.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	e.style['r'] = "10" should not set the property value
+Pass	e.style['r'] = "auto" should not set the property value
+Pass	e.style['r'] = "10px 20px" should not set the property value
+Pass	e.style['r'] = "-1px" should not set the property value
+Pass	e.style['r'] = "-10%" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/geometry/parsing/rx-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/geometry/parsing/rx-invalid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	e.style['rx'] = "10" should not set the property value
+Pass	e.style['rx'] = "none" should not set the property value
+Pass	e.style['rx'] = "10px 20px" should not set the property value
+Pass	e.style['rx'] = "-1px" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/geometry/parsing/ry-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/geometry/parsing/ry-invalid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	e.style['ry'] = "10" should not set the property value
+Pass	e.style['ry'] = "none" should not set the property value
+Pass	e.style['ry'] = "10px 20px" should not set the property value
+Pass	e.style['ry'] = "-1px" should not set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/svg/geometry/parsing/r-invalid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/geometry/parsing/r-invalid.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="8000px">
+  <title>SVG Geometry Properties: parsing r with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#R"/>
+    <h:meta name="assert" content="r supports only the grammar '&lt;length-percentage&gt;'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("r", "10");
+test_invalid_value("r", "auto");
+test_invalid_value("r", "10px 20px");
+test_invalid_value("r", "-1px");
+test_invalid_value("r", "-10%");
+
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/geometry/parsing/rx-invalid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/geometry/parsing/rx-invalid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="8000px">
+  <title>SVG Geometry Properties: parsing rx with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RX"/>
+    <h:meta name="assert" content="rx supports only the grammar '&lt;length-percentage&gt; | auto'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("rx", "10");
+test_invalid_value("rx", "none");
+test_invalid_value("rx", "10px 20px");
+test_invalid_value("rx", "-1px");
+
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/geometry/parsing/ry-invalid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/geometry/parsing/ry-invalid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="8000px">
+  <title>SVG Geometry Properties: parsing ry with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html#RY"/>
+    <h:meta name="assert" content="ry supports only the grammar '&lt;length-percentage&gt; | auto'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("ry", "10");
+test_invalid_value("ry", "none");
+test_invalid_value("ry", "10px 20px");
+test_invalid_value("ry", "-1px");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
This PR disallows negative values for the `r`, `rx` and `ry` properties.

The spec says that a negative value for any of these properties must be treated as an [illegal value](https://www.w3.org/TR/2011/REC-CSS2-20110607/syndata.html#illegalvalues).