### PR TITLE
LibWeb/SVG: Disallow negative `stroke-dasharray` values

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -2045,11 +2045,18 @@ RefPtr<CSSStyleValue const> Parser::parse_stroke_dasharray_value(TokenStream<Com
 
         // A <dasharray> is a list of comma and/or white space separated <number> or <length-percentage> values. A <number> value represents a value in user units.
         auto value = parse_number_value(tokens);
+        if (value && value->is_number() && value->as_number().value() < 0)
+            return {};
+
         if (value) {
             dashes.append(value.release_nonnull());
         } else {
             auto value = parse_length_percentage_value(tokens);
             if (!value)
+                return {};
+            if (value->is_percentage() && value->as_percentage().value() < 0)
+                return {};
+            if (value->is_length() && value->as_length().length().raw_value() < 0)
                 return {};
             dashes.append(value.release_nonnull());
         }

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dasharray-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/stroke-dasharray-invalid.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 7 tests
+
+7 Pass
+Pass	e.style['stroke-dasharray'] = "auto" should not set the property value
+Pass	e.style['stroke-dasharray'] = "none 10px" should not set the property value
+Pass	e.style['stroke-dasharray'] = "20px / 30px" should not set the property value
+Pass	e.style['stroke-dasharray'] = "-40px" should not set the property value
+Pass	e.style['stroke-dasharray'] = "calc(2px + 3)" should not set the property value
+Pass	e.style['stroke-dasharray'] = "calc(10% + 5)" should not set the property value
+Pass	e.style['stroke-dasharray'] = "calc(40 + calc(3px + 6%))" should not set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dasharray-invalid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/stroke-dasharray-invalid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing stroke-dasharray with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty"/>
+    <h:meta name="assert" content="stroke-dasharray supports only the grammar 'none | dasharray'"/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("stroke-dasharray", "auto");
+test_invalid_value("stroke-dasharray", "none 10px");
+test_invalid_value("stroke-dasharray", "20px / 30px");
+test_invalid_value("stroke-dasharray", "-40px");
+test_invalid_value("stroke-dasharray", "calc(2px + 3)");
+test_invalid_value("stroke-dasharray", "calc(10% + 5)");
+test_invalid_value("stroke-dasharray", "calc(40 + calc(3px + 6%))");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
The spec says that if any value in a `<dasharray>` is negative then the value is invalid.