### PR TITLE
LibURL: Fix logic for getting public suffix from a host

### DIFF
--- a/Libraries/LibURL/CMakeLists.txt
+++ b/Libraries/LibURL/CMakeLists.txt
@@ -21,4 +21,3 @@ set(SOURCES
 
 serenity_lib(LibURL url)
 target_link_libraries(LibURL PRIVATE LibUnicode LibTextCodec LibRegex LibCrypto)
-target_compile_definitions(LibURL PRIVATE ENABLE_PUBLIC_SUFFIX=$<BOOL:${ENABLE_PUBLIC_SUFFIX_DOWNLOAD}>)

--- a/Libraries/LibURL/Host.cpp
+++ b/Libraries/LibURL/Host.cpp
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
- * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2023-2025, Shannon Booth <shannon@serenityos.org>
  * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibURL/Host.h>
+#include <LibURL/PublicSuffixData.h>
 #include <LibURL/URL.h>
 
 namespace URL {
@@ -193,7 +194,7 @@ Optional<String> Host::public_suffix() const
     // 3. Let publicSuffix be the public suffix determined by running the Public Suffix List algorithm with host as domain. [PSL]
     // NOTE: The spec algorithm for the public suffix returns "*" by default, but get_public_suffix() returns an empty Optional.
     //       Remove the `value_or()` if and when we update it.
-    auto public_suffix = get_public_suffix(host_string.bytes_as_string_view()).value_or("*"_string);
+    auto public_suffix = PublicSuffixData::the()->get_public_suffix(host_string).value_or("*"_string);
 
     // 4. Assert: publicSuffix is an ASCII string that does not end with ".".
     VERIFY(public_suffix.is_ascii());

--- a/Libraries/LibURL/Host.cpp
+++ b/Libraries/LibURL/Host.cpp
@@ -192,13 +192,19 @@ Optional<String> Host::public_suffix() const
     auto trailing_dot = host_string.ends_with('.') ? "."sv : ""sv;
 
     // 3. Let publicSuffix be the public suffix determined by running the Public Suffix List algorithm with host as domain. [PSL]
-    // NOTE: The spec algorithm for the public suffix returns "*" by default, but get_public_suffix() returns an empty Optional.
-    //       Remove the `value_or()` if and when we update it.
-    auto public_suffix = PublicSuffixData::the()->get_public_suffix(host_string).value_or("*"_string);
+    // FIXME: Unify this logic with registrable domain.
+    auto public_suffix = PublicSuffixData::the()->get_public_suffix(host_string);
+    if (!public_suffix.has_value()) {
+        auto last_dot = host_string.bytes_as_string_view().find_last('.');
+        if (last_dot.has_value())
+            public_suffix = MUST(host_string.substring_from_byte_offset(last_dot.value() + 1));
+        else
+            public_suffix = host_string;
+    }
 
     // 4. Assert: publicSuffix is an ASCII string that does not end with ".".
-    VERIFY(public_suffix.is_ascii());
-    VERIFY(!public_suffix.ends_with('.'));
+    VERIFY(public_suffix->is_ascii());
+    VERIFY(!public_suffix->ends_with('.'));
 
     // 5. Return publicSuffix and trailingDot concatenated.
     return MUST(String::formatted("{}{}", public_suffix, trailing_dot));
@@ -219,8 +225,7 @@ Optional<String> Host::registrable_domain() const
     auto trailing_dot = host_string.ends_with('.') ? "."sv : ""sv;
 
     // 3. Let registrableDomain be the registrable domain determined by running the Public Suffix List algorithm with host as domain. [PSL]
-    // NOTE: The spec algorithm for the public suffix returns "*" by default, but get_public_suffix() returns an empty Optional.
-    //       Remove the `value_or()` if and when we update it.
+    // FIXME: This is not correct, we should be doing the same as public_suffix() above.
     auto registrable_domain = get_registrable_domain(host_string).value_or("*"_string);
 
     // 4. Assert: registrableDomain is an ASCII string that does not end with ".".

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -496,16 +496,11 @@ bool is_public_suffix(StringView host)
     return PublicSuffixData::the()->is_public_suffix(host);
 }
 
-Optional<String> get_public_suffix(StringView host)
-{
-    return PublicSuffixData::the()->get_public_suffix(host);
-}
-
 // https://github.com/publicsuffix/list/wiki/Format#algorithm
 Optional<String> get_registrable_domain(StringView host)
 {
     // The registered or registrable domain is the public suffix plus one additional label.
-    auto public_suffix = get_public_suffix(host);
+    auto public_suffix = PublicSuffixData::the()->get_public_suffix(host);
     if (!public_suffix.has_value() || !host.ends_with(*public_suffix))
         return {};
 

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -14,11 +14,8 @@
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
 #include <LibURL/Parser.h>
+#include <LibURL/PublicSuffixData.h>
 #include <LibURL/URL.h>
-
-#if defined(ENABLE_PUBLIC_SUFFIX)
-#    include <LibURL/PublicSuffixData.h>
-#endif
 
 namespace URL {
 
@@ -494,22 +491,14 @@ ByteString percent_decode(StringView input)
     return builder.to_byte_string();
 }
 
-bool is_public_suffix([[maybe_unused]] StringView host)
+bool is_public_suffix(StringView host)
 {
-#if defined(ENABLE_PUBLIC_SUFFIX)
     return PublicSuffixData::the()->is_public_suffix(host);
-#else
-    return false;
-#endif
 }
 
-Optional<String> get_public_suffix([[maybe_unused]] StringView host)
+Optional<String> get_public_suffix(StringView host)
 {
-#if defined(ENABLE_PUBLIC_SUFFIX)
     return MUST(PublicSuffixData::the()->get_public_suffix(host));
-#else
-    return {};
-#endif
 }
 
 // https://github.com/publicsuffix/list/wiki/Format#algorithm

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -498,7 +498,7 @@ bool is_public_suffix(StringView host)
 
 Optional<String> get_public_suffix(StringView host)
 {
-    return MUST(PublicSuffixData::the()->get_public_suffix(host));
+    return PublicSuffixData::the()->get_public_suffix(host);
 }
 
 // https://github.com/publicsuffix/list/wiki/Format#algorithm

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -202,7 +202,6 @@ Optional<URL> create_with_file_scheme(ByteString const& path, ByteString const& 
 URL create_with_data(StringView mime_type, StringView payload, bool is_base64 = false);
 
 bool is_public_suffix(StringView host);
-Optional<String> get_public_suffix(StringView host);
 Optional<String> get_registrable_domain(StringView host);
 
 inline URL about_blank() { return URL::about("blank"_string); }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3845,10 +3845,10 @@ static bool is_a_registrable_domain_suffix_of_or_is_equal_to(StringView host_suf
         //     * hostSuffix equals hostSuffix's public suffix; or
         //     * hostSuffix, prefixed by U+002E (.), matches the end of originalHost's public suffix,
         //    then return false. [URL]
-        if (host_suffix_string == URL::get_public_suffix(host_suffix_string))
+        if (host_suffix_string == host_suffix->public_suffix())
             return false;
 
-        auto original_host_public_suffix = URL::get_public_suffix(original_host_string);
+        auto original_host_public_suffix = original_host.public_suffix();
         VERIFY(original_host_public_suffix.has_value());
 
         if (original_host_public_suffix->ends_with_bytes(prefixed_host_suffix))

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibURL/Parser.h>
+#include <LibURL/PublicSuffixData.h>
 #include <LibWebView/URL.h>
 
 namespace WebView {
@@ -61,7 +62,7 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
         if (any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); }))
             return url;
 
-        auto public_suffix = URL::get_public_suffix(domain);
+        auto public_suffix = URL::PublicSuffixData::the()->get_public_suffix(domain);
         if (!public_suffix.has_value() || *public_suffix == domain) {
             if (append_tld == AppendTLD::Yes)
                 url->set_host(MUST(String::formatted("{}.com", domain)));
@@ -120,7 +121,7 @@ static URLParts break_web_url_into_parts(URL::URL const& url, StringView url_str
         domain = url_without_scheme;
     }
 
-    auto public_suffix = URL::get_public_suffix(domain);
+    auto public_suffix = URL::PublicSuffixData::the()->get_public_suffix(domain);
     if (!public_suffix.has_value() || !domain.ends_with(*public_suffix))
         return { scheme, domain, remainder };
 

--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -24,7 +24,6 @@ serenity_option(ENABLE_ALL_THE_DEBUG_MACROS OFF CACHE BOOL "Enable all debug mac
 serenity_option(ENABLE_ALL_DEBUG_FACILITIES OFF CACHE BOOL "Enable all noisy debug symbols and options. Not recommended for normal developer use")
 serenity_option(ENABLE_COMPILETIME_HEADER_CHECK OFF CACHE BOOL "Enable compiletime check that each library header compiles stand-alone")
 
-serenity_option(ENABLE_PUBLIC_SUFFIX_DOWNLOAD ON CACHE BOOL "Enable download of the Public Suffix List at build time")
 serenity_option(INCLUDE_WASM_SPEC_TESTS OFF CACHE BOOL "Download and include the WebAssembly spec testsuite")
 serenity_option(INCLUDE_FLAC_SPEC_TESTS OFF CACHE BOOL "Download and include the FLAC spec testsuite")
 serenity_option(ENABLE_CACERT_DOWNLOAD ON CACHE BOOL "Enable download of cacert.pem at build time")

--- a/Meta/CMake/public_suffix.cmake
+++ b/Meta/CMake/public_suffix.cmake
@@ -1,29 +1,24 @@
 include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
 
-if (ENABLE_PUBLIC_SUFFIX_DOWNLOAD)
-    set(PUBLIC_SUFFIX_PATH "${SERENITY_CACHE_DIR}/PublicSuffix" CACHE PATH "Download location for PublicSuffix files")
-    set(PUBLIC_SUFFIX_DATA_URL "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat")
-    set(PUBLIC_SUFFIX_DATA_PATH "${PUBLIC_SUFFIX_PATH}/public_suffix_list.dat")
-
-    set(PUBLIC_SUFFIX_DATA_HEADER PublicSuffixData.h)
-    set(PUBLIC_SUFFIX_DATA_IMPLEMENTATION PublicSuffixData.cpp)
-
-    if (ENABLE_NETWORK_DOWNLOADS)
-        download_file("${PUBLIC_SUFFIX_DATA_URL}" "${PUBLIC_SUFFIX_DATA_PATH}")
-    else()
-        message(STATUS "Skipping download of ${PUBLIC_SUFFIX_DATA_URL}, expecting it to be in ${PUBLIC_SUFFIX_DATA_PATH}")
-    endif()
-    invoke_cpp_generator(
-        "PublicSuffixData"
-        Lagom::GeneratePublicSuffixData
-        "${PUBLIC_SUFFIX_PATH}/"
-        "${PUBLIC_SUFFIX_DATA_HEADER}"
-        "${PUBLIC_SUFFIX_DATA_IMPLEMENTATION}"
-        arguments -p "${PUBLIC_SUFFIX_DATA_PATH}"
-    )
-
-    set(PUBLIC_SUFFIX_SOURCES
-    	${PUBLIC_SUFFIX_DATA_HEADER}
-    	${PUBLIC_SUFFIX_DATA_IMPLEMENTATION}
-    )
+set(PUBLIC_SUFFIX_PATH "${SERENITY_CACHE_DIR}/PublicSuffix" CACHE PATH "Download location for PublicSuffix files")
+set(PUBLIC_SUFFIX_DATA_URL "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat")
+set(PUBLIC_SUFFIX_DATA_PATH "${PUBLIC_SUFFIX_PATH}/public_suffix_list.dat")
+set(PUBLIC_SUFFIX_DATA_HEADER PublicSuffixData.h)
+set(PUBLIC_SUFFIX_DATA_IMPLEMENTATION PublicSuffixData.cpp)
+if (ENABLE_NETWORK_DOWNLOADS)
+    download_file("${PUBLIC_SUFFIX_DATA_URL}" "${PUBLIC_SUFFIX_DATA_PATH}")
+else()
+    message(STATUS "Skipping download of ${PUBLIC_SUFFIX_DATA_URL}, expecting it to be in ${PUBLIC_SUFFIX_DATA_PATH}")
 endif()
+invoke_cpp_generator(
+    "PublicSuffixData"
+    Lagom::GeneratePublicSuffixData
+    "${PUBLIC_SUFFIX_PATH}/"
+    "${PUBLIC_SUFFIX_DATA_HEADER}"
+    "${PUBLIC_SUFFIX_DATA_IMPLEMENTATION}"
+    arguments -p "${PUBLIC_SUFFIX_DATA_PATH}"
+)
+set(PUBLIC_SUFFIX_SOURCES
+	${PUBLIC_SUFFIX_DATA_HEADER}
+	${PUBLIC_SUFFIX_DATA_IMPLEMENTATION}
+)

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -641,3 +641,51 @@ TEST_CASE(get_registrable_domain)
         EXPECT_EQ(*domain, "ladybird.github.io"sv);
     }
 }
+
+TEST_CASE(public_suffix)
+{
+    {
+        auto domain = URL::Parser::parse_host("com"sv);
+        EXPECT_EQ(domain->public_suffix(), "com"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("example.com"sv);
+        EXPECT_EQ(domain->public_suffix(), "com"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("www.example.com"sv);
+        EXPECT_EQ(domain->public_suffix(), "com"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("EXAMPLE.COM"sv);
+        EXPECT_EQ(domain->public_suffix(), "com"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("www.example.com."sv);
+        EXPECT_EQ(domain->public_suffix(), "com."sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("github.io"sv);
+        EXPECT_EQ(domain->public_suffix(), "github.io"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("whatwg.github.io"sv);
+        EXPECT_EQ(domain->public_suffix(), "github.io"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("إختبار"sv);
+        EXPECT_EQ(domain->public_suffix(), "xn--kgbechtv"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("example.إختبار"sv);
+        EXPECT_EQ(domain->public_suffix(), "xn--kgbechtv"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("sub.example.إختبار"sv);
+        EXPECT_EQ(domain->public_suffix(), "xn--kgbechtv"sv);
+    }
+    {
+        auto domain = URL::Parser::parse_host("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"sv);
+        EXPECT_EQ(domain->public_suffix(), OptionalNone {});
+    }
+}


### PR DESCRIPTION
This fixes a recently introduced regression after using this function in the Document.domain setter, exposing this issue.

Unfortunately get_registrable_domain is also broken, which I've only left a FIXME for now since I was getting a weird result when given ".com" which I haven't gotten around to fully looking into and understanding, and this already fixes a bunch of WPT regressions