### PR TITLE
LibWeb: Validate operator count when parsing a calculation

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -4050,7 +4050,19 @@ RefPtr<CalculationNode const> Parser::parse_a_calculation(Vector<ComponentValue>
         }
         //    Otherwise, replace values with a Sum node containing the value items of values as its children.
         if (!single_value.has_value()) {
-            values.remove_all_matching([](CalcParsing::Node& value) { return value.has<CalcParsing::Operator>(); });
+            auto operator_count = 0u;
+            for (size_t i = 0; i < values.size();) {
+                auto& value = values[i];
+                if (value.has<CalcParsing::Operator>()) {
+                    operator_count++;
+                    values.remove(i);
+                } else {
+                    i++;
+                }
+            }
+            if (values.size() == 0 || operator_count != values.size() - 1)
+                return nullptr;
+
             single_value = make<CalcParsing::SumNode>(move(values));
         }
     }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-columns-rows-get-set-multiple.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-columns-rows-get-set-multiple.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 40 tests
 
-35 Pass
-5 Fail
+36 Pass
+4 Fail
 Pass	Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithFixedElement' : grid-template-columns = '7px 11px', grid-template-rows = '17px 2px'
 Pass	Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithPercentElement' : grid-template-columns = '400px 800px', grid-template-rows = '150px 450px'
 Fail	Test getting grid-template-columns and grid-template-rows set through CSS for element 'gridWithPercentWithoutSize' : grid-template-columns = '3.5px 7px', grid-template-rows = '4px 12px'
@@ -39,7 +39,7 @@ Pass	Test setting bad JS values: grid-template-columns = 'auto none 16em', grid-
 Pass	Test setting bad JS values: grid-template-columns = '-webkit-fit-content -webkit-fit-content', grid-template-rows = '-webkit-fit-available -webkit-fit-available'
 Pass	Test setting bad JS values: grid-template-columns = '-10px minmax(16px, 32px)', grid-template-rows = 'minmax(10%, 15%) -10vw'
 Pass	Test setting bad JS values: grid-template-columns = '10px minmax(16px, -1vw)', grid-template-rows = 'minmax(-1%, 15%) 10vw'
-Fail	Test setting bad JS values: grid-template-columns = '10px calc(16px 30px)', grid-template-rows = 'calc(25px + auto) 2em'
+Pass	Test setting bad JS values: grid-template-columns = '10px calc(16px 30px)', grid-template-rows = 'calc(25px + auto) 2em'
 Pass	Test setting bad JS values: grid-template-columns = 'minmax(min-content, calc() 250px', grid-template-rows = 'calc(2em('
 Pass	Test setting grid-template-columns and grid-template-rows to 'inherit' through JS
 Pass	Test the default value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/exp-log-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/exp-log-invalid.txt
@@ -1,0 +1,54 @@
+Harness status: OK
+
+Found 48 tests
+
+46 Pass
+2 Fail
+Pass	e.style['opacity'] = "exp()" should not set the property value
+Pass	e.style['opacity'] = "exp( )" should not set the property value
+Pass	e.style['opacity'] = "exp(,)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, )" should not set the property value
+Pass	e.style['opacity'] = "exp(, 1)" should not set the property value
+Pass	e.style['opacity'] = "exp(1 + )" should not set the property value
+Pass	e.style['opacity'] = "exp(1 - )" should not set the property value
+Pass	e.style['opacity'] = "exp(1 * )" should not set the property value
+Pass	e.style['opacity'] = "exp(1 / )" should not set the property value
+Pass	e.style['opacity'] = "exp(1 2)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, , 2)" should not set the property value
+Pass	e.style['opacity'] = "log()" should not set the property value
+Pass	e.style['opacity'] = "log( )" should not set the property value
+Pass	e.style['opacity'] = "log(,)" should not set the property value
+Fail	e.style['opacity'] = "log(1, )" should not set the property value
+Pass	e.style['opacity'] = "log(, 1)" should not set the property value
+Pass	e.style['opacity'] = "log(1 + )" should not set the property value
+Pass	e.style['opacity'] = "log(1 - )" should not set the property value
+Pass	e.style['opacity'] = "log(1 * )" should not set the property value
+Pass	e.style['opacity'] = "log(1 / )" should not set the property value
+Pass	e.style['opacity'] = "log(1 2)" should not set the property value
+Pass	e.style['opacity'] = "log(1, , 2)" should not set the property value
+Pass	e.style['opacity'] = "exp(0px)" should not set the property value
+Pass	e.style['opacity'] = "exp(0s)" should not set the property value
+Pass	e.style['opacity'] = "exp(0deg)" should not set the property value
+Pass	e.style['opacity'] = "exp(0Hz)" should not set the property value
+Pass	e.style['opacity'] = "exp(0dpi)" should not set the property value
+Pass	e.style['opacity'] = "exp(0fr)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, 1%)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, 0px)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, 0s)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, 0deg)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, 0Hz)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, 0dpi)" should not set the property value
+Pass	e.style['opacity'] = "exp(1, 0fr)" should not set the property value
+Pass	e.style['opacity'] = "log(0px)" should not set the property value
+Pass	e.style['opacity'] = "log(0s)" should not set the property value
+Pass	e.style['opacity'] = "log(0deg)" should not set the property value
+Pass	e.style['opacity'] = "log(0Hz)" should not set the property value
+Pass	e.style['opacity'] = "log(0dpi)" should not set the property value
+Pass	e.style['opacity'] = "log(0fr)" should not set the property value
+Pass	e.style['opacity'] = "log(1, 1%)" should not set the property value
+Pass	e.style['opacity'] = "log(1, 0px)" should not set the property value
+Pass	e.style['opacity'] = "log(1, 0s)" should not set the property value
+Pass	e.style['opacity'] = "log(1, 0deg)" should not set the property value
+Pass	e.style['opacity'] = "log(1, 0Hz)" should not set the property value
+Pass	e.style['opacity'] = "log(1, 0dpi)" should not set the property value
+Fail	e.style['opacity'] = "log(1, 0fr)" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/hypot-pow-sqrt-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/hypot-pow-sqrt-invalid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 49 tests
 
-47 Pass
-2 Fail
+49 Pass
 Pass	e.style['opacity'] = "hypot()" should not set the property value
 Pass	e.style['opacity'] = "hypot( )" should not set the property value
 Pass	e.style['opacity'] = "hypot(,)" should not set the property value
@@ -13,7 +12,7 @@ Pass	e.style['opacity'] = "hypot(1 + )" should not set the property value
 Pass	e.style['opacity'] = "hypot(1 - )" should not set the property value
 Pass	e.style['opacity'] = "hypot(1 * )" should not set the property value
 Pass	e.style['opacity'] = "hypot(1 / )" should not set the property value
-Fail	e.style['opacity'] = "hypot(1 2)" should not set the property value
+Pass	e.style['opacity'] = "hypot(1 2)" should not set the property value
 Pass	e.style['opacity'] = "hypot(1, , 2)" should not set the property value
 Pass	e.style['opacity'] = "sqrt()" should not set the property value
 Pass	e.style['opacity'] = "sqrt( )" should not set the property value
@@ -24,7 +23,7 @@ Pass	e.style['opacity'] = "sqrt(1 + )" should not set the property value
 Pass	e.style['opacity'] = "sqrt(1 - )" should not set the property value
 Pass	e.style['opacity'] = "sqrt(1 * )" should not set the property value
 Pass	e.style['opacity'] = "sqrt(1 / )" should not set the property value
-Fail	e.style['opacity'] = "sqrt(1 2)" should not set the property value
+Pass	e.style['opacity'] = "sqrt(1 2)" should not set the property value
 Pass	e.style['opacity'] = "sqrt(1, , 2)" should not set the property value
 Pass	e.style['opacity'] = "sqrt(1, 2)" should not set the property value
 Pass	e.style['opacity'] = "pow( )" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-angle-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-angle-invalid.txt
@@ -1,0 +1,57 @@
+Harness status: OK
+
+Found 52 tests
+
+52 Pass
+Pass	e.style['transform'] = "rotate(min())" should not set the property value
+Pass	e.style['transform'] = "rotate(min( ))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(,))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1dag))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, ))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(, 1deg))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg + ))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg - ))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg * ))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg / ))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg 2deg))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, , 2deg))" should not set the property value
+Pass	e.style['transform'] = "rotate(max())" should not set the property value
+Pass	e.style['transform'] = "rotate(max( ))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(,))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1dag))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, ))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(, 1deg))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg + ))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg - ))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg * ))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg / ))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg 2deg))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, , 2deg))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(0))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(0%))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(0px))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(0s))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(0Hz))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(0dpi))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(0fr))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, 0))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, 0%))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, 0px))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, 0s))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, 0Hz))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, 0dpi))" should not set the property value
+Pass	e.style['transform'] = "rotate(min(1deg, 0fr))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(0))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(0%))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(0px))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(0s))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(0Hz))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(0dpi))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(0fr))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, 0))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, 0%))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, 0px))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, 0s))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, 0Hz))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, 0dpi))" should not set the property value
+Pass	e.style['transform'] = "rotate(max(1deg, 0fr))" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-length-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-length-invalid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 48 tests
 
-46 Pass
-2 Fail
+48 Pass
 Pass	e.style['border-left-width'] = "min()" should not set the property value
 Pass	e.style['border-left-width'] = "min( )" should not set the property value
 Pass	e.style['border-left-width'] = "min(,)" should not set the property value
@@ -14,7 +13,7 @@ Pass	e.style['border-left-width'] = "min(1px + )" should not set the property va
 Pass	e.style['border-left-width'] = "min(1px - )" should not set the property value
 Pass	e.style['border-left-width'] = "min(1px * )" should not set the property value
 Pass	e.style['border-left-width'] = "min(1px / )" should not set the property value
-Fail	e.style['border-left-width'] = "min(1px 2px)" should not set the property value
+Pass	e.style['border-left-width'] = "min(1px 2px)" should not set the property value
 Pass	e.style['border-left-width'] = "min(1px, , 2px)" should not set the property value
 Pass	e.style['border-left-width'] = "max()" should not set the property value
 Pass	e.style['border-left-width'] = "max( )" should not set the property value
@@ -26,7 +25,7 @@ Pass	e.style['border-left-width'] = "max(1px + )" should not set the property va
 Pass	e.style['border-left-width'] = "max(1px - )" should not set the property value
 Pass	e.style['border-left-width'] = "max(1px * )" should not set the property value
 Pass	e.style['border-left-width'] = "max(1px / )" should not set the property value
-Fail	e.style['border-left-width'] = "max(1px 2px)" should not set the property value
+Pass	e.style['border-left-width'] = "max(1px 2px)" should not set the property value
 Pass	e.style['border-left-width'] = "max(1px, , 2px)" should not set the property value
 Pass	e.style['border-left-width'] = "min(0)" should not set the property value
 Pass	e.style['border-left-width'] = "min(0%)" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-percentage-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-percentage-invalid.txt
@@ -1,0 +1,53 @@
+Harness status: OK
+
+Found 48 tests
+
+48 Pass
+Pass	e.style['margin-left'] = "min()" should not set the property value
+Pass	e.style['margin-left'] = "min( )" should not set the property value
+Pass	e.style['margin-left'] = "min(,)" should not set the property value
+Pass	e.style['margin-left'] = "min(1#)" should not set the property value
+Pass	e.style['margin-left'] = "min(%1)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, )" should not set the property value
+Pass	e.style['margin-left'] = "min(, 1%)" should not set the property value
+Pass	e.style['margin-left'] = "min(1% + )" should not set the property value
+Pass	e.style['margin-left'] = "min(1% - )" should not set the property value
+Pass	e.style['margin-left'] = "min(1% * )" should not set the property value
+Pass	e.style['margin-left'] = "min(1% / )" should not set the property value
+Pass	e.style['margin-left'] = "min(1% 2%)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, , 2%)" should not set the property value
+Pass	e.style['margin-left'] = "max()" should not set the property value
+Pass	e.style['margin-left'] = "max( )" should not set the property value
+Pass	e.style['margin-left'] = "max(,)" should not set the property value
+Pass	e.style['margin-left'] = "max(1#)" should not set the property value
+Pass	e.style['margin-left'] = "max(%1)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, )" should not set the property value
+Pass	e.style['margin-left'] = "max(, 1%)" should not set the property value
+Pass	e.style['margin-left'] = "max(1% + )" should not set the property value
+Pass	e.style['margin-left'] = "max(1% - )" should not set the property value
+Pass	e.style['margin-left'] = "max(1% * )" should not set the property value
+Pass	e.style['margin-left'] = "max(1% / )" should not set the property value
+Pass	e.style['margin-left'] = "max(1% 2%)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, , 2%)" should not set the property value
+Pass	e.style['margin-left'] = "min(0s)" should not set the property value
+Pass	e.style['margin-left'] = "min(0deg)" should not set the property value
+Pass	e.style['margin-left'] = "min(0Hz)" should not set the property value
+Pass	e.style['margin-left'] = "min(0dpi)" should not set the property value
+Pass	e.style['margin-left'] = "min(0fr)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, 0)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, 0s)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, 0deg)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, 0Hz)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, 0dpi)" should not set the property value
+Pass	e.style['margin-left'] = "min(1%, 0fr)" should not set the property value
+Pass	e.style['margin-left'] = "max(0s)" should not set the property value
+Pass	e.style['margin-left'] = "max(0deg)" should not set the property value
+Pass	e.style['margin-left'] = "max(0Hz)" should not set the property value
+Pass	e.style['margin-left'] = "max(0dpi)" should not set the property value
+Pass	e.style['margin-left'] = "max(0fr)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, 0)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, 0s)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, 0deg)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, 0Hz)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, 0dpi)" should not set the property value
+Pass	e.style['margin-left'] = "max(1%, 0fr)" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-time-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/minmax-time-invalid.txt
@@ -1,0 +1,57 @@
+Harness status: OK
+
+Found 52 tests
+
+52 Pass
+Pass	e.style['transition-delay'] = "min()" should not set the property value
+Pass	e.style['transition-delay'] = "min( )" should not set the property value
+Pass	e.style['transition-delay'] = "min(,)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1mt)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, )" should not set the property value
+Pass	e.style['transition-delay'] = "min(, 1s)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s + )" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s - )" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s * )" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s / )" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s 2s)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, , 2s)" should not set the property value
+Pass	e.style['transition-delay'] = "max()" should not set the property value
+Pass	e.style['transition-delay'] = "max( )" should not set the property value
+Pass	e.style['transition-delay'] = "max(,)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1dag)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, )" should not set the property value
+Pass	e.style['transition-delay'] = "max(, 1s)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s + )" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s - )" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s * )" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s / )" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s 2s)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, , 2s)" should not set the property value
+Pass	e.style['transition-delay'] = "min(0)" should not set the property value
+Pass	e.style['transition-delay'] = "min(0%)" should not set the property value
+Pass	e.style['transition-delay'] = "min(0px)" should not set the property value
+Pass	e.style['transition-delay'] = "min(0deg)" should not set the property value
+Pass	e.style['transition-delay'] = "min(0Hz)" should not set the property value
+Pass	e.style['transition-delay'] = "min(0dpi)" should not set the property value
+Pass	e.style['transition-delay'] = "min(0fr)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, 0)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, 0%)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, 0px)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, 0deg)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, 0Hz)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, 0dpi)" should not set the property value
+Pass	e.style['transition-delay'] = "min(1s, 0fr)" should not set the property value
+Pass	e.style['transition-delay'] = "max(0)" should not set the property value
+Pass	e.style['transition-delay'] = "max(0%)" should not set the property value
+Pass	e.style['transition-delay'] = "max(0px)" should not set the property value
+Pass	e.style['transition-delay'] = "max(0deg)" should not set the property value
+Pass	e.style['transition-delay'] = "max(0Hz)" should not set the property value
+Pass	e.style['transition-delay'] = "max(0dpi)" should not set the property value
+Pass	e.style['transition-delay'] = "max(0fr)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, 0)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, 0%)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, 0px)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, 0deg)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, 0Hz)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, 0dpi)" should not set the property value
+Pass	e.style['transition-delay'] = "max(1s, 0fr)" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signs-abs-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signs-abs-invalid.txt
@@ -1,0 +1,58 @@
+Harness status: OK
+
+Found 52 tests
+
+51 Pass
+1 Fail
+Pass	e.style['font-weight'] = "abs()" should not set the property value
+Pass	e.style['font-weight'] = "abs( )" should not set the property value
+Pass	e.style['font-weight'] = "abs(,)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, )" should not set the property value
+Pass	e.style['font-weight'] = "abs(, 1)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1 + )" should not set the property value
+Pass	e.style['font-weight'] = "abs(1 - )" should not set the property value
+Pass	e.style['font-weight'] = "abs(1 * )" should not set the property value
+Pass	e.style['font-weight'] = "abs(1 / )" should not set the property value
+Pass	e.style['font-weight'] = "abs(1 2)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, , 2)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 2)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 1%)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 0px)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 0s)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 0deg)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 0Hz)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 0dpi)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1, 0fr)" should not set the property value
+Pass	e.style['font-weight'] = "sign()" should not set the property value
+Pass	e.style['font-weight'] = "sign( )" should not set the property value
+Pass	e.style['font-weight'] = "sign(,)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, )" should not set the property value
+Pass	e.style['font-weight'] = "sign(, 1)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1 + )" should not set the property value
+Pass	e.style['font-weight'] = "sign(1 - )" should not set the property value
+Pass	e.style['font-weight'] = "sign(1 * )" should not set the property value
+Pass	e.style['font-weight'] = "sign(1 / )" should not set the property value
+Pass	e.style['font-weight'] = "sign(1 2)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, , 2)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 2)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 1%)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 0px)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 0s)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 0deg)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 0Hz)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 0dpi)" should not set the property value
+Pass	e.style['font-weight'] = "sign(1, 0fr)" should not set the property value
+Pass	e.style['font-weight'] = "abs(0px)" should not set the property value
+Pass	e.style['font-weight'] = "abs(0s)" should not set the property value
+Pass	e.style['font-weight'] = "abs(0deg)" should not set the property value
+Pass	e.style['font-weight'] = "abs(0Hz)" should not set the property value
+Pass	e.style['font-weight'] = "abs(0dpi)" should not set the property value
+Pass	e.style['font-weight'] = "abs(0fr)" should not set the property value
+Pass	e.style['font-weight'] = "abs(1%)" should not set the property value
+Pass	e.style['font-weight'] = "sign(10px + 5rad)" should not set the property value
+Fail	e.style['font-weight'] = "sign(10%)" should not set the property value
+Pass	e.style['tab-size'] = "abs(10%)" should not set the property value
+Pass	e.style['tab-size'] = "1px * sign(10%)" should not set the property value
+Pass	e.style['tab-size'] = "1px * sign(1em + 10%)" should not set the property value
+Pass	e.style['margin-left'] = "1px * sign(10px + 5rad)" should not set the property value
+Pass	e.style['tab-size'] = "1px * sign(10px + 5rad)" should not set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/exp-log-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/exp-log-invalid.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#exponent-funcs">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#numbers">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-type-checking">
+<link rel="author" title="Apple Inc">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/parsing-testcommon.js"></script>
+<script>
+function test_invalid_number(value) {
+  test_invalid_value('opacity', value);
+}
+
+// Syntax checking
+test_invalid_number('exp()');
+test_invalid_number('exp( )');
+test_invalid_number('exp(,)');
+test_invalid_number('exp(1, )');
+test_invalid_number('exp(, 1)');
+test_invalid_number('exp(1 + )');
+test_invalid_number('exp(1 - )');
+test_invalid_number('exp(1 * )');
+test_invalid_number('exp(1 / )');
+test_invalid_number('exp(1 2)');
+test_invalid_number('exp(1, , 2)');
+test_invalid_number('log()');
+test_invalid_number('log( )');
+test_invalid_number('log(,)');
+test_invalid_number('log(1, )');
+test_invalid_number('log(, 1)');
+test_invalid_number('log(1 + )');
+test_invalid_number('log(1 - )');
+test_invalid_number('log(1 * )');
+test_invalid_number('log(1 / )');
+test_invalid_number('log(1 2)');
+test_invalid_number('log(1, , 2)');
+
+// Type checking
+test_invalid_number('exp(0px)');
+test_invalid_number('exp(0s)');
+test_invalid_number('exp(0deg)');
+test_invalid_number('exp(0Hz)');
+test_invalid_number('exp(0dpi)');
+test_invalid_number('exp(0fr)');
+test_invalid_number('exp(1, 1%)');
+test_invalid_number('exp(1, 0px)');
+test_invalid_number('exp(1, 0s)');
+test_invalid_number('exp(1, 0deg)');
+test_invalid_number('exp(1, 0Hz)');
+test_invalid_number('exp(1, 0dpi)');
+test_invalid_number('exp(1, 0fr)');
+test_invalid_number('log(0px)');
+test_invalid_number('log(0s)');
+test_invalid_number('log(0deg)');
+test_invalid_number('log(0Hz)');
+test_invalid_number('log(0dpi)');
+test_invalid_number('log(0fr)');
+test_invalid_number('log(1, 1%)');
+test_invalid_number('log(1, 0px)');
+test_invalid_number('log(1, 0s)');
+test_invalid_number('log(1, 0deg)');
+test_invalid_number('log(1, 0Hz)');
+test_invalid_number('log(1, 0dpi)');
+test_invalid_number('log(1, 0fr)');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/minmax-angle-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/minmax-angle-invalid.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#comp-func">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#angles">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-type-checking">
+<link rel="author" title="Xiaocheng Hu" href="mailto:xiaochengh@chromium.org">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/parsing-testcommon.js"></script>
+<script>
+function test_invalid_angle(value) {
+  test_invalid_value('transform', `rotate(${value})`);
+}
+
+// Syntax checking
+test_invalid_angle('min()');
+test_invalid_angle('min( )');
+test_invalid_angle('min(,)');
+test_invalid_angle('min(1dag)');
+test_invalid_angle('min(1deg, )');
+test_invalid_angle('min(, 1deg)');
+test_invalid_angle('min(1deg + )');
+test_invalid_angle('min(1deg - )');
+test_invalid_angle('min(1deg * )');
+test_invalid_angle('min(1deg / )');
+test_invalid_angle('min(1deg 2deg)');
+test_invalid_angle('min(1deg, , 2deg)');
+test_invalid_angle('max()');
+test_invalid_angle('max( )');
+test_invalid_angle('max(,)');
+test_invalid_angle('max(1dag)');
+test_invalid_angle('max(1deg, )');
+test_invalid_angle('max(, 1deg)');
+test_invalid_angle('max(1deg + )');
+test_invalid_angle('max(1deg - )');
+test_invalid_angle('max(1deg * )');
+test_invalid_angle('max(1deg / )');
+test_invalid_angle('max(1deg 2deg)');
+test_invalid_angle('max(1deg, , 2deg)');
+
+// Type checking
+test_invalid_angle('min(0)');
+test_invalid_angle('min(0%)');
+test_invalid_angle('min(0px)');
+test_invalid_angle('min(0s)');
+test_invalid_angle('min(0Hz)');
+test_invalid_angle('min(0dpi)');
+test_invalid_angle('min(0fr)');
+test_invalid_angle('min(1deg, 0)');
+test_invalid_angle('min(1deg, 0%)');
+test_invalid_angle('min(1deg, 0px)');
+test_invalid_angle('min(1deg, 0s)');
+test_invalid_angle('min(1deg, 0Hz)');
+test_invalid_angle('min(1deg, 0dpi)');
+test_invalid_angle('min(1deg, 0fr)');
+test_invalid_angle('max(0)');
+test_invalid_angle('max(0%)');
+test_invalid_angle('max(0px)');
+test_invalid_angle('max(0s)');
+test_invalid_angle('max(0Hz)');
+test_invalid_angle('max(0dpi)');
+test_invalid_angle('max(0fr)');
+test_invalid_angle('max(1deg, 0)');
+test_invalid_angle('max(1deg, 0%)');
+test_invalid_angle('max(1deg, 0px)');
+test_invalid_angle('max(1deg, 0s)');
+test_invalid_angle('max(1deg, 0Hz)');
+test_invalid_angle('max(1deg, 0dpi)');
+test_invalid_angle('max(1deg, 0fr)');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/minmax-percentage-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/minmax-percentage-invalid.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#comp-func">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#percentages">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-type-checking">
+<link rel="author" title="Xiaocheng Hu" href="mailto:xiaochengh@chromium.org">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/parsing-testcommon.js"></script>
+<script>
+function test_invalid_percentage(value) {
+  test_invalid_value('margin-left', value);
+}
+
+// Syntax checking
+test_invalid_percentage('min()');
+test_invalid_percentage('min( )');
+test_invalid_percentage('min(,)');
+test_invalid_percentage('min(1#)');
+test_invalid_percentage('min(%1)');
+test_invalid_percentage('min(1%, )');
+test_invalid_percentage('min(, 1%)');
+test_invalid_percentage('min(1% + )');
+test_invalid_percentage('min(1% - )');
+test_invalid_percentage('min(1% * )');
+test_invalid_percentage('min(1% / )');
+test_invalid_percentage('min(1% 2%)');
+test_invalid_percentage('min(1%, , 2%)');
+test_invalid_percentage('max()');
+test_invalid_percentage('max( )');
+test_invalid_percentage('max(,)');
+test_invalid_percentage('max(1#)');
+test_invalid_percentage('max(%1)');
+test_invalid_percentage('max(1%, )');
+test_invalid_percentage('max(, 1%)');
+test_invalid_percentage('max(1% + )');
+test_invalid_percentage('max(1% - )');
+test_invalid_percentage('max(1% * )');
+test_invalid_percentage('max(1% / )');
+test_invalid_percentage('max(1% 2%)');
+test_invalid_percentage('max(1%, , 2%)');
+
+// Type checking
+test_invalid_percentage('min(0s)');
+test_invalid_percentage('min(0deg)');
+test_invalid_percentage('min(0Hz)');
+test_invalid_percentage('min(0dpi)');
+test_invalid_percentage('min(0fr)');
+test_invalid_percentage('min(1%, 0)');
+test_invalid_percentage('min(1%, 0s)');
+test_invalid_percentage('min(1%, 0deg)');
+test_invalid_percentage('min(1%, 0Hz)');
+test_invalid_percentage('min(1%, 0dpi)');
+test_invalid_percentage('min(1%, 0fr)');
+test_invalid_percentage('max(0s)');
+test_invalid_percentage('max(0deg)');
+test_invalid_percentage('max(0Hz)');
+test_invalid_percentage('max(0dpi)');
+test_invalid_percentage('max(0fr)');
+test_invalid_percentage('max(1%, 0)');
+test_invalid_percentage('max(1%, 0s)');
+test_invalid_percentage('max(1%, 0deg)');
+test_invalid_percentage('max(1%, 0Hz)');
+test_invalid_percentage('max(1%, 0dpi)');
+test_invalid_percentage('max(1%, 0fr)');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/minmax-time-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/minmax-time-invalid.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#comp-func">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#time">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-type-checking">
+<link rel="author" title="Xiaocheng Hu" href="mailto:xiaochengh@chromium.org">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/parsing-testcommon.js"></script>
+<script>
+function test_invalid_time(value) {
+  test_invalid_value('transition-delay', value);
+}
+
+// Syntax checking
+test_invalid_time('min()');
+test_invalid_time('min( )');
+test_invalid_time('min(,)');
+test_invalid_time('min(1mt)');
+test_invalid_time('min(1s, )');
+test_invalid_time('min(, 1s)');
+test_invalid_time('min(1s + )');
+test_invalid_time('min(1s - )');
+test_invalid_time('min(1s * )');
+test_invalid_time('min(1s / )');
+test_invalid_time('min(1s 2s)');
+test_invalid_time('min(1s, , 2s)');
+test_invalid_time('max()');
+test_invalid_time('max( )');
+test_invalid_time('max(,)');
+test_invalid_time('max(1dag)');
+test_invalid_time('max(1s, )');
+test_invalid_time('max(, 1s)');
+test_invalid_time('max(1s + )');
+test_invalid_time('max(1s - )');
+test_invalid_time('max(1s * )');
+test_invalid_time('max(1s / )');
+test_invalid_time('max(1s 2s)');
+test_invalid_time('max(1s, , 2s)');
+
+// Type checking
+test_invalid_time('min(0)');
+test_invalid_time('min(0%)');
+test_invalid_time('min(0px)');
+test_invalid_time('min(0deg)');
+test_invalid_time('min(0Hz)');
+test_invalid_time('min(0dpi)');
+test_invalid_time('min(0fr)');
+test_invalid_time('min(1s, 0)');
+test_invalid_time('min(1s, 0%)');
+test_invalid_time('min(1s, 0px)');
+test_invalid_time('min(1s, 0deg)');
+test_invalid_time('min(1s, 0Hz)');
+test_invalid_time('min(1s, 0dpi)');
+test_invalid_time('min(1s, 0fr)');
+test_invalid_time('max(0)');
+test_invalid_time('max(0%)');
+test_invalid_time('max(0px)');
+test_invalid_time('max(0deg)');
+test_invalid_time('max(0Hz)');
+test_invalid_time('max(0dpi)');
+test_invalid_time('max(0fr)');
+test_invalid_time('max(1s, 0)');
+test_invalid_time('max(1s, 0%)');
+test_invalid_time('max(1s, 0px)');
+test_invalid_time('max(1s, 0deg)');
+test_invalid_time('max(1s, 0Hz)');
+test_invalid_time('max(1s, 0dpi)');
+test_invalid_time('max(1s, 0fr)');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/signs-abs-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/signs-abs-invalid.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#comp-func">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#numbers">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-type-checking">
+<link rel="author" title="Apple Inc">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/parsing-testcommon.js"></script>
+<script>
+function test_invalid_number(value) {
+  test_invalid_value('font-weight', value);
+}
+
+function test_invalid_length_percentage(value) {
+  test_invalid_value('margin-left', value);
+  test_invalid_length(value);
+}
+
+function test_invalid_length(value) {
+  test_invalid_value('tab-size', value);
+}
+
+// Syntax checking
+test_invalid_number('abs()');
+test_invalid_number('abs( )');
+test_invalid_number('abs(,)');
+test_invalid_number('abs(1, )');
+test_invalid_number('abs(, 1)');
+test_invalid_number('abs(1 + )');
+test_invalid_number('abs(1 - )');
+test_invalid_number('abs(1 * )');
+test_invalid_number('abs(1 / )');
+test_invalid_number('abs(1 2)');
+test_invalid_number('abs(1, , 2)');
+test_invalid_number('abs(1, 2)');
+test_invalid_number('abs(1, 1%)');
+test_invalid_number('abs(1, 0px)');
+test_invalid_number('abs(1, 0s)');
+test_invalid_number('abs(1, 0deg)');
+test_invalid_number('abs(1, 0Hz)');
+test_invalid_number('abs(1, 0dpi)');
+test_invalid_number('abs(1, 0fr)');
+test_invalid_number('sign()');
+test_invalid_number('sign( )');
+test_invalid_number('sign(,)');
+test_invalid_number('sign(1, )');
+test_invalid_number('sign(, 1)');
+test_invalid_number('sign(1 + )');
+test_invalid_number('sign(1 - )');
+test_invalid_number('sign(1 * )');
+test_invalid_number('sign(1 / )');
+test_invalid_number('sign(1 2)');
+test_invalid_number('sign(1, , 2)');
+test_invalid_number('sign(1, 2)');
+test_invalid_number('sign(1, 1%)');
+test_invalid_number('sign(1, 0px)');
+test_invalid_number('sign(1, 0s)');
+test_invalid_number('sign(1, 0deg)');
+test_invalid_number('sign(1, 0Hz)');
+test_invalid_number('sign(1, 0dpi)');
+test_invalid_number('sign(1, 0fr)');
+
+// Type checking
+test_invalid_number('abs(0px)');
+test_invalid_number('abs(0s)');
+test_invalid_number('abs(0deg)');
+test_invalid_number('abs(0Hz)');
+test_invalid_number('abs(0dpi)');
+test_invalid_number('abs(0fr)');
+test_invalid_number('abs(1%)');
+test_invalid_number('sign(10px + 5rad)');
+test_invalid_number('sign(10%)');
+test_invalid_length('abs(10%)');
+test_invalid_length('1px * sign(10%)');
+test_invalid_length('1px * sign(1em + 10%)');
+test_invalid_length_percentage('1px * sign(10px + 5rad)');
+</script>


### PR DESCRIPTION
Previously, we would allow calc values such as `calc(min(1 2))`, which would be simplified to `calc(3)` because we assumed  that numbers not separated by an operator represented a sum. We now validate that the number of operators we see is as we would expect before collecting these values into a sum node.

Fixes at least 16 WPT subtests.