### PR TITLE
LibURL: Differentiate cross site opaque origins

### DIFF
--- a/Libraries/LibURL/Site.cpp
+++ b/Libraries/LibURL/Site.cpp
@@ -36,9 +36,8 @@ bool Site::is_same_site(Site const& other) const
 {
     // 1. If A and B are the same opaque origin, then return true.
     // NOTE: Origins in sites are always opaque.
-    // FIXME: Currently all opaque origins are identical, how should we distinguish them?
     if (m_value.has<Origin>() && other.m_value.has<Origin>())
-        return true;
+        return m_value.get<Origin>().nonce() == other.m_value.get<Origin>().nonce();
 
     // 2. If A or B is an opaque origin, then return false.
     if (m_value.has<Origin>() || other.m_value.has<Origin>())

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -689,3 +689,23 @@ TEST_CASE(public_suffix)
         EXPECT_EQ(domain->public_suffix(), OptionalNone {});
     }
 }
+
+TEST_CASE(same_site)
+{
+    auto opaque_origin = URL::Origin::create_opaque();
+    auto second_opaque_origin = URL::Origin::create_opaque();
+
+    auto site1_https_url = URL::Parser::basic_parse("https://www.ladybird.org"sv).value();
+    auto site1_https_second_url = URL::Parser::basic_parse("https://www.ladybird.org/some/file/path"sv).value();
+    auto site1_http_url = URL::Parser::basic_parse("http://www.ladybird.org"sv).value();
+
+    auto site2_https_url = URL::Parser::basic_parse("https://www.serenityos.org"sv).value();
+
+    EXPECT(!opaque_origin.is_same_site(second_opaque_origin));
+    EXPECT(opaque_origin.is_same_site(opaque_origin));
+    EXPECT(!opaque_origin.is_same_site(site1_https_url.origin()));
+
+    EXPECT(site1_https_url.origin().is_same_site(site1_https_second_url.origin()));
+    EXPECT(!site1_https_url.origin().is_same_site(site1_http_url.origin()));
+    EXPECT(!site1_https_url.origin().is_same_site(site2_https_url.origin()));
+}


### PR DESCRIPTION
Previously if we had two opaque origins both URLs were being treated as same site.