### PR TITLE
LibWeb: Use correct previous word location when moving selection offset

### DIFF
--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -629,7 +629,7 @@ void Selection::move_offset_to_previous_word(bool collapse_selection)
     while (true) {
         auto focus_offset = this->focus_offset();
         if (auto offset = text_node.word_segmenter().previous_boundary(focus_offset); offset.has_value()) {
-            auto word = text_node.data().code_points().substring_view(focus_offset, focus_offset - *offset);
+            auto word = text_node.data().code_points().unicode_substring_view(*offset, focus_offset - *offset);
             if (collapse_selection) {
                 MUST(collapse(anchor_node, *offset));
                 m_document->reset_cursor_blink_cycle();

--- a/Tests/LibWeb/Crash/wpt-import/selection/crashtests/selection-modify-per-word-in-table-header-group.html
+++ b/Tests/LibWeb/Crash/wpt-import/selection/crashtests/selection-modify-per-word-in-table-header-group.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+dialog {
+  display: table-header-group;
+  translate: -1px 0px 0px;
+  position: sticky;
+}
+</style>
+<script>
+addEventListener("DOMContentLoaded", () => {
+  window.find("1");
+  getSelection().modify("move", "left", "word");
+}, {once: true});
+</script>
+</head>
+<body>
+<dialog>
+<span style="position: fixed">1</span>
+<table dir="rtl"></table>
+<video>
+</video>
+</dialog>
+</body>
+</html>


### PR DESCRIPTION
Previously, this incorrect offset could cause a crash when moving the selection to the previous word.