### PR TITLE
LibWeb: Avoid infinite loop in HTMLElement.scrollParent

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -98,6 +98,7 @@ enum class InvalidateLayoutTreeReason {
     X(HTMLElementOffsetParent)             \
     X(HTMLElementOffsetTop)                \
     X(HTMLElementOffsetWidth)              \
+    X(HTMLElementScrollParent)             \
     X(HTMLEventLoopRenderingUpdate)        \
     X(HTMLImageElementHeight)              \
     X(HTMLImageElementWidth)               \

--- a/Tests/LibWeb/Text/expected/HTML/scrollParent-infinite-loop.txt
+++ b/Tests/LibWeb/Text/expected/HTML/scrollParent-infinite-loop.txt
@@ -1,0 +1,1 @@
+PASS (didn't hang)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollParent-shadow-tree.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollParent-shadow-tree.txt
@@ -2,8 +2,9 @@ Harness status: OK
 
 Found 4 tests
 
-4 Fail
-Fail	scrollParent skips intermediate closed shadow tree nodes
+3 Pass
+1 Fail
+Pass	scrollParent skips intermediate closed shadow tree nodes
 Fail	scrollParent skips intermediate open shadow tree nodes
-Fail	scrollParent from inside closed shadow tree
-Fail	scrollParent from inside open shadow tree
+Pass	scrollParent from inside closed shadow tree
+Pass	scrollParent from inside open shadow tree

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollParent.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrollParent.txt
@@ -2,14 +2,14 @@ Harness status: OK
 
 Found 9 tests
 
-3 Pass
-6 Fail
-Fail	scrollParent returns the nearest scroll container.
-Fail	hidden element is a scroll container.
+7 Pass
+2 Fail
+Pass	scrollParent returns the nearest scroll container.
+Pass	hidden element is a scroll container.
 Pass	Element with no box has null scrollParent.
-Fail	scrollParent follows absolute positioned containing block chain.
+Pass	scrollParent follows absolute positioned containing block chain.
 Fail	scrollParent follows fixed positioned containing block chain.
-Pass	scrollParent of element fixed to root is null.
-Fail	scrollParent of child in root viewport returns document scrolling element.
-Fail	scrollParent of fixed element contained within root is document scrolling element.
+Fail	scrollParent of element fixed to root is null.
+Pass	scrollParent of child in root viewport returns document scrolling element.
+Pass	scrollParent of fixed element contained within root is document scrolling element.
 Pass	scrollParent of body is null.

--- a/Tests/LibWeb/Text/input/HTML/scrollParent-infinite-loop.html
+++ b/Tests/LibWeb/Text/input/HTML/scrollParent-infinite-loop.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<script src="../include.js"></script>
+<body><div id=foo><div id=bar></div></div>
+<script>
+    test(() => {
+        bar.scrollParent;
+        println("PASS (didn't hang)");
+    });
+</script>


### PR DESCRIPTION
We were failing to actually climb up the containing block chain, causing this API to infinite loop for anything but the most trivial cases.

By fixing the loop structure, we also make a bunch of the already imported WPT tests pass. :^)