### PR TITLE
Meta: Fix CMake configure warning in unix angle vcpkg port

### DIFF
--- a/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake
@@ -156,7 +156,7 @@ function(checkout_in_path PATH URL REF)
         URL "${URL}"
         REF "${REF}"
     )
-    if (WIN32)
+    if (VCPKG_HOST_IS_WIN32)
         file(COPY "${DEP_SOURCE_PATH}/" DESTINATION "${PATH}")
     else()
         file(RENAME "${DEP_SOURCE_PATH}" "${PATH}")


### PR DESCRIPTION
Reduces some warning log noise during CMake configuration


### Before
```
The following packages will be built and installed:
    angle:x64-linux-dynamic@chromium_5414#9 -- /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle
Restored 0 package(s) from /home/ayeteadoe/Development/ladybird/Build/caches/vcpkg-binary-cache in 5.19 us. Use --debug to see more details.
Installing 1/1 angle:x64-linux-dynamic@chromium_5414#9...
Building angle:x64-linux-dynamic@chromium_5414#9...
/home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/debug-triplets/x64-linux-dynamic.cmake: info: loaded overlay triplet from here
/home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle: info: installing overlay port from here
CMake Warning at /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake:2 (message):
  Building with a gcc version less than 6.1 is not supported.
Call Stack (most recent call first):
  scripts/ports.cmake:206 (include)


CMake Warning at /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake:3 (message):
  angle currently requires the following libraries from the system package
  manager:

      mesa-common-dev

  

  These can be installed on Ubuntu systems via apt-get install
  mesa-common-dev.
Call Stack (most recent call first):
  scripts/ports.cmake:206 (include)


-- Using cached google-angle-48103cb2f2b292cb50cc5a29546b358b2e47fd29.tar.gz
-- Cleaning sources at /home/ayeteadoe/Development/ladybird/Build/vcpkg/buildtrees/angle/src/8b2e47fd29-f7f0f8ba5c.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source /home/ayeteadoe/Development/ladybird/Build/vcpkg/downloads/google-angle-48103cb2f2b292cb50cc5a29546b358b2e47fd29.tar.gz
-- Applying patch 001-fix-builder-error.patch
-- Using source at /home/ayeteadoe/Development/ladybird/Build/vcpkg/buildtrees/angle/src/8b2e47fd29-f7f0f8ba5c.clean
-- Using cached gni-to-cmake.py
-- Setting up python virtual environment...
-- Installing python packages: ply
-- Setting up python virtual environment... finished.
-- Using cached include_CMakeLists.txt
-- Using cached WebKitCompilerFlags.cmake
-- Using cached DetectSSE2.cmake
-- Using cached WebKitMacros.cmake
-- Using cached /home/ayeteadoe/Development/ladybird/Build/vcpkg/downloads/angle-788cb3c270e8700b425c7bdca1f9ce6b0c1400a9.tar.gz
-- Extracting source /home/ayeteadoe/Development/ladybird/Build/vcpkg/downloads/angle-788cb3c270e8700b425c7bdca1f9ce6b0c1400a9.tar.gz
-- Using source at /home/ayeteadoe/Development/ladybird/Build/vcpkg/buildtrees/angle/src/6b0c1400a9-00a4ca259f.clean
CMake Warning at scripts/ports.cmake:182 (message):
  Unexpected UNKNOWN_READ_ACCESS on variable WIN32 in script mode.

  This variable name insufficiently expresses whether it refers to the target
  system or to the host system.  Use a prefixed variable instead.

  - Variables providing information about the host:

    CMAKE_HOST_<SYSTEM>
    VCPKG_HOST_IS_<SYSTEM>

  - Variables providing information about the target:

    VCPKG_TARGET_IS_<SYSTEM>
    VCPKG_DETECTED_<VARIABLE> (using vcpkg_cmake_get_vars)

Call Stack (most recent call first):
  /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake:9223372036854775807 (z_vcpkg_warn_ambiguous_system_variables)
  /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake:159 (if)
  /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake:167 (checkout_in_path)
  scripts/ports.cmake:206 (include)


-- Configuring x64-linux-dynamic
```

### After
```
The following packages will be built and installed:
    angle:x64-linux-dynamic@chromium_5414#9 -- /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle
Restored 0 package(s) from /home/ayeteadoe/Development/ladybird/Build/caches/vcpkg-binary-cache in 7.28 us. Use --debug to see more details.
Installing 1/1 angle:x64-linux-dynamic@chromium_5414#9...
Building angle:x64-linux-dynamic@chromium_5414#9...
/home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/debug-triplets/x64-linux-dynamic.cmake: info: loaded overlay triplet from here
/home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle: info: installing overlay port from here
CMake Warning at /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake:2 (message):
  Building with a gcc version less than 6.1 is not supported.
Call Stack (most recent call first):
  scripts/ports.cmake:206 (include)


CMake Warning at /home/ayeteadoe/Development/ladybird/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake:3 (message):
  angle currently requires the following libraries from the system package
  manager:

      mesa-common-dev

  

  These can be installed on Ubuntu systems via apt-get install
  mesa-common-dev.
Call Stack (most recent call first):
  scripts/ports.cmake:206 (include)


-- Using cached google-angle-48103cb2f2b292cb50cc5a29546b358b2e47fd29.tar.gz
-- Cleaning sources at /home/ayeteadoe/Development/ladybird/Build/vcpkg/buildtrees/angle/src/8b2e47fd29-f7f0f8ba5c.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source /home/ayeteadoe/Development/ladybird/Build/vcpkg/downloads/google-angle-48103cb2f2b292cb50cc5a29546b358b2e47fd29.tar.gz
-- Applying patch 001-fix-builder-error.patch
-- Using source at /home/ayeteadoe/Development/ladybird/Build/vcpkg/buildtrees/angle/src/8b2e47fd29-f7f0f8ba5c.clean
-- Using cached gni-to-cmake.py
-- Setting up python virtual environment...
-- Installing python packages: ply
-- Setting up python virtual environment... finished.
-- Using cached include_CMakeLists.txt
-- Using cached WebKitCompilerFlags.cmake
-- Using cached DetectSSE2.cmake
-- Using cached WebKitMacros.cmake
-- Using cached /home/ayeteadoe/Development/ladybird/Build/vcpkg/downloads/angle-788cb3c270e8700b425c7bdca1f9ce6b0c1400a9.tar.gz
-- Extracting source /home/ayeteadoe/Development/ladybird/Build/vcpkg/downloads/angle-788cb3c270e8700b425c7bdca1f9ce6b0c1400a9.tar.gz
-- Using source at /home/ayeteadoe/Development/ladybird/Build/vcpkg/buildtrees/angle/src/6b0c1400a9-00a4ca259f.clean
-- Configuring x64-linux-dynamic
```