### PR TITLE
LibWeb: Add OffscreenCanvas to ImageBitmap invalid-types-no-crash test

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
@@ -4,4 +4,5 @@ HTMLImageElement  [ Error ]: InvalidStateError: image argument is not usable
 SVGImageElement   [ Error ]: InvalidStateError: image argument is not usable
 HTMLCanvasElement [ Error ]: Error: Not Implemented: createImageBitmap() for HTMLCanvasElement
 ImageBitmap       [ Error ]: TypeError: No union types matched
+OffscreenCanvas   [ Error ]: Error: Not Implemented: createImageBitmap() for OffscreenCanvas
 HTMLVideoElement  [ Error ]: InvalidStateError: image argument is not usable

--- a/Tests/LibWeb/Text/input/HTML/image-bitmap-from-invalid-types-no-crash.html
+++ b/Tests/LibWeb/Text/input/HTML/image-bitmap-from-invalid-types-no-crash.html
@@ -17,6 +17,8 @@
     let svgImg = document.createElement("img");
     svgImg = document.createElementNS("http://www.w3.org/2000/svg", "image");
 
+    let offscreenCanvas = new OffscreenCanvas(42, 42);
+
     let video = document.createElement("video");
     let file = new Blob([
         new Uint8Array([
@@ -32,6 +34,7 @@
         [svgImg, "SVGImageElement"],
         [canvas, "HTMLCanvasElement"],
         [imageBitmap, "ImageBitmap"],
+        [offscreenCanvas, "OffscreenCanvas"],
         [video, "HTMLVideoElement"],
     ];
 


### PR DESCRIPTION
Now that https://github.com/LadybirdBrowser/ladybird/pull/3788 and https://github.com/LadybirdBrowser/ladybird/commit/1d62bf7049fabaecc85a3d211d9bb7938a476823 have been merged, the invalid types ImageBitmap creation test can add the new unimplemented input