### PR TITLE
Meta: Fix windows vcpkg angle port

### DIFF
--- a/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/angle/portfile.cmake
@@ -156,7 +156,7 @@ function(checkout_in_path PATH URL REF)
         URL "${URL}"
         REF "${REF}"
     )
-    if (VCPKG_HOST_IS_WIN32)
+    if (CMAKE_HOST_WIN32)
         file(COPY "${DEP_SOURCE_PATH}/" DESTINATION "${PATH}")
     else()
         file(RENAME "${DEP_SOURCE_PATH}" "${PATH}")


### PR DESCRIPTION
It was working for about 4 hours in upstream until [the angle upgrade](https://github.com/LadybirdBrowser/ladybird/commit/286fa7b3caa6f37ed2e8c048f0b29a0ef627bf45) and my [unix angle config warning noise reduction fix](https://github.com/LadybirdBrowser/ladybird/commit/3bce1934b152634d3e8fa11bfd257628f7fa62d2) broke it 😅 

The angle build completes successfully on `Windows_Sanitizer_CI` locally, but this should get the `windows` label to confirm. Or alternatively, you can see the results of https://github.com/LadybirdBrowser/ladybird/actions/runs/15991077080/job/45104302629?pr=5229 as that PR is rebased on-top of this commit currently