### PR TITLE
LibWeb: Throw SyntaxError when FontFaceSet contains var

### DIFF
--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -175,12 +175,11 @@ static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm&
 {
     // 1. Parse font using the CSS value syntax of the font property. If a syntax error occurs, return a syntax error.
     auto property = parse_css_value(CSS::Parser::ParsingParams(), font, PropertyID::Font);
-    if (!property)
+    if (!property || !property->is_shorthand())
         return WebIDL::SyntaxError::create(realm, "Unable to parse font"_string);
 
     // If the parsed value is a CSS-wide keyword, return a syntax error.
-    if (property->is_css_wide_keyword())
-        return WebIDL::SyntaxError::create(realm, "Parsed font is a CSS-wide keyword"_string);
+    // Note: This case is already caught by the is_shorthand check.
 
     // FIXME: Absolutize all relative lengths against the initial values of the corresponding properties. (For example, a
     //        relative font weight like bolder is evaluated against the initial value normal.)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-font-loading/fontfaceset-load-var.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-font-loading/fontfaceset-load-var.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	Loading "var(--x) serif" causes SyntaxError (document)
+Pass	Loading "var(--x, 10px) serif" causes SyntaxError (document)
+Pass	Loading "var(--x) serif" causes SyntaxError (worker)
+Pass	Loading "var(--x, 10px) serif" causes SyntaxError (worker)

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-font-loading/fontfaceset-load-var.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-font-loading/fontfaceset-load-var.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>SyntaxError thrown when matching loading values with var()</title>
+<link rel="help" href="https://drafts.csswg.org/css-font-loading/#font-face-set-load">
+<link rel="help" href="https://drafts.csswg.org/css-font-loading/#find-the-matching-font-faces">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+
+  function load_on_worker(keyword) {
+    return new Promise((resolve, reject) =>{
+      var blob = new Blob([`
+        self.fonts.load('${keyword}').then(
+          ()=>{ self.postMessage('success') },
+          (e)=>{ self.postMessage(e) }
+        );
+      `]);
+      var blob_url = window.URL.createObjectURL(blob);
+      let worker = new Worker(blob_url);
+      worker.onmessage = msg => {
+        if (msg === 'success')
+          resolve(msg.data)
+        else
+          reject(msg.data)
+      }
+    });
+  }
+
+  promise_test(test => {
+    return promise_rejects_dom(test, 'SyntaxError', document.fonts.load('var(--x) serif'));
+  }, 'Loading "var(--x) serif" causes SyntaxError (document)')
+
+  promise_test(test => {
+    return promise_rejects_dom(test, 'SyntaxError', document.fonts.load('var(--x, 10px) serif'));
+  }, 'Loading "var(--x, 10px) serif" causes SyntaxError (document)')
+
+  promise_test(test => {
+    return promise_rejects_dom(test, 'SyntaxError', load_on_worker('var(--x) serif'));
+  }, 'Loading "var(--x) serif" causes SyntaxError (worker)')
+
+  promise_test(test => {
+    return promise_rejects_dom(test, 'SyntaxError', load_on_worker('var(--x, 10px) serif'));
+  }, 'Loading "var(--x, 10px) serif" causes SyntaxError (worker)')
+
+</script>


### PR DESCRIPTION
..instead of crashing.