### PR TITLE
Meta: Update vcpkg baseline

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "2d1eb6affae7b2ef01c0312514d7218113dd5d25",
+  "builtin-baseline": "a7ef72790b3f4a6c1f940503e418f71380ac94a7",
   "dependencies": [
     {
       "name": "angle",


### PR DESCRIPTION
This bump includes a new version of meson that unbreaks the build on macOS 26 with xcode 26.