### PR TITLE
Tests: Unskip `selection-over-multiple-code-units.html` test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -318,7 +318,3 @@ Text/input/wpt-import/IndexedDB/idbfactory_open.any.html
 Text/input/XHR/XMLHttpRequest-override-mimetype-blob.html
 
 Text/input/wpt-import/webaudio/the-audio-api/the-periodicwave-interface/periodicWave.html
-
-; Flaky in CI.
-; https://github.com/LadybirdBrowser/ladybird/issues/5257
-Text/input/selection-over-multiple-code-units.html

--- a/Tests/LibWeb/Text/input/selection-over-multiple-code-units.html
+++ b/Tests/LibWeb/Text/input/selection-over-multiple-code-units.html
@@ -2,16 +2,18 @@
 <script src="include.js"></script>
 😭foobar😭
 <script>
-test(() => {
-    document.body.offsetWidth;  // force layout
+asyncTest(done => {
+    window.addEventListener('load', () => {
+        internals.mouseDown(55, 20);
+        internals.movePointerTo(110, 20);
 
-    internals.mouseDown(55, 20);
-    internals.movePointerTo(110, 20);
+        const activeRange = window.getSelection().getRangeAt(0);
+        printElement(activeRange.startContainer);
+        println(activeRange.startOffset);
+        printElement(activeRange.endContainer);
+        println(activeRange.endOffset);
 
-    const activeRange = window.getSelection().getRangeAt(0);
-    printElement(activeRange.startContainer);
-    println(activeRange.startOffset);
-    printElement(activeRange.endContainer);
-    println(activeRange.endOffset);
+        done();
+    });
 });
 </script>


### PR DESCRIPTION
The flake was reproducible by running the entire LibWeb test suite over and over again with sanitizers enabled. By making the test async and run at window `load` time instead of document `DOMContentLoaded` time, I've not been able to reproduce the issue locally.

Ideally I was able to find the underlying cause for this bug, but for now I'd rather run this regression test.

Disabled in #5258, fixes #5257.