### PR TITLE
LibWeb/Painting: Make transparent inset/outset borders transparent

### DIFF
--- a/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -20,16 +20,20 @@ static Color light_color_for_inset_and_outset(Color const& color)
 {
     auto hsv = color.to_hsv();
     if (hsv.value >= dark_light_absolute_value_difference)
-        return Color::from_hsv(hsv);
-    return Color::from_hsv({ hsv.hue, hsv.saturation, hsv.value + dark_light_absolute_value_difference });
+        return color;
+    auto result = Color::from_hsv({ hsv.hue, hsv.saturation, hsv.value + dark_light_absolute_value_difference });
+    result.set_alpha(color.alpha());
+    return result;
 }
 
 static Color dark_color_for_inset_and_outset(Color const& color)
 {
     auto hsv = color.to_hsv();
     if (hsv.value < dark_light_absolute_value_difference)
-        return Color::from_hsv(hsv);
-    return Color::from_hsv({ hsv.hue, hsv.saturation, hsv.value - dark_light_absolute_value_difference });
+        return color;
+    auto result = Color::from_hsv({ hsv.hue, hsv.saturation, hsv.value - dark_light_absolute_value_difference });
+    result.set_alpha(color.alpha());
+    return result;
 }
 
 Gfx::Color border_color(BorderEdge edge, BordersDataDevicePixels const& borders_data)

--- a/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -54,13 +54,14 @@ Gfx::Color border_color(BorderEdge edge, BordersDataDevicePixels const& borders_
     }();
 
     if (border_data.line_style == CSS::LineStyle::Inset) {
-        auto top_left_color = dark_color_for_inset_and_outset(border_data.color);
-        auto bottom_right_color = light_color_for_inset_and_outset(border_data.color);
-        return (edge == BorderEdge::Left || edge == BorderEdge::Top) ? top_left_color : bottom_right_color;
-    } else if (border_data.line_style == CSS::LineStyle::Outset) {
-        auto top_left_color = light_color_for_inset_and_outset(border_data.color);
-        auto bottom_right_color = dark_color_for_inset_and_outset(border_data.color);
-        return (edge == BorderEdge::Left || edge == BorderEdge::Top) ? top_left_color : bottom_right_color;
+        if (edge == BorderEdge::Left || edge == BorderEdge::Top)
+            return dark_color_for_inset_and_outset(border_data.color);
+        return light_color_for_inset_and_outset(border_data.color);
+    }
+    if (border_data.line_style == CSS::LineStyle::Outset) {
+        if (edge == BorderEdge::Left || edge == BorderEdge::Top)
+            return light_color_for_inset_and_outset(border_data.color);
+        return dark_color_for_inset_and_outset(border_data.color);
     }
 
     return border_data.color;

--- a/Tests/LibWeb/Ref/expected/css/transparent-borders-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/transparent-borders-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/transparent-borders-ref.html" />
+<style>
+  .example {
+    width: 40px;
+    height: 40px;
+    background: orange;
+    margin-bottom: 10px;
+  }
+</style>
+<div class="example"></div>
+<div class="example"></div>
+<div class="example"></div>
+<div class="example"></div>
+<div class="example"></div>
+<div class="example"></div>
+<div class="example"></div>

--- a/Tests/LibWeb/Ref/input/css/transparent-borders.html
+++ b/Tests/LibWeb/Ref/input/css/transparent-borders.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/transparent-borders-ref.html" />
+<style>
+  .example {
+    width: 0;
+    height: 0;
+    background: orange;
+    border: 20px solid transparent;
+    margin-bottom: 10px;
+  }
+</style>
+<div class="example" style="border-style: dotted"></div>
+<div class="example" style="border-style: dashed"></div>
+<div class="example" style="border-style: solid"></div>
+<div class="example" style="border-style: groove"></div>
+<div class="example" style="border-style: ridge"></div>
+<div class="example" style="border-style: inset"></div>
+<div class="example" style="border-style: outset"></div>


### PR DESCRIPTION
With this test:
```html
<!DOCTYPE html>
<style>
  .example {
    width: 0;
    height: 0;
    background: orange;
    border: 20px solid transparent;
    margin-bottom: 10px;
  }
</style>
<div class="example" style="border-style: dotted"></div>
<div class="example" style="border-style: dashed"></div>
<div class="example" style="border-style: solid"></div>
<div class="example" style="border-style: groove"></div>
<div class="example" style="border-style: ridge"></div>
<div class="example" style="border-style: inset"></div>
<div class="example" style="border-style: outset"></div>
```

Before:
![transparent-borders](https://github.com/user-attachments/assets/41718a1e-b778-4fa5-97f6-5863c7581b72)

After:
![transparent-borders-ref](https://github.com/user-attachments/assets/e5953bfa-df52-4c75-9c69-e9a9998a98c2)
