### PR TITLE
Meta: Pin harfbuzz to 10.2.0 for now

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -161,6 +161,10 @@
       "version": "2.15.0#4"
     },
     {
+      "name": "harfbuzz",
+      "version": "10.2.0#0"
+    },
+    {
       "name": "icu",
       "version": "76.1#0"
     },


### PR DESCRIPTION
Several of us (including our WPT runner) are getting linker errors with 11.2.0, as Qt is pulling in the system harfbuzz.