### PR TITLE
LibWeb/Painting: Don't paint invisible paintables

### DIFF
--- a/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -32,6 +32,9 @@ constexpr float sin_60_deg = 0.866025403f;
 
 void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
 {
+    if (!is_visible())
+        return;
+
     if (phase == PaintPhase::Overlay)
         PaintableBox::paint(context, phase);
     if (phase != PaintPhase::Foreground)

--- a/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.cpp
@@ -33,6 +33,9 @@ TraversalDecision SVGForeignObjectPaintable::hit_test(CSSPixelPoint position, Hi
 
 void SVGForeignObjectPaintable::paint(PaintContext& context, PaintPhase phase) const
 {
+    if (!is_visible())
+        return;
+
     PaintableWithLines::paint(context, phase);
 }
 

--- a/Tests/LibWeb/Ref/expected/css/hidden-list-item-markers-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/hidden-list-item-markers-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+There should be nothing visible below.

--- a/Tests/LibWeb/Ref/input/css/hidden-list-item-markers.html
+++ b/Tests/LibWeb/Ref/input/css/hidden-list-item-markers.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/hidden-list-item-markers-ref.html" />
+<style>
+  .hidden {
+    visibility: hidden;
+  }
+  .display-none {
+    display: none;
+  }
+  #a { color: red; }
+  #b { color: green; }
+  #c { color: blue; }
+  #d { color: orange; }
+</style>
+There should be nothing visible below.
+<ul class="hidden">
+  <li id="a"></li>
+</ul>
+<ul class="display-none">
+  <li id="b"></li>
+</ul>
+<ul>
+  <li class="hidden" id="c"></li>
+  <li class="display-none" id="d"></li>
+</ul>


### PR DESCRIPTION
This check technically isn't necessary in `SVGForeignObjectPaintable::paint()` because `PaintableWithLines::paint (context, phase);` does the check already, but I've added it there anyway to save some debugging time if someone does add more code there. :^)