### PR TITLE
Tests/LibWeb: Import webstorage symbol-props WPT test

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/webstorage/symbol-props.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webstorage/symbol-props.window.txt
@@ -1,0 +1,19 @@
+Harness status: OK
+
+Found 14 tests
+
+14 Pass
+Pass	localStorage: plain set + get (loose)
+Pass	localStorage: plain set + get (strict)
+Pass	localStorage: defineProperty + get
+Pass	localStorage: defineProperty not configurable
+Pass	localStorage: get with symbol on prototype
+Pass	localStorage: delete existing property
+Pass	localStorage: delete non-existent property
+Pass	sessionStorage: plain set + get (loose)
+Pass	sessionStorage: plain set + get (strict)
+Pass	sessionStorage: defineProperty + get
+Pass	sessionStorage: defineProperty not configurable
+Pass	sessionStorage: get with symbol on prototype
+Pass	sessionStorage: delete existing property
+Pass	sessionStorage: delete non-existent property

--- a/Tests/LibWeb/Text/input/wpt-import/webstorage/symbol-props.window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webstorage/symbol-props.window.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../webstorage/symbol-props.window.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/webstorage/symbol-props.window.js
+++ b/Tests/LibWeb/Text/input/wpt-import/webstorage/symbol-props.window.js
@@ -1,0 +1,81 @@
+["localStorage", "sessionStorage"].forEach(function(name) {
+    test(function() {
+        var key = Symbol();
+
+        var storage = window[name];
+        storage.clear();
+
+        storage[key] = "test";
+        assert_equals(storage[key], "test");
+    }, name + ": plain set + get (loose)");
+
+    test(function() {
+        "use strict";
+        var key = Symbol();
+
+        var storage = window[name];
+        storage.clear();
+
+        storage[key] = "test";
+        assert_equals(storage[key], "test");
+    }, name + ": plain set + get (strict)");
+
+    test(function() {
+        var key = Symbol();
+
+        var storage = window[name];
+        storage.clear();
+
+        Object.defineProperty(storage, key, { "value": "test" });
+        assert_equals(storage[key], "test");
+    }, name + ": defineProperty + get");
+
+    test(function() {
+        var key = Symbol();
+
+        var storage = window[name];
+        storage.clear();
+
+        Object.defineProperty(storage, key, { "value": "test", "configurable": false });
+        assert_equals(storage[key], "test");
+        var desc = Object.getOwnPropertyDescriptor(storage, key);
+        assert_false(desc.configurable, "configurable");
+
+        assert_false(delete storage[key]);
+        assert_equals(storage[key], "test");
+    }, name + ": defineProperty not configurable");
+
+    test(function() {
+        var key = Symbol();
+        Storage.prototype[key] = "test";
+        this.add_cleanup(function() { delete Storage.prototype[key]; });
+
+        var storage = window[name];
+        storage.clear();
+
+        assert_equals(storage[key], "test");
+        var desc = Object.getOwnPropertyDescriptor(storage, key);
+        assert_equals(desc, undefined);
+    }, name + ": get with symbol on prototype");
+
+    test(function() {
+        var key = Symbol();
+
+        var storage = window[name];
+        storage.clear();
+
+        storage[key] = "test";
+        assert_true(delete storage[key]);
+        assert_equals(storage[key], undefined);
+    }, name + ": delete existing property");
+
+    test(function() {
+        var key = Symbol();
+
+        var storage = window[name];
+        storage.clear();
+
+        assert_true(delete storage[key]);
+        assert_equals(storage[key], undefined);
+    }, name + ": delete non-existent property");
+});


### PR DESCRIPTION
I noticed a subtest in this test failing along with every other browser. After investigation, the failure was due to testing the previous specification before:

https://github.com/whatwg/webidl/commit/3fb6ab4

So this imports the now adjusted WPT test as of:

https://github.com/web-platform-tests/wpt/commit/bb3f032