### PR TITLE
LibWeb: Dump PaintableBox dimensions for inline layout nodes

### DIFF
--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -919,17 +919,14 @@ void dump_tree(StringBuilder& builder, Painting::Paintable const& paintable, boo
 
     builder.appendff("{}{} ({})", paintable.class_name(), color_off, paintable.layout_node().debug_description());
 
-    if (paintable.layout_node().is_box()) {
-        auto const& paintable_box = static_cast<Painting::PaintableBox const&>(paintable);
-        builder.appendff(" {}", paintable_box.absolute_border_box_rect());
+    if (auto const* paintable_box = as_if<Painting::PaintableBox>(paintable)) {
+        builder.appendff(" {}", paintable_box->absolute_border_box_rect());
 
-        if (paintable_box.has_scrollable_overflow()) {
-            builder.appendff(" overflow: {}", paintable_box.scrollable_overflow_rect());
-        }
+        if (paintable_box->has_scrollable_overflow())
+            builder.appendff(" overflow: {}", paintable_box->scrollable_overflow_rect());
 
-        if (!paintable_box.scroll_offset().is_zero()) {
-            builder.appendff(" scroll-offset: {}", paintable_box.scroll_offset());
-        }
+        if (!paintable_box->scroll_offset().is_zero())
+            builder.appendff(" scroll-offset: {}", paintable_box->scroll_offset());
     }
     builder.append("\n"sv);
     for (auto const* child = paintable.first_child(); child; child = child->next_sibling()) {

--- a/Tests/LibWeb/Layout/expected/abspos-static-position-containing-block-inline-situation.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-static-position-containing-block-inline-situation.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x18]
-    PaintableWithLines (InlineNode<BODY>)
+    PaintableWithLines (InlineNode<BODY>) [8,13 36.84375x18]
       PaintableWithLines (BlockContainer<MAIN>) [8,13 0x0]
         PaintableWithLines (BlockContainer<DIV>) [8,0 36.84375x18]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/acid1.txt
+++ b/Tests/LibWeb/Layout/expected/acid1.txt
@@ -140,19 +140,19 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableWithLines (BlockContainer<P>) [235,55 139.96875x10]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer(anonymous)) [235,65 139.96875x0]
-                PaintableWithLines (InlineNode<FORM>)
+                PaintableWithLines (InlineNode<FORM>) [235,65 0x10]
               PaintableWithLines (BlockContainer(anonymous)) [235,65 139.96875x19]
                 PaintableWithLines (BlockContainer<P>) [235,65 139.96875x19]
                   TextPaintable (TextNode<#text>)
                   RadioButtonPaintable (RadioButton<INPUT>) [262.5,65 12x12]
               PaintableWithLines (BlockContainer(anonymous)) [235,84 139.96875x0]
-                PaintableWithLines (InlineNode<FORM>)
+                PaintableWithLines (InlineNode<FORM>) [235,84 0x10]
               PaintableWithLines (BlockContainer(anonymous)) [235,84 139.96875x19]
                 PaintableWithLines (BlockContainer<P>) [235,84 139.96875x19]
                   TextPaintable (TextNode<#text>)
                   RadioButtonPaintable (RadioButton<INPUT>) [280.171875,84 12x12]
               PaintableWithLines (BlockContainer(anonymous)) [235,103 139.96875x0]
-                PaintableWithLines (InlineNode<FORM>)
+                PaintableWithLines (InlineNode<FORM>) [235,103 0x10]
             PaintableWithLines (BlockContainer<LI>) [394.96875,45 80x120]
               TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<LI>#baz) [135,175 120x120]
@@ -168,10 +168,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [20,30 480x0]
       PaintableWithLines (BlockContainer<P>) [20,335 480x65]
         TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<A>)
+        PaintableWithLines (InlineNode<A>) [227.9375,361 103.03125x13]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<A>)
+        PaintableWithLines (InlineNode<A>) [365.59375,387 59.90625x13]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [20,400 480x0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/block-inside-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/block-inside-inline.txt
@@ -29,10 +29,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>) [43.15625,8 27.640625x18]
         PaintableWithLines (BlockContainer(anonymous)) [43.15625,8 27.640625x0]
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [43.15625,8 0x18]
         PaintableWithLines (BlockContainer(anonymous)) [43.15625,8 27.640625x18]
           PaintableWithLines (BlockContainer<DIV>) [43.15625,8 27.640625x18]
             TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [43.15625,26 27.640625x0]
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [43.15625,26 0x18]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/box-with-percentage-height-wrapped-in-anonymous.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/box-with-percentage-height-wrapped-in-anonymous.txt
@@ -20,10 +20,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100] overflow: [8,8 784x136]
       PaintableWithLines (BlockContainer<DIV>.outer) [8,8 100x100] overflow: [8,8 100x136]
         PaintableWithLines (BlockContainer(anonymous)) [8,8 100x18]
-          PaintableWithLines (InlineNode<DIV>.inline)
+          PaintableWithLines (InlineNode<DIV>.inline) [8,8 9.34375x18]
             TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [8,26 100x100]
           PaintableWithLines (BlockContainer<DIV>.inner) [8,26 100x100]
         PaintableWithLines (BlockContainer(anonymous)) [8,126 100x18]
-          PaintableWithLines (InlineNode<DIV>.inline)
+          PaintableWithLines (InlineNode<DIV>.inline) [8,126 9.46875x18]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
@@ -12,5 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x43]
     PaintableWithLines (BlockContainer<BODY>) [8,13 784x17]
       PaintableWithLines (BlockContainer<PRE>) [8,13 784x17]
-        PaintableWithLines (InlineNode<SPAN>)
+        PaintableWithLines (InlineNode<SPAN>) [9,14 6.5x15]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-leading-and-trailing-metrics.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-leading-and-trailing-metrics.txt
@@ -56,23 +56,23 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<DIV>#a) [8,8 784x20]
         PaintableWithLines (BlockContainer<I>) [9,9 88.453125x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<B>)
+        PaintableWithLines (InlineNode<B>) [97.453125,9 61.296875x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<U>)
+        PaintableWithLines (InlineNode<U>) [158.75,9 41.296875x18]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
       PaintableWithLines (BlockContainer<DIV>#b) [8,28 784x20]
-        PaintableWithLines (InlineNode<I>)
+        PaintableWithLines (InlineNode<I>) [9,29 61.296875x18]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<B>) [70.296875,29 88.453125x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<U>)
+        PaintableWithLines (InlineNode<U>) [158.75,29 41.296875x18]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,48 784x0]
       PaintableWithLines (BlockContainer<DIV>#c) [8,48 784x20]
-        PaintableWithLines (InlineNode<I>)
+        PaintableWithLines (InlineNode<I>) [9,49 41.296875x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<B>)
+        PaintableWithLines (InlineNode<B>) [50.296875,49 81.296875x18]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<U>) [131.59375,49 88.453125x18]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-vertical-align-middle.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-vertical-align-middle.txt
@@ -11,6 +11,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
-      PaintableWithLines (InlineNode<SPAN>)
+      PaintableWithLines (InlineNode<SPAN>) [8,48 135.15625x100]
         TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<SPAN>.thing) [43.15625,8 100x100]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/leading-margin-on-inline-content-that-starts-with-collapsible-whitespace.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/leading-margin-on-inline-content-that-starts-with-collapsible-whitespace.txt
@@ -14,7 +14,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
-      PaintableWithLines (InlineNode<DIV>)
+      PaintableWithLines (InlineNode<DIV>) [28,8 82.125x18]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<DIV>)
+      PaintableWithLines (InlineNode<DIV>) [150.125,8 39.5625x18]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline-start.txt
@@ -13,5 +13,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [9,9 502x84]
       PaintableWithLines (BlockContainer<DIV>.a) [10,10 500x82]
         PaintableWithLines (BlockContainer<DIV>.b) [91,31 328x20]
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [92,31 41.78125x20]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-padding-block-inline.txt
@@ -13,5 +13,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [9,9 502x104]
       PaintableWithLines (BlockContainer<DIV>.a) [10,10 500x102]
         PaintableWithLines (BlockContainer<DIV>.b) [71,51 378x20]
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [72,51 41.78125x20]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -37,11 +37,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x169]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x148]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
-        PaintableWithLines (InlineNode<SPAN>)
+        PaintableWithLines (InlineNode<SPAN>) [8,8 136.609375x18]
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode<B>)
+          PaintableWithLines (InlineNode<B>) [44.40625,33 100.203125x18]
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode<I>)
+            PaintableWithLines (InlineNode<I>) [89.25,58 55.359375x18]
               TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>) [8,26 784x130]
         PaintableWithLines (BlockContainer(anonymous)) [8,26 784x72]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
@@ -22,9 +22,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<B>)
+      PaintableWithLines (InlineNode<B>) [43.15625,33 27.640625x18]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<B>)
-        PaintableWithLines (InlineNode<I>)
+      PaintableWithLines (InlineNode<B>) [53.796875,58 27.203125x18]
+        PaintableWithLines (InlineNode<I>) [53.796875,58 27.203125x18]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
+++ b/Tests/LibWeb/Layout/expected/br-should-not-generate-pseudo-before.txt
@@ -19,7 +19,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x94]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x70]
       PaintableWithLines (BlockContainer<P>) [8,16 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,16 10.625x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,50 784x36]

--- a/Tests/LibWeb/Layout/expected/button-with-before-and-after-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/button-with-before-and-after-pseudo-elements.txt
@@ -24,8 +24,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<BUTTON>) [8,8 92x22]
         PaintableWithLines (BlockContainer(anonymous)) [13,10 82x18]
           PaintableWithLines (BlockContainer(anonymous)) [13,10 82x18]
-            PaintableWithLines (InlineNode(anonymous))
+            PaintableWithLines (InlineNode(anonymous)) [13,10 27.15625x18]
               TextPaintable (TextNode<#text>)
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode(anonymous))
+            PaintableWithLines (InlineNode(anonymous)) [67.796875,10 27.203125x18]
               TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-all-unset.txt
+++ b/Tests/LibWeb/Layout/expected/css-all-unset.txt
@@ -12,8 +12,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x18]
-    PaintableWithLines (InlineNode<HEAD>)
-      PaintableWithLines (InlineNode<STYLE>)
+    PaintableWithLines (InlineNode<HEAD>) [0,0 134.984375x18]
+      PaintableWithLines (InlineNode<STYLE>) [0,0 134.984375x18]
         TextPaintable (TextNode<#text>)
-    PaintableWithLines (InlineNode<BODY>)
+    PaintableWithLines (InlineNode<BODY>) [134.984375,0 103.140625x18]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-attr-typed-fallback.txt
+++ b/Tests/LibWeb/Layout/expected/css-attr-typed-fallback.txt
@@ -30,7 +30,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x148]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x132]
       PaintableWithLines (BlockContainer<DIV>.string) [8,8 102x22]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [9,9 41.53125x18]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,30 784x0]
       PaintableWithLines (BlockContainer<DIV>.string-no-fallback) [8,30 102x22]

--- a/Tests/LibWeb/Layout/expected/css-counters/basic.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/basic.txt
@@ -91,44 +91,44 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x324]
       PaintableWithLines (BlockContainer<DIV>) [8,16 784x154]
         PaintableWithLines (BlockContainer<P>) [8,16 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,16 28.8125x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,50 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,50 31.28125x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,84 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,84 31.5625x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,118 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,118 30.21875x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,152 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,152 30.921875x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>) [8,186 784x154]
         PaintableWithLines (BlockContainer<P>) [8,186 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,186 31.28125x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,220 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,220 33.75x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,254 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,254 34.03125x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,288 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,288 32.6875x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<P>) [8,322 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,322 33.390625x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,356 784x0]

--- a/Tests/LibWeb/Layout/expected/css-counters/counters-function.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/counters-function.txt
@@ -171,83 +171,83 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<DIV>.ol) [8,8 784x270]
         PaintableWithLines (BlockContainer(anonymous)) [24,8 768x0]
         PaintableWithLines (BlockContainer<DIV>.li) [24,8 768x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [24,8 18.125x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [24,26 768x0]
         PaintableWithLines (BlockContainer<DIV>.li) [24,26 768x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [24,26 20.59375x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [24,44 768x0]
         PaintableWithLines (BlockContainer<DIV>.li) [24,44 768x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [24,44 20.875x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [24,62 768x0]
         PaintableWithLines (BlockContainer<DIV>.li) [24,62 768x162]
           PaintableWithLines (BlockContainer(anonymous)) [24,62 768x18]
-            PaintableWithLines (InlineNode(anonymous))
+            PaintableWithLines (InlineNode(anonymous)) [24,62 11.53125x18]
               TextPaintable (TextNode<#text>)
           PaintableWithLines (BlockContainer<DIV>.ol) [24,80 768x144]
             PaintableWithLines (BlockContainer(anonymous)) [40,80 752x0]
             PaintableWithLines (BlockContainer<DIV>.li) [40,80 752x18]
-              PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode(anonymous)) [40,80 30.21875x18]
                 TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer(anonymous)) [40,98 752x0]
             PaintableWithLines (BlockContainer<DIV>.li) [40,98 752x18]
-              PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode(anonymous)) [40,98 32.6875x18]
                 TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer(anonymous)) [40,116 752x0]
             PaintableWithLines (BlockContainer<DIV>.li) [40,116 752x72]
               PaintableWithLines (BlockContainer(anonymous)) [40,116 752x18]
-                PaintableWithLines (InlineNode(anonymous))
+                PaintableWithLines (InlineNode(anonymous)) [40,116 24.96875x18]
                   TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<DIV>.ol) [40,134 752x54]
                 PaintableWithLines (BlockContainer(anonymous)) [56,134 736x0]
                 PaintableWithLines (BlockContainer<DIV>.li) [56,134 736x18]
-                  PaintableWithLines (InlineNode(anonymous))
+                  PaintableWithLines (InlineNode(anonymous)) [56,134 43.65625x18]
                     TextPaintable (TextNode<#text>)
                   TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [56,152 736x0]
                 PaintableWithLines (BlockContainer<DIV>.li) [56,152 736x18]
-                  PaintableWithLines (InlineNode(anonymous))
+                  PaintableWithLines (InlineNode(anonymous)) [56,152 46.125x18]
                     TextPaintable (TextNode<#text>)
                   TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [56,170 736x0]
                 PaintableWithLines (BlockContainer<DIV>.li) [56,170 736x18]
-                  PaintableWithLines (InlineNode(anonymous))
+                  PaintableWithLines (InlineNode(anonymous)) [56,170 46.40625x18]
                     TextPaintable (TextNode<#text>)
                   TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [56,188 736x0]
               PaintableWithLines (BlockContainer(anonymous)) [40,188 752x0]
             PaintableWithLines (BlockContainer(anonymous)) [40,188 752x0]
             PaintableWithLines (BlockContainer<DIV>.li) [40,188 752x18]
-              PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode(anonymous)) [40,188 31.625x18]
                 TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer(anonymous)) [40,206 752x0]
             PaintableWithLines (BlockContainer<DIV>.li) [40,206 752x18]
-              PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode(anonymous)) [40,206 32.328125x18]
                 TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer(anonymous)) [40,224 752x0]
           PaintableWithLines (BlockContainer(anonymous)) [24,224 768x0]
         PaintableWithLines (BlockContainer(anonymous)) [24,224 768x0]
         PaintableWithLines (BlockContainer<DIV>.li) [24,224 768x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [24,224 20.234375x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [24,242 768x0]
         PaintableWithLines (BlockContainer<DIV>.li) [24,242 768x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [24,242 20.515625x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [24,260 768x0]
         PaintableWithLines (BlockContainer<DIV>.li) [24,260 768x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [24,260 20.5x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [24,278 768x0]

--- a/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
@@ -46,22 +46,22 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x186]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x154]
       PaintableWithLines (BlockContainer<P>) [8,16 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,16 18.125x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<P>) [8,50 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,50 20.59375x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<P>) [8,84 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,84 20.875x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<P>) [8,118 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,118 19.53125x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<P>) [8,152 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,152 20.234375x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-font-size-math.txt
+++ b/Tests/LibWeb/Layout/expected/css-font-size-math.txt
@@ -26,13 +26,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x99]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x83]
-      PaintableWithLines (InlineNode<SPAN>)
+      PaintableWithLines (InlineNode<SPAN>) [8,26 78.9375x59]
         TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<SPAN>)
+        PaintableWithLines (InlineNode<SPAN>) [47.09375,39 39.84375x42]
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [66.875,48 20.0625x30]
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode<SPAN>)
+            PaintableWithLines (InlineNode<SPAN>) [73.6875,55 13.25x21]
               TextPaintable (TextNode<#text>)
-              PaintableWithLines (InlineNode<SPAN>)
+              PaintableWithLines (InlineNode<SPAN>) [78.53125,59 8.40625x15]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
@@ -15,6 +15,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x63]
     PaintableWithLines (BlockContainer<BODY>) [8,20 784x23]
       PaintableWithLines (BlockContainer<P>) [8,20 784x23]
-        PaintableWithLines (InlineNode<A>)
+        PaintableWithLines (InlineNode<A>) [8,10 183.9375x43]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,63 784x0]

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
@@ -15,6 +15,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x63]
     PaintableWithLines (BlockContainer<BODY>) [8,20 784x23]
       PaintableWithLines (BlockContainer<P>) [8,20 784x23]
-        PaintableWithLines (InlineNode<A>)
+        PaintableWithLines (InlineNode<A>) [8,15 151.390625x33]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,63 784x0]

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -37,6 +37,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableWithLines (BlockContainer<a>) [319,123 102x102]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>) [8,234 784x48]
-        PaintableWithLines (InlineNode<A>)
+        PaintableWithLines (InlineNode<A>) [9,234 101.484375x48]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,282 784x0]

--- a/Tests/LibWeb/Layout/expected/css-quotes-nesting.txt
+++ b/Tests/LibWeb/Layout/expected/css-quotes-nesting.txt
@@ -211,15 +211,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x54]
       PaintableWithLines (BlockContainer<DIV>.a) [8,8 784x18]
-        PaintableWithLines (InlineNode<SPAN>)
+        PaintableWithLines (InlineNode<SPAN>) [8,8 72.140625x18]
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [17.34375,8 58.234375x18]
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode<SPAN>)
+            PaintableWithLines (InlineNode<SPAN>) [26.8125,8 39.46875x18]
               TextPaintable (TextNode<#text>)
-              PaintableWithLines (InlineNode<SPAN>)
+              PaintableWithLines (InlineNode<SPAN>) [35.703125,8 23.015625x18]
                 TextPaintable (TextNode<#text>)
-                PaintableWithLines (InlineNode<SPAN>)
+                PaintableWithLines (InlineNode<SPAN>) [43.5625,8 8.71875x18]
                   TextPaintable (TextNode<#text>)
                 TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
@@ -227,74 +227,74 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
       PaintableWithLines (BlockContainer<DIV>.b) [8,26 784x18]
-        PaintableWithLines (InlineNode<SPAN>)
-          PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode<SPAN>) [8,26 130.578125x18]
+          PaintableWithLines (InlineNode(anonymous)) [8,26 5.84375x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode<SPAN>)
-            PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode<SPAN>) [23.1875,26 104.984375x18]
+            PaintableWithLines (InlineNode(anonymous)) [23.1875,26 5.84375x18]
               TextPaintable (TextNode<#text>)
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode<SPAN>)
-              PaintableWithLines (InlineNode(anonymous))
+            PaintableWithLines (InlineNode<SPAN>) [38.5,26 74.53125x18]
+              PaintableWithLines (InlineNode(anonymous)) [38.5,26 5.84375x18]
                 TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
-              PaintableWithLines (InlineNode<SPAN>)
-                PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode<SPAN>) [53.234375,26 46.390625x18]
+                PaintableWithLines (InlineNode(anonymous)) [53.234375,26 5.84375x18]
                   TextPaintable (TextNode<#text>)
                 TextPaintable (TextNode<#text>)
-                PaintableWithLines (InlineNode<SPAN>)
-                  PaintableWithLines (InlineNode(anonymous))
+                PaintableWithLines (InlineNode<SPAN>) [66.9375,26 20.40625x18]
+                  PaintableWithLines (InlineNode(anonymous)) [66.9375,26 5.84375x18]
                     TextPaintable (TextNode<#text>)
                   TextPaintable (TextNode<#text>)
-                  PaintableWithLines (InlineNode(anonymous))
+                  PaintableWithLines (InlineNode(anonymous)) [81.5,26 5.84375x18]
                     TextPaintable (TextNode<#text>)
                 TextPaintable (TextNode<#text>)
-                PaintableWithLines (InlineNode(anonymous))
+                PaintableWithLines (InlineNode(anonymous)) [93.78125,26 5.84375x18]
                   TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
-              PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode(anonymous)) [107.1875,26 5.84375x18]
                 TextPaintable (TextNode<#text>)
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode(anonymous))
+            PaintableWithLines (InlineNode(anonymous)) [122.328125,26 5.84375x18]
               TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [132.734375,26 5.84375x18]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,44 784x0]
       PaintableWithLines (BlockContainer<DIV>.c) [8,44 784x18]
-        PaintableWithLines (InlineNode<SPAN>)
-          PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode<SPAN>) [8,44 140.234375x18]
+          PaintableWithLines (InlineNode(anonymous)) [8,44 5.484375x18]
             TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode<SPAN>)
-            PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode<SPAN>) [22.828125,44 116.03125x18]
+            PaintableWithLines (InlineNode(anonymous)) [22.828125,44 7.625x18]
               TextPaintable (TextNode<#text>)
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode<SPAN>)
-              PaintableWithLines (InlineNode(anonymous))
+            PaintableWithLines (InlineNode<SPAN>) [39.921875,44 81.984375x18]
+              PaintableWithLines (InlineNode(anonymous)) [39.921875,44 6.953125x18]
                 TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
-              PaintableWithLines (InlineNode<SPAN>)
-                PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode<SPAN>) [55.765625,44 51.359375x18]
+                PaintableWithLines (InlineNode(anonymous)) [55.765625,44 6.953125x18]
                   TextPaintable (TextNode<#text>)
                 TextPaintable (TextNode<#text>)
-                PaintableWithLines (InlineNode<SPAN>)
-                  PaintableWithLines (InlineNode(anonymous))
+                PaintableWithLines (InlineNode<SPAN>) [70.578125,44 22.890625x18]
+                  PaintableWithLines (InlineNode(anonymous)) [70.578125,44 6.953125x18]
                     TextPaintable (TextNode<#text>)
                   TextPaintable (TextNode<#text>)
-                  PaintableWithLines (InlineNode(anonymous))
+                  PaintableWithLines (InlineNode(anonymous)) [86.25,44 7.21875x18]
                     TextPaintable (TextNode<#text>)
                 TextPaintable (TextNode<#text>)
-                PaintableWithLines (InlineNode(anonymous))
+                PaintableWithLines (InlineNode(anonymous)) [99.90625,44 7.21875x18]
                   TextPaintable (TextNode<#text>)
               TextPaintable (TextNode<#text>)
-              PaintableWithLines (InlineNode(anonymous))
+              PaintableWithLines (InlineNode(anonymous)) [114.6875,44 7.21875x18]
                 TextPaintable (TextNode<#text>)
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode(anonymous))
+            PaintableWithLines (InlineNode(anonymous)) [131.203125,44 7.65625x18]
               TextPaintable (TextNode<#text>)
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [143.421875,44 4.8125x18]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,62 784x0]

--- a/Tests/LibWeb/Layout/expected/css/counters-on-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/css/counters-on-pseudo-elements.txt
@@ -32,15 +32,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x54]
       PaintableWithLines (BlockContainer<DIV>#a) [8,8 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,8 18.6875x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>#b) [8,26 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,26 21.15625x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>#c) [8,44 784x18]
-        PaintableWithLines (InlineNode(anonymous))
+        PaintableWithLines (InlineNode(anonymous)) [8,44 21.4375x18]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,62 784x0]

--- a/Tests/LibWeb/Layout/expected/details-open.txt
+++ b/Tests/LibWeb/Layout/expected/details-open.txt
@@ -26,6 +26,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           MarkerPaintable (ListItemMarkerBox(anonymous)) [8,8.5 12x17]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<SLOT>) [8,26 784x18]
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [8,26 82.3125x18]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,44 784x0]

--- a/Tests/LibWeb/Layout/expected/dialog-open-non-modal.txt
+++ b/Tests/LibWeb/Layout/expected/dialog-open-non-modal.txt
@@ -14,5 +14,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIALOG>) [339.84375,8 120.3125x56]
-        PaintableWithLines (InlineNode<SPAN>)
+        PaintableWithLines (InlineNode<SPAN>) [358.84375,27 82.3125x18]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-contents-with-in-children.txt
@@ -7,5 +7,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x18]
-    PaintableWithLines (InlineNode<SPAN>)
+    PaintableWithLines (InlineNode<SPAN>) [0,0 51.75x18]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
+++ b/Tests/LibWeb/Layout/expected/display-table-inline-children.txt
@@ -28,6 +28,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 1208x616]
         PaintableBox (Box<DIV>.aligncenter.block-image) [8,8 1200x600]
           PaintableBox (Box(anonymous)) [8,8 1200x600]
             PaintableWithLines (BlockContainer(anonymous)) [8,8 1200x600]
-              PaintableWithLines (InlineNode<A>)
+              PaintableWithLines (InlineNode<A>) [8,8 1200x600]
                 ImagePaintable (ImageBox<IMG>) [8,8 1200x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,608 784x0]

--- a/Tests/LibWeb/Layout/expected/font-fractional-size.txt
+++ b/Tests/LibWeb/Layout/expected/font-fractional-size.txt
@@ -24,11 +24,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x25]
-      PaintableWithLines (InlineNode<SPAN>.a)
+      PaintableWithLines (InlineNode<SPAN>.a) [8,8 12.4375x24]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<SPAN>.b)
+      PaintableWithLines (InlineNode<SPAN>.b) [28.4375,8 12.734375x24]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<SPAN>.c)
+      PaintableWithLines (InlineNode<SPAN>.c) [49.171875,8 13.03125x25]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/font-size-legacy.txt
+++ b/Tests/LibWeb/Layout/expected/font-size-legacy.txt
@@ -9,5 +9,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
-      PaintableWithLines (InlineNode<FONT>)
+      PaintableWithLines (InlineNode<FONT>) [8,11 24.109375x14]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
+++ b/Tests/LibWeb/Layout/expected/font-with-many-normal-values.txt
@@ -31,14 +31,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
-      PaintableWithLines (InlineNode<SPAN>.one)
+      PaintableWithLines (InlineNode<SPAN>.one) [8,8 79.296875x200]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<SPAN>.two)
+      PaintableWithLines (InlineNode<SPAN>.two) [95.296875,8 110.15625x200]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<SPAN>.three)
+      PaintableWithLines (InlineNode<SPAN>.three) [213.453125,8 113.671875x200]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<SPAN>.four)
+      PaintableWithLines (InlineNode<SPAN>.four) [335.125,8 96.875x200]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/host-pseudo-class-basic.txt
+++ b/Tests/LibWeb/Layout/expected/host-pseudo-class-basic.txt
@@ -15,5 +15,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x48]
       PaintableWithLines (BlockContainer<MAIN>) [8,8 784x48]
         PaintableWithLines (BlockContainer<DIV>) [8,8 373.96875x48]
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [23,23 343.96875x18]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/inline-fragment-ordering-flakiness.txt
+++ b/Tests/LibWeb/Layout/expected/inline-fragment-ordering-flakiness.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x18]
-    PaintableWithLines (InlineNode<BODY>)
+    PaintableWithLines (InlineNode<BODY>) [8,0 73.6875x18]
       PaintableWithLines (BlockContainer<MAIN>) [8,0 36.84375x18]
         PaintableWithLines (BlockContainer<DIV>) [8,0 36.84375x18]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
@@ -17,10 +17,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x79.875]
     PaintableWithLines (BlockContainer<BODY>) [8,21.4375 784x37]
       PaintableWithLines (BlockContainer(anonymous)) [8,21.4375 784x0]
-        PaintableWithLines (InlineNode<A>)
-          PaintableWithLines (InlineNode<SPAN>#foo)
+        PaintableWithLines (InlineNode<A>) [8,21.4375 0x18]
+          PaintableWithLines (InlineNode<SPAN>#foo) [8,21.4375 0x18]
       PaintableWithLines (BlockContainer(anonymous)) [8,21.4375 784x37]
         PaintableWithLines (BlockContainer<H1>) [8,21.4375 784x37]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,79.875 784x0]
-        PaintableWithLines (InlineNode<A>)
+        PaintableWithLines (InlineNode<A>) [8,79.875 0x18]

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/simple-update-inside-svg-subtree.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/simple-update-inside-svg-subtree.txt
@@ -14,4 +14,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
         SVGGraphicsPaintable (SVGGraphicsBox<symbol>) [8,8 300x150]
-          PaintableWithLines (InlineNode<set>#set)
+          PaintableWithLines (InlineNode<set>#set) [8,8 0x18]

--- a/Tests/LibWeb/Layout/expected/list-item-marker-pseudo-placement.txt
+++ b/Tests/LibWeb/Layout/expected/list-item-marker-pseudo-placement.txt
@@ -23,10 +23,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (ListItemBox<SPAN>) [8,8 784x36]
         MarkerPaintable (ListItemMarkerBox(anonymous)) [-16,8.5 12x17]
         PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,8 52.53125x18]
             TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DIV>) [8,26 784x0]
         PaintableWithLines (BlockContainer(anonymous)) [8,26 784x18]
-          PaintableWithLines (InlineNode(anonymous))
+          PaintableWithLines (InlineNode(anonymous)) [8,26 40.1875x18]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,44 784x0]

--- a/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/nowrap-and-no-line-break-opportunity.txt
@@ -21,9 +21,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
       PaintableWithLines (BlockContainer<DIV>.fixed_width) [8,8 52x20]
-        PaintableWithLines (InlineNode<SPAN>.nowrap)
+        PaintableWithLines (InlineNode<SPAN>.nowrap) [9,9 33.921875x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<SPAN>)
+        PaintableWithLines (InlineNode<SPAN>) [42.921875,9 11.5625x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<SPAN>.nowrap)
+        PaintableWithLines (InlineNode<SPAN>.nowrap) [54.484375,9 33.921875x18]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/object-fallback.txt
+++ b/Tests/LibWeb/Layout/expected/object-fallback.txt
@@ -10,5 +10,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
-      PaintableWithLines (InlineNode<OBJECT>)
+      PaintableWithLines (InlineNode<OBJECT>) [8,8 181.5x18]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/ol-render-deep-hybrid-list-item-list.txt
+++ b/Tests/LibWeb/Layout/expected/ol-render-deep-hybrid-list-item-list.txt
@@ -151,11 +151,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [48,192 744x0]
         PaintableWithLines (BlockContainer<P>) [48,192 744x18]
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [48,192 35.265625x18]
             TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode<SPAN>)
+            PaintableWithLines (InlineNode<SPAN>) [59.5625,192 23.703125x18]
               TextPaintable (TextNode<#text>)
-              PaintableWithLines (InlineNode<SPAN>)
+              PaintableWithLines (InlineNode<SPAN>) [70.65625,192 12.609375x18]
                 TextPaintable (TextNode<#text>)
         PaintableWithLines (ListItemBox<LI>) [48,226 744x18]
           MarkerPaintable (ListItemMarkerBox(anonymous)) [15.09375,226.5 20.90625x17]

--- a/Tests/LibWeb/Layout/expected/overflow-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/overflow-with-padding.txt
@@ -49,7 +49,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<DIV>.outer) [8,8 452x122] overflow: [9,9 450x152]
         PaintableWithLines (BlockContainer<DIV>.inner) [34,34 402x102]
           TextPaintable (TextNode<#text>)
-          PaintableWithLines (InlineNode<SPAN>)
+          PaintableWithLines (InlineNode<SPAN>) [35,35 0x18]
       PaintableWithLines (BlockContainer(anonymous)) [8,130 784x0]
       PaintableWithLines (BlockContainer<DIV>.outer) [8,130 452x122] overflow: [9,131 450x260]
         PaintableWithLines (BlockContainer<DIV>.inner) [34,156 402x102] overflow: [35,157 400x234]

--- a/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
+++ b/Tests/LibWeb/Layout/expected/percentage-max-height-when-containing-block-has-indefinite-height.txt
@@ -48,7 +48,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [10,32 780x0]
       PaintableWithLines (BlockContainer<DIV>.inline.formatting-context) [10,32 780x20]
-        PaintableWithLines (InlineNode<DIV>)
+        PaintableWithLines (InlineNode<DIV>) [11,32 43.296875x20]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [10,52 780x0]
       PaintableBox (Box<DIV>.flex.formatting-context) [10,52 780x22]

--- a/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
+++ b/Tests/LibWeb/Layout/expected/picture-source-media-query.txt
@@ -14,6 +14,6 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x416]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x400]
-      PaintableWithLines (InlineNode<PICTURE>)
-        PaintableWithLines (InlineNode<SOURCE>)
+      PaintableWithLines (InlineNode<PICTURE>) [8,8 400x400]
+        PaintableWithLines (InlineNode<SOURCE>) [8,8 0x18]
         ImagePaintable (ImageBox<IMG>) [8,8 400x400]

--- a/Tests/LibWeb/Layout/expected/popovertarget-button.txt
+++ b/Tests/LibWeb/Layout/expected/popovertarget-button.txt
@@ -25,5 +25,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableWithLines (BlockContainer(anonymous)) [13,19 0x0]
   PaintableWithLines (BlockContainer(anonymous)) [0,0 800x600]
   PaintableWithLines (BlockContainer<DIV>#pop) [351.84375,284 96.3125x32]
-    PaintableWithLines (InlineNode<SPAN>)
+    PaintableWithLines (InlineNode<SPAN>) [358.84375,291 82.3125x18]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -10,5 +10,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
-      PaintableWithLines (InlineNode<PRE>)
+      PaintableWithLines (InlineNode<PRE>) [8,9 18.15625x17]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
+++ b/Tests/LibWeb/Layout/expected/shadow-tree-removed-from-dom-receives-event.txt
@@ -14,6 +14,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableWithLines (BlockContainer<DIV>#container) [8,8 784x18]
-        PaintableWithLines (InlineNode<SPAN>)
+        PaintableWithLines (InlineNode<SPAN>) [8,8 43.421875x18]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]

--- a/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
+++ b/Tests/LibWeb/Layout/expected/space-is-soft-line-break-opportunity.txt
@@ -19,8 +19,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x54]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x38]
       PaintableWithLines (BlockContainer<DIV>.fixed_width) [8,8 52x38]
-        PaintableWithLines (InlineNode<SPAN>.nowrap)
+        PaintableWithLines (InlineNode<SPAN>.nowrap) [9,9 33.921875x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (InlineNode<SPAN>)
-        PaintableWithLines (InlineNode<SPAN>.nowrap)
+        PaintableWithLines (InlineNode<SPAN>) [9,9 0x18]
+        PaintableWithLines (InlineNode<SPAN>.nowrap) [9,27 33.921875x18]
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/span-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/span-with-padding.txt
@@ -9,5 +9,5 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x37]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
-      PaintableWithLines (InlineNode<SPAN>)
+      PaintableWithLines (InlineNode<SPAN>) [8,-20 198.28125x127]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -6,4 +6,4 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<svg>) [0,0 800x0]
-    PaintableWithLines (InlineNode<rect>)
+    PaintableWithLines (InlineNode<rect>) [0,0 0x18]

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -43,7 +43,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableWithLines (BlockContainer<TD>) [10,10 2x10]
               PaintableWithLines (BlockContainer<TD>) [14,10 41.21875x22]
                 PaintableWithLines (BlockContainer(anonymous)) [16,12 37.21875x18]
-                  PaintableWithLines (InlineNode<A>)
+                  PaintableWithLines (InlineNode<A>) [16,12 37.21875x18]
                     TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,22 45.21875x10]
               PaintableWithLines (BlockContainer<TD>) [10,22 2x10]

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-vs-top.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-vs-top.txt
@@ -27,5 +27,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                 PaintableWithLines (BlockContainer<TD>) [10,10 342.5x115]
                   PaintableWithLines (BlockContainer(anonymous)) [10,10 342.5x115]
                     TextPaintable (TextNode<#text>)
-                    PaintableWithLines (InlineNode<SPAN>)
+                    PaintableWithLines (InlineNode<SPAN>) [179.734375,10 172.765625x115]
                       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/vertical-align-middle.txt
+++ b/Tests/LibWeb/Layout/expected/vertical-align-middle.txt
@@ -16,6 +16,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
-      PaintableWithLines (InlineNode<A>)
+      PaintableWithLines (InlineNode<A>) [8,23 91.296875x50]
         TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer<DIV>.test) [49.296875,8 50x50]

--- a/Tests/LibWeb/Layout/expected/writing-modes-direction-inline.txt
+++ b/Tests/LibWeb/Layout/expected/writing-modes-direction-inline.txt
@@ -17,8 +17,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
-      PaintableWithLines (InlineNode<SPAN>)
+      PaintableWithLines (InlineNode<SPAN>) [689.9375,8 46.71875x18]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<SPAN>)
+      PaintableWithLines (InlineNode<SPAN>) [744.65625,8 47.34375x18]
         TextPaintable (TextNode<#text>)


### PR DESCRIPTION
We were only dumping a PaintableBox' dimensions if its layout node was a Layout::Box as well, causing us to not dump the dimensions of paintables for inline nodes in the paintable tree.