### PR TITLE
LibWeb: Fix hit testing of anonymous containers' contents

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5660,11 +5660,10 @@ GC::RootVector<GC::Ref<Element>> Document::elements_from_point(double x, double 
     // 3. For each box in the viewport, in paint order, starting with the topmost box, that would be a target for
     //    hit testing at coordinates x,y even if nothing would be overlapping it, when applying the transforms that
     //    apply to the descendants of the viewport, append the associated element to sequence.
-    if (auto const* paintable_box = this->paintable_box(); paintable_box) {
+    if (auto const* paintable_box = this->paintable_box()) {
         (void)paintable_box->hit_test(position, Painting::HitTestType::Exact, [&](Painting::HitTestResult result) {
-            auto* dom_node = result.dom_node();
-            if (dom_node && dom_node->is_element() && result.paintable->visible_for_hit_testing())
-                sequence.append(*static_cast<Element*>(dom_node));
+            if (auto* element = as_if<Element>(result.dom_node()))
+                sequence.append(*element);
             return TraversalDecision::Continue;
         });
     }

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -43,10 +43,9 @@ void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_
         begin_new_line(true, break_count == 0);
         break_count++;
         floats_intrude_at_current_y = m_context.any_floats_intrude_at_block_offset(m_current_block_offset);
-    } while ((floats_intrude_at_current_y && !m_context.can_fit_new_line_at_block_offset(m_current_block_offset))
-        || (next_item_width.has_value()
-            && next_item_width.value() > m_available_width_for_current_line
-            && floats_intrude_at_current_y));
+    } while (floats_intrude_at_current_y
+        && (!m_context.can_fit_new_line_at_block_offset(m_current_block_offset)
+            || (next_item_width.value_or(0) > m_available_width_for_current_line)));
 }
 
 void LineBuilder::begin_new_line(bool increment_y, bool is_first_break_in_sequence)

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1185,8 +1185,8 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
     if (m_fragments.is_empty()
         && !has_children()
         && type == HitTestType::TextCursor
-        && layout_node_with_style_and_box_metrics().dom_node()
-        && layout_node_with_style_and_box_metrics().dom_node()->is_editable()) {
+        && layout_node().dom_node()
+        && layout_node().dom_node()->is_editable()) {
         HitTestResult const hit_test_result {
             .paintable = const_cast<PaintableWithLines&>(*this),
             .index_in_node = 0,
@@ -1197,7 +1197,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
             return TraversalDecision::Break;
     }
 
-    if (!layout_node_with_style_and_box_metrics().children_are_inline() || m_fragments.is_empty())
+    if (!layout_node().children_are_inline() || m_fragments.is_empty())
         return PaintableBox::hit_test(position, type, callback);
 
     // NOTE: This CSSPixels -> Float -> CSSPixels conversion is because we can't AffineTransform::map() a CSSPixelPoint.
@@ -1278,7 +1278,8 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
         }
     }
 
-    if (!stacking_context() && is_visible() && absolute_border_box_rect().contains(transformed_position_adjusted_by_scroll_offset)) {
+    if (!stacking_context() && is_visible() && !layout_node().is_anonymous()
+        && absolute_border_box_rect().contains(position_adjusted_by_scroll_offset)) {
         if (callback(HitTestResult { const_cast<PaintableWithLines&>(*this) }) == TraversalDecision::Break)
             return TraversalDecision::Break;
     }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1203,7 +1203,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
             return TraversalDecision::Break;
     }
 
-    if (!layout_node().children_are_inline() || m_fragments.is_empty())
+    if (!layout_node().children_are_inline())
         return PaintableBox::hit_test(position, type, callback);
 
     // NOTE: This CSSPixels -> Float -> CSSPixels conversion is because we can't AffineTransform::map() a CSSPixelPoint.
@@ -1282,7 +1282,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
         }
     }
 
-    if (!stacking_context() && is_visible() && !layout_node().is_anonymous()
+    if (!stacking_context() && is_visible() && (!layout_node().is_anonymous() || layout_node().is_positioned())
         && absolute_border_box_rect().contains(position_adjusted_by_scroll_offset)) {
         if (callback(HitTestResult { const_cast<PaintableWithLines&>(*this) }) == TraversalDecision::Break)
             return TraversalDecision::Break;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -147,6 +147,7 @@ public:
 
     [[nodiscard]] virtual TraversalDecision hit_test(CSSPixelPoint position, HitTestType type, Function<TraversalDecision(HitTestResult)> const& callback) const override;
     Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;
+    [[nodiscard]] TraversalDecision hit_test_children(CSSPixelPoint, HitTestType, Function<TraversalDecision(HitTestResult)> const&) const;
     [[nodiscard]] TraversalDecision hit_test_continuation(Function<TraversalDecision(HitTestResult)> const& callback) const;
 
     virtual bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;

--- a/Tests/LibWeb/Text/expected/hit_testing/empty-anonymous-container-overlapping.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/empty-anonymous-container-overlapping.txt
@@ -1,0 +1,3 @@
+<#text>
+index: 4
+<A id="target">

--- a/Tests/LibWeb/Text/expected/hit_testing/inline-content-inside-anonymous-container.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/inline-content-inside-anonymous-container.txt
@@ -1,0 +1,12 @@
+<#text>
+index: 4
+<BODY>
+---
+<#text>
+index: 20
+<A id="target">
+---
+<DIV id="a">
+index: 0
+<BODY>
+---

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/elementsFromPoint-inline-htb-ltr.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/elementsFromPoint-inline-htb-ltr.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	elementsFromPoint should return all elements under a point

--- a/Tests/LibWeb/Text/input/hit_testing/empty-anonymous-container-overlapping.html
+++ b/Tests/LibWeb/Text/input/hit_testing/empty-anonymous-container-overlapping.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+#a {
+    margin-bottom: -20px;
+}
+body {
+    border: 1px solid blue;
+}
+</style>
+<script src="../include.js"></script>
+<div id="a"><a href="#" id="target">You should be able to click this link</a></div><br>
+<script>
+test(() => {
+    const hit = internals.hitTest(50, 18);
+    printElement(hit.node);
+    println(`index: ${hit.indexInNode}`);
+    printElement(hit.node.parentNode);
+});
+</script>

--- a/Tests/LibWeb/Text/input/hit_testing/inline-content-inside-anonymous-container.html
+++ b/Tests/LibWeb/Text/input/hit_testing/inline-content-inside-anonymous-container.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+#a {
+    margin-bottom: -20px;
+}
+body {
+    border: 1px solid blue;
+}
+</style>
+<script src="../include.js"></script>
+<div id="a"><a href="#" id="target">You should be able to click this link</a></div>just some text
+<script>
+test(() => {
+    logHitTest = (x, y) => {
+        const hit = internals.hitTest(x, y);
+        printElement(hit.node);
+        println(`index: ${hit.indexInNode}`);
+        printElement(hit.node.parentNode);
+        println('---');
+    }
+
+    logHitTest(40, 18);
+    logHitTest(185, 18);
+    logHitTest(600, 18);
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/elementsFromPoint-inline-htb-ltr.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/elementsFromPoint-inline-htb-ltr.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<link rel="help" href="https://www.w3.org/TR/cssom-view-1/#extensions-to-the-document-interface">
+<div id="container" style="width:200px; height:200px; writing-mode:horizontal-tb; direction:ltr;">
+  <span id="target">target</span>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  test(()=> {
+      var elements = document.elementsFromPoint(15, 15);
+      assert_equals(elements.length, 4);
+      assert_equals(elements[0].id, "target");
+      assert_equals(elements[1].id, "container");
+      assert_equals(elements[2].nodeName, "BODY");
+      assert_equals(elements[3].nodeName, "HTML");
+  }, "elementsFromPoint should return all elements under a point");
+</script>


### PR DESCRIPTION
A `PaintableWithLines` will first try to see if there are any fragments that have a hit. If not, it falls back to hit testing against its border box rect.

However, inline content is often hoisted out of its parent into an anonymous container to maintain the invariant that all layout nodes either have inline or block level children. If that's the case, we should not check the border box rect of the anonymous container, because we might trigger a hit too early if the node has previous siblings in its original parent node that overlap with their bounds.

By ignoring anonymous nodes, we leave the border box hit testing to the nearest non-anonymous ancestor, which correctly applies the hit testing order to its children.