### PR TITLE
AK: Fix usage of constexpr within Utf16View and related utilities

### DIFF
--- a/AK/UnicodeUtils.h
+++ b/AK/UnicodeUtils.h
@@ -137,7 +137,7 @@ template<typename Callback>
 }
 
 template<FallibleFunction<char16_t> Callback>
-constexpr ErrorOr<size_t> try_code_point_to_utf16(u32 code_point, Callback callback)
+ALWAYS_INLINE ErrorOr<size_t> try_code_point_to_utf16(u32 code_point, Callback callback)
 {
     if (code_point < FIRST_SUPPLEMENTARY_PLANE_CODE_POINT) {
         TRY(callback(static_cast<char16_t>(code_point)));

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -88,7 +88,7 @@ public:
     }
 
 private:
-    Utf16CodePointIterator(char16_t const* ptr, size_t length)
+    constexpr Utf16CodePointIterator(char16_t const* ptr, size_t length)
         : m_iterator(ptr)
         , m_remaining_code_units(length)
     {
@@ -346,9 +346,7 @@ struct Traits<Utf16View> : public DefaultTraits<Utf16View> {
 
 [[nodiscard]] ALWAYS_INLINE AK_STRING_VIEW_LITERAL_CONSTEVAL AK::Utf16View operator""sv(char16_t const* string, size_t length)
 {
-    AK::Utf16View view { string, length };
-    ASSERT(view.validate());
-    return view;
+    return { string, length };
 }
 
 #if USING_AK_GLOBALLY


### PR DESCRIPTION
* Error and ErrorOr are not themelves constexpr, so a function returning these types cannot be constexpr.

* The UDL was trying to call Utf16View::validate, which is not constexpr itself. The compiler will actually already raise an error if a UTF-16 literal is invalid, so let's just avoid the call altogether.

Fixes #5291
(I think - I don't have Apple Clang 16 to test with - @shannonbooth are you able to build with these patches?)