### PR TITLE
LibWeb/DOM: Abort any ongoing navigation in Document.open

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -707,6 +707,10 @@ WebIDL::ExceptionOr<Document*> Document::open(Optional<String> const&, Optional<
     // If document belongs to a child navigable, we need to make sure its initial navigation is done,
     // because subsequent steps will modify "initial about:blank" to false, which would cause
     // initial navigation to fail in case it was "about:blank".
+    //
+    // FIXME: We should get rid of this, this is not correct and is likely causing problems other than what
+    //        we are working around above. Hopefully this can be removed once we properly implement Document::abort
+    //        to cancel ongoing navigations.
     if (auto navigable = this->navigable(); navigable && navigable->container() && !navigable->container()->content_navigable_has_session_history_entry_and_ready_for_navigation()) {
         HTML::main_thread_event_loop().spin_processing_tasks_with_source_until(HTML::Task::Source::NavigationAndTraversal, GC::create_function(heap(), [navigable_container = navigable->container()] {
             return navigable_container->content_navigable_has_session_history_entry_and_ready_for_navigation();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -740,7 +740,9 @@ WebIDL::ExceptionOr<Document*> Document::open(Optional<String> const&, Optional<
     if (m_active_parser_was_aborted)
         return this;
 
-    // FIXME: 8. If document's browsing context is non-null and there is an existing attempt to navigate document's browsing context, then stop document loading given document.
+    // 8. If document's node navigable is non-null and document's node navigable's ongoing navigation is a navigation ID, then stop loading document's node navigable.
+    if (auto navigable = this->navigable(); navigable && navigable->ongoing_navigation().has<String>())
+        navigable->stop_loading();
 
     // FIXME: 9. For each shadow-including inclusive descendant node of document, erase all event listeners and handlers given node.
 


### PR DESCRIPTION
Unfortunately this does not achieve it's intended effect
in at least the WPT test of:

document-open-cancels-javascript-url-navigation.html

As we do not implement step 2 of Document::abort. Since this does
not seem to break anything and is also updating an out of date
spec comment, put this step in place anyhow.

Spurred from investigation of #2893 as well looking into navigation
issues in general.