### PR TITLE
LibWeb: Set Document origin for DOMParser created documents

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -850,7 +850,7 @@ GC::Ptr<HTML::WindowProxy const> Document::default_view() const
 
 URL::Origin const& Document::origin() const
 {
-    return m_origin.value();
+    return m_origin;
 }
 
 void Document::set_origin(URL::Origin const& origin)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6331,6 +6331,10 @@ GC::Ref<Document> Document::parse_html_unsafe(JS::VM& vm, StringView html)
     // 4. Parse HTML from a string given document and compliantHTML. // FIXME: Use compliantHTML.
     document->parse_html_from_a_string(html);
 
+    // AD-HOC: Setting the origin to match that of the associated document matches the behavior of existing browsers.
+    auto& associated_document = as<HTML::Window>(realm.global_object()).associated_document();
+    document->set_origin(associated_document.origin());
+
     // 5. Return document.
     return document;
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1088,7 +1088,7 @@ private:
     String m_referrer;
 
     // https://dom.spec.whatwg.org/#concept-document-origin
-    Optional<URL::Origin> m_origin;
+    URL::Origin m_origin { URL::Origin::create_opaque() };
 
     GC::Ptr<HTMLCollection> m_applets;
     GC::Ptr<HTMLCollection> m_anchors;

--- a/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -43,18 +43,18 @@ GC::Ref<DOM::Document> DOMParser::parse_from_string(StringView string, Bindings:
 
     // 2. Let document be a new Document, whose content type is type and url is this's relevant global object's associated Document's URL.
     GC::Ptr<DOM::Document> document;
+    auto& associated_document = as<HTML::Window>(relevant_global_object(*this)).associated_document();
 
     // 3. Switch on type:
     if (type == Bindings::DOMParserSupportedType::Text_Html) {
         // -> "text/html"
-        document = HTML::HTMLDocument::create(realm(), as<HTML::Window>(relevant_global_object(*this)).associated_document().url());
-        document->set_content_type(Bindings::idl_enum_to_string(type));
+        document = HTML::HTMLDocument::create(realm(), associated_document.url());
 
         // 1. Parse HTML from a string given document and compliantString. FIXME: Use compliantString.
         document->parse_html_from_a_string(string);
     } else {
         // -> Otherwise
-        document = DOM::XMLDocument::create(realm(), as<HTML::Window>(relevant_global_object(*this)).associated_document().url());
+        document = DOM::XMLDocument::create(realm(), associated_document.url());
         document->set_content_type(Bindings::idl_enum_to_string(type));
         document->set_document_type(DOM::Document::Type::XML);
 
@@ -75,6 +75,11 @@ GC::Ref<DOM::Document> DOMParser::parse_from_string(StringView string, Bindings:
             MUST(document->append_child(*root));
         }
     }
+
+    // AD-HOC: Setting the origin to match that of the associated document matches the behavior of existing browsers
+    //         and avoids a crash, since we expect the origin to always be set.
+    // Spec issue: https://github.com/whatwg/html/issues/11429
+    document->set_origin(associated_document.origin());
 
     // 3. Return document.
     return *document;

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Node-cloneNode-document-with-doctype.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Node-cloneNode-document-with-doctype.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	Created with the createDocument/createDocumentType
+Pass	Created with the createHTMLDocument
+Pass	Created with DOMParser

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Node-cloneNode-document-with-doctype.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Node-cloneNode-document-with-doctype.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cloning of a document with a doctype</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-clonenode">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone">
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const doctype = document.implementation.createDocumentType("name", "publicId", "systemId");
+  const doc = document.implementation.createDocument("namespace", "", doctype);
+
+  const clone = doc.cloneNode(true);
+
+  assert_equals(clone.childNodes.length, 1, "Only one child node");
+  assert_equals(clone.childNodes[0].nodeType, Node.DOCUMENT_TYPE_NODE, "Is a document fragment");
+  assert_equals(clone.childNodes[0].name, "name");
+  assert_equals(clone.childNodes[0].publicId, "publicId");
+  assert_equals(clone.childNodes[0].systemId, "systemId");
+}, "Created with the createDocument/createDocumentType");
+
+test(() => {
+  const doc = document.implementation.createHTMLDocument();
+
+  const clone = doc.cloneNode(true);
+
+  assert_equals(clone.childNodes.length, 2, "Two child nodes");
+  assert_equals(clone.childNodes[0].nodeType, Node.DOCUMENT_TYPE_NODE, "Is a document fragment");
+  assert_equals(clone.childNodes[0].name, "html");
+  assert_equals(clone.childNodes[0].publicId, "");
+  assert_equals(clone.childNodes[0].systemId, "");
+}, "Created with the createHTMLDocument");
+
+test(() => {
+  const parser = new window.DOMParser();
+  const doc = parser.parseFromString("<!DOCTYPE html><html></html>", "text/html");
+
+  const clone = doc.cloneNode(true);
+
+  assert_equals(clone.childNodes.length, 2, "Two child nodes");
+  assert_equals(clone.childNodes[0].nodeType, Node.DOCUMENT_TYPE_NODE, "Is a document fragment");
+  assert_equals(clone.childNodes[0].name, "html");
+  assert_equals(clone.childNodes[0].publicId, "");
+  assert_equals(clone.childNodes[0].systemId, "");
+}, "Created with DOMParser");
+
+</script>


### PR DESCRIPTION
Previously, a crash would occur when accessing the origin of a document created with DOMParser.

Relevant spec issue: https://github.com/whatwg/html/issues/11429