### PR TITLE
LibWeb: Serialize colors with unresolved components correctly

### DIFF
--- a/Libraries/LibWeb/CSS/Angle.cpp
+++ b/Libraries/LibWeb/CSS/Angle.cpp
@@ -88,7 +88,7 @@ Optional<Angle::Type> Angle::unit_from_name(StringView name)
 
 Angle Angle::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, Layout::Node const& layout_node, Angle const& reference_value)
 {
-    return calculated->resolve_angle(
+    return calculated->resolve_angle_deprecated(
                          {
                              .percentage_basis = reference_value,
                              .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node),

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -450,7 +450,7 @@ int CSSStyleValue::to_font_weight() const
         return round_to<int>(as_number().number());
     }
     if (is_calculated()) {
-        auto maybe_weight = as_calculated().resolve_integer({});
+        auto maybe_weight = as_calculated().resolve_integer_deprecated({});
         if (maybe_weight.has_value())
             return maybe_weight.value();
     }

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -393,7 +393,7 @@ public:
 
     virtual ValueComparingNonnullRefPtr<CSSStyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
 
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const { return {}; }
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const { return {}; }
     Keyword to_keyword() const;
 
     virtual String to_string(SerializationMode) const = 0;

--- a/Libraries/LibWeb/CSS/CalculatedOr.cpp
+++ b/Libraries/LibWeb/CSS/CalculatedOr.cpp
@@ -19,7 +19,7 @@ namespace Web::CSS {
 
 Optional<Angle> AngleOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_angle(context);
+    return calculated->resolve_angle_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> AngleOrCalculated::create_style_value() const
@@ -29,7 +29,7 @@ NonnullRefPtr<CSSStyleValue const> AngleOrCalculated::create_style_value() const
 
 Optional<Flex> FlexOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_flex(context);
+    return calculated->resolve_flex_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> FlexOrCalculated::create_style_value() const
@@ -39,7 +39,7 @@ NonnullRefPtr<CSSStyleValue const> FlexOrCalculated::create_style_value() const
 
 Optional<Frequency> FrequencyOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_frequency(context);
+    return calculated->resolve_frequency_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> FrequencyOrCalculated::create_style_value() const
@@ -49,7 +49,7 @@ NonnullRefPtr<CSSStyleValue const> FrequencyOrCalculated::create_style_value() c
 
 Optional<i64> IntegerOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_integer(context);
+    return calculated->resolve_integer_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> IntegerOrCalculated::create_style_value() const
@@ -59,7 +59,7 @@ NonnullRefPtr<CSSStyleValue const> IntegerOrCalculated::create_style_value() con
 
 Optional<Length> LengthOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_length(context);
+    return calculated->resolve_length_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> LengthOrCalculated::create_style_value() const
@@ -69,7 +69,7 @@ NonnullRefPtr<CSSStyleValue const> LengthOrCalculated::create_style_value() cons
 
 Optional<double> NumberOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_number(context);
+    return calculated->resolve_number_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> NumberOrCalculated::create_style_value() const
@@ -79,7 +79,7 @@ NonnullRefPtr<CSSStyleValue const> NumberOrCalculated::create_style_value() cons
 
 Optional<Percentage> PercentageOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_percentage(context);
+    return calculated->resolve_percentage_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> PercentageOrCalculated::create_style_value() const
@@ -89,7 +89,7 @@ NonnullRefPtr<CSSStyleValue const> PercentageOrCalculated::create_style_value() 
 
 Optional<Resolution> ResolutionOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_resolution(context);
+    return calculated->resolve_resolution_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> ResolutionOrCalculated::create_style_value() const
@@ -99,7 +99,7 @@ NonnullRefPtr<CSSStyleValue const> ResolutionOrCalculated::create_style_value() 
 
 Optional<Time> TimeOrCalculated::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, CalculationResolutionContext const& context) const
 {
-    return calculated->resolve_time(context);
+    return calculated->resolve_time_deprecated(context);
 }
 
 NonnullRefPtr<CSSStyleValue const> TimeOrCalculated::create_style_value() const

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -309,7 +309,7 @@ CSSPixels ComputedProperties::compute_line_height(CSSPixelRect const& viewport_r
             .length_resolution_context = Length::ResolutionContext { viewport_rect, font_metrics, root_font_metrics },
         };
         if (line_height.as_calculated().resolves_to_number()) {
-            auto resolved = line_height.as_calculated().resolve_number(context);
+            auto resolved = line_height.as_calculated().resolve_number_deprecated(context);
             if (!resolved.has_value()) {
                 dbgln("FIXME: Failed to resolve calc() line-height (number): {}", line_height.as_calculated().to_string(SerializationMode::Normal));
                 return CSSPixels::nearest_value_for(m_font_list->first().pixel_metrics().line_spacing());
@@ -317,7 +317,7 @@ CSSPixels ComputedProperties::compute_line_height(CSSPixelRect const& viewport_r
             return Length(resolved.value(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
         }
 
-        auto resolved = line_height.as_calculated().resolve_length(context);
+        auto resolved = line_height.as_calculated().resolve_length_deprecated(context);
         if (!resolved.has_value()) {
             dbgln("FIXME: Failed to resolve calc() line-height: {}", line_height.as_calculated().to_string(SerializationMode::Normal));
             return CSSPixels::nearest_value_for(m_font_list->first().pixel_metrics().line_spacing());
@@ -347,7 +347,7 @@ Optional<int> ComputedProperties::z_index() const
         return clamp(value.as_integer().integer());
     }
     if (value.is_calculated()) {
-        auto maybe_double = value.as_calculated().resolve_number({});
+        auto maybe_double = value.as_calculated().resolve_number_deprecated({});
         if (maybe_double.has_value()) {
             return clamp(maybe_double.value());
         }
@@ -365,13 +365,13 @@ float ComputedProperties::resolve_opacity_value(CSSStyleValue const& value)
         auto const& calculated = value.as_calculated();
         CalculationResolutionContext context {};
         if (calculated.resolves_to_percentage()) {
-            auto maybe_percentage = value.as_calculated().resolve_percentage(context);
+            auto maybe_percentage = value.as_calculated().resolve_percentage_deprecated(context);
             if (maybe_percentage.has_value())
                 unclamped_opacity = maybe_percentage->as_fraction();
             else
                 dbgln("Unable to resolve calc() as opacity (percentage): {}", value.to_string(SerializationMode::Normal));
         } else if (calculated.resolves_to_number()) {
-            auto maybe_number = value.as_calculated().resolve_number(context);
+            auto maybe_number = value.as_calculated().resolve_number_deprecated(context);
             if (maybe_number.has_value())
                 unclamped_opacity = maybe_number.value();
             else
@@ -517,7 +517,7 @@ Length ComputedProperties::border_spacing_horizontal(Layout::Node const& layout_
         if (style_value.is_length())
             return style_value.as_length().length();
         if (style_value.is_calculated())
-            return style_value.as_calculated().resolve_length({ .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }).value_or(Length(0, Length::Type::Px));
+            return style_value.as_calculated().resolve_length_deprecated({ .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }).value_or(Length(0, Length::Type::Px));
         return {};
     };
 
@@ -539,7 +539,7 @@ Length ComputedProperties::border_spacing_vertical(Layout::Node const& layout_no
         if (style_value.is_length())
             return style_value.as_length().length();
         if (style_value.is_calculated())
-            return style_value.as_calculated().resolve_length({ .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }).value_or(Length(0, Length::Type::Px));
+            return style_value.as_calculated().resolve_length_deprecated({ .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }).value_or(Length(0, Length::Type::Px));
         return {};
     };
 
@@ -1181,7 +1181,7 @@ Vector<ShadowData> ComputedProperties::shadow(PropertyID property_id, Layout::No
         if (value->is_length())
             return value->as_length().length();
         if (value->is_calculated())
-            return value->as_calculated().resolve_length({ .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) });
+            return value->as_calculated().resolve_length_deprecated({ .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) });
         return {};
     };
 
@@ -1883,7 +1883,7 @@ Vector<CounterData> ComputedProperties::counter_data(PropertyID property_id) con
                 if (counter.value->is_integer()) {
                     data.value = AK::clamp_to<i32>(counter.value->as_integer().integer());
                 } else if (counter.value->is_calculated()) {
-                    auto maybe_int = counter.value->as_calculated().resolve_integer({});
+                    auto maybe_int = counter.value->as_calculated().resolve_integer_deprecated({});
                     if (maybe_int.has_value())
                         data.value = AK::clamp_to<i32>(*maybe_int);
                 } else {

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -226,7 +226,7 @@ Color ComputedProperties::color_or_fallback(PropertyID id, Layout::NodeWithStyle
     auto const& value = property(id);
     if (!value.has_color())
         return fallback;
-    return value.to_color(node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(node) });
+    return value.to_color(node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(node) }).value();
 }
 
 // https://drafts.csswg.org/css-color-adjust-1/#determine-the-used-color-scheme
@@ -447,7 +447,7 @@ Color ComputedProperties::flood_color(Layout::NodeWithStyle const& node) const
 {
     auto const& value = property(PropertyID::FloodColor);
     if (value.has_color()) {
-        return value.to_color(node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(node) });
+        return value.to_color(node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(node) }).value();
     }
 
     return InitialValues::flood_color();
@@ -940,7 +940,7 @@ Color ComputedProperties::caret_color(Layout::NodeWithStyle const& node) const
         return node.computed_values().color();
 
     if (value.has_color())
-        return value.to_color(node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(node) });
+        return value.to_color(node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(node) }).value();
 
     return InitialValues::caret_color();
 }
@@ -1203,7 +1203,7 @@ Vector<ShadowData> ComputedProperties::shadow(PropertyID property_id, Layout::No
             maybe_offset_y.release_value(),
             maybe_blur_radius.release_value(),
             maybe_spread_distance.release_value(),
-            value.color()->to_color(as<Layout::NodeWithStyle>(layout_node), { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }),
+            value.color()->to_color(as<Layout::NodeWithStyle>(layout_node), { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }).value(),
             value.placement()
         };
     };
@@ -1826,7 +1826,7 @@ Color ComputedProperties::stop_color() const
         // FIXME: This is used by the SVGStopElement, which does not participate in layout, so we can't pass a layout
         //        node or CalculationResolutionContext. This means we don't support all valid colors (e.g. palette
         //        colors, calculated values which depend on length resolution, etc)
-        return value->to_color({}, {});
+        return value->to_color({}, {}).value_or(Color::Black);
     }
     return Color::Black;
 }
@@ -1910,8 +1910,8 @@ ScrollbarColorData ComputedProperties::scrollbar_color(Layout::NodeWithStyle con
 
     if (value.is_scrollbar_color()) {
         auto& scrollbar_color_value = value.as_scrollbar_color();
-        auto thumb_color = scrollbar_color_value.thumb_color()->to_color(layout_node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) });
-        auto track_color = scrollbar_color_value.track_color()->to_color(layout_node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) });
+        auto thumb_color = scrollbar_color_value.thumb_color()->to_color(layout_node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }).value();
+        auto track_color = scrollbar_color_value.track_color()->to_color(layout_node, { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) }).value();
         return { thumb_color, track_color };
     }
 

--- a/Libraries/LibWeb/CSS/Frequency.cpp
+++ b/Libraries/LibWeb/CSS/Frequency.cpp
@@ -67,7 +67,7 @@ Optional<Frequency::Type> Frequency::unit_from_name(StringView name)
 
 Frequency Frequency::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, Layout::Node const& layout_node, Frequency const& reference_value)
 {
-    return calculated->resolve_frequency(
+    return calculated->resolve_frequency_deprecated(
                          {
                              .percentage_basis = reference_value,
                              .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node),

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -423,7 +423,7 @@ Length Length::absolutized(CSSPixelRect const& viewport_rect, FontMetrics const&
 
 Length Length::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, Layout::Node const& layout_node, Length const& reference_value)
 {
-    return calculated->resolve_length(
+    return calculated->resolve_length_deprecated(
                          {
                              .percentage_basis = reference_value,
                              .length_resolution_context = ResolutionContext::for_layout_node(layout_node),
@@ -433,7 +433,7 @@ Length Length::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> cons
 
 Length Length::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, Layout::Node const& layout_node, CSSPixels reference_value)
 {
-    return calculated->resolve_length(
+    return calculated->resolve_length_deprecated(
                          {
                              .percentage_basis = make_px(reference_value),
                              .length_resolution_context = ResolutionContext::for_layout_node(layout_node),

--- a/Libraries/LibWeb/CSS/ParsedFontFace.cpp
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.cpp
@@ -60,7 +60,7 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
             return value.as_percentage().percentage();
         if (value.is_calculated()) {
             // FIXME: These should probably be simplified already?
-            return value.as_calculated().resolve_percentage({});
+            return value.as_calculated().resolve_percentage_deprecated({});
         }
         if (value.to_keyword() == Keyword::Normal)
             return {};
@@ -139,7 +139,7 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
                 if (setting_value->is_integer()) {
                     settings.set(feature_tag->as_open_type_tagged().tag(), setting_value->as_integer().integer());
                 } else if (setting_value->is_calculated() && setting_value->as_calculated().resolves_to_number()) {
-                    if (auto integer = setting_value->as_calculated().resolve_integer({}); integer.has_value()) {
+                    if (auto integer = setting_value->as_calculated().resolve_integer_deprecated({}); integer.has_value()) {
                         settings.set(feature_tag->as_open_type_tagged().tag(), *integer);
                     }
                 }
@@ -161,7 +161,7 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
                 if (setting_value->is_number()) {
                     settings.set(variation_tag->as_open_type_tagged().tag(), setting_value->as_number().number());
                 } else if (setting_value->is_calculated() && setting_value->as_calculated().resolves_to_number()) {
-                    if (auto number = setting_value->as_calculated().resolve_number({}); number.has_value()) {
+                    if (auto number = setting_value->as_calculated().resolve_number_deprecated({}); number.has_value()) {
                         settings.set(variation_tag->as_open_type_tagged().tag(), *number);
                     }
                 }

--- a/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/DescriptorParsing.cpp
@@ -188,7 +188,7 @@ Parser::ParseErrorOr<NonnullRefPtr<CSSStyleValue const>> Parser::parse_descripto
                         }
                         // All calculations in descriptors must be resolvable at parse-time.
                         if (percentage_value->is_calculated()) {
-                            auto percentage = percentage_value->as_calculated().resolve_percentage({});
+                            auto percentage = percentage_value->as_calculated().resolve_percentage_deprecated({});
                             if (percentage.has_value() && percentage->value() >= 0)
                                 return PercentageStyleValue::create(percentage.release_value());
                             return nullptr;

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -3629,7 +3629,7 @@ RefPtr<CSSStyleValue const> Parser::parse_opacity_value(PropertyID property_id, 
     if (value->is_percentage())
         value = NumberStyleValue::create(value->as_percentage().percentage().as_fraction());
     if (value->is_calculated() && value->as_calculated().resolves_to_percentage()) {
-        auto maybe_percentage = value->as_calculated().resolve_percentage({});
+        auto maybe_percentage = value->as_calculated().resolve_percentage_deprecated({});
         if (maybe_percentage.has_value()) {
             auto resolved_percentage = maybe_percentage->as_fraction();
             CalculationContext context {};

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -363,7 +363,7 @@ Optional<Ratio> Parser::parse_ratio(TokenStream<ComponentValue>& tokens)
                 return maybe_calc->as_number().value();
             if (!maybe_calc->is_calculated() || !maybe_calc->as_calculated().resolves_to_number())
                 return {};
-            if (auto resolved_number = maybe_calc->as_calculated().resolve_number({}); resolved_number.has_value() && resolved_number.value() >= 0) {
+            if (auto resolved_number = maybe_calc->as_calculated().resolve_number_deprecated({}); resolved_number.has_value() && resolved_number.value() >= 0) {
                 return resolved_number.value();
             }
         }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1972,7 +1972,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
         } else if (font_size.is_length()) {
             maybe_length = font_size.as_length().length();
         } else if (font_size.is_calculated()) {
-            maybe_length = font_size.as_calculated().resolve_length({
+            maybe_length = font_size.as_calculated().resolve_length_deprecated({
                 .percentage_basis = Length::make_px(parent_font_size),
                 .length_resolution_context = length_resolution_context,
             });
@@ -3196,7 +3196,7 @@ void StyleComputer::compute_math_depth(ComputedProperties& style, DOM::Element c
         if (integer_value.is_integer())
             return integer_value.as_integer().integer();
         if (integer_value.is_calculated())
-            return integer_value.as_calculated().resolve_integer({}).value();
+            return integer_value.as_calculated().resolve_integer_deprecated({}).value();
         VERIFY_NOT_REACHED();
     };
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.cpp
@@ -53,12 +53,11 @@ Optional<double> CSSColorValue::resolve_hue(CSSStyleValue const& style_value, Ca
 
     if (style_value.is_calculated()) {
         if (style_value.as_calculated().resolves_to_number())
-            return normalized(style_value.as_calculated().resolve_number(resolution_context).value());
+            return normalized(style_value.as_calculated().resolve_number_deprecated(resolution_context).value());
 
         if (style_value.as_calculated().resolves_to_angle())
-            return normalized(style_value.as_calculated().resolve_angle(resolution_context).value().to_degrees());
+            return normalized(style_value.as_calculated().resolve_angle_deprecated(resolution_context).value().to_degrees());
     }
-
     if (style_value.is_keyword() && style_value.to_keyword() == Keyword::None)
         return 0;
 
@@ -81,9 +80,9 @@ Optional<double> CSSColorValue::resolve_with_reference_value(CSSStyleValue const
     if (style_value.is_calculated()) {
         auto const& calculated = style_value.as_calculated();
         if (calculated.resolves_to_number())
-            return calculated.resolve_number(resolution_context).value();
+            return calculated.resolve_number_deprecated(resolution_context).value();
         if (calculated.resolves_to_percentage())
-            return normalize_percentage(calculated.resolve_percentage(resolution_context).value());
+            return normalize_percentage(calculated.resolve_percentage_deprecated(resolution_context).value());
     }
 
     if (style_value.is_keyword() && style_value.to_keyword() == Keyword::None)
@@ -110,9 +109,9 @@ Optional<double> CSSColorValue::resolve_alpha(CSSStyleValue const& style_value, 
     if (style_value.is_calculated()) {
         auto const& calculated = style_value.as_calculated();
         if (calculated.resolves_to_number())
-            return normalized(calculated.resolve_number(resolution_context).value());
+            return normalized(calculated.resolve_number_deprecated(resolution_context).value());
         if (calculated.resolves_to_percentage())
-            return normalized(calculated.resolve_percentage(resolution_context).value().as_fraction());
+            return normalized(calculated.resolve_percentage_deprecated(resolution_context).value().as_fraction());
     }
 
     if (style_value.is_keyword() && style_value.to_keyword() == Keyword::None)

--- a/Libraries/LibWeb/CSS/StyleValues/CSSHSL.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSHSL.h
@@ -29,7 +29,7 @@ public:
     CSSStyleValue const& l() const { return *m_properties.l; }
     CSSStyleValue const& alpha() const { return *m_properties.alpha; }
 
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
 
     virtual String to_string(SerializationMode) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSHWB.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSHWB.h
@@ -29,7 +29,7 @@ public:
     CSSStyleValue const& b() const { return *m_properties.b; }
     CSSStyleValue const& alpha() const { return *m_properties.alpha; }
 
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
 
     virtual String to_string(SerializationMode) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.cpp
@@ -135,7 +135,7 @@ bool CSSKeywordValue::has_color() const
     return is_color(keyword());
 }
 
-Color CSSKeywordValue::to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const&) const
+Optional<Color> CSSKeywordValue::to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const&) const
 {
     if (keyword() == Keyword::Currentcolor) {
         if (!node.has_value() || !node->has_style())

--- a/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
@@ -51,7 +51,7 @@ public:
 
     static bool is_color(Keyword);
     virtual bool has_color() const override;
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const&) const override;
     virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(CSSKeywordValue const& other) const { return m_keyword == other.m_keyword; }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLCHLike.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLCHLike.h
@@ -56,7 +56,7 @@ public:
     }
     virtual ~CSSLCH() override = default;
 
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
 
     virtual String to_string(SerializationMode) const override;
 };
@@ -70,7 +70,7 @@ public:
     }
     virtual ~CSSOKLCH() override = default;
 
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
 
     virtual String to_string(SerializationMode) const override;
 };

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.cpp
@@ -26,14 +26,17 @@ bool CSSLabLike::equals(CSSStyleValue const& other) const
     return m_properties == other_lab_like.m_properties;
 }
 
-Color CSSOKLab::to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const& resolution_context) const
+Optional<Color> CSSOKLab::to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const& resolution_context) const
 {
-    auto const l_val = clamp(resolve_with_reference_value(m_properties.l, 1.0, resolution_context).value_or(0), 0, 1);
-    auto const a_val = resolve_with_reference_value(m_properties.a, 0.4, resolution_context).value_or(0);
-    auto const b_val = resolve_with_reference_value(m_properties.b, 0.4, resolution_context).value_or(0);
-    auto const alpha_val = resolve_alpha(m_properties.alpha, resolution_context).value_or(1);
+    auto const l_val = resolve_with_reference_value(m_properties.l, 1.0, resolution_context);
+    auto const a_val = resolve_with_reference_value(m_properties.a, 0.4, resolution_context);
+    auto const b_val = resolve_with_reference_value(m_properties.b, 0.4, resolution_context);
+    auto const alpha_val = resolve_alpha(m_properties.alpha, resolution_context);
 
-    return Color::from_oklab(l_val, a_val, b_val, alpha_val);
+    if (!l_val.has_value() || !a_val.has_value() || !b_val.has_value() || !alpha_val.has_value())
+        return {};
+
+    return Color::from_oklab(clamp(l_val.value(), 0, 1), a_val.value(), b_val.value(), alpha_val.value());
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-oklab-oklch
@@ -56,14 +59,17 @@ String CSSOKLab::to_string(SerializationMode mode) const
     return MUST(builder.to_string());
 }
 
-Color CSSLab::to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const& resolution_context) const
+Optional<Color> CSSLab::to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const& resolution_context) const
 {
-    auto const l_val = clamp(resolve_with_reference_value(m_properties.l, 100, resolution_context).value_or(0), 0, 100);
-    auto const a_val = resolve_with_reference_value(m_properties.a, 125, resolution_context).value_or(0);
-    auto const b_val = resolve_with_reference_value(m_properties.b, 125, resolution_context).value_or(0);
-    auto const alpha_val = resolve_alpha(m_properties.alpha, resolution_context).value_or(1);
+    auto l_val = resolve_with_reference_value(m_properties.l, 100, resolution_context);
+    auto a_val = resolve_with_reference_value(m_properties.a, 125, resolution_context);
+    auto b_val = resolve_with_reference_value(m_properties.b, 125, resolution_context);
+    auto alpha_val = resolve_alpha(m_properties.alpha, resolution_context);
 
-    return Color::from_lab(l_val, a_val, b_val, alpha_val);
+    if (!l_val.has_value() || !a_val.has_value() || !b_val.has_value() || !alpha_val.has_value())
+        return {};
+
+    return Color::from_lab(clamp(l_val.value(), 0, 100), a_val.value(), b_val.value(), alpha_val.value());
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-lab-lch

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.h
@@ -51,7 +51,7 @@ protected:
 // https://drafts.css-houdini.org/css-typed-om-1/#cssoklab
 class CSSOKLab final : public CSSLabLike {
 public:
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
     virtual String to_string(SerializationMode) const override;
 
     CSSOKLab(Badge<CSSLabLike>, ValueComparingNonnullRefPtr<CSSStyleValue const> l, ValueComparingNonnullRefPtr<CSSStyleValue const> a, ValueComparingNonnullRefPtr<CSSStyleValue const> b, ValueComparingNonnullRefPtr<CSSStyleValue const> alpha)
@@ -63,7 +63,7 @@ public:
 // https://drafts.css-houdini.org/css-typed-om-1/#csslab
 class CSSLab final : public CSSLabLike {
 public:
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
     virtual String to_string(SerializationMode) const override;
 
     CSSLab(Badge<CSSLabLike>, ValueComparingNonnullRefPtr<CSSStyleValue const> l, ValueComparingNonnullRefPtr<CSSStyleValue const> a, ValueComparingNonnullRefPtr<CSSStyleValue const> b, ValueComparingNonnullRefPtr<CSSStyleValue const> alpha)

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLightDark.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLightDark.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::CSS {
 
-Color CSSLightDark::to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const& resolution_context) const
+Optional<Color> CSSLightDark::to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const& resolution_context) const
 {
     if (node.has_value() && node.value().computed_values().color_scheme() == PreferredColorScheme::Dark)
         return m_properties.dark->to_color(node, resolution_context);

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLightDark.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLightDark.h
@@ -21,7 +21,7 @@ public:
     }
 
     virtual bool equals(CSSStyleValue const&) const override;
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
     virtual String to_string(SerializationMode) const override;
 
 private:

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -33,9 +33,9 @@ Color CSSRGB::to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolu
         if (style_value.is_calculated()) {
             auto const& calculated = style_value.as_calculated();
             if (calculated.resolves_to_number())
-                return normalized(calculated.resolve_number(resolution_context).value());
+                return normalized(calculated.resolve_number_deprecated(resolution_context).value());
             if (calculated.resolves_to_percentage())
-                return normalized(calculated.resolve_percentage(resolution_context).value().value() * 255 / 100);
+                return normalized(calculated.resolve_percentage_deprecated(resolution_context).value().value() * 255 / 100);
         }
 
         if (style_value.is_keyword() && style_value.to_keyword() == Keyword::None)

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -92,8 +92,20 @@ String CSSRGB::to_string(SerializationMode mode) const
     if (auto color = to_color({}, {}); color.has_value())
         return serialize_a_srgb_value(color.value());
 
-    // FIXME: Do this properly, taking unresolved calculated values into account.
-    return ""_string;
+    StringBuilder builder;
+    builder.append("rgb("sv);
+    serialize_color_component(builder, mode, m_properties.r, 255, 0, 255);
+    builder.append(" "sv);
+    serialize_color_component(builder, mode, m_properties.g, 255, 0, 255);
+    builder.append(" "sv);
+    serialize_color_component(builder, mode, m_properties.b, 255, 0, 255);
+    if ((!m_properties.alpha->is_number() || m_properties.alpha->as_number().number() < 1) && (!m_properties.alpha->is_percentage() || m_properties.alpha->as_percentage().percentage().as_fraction() < 1)) {
+        builder.append(" / "sv);
+        serialize_alpha_component(builder, mode, m_properties.alpha);
+    }
+    builder.append(")"sv);
+
+    return builder.to_string_without_validation();
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.h
@@ -29,7 +29,7 @@ public:
     CSSStyleValue const& b() const { return *m_properties.b; }
     CSSStyleValue const& alpha() const { return *m_properties.alpha; }
 
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
 
     virtual String to_string(SerializationMode) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -2669,7 +2669,7 @@ bool CalculatedStyleValue::equals(CSSStyleValue const& other) const
     return m_calculation->equals(*other.as_calculated().m_calculation);
 }
 
-Optional<Angle> CalculatedStyleValue::resolve_angle(CalculationResolutionContext const& context) const
+Optional<Angle> CalculatedStyleValue::resolve_angle_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_angle(m_context.percentages_resolve_as))
@@ -2677,7 +2677,7 @@ Optional<Angle> CalculatedStyleValue::resolve_angle(CalculationResolutionContext
     return {};
 }
 
-Optional<Flex> CalculatedStyleValue::resolve_flex(CalculationResolutionContext const& context) const
+Optional<Flex> CalculatedStyleValue::resolve_flex_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_flex(m_context.percentages_resolve_as))
@@ -2685,7 +2685,7 @@ Optional<Flex> CalculatedStyleValue::resolve_flex(CalculationResolutionContext c
     return {};
 }
 
-Optional<Frequency> CalculatedStyleValue::resolve_frequency(CalculationResolutionContext const& context) const
+Optional<Frequency> CalculatedStyleValue::resolve_frequency_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_frequency(m_context.percentages_resolve_as))
@@ -2693,7 +2693,7 @@ Optional<Frequency> CalculatedStyleValue::resolve_frequency(CalculationResolutio
     return {};
 }
 
-Optional<Length> CalculatedStyleValue::resolve_length(CalculationResolutionContext const& context) const
+Optional<Length> CalculatedStyleValue::resolve_length_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_length(m_context.percentages_resolve_as))
@@ -2701,7 +2701,7 @@ Optional<Length> CalculatedStyleValue::resolve_length(CalculationResolutionConte
     return {};
 }
 
-Optional<Percentage> CalculatedStyleValue::resolve_percentage(CalculationResolutionContext const& context) const
+Optional<Percentage> CalculatedStyleValue::resolve_percentage_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_percentage())
@@ -2709,7 +2709,7 @@ Optional<Percentage> CalculatedStyleValue::resolve_percentage(CalculationResolut
     return {};
 }
 
-Optional<Resolution> CalculatedStyleValue::resolve_resolution(CalculationResolutionContext const& context) const
+Optional<Resolution> CalculatedStyleValue::resolve_resolution_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_resolution(m_context.percentages_resolve_as))
@@ -2717,7 +2717,7 @@ Optional<Resolution> CalculatedStyleValue::resolve_resolution(CalculationResolut
     return {};
 }
 
-Optional<Time> CalculatedStyleValue::resolve_time(CalculationResolutionContext const& context) const
+Optional<Time> CalculatedStyleValue::resolve_time_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_time(m_context.percentages_resolve_as))
@@ -2725,7 +2725,7 @@ Optional<Time> CalculatedStyleValue::resolve_time(CalculationResolutionContext c
     return {};
 }
 
-Optional<double> CalculatedStyleValue::resolve_number(CalculationResolutionContext const& context) const
+Optional<double> CalculatedStyleValue::resolve_number_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (!result.type().has_value() || !result.type()->matches_number(m_context.percentages_resolve_as))
@@ -2740,7 +2740,7 @@ Optional<double> CalculatedStyleValue::resolve_number(CalculationResolutionConte
     return value;
 }
 
-Optional<i64> CalculatedStyleValue::resolve_integer(CalculationResolutionContext const& context) const
+Optional<i64> CalculatedStyleValue::resolve_integer_deprecated(CalculationResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context);
     if (result.type().has_value() && result.type()->matches_number(m_context.percentages_resolve_as))

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -77,32 +77,32 @@ public:
 
     bool resolves_to_angle() const { return m_resolved_type.matches_angle(m_context.percentages_resolve_as); }
     bool resolves_to_angle_percentage() const { return m_resolved_type.matches_angle_percentage(m_context.percentages_resolve_as); }
-    Optional<Angle> resolve_angle(CalculationResolutionContext const&) const;
+    Optional<Angle> resolve_angle_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_flex() const { return m_resolved_type.matches_flex(m_context.percentages_resolve_as); }
-    Optional<Flex> resolve_flex(CalculationResolutionContext const&) const;
+    Optional<Flex> resolve_flex_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_frequency() const { return m_resolved_type.matches_frequency(m_context.percentages_resolve_as); }
     bool resolves_to_frequency_percentage() const { return m_resolved_type.matches_frequency_percentage(m_context.percentages_resolve_as); }
-    Optional<Frequency> resolve_frequency(CalculationResolutionContext const&) const;
+    Optional<Frequency> resolve_frequency_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_length() const { return m_resolved_type.matches_length(m_context.percentages_resolve_as); }
     bool resolves_to_length_percentage() const { return m_resolved_type.matches_length_percentage(m_context.percentages_resolve_as); }
-    Optional<Length> resolve_length(CalculationResolutionContext const&) const;
+    Optional<Length> resolve_length_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_percentage() const { return m_resolved_type.matches_percentage(); }
-    Optional<Percentage> resolve_percentage(CalculationResolutionContext const&) const;
+    Optional<Percentage> resolve_percentage_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_resolution() const { return m_resolved_type.matches_resolution(m_context.percentages_resolve_as); }
-    Optional<Resolution> resolve_resolution(CalculationResolutionContext const&) const;
+    Optional<Resolution> resolve_resolution_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_time() const { return m_resolved_type.matches_time(m_context.percentages_resolve_as); }
     bool resolves_to_time_percentage() const { return m_resolved_type.matches_time_percentage(m_context.percentages_resolve_as); }
-    Optional<Time> resolve_time(CalculationResolutionContext const&) const;
+    Optional<Time> resolve_time_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_number() const { return m_resolved_type.matches_number(m_context.percentages_resolve_as); }
-    Optional<double> resolve_number(CalculationResolutionContext const&) const;
-    Optional<i64> resolve_integer(CalculationResolutionContext const&) const;
+    Optional<double> resolve_number_deprecated(CalculationResolutionContext const&) const;
+    Optional<i64> resolve_integer_deprecated(CalculationResolutionContext const&) const;
 
     bool resolves_to_dimension() const { return m_resolved_type.matches_dimension(); }
 

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -75,34 +75,45 @@ public:
     virtual String to_string(SerializationMode) const override;
     virtual bool equals(CSSStyleValue const& other) const override;
 
+    Optional<CalculationResult> resolve_value(CalculationResolutionContext const&) const;
+
     bool resolves_to_angle() const { return m_resolved_type.matches_angle(m_context.percentages_resolve_as); }
     bool resolves_to_angle_percentage() const { return m_resolved_type.matches_angle_percentage(m_context.percentages_resolve_as); }
     Optional<Angle> resolve_angle_deprecated(CalculationResolutionContext const&) const;
+    Optional<Angle> resolve_angle(CalculationResolutionContext const&) const;
 
     bool resolves_to_flex() const { return m_resolved_type.matches_flex(m_context.percentages_resolve_as); }
     Optional<Flex> resolve_flex_deprecated(CalculationResolutionContext const&) const;
+    Optional<Flex> resolve_flex(CalculationResolutionContext const&) const;
 
     bool resolves_to_frequency() const { return m_resolved_type.matches_frequency(m_context.percentages_resolve_as); }
     bool resolves_to_frequency_percentage() const { return m_resolved_type.matches_frequency_percentage(m_context.percentages_resolve_as); }
     Optional<Frequency> resolve_frequency_deprecated(CalculationResolutionContext const&) const;
+    Optional<Frequency> resolve_frequency(CalculationResolutionContext const&) const;
 
     bool resolves_to_length() const { return m_resolved_type.matches_length(m_context.percentages_resolve_as); }
     bool resolves_to_length_percentage() const { return m_resolved_type.matches_length_percentage(m_context.percentages_resolve_as); }
     Optional<Length> resolve_length_deprecated(CalculationResolutionContext const&) const;
+    Optional<Length> resolve_length(CalculationResolutionContext const&) const;
 
     bool resolves_to_percentage() const { return m_resolved_type.matches_percentage(); }
     Optional<Percentage> resolve_percentage_deprecated(CalculationResolutionContext const&) const;
+    Optional<Percentage> resolve_percentage(CalculationResolutionContext const&) const;
 
     bool resolves_to_resolution() const { return m_resolved_type.matches_resolution(m_context.percentages_resolve_as); }
     Optional<Resolution> resolve_resolution_deprecated(CalculationResolutionContext const&) const;
+    Optional<Resolution> resolve_resolution(CalculationResolutionContext const&) const;
 
     bool resolves_to_time() const { return m_resolved_type.matches_time(m_context.percentages_resolve_as); }
     bool resolves_to_time_percentage() const { return m_resolved_type.matches_time_percentage(m_context.percentages_resolve_as); }
     Optional<Time> resolve_time_deprecated(CalculationResolutionContext const&) const;
+    Optional<Time> resolve_time(CalculationResolutionContext const&) const;
 
     bool resolves_to_number() const { return m_resolved_type.matches_number(m_context.percentages_resolve_as); }
     Optional<double> resolve_number_deprecated(CalculationResolutionContext const&) const;
+    Optional<double> resolve_number(CalculationResolutionContext const&) const;
     Optional<i64> resolve_integer_deprecated(CalculationResolutionContext const&) const;
+    Optional<i64> resolve_integer(CalculationResolutionContext const&) const;
 
     bool resolves_to_dimension() const { return m_resolved_type.matches_dimension(); }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ColorFunctionStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorFunctionStyleValue.cpp
@@ -102,14 +102,14 @@ String ColorFunctionStyleValue::to_string(SerializationMode mode) const
             CalculationResolutionContext context {};
             auto const& calculated = value->as_calculated();
             if (calculated.resolves_to_percentage()) {
-                if (auto resolved_percentage = calculated.resolve_percentage(context); resolved_percentage.has_value()) {
+                if (auto resolved_percentage = calculated.resolve_percentage_deprecated(context); resolved_percentage.has_value()) {
                     auto resolved_number = resolved_percentage->value() / 100;
                     if (!isfinite(resolved_number))
                         resolved_number = 0;
                     return NumberStyleValue::create(resolved_number);
                 }
             } else if (calculated.resolves_to_number()) {
-                if (auto resolved_number = calculated.resolve_number(context); resolved_number.has_value())
+                if (auto resolved_number = calculated.resolve_number_deprecated(context); resolved_number.has_value())
                     return NumberStyleValue::create(*resolved_number);
             }
         }

--- a/Libraries/LibWeb/CSS/StyleValues/ColorFunctionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorFunctionStyleValue.h
@@ -18,7 +18,7 @@ public:
     static ValueComparingNonnullRefPtr<ColorFunctionStyleValue const> create(StringView color_space, ValueComparingNonnullRefPtr<CSSStyleValue const> c1, ValueComparingNonnullRefPtr<CSSStyleValue const> c2, ValueComparingNonnullRefPtr<CSSStyleValue const> c3, ValueComparingRefPtr<CSSStyleValue const> alpha = {});
 
     virtual bool equals(CSSStyleValue const&) const override;
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const& resolution_context) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const& resolution_context) const override;
     virtual String to_string(SerializationMode) const override;
 
     virtual bool is_color_function() const override { return true; }
@@ -43,7 +43,7 @@ private:
         float alpha {};
     };
 
-    Resolved resolve_properties(CalculationResolutionContext const& resolution_context) const;
+    Optional<Resolved> resolve_properties(CalculationResolutionContext const& resolution_context) const;
 
     Properties m_properties;
 };

--- a/Libraries/LibWeb/CSS/StyleValues/ColorMixStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorMixStyleValue.cpp
@@ -175,15 +175,19 @@ ColorMixStyleValue::PercentageNormalizationResult ColorMixStyleValue::normalize_
 }
 
 // https://drafts.csswg.org/css-color-5/#color-mix-result
-Color ColorMixStyleValue::to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const& resolution_context) const
+Optional<Color> ColorMixStyleValue::to_color(Optional<Layout::NodeWithStyle const&> node, CalculationResolutionContext const& resolution_context) const
 {
     // FIXME: Take the color space and hue interpolation method into account.
     // The current implementation only uses oklab interpolation.
     auto normalized_percentages = normalize_percentages();
-    auto from_color = m_properties.first_component.color;
-    auto to_color = m_properties.second_component.color;
+    auto from_color = m_properties.first_component.color->to_color(node, resolution_context);
+    auto to_color = m_properties.second_component.color->to_color(node, resolution_context);
     auto delta = normalized_percentages.p2.value() / 100;
-    return interpolate_color(from_color->to_color(node, resolution_context), to_color->to_color(node, resolution_context), delta, ColorSyntax::Modern);
+
+    if (!from_color.has_value() || !to_color.has_value())
+        return {};
+
+    return interpolate_color(from_color.value(), to_color.value(), delta, ColorSyntax::Modern);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ColorMixStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorMixStyleValue.h
@@ -30,7 +30,7 @@ public:
     static ValueComparingNonnullRefPtr<ColorMixStyleValue const> create(ColorInterpolationMethod, ColorMixComponent first_component, ColorMixComponent second_component);
 
     virtual bool equals(CSSStyleValue const&) const override;
-    virtual Color to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
+    virtual Optional<Color> to_color(Optional<Layout::NodeWithStyle const&>, CalculationResolutionContext const&) const override;
     virtual String to_string(SerializationMode) const override;
 
 private:

--- a/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -34,10 +34,10 @@ float FilterOperation::Color::resolved_amount() const
     if (amount.is_calculated()) {
         CalculationResolutionContext context {};
         if (amount.calculated()->resolves_to_number())
-            return amount.calculated()->resolve_number(context).value();
+            return amount.calculated()->resolve_number_deprecated(context).value();
 
         if (amount.calculated()->resolves_to_percentage())
-            return amount.calculated()->resolve_percentage(context)->as_fraction();
+            return amount.calculated()->resolve_percentage_deprecated(context)->as_fraction();
     }
 
     VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
@@ -68,7 +68,7 @@ String TransformationStyleValue::to_string(SerializationMode mode) const
             if (value->is_number())
                 return value->as_number().number();
             if (value->is_calculated() && value->as_calculated().resolves_to_number())
-                return value->as_calculated().resolve_number({});
+                return value->as_calculated().resolve_number_deprecated({});
 
             VERIFY_NOT_REACHED();
         };

--- a/Libraries/LibWeb/CSS/Time.cpp
+++ b/Libraries/LibWeb/CSS/Time.cpp
@@ -78,7 +78,7 @@ Optional<Time::Type> Time::unit_from_name(StringView name)
 
 Time Time::resolve_calculated(NonnullRefPtr<CalculatedStyleValue const> const& calculated, Layout::Node const& layout_node, Time const& reference_value)
 {
-    return calculated->resolve_time(
+    return calculated->resolve_time_deprecated(
                          {
                              .percentage_basis = reference_value,
                              .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node),

--- a/Libraries/LibWeb/CSS/Transformation.cpp
+++ b/Libraries/LibWeb/CSS/Transformation.cpp
@@ -43,7 +43,7 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
                         return length.absolute_length_to_px().to_float();
                 }
                 if (value.is_calculated() && value.calculated()->resolves_to_length()) {
-                    if (auto const& resolved = value.calculated()->resolve_length(context); resolved->is_absolute())
+                    if (auto const& resolved = value.calculated()->resolve_length_deprecated(context); resolved->is_absolute())
                         return resolved->absolute_length_to_px().to_float();
                 }
                 return Error::from_string_literal("Transform contains non absolute units");
@@ -55,9 +55,9 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
                     return value.percentage().as_fraction();
                 if (value.is_calculated()) {
                     if (value.calculated()->resolves_to_number())
-                        return value.calculated()->resolve_number(context).value();
+                        return value.calculated()->resolve_number_deprecated(context).value();
                     if (value.calculated()->resolves_to_percentage())
-                        return value.calculated()->resolve_percentage(context)->as_fraction();
+                        return value.calculated()->resolve_percentage_deprecated(context)->as_fraction();
                 }
                 return Error::from_string_literal("Transform contains non absolute units");
             });

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1677,7 +1677,7 @@ void Document::obtain_theme_color()
                     resolution_context.length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*html_element()->layout_node());
                 }
 
-                theme_color = css_value->to_color(root_node, resolution_context);
+                theme_color = css_value->to_color(root_node, resolution_context).value();
                 return TraversalDecision::Break;
             }
         }

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -1175,7 +1175,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
                 return NumericLimits<u8>::max();
             VERIFY(is<Layout::NodeWithStyle>(node->layout_node()));
             auto& layout_node = *static_cast<Layout::NodeWithStyle*>(node->layout_node());
-            return background_color.value()->to_color(layout_node, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(layout_node) }).alpha();
+            return background_color.value()->to_color(layout_node, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(layout_node) }).value().alpha();
         };
         while (resolved_background_alpha() == 0 && node->parent() && is<DOM::Element>(*node->parent()))
             node = node->parent();

--- a/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
@@ -52,7 +52,7 @@ public:
                         resolution_context.length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*context->layout_node());
                     }
 
-                    auto parsedValue = style_value->to_color(layout_node, resolution_context);
+                    auto parsedValue = style_value->to_color(layout_node, resolution_context).value_or(Color::Black);
 
                     // 4. Set this's fill style to parsedValue.
                     my_drawing_state().fill_style = parsedValue;
@@ -105,7 +105,7 @@ public:
                         resolution_context.length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*context->layout_node());
                     }
 
-                    auto parsedValue = style_value->to_color(layout_node, resolution_context);
+                    auto parsedValue = style_value->to_color(layout_node, resolution_context).value_or(Color::Black);
 
                     // 4. Set this's stroke style to parsedValue.
                     my_drawing_state().stroke_style = parsedValue;

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -950,7 +950,7 @@ void CanvasRenderingContext2D::set_shadow_color(String color)
             resolution_context.length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*node);
         }
 
-        auto parsedValue = style_value->to_color(layout_node, resolution_context);
+        auto parsedValue = style_value->to_color(layout_node, resolution_context).value_or(Color::Black);
 
         // 4. Set this's shadow color to parsedValue.
         drawing_state().shadow_color = parsedValue;

--- a/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
@@ -288,7 +288,7 @@ void OffscreenCanvasRenderingContext2D::set_shadow_color(String color)
     // 2. Let parsedValue be the result of parsing the given value with context if non-null.
     auto style_value = parse_css_value(CSS::Parser::ParsingParams(), color, CSS::PropertyID::Color);
     if (style_value && style_value->has_color()) {
-        auto parsedValue = style_value->to_color({}, {});
+        auto parsedValue = style_value->to_color({}, {}).value_or(Color::Black);
 
         // 4. Set this's shadow color to parsedValue.
         drawing_state().shadow_color = parsedValue;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -563,7 +563,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle& node, UsedValues const* co
                 auto containing_block_size_as_length = width ? containing_block_used_values->content_width() : containing_block_used_values->content_height();
                 context.percentage_basis = CSS::Length::make_px(containing_block_size_as_length);
             }
-            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.calculated().resolve_length(context)->to_px(node), size, width));
+            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.calculated().resolve_length_deprecated(context)->to_px(node), size, width));
             return true;
         }
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -835,7 +835,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     do_border_style(computed_values.border_bottom(), CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor, CSS::PropertyID::BorderBottomStyle);
 
     if (auto const& outline_color = computed_style.property(CSS::PropertyID::OutlineColor); outline_color.has_color())
-        computed_values.set_outline_color(outline_color.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }));
+        computed_values.set_outline_color(outline_color.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }).value());
     if (auto const& outline_offset = computed_style.property(CSS::PropertyID::OutlineOffset); outline_offset.is_length())
         computed_values.set_outline_offset(outline_offset.as_length().length());
     computed_values.set_outline_style(computed_style.outline_style());
@@ -875,16 +875,16 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
 
     auto const& fill = computed_style.property(CSS::PropertyID::Fill);
     if (fill.has_color())
-        computed_values.set_fill(fill.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }));
+        computed_values.set_fill(fill.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }).value());
     else if (fill.is_url())
         computed_values.set_fill(fill.as_url().url());
     auto const& stroke = computed_style.property(CSS::PropertyID::Stroke);
     if (stroke.has_color())
-        computed_values.set_stroke(stroke.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }));
+        computed_values.set_stroke(stroke.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }).value());
     else if (stroke.is_url())
         computed_values.set_stroke(stroke.as_url().url());
     if (auto const& stop_color = computed_style.property(CSS::PropertyID::StopColor); stop_color.has_color())
-        computed_values.set_stop_color(stop_color.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }));
+        computed_values.set_stop_color(stop_color.to_color(*this, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }).value());
     auto const& stroke_width = computed_style.property(CSS::PropertyID::StrokeWidth);
     // FIXME: Converting to pixels isn't really correct - values should be in "user units"
     //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -781,14 +781,14 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_transition_delay(transition_delay.time());
     } else if (transition_delay_property.is_calculated()) {
         auto const& transition_delay = transition_delay_property.as_calculated();
-        computed_values.set_transition_delay(transition_delay.resolve_time({ .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }).value());
+        computed_values.set_transition_delay(transition_delay.resolve_time_deprecated({ .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) }).value());
     }
 
     auto resolve_border_width = [&](CSS::PropertyID width_property) -> CSSPixels {
         auto const& value = computed_style.property(width_property);
         if (value.is_calculated())
             return max(CSSPixels { 0 },
-                value.as_calculated().resolve_length({ .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) })->to_px(*this));
+                value.as_calculated().resolve_length_deprecated({ .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this) })->to_px(*this));
         if (value.is_length()) {
             // FIXME: Currently, interpolation can set property values outside of their valid range.
             //        We should instead clamp property values to the valid range when interpolating.

--- a/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -587,7 +587,7 @@ Optional<BordersData> borders_data_for_outline(Layout::Node const& layout_node, 
         // `auto` lets us do whatever we want for the outline. 2px of the accent colour seems reasonable.
         line_style = CSS::LineStyle::Solid;
         // NOTE: CalculationResolutionContext is not required here as Accentcolor keyword value is guaranteed to not rely on it to resolve.
-        outline_color = CSS::CSSKeywordValue::create(CSS::Keyword::Accentcolor)->to_color(*static_cast<Layout::NodeWithStyle const*>(&layout_node), {});
+        outline_color = CSS::CSSKeywordValue::create(CSS::Keyword::Accentcolor)->to_color(*static_cast<Layout::NodeWithStyle const*>(&layout_node), {}).value();
         outline_width = 2;
     } else {
         line_style = CSS::keyword_to_line_style(CSS::to_keyword(outline_style)).value_or(CSS::LineStyle::None);

--- a/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -30,7 +30,7 @@ static ColorStopData resolve_color_stop_positions(Layout::NodeWithStyle const& n
 
     resolved_color_stops.ensure_capacity(expanded_size);
     for (auto& stop : color_stop_list) {
-        auto resolved_stop = Gfx::ColorStop { .color = stop.color_stop.color->to_color(node, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(node) }) };
+        auto resolved_stop = Gfx::ColorStop { .color = stop.color_stop.color->to_color(node, { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(node) }).value() };
         for (int i = 0; i < color_stop_length(stop); i++)
             resolved_color_stops.append(resolved_stop);
     }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-hsl.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-hsl.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 59 tests
 
-41 Pass
-18 Fail
+59 Pass
 Pass	e.style['color'] = "hsl(120 30% 50%)" should set the property value
 Pass	e.style['color'] = "hsl(120 30% 50% / 0.5)" should set the property value
 Pass	e.style['color'] = "hsl(none none none)" should set the property value
@@ -45,21 +44,21 @@ Pass	e.style['color'] = "hsl(calc(0 / 0) 100% 50%)" should set the property valu
 Pass	e.style['color'] = "hsl(90 50% 50% / calc(infinity))" should set the property value
 Pass	e.style['color'] = "hsl(90 50% 50% / calc(-infinity))" should set the property value
 Pass	e.style['color'] = "hsl(90 50% 50% / calc(0 / 0))" should set the property value
-Fail	e.style['color'] = "hsl(calc(50deg + (sign(1em - 10px) * 10deg)), 0%, 0%, 50%)" should set the property value
-Fail	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)), 0%, 0%, 50%)" should set the property value
-Fail	e.style['color'] = "hsl(calc(50 + (sign(1em - 10px) * 10)), 0%, 0%, 50%)" should set the property value
-Fail	e.style['color'] = "hsla(calc(50 + (sign(1em - 10px) * 10)), 0%, 0%, 50%)" should set the property value
-Fail	e.style['color'] = "hsl(0deg, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "hsla(0deg, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "hsl(0, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "hsla(0, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "hsl(calc(50deg + (sign(1em - 10px) * 10deg)) 0% 0% / 50%)" should set the property value
-Fail	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)) 0% 0% / 50%)" should set the property value
-Fail	e.style['color'] = "hsl(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
-Fail	e.style['color'] = "hsla(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
-Fail	e.style['color'] = "hsl(0deg 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "hsla(0deg 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "hsl(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
-Fail	e.style['color'] = "hsla(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
-Fail	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)) -100 300 / 0.5)" should set the property value
-Fail	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)) -100% 300% / 0.5)" should set the property value
+Pass	e.style['color'] = "hsl(calc(50deg + (sign(1em - 10px) * 10deg)), 0%, 0%, 50%)" should set the property value
+Pass	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)), 0%, 0%, 50%)" should set the property value
+Pass	e.style['color'] = "hsl(calc(50 + (sign(1em - 10px) * 10)), 0%, 0%, 50%)" should set the property value
+Pass	e.style['color'] = "hsla(calc(50 + (sign(1em - 10px) * 10)), 0%, 0%, 50%)" should set the property value
+Pass	e.style['color'] = "hsl(0deg, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "hsla(0deg, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "hsl(0, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "hsla(0, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "hsl(calc(50deg + (sign(1em - 10px) * 10deg)) 0% 0% / 50%)" should set the property value
+Pass	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)) 0% 0% / 50%)" should set the property value
+Pass	e.style['color'] = "hsl(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
+Pass	e.style['color'] = "hsla(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
+Pass	e.style['color'] = "hsl(0deg 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "hsla(0deg 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "hsl(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "hsla(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)) -100 300 / 0.5)" should set the property value
+Pass	e.style['color'] = "hsla(calc(50deg + (sign(1em - 10px) * 10deg)) -100% 300% / 0.5)" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-hwb.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-hwb.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 38 tests
 
-34 Pass
-4 Fail
+38 Pass
 Pass	e.style['color'] = "hwb(120 30% 50%)" should set the property value
 Pass	e.style['color'] = "hwb(120 30% 50% / 0.5)" should set the property value
 Pass	e.style['color'] = "hwb(none none none)" should set the property value
@@ -38,7 +37,7 @@ Pass	e.style['color'] = "hwb(calc(0 / 0) 20% 10%)" should set the property value
 Pass	e.style['color'] = "hwb(90 20% 10% / calc(infinity))" should set the property value
 Pass	e.style['color'] = "hwb(90 20% 10% / calc(-infinity))" should set the property value
 Pass	e.style['color'] = "hwb(90 20% 10% / calc(0 / 0))" should set the property value
-Fail	e.style['color'] = "hwb(calc(110deg + (sign(1em - 10px) * 10deg)) 30% 50% / 50%)" should set the property value
-Fail	e.style['color'] = "hwb(calc(110 + (sign(1em - 10px) * 10)) 30 50 / 0.5)" should set the property value
-Fail	e.style['color'] = "hwb(120deg 30% 50% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "hwb(120 30 50 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "hwb(calc(110deg + (sign(1em - 10px) * 10deg)) 30% 50% / 50%)" should set the property value
+Pass	e.style['color'] = "hwb(calc(110 + (sign(1em - 10px) * 10)) 30 50 / 0.5)" should set the property value
+Pass	e.style['color'] = "hwb(120deg 30% 50% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "hwb(120 30 50 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-rgb.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-color/parsing/color-valid-rgb.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 70 tests
 
-48 Pass
-22 Fail
+70 Pass
 Pass	e.style['color'] = "rgb(none none none)" should set the property value
 Pass	e.style['color'] = "rgb(none none none / none)" should set the property value
 Pass	e.style['color'] = "rgb(128 none none)" should set the property value
@@ -52,25 +51,25 @@ Pass	e.style['color'] = "rgb(calc(0 / 0), 0, 0)" should set the property value
 Pass	e.style['color'] = "rgb(0, calc(0 / 0), 0)" should set the property value
 Pass	e.style['color'] = "rgb(0, 0, calc(0 / 0))" should set the property value
 Pass	e.style['color'] = "rgba(0, 0, 0, calc(0 / 0))" should set the property value
-Fail	e.style['color'] = "rgb(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)" should set the property value
-Fail	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)" should set the property value
-Fail	e.style['color'] = "rgb(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)" should set the property value
-Fail	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)" should set the property value
-Fail	e.style['color'] = "rgb(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "rgba(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "rgb(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
-Fail	e.style['color'] = "rgba(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
-Fail	e.style['color'] = "rgb(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)" should set the property value
-Fail	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)" should set the property value
-Fail	e.style['color'] = "rgb(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
-Fail	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
-Fail	e.style['color'] = "rgb(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "rgba(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
-Fail	e.style['color'] = "rgb(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
-Fail	e.style['color'] = "rgba(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
-Fail	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)) 0 0% / 0.5)" should set the property value
-Fail	e.style['color'] = "rgba(0% 0 0% / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
-Fail	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)) 400 -400 / 0.5)" should set the property value
-Fail	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)) 400% -400% / 0.5)" should set the property value
-Fail	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)), 400, -400, 0.5)" should set the property value
-Fail	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)), 400%, -400%, 0.5)" should set the property value
+Pass	e.style['color'] = "rgb(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)" should set the property value
+Pass	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)), 0%, 0%, 50%)" should set the property value
+Pass	e.style['color'] = "rgb(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)" should set the property value
+Pass	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)), 0, 0, 0.5)" should set the property value
+Pass	e.style['color'] = "rgb(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "rgba(0%, 0%, 0%, calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "rgb(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "rgba(0, 0, 0, calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "rgb(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)" should set the property value
+Pass	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)) 0% 0% / 50%)" should set the property value
+Pass	e.style['color'] = "rgb(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
+Pass	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)) 0 0 / 0.5)" should set the property value
+Pass	e.style['color'] = "rgb(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "rgba(0% 0% 0% / calc(50% + (sign(1em - 10px) * 10%)))" should set the property value
+Pass	e.style['color'] = "rgb(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "rgba(0 0 0 / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)) 0 0% / 0.5)" should set the property value
+Pass	e.style['color'] = "rgba(0% 0 0% / calc(0.75 + (sign(1em - 10px) * 0.1)))" should set the property value
+Pass	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)) 400 -400 / 0.5)" should set the property value
+Pass	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)) 400% -400% / 0.5)" should set the property value
+Pass	e.style['color'] = "rgba(calc(50 + (sign(1em - 10px) * 10)), 400, -400, 0.5)" should set the property value
+Pass	e.style['color'] = "rgba(calc(50% + (sign(1em - 10px) * 10%)), 400%, -400%, 0.5)" should set the property value


### PR DESCRIPTION
We now serialize RGB, HSL and HWB colors correctly when we don't have all the required information (e.g. colors such as `rgb(sign(1px - 1em) 0 0 / 0)` that rely on compute-time information in `getPropertyValue()`)

Gains us 44 WPT subtests passes.

As part of this I have marked the existing `CalculatedStyleValue::resolve_*` methods as deprecated and added new ones which are built on top of the (spec adherent) `simplify_a_calculation_tree` algorithm. There is still more work to be done here to port all callers over to these new methods.

See individual commits for more details.