### PR TITLE
LibWeb/CSP: Implement manifest-src, media-src and object-src directives

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/ManifestSourceDirective.cpp
     ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
     ContentSecurityPolicy/Directives/Names.cpp
+    ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp
     ContentSecurityPolicy/Directives/SourceExpression.cpp
     ContentSecurityPolicy/Policy.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/ImageSourceDirective.cpp
     ContentSecurityPolicy/Directives/KeywordSources.cpp
     ContentSecurityPolicy/Directives/ManifestSourceDirective.cpp
+    ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp
     ContentSecurityPolicy/Directives/SourceExpression.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/FrameSourceDirective.cpp
     ContentSecurityPolicy/Directives/ImageSourceDirective.cpp
     ContentSecurityPolicy/Directives/KeywordSources.cpp
+    ContentSecurityPolicy/Directives/ManifestSourceDirective.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp
     ContentSecurityPolicy/Directives/SourceExpression.cpp

--- a/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h
@@ -11,11 +11,11 @@
 namespace Web::ContentSecurityPolicy {
 
 void report_content_security_policy_violations_for_request(JS::Realm&, GC::Ref<Fetch::Infrastructure::Request>);
-[[nodiscard]] Directives::Directive::Result should_request_be_blocked_by_content_security_policy(JS::Realm&, GC::Ref<Fetch::Infrastructure::Request>);
-[[nodiscard]] Directives::Directive::Result should_response_to_request_be_blocked_by_content_security_policy(JS::Realm&, GC::Ref<Fetch::Infrastructure::Response>, GC::Ref<Fetch::Infrastructure::Request>);
+Directives::Directive::Result should_request_be_blocked_by_content_security_policy(JS::Realm&, GC::Ref<Fetch::Infrastructure::Request>);
+Directives::Directive::Result should_response_to_request_be_blocked_by_content_security_policy(JS::Realm&, GC::Ref<Fetch::Infrastructure::Response>, GC::Ref<Fetch::Infrastructure::Request>);
 
-[[nodiscard]] Directives::Directive::Result should_navigation_request_of_type_be_blocked_by_content_security_policy(GC::Ref<Fetch::Infrastructure::Request> navigation_request, Directives::Directive::NavigationType navigation_type);
-[[nodiscard]] Directives::Directive::Result should_navigation_response_to_navigation_request_of_type_in_target_be_blocked_by_content_security_policy(
+Directives::Directive::Result should_navigation_request_of_type_be_blocked_by_content_security_policy(GC::Ref<Fetch::Infrastructure::Request> navigation_request, Directives::Directive::NavigationType navigation_type);
+Directives::Directive::Result should_navigation_response_to_navigation_request_of_type_in_target_be_blocked_by_content_security_policy(
     GC::Ptr<Fetch::Infrastructure::Request> navigation_request,
     GC::Ref<Fetch::Infrastructure::Response> navigation_response,
     GC::Ref<PolicyList> response_csp_list,

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ConnectSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ConnectSourceDirective.h
@@ -18,8 +18,8 @@ class ConnectSourceDirective final : public Directive {
 public:
     virtual ~ConnectSourceDirective() = default;
 
-    [[nodiscard]] virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
-    [[nodiscard]] virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
 
 private:
     ConnectSourceDirective(String name, Vector<String> value);

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/Directive.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/Directive.h
@@ -22,7 +22,7 @@ class Directive : public GC::Cell {
     GC_DECLARE_ALLOCATOR(Directive);
 
 public:
-    enum class Result {
+    enum class [[nodiscard]] Result {
         Blocked,
         Allowed,
     };
@@ -52,44 +52,44 @@ public:
     // 1. A pre-request check, which takes a request and a policy as an argument, and is executed during
     //    § 4.1.2 Should request be blocked by Content Security Policy?. This algorithm returns "Allowed"
     //    unless otherwise specified.
-    [[nodiscard]] virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const { return Result::Allowed; }
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const { return Result::Allowed; }
 
     // https://w3c.github.io/webappsec-csp/#directive-post-request-check
     // 2. A post-request check, which takes a request, a response, and a policy as arguments, and is executed during
     //    § 4.1.3 Should response to request be blocked by Content Security Policy?. This algorithm returns "Allowed"
     //    unless otherwise specified.
-    [[nodiscard]] virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const { return Result::Allowed; }
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const { return Result::Allowed; }
 
     // https://w3c.github.io/webappsec-csp/#directive-inline-check
     // 3. An inline check, which takes an Element, a type string, a policy, and a source string as arguments, and is
     //    executed during § 4.2.3 Should element’s inline type behavior be blocked by Content Security Policy? and
     //    during § 4.2.4 Should navigation request of type be blocked by Content Security Policy? for javascript:
     //    requests. This algorithm returns "Allowed" unless otherwise specified.
-    [[nodiscard]] virtual Result inline_check(GC::Heap&, GC::Ptr<DOM::Element const>, InlineType, GC::Ref<Policy const>, String const&) const { return Result::Allowed; }
+    virtual Result inline_check(GC::Heap&, GC::Ptr<DOM::Element const>, InlineType, GC::Ref<Policy const>, String const&) const { return Result::Allowed; }
 
     // https://w3c.github.io/webappsec-csp/#directive-initialization
     // 4. An initialization, which takes a Document or global object and a policy as arguments. This algorithm is
     //    executed during § 4.2.1 Run CSP initialization for a Document and § 4.2.6 Run CSP initialization for
     //    a global object. Unless otherwise specified, it has no effect and it returns "Allowed".
-    [[nodiscard]] virtual Result initialization(Variant<GC::Ref<DOM::Document const>, GC::Ref<HTML::WorkerGlobalScope const>>, GC::Ref<Policy const>) const { return Result::Allowed; }
+    virtual Result initialization(Variant<GC::Ref<DOM::Document const>, GC::Ref<HTML::WorkerGlobalScope const>>, GC::Ref<Policy const>) const { return Result::Allowed; }
 
     // https://w3c.github.io/webappsec-csp/#directive-pre-navigation-check
     // 5. A pre-navigation check, which takes a request, a navigation type string ("form-submission" or "other")
     //    and a policy as arguments, and is executed during § 4.2.4 Should navigation request of type be blocked by
     //    Content Security Policy?. It returns "Allowed" unless otherwise specified.
-    [[nodiscard]] virtual Result pre_navigation_check(GC::Ref<Fetch::Infrastructure::Request const>, NavigationType, GC::Ref<Policy const>) const { return Result::Allowed; }
+    virtual Result pre_navigation_check(GC::Ref<Fetch::Infrastructure::Request const>, NavigationType, GC::Ref<Policy const>) const { return Result::Allowed; }
 
     // https://w3c.github.io/webappsec-csp/#directive-navigation-response-check
     // 6. A navigation response check, which takes a request, a navigation type string ("form-submission" or "other"),
     //    a response, a navigable, a check type string ("source" or "response"), and a policy as arguments, and is
     //    executed during § 4.2.5 Should navigation response to navigation request of type in target be blocked by
     //    Content Security Policy?. It returns "Allowed" unless otherwise specified.
-    [[nodiscard]] virtual Result navigation_response_check(GC::Ref<Fetch::Infrastructure::Request const>, NavigationType, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<HTML::Navigable const>, CheckType, GC::Ref<Policy const>) const { return Result::Allowed; }
+    virtual Result navigation_response_check(GC::Ref<Fetch::Infrastructure::Request const>, NavigationType, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<HTML::Navigable const>, CheckType, GC::Ref<Policy const>) const { return Result::Allowed; }
 
     // https://w3c.github.io/webappsec-csp/#directive-webrtc-pre-connect-check
     // 7. A webrtc pre-connect check, which takes a policy, and is executed during § 4.3.1 Should RTC connections be
     //    blocked for global?. It returns "Allowed" unless otherwise specified.
-    [[nodiscard]] virtual Result webrtc_pre_connect_check(GC::Ref<Policy const>) const { return Result::Allowed; }
+    virtual Result webrtc_pre_connect_check(GC::Ref<Policy const>) const { return Result::Allowed; }
 
     [[nodiscard]] String const& name() const { return m_name; }
     [[nodiscard]] Vector<String> const& value() const { return m_value; }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/FontSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/FrameSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ImageSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
@@ -28,6 +29,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ImgSrc)
         return heap.allocate<ImageSourceDirective>(move(name), move(value));
+
+    if (name == Names::ManifestSrc)
+        return heap.allocate<ManifestSourceDirective>(move(name), move(value));
 
     return heap.allocate<Directive>(move(name), move(value));
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
 
@@ -36,6 +37,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::MediaSrc)
         return heap.allocate<MediaSourceDirective>(move(name), move(value));
+
+    if (name == Names::ObjectSrc)
+        return heap.allocate<ObjectSourceDirective>(move(name), move(value));
 
     return heap.allocate<Directive>(move(name), move(value));
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/FrameSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ImageSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
@@ -32,6 +33,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ManifestSrc)
         return heap.allocate<ManifestSourceDirective>(move(name), move(value));
+
+    if (name == Names::MediaSrc)
+        return heap.allocate<MediaSourceDirective>(move(name), move(value));
 
     return heap.allocate<Directive>(move(name), move(value));
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
@@ -240,7 +240,7 @@ FlyString get_the_effective_directive_for_inline_checks(Directive::InlineType ty
 //            expression. script-src http: is treated as equivalent to script-src http: https:,
 //            script-src http://example.com to script-src http://example.com https://example.com,
 //            and connect-src ws: to connect-src ws: wss:.
-[[nodiscard]] static MatchResult scheme_part_matches(StringView a, StringView b)
+static MatchResult scheme_part_matches(StringView a, StringView b)
 {
     // 1. If one of the following is true, return "Matches":
     //    1. A is an ASCII case-insensitive match for B.
@@ -273,7 +273,7 @@ FlyString get_the_effective_directive_for_inline_checks(Directive::InlineType ty
 // More formally, ASCII string pattern and host host are said to host-part match if the following algorithm returns "Matches":
 // Spec Note: The matching relation is asymmetric. That is, pattern matching host does not mean that host will match pattern.
 //            For example, *.example.com host-part matches www.example.com, but www.example.com does not host-part match *.example.com.
-[[nodiscard]] static MatchResult host_part_matches(StringView pattern, Optional<URL::Host> const& maybe_host)
+static MatchResult host_part_matches(StringView pattern, Optional<URL::Host> const& maybe_host)
 {
     // 1. If host is not a domain, return "Does Not Match".
     // Spec Note: A future version of this specification may allow literal IPv6 and IPv4 addresses, depending on usage and demand.
@@ -321,7 +321,7 @@ FlyString get_the_effective_directive_for_inline_checks(Directive::InlineType ty
 // An ASCII string input port-part matches URL url if a CSP source expression that contained the first as a port-part
 // could potentially match a URL containing the latter’s port and scheme. For example, "80" port-part matches
 // matches http://example.com.
-[[nodiscard]] static MatchResult port_part_matches(Optional<StringView> input, URL::URL const& url)
+static MatchResult port_part_matches(Optional<StringView> input, URL::URL const& url)
 {
     // FIXME: 1. Assert: input is the empty string, "*", or a sequence of ASCII digits.
 
@@ -367,7 +367,7 @@ FlyString get_the_effective_directive_for_inline_checks(Directive::InlineType ty
 // "/subdirectory/" path-part matches "/subdirectory/file".
 // Spec Note: The matching relation is asymmetric. That is, path A matching path B does not mean that path B will
 //            match path A.
-[[nodiscard]] static MatchResult path_part_matches(StringView a, StringView b)
+static MatchResult path_part_matches(StringView a, StringView b)
 {
     // 1. If path A is the empty string, return "Matches".
     if (a.is_empty())

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h
@@ -14,26 +14,26 @@
 
 namespace Web::ContentSecurityPolicy::Directives {
 
-enum class ShouldExecute {
+enum class [[nodiscard]] ShouldExecute {
     No,
     Yes,
 };
 
-enum class MatchResult {
+enum class [[nodiscard]] MatchResult {
     DoesNotMatch,
     Matches,
 };
 
 [[nodiscard]] Optional<FlyString> get_the_effective_directive_for_request(GC::Ref<Fetch::Infrastructure::Request const> request);
 [[nodiscard]] Vector<StringView> get_fetch_directive_fallback_list(Optional<FlyString> directive_name);
-[[nodiscard]] ShouldExecute should_fetch_directive_execute(Optional<FlyString> effective_directive_name, FlyString const& directive_name, GC::Ref<Policy const> policy);
+ShouldExecute should_fetch_directive_execute(Optional<FlyString> effective_directive_name, FlyString const& directive_name, GC::Ref<Policy const> policy);
 
 [[nodiscard]] FlyString get_the_effective_directive_for_inline_checks(Directive::InlineType type);
 
-[[nodiscard]] MatchResult does_url_match_expression_in_origin_with_redirect_count(URL::URL const& url, String const& expression, URL::Origin const& origin, u8 redirect_count);
-[[nodiscard]] MatchResult does_url_match_source_list_in_origin_with_redirect_count(URL::URL const& url, Vector<String> const& source_list, URL::Origin const& origin, u8 redirect_count);
+MatchResult does_url_match_expression_in_origin_with_redirect_count(URL::URL const& url, String const& expression, URL::Origin const& origin, u8 redirect_count);
+MatchResult does_url_match_source_list_in_origin_with_redirect_count(URL::URL const& url, Vector<String> const& source_list, URL::Origin const& origin, u8 redirect_count);
 
-[[nodiscard]] MatchResult does_request_match_source_list(GC::Ref<Fetch::Infrastructure::Request const> request, Vector<String> const& source_list, GC::Ref<Policy const> policy);
-[[nodiscard]] MatchResult does_response_match_source_list(GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Fetch::Infrastructure::Request const> request, Vector<String> const& source_list, GC::Ref<Policy const> policy);
+MatchResult does_request_match_source_list(GC::Ref<Fetch::Infrastructure::Request const> request, Vector<String> const& source_list, GC::Ref<Policy const> policy);
+MatchResult does_response_match_source_list(GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Fetch::Infrastructure::Request const> request, Vector<String> const& source_list, GC::Ref<Policy const> policy);
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/FontSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/FontSourceDirective.h
@@ -18,8 +18,8 @@ class FontSourceDirective final : public Directive {
 public:
     virtual ~FontSourceDirective() = default;
 
-    [[nodiscard]] virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
-    [[nodiscard]] virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
 
 private:
     FontSourceDirective(String name, Vector<String> value);

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/FrameSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/FrameSourceDirective.h
@@ -18,8 +18,8 @@ class FrameSourceDirective final : public Directive {
 public:
     virtual ~FrameSourceDirective() = default;
 
-    [[nodiscard]] virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
-    [[nodiscard]] virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
 
 private:
     FrameSourceDirective(String name, Vector<String> value);

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ImageSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ImageSourceDirective.h
@@ -18,8 +18,8 @@ class ImageSourceDirective final : public Directive {
 public:
     virtual ~ImageSourceDirective() = default;
 
-    [[nodiscard]] virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
-    [[nodiscard]] virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
 
 private:
     ImageSourceDirective(String name, Vector<String> value);

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(ManifestSourceDirective);
+
+ManifestSourceDirective::ManifestSourceDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#manifest-src-pre-request
+Directive::Result ManifestSourceDirective::pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, manifest-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ManifestSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. If the result of executing § 6.7.2.5 Does request match source list? on request, this directive’s value,
+    //    and policy, is "Does Not Match", return "Blocked".
+    if (does_request_match_source_list(request, value(), policy) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 4. Return "Allowed".
+    return Result::Allowed;
+}
+
+// https://w3c.github.io/webappsec-csp/#manifest-src-post-request
+Directive::Result ManifestSourceDirective::post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, manifest-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ManifestSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. If the result of executing § 6.7.2.6 Does response to request match source list? on response, request, this
+    //    directive’s value, and policy, is "Does Not Match", return "Blocked".
+    if (does_response_match_source_list(response, request, value(), policy) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 4. Return "Allowed".
+    return Result::Allowed;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ManifestSourceDirective.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-manifest-src
+class ManifestSourceDirective final : public Directive {
+    GC_CELL(ManifestSourceDirective, Directive)
+    GC_DECLARE_ALLOCATOR(ManifestSourceDirective);
+
+public:
+    virtual ~ManifestSourceDirective() = default;
+
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+
+private:
+    ManifestSourceDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(MediaSourceDirective);
+
+MediaSourceDirective::MediaSourceDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#media-src-pre-request
+Directive::Result MediaSourceDirective::pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, media-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::MediaSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. If the result of executing § 6.7.2.5 Does request match source list? on request, this directive’s value,
+    //    and policy, is "Does Not Match", return "Blocked".
+    if (does_request_match_source_list(request, value(), policy) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 4. Return "Allowed".
+    return Result::Allowed;
+}
+
+// https://w3c.github.io/webappsec-csp/#media-src-post-request
+Directive::Result MediaSourceDirective::post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, media-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::MediaSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. If the result of executing § 6.7.2.6 Does response to request match source list? on response, request, this
+    //    directive’s value, and policy, is "Does Not Match", return "Blocked".
+    if (does_response_match_source_list(response, request, value(), policy) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 4. Return "Allowed".
+    return Result::Allowed;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-media-src
+class MediaSourceDirective final : public Directive {
+    GC_CELL(MediaSourceDirective, Directive)
+    GC_DECLARE_ALLOCATOR(MediaSourceDirective);
+
+public:
+    virtual ~MediaSourceDirective() = default;
+
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+
+private:
+    MediaSourceDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(ObjectSourceDirective);
+
+ObjectSourceDirective::ObjectSourceDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#object-src-pre-request
+Directive::Result ObjectSourceDirective::pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, object-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ObjectSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. If the result of executing § 6.7.2.5 Does request match source list? on request, this directive’s value,
+    //    and policy, is "Does Not Match", return "Blocked".
+    if (does_request_match_source_list(request, value(), policy) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 4. Return "Allowed".
+    return Result::Allowed;
+}
+
+// https://w3c.github.io/webappsec-csp/#object-src-post-request
+Directive::Result ObjectSourceDirective::post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, object-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ObjectSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. If the result of executing § 6.7.2.6 Does response to request match source list? on response, request, this
+    //    directive’s value, and policy, is "Does Not Match", return "Blocked".
+    if (does_response_match_source_list(response, request, value(), policy) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 4. Return "Allowed".
+    return Result::Allowed;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-object-src
+class ObjectSourceDirective final : public Directive {
+    GC_CELL(ObjectSourceDirective, Directive)
+    GC_DECLARE_ALLOCATOR(ObjectSourceDirective);
+
+public:
+    virtual ~ObjectSourceDirective() = default;
+
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+
+private:
+    ObjectSourceDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -136,6 +136,7 @@ class FontSourceDirective;
 class FrameSourceDirective;
 class ImageSourceDirective;
 class ManifestSourceDirective;
+class MediaSourceDirective;
 struct SerializedDirective;
 
 }

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -135,6 +135,7 @@ class Directive;
 class FontSourceDirective;
 class FrameSourceDirective;
 class ImageSourceDirective;
+class ManifestSourceDirective;
 struct SerializedDirective;
 
 }

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -137,6 +137,7 @@ class FrameSourceDirective;
 class ImageSourceDirective;
 class ManifestSourceDirective;
 class MediaSourceDirective;
+class ObjectSourceDirective;
 struct SerializedDirective;
 
 }


### PR DESCRIPTION
Part 9 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854

A few more simple directives before introducing the more complex script-src directives.