### PR TITLE
RequestServer: Wait until initial connection is open for multiplexing

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -487,6 +487,7 @@ void ConnectionFromClient::start_request(i32 request_id, ByteString method, URL:
             set_option(CURLOPT_URL, url.to_string().to_byte_string().characters());
             set_option(CURLOPT_PORT, url.port_or_default());
             set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
+            set_option(CURLOPT_PIPEWAIT, 1L);
 
             bool did_set_body = false;
 


### PR DESCRIPTION
By default, if multiple requests start to a newly seen origin, curl will not wait for a connection to open to figure out if the server supports multiplexing and will instead open a new connection for each request (including a new TLS session and such)

This is particularly an issue for initial page load, where a complex website could, for example, request tens of items at once (e.g. a bunch of scripts).

We can be kinder to servers that support multiplexing by telling curl to wait till an initial connection is established to determine if multiplexing is supported.

On my machine and internet connection, this reduces the amount of connections to github.githubassets.com on initial load of https://github.com/LadybirdBrowser/ladybird from 12 to 2.

Pcap files (extension changed from pcapng to txt to allow uploading to GitHub)
[before_pipewait.txt](https://github.com/user-attachments/files/21076973/before_pipewait.txt)
[after_pipewait.txt](https://github.com/user-attachments/files/21076977/after_pipewait.txt)
