### PR TITLE
LibWeb: Add missing ValueInlines include to CanvasSettings.cpp

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasSettings.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasSettings.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/FlyString.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/HTML/Canvas/CanvasSettings.h>
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2dsettings


### PR DESCRIPTION
This missing include is causing an error in distribution builds.