### PR TITLE
LibWeb/CSP+LibJS: Implement the script-src directive

### DIFF
--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -209,9 +209,6 @@ public:
         bool try_parse_arrow_function_expression_failed;
     };
 
-    // Needs to mess with m_state, and we're not going to expose a non-const getter for that :^)
-    friend ThrowCompletionOr<GC::Ref<ECMAScriptFunctionObject>> FunctionConstructor::create_dynamic_function(VM&, FunctionObject&, FunctionObject*, FunctionKind, ReadonlySpan<String> parameter_args, String const& body_arg);
-
     static Parser parse_function_body_from_string(ByteString const& body_string, u16 parse_options, NonnullRefPtr<FunctionParameters const>, FunctionKind kind, FunctionParsingInsights&);
 
 private:

--- a/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/AsyncGeneratorFunctionConstructor.cpp
@@ -42,15 +42,22 @@ ThrowCompletionOr<GC::Ref<Object>> AsyncGeneratorFunctionConstructor::construct(
 {
     auto& vm = this->vm();
 
+    ReadonlySpan<Value> arguments = vm.running_execution_context().arguments;
+
+    ReadonlySpan<Value> parameter_args = arguments;
+    if (!parameter_args.is_empty())
+        parameter_args = parameter_args.slice(0, parameter_args.size() - 1);
+
     // 1. Let C be the active function object.
     auto* constructor = vm.active_function_object();
 
     // 2. If bodyArg is not present, set bodyArg to the empty String.
-    // NOTE: This does that, as well as the string extraction done inside of CreateDynamicFunction
-    auto extracted = TRY(extract_parameter_arguments_and_body(vm, vm.running_execution_context().arguments));
+    Value body_arg = &vm.empty_string();
+    if (!arguments.is_empty())
+        body_arg = arguments.last();
 
     // 3. Return ? CreateDynamicFunction(C, NewTarget, async-generator, parameterArgs, bodyArg).
-    return TRY(FunctionConstructor::create_dynamic_function(vm, *constructor, &new_target, FunctionKind::AsyncGenerator, extracted.parameters, extracted.body));
+    return TRY(FunctionConstructor::create_dynamic_function(vm, *constructor, &new_target, FunctionKind::AsyncGenerator, parameter_args, body_arg));
 }
 
 }

--- a/Libraries/LibJS/Runtime/FunctionConstructor.h
+++ b/Libraries/LibJS/Runtime/FunctionConstructor.h
@@ -11,19 +11,12 @@
 
 namespace JS {
 
-struct ParameterArgumentsAndBody {
-    Vector<String> parameters;
-    String body;
-};
-
-JS_API ThrowCompletionOr<ParameterArgumentsAndBody> extract_parameter_arguments_and_body(VM&, Span<Value> arguments);
-
 class JS_API FunctionConstructor final : public NativeFunction {
     JS_OBJECT(FunctionConstructor, NativeFunction);
     GC_DECLARE_ALLOCATOR(FunctionConstructor);
 
 public:
-    static ThrowCompletionOr<GC::Ref<ECMAScriptFunctionObject>> create_dynamic_function(VM&, FunctionObject& constructor, FunctionObject* new_target, FunctionKind kind, ReadonlySpan<String> parameter_args, String const& body_string);
+    static ThrowCompletionOr<GC::Ref<ECMAScriptFunctionObject>> create_dynamic_function(VM&, FunctionObject& constructor, FunctionObject* new_target, FunctionKind kind, ReadonlySpan<Value> parameter_args, Value body_arg);
 
     virtual void initialize(Realm&) override;
     virtual ~FunctionConstructor() override = default;

--- a/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
@@ -40,15 +40,22 @@ ThrowCompletionOr<GC::Ref<Object>> GeneratorFunctionConstructor::construct(Funct
 {
     auto& vm = this->vm();
 
+    ReadonlySpan<Value> arguments = vm.running_execution_context().arguments;
+
+    ReadonlySpan<Value> parameter_args = arguments;
+    if (!parameter_args.is_empty())
+        parameter_args = parameter_args.slice(0, parameter_args.size() - 1);
+
     // 1. Let C be the active function object.
     auto* constructor = vm.active_function_object();
 
     // 2. If bodyArg is not present, set bodyArg to the empty String.
-    // NOTE: This does that, as well as the string extraction done inside of CreateDynamicFunction
-    auto extracted = TRY(extract_parameter_arguments_and_body(vm, vm.running_execution_context().arguments));
+    Value body_arg = &vm.empty_string();
+    if (!arguments.is_empty())
+        body_arg = arguments.last();
 
     // 3. Return ? CreateDynamicFunction(C, NewTarget, generator, parameterArgs, bodyArg).
-    return TRY(FunctionConstructor::create_dynamic_function(vm, *constructor, &new_target, FunctionKind::Generator, extracted.parameters, extracted.body));
+    return TRY(FunctionConstructor::create_dynamic_function(vm, *constructor, &new_target, FunctionKind::Generator, parameter_args, body_arg));
 }
 
 }

--- a/Libraries/LibJS/Runtime/ShadowRealm.h
+++ b/Libraries/LibJS/Runtime/ShadowRealm.h
@@ -34,7 +34,7 @@ private:
 };
 
 ThrowCompletionOr<void> copy_name_and_length(VM&, FunctionObject& function, FunctionObject& target, Optional<StringView> prefix = {}, Optional<unsigned> arg_count = {});
-ThrowCompletionOr<Value> perform_shadow_realm_eval(VM&, StringView source_text, Realm& caller_realm, Realm& eval_realm);
+ThrowCompletionOr<Value> perform_shadow_realm_eval(VM&, Value source, Realm& caller_realm, Realm& eval_realm);
 ThrowCompletionOr<Value> shadow_realm_import_value(VM&, String specifier_string, String export_name_string, Realm& caller_realm, Realm& eval_realm);
 ThrowCompletionOr<Value> get_wrapped_value(VM&, Realm& caller_realm, Value);
 NonnullOwnPtr<ExecutionContext> get_shadow_realm_context(Realm& shadow_realm, bool strict_eval, u32 registers_and_constants_and_locals_count);

--- a/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ShadowRealmPrototype.cpp
@@ -41,8 +41,7 @@ JS_DEFINE_NATIVE_FUNCTION(ShadowRealmPrototype::evaluate)
     auto object = TRY(typed_this_object(vm));
 
     // 3. If Type(sourceText) is not String, throw a TypeError exception.
-    if (!source_text.is_string())
-        return vm.throw_completion<TypeError>(ErrorType::NotAString, source_text);
+    // FIXME: This step is intentionally skipped, see perform_shadow_realm_eval.
 
     // 4. Let callerRealm be the current Realm Record.
     auto* caller_realm = vm.current_realm();
@@ -51,7 +50,7 @@ JS_DEFINE_NATIVE_FUNCTION(ShadowRealmPrototype::evaluate)
     auto& eval_realm = object->shadow_realm();
 
     // 6. Return ? PerformShadowRealmEval(sourceText, callerRealm, evalRealm).
-    return perform_shadow_realm_eval(vm, source_text.as_string().utf8_string_view(), *caller_realm, eval_realm);
+    return perform_shadow_realm_eval(vm, source_text, *caller_realm, eval_realm);
 }
 
 // 3.4.2 ShadowRealm.prototype.importValue ( specifier, exportName ), https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.importvalue

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -124,8 +124,20 @@ VM::VM(ErrorMessages error_messages)
         return Vector<String> { "type"_string };
     };
 
-    // 19.2.1.2 HostEnsureCanCompileStrings ( calleeRealm, parameterStrings, bodyString, direct ), https://tc39.es/ecma262/#sec-hostensurecancompilestrings
-    host_ensure_can_compile_strings = [](Realm&, ReadonlySpan<String>, StringView, EvalMode) -> ThrowCompletionOr<void> {
+    // 1 HostGetCodeForEval ( argument ), https://tc39.es/proposal-dynamic-code-brand-checks/#sec-hostgetcodeforeval
+    host_get_code_for_eval = [](Object const&) -> GC::Ptr<PrimitiveString> {
+        // The host-defined abstract operation HostGetCodeForEval takes argument argument (an Object) and returns a
+        // String or NO-CODE. It allows host environments to return a String of code from argument to be used by eval,
+        // rather than eval returning argument.
+        //
+        // argument represents the Object to be checked for code.
+        //
+        // The default implementation of HostGetCodeForEval is to return NO-CODE.
+        return {};
+    };
+
+    // 2 HostEnsureCanCompileStrings ( calleeRealm, parameterStrings, bodyString, codeString, compilationType, parameterArgs, bodyArg ), https://tc39.es/proposal-dynamic-code-brand-checks/#sec-hostensurecancompilestrings
+    host_ensure_can_compile_strings = [](Realm&, ReadonlySpan<String>, StringView, StringView, CompilationType, ReadonlySpan<Value>, Value) -> ThrowCompletionOr<void> {
         // The host-defined abstract operation HostEnsureCanCompileStrings takes arguments calleeRealm (a Realm Record),
         // parameterStrings (a List of Strings), bodyString (a String), and direct (a Boolean) and returns either a normal
         // completion containing unused or a throw completion.

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -49,6 +49,7 @@ enum class CompilationType {
     DirectEval,
     IndirectEval,
     Function,
+    Timer,
 };
 
 class JS_API VM : public RefCounted<VM> {

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -45,6 +45,12 @@ enum class EvalMode {
     Indirect
 };
 
+enum class CompilationType {
+    DirectEval,
+    IndirectEval,
+    Function,
+};
+
 class JS_API VM : public RefCounted<VM> {
 public:
     static NonnullRefPtr<VM> create();
@@ -284,7 +290,8 @@ public:
     Function<void(FinalizationRegistry&)> host_enqueue_finalization_registry_cleanup_job;
     Function<void(GC::Ref<GC::Function<ThrowCompletionOr<Value>()>>, Realm*)> host_enqueue_promise_job;
     Function<GC::Ref<JobCallback>(FunctionObject&)> host_make_job_callback;
-    Function<ThrowCompletionOr<void>(Realm&, ReadonlySpan<String>, StringView, EvalMode)> host_ensure_can_compile_strings;
+    Function<GC::Ptr<PrimitiveString>(Object const&)> host_get_code_for_eval;
+    Function<ThrowCompletionOr<void>(Realm&, ReadonlySpan<String>, StringView, StringView, CompilationType, ReadonlySpan<Value>, Value)> host_ensure_can_compile_strings;
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
     Function<ThrowCompletionOr<HandledByHost>(ArrayBuffer&, size_t)> host_resize_array_buffer;
     Function<void(StringView)> host_unrecognized_date_string;

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -25,6 +25,9 @@
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Bindings/SyntheticHostDefined.h>
 #include <LibWeb/Bindings/WindowExposedInterfaces.h>
+#include <LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/CustomElements/CustomElementDefinition.h>
 #include <LibWeb/HTML/EventNames.h>
@@ -114,7 +117,19 @@ void initialize_main_thread_vm(AgentType type)
         return {};
     };
 
-    // FIXME: Implement 8.1.5.2 HostEnsureCanCompileStrings(callerRealm, calleeRealm), https://html.spec.whatwg.org/multipage/webappapis.html#hostensurecancompilestrings(callerrealm,-calleerealm)
+    // 8.1.6.2 HostEnsureCanCompileStrings(realm, parameterStrings, bodyString, codeString, compilationType, parameterArgs, bodyArg), https://html.spec.whatwg.org/multipage/webappapis.html#hostensurecancompilestrings(realm,-parameterstrings,-bodystring,-codestring,-compilationtype,-parameterargs,-bodyarg)
+    s_main_thread_vm->host_ensure_can_compile_strings = [](JS::Realm& realm, ReadonlySpan<String> parameter_strings, StringView body_string, StringView code_string, JS::CompilationType compilation_type, ReadonlySpan<JS::Value> parameter_args, JS::Value body_arg) -> JS::ThrowCompletionOr<void> {
+        // 1. Perform ? EnsureCSPDoesNotBlockStringCompilation(realm, parameterStrings, bodyString, codeString, compilationType, parameterArgs, bodyArg). [CSP]
+        return ContentSecurityPolicy::ensure_csp_does_not_block_string_compilation(realm, parameter_strings, body_string, code_string, compilation_type, parameter_args, body_arg);
+    };
+
+    // 8.1.6.3 HostGetCodeForEval(argument), https://html.spec.whatwg.org/multipage/webappapis.html#hostgetcodeforeval(argument)
+    s_main_thread_vm->host_get_code_for_eval = [](JS::Object const&) -> GC::Ptr<JS::PrimitiveString> {
+        // FIXME: 1. If argument is a TrustedScript object, then return argument's data.
+
+        // 2. Otherwise, return no-code.
+        return {};
+    };
 
     // 8.1.5.3 HostPromiseRejectionTracker(promise, operation), https://html.spec.whatwg.org/multipage/webappapis.html#the-hostpromiserejectiontracker-implementation
     // https://whatpr.org/html/9893/webappapis.html#the-hostpromiserejectiontracker-implementation

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
+    ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp
     ContentSecurityPolicy/Directives/SourceExpression.cpp
     ContentSecurityPolicy/Policy.cpp

--- a/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.cpp
@@ -6,11 +6,16 @@
 
 #include <LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/KeywordSources.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
 #include <LibWeb/ContentSecurityPolicy/Violation.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/Infra/Strings.h>
+#include <LibWeb/WebAssembly/WebAssembly.h>
 
 namespace Web::ContentSecurityPolicy {
 
@@ -320,6 +325,235 @@ Directives::Directive::Result should_navigation_response_to_navigation_request_o
 
     // 4. Return result.
     return result;
+}
+
+// https://w3c.github.io/webappsec-csp/#should-block-inline
+Directives::Directive::Result should_elements_inline_type_behavior_be_blocked_by_content_security_policy(JS::Realm& realm, GC::Ref<DOM::Element> element, Directives::Directive::InlineType type, String const& source)
+{
+    // Spec Note: The valid values for type are "script", "script attribute", "style", and "style attribute".
+    VERIFY(type == Directives::Directive::InlineType::Script || type == Directives::Directive::InlineType::ScriptAttribute || type == Directives::Directive::InlineType::Style || type == Directives::Directive::InlineType::StyleAttribute);
+
+    // 1. Assert: element is not null.
+    // NOTE: Already done by only accepting a GC::Ref.
+
+    // 2. Let result be "Allowed".
+    auto result = Directives::Directive::Result::Allowed;
+
+    // 3. For each policy of element’s Document's global object’s CSP list:
+    auto& global_object = element->document().realm().global_object();
+    auto csp_list = PolicyList::from_object(global_object);
+    VERIFY(csp_list);
+
+    for (auto const policy : csp_list->policies()) {
+        // 1. For each directive of policy’s directive set:
+        for (auto const directive : policy->directives()) {
+            // 1. If directive’s inline check returns "Allowed" when executed upon element, type, policy and source,
+            //    skip to the next directive.
+            if (directive->inline_check(realm.heap(), element, type, policy, source) == Directives::Directive::Result::Allowed)
+                continue;
+
+            // 2. Let directive-name be the result of executing § 6.8.2 Get the effective directive for inline checks
+            //    on type.
+            auto directive_name = Directives::get_the_effective_directive_for_inline_checks(type);
+
+            // 3. Otherwise, let violation be the result of executing § 2.4.1 Create a violation object for global,
+            //   policy, and directive on the current settings object’s global object, policy, and directive-name.
+            // FIXME: File spec issue about using "current settings object" here, as it can run outside of a script
+            //        context (for example, a just parsed inline script being prepared)
+            auto violation = Violation::create_a_violation_object_for_global_policy_and_directive(realm, global_object, policy, directive_name.to_string());
+
+            // 4. Set violation’s resource to "inline".
+            violation->set_resource(Violation::Resource::Inline);
+
+            // 5. Set violation’s element to element.
+            violation->set_element(element);
+
+            // 6. If directive’s value contains the expression "'report-sample'", then set violation’s sample to the
+            //    substring of source containing its first 40 characters.
+            // FIXME: Should this be case insensitive?
+            auto maybe_report_sample = directive->value().find_if([](auto const& directive_value) {
+                return directive_value.equals_ignoring_ascii_case(Directives::KeywordSources::ReportSample);
+            });
+
+            if (!maybe_report_sample.is_end()) {
+                Utf8View source_view { source };
+                auto sample = source_view.unicode_substring_view(0, min(source_view.length(), 40));
+                violation->set_sample(String::from_utf8_without_validation(sample.as_string().bytes()));
+            }
+
+            // 7. Execute § 5.5 Report a violation on violation.
+            violation->report_a_violation(realm);
+
+            // 8. If policy’s disposition is "enforce", then set result to "Blocked".
+            if (policy->disposition() == Policy::Disposition::Enforce) {
+                result = Directives::Directive::Result::Blocked;
+            }
+        }
+    }
+
+    // 4. Return result.
+    return result;
+}
+
+// https://w3c.github.io/webappsec-csp/#can-compile-strings
+JS::ThrowCompletionOr<void> ensure_csp_does_not_block_string_compilation(JS::Realm& realm, ReadonlySpan<String>, StringView, StringView code_string, JS::CompilationType, ReadonlySpan<JS::Value>, JS::Value)
+{
+    // FIXME: 1. If compilationType is "TIMER", then:
+    //           1. Let sourceString be codeString.
+    StringView source_string = code_string;
+    // FIXME: 2. Else:
+    // FIXME: We don't do these two steps as we don't currently support Trusted Types.
+
+    // 3. Let result be "Allowed".
+    auto result = Directives::Directive::Result::Allowed;
+
+    // 4. Let global be realm’s global object.
+    auto& global = realm.global_object();
+
+    // 5. For each policy of global’s CSP list:
+    auto csp_list = PolicyList::from_object(global);
+    VERIFY(csp_list);
+    for (auto const policy : csp_list->policies()) {
+        // 1. Let source-list be null.
+        Optional<Vector<String>> maybe_source_list;
+
+        // 2. If policy contains a directive whose name is "script-src", then set source-list to that directive's value.
+        auto maybe_script_src = policy->directives().find_if([](auto const& directive) {
+            return directive->name() == Directives::Names::ScriptSrc;
+        });
+
+        if (!maybe_script_src.is_end()) {
+            maybe_source_list = (*maybe_script_src)->value();
+        } else {
+            //   Otherwise if policy contains a directive whose name is "default-src", then set source-list to that
+            //   directive’s value.
+            auto maybe_default_src = policy->directives().find_if([](auto const& directive) {
+                return directive->name() == Directives::Names::DefaultSrc;
+            });
+
+            if (!maybe_default_src.is_end())
+                maybe_source_list = (*maybe_default_src)->value();
+        }
+
+        // 3. If source-list is not null, and does not contain a source expression which is an ASCII case-insensitive
+        //    match for the string "'unsafe-eval'", then:
+        if (maybe_source_list.has_value()) {
+            auto const& source_list = maybe_source_list.value();
+
+            auto maybe_unsafe_eval = source_list.find_if([](auto const& directive_value) {
+                return directive_value.equals_ignoring_ascii_case(Directives::KeywordSources::UnsafeEval);
+            });
+
+            if (maybe_unsafe_eval.is_end()) {
+                // 1. Let violation be the result of executing § 2.4.1 Create a violation object for global, policy,
+                //    and directive on global, policy, and "script-src".
+                auto script_src_string = Directives::Names::ScriptSrc.to_string();
+                auto violation = Violation::create_a_violation_object_for_global_policy_and_directive(realm, global, policy, script_src_string);
+
+                // 2. Set violation’s resource to "eval".
+                violation->set_resource(Violation::Resource::Eval);
+
+                // 3. If source-list contains the expression "'report-sample'", then set violation’s sample to the
+                //    substring of sourceString containing its first 40 characters.
+                // FIXME: Should this be case insensitive?
+                auto maybe_report_sample = source_list.find_if([](auto const& directive_value) {
+                    return directive_value.equals_ignoring_ascii_case(Directives::KeywordSources::ReportSample);
+                });
+
+                if (!maybe_report_sample.is_end()) {
+                    Utf8View source_view { source_string };
+                    auto sample = source_view.unicode_substring_view(0, min(source_view.length(), 40));
+                    violation->set_sample(String::from_utf8_without_validation(sample.as_string().bytes()));
+                }
+
+                // 4. Execute § 5.5 Report a violation on violation.
+                violation->report_a_violation(realm);
+
+                // 5. If policy’s disposition is "enforce", then set result to "Blocked".
+                if (policy->disposition() == Policy::Disposition::Enforce)
+                    result = Directives::Directive::Result::Blocked;
+            }
+        }
+    }
+
+    // 6. If result is "Blocked", throw an EvalError exception.
+    if (result == Directives::Directive::Result::Blocked) {
+        return realm.vm().throw_completion<JS::EvalError>("Blocked by Content Security Policy"sv);
+    }
+
+    return {};
+}
+
+// https://w3c.github.io/webappsec-csp/#can-compile-wasm-bytes
+JS::ThrowCompletionOr<void> ensure_csp_does_not_block_wasm_byte_compilation(JS::Realm& realm)
+{
+    // 1. Let global be realm’s global object.
+    auto& global = realm.global_object();
+
+    // 2. Let result be "Allowed".
+    auto result = Directives::Directive::Result::Allowed;
+
+    // 3. For each policy of global’s CSP list:
+    auto csp_list = PolicyList::from_object(global);
+    VERIFY(csp_list);
+    for (auto const policy : csp_list->policies()) {
+        // 1. Let source-list be null.
+        Optional<Vector<String>> maybe_source_list;
+
+        // 2. If policy contains a directive whose name is "script-src", then set source-list to that directive's value.
+        auto maybe_script_src = policy->directives().find_if([](auto const& directive) {
+            return directive->name() == Directives::Names::ScriptSrc;
+        });
+
+        if (!maybe_script_src.is_end()) {
+            maybe_source_list = (*maybe_script_src)->value();
+        } else {
+            //   Otherwise if policy contains a directive whose name is "default-src", then set source-list to that
+            //   directive’s value.
+            auto maybe_default_src = policy->directives().find_if([](auto const& directive) {
+                return directive->name() == Directives::Names::DefaultSrc;
+            });
+
+            if (!maybe_default_src.is_end())
+                maybe_source_list = (*maybe_default_src)->value();
+        }
+
+        // 3. If source-list is non-null, and does not contain a source expression which is an ASCII case-insensitive
+        //    match for the string "'unsafe-eval'", and does not contain a source expression which is an ASCII
+        //    case-insensitive match for the string "'wasm-unsafe-eval'", then:
+        if (maybe_source_list.has_value()) {
+            auto const& source_list = maybe_source_list.value();
+
+            auto maybe_unsafe_eval = source_list.find_if([](auto const& directive_value) {
+                return directive_value.equals_ignoring_ascii_case(Directives::KeywordSources::UnsafeEval)
+                    || directive_value.equals_ignoring_ascii_case(Directives::KeywordSources::WasmUnsafeEval);
+            });
+
+            if (maybe_unsafe_eval.is_end()) {
+                // 1. Let violation be the result of executing § 2.4.1 Create a violation object for global, policy,
+                //    and directive on global, policy, and "script-src".
+                auto script_src_string = Directives::Names::ScriptSrc.to_string();
+                auto violation = Violation::create_a_violation_object_for_global_policy_and_directive(realm, global, policy, script_src_string);
+
+                // 2. Set violation’s resource to "wasm-eval".
+                violation->set_resource(Violation::Resource::WasmEval);
+
+                // 3. Execute § 5.5 Report a violation on violation.
+                violation->report_a_violation(realm);
+
+                // 4. If policy’s disposition is "enforce", then set result to "Blocked".
+                if (policy->disposition() == Policy::Disposition::Enforce)
+                    result = Directives::Directive::Result::Blocked;
+            }
+        }
+    }
+
+    // 4. If result is "Blocked", throw a WebAssembly.CompileError exception.
+    if (result == Directives::Directive::Result::Blocked) {
+        return realm.vm().throw_completion<WebAssembly::CompileError>("Blocked by Content Security Policy"sv);
+    }
+
+    return {};
 }
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Runtime/VM.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
 
 namespace Web::ContentSecurityPolicy {
@@ -21,5 +22,9 @@ Directives::Directive::Result should_navigation_response_to_navigation_request_o
     GC::Ref<PolicyList> response_csp_list,
     Directives::Directive::NavigationType navigation_type,
     GC::Ref<HTML::Navigable> target);
+
+Directives::Directive::Result should_elements_inline_type_behavior_be_blocked_by_content_security_policy(JS::Realm&, GC::Ref<DOM::Element> element, Directives::Directive::InlineType type, String const& source);
+JS::ThrowCompletionOr<void> ensure_csp_does_not_block_string_compilation(JS::Realm& realm, ReadonlySpan<String> parameter_strings, StringView body_string, StringView code_string, JS::CompilationType compilation_type, ReadonlySpan<JS::Value> parameter_args, JS::Value body_arg);
+JS::ThrowCompletionOr<void> ensure_csp_does_not_block_wasm_byte_compilation(JS::Realm&);
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
 
@@ -40,6 +41,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ObjectSrc)
         return heap.allocate<ObjectSourceDirective>(move(name), move(value));
+
+    if (name == Names::ScriptSrc)
+        return heap.allocate<ScriptSourceDirective>(move(name), move(value));
 
     return heap.allocate<Directive>(move(name), move(value));
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h
@@ -35,5 +35,11 @@ MatchResult does_url_match_source_list_in_origin_with_redirect_count(URL::URL co
 
 MatchResult does_request_match_source_list(GC::Ref<Fetch::Infrastructure::Request const> request, Vector<String> const& source_list, GC::Ref<Policy const> policy);
 MatchResult does_response_match_source_list(GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Fetch::Infrastructure::Request const> request, Vector<String> const& source_list, GC::Ref<Policy const> policy);
+MatchResult does_nonce_match_source_list(String const& nonce, Vector<String> const& source_list);
+
+Directive::Result script_directives_pre_request_check(GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Directive const> directive, GC::Ref<Policy const> policy);
+Directive::Result script_directives_post_request_check(GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Directive const> directive, GC::Ref<Policy const> policy);
+
+MatchResult does_element_match_source_list_for_type_and_source(GC::Ptr<DOM::Element const> element, Vector<String> const& source_list, Directive::InlineType type, String const& source);
 
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(ScriptSourceDirective);
+
+ScriptSourceDirective::ScriptSourceDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#script-src-pre-request
+Directive::Result ScriptSourceDirective::pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, script-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ScriptSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. Return the result of executing § 6.7.1.1 Script directives pre-request check on request, this directive,
+    //    and policy.
+    return script_directives_pre_request_check(request, *this, policy);
+}
+
+// https://w3c.github.io/webappsec-csp/#script-src-post-request
+Directive::Result ScriptSourceDirective::post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, script-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ScriptSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. Return the result of executing § 6.7.1.2 Script directives post-request check on request, response, this
+    //    directive, and policy.
+    return script_directives_post_request_check(request, response, *this, policy);
+}
+
+// https://w3c.github.io/webappsec-csp/#script-src-inline
+Directive::Result ScriptSourceDirective::inline_check(GC::Heap&, GC::Ptr<DOM::Element const> element, InlineType type, GC::Ref<Policy const> policy, String const& source) const
+{
+    // 1. Assert: element is not null or type is "navigation".
+    VERIFY(element || type == InlineType::Navigation);
+
+    // 2. Let name be the result of executing § 6.8.2 Get the effective directive for inline checks on type.
+    auto name = get_the_effective_directive_for_inline_checks(type);
+
+    // 3. If the result of executing § 6.8.4 Should fetch directive execute on name, script-src and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ScriptSrc, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 4. If the result of executing § 6.7.3.3 Does element match source list for type and source? on element, this
+    //    directive’s value, type, and source, is "Does Not Match", return "Blocked".
+    if (does_element_match_source_list_for_type_and_source(element, value(), type, source) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 5. Return "Allowed".
+    return Result::Allowed;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-script-src
+class ScriptSourceDirective final : public Directive {
+    GC_CELL(ScriptSourceDirective, Directive)
+    GC_DECLARE_ALLOCATOR(ScriptSourceDirective);
+
+public:
+    virtual ~ScriptSourceDirective() = default;
+
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+    virtual Result inline_check(GC::Heap&, GC::Ptr<DOM::Element const>, InlineType, GC::Ref<Policy const>, String const&) const override;
+
+private:
+    ScriptSourceDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4071,4 +4071,9 @@ bool Element::should_indicate_focus() const
     return false;
 }
 
+void Element::set_had_duplicate_attribute_during_tokenization(Badge<HTML::HTMLParser>)
+{
+    m_had_duplicate_attribute_during_tokenization = true;
+}
+
 }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -514,6 +514,9 @@ public:
 
     virtual bool contributes_a_script_blocking_style_sheet() const { return false; }
 
+    void set_had_duplicate_attribute_during_tokenization(Badge<HTML::HTMLParser>);
+    bool had_duplicate_attribute_during_tokenization() const { return m_had_duplicate_attribute_during_tokenization; }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -611,6 +614,13 @@ private:
     bool m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator : 1 { false };
 
     size_t m_sibling_invalidation_distance { 0 };
+
+    // https://w3c.github.io/webappsec-csp/#is-element-nonceable
+    // AD-HOC: We need to know the element had a duplicate attribute when it was created from the HTML parser.
+    //         However, there currently isn't any specified way to do this, so we store a flag on the token, which is
+    //         then passed down to here. This is used by Content Security Policy to disable the nonce attribute if this
+    //         flag is set.
+    bool m_had_duplicate_attribute_during_tokenization { false };
 
     OwnPtr<CSS::CountersSet> m_counters_set;
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -138,6 +138,7 @@ class ImageSourceDirective;
 class ManifestSourceDirective;
 class MediaSourceDirective;
 class ObjectSourceDirective;
+class ScriptSourceDirective;
 struct SerializedDirective;
 
 }

--- a/Libraries/LibWeb/HTML/HTMLOrSVGElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGElement.h
@@ -18,7 +18,7 @@ public:
     [[nodiscard]] GC::Ref<DOMStringMap> dataset();
 
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce
-    String const& nonce() { return m_cryptographic_nonce; }
+    String const& nonce() const { return m_cryptographic_nonce; }
     void set_nonce(String const& nonce) { m_cryptographic_nonce = nonce; }
 
     void focus();

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -10,6 +10,7 @@
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/HTMLScriptElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/ContentSecurityPolicy/BlockingAlgorithms.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
@@ -274,8 +275,13 @@ void HTMLScriptElement::prepare_script()
         return;
     }
 
-    // FIXME: 19. If el does not have a src content attribute, and the Should element's inline behavior be blocked by Content Security Policy?
-    //            algorithm returns "Blocked" when given el, "script", and source text, then return. [CSP]
+    // 19. If el does not have a src content attribute, and the Should element's inline behavior be blocked by Content Security Policy?
+    //     algorithm returns "Blocked" when given el, "script", and source text, then return. [CSP]
+    if (!has_attribute(AttributeNames::src)
+        && ContentSecurityPolicy::should_elements_inline_type_behavior_be_blocked_by_content_security_policy(realm(), *this, ContentSecurityPolicy::Directives::Directive::InlineType::Script, source_text) == ContentSecurityPolicy::Directives::Directive::Result::Blocked) {
+        dbgln("HTMLScriptElement: Refusing to run inline script because it violates the Content Security Policy.");
+        return;
+    }
 
     // 20. If el has an event attribute and a for attribute, and el's type is "classic", then:
     if (m_script_type == ScriptType::Classic && has_attribute(HTML::AttributeNames::event) && has_attribute(HTML::AttributeNames::for_)) {
@@ -325,7 +331,8 @@ void HTMLScriptElement::prepare_script()
     // 23. Let module script credentials mode be the CORS settings attribute credentials mode for el's crossorigin content attribute.
     auto module_script_credential_mode = cors_settings_attribute_credentials_mode(m_crossorigin);
 
-    // FIXME: 24. Let cryptographic nonce be el's [[CryptographicNonce]] internal slot's value.
+    // 24. Let cryptographic nonce be el's [[CryptographicNonce]] internal slot's value.
+    auto cryptographic_nonce = m_cryptographic_nonce;
 
     // 25. If el has an integrity attribute, then let integrity metadata be that attribute's value.
     //     Otherwise, let integrity metadata be the empty string.
@@ -350,7 +357,7 @@ void HTMLScriptElement::prepare_script()
     //     credentials mode is module script credentials mode, referrer policy is referrer policy,
     //     and fetch priority is fetch priority.
     ScriptFetchOptions options {
-        .cryptographic_nonce = {}, // FIXME
+        .cryptographic_nonce = move(cryptographic_nonce),
         .integrity_metadata = move(integrity_metadata),
         .parser_metadata = parser_metadata,
         .credentials_mode = module_script_credential_mode,

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -816,6 +816,11 @@ GC::Ref<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, Opt
     // 9. Let element be the result of creating an element given document, localName, given namespace, null, is, and willExecuteScript.
     auto element = create_element(*document, local_name, namespace_, {}, is_value, will_execute_script).release_value_but_fixme_should_propagate_errors();
 
+    // AD-HOC: See AD-HOC comment on Element.m_had_duplicate_attribute_during_tokenization about why this is done.
+    if (token.had_duplicate_attribute()) {
+        element->set_had_duplicate_attribute_during_tokenization({});
+    }
+
     // AD-HOC: Let <link> elements know which document they were originally parsed for.
     //         This is used for the render-blocking logic.
     if (local_name == HTML::TagNames::link && namespace_ == Namespace::HTML) {

--- a/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLToken.cpp
@@ -98,6 +98,7 @@ void HTMLToken::normalize_attributes()
             // This is a duplicate attribute, remove it.
             tag_attributes.remove(i);
             --i;
+            m_had_duplicate_attribute = true;
         }
     }
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLToken.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLToken.h
@@ -328,6 +328,7 @@ public:
     void set_end_position(Badge<HTMLTokenizer>, Position end_position) { m_end_position = end_position; }
 
     void normalize_attributes();
+    bool had_duplicate_attribute() const { return m_had_duplicate_attribute; }
 
 private:
     Vector<Attribute> const* tag_attributes() const
@@ -354,6 +355,11 @@ private:
     // Type::StartTag and Type::EndTag
     bool m_tag_self_closing { false };
     bool m_tag_self_closing_acknowledged { false };
+
+    // AD-HOC: We need to know if the token had duplicate attributes, as Content Security Policy disables the nonce
+    //         attribute on the element that will be created from such a token.
+    //         https://w3c.github.io/webappsec-csp/#is-element-nonceable
+    bool m_had_duplicate_attribute { false };
 
     // Type::StartTag and Type::EndTag (tag name)
     FlyString m_string_data;

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -94,6 +94,7 @@ JS::NativeFunction* create_native_function(JS::VM&, Wasm::FunctionAddress addres
 JS::ThrowCompletionOr<Wasm::Value> to_webassembly_value(JS::VM&, JS::Value value, Wasm::ValueType const& type);
 Wasm::Value default_webassembly_value(JS::VM&, Wasm::ValueType type);
 JS::Value to_js_value(JS::VM&, Wasm::Value& wasm_value, Wasm::ValueType type);
+JS::ThrowCompletionOr<void> host_ensure_can_compile_wasm_bytes(JS::VM&);
 
 extern HashMap<GC::Ptr<JS::Object>, WebAssemblyCache> s_caches;
 


### PR DESCRIPTION
Part 10 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854

The script-src directive is one of the most complex directives in Content Security Policy, so its implementation is here as a PR with its required infrastructure changes and no other directives.