### PR TITLE
Verify that save/restore are balanced within paintable 

### DIFF
--- a/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -31,7 +31,7 @@ ScopedCornerRadiusClip::ScopedCornerRadiusClip(PaintContext& context, DevicePixe
 
 ScopedCornerRadiusClip::~ScopedCornerRadiusClip()
 {
-    if (!m_has_radius && m_do_apply)
+    if (!m_do_apply || !m_has_radius)
         return;
     m_context.display_list_recorder().restore();
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2023-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -275,16 +275,19 @@ void DisplayListRecorder::translate(Gfx::IntPoint delta)
 
 void DisplayListRecorder::save()
 {
+    ++m_save_nesting_level;
     append(Save {});
 }
 
 void DisplayListRecorder::save_layer()
 {
+    ++m_save_nesting_level;
     append(SaveLayer {});
 }
 
 void DisplayListRecorder::restore()
 {
+    --m_save_nesting_level;
     append(Restore {});
 }
 
@@ -419,6 +422,8 @@ void DisplayListRecorder::apply_opacity(float opacity)
 
 void DisplayListRecorder::apply_compositing_and_blending_operator(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)
 {
+    // Implementation of this item does saveLayer(), so we need to increment the nesting level.
+    m_save_nesting_level++;
     append(ApplyCompositeAndBlendingOperator { .compositing_and_blending_operator = compositing_and_blending_operator });
 }
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -11,7 +11,6 @@
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Gradients.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Palette.h>
@@ -19,17 +18,12 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/ScalingMode.h>
-#include <LibGfx/Size.h>
-#include <LibGfx/TextAlignment.h>
-#include <LibGfx/TextLayout.h>
-#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/Painting/BorderRadiiData.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/Command.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/GradientData.h>
 #include <LibWeb/Painting/PaintBoxShadowParams.h>
-#include <LibWeb/Painting/PaintStyle.h>
 
 namespace Web::Painting {
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2023-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -160,6 +160,8 @@ public:
     DisplayList& display_list() { return m_command_list; }
 
     void append(Command&& command);
+
+    int m_save_nesting_level { 0 };
 
 private:
     Vector<Optional<i32>> m_scroll_frame_id_stack;

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -1,13 +1,14 @@
 /*
  * Copyright (c) 2020-2022, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
- * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2024-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/QuickSort.h>
+#include <AK/TemporaryChange.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibGfx/Rect.h>
@@ -24,9 +25,13 @@ namespace Web::Painting {
 
 static void paint_node(Paintable const& paintable, PaintContext& context, PaintPhase phase)
 {
+    TemporaryChange save_nesting_level(context.display_list_recorder().m_save_nesting_level, 0);
+
     paintable.before_paint(context, phase);
     paintable.paint(context, phase);
     paintable.after_paint(context, phase);
+
+    VERIFY(context.display_list_recorder().m_save_nesting_level == 0);
 }
 
 StackingContext::StackingContext(PaintableBox& paintable, StackingContext* parent, size_t index_in_tree_order)


### PR DESCRIPTION
Unbalanced save/restore within display list items recorded for a paintable means that some state only relevant for the paintable leaks to subsequent paintables, which is never expected behavior.