### PR TITLE
LibWeb: Delete `before_children_paint` and `after_children_paint` hooks

### DIFF
--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -73,9 +73,6 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) const { }
 
-    virtual void before_children_paint(PaintContext&, PaintPhase) const { }
-    virtual void after_children_paint(PaintContext&, PaintPhase) const { }
-
     virtual void apply_scroll_offset(PaintContext&, PaintPhase) const { }
     virtual void reset_scroll_offset(PaintContext&, PaintPhase) const { }
 

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -29,22 +29,6 @@ Layout::SVGSVGBox const& SVGSVGPaintable::layout_box() const
     return static_cast<Layout::SVGSVGBox const&>(layout_node());
 }
 
-void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase phase) const
-{
-    PaintableBox::before_children_paint(context, phase);
-    if (phase != PaintPhase::Foreground)
-        return;
-    context.display_list_recorder().push_scroll_frame_id(scroll_frame_id());
-}
-
-void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase) const
-{
-    PaintableBox::after_children_paint(context, phase);
-    if (phase != PaintPhase::Foreground)
-        return;
-    context.display_list_recorder().pop_scroll_frame_id();
-}
-
 static Gfx::FloatMatrix4x4 matrix_with_scaled_translation(Gfx::FloatMatrix4x4 matrix, float scale)
 {
     auto* m = matrix.elements();
@@ -132,12 +116,10 @@ void SVGSVGPaintable::paint_descendants(PaintContext& context, PaintableBox cons
     if (phase != PaintPhase::Foreground)
         return;
 
-    paintable.before_children_paint(context, PaintPhase::Foreground);
     paintable.for_each_child_of_type<PaintableBox>([&](PaintableBox& child) {
         paint_svg_box(context, child, phase);
         return IterationDecision::Continue;
     });
-    paintable.after_children_paint(context, PaintPhase::Foreground);
 }
 
 }

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.h
@@ -18,9 +18,6 @@ class SVGSVGPaintable final : public PaintableBox {
 public:
     static GC::Ref<SVGSVGPaintable> create(Layout::SVGSVGBox const&);
 
-    virtual void before_children_paint(PaintContext&, PaintPhase) const override;
-    virtual void after_children_paint(PaintContext&, PaintPhase) const override;
-
     Layout::SVGSVGBox const& layout_box() const;
 
     static void paint_svg_box(PaintContext& context, PaintableBox const& svg_box, PaintPhase phase);

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -111,8 +111,6 @@ void StackingContext::paint_svg(PaintContext& context, PaintableBox const& paint
 
 void StackingContext::paint_descendants(PaintContext& context, Paintable const& paintable, StackingContextPaintPhase phase)
 {
-    paintable.before_children_paint(context, to_paint_phase(phase));
-
     paintable.for_each_child([&context, phase](auto& child) {
         if (child.layout_node().is_svg_svg_box()) {
             paint_svg(context, static_cast<PaintableBox const&>(child), to_paint_phase(phase));
@@ -190,8 +188,6 @@ void StackingContext::paint_descendants(PaintContext& context, Paintable const& 
 
         return IterationDecision::Continue;
     });
-
-    paintable.after_children_paint(context, to_paint_phase(phase));
 }
 
 void StackingContext::paint_child(PaintContext& context, StackingContext const& child)
@@ -201,14 +197,7 @@ void StackingContext::paint_child(PaintContext& context, StackingContext const& 
 
     const_cast<StackingContext&>(child).set_last_paint_generation_id(context.paint_generation_id());
 
-    auto parent_paintable = child.paintable_box().parent();
-    if (parent_paintable)
-        parent_paintable->before_children_paint(context, PaintPhase::Foreground);
-
     child.paint(context);
-
-    if (parent_paintable)
-        parent_paintable->after_children_paint(context, PaintPhase::Foreground);
 }
 
 void StackingContext::paint_internal(PaintContext& context) const
@@ -250,16 +239,11 @@ void StackingContext::paint_internal(PaintContext& context) const
     for (auto const& paintable : m_positioned_descendants_and_stacking_contexts_with_stack_level_0) {
         // At this point, `paintable_box` is a positioned descendant with z-index: auto.
         // FIXME: This is basically duplicating logic found elsewhere in this same function. Find a way to make this more elegant.
-        auto* parent_paintable = paintable->parent();
-        if (parent_paintable)
-            parent_paintable->before_children_paint(context, PaintPhase::Foreground);
         if (auto* child = paintable->stacking_context()) {
             paint_child(context, *child);
         } else {
             paint_node_as_stacking_context(paintable, context);
         }
-        if (parent_paintable)
-            parent_paintable->after_children_paint(context, PaintPhase::Foreground);
     };
 
     // Stacking contexts formed by positioned descendants with z-indices greater than or equal to 1 in z-index order


### PR DESCRIPTION
These were only used in SVGSVGPaintable to apply scroll frame id, which is already handled by `before_paint()` and `after_paint()` hooks in PaintableBox.