### PR TITLE
LibWeb: Verify that save and restore are balanced within StackingContext

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -417,6 +417,8 @@ void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutt
 
 void DisplayListRecorder::apply_opacity(float opacity)
 {
+    // Implementation of this item does saveLayer(), so we need to increment the nesting level.
+    ++m_save_nesting_level;
     append(ApplyOpacity { .opacity = opacity });
 }
 
@@ -429,6 +431,8 @@ void DisplayListRecorder::apply_compositing_and_blending_operator(Gfx::Compositi
 
 void DisplayListRecorder::apply_filter(Gfx::Filter filter)
 {
+    // Implementation of this item does saveLayer(), so we need to increment the nesting level.
+    ++m_save_nesting_level;
     append(ApplyFilter { .filter = move(filter) });
 }
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -291,6 +291,11 @@ void StackingContext::paint(PaintContext& context) const
     if (opacity == 0.0f)
         return;
 
+    TemporaryChange save_nesting_level(context.display_list_recorder().m_save_nesting_level, 0);
+    ScopeGuard verify_save_and_restore_are_balanced([&] {
+        VERIFY(context.display_list_recorder().m_save_nesting_level == 0);
+    });
+
     DisplayListRecorderStateSaver saver(context.display_list_recorder());
 
     auto to_device_pixels_scale = float(context.device_pixels_per_css_pixel());


### PR DESCRIPTION
Unbalanced save and restore means that effects only relevant to a stacking context leak outside, which is never expected behavior. Having a `VERIFY()` for that makes it much easier to catch such issues.