### PR TITLE
Meta: Include the `--install-fonts` argument when running WPT

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -84,6 +84,7 @@ WPT_ARGS=(
     "--install-webdriver"
     "--webdriver-arg=--force-cpu-painting"
     "--no-pause-after-test"
+    "--install-fonts"
     "${EXTRA_WPT_ARGS[@]}"
 )
 IMPORT_ARGS=()


### PR DESCRIPTION
This ensures the Ahem test font is installed.

Tested by running: `./Meta/WPT.sh run infrastructure/assumptions/ahem.html` on the WPT runner machine - for some reason the test already passed for me locally.