### PR TITLE
CI+CMake: Enable vcpkg source assets cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os_name: ['Linux']
         arch: ['x86_64']
-        build_preset: ['Sanitizer_CI']
+        build_preset: ['Sanitizer']
         toolchain: ['GNU']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
@@ -25,21 +25,21 @@ jobs:
         include:
           - os_name: 'Linux'
             arch: 'x86_64'
-            build_preset: 'Sanitizer_CI'
+            build_preset: 'Sanitizer'
             toolchain: 'Clang'
             clang_plugins: true
             runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
 
           - os_name: 'macOS'
             arch: 'arm64'
-            build_preset: 'Sanitizer_CI'
+            build_preset: 'Sanitizer'
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["macos-15", "self-hosted"]'
 
           - os_name: 'Linux'
             arch: 'x86_64'
-            build_preset: 'Fuzzers_CI'
+            build_preset: 'Fuzzers'
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'

--- a/.github/workflows/js-artifacts.yml
+++ b/.github/workflows/js-artifacts.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Create build directory Ubuntu
         run: |
-          cmake --preset Distribution_CI \
+          cmake --preset Distribution \
             -DCMAKE_C_COMPILER=clang-20 \
             -DCMAKE_CXX_COMPILER=clang++-20 \
             -DENABLE_GUI_TARGETS=OFF
@@ -73,7 +73,7 @@ jobs:
       #        See: https://github.com/microsoft/vcpkg/discussions/19454
       - name: Create build directory macOS
         run: |
-          cmake --preset Distribution_CI \
+          cmake --preset Distribution \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
             -DENABLE_GUI_TARGETS=OFF
         if: ${{ matrix.os_name == 'macOS' }}

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -126,7 +126,7 @@ jobs:
         run: sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
 
       - name: Create Build Environment
-        if: ${{ inputs.os_name != 'Windows' && inputs.build_preset != 'Fuzzers_CI' }}
+        if: ${{ inputs.os_name != 'Windows' && inputs.build_preset != 'Fuzzers' }}
         working-directory: ${{ github.workspace }}
         env:
           VCPKG_CACHE_SAS: ${{ github.ref == 'refs/heads/master' && secrets.VCPKG_CACHE_SAS || '' }}
@@ -148,10 +148,10 @@ jobs:
           cmake --preset ${{ inputs.build_preset }} -B Build
 
       - name: Create Build Environment (Fuzzers)
-        if: ${{ inputs.build_preset == 'Fuzzers_CI' }}
+        if: ${{ inputs.build_preset == 'Fuzzers' }}
         working-directory: ${{ github.workspace }}
         run: |
-          cmake --preset=Distribution_CI -S Meta/Lagom -B ${{ github.workspace }}/Build/tools-build \
+          cmake --preset=Distribution -S Meta/Lagom -B ${{ github.workspace }}/Build/tools-build \
             -DLAGOM_TOOLS_ONLY=ON \
             -DINSTALL_LAGOM_TOOLS=ON \
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/Build/tools-install \
@@ -175,7 +175,7 @@ jobs:
           cmake --install . --strip --prefix ${{ github.workspace }}/Install
 
       - name: Build - macOS with Qt
-        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
+        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: |
           cmake --preset ${{ inputs.build_preset }} -B Build -DENABLE_QT=ON
@@ -194,33 +194,24 @@ jobs:
       # === TEST ===
 
       - name: Test
-        if: ${{ inputs.os_name != 'Windows' && inputs.build_preset == 'Sanitizer_CI' }}
+        if: ${{ contains(inputs.build_preset, 'Sanitizer') }}
         working-directory: ${{ github.workspace }}
-        run: ctest --preset Sanitizer --output-on-failure --test-dir Build --timeout 1800
+        run: ctest --preset ${{ inputs.build_preset }} --output-on-failure --test-dir Build --timeout 1800
         env:
           TESTS_ONLY: 1
           # NOTE: These are appended to the preset's options.
-          ASAN_OPTIONS: 'log_path=${{ github.workspace }}/asan.log'
-          UBSAN_OPTIONS: 'log_path=${{ github.workspace }}/ubsan.log'
+          ASAN_OPTIONS: 'log_path="${{ github.workspace }}/asan.log"'
+          UBSAN_OPTIONS: 'log_path="${{ github.workspace }}/ubsan.log"'
 
       - name: Test
-        if: ${{ inputs.build_preset != 'Fuzzers_CI' && !contains(inputs.build_preset, 'Sanitizer_CI') }}
+        if: ${{ inputs.build_preset != 'Fuzzers' && !contains(inputs.build_preset, 'Sanitizer') }}
         working-directory: ${{ github.workspace }}
         run: ctest --output-on-failure --test-dir Build --timeout 1800
         env:
           TESTS_ONLY: 1
 
-      - name: Test (Windows)
-        if: ${{ inputs.os_name == 'Windows' }}
-        working-directory: ${{ github.workspace }}
-        run: ctest --preset ${{ inputs.build_preset }} --test-dir Build --timeout 1800
-        env:
-          TESTS_ONLY: 1
-          ASAN_OPTIONS: 'log_path="${{ github.workspace }}\asan.log"'
-          UBSAN_OPTIONS: 'log_path="${{ github.workspace }}\ubsan.log"'
-
       - name: Upload LibWeb Test Artifacts
-        if: ${{ always() && inputs.build_preset != 'Fuzzers_CI' }}
+        if: ${{ always() && inputs.build_preset != 'Fuzzers' }}
         uses: actions/upload-artifact@v4
         with:
           name: libweb-test-artifacts-${{ inputs.os_name }}-${{ inputs.build_preset }}-${{ inputs.toolchain }}-${{ inputs.clang-plugins }}
@@ -229,7 +220,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Sanitizer Output
-        if: ${{ !cancelled() && inputs.build_preset == 'Sanitizer_CI' }}
+        if: ${{ !cancelled() && inputs.build_preset == 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: |
           log_output=$(find . -maxdepth 1 \( -name 'asan.log.*' -o -name 'ubsan.log.*' \) -exec cat {} \; )
@@ -241,7 +232,7 @@ jobs:
           fi
 
       - name: Lints
-        if: ${{ inputs.os_name == 'Linux' && inputs.build_preset == 'Sanitizer_CI' }}
+        if: ${{ inputs.os_name == 'Linux' && inputs.build_preset == 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: |
           set -e

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -65,7 +65,7 @@ jobs:
         if: ${{ inputs.os_name != 'Windows' }}
         id: 'build-parameters'
         run: |
-          CMAKE_OPTIONS="-DENABLE_QT=ON"
+          CMAKE_OPTIONS=""
           if ${{ inputs.toolchain == 'Swift' }} ; then
             echo "host_cc=$(swiftly use --print-location)/usr/bin/clang" >> "$GITHUB_OUTPUT"
             echo "host_cxx=$(swiftly use --print-location)/usr/bin/clang++" >> "$GITHUB_OUTPUT"
@@ -139,14 +139,12 @@ jobs:
         if: ${{ inputs.os_name == 'Windows' }}
         working-directory: ${{ github.workspace }}
         run: |
-          cmake --preset ${{ inputs.build_preset }}
+          cmake --preset ${{ inputs.build_preset }} -B Build
 
       - name: Create Build Environment (Fuzzers)
         if: ${{ inputs.build_preset == 'Fuzzers_CI' }}
         working-directory: ${{ github.workspace }}
         run: |
-          set -e
-
           cmake --preset=Distribution_CI -S Meta/Lagom -B ${{ github.workspace }}/Build/tools-build \
             -DLAGOM_TOOLS_ONLY=ON \
             -DINSTALL_LAGOM_TOOLS=ON \
@@ -165,28 +163,17 @@ jobs:
       # === BUILD ===
 
       - name: Build
-        if: ${{ inputs.os_name != 'Windows' }}
         working-directory: ${{ github.workspace }}/Build
         run: |
-          set -e
           cmake --build .
           cmake --install . --strip --prefix ${{ github.workspace }}/Install
 
-      - name: Build (Windows)
-        if: ${{ inputs.os_name == 'Windows' }}
+      - name: Build - macOS with Qt
+        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}
         run: |
-          cmake --build --preset ${{ inputs.build_preset }}
-
-      - name: Enable the Ladybird AppKit chrome
-        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
-        working-directory: ${{ github.workspace }}
-        run: cmake -B Build -DENABLE_QT=OFF
-
-      - name: Build the Ladybird AppKit chrome
-        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
-        working-directory: ${{ github.workspace }}/Build
-        run: cmake --build .
+          cmake --preset ${{ inputs.build_preset }} -B Build -DENABLE_QT=ON
+          cmake --build Build
 
       - name: Save Caches
         uses: ./.github/actions/cache-save
@@ -220,7 +207,7 @@ jobs:
       - name: Test (Windows)
         if: ${{ inputs.os_name == 'Windows' }}
         working-directory: ${{ github.workspace }}
-        run: ctest --preset ${{ inputs.build_preset }} --timeout 1800
+        run: ctest --preset ${{ inputs.build_preset }} --test-dir Build --timeout 1800
         env:
           TESTS_ONLY: 1
           ASAN_OPTIONS: 'log_path="${{ github.workspace }}\asan.log"'

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -128,6 +128,9 @@ jobs:
       - name: Create Build Environment
         if: ${{ inputs.os_name != 'Windows' && inputs.build_preset != 'Fuzzers_CI' }}
         working-directory: ${{ github.workspace }}
+        env:
+          VCPKG_CACHE_SAS: ${{ github.ref == 'refs/heads/master' && secrets.VCPKG_CACHE_SAS || '' }}
+          VCPKG_CACHE_MODE: ${{ github.ref == 'refs/heads/master' && 'write' || '' }}
         run: |
           cmake --preset ${{ inputs.build_preset }} -B Build \
             ${{ steps.build-parameters.outputs.cmake_options }} \
@@ -138,6 +141,9 @@ jobs:
       - name: Create Build Environment (Windows)
         if: ${{ inputs.os_name == 'Windows' }}
         working-directory: ${{ github.workspace }}
+        env:
+          VCPKG_CACHE_SAS: ${{ github.ref == 'refs/heads/master' && secrets.VCPKG_CACHE_SAS || '' }}
+          VCPKG_CACHE_MODE: ${{ github.ref == 'refs/heads/master' && 'write' || '' }}
         run: |
           cmake --preset ${{ inputs.build_preset }} -B Build
 

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os_name: ['Linux']
         arch: ['arm64']
-        build_preset: ['Sanitizer_CI']
+        build_preset: ['Sanitizer']
         toolchain: ['Clang']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404-arm"]']
@@ -28,35 +28,35 @@ jobs:
         include:
           - os_name: 'Linux'
             arch: 'x86_64'
-            build_preset: 'Distribution_CI'
+            build_preset: 'Distribution'
             toolchain: 'GNU'
             clang_plugins: false
             runner_labels: '["blacksmith-8vcpu-ubuntu-2404"]'
 
           - os_name: 'macOS'
             arch: 'arm64'
-            build_preset: 'Distribution_CI'
+            build_preset: 'Distribution'
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["macos-15"]'
 
           - os_name: 'Linux'
             arch: 'arm64'
-            build_preset: 'Distribution_CI'
+            build_preset: 'Distribution'
             toolchain: 'Clang'
             clang_plugins: false
             runner_labels: '["blacksmith-8vcpu-ubuntu-2404-arm"]'
 
           - os_name: 'Linux'
             arch: 'x86_64'
-            build_preset: 'Sanitizer_CI'
+            build_preset: 'Sanitizer'
             toolchain: 'Swift'
             clang_plugins: false
             runner_labels: '["blacksmith-8vcpu-ubuntu-2404"]'
 
           - os_name: 'macOS'
             arch: 'arm64'
-            build_preset: 'Sanitizer_CI'
+            build_preset: 'Sanitizer'
             toolchain: 'Swift'
             clang_plugins: false
             runner_labels: '["macos-15"]'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,8 @@
       "environment": {
         "LADYBIRD_SOURCE_DIR": "${fileDir}",
         "VCPKG_ROOT": "${fileDir}/Build/vcpkg",
-        "VCPKG_BINARY_SOURCES": "clear;files,${fileDir}/Build/caches/vcpkg-binary-cache,readwrite;$penv{VCPKG_BINARY_SOURCES}"
+        "VCPKG_BINARY_SOURCES": "clear;files,${fileDir}/Build/caches/vcpkg-binary-cache,readwrite;$penv{VCPKG_BINARY_SOURCES}",
+        "X_VCPKG_ASSET_SOURCES": "clear;x-azurl,https://vcpkg-cache.app.ladybird.org/ladybird/source-assets/,$penv{VCPKG_CACHE_SAS},read$penv{VCPKG_CACHE_MODE}"
       },
       "vendor": {
         "jetbrains.com/clion": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -135,22 +135,8 @@
       }
     },
     {
-      "hidden": true,
-      "name": "vcpkg_ci",
-      "description": "FIXME: Use the GitHub Actions vcpkg cache"
-    },
-    {
-      "name": "CI",
-      "displayName": "Non-Sanitizer CI Config",
-      "inherits": [
-        "vcpkg_ci",
-        "unix_base"
-      ]
-    },
-    {
       "name": "Windows_CI",
       "inherits":  [
-        "vcpkg_ci",
         "windows_base"
       ],
       "displayName": "Windows CI Config",
@@ -158,23 +144,6 @@
         "ENABLE_WINDOWS_CI": "ON",
         "ENABLE_QT": "OFF"
       }
-    },
-    {
-      "name": "Distribution_CI",
-      "inherits": [
-        "vcpkg_ci",
-        "Distribution"
-      ],
-      "displayName": "Distribution CI Config",
-      "description": "Distribution build with GitHub Actions cache"
-    },
-    {
-      "name": "Sanitizer_CI",
-      "inherits": [
-        "vcpkg_ci",
-        "Sanitizer"
-      ],
-      "displayName": "Sanitizer CI Config"
     },
     {
       "name": "Windows_Sanitizer_CI",
@@ -204,15 +173,6 @@
         "ENABLE_FUZZERS_LIBFUZZER": "ON",
         "ENABLE_ADDRESS_SANITIZER": "ON"
       }
-    },
-    {
-      "name": "Fuzzers_CI",
-      "inherits": [
-        "vcpkg_ci",
-        "Fuzzers"
-      ],
-      "displayName": "Fuzzers CI Config",
-      "description": "Fuzzers build with GitHub Actions cache"
     },
     {
       "name": "Swift_Release",


### PR DESCRIPTION
I've set up a shared vcpkg source assets cache using Azurite. By default, it runs in read-only mode allowing anyone who builds Ladybird to use the cache to speed up downloads of source tarballs. This should alleviate some of the more slower vcpkgs downloads I've been seeing lately.

CI runs on master put vcpkg in readwrite mode, updating the cache for everyone.