### PR TITLE
Apply either enclosing or own clip rect depending on PaintPhase

### DIFF
--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -73,9 +73,6 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) const { }
 
-    virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const { }
-    virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const { }
-
     [[nodiscard]] virtual TraversalDecision hit_test(CSSPixelPoint, HitTestType, Function<TraversalDecision(HitTestResult)> const& callback) const;
 
     virtual bool wants_mouse_events() const { return false; }

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -73,9 +73,6 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) const { }
 
-    virtual void apply_scroll_offset(PaintContext&, PaintPhase) const { }
-    virtual void reset_scroll_offset(PaintContext&, PaintPhase) const { }
-
     virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const { }
     virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const { }
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -76,9 +76,6 @@ public:
     virtual void apply_scroll_offset(PaintContext&, PaintPhase) const { }
     virtual void reset_scroll_offset(PaintContext&, PaintPhase) const { }
 
-    virtual void apply_own_clip_rect(PaintContext&, PaintPhase) const { }
-    virtual void clear_own_clip_rect(PaintContext&, PaintPhase) const { }
-
     virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const { }
     virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const { }
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -331,7 +331,7 @@ void PaintableBox::before_paint(PaintContext& context, PaintPhase phase) const
     } else if (!has_css_transform()) {
         apply_clip_overflow_rect(context, phase);
     }
-    apply_scroll_offset(context, phase);
+    apply_scroll_offset(context);
 }
 
 void PaintableBox::after_paint(PaintContext& context, PaintPhase phase) const
@@ -339,7 +339,7 @@ void PaintableBox::after_paint(PaintContext& context, PaintPhase phase) const
     if (!is_visible())
         return;
 
-    reset_scroll_offset(context, phase);
+    reset_scroll_offset(context);
     if (first_is_one_of(phase, PaintPhase::Background, PaintPhase::Foreground) && own_clip_frame()) {
         restore_clip(context, own_clip_frame());
     } else if (!has_css_transform()) {
@@ -619,14 +619,14 @@ BorderRadiiData PaintableBox::normalized_border_radii_data(ShrinkRadiiForBorders
     return border_radii_data;
 }
 
-void PaintableBox::apply_scroll_offset(PaintContext& context, PaintPhase) const
+void PaintableBox::apply_scroll_offset(PaintContext& context) const
 {
     if (scroll_frame_id().has_value()) {
         context.display_list_recorder().push_scroll_frame_id(scroll_frame_id().value());
     }
 }
 
-void PaintableBox::reset_scroll_offset(PaintContext& context, PaintPhase) const
+void PaintableBox::reset_scroll_offset(PaintContext& context) const
 {
     if (scroll_frame_id().has_value()) {
         context.display_list_recorder().pop_scroll_frame_id();

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -136,8 +136,8 @@ public:
 
     virtual void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes) override;
 
-    virtual void apply_scroll_offset(PaintContext&, PaintPhase) const override;
-    virtual void reset_scroll_offset(PaintContext&, PaintPhase) const override;
+    void apply_scroll_offset(PaintContext&) const;
+    void reset_scroll_offset(PaintContext&) const;
 
     virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const override;
     virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const override;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -142,9 +142,6 @@ public:
     virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const override;
     virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const override;
 
-    virtual void apply_own_clip_rect(PaintContext&, PaintPhase) const override;
-    virtual void clear_own_clip_rect(PaintContext&, PaintPhase) const override;
-
     [[nodiscard]] virtual TraversalDecision hit_test(CSSPixelPoint position, HitTestType type, Function<TraversalDecision(HitTestResult)> const& callback) const override;
     Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;
     [[nodiscard]] TraversalDecision hit_test_children(CSSPixelPoint, HitTestType, Function<TraversalDecision(HitTestResult)> const&) const;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -139,8 +139,8 @@ public:
     void apply_scroll_offset(PaintContext&) const;
     void reset_scroll_offset(PaintContext&) const;
 
-    virtual void apply_clip_overflow_rect(PaintContext&, PaintPhase) const override;
-    virtual void clear_clip_overflow_rect(PaintContext&, PaintPhase) const override;
+    void apply_clip_overflow_rect(PaintContext&, PaintPhase) const;
+    void clear_clip_overflow_rect(PaintContext&, PaintPhase) const;
 
     [[nodiscard]] virtual TraversalDecision hit_test(CSSPixelPoint position, HitTestType type, Function<TraversalDecision(HitTestResult)> const& callback) const override;
     Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType) const;

--- a/Libraries/LibWeb/Painting/SVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPaintable.cpp
@@ -17,6 +17,26 @@ SVGPaintable::SVGPaintable(Layout::SVGBox const& layout_box)
 {
 }
 
+void SVGPaintable::before_paint(PaintContext& context, PaintPhase phase) const
+{
+    if (!is_visible())
+        return;
+    if (!has_css_transform()) {
+        apply_clip_overflow_rect(context, phase);
+    }
+    apply_scroll_offset(context, phase);
+}
+
+void SVGPaintable::after_paint(PaintContext& context, PaintPhase phase) const
+{
+    if (!is_visible())
+        return;
+    reset_scroll_offset(context, phase);
+    if (!has_css_transform()) {
+        clear_clip_overflow_rect(context, phase);
+    }
+}
+
 Layout::SVGBox const& SVGPaintable::layout_box() const
 {
     return static_cast<Layout::SVGBox const&>(layout_node());

--- a/Libraries/LibWeb/Painting/SVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPaintable.cpp
@@ -24,14 +24,14 @@ void SVGPaintable::before_paint(PaintContext& context, PaintPhase phase) const
     if (!has_css_transform()) {
         apply_clip_overflow_rect(context, phase);
     }
-    apply_scroll_offset(context, phase);
+    apply_scroll_offset(context);
 }
 
 void SVGPaintable::after_paint(PaintContext& context, PaintPhase phase) const
 {
     if (!is_visible())
         return;
-    reset_scroll_offset(context, phase);
+    reset_scroll_offset(context);
     if (!has_css_transform()) {
         clear_clip_overflow_rect(context, phase);
     }

--- a/Libraries/LibWeb/Painting/SVGPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGPaintable.h
@@ -22,6 +22,9 @@ protected:
 
     SVGPaintable(Layout::SVGBox const&);
 
+    virtual void before_paint(PaintContext&, PaintPhase) const override;
+    virtual void after_paint(PaintContext&, PaintPhase) const override;
+
     virtual CSSPixelRect compute_absolute_rect() const override;
 };
 

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -24,6 +24,26 @@ SVGSVGPaintable::SVGSVGPaintable(Layout::SVGSVGBox const& layout_box)
 {
 }
 
+void SVGSVGPaintable::before_paint(PaintContext& context, PaintPhase phase) const
+{
+    if (!is_visible())
+        return;
+    if (!has_css_transform()) {
+        apply_clip_overflow_rect(context, phase);
+    }
+    apply_scroll_offset(context, phase);
+}
+
+void SVGSVGPaintable::after_paint(PaintContext& context, PaintPhase phase) const
+{
+    if (!is_visible())
+        return;
+    reset_scroll_offset(context, phase);
+    if (!has_css_transform()) {
+        clear_clip_overflow_rect(context, phase);
+    }
+}
+
 Layout::SVGSVGBox const& SVGSVGPaintable::layout_box() const
 {
     return static_cast<Layout::SVGSVGBox const&>(layout_node());

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -31,14 +31,14 @@ void SVGSVGPaintable::before_paint(PaintContext& context, PaintPhase phase) cons
     if (!has_css_transform()) {
         apply_clip_overflow_rect(context, phase);
     }
-    apply_scroll_offset(context, phase);
+    apply_scroll_offset(context);
 }
 
 void SVGSVGPaintable::after_paint(PaintContext& context, PaintPhase phase) const
 {
     if (!is_visible())
         return;
-    reset_scroll_offset(context, phase);
+    reset_scroll_offset(context);
     if (!has_css_transform()) {
         clear_clip_overflow_rect(context, phase);
     }

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.h
@@ -23,6 +23,9 @@ public:
     static void paint_svg_box(PaintContext& context, PaintableBox const& svg_box, PaintPhase phase);
     static void paint_descendants(PaintContext& context, PaintableBox const& paintable, PaintPhase phase);
 
+    virtual void before_paint(PaintContext&, PaintPhase) const override;
+    virtual void after_paint(PaintContext&, PaintPhase) const override;
+
 protected:
     SVGSVGPaintable(Layout::SVGSVGBox const&);
 


### PR DESCRIPTION
Previously, we always applied the enclosing clip rectangle for all paint
phases except overlays, and the own clip rectangle for the background
and foreground phases. The problem is that applying a clip rectangle
means emitting an AddClipRect display list item for each clip rectangle
in the containing block. With this change, we choose whether to include
the own clip based on the paint phase and this way avoid emitting
AddClipRect for enclosing clip rectangles twice.