### PR TITLE
RequestServer: Simplify library creation for implementation library

### DIFF
--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -21,7 +21,8 @@ if (ANDROID)
     set(RS_LIB_TYPE SHARED)
 endif()
 
-ladybird_lib(requestserverservice TYPE ${RS_LIB_TYPE})
+add_library(requestserverservice ${RS_LIB_TYPE} ${SOURCES} ${GENERATED_SOURCES})
+ladybird_generated_sources(requestserverservice)
 
 find_package(PkgConfig)
 find_package(CURL REQUIRED)


### PR DESCRIPTION
Using ladybird_lib() adds all sorts of extra goodies to the target, such as installation, soname setting, a custom target name, adding lagom- to the name of the library, etc. All we need for this impl lib is the generated sources support, so move to a bare add_library() call instead.

The previous call was also wrong, and always created liblagom-TYPE.so.