### PR TITLE
LibWeb: Do not crash when navigating to `mailto:` links

### DIFF
--- a/Tests/LibWeb/Text/expected/navigation/navigate-mailto-crash.txt
+++ b/Tests/LibWeb/Text/expected/navigation/navigate-mailto-crash.txt
@@ -1,0 +1,1 @@
+PASS (did not crash)

--- a/Tests/LibWeb/Text/input/navigation/navigate-mailto-crash.html
+++ b/Tests/LibWeb/Text/input/navigation/navigate-mailto-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<a href="mailto:contact@ladybird.org">please don't crash</a>
+<script>
+asyncTest(done => {
+    document.querySelector('a').click();
+
+    // The crash happened asynchronously, so we wait for a small amount of time before passing the test.
+    setTimeout(() => {
+        println('PASS (did not crash)');
+        done();
+    }, 100);
+});
+</script>


### PR DESCRIPTION
We forgot to implement a couple of "otherwise," statements from the "populating a session history entry" spec. While we're here, let's update the spec copy where relevant.