### PR TITLE
Meta: Disable clang-tidy's const correctness checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,6 +32,7 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-reserved-identifier,-cert-dcl37-c,-cert-dcl51-cpp,
   -cert-dcl21-cpp,
+  -misc-const-correctness,
   -misc-include-cleaner,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,


### PR DESCRIPTION
Using `const` should not be warned about everywhere if it does not have a clear advantages. Compilers are able to deduce constness in most cases and on top of that, it's generally accepted that using `const` communicates developer intent above all else.