### PR TITLE
LibJS+LibUnicode: Remove unused FormatNumericToString AO

### DIFF
--- a/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -145,12 +145,6 @@ int currency_digits(StringView currency)
     return 2;
 }
 
-// 16.5.3 FormatNumericToString ( intlObject, x ), https://tc39.es/ecma402/#sec-formatnumerictostring
-String format_numeric_to_string(NumberFormatBase const& intl_object, MathematicalValue const& number)
-{
-    return intl_object.formatter().format_to_decimal(number.to_value());
-}
-
 // 16.5.4 PartitionNumberPattern ( numberFormat, x ), https://tc39.es/ecma402/#sec-partitionnumberpattern
 Vector<Unicode::NumberFormat::Partition> partition_number_pattern(NumberFormat const& number_format, MathematicalValue const& number)
 {

--- a/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -180,7 +180,6 @@ private:
 };
 
 JS_API int currency_digits(StringView currency);
-JS_API String format_numeric_to_string(NumberFormatBase const& intl_object, MathematicalValue const& number);
 JS_API Vector<Unicode::NumberFormat::Partition> partition_number_pattern(NumberFormat const&, MathematicalValue const& number);
 JS_API String format_numeric(NumberFormat const&, MathematicalValue const& number);
 JS_API GC::Ref<Array> format_numeric_to_parts(VM&, NumberFormat const&, MathematicalValue const& number);

--- a/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Libraries/LibUnicode/NumberFormat.cpp
@@ -616,21 +616,6 @@ public:
         return icu_string_to_string(result);
     }
 
-    virtual String format_to_decimal(Value const& value) const override
-    {
-        UErrorCode status = U_ZERO_ERROR;
-
-        auto formatted = format_impl(value);
-        if (!formatted.has_value())
-            return {};
-
-        auto result = formatted->toDecimalNumber<StringBuilder>(status);
-        if (icu_failure(status))
-            return {};
-
-        return MUST(result.to_string());
-    }
-
     virtual Vector<Partition> format_to_parts(Value const& value) const override
     {
         auto formatted = format_impl(value);

--- a/Libraries/LibUnicode/NumberFormat.h
+++ b/Libraries/LibUnicode/NumberFormat.h
@@ -156,7 +156,6 @@ public:
     using Value = Variant<double, String>;
 
     virtual String format(Value const&) const = 0;
-    virtual String format_to_decimal(Value const&) const = 0;
     virtual Vector<Partition> format_to_parts(Value const&) const = 0;
 
     virtual String format_range(Value const&, Value const&) const = 0;


### PR DESCRIPTION
Noticed while looking at UTF-16 stuff.