### PR TITLE
LibWeb: Account for natural aspect ratio in calculate_min_content_height

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1513,8 +1513,11 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     if (box.is_block_container() || box.display().is_table_inside())
         return calculate_max_content_height(box, width);
 
-    if (box.has_natural_height())
+    if (box.has_natural_height()) {
+        if (box.has_natural_aspect_ratio())
+            return width / *box.natural_aspect_ratio();
         return *box.natural_height();
+    }
 
     auto& cache = box.cached_intrinsic_sizes().min_content_height.ensure(width);
     if (cache.has_value())

--- a/Tests/LibWeb/Layout/expected/grid/img-with-percentage-width-and-height.txt
+++ b/Tests/LibWeb/Layout/expected/grid/img-with-percentage-width-and-height.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 50x50 [GFC] children: not-inline
+      ImageBox <img> at (8,8) content-size 50x50 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableBox (Box<BODY>) [8,8 50x50]
+      ImagePaintable (ImageBox<IMG>) [8,8 50x50]

--- a/Tests/LibWeb/Layout/input/grid/img-with-percentage-width-and-height.html
+++ b/Tests/LibWeb/Layout/input/grid/img-with-percentage-width-and-height.html
@@ -1,0 +1,12 @@
+<!doctype html><style>
+body {
+    display: grid;
+    width: 50px;
+    height: 50px;
+}
+img {
+    grid-area: 1 / 1;
+    height: 100%;
+    width: 100%;
+}
+</style><body><img src="../../../Assets/120.png">

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/flex-aspect-ratio-img-column-011.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/flex-aspect-ratio-img-column-011.txt
@@ -2,15 +2,15 @@ Harness status: OK
 
 Found 10 tests
 
-7 Pass
-3 Fail
+9 Pass
+1 Fail
 Pass	.flexbox 1
 Pass	.flexbox 2
 Pass	.flexbox 3
 Pass	.flexbox 4
 Fail	.flexbox 5
 Pass	.flexbox 6
-Fail	.flexbox 7
+Pass	.flexbox 7
 Pass	.flexbox 8
 Pass	.flexbox 9
-Fail	.flexbox 10
+Pass	.flexbox 10


### PR DESCRIPTION
By the time we calculate the min-content height, the width is already known, so we can use it to calculate the height based on the natural aspect ratio.