### PR TITLE
LibWeb/CSS: Update definition for `cursor` property

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1061,16 +1061,16 @@ Vector<CursorData> ComputedProperties::cursor() const
                 continue;
             }
 
-            if (auto keyword = keyword_to_cursor(item->to_keyword()); keyword.has_value())
+            if (auto keyword = keyword_to_cursor_predefined(item->to_keyword()); keyword.has_value())
                 cursors.append(keyword.release_value());
         }
     } else if (value.is_keyword()) {
-        if (auto keyword = keyword_to_cursor(value.to_keyword()); keyword.has_value())
+        if (auto keyword = keyword_to_cursor_predefined(value.to_keyword()); keyword.has_value())
             cursors.append(keyword.release_value());
     }
 
     if (cursors.is_empty())
-        cursors.append(Cursor::Auto);
+        cursors.append(CursorPredefined::Auto);
 
     return cursors;
 }

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -86,7 +86,7 @@ struct ScrollbarColorData {
     Color track_color { Color::Transparent };
 };
 
-using CursorData = Variant<NonnullRefPtr<CursorStyleValue const>, Cursor>;
+using CursorData = Variant<NonnullRefPtr<CursorStyleValue const>, CursorPredefined>;
 
 using ListStyleType = Variant<CounterStyleNameKeyword, String>;
 
@@ -105,7 +105,7 @@ public:
     static CSS::Clip clip() { return CSS::Clip::make_auto(); }
     static CSS::PreferredColorScheme color_scheme() { return CSS::PreferredColorScheme::Auto; }
     static CSS::ContentVisibility content_visibility() { return CSS::ContentVisibility::Visible; }
-    static CursorData cursor() { return { CSS::Cursor::Auto }; }
+    static CursorData cursor() { return { CSS::CursorPredefined::Auto }; }
     static CSS::WhiteSpaceCollapse white_space_collapse() { return CSS::WhiteSpaceCollapse::Collapse; }
     static CSS::WordBreak word_break() { return CSS::WordBreak::Normal; }
     static CSS::LengthOrCalculated word_spacing() { return CSS::Length::make_px(0); }

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -150,7 +150,7 @@
     "anonymous",
     "use-credentials"
   ],
-  "cursor": [
+  "cursor-predefined": [
     "auto",
     "default",
     "none",

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1052,10 +1052,11 @@ RefPtr<CSSStyleValue const> Parser::parse_counter_set_value(TokenStream<Componen
     return parse_counter_definitions_value(tokens, AllowReversed::No, 0);
 }
 
-// https://drafts.csswg.org/css-ui-3/#cursor
+// https://drafts.csswg.org/css-ui-4/#cursor
 RefPtr<CSSStyleValue const> Parser::parse_cursor_value(TokenStream<ComponentValue>& tokens)
 {
-    // [ [<url> [<x> <y>]?,]* <built-in-cursor> ]
+    // <cursor-image>#? <cursor-predefined>
+    // <cursor-image> = <url> <number>{2}?
     // So, any number of custom cursor definitions, and then a mandatory cursor name keyword, all comma-separated.
 
     auto transaction = tokens.begin_transaction();
@@ -1071,7 +1072,7 @@ RefPtr<CSSStyleValue const> Parser::parse_cursor_value(TokenStream<ComponentValu
             // Cursor keyword
             part_tokens.discard_whitespace();
             auto keyword_value = parse_keyword_value(part_tokens);
-            if (!keyword_value || !keyword_to_cursor(keyword_value->to_keyword()).has_value())
+            if (!keyword_value || !keyword_to_cursor_predefined(keyword_value->to_keyword()).has_value())
                 return {};
 
             part_tokens.discard_whitespace();
@@ -1081,7 +1082,7 @@ RefPtr<CSSStyleValue const> Parser::parse_cursor_value(TokenStream<ComponentValu
             cursors.append(keyword_value.release_nonnull());
         } else {
             // Custom cursor definition
-            // <url> [<x> <y>]?
+            // <cursor-image> = <url> <number>{2}?
             // "Conforming user agents may, instead of <url>, support <image> which is a superset."
 
             part_tokens.discard_whitespace();
@@ -1092,7 +1093,7 @@ RefPtr<CSSStyleValue const> Parser::parse_cursor_value(TokenStream<ComponentValu
             part_tokens.discard_whitespace();
 
             if (part_tokens.has_next_token()) {
-                // x and y, which are both <number>
+                // <number>{2}, which are the x and y coordinates of the hotspot
                 auto x = parse_number(part_tokens);
                 part_tokens.discard_whitespace();
                 auto y = parse_number(part_tokens);

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1334,7 +1334,8 @@
     "initial": "auto",
     "valid-types": [
       "url",
-      "cursor"
+      "cursor-predefined",
+      "number [-∞,∞]"
     ]
   },
   "cx": {

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -98,62 +98,62 @@ static Gfx::Cursor resolve_cursor(Layout::NodeWithStyle const& layout_node, Vect
 {
     for (auto const& cursor : cursor_data) {
         auto result = cursor.visit(
-            [auto_cursor](CSS::Cursor css_cursor) -> Optional<Gfx::Cursor> {
+            [auto_cursor](CSS::CursorPredefined css_cursor) -> Optional<Gfx::Cursor> {
                 switch (css_cursor) {
-                case CSS::Cursor::Crosshair:
-                case CSS::Cursor::Cell:
+                case CSS::CursorPredefined::Crosshair:
+                case CSS::CursorPredefined::Cell:
                     return Gfx::StandardCursor::Crosshair;
-                case CSS::Cursor::Grab:
-                case CSS::Cursor::Grabbing:
+                case CSS::CursorPredefined::Grab:
+                case CSS::CursorPredefined::Grabbing:
                     return Gfx::StandardCursor::Drag;
-                case CSS::Cursor::Pointer:
+                case CSS::CursorPredefined::Pointer:
                     return Gfx::StandardCursor::Hand;
-                case CSS::Cursor::Help:
+                case CSS::CursorPredefined::Help:
                     return Gfx::StandardCursor::Help;
-                case CSS::Cursor::None:
+                case CSS::CursorPredefined::None:
                     return Gfx::StandardCursor::Hidden;
-                case CSS::Cursor::NotAllowed:
+                case CSS::CursorPredefined::NotAllowed:
                     return Gfx::StandardCursor::Disallowed;
-                case CSS::Cursor::Text:
-                case CSS::Cursor::VerticalText:
+                case CSS::CursorPredefined::Text:
+                case CSS::CursorPredefined::VerticalText:
                     return Gfx::StandardCursor::IBeam;
-                case CSS::Cursor::Move:
-                case CSS::Cursor::AllScroll:
+                case CSS::CursorPredefined::Move:
+                case CSS::CursorPredefined::AllScroll:
                     return Gfx::StandardCursor::Move;
-                case CSS::Cursor::Progress:
-                case CSS::Cursor::Wait:
+                case CSS::CursorPredefined::Progress:
+                case CSS::CursorPredefined::Wait:
                     return Gfx::StandardCursor::Wait;
-                case CSS::Cursor::ColResize:
+                case CSS::CursorPredefined::ColResize:
                     return Gfx::StandardCursor::ResizeColumn;
-                case CSS::Cursor::EResize:
-                case CSS::Cursor::WResize:
-                case CSS::Cursor::EwResize:
+                case CSS::CursorPredefined::EResize:
+                case CSS::CursorPredefined::WResize:
+                case CSS::CursorPredefined::EwResize:
                     return Gfx::StandardCursor::ResizeHorizontal;
-                case CSS::Cursor::RowResize:
+                case CSS::CursorPredefined::RowResize:
                     return Gfx::StandardCursor::ResizeRow;
-                case CSS::Cursor::NResize:
-                case CSS::Cursor::SResize:
-                case CSS::Cursor::NsResize:
+                case CSS::CursorPredefined::NResize:
+                case CSS::CursorPredefined::SResize:
+                case CSS::CursorPredefined::NsResize:
                     return Gfx::StandardCursor::ResizeVertical;
-                case CSS::Cursor::NeResize:
-                case CSS::Cursor::SwResize:
-                case CSS::Cursor::NeswResize:
+                case CSS::CursorPredefined::NeResize:
+                case CSS::CursorPredefined::SwResize:
+                case CSS::CursorPredefined::NeswResize:
                     return Gfx::StandardCursor::ResizeDiagonalBLTR;
-                case CSS::Cursor::NwResize:
-                case CSS::Cursor::SeResize:
-                case CSS::Cursor::NwseResize:
+                case CSS::CursorPredefined::NwResize:
+                case CSS::CursorPredefined::SeResize:
+                case CSS::CursorPredefined::NwseResize:
                     return Gfx::StandardCursor::ResizeDiagonalTLBR;
-                case CSS::Cursor::ZoomIn:
-                case CSS::Cursor::ZoomOut:
+                case CSS::CursorPredefined::ZoomIn:
+                case CSS::CursorPredefined::ZoomOut:
                     return Gfx::StandardCursor::Zoom;
-                case CSS::Cursor::Auto:
+                case CSS::CursorPredefined::Auto:
                     return auto_cursor;
-                case CSS::Cursor::ContextMenu:
-                case CSS::Cursor::Alias:
-                case CSS::Cursor::Copy:
-                case CSS::Cursor::NoDrop:
+                case CSS::CursorPredefined::ContextMenu:
+                case CSS::CursorPredefined::Alias:
+                case CSS::CursorPredefined::Copy:
+                case CSS::CursorPredefined::NoDrop:
                     // FIXME: No corresponding GFX Standard Cursor, fallthrough to None
-                case CSS::Cursor::Default:
+                case CSS::CursorPredefined::Default:
                 default:
                     return Gfx::StandardCursor::None;
                 }


### PR DESCRIPTION
No functional changes. The main difference is renaming the cursor enum to match the spec term `<cursor-predefined>`, which is a bit more verbose but clearer in meaning.

Corresponds to https://github.com/w3c/csswg-drafts/commit/1a57a4025c8778dab45ef8d5fbd482e4d6c4ebce