### PR TITLE
LibWeb: Don't fail on non-fill keyword in <border-image-slice>

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1790,19 +1790,15 @@ RefPtr<CSSStyleValue const> Parser::parse_border_image_slice_value(TokenStream<C
     RefPtr<CSSStyleValue const> bottom;
     RefPtr<CSSStyleValue const> left;
 
-    auto parse_fill = [&](TokenStream<ComponentValue>& fill_tokens) -> Optional<bool> {
-        if (auto keyword = parse_keyword_value(fill_tokens)) {
-            if (fill || keyword->to_keyword() != Keyword::Fill)
-                return {};
+    auto parse_fill = [](TokenStream<ComponentValue>& fill_tokens) {
+        if (fill_tokens.next_token().is_ident("fill"sv)) {
+            fill_tokens.discard_a_token();
             return true;
         }
         return false;
     };
 
-    auto maybe_fill_value = parse_fill(tokens);
-    if (!maybe_fill_value.has_value())
-        return nullptr;
-    if (*maybe_fill_value)
+    if (parse_fill(tokens))
         fill = true;
 
     Vector<ValueComparingNonnullRefPtr<CSSStyleValue const>> number_percentages;
@@ -1847,12 +1843,11 @@ RefPtr<CSSStyleValue const> Parser::parse_border_image_slice_value(TokenStream<C
         return nullptr;
     }
 
-    if (tokens.has_next_token()) {
-        maybe_fill_value = parse_fill(tokens);
-        if (!maybe_fill_value.has_value())
+    if (tokens.has_next_token() && parse_fill(tokens)) {
+        if (fill)
             return nullptr;
-        if (*maybe_fill_value)
-            fill = true;
+
+        fill = true;
     }
 
     transaction.commit();

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1645,6 +1645,7 @@ RefPtr<CSSStyleValue const> Parser::parse_border_value(PropertyID property_id, T
     if (!border_color)
         border_color = property_initial_value(color_property);
 
+    // FIXME: Also reset border-image, in line with the spec: https://www.w3.org/TR/css-backgrounds-3/#border-shorthands
     transaction.commit();
     return ShorthandStyleValue::create(property_id,
         { width_property, style_property, color_property },

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -679,15 +679,6 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
         }
     };
 
-    if (property_id == CSS::PropertyID::Border) {
-        for_each_property_expanding_shorthands(CSS::PropertyID::BorderTop, value, set_longhand_property);
-        for_each_property_expanding_shorthands(CSS::PropertyID::BorderRight, value, set_longhand_property);
-        for_each_property_expanding_shorthands(CSS::PropertyID::BorderBottom, value, set_longhand_property);
-        for_each_property_expanding_shorthands(CSS::PropertyID::BorderLeft, value, set_longhand_property);
-        // FIXME: Also reset border-image, in line with the spec: https://www.w3.org/TR/css-backgrounds-3/#border-shorthands
-        return;
-    }
-
     if (property_id == CSS::PropertyID::BorderStyle) {
         assign_edge_values(PropertyID::BorderTopStyle, PropertyID::BorderRightStyle, PropertyID::BorderBottomStyle, PropertyID::BorderLeftStyle, value);
         return;

--- a/Tests/LibWeb/Text/expected/css/border-image-non-fill-keyword.txt
+++ b/Tests/LibWeb/Text/expected/css/border-image-non-fill-keyword.txt
@@ -1,0 +1,1 @@
+#foo { border-image: none 100% / 1 / 0 stretch; }

--- a/Tests/LibWeb/Text/input/css/border-image-non-fill-keyword.html
+++ b/Tests/LibWeb/Text/input/css/border-image-non-fill-keyword.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #foo {
+        border-image: 100% none;
+    }
+</style>
+<script>
+    test(() => {
+        println(document.styleSheets[0].cssRules[0].cssText);
+    });
+</script>


### PR DESCRIPTION
Previously if we encountered a keyword other than `fill` when parsing `<border-image-slice` we would return a nullptr.

This could cause issues when we parse `<border-image-slice>` as part of parsing `border-image`, for example `border-image: 100% none` would fail as we would try parse `none` as part of the `<border-image-slice>` instead of `<border-image-source>`.

This change makes it so that we don't consume the token and leave it to be parsed as part of the next section of the grammar.

PR also includes an unrelated commit to remove some unused code in `StyleComputer::for_each_property_expanding_shorthands`