### PR TITLE
LibWeb: Remove setting the Skia backend context in Navigable

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -150,7 +150,6 @@ Navigable::Navigable(GC::Ref<Page> page, bool is_svg_page)
         }
 
         m_rendering_thread.set_skia_player(move(skia_player));
-        m_rendering_thread.set_skia_backend_context(m_skia_backend_context);
         m_rendering_thread.start(display_list_player_type);
     }
 }

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -28,7 +28,6 @@ public:
 
     void start(DisplayListPlayerType);
     void set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player) { m_skia_player = move(player); }
-    void set_skia_backend_context(RefPtr<Gfx::SkiaBackendContext> context) { m_skia_backend_context = move(context); }
     void enqueue_rendering_task(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
 private:
@@ -38,7 +37,6 @@ private:
     DisplayListPlayerType m_display_list_player_type;
 
     OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
-    RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
 
     RefPtr<Threading::Thread> m_thread;
     Atomic<bool> m_exit { false };


### PR DESCRIPTION
This is unused. The backend context is also referenced in the Skia player, which we move to the rendering thread.