### PR TITLE
LibWeb: Remove UA styles for h1 in article, aside, nav and section

### DIFF
--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -490,36 +490,6 @@ h6 {
     font-weight: bold;
 }
 
-:is(article, aside, nav, section) h1 {
-    margin-top: 0.83em;
-    margin-bottom: 0.83em;
-    font-size: 1.50em;
-}
-
-:is(article, aside, nav, section) :is(article, aside, nav, section) h1 {
-    margin-top: 1.00em;
-    margin-bottom: 1.00em;
-    font-size: 1.17em;
-}
-
-:is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) h1 {
-    margin-top: 1.33em;
-    margin-bottom: 1.33em;
-    font-size: 1.00em;
-}
-
-:is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) h1 {
-    margin-top: 1.67em;
-    margin-bottom: 1.67em;
-    font-size: 0.83em;
-}
-
-:is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) :is(article, aside, nav, section) h1 {
-    margin-top: 2.33em;
-    margin-bottom: 2.33em;
-    font-size: 0.67em;
-}
-
 /* 15.3.7 Lists
  * https://html.spec.whatwg.org/multipage/rendering.html#lists
  */

--- a/Tests/LibWeb/Text/expected/wpt-import/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.txt
@@ -1,0 +1,566 @@
+Harness status: OK
+
+Found 561 tests
+
+561 Pass
+Pass	<h1> - display
+Pass	<h1> - margin-top
+Pass	<h1> - margin-right
+Pass	<h1> - margin-bottom
+Pass	<h1> - margin-left
+Pass	<h1> - padding-top
+Pass	<h1> - padding-right
+Pass	<h1> - padding-bottom
+Pass	<h1> - padding-left
+Pass	<h1> - font-size
+Pass	<h1> - font-weight
+Pass	<h2> - display
+Pass	<h2> - margin-top
+Pass	<h2> - margin-right
+Pass	<h2> - margin-bottom
+Pass	<h2> - margin-left
+Pass	<h2> - padding-top
+Pass	<h2> - padding-right
+Pass	<h2> - padding-bottom
+Pass	<h2> - padding-left
+Pass	<h2> - font-size
+Pass	<h2> - font-weight
+Pass	<h3> - display
+Pass	<h3> - margin-top
+Pass	<h3> - margin-right
+Pass	<h3> - margin-bottom
+Pass	<h3> - margin-left
+Pass	<h3> - padding-top
+Pass	<h3> - padding-right
+Pass	<h3> - padding-bottom
+Pass	<h3> - padding-left
+Pass	<h3> - font-size
+Pass	<h3> - font-weight
+Pass	<h4> - display
+Pass	<h4> - margin-top
+Pass	<h4> - margin-right
+Pass	<h4> - margin-bottom
+Pass	<h4> - margin-left
+Pass	<h4> - padding-top
+Pass	<h4> - padding-right
+Pass	<h4> - padding-bottom
+Pass	<h4> - padding-left
+Pass	<h4> - font-size
+Pass	<h4> - font-weight
+Pass	<h5> - display
+Pass	<h5> - margin-top
+Pass	<h5> - margin-right
+Pass	<h5> - margin-bottom
+Pass	<h5> - margin-left
+Pass	<h5> - padding-top
+Pass	<h5> - padding-right
+Pass	<h5> - padding-bottom
+Pass	<h5> - padding-left
+Pass	<h5> - font-size
+Pass	<h5> - font-weight
+Pass	<h6> - display
+Pass	<h6> - margin-top
+Pass	<h6> - margin-right
+Pass	<h6> - margin-bottom
+Pass	<h6> - margin-left
+Pass	<h6> - padding-top
+Pass	<h6> - padding-right
+Pass	<h6> - padding-bottom
+Pass	<h6> - padding-left
+Pass	<h6> - font-size
+Pass	<h6> - font-weight
+Pass	<hgroup> - display
+Pass	<hgroup> - margin-top
+Pass	<hgroup> - margin-right
+Pass	<hgroup> - margin-bottom
+Pass	<hgroup> - margin-left
+Pass	<hgroup> - padding-top
+Pass	<hgroup> - padding-right
+Pass	<hgroup> - padding-bottom
+Pass	<hgroup> - padding-left
+Pass	<hgroup> - font-size
+Pass	<hgroup> - font-weight
+Pass	<article> - display
+Pass	<article> - margin-top
+Pass	<article> - margin-right
+Pass	<article> - margin-bottom
+Pass	<article> - margin-left
+Pass	<article> - padding-top
+Pass	<article> - padding-right
+Pass	<article> - padding-bottom
+Pass	<article> - padding-left
+Pass	<article> - font-size
+Pass	<article> - font-weight
+Pass	<aside> - display
+Pass	<aside> - margin-top
+Pass	<aside> - margin-right
+Pass	<aside> - margin-bottom
+Pass	<aside> - margin-left
+Pass	<aside> - padding-top
+Pass	<aside> - padding-right
+Pass	<aside> - padding-bottom
+Pass	<aside> - padding-left
+Pass	<aside> - font-size
+Pass	<aside> - font-weight
+Pass	<nav> - display
+Pass	<nav> - margin-top
+Pass	<nav> - margin-right
+Pass	<nav> - margin-bottom
+Pass	<nav> - margin-left
+Pass	<nav> - padding-top
+Pass	<nav> - padding-right
+Pass	<nav> - padding-bottom
+Pass	<nav> - padding-left
+Pass	<nav> - font-size
+Pass	<nav> - font-weight
+Pass	<section> - display
+Pass	<section> - margin-top
+Pass	<section> - margin-right
+Pass	<section> - margin-bottom
+Pass	<section> - margin-left
+Pass	<section> - padding-top
+Pass	<section> - padding-right
+Pass	<section> - padding-bottom
+Pass	<section> - padding-left
+Pass	<section> - font-size
+Pass	<section> - font-weight
+Pass	<h1> (in <article>) - display
+Pass	<h1> (in <article>) - margin-top
+Pass	<h1> (in <article>) - margin-right
+Pass	<h1> (in <article>) - margin-bottom
+Pass	<h1> (in <article>) - margin-left
+Pass	<h1> (in <article>) - padding-top
+Pass	<h1> (in <article>) - padding-right
+Pass	<h1> (in <article>) - padding-bottom
+Pass	<h1> (in <article>) - padding-left
+Pass	<h1> (in <article>) - font-size
+Pass	<h1> (in <article>) - font-weight
+Pass	<h1> (in <article><article>) - display
+Pass	<h1> (in <article><article>) - margin-top
+Pass	<h1> (in <article><article>) - margin-right
+Pass	<h1> (in <article><article>) - margin-bottom
+Pass	<h1> (in <article><article>) - margin-left
+Pass	<h1> (in <article><article>) - padding-top
+Pass	<h1> (in <article><article>) - padding-right
+Pass	<h1> (in <article><article>) - padding-bottom
+Pass	<h1> (in <article><article>) - padding-left
+Pass	<h1> (in <article><article>) - font-size
+Pass	<h1> (in <article><article>) - font-weight
+Pass	<h1> (in <article><article><article>) - display
+Pass	<h1> (in <article><article><article>) - margin-top
+Pass	<h1> (in <article><article><article>) - margin-right
+Pass	<h1> (in <article><article><article>) - margin-bottom
+Pass	<h1> (in <article><article><article>) - margin-left
+Pass	<h1> (in <article><article><article>) - padding-top
+Pass	<h1> (in <article><article><article>) - padding-right
+Pass	<h1> (in <article><article><article>) - padding-bottom
+Pass	<h1> (in <article><article><article>) - padding-left
+Pass	<h1> (in <article><article><article>) - font-size
+Pass	<h1> (in <article><article><article>) - font-weight
+Pass	<h1> (in <article><article><article><article>) - display
+Pass	<h1> (in <article><article><article><article>) - margin-top
+Pass	<h1> (in <article><article><article><article>) - margin-right
+Pass	<h1> (in <article><article><article><article>) - margin-bottom
+Pass	<h1> (in <article><article><article><article>) - margin-left
+Pass	<h1> (in <article><article><article><article>) - padding-top
+Pass	<h1> (in <article><article><article><article>) - padding-right
+Pass	<h1> (in <article><article><article><article>) - padding-bottom
+Pass	<h1> (in <article><article><article><article>) - padding-left
+Pass	<h1> (in <article><article><article><article>) - font-size
+Pass	<h1> (in <article><article><article><article>) - font-weight
+Pass	<h1> (in <article><article><article><article><article>) - display
+Pass	<h1> (in <article><article><article><article><article>) - margin-top
+Pass	<h1> (in <article><article><article><article><article>) - margin-right
+Pass	<h1> (in <article><article><article><article><article>) - margin-bottom
+Pass	<h1> (in <article><article><article><article><article>) - margin-left
+Pass	<h1> (in <article><article><article><article><article>) - padding-top
+Pass	<h1> (in <article><article><article><article><article>) - padding-right
+Pass	<h1> (in <article><article><article><article><article>) - padding-bottom
+Pass	<h1> (in <article><article><article><article><article>) - padding-left
+Pass	<h1> (in <article><article><article><article><article>) - font-size
+Pass	<h1> (in <article><article><article><article><article>) - font-weight
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - display
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - margin-top
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - margin-right
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - margin-bottom
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - margin-left
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - padding-top
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - padding-right
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - padding-bottom
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - padding-left
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - font-size
+Pass	<h1> (in <article><article><article><article><article><hgroup>) - font-weight
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - display
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - margin-top
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - margin-right
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - margin-bottom
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - margin-left
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - padding-top
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - padding-right
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - padding-bottom
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - padding-left
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - font-size
+Pass	<h2> (in <article><article><article><article><article><hgroup>) - font-weight
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - display
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - margin-top
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - margin-right
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - margin-bottom
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - margin-left
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - padding-top
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - padding-right
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - padding-bottom
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - padding-left
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - font-size
+Pass	<h3> (in <article><article><article><article><article><hgroup>) - font-weight
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - display
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - margin-top
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - margin-right
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - margin-bottom
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - margin-left
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - padding-top
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - padding-right
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - padding-bottom
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - padding-left
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - font-size
+Pass	<h4> (in <article><article><article><article><article><hgroup>) - font-weight
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - display
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - margin-top
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - margin-right
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - margin-bottom
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - margin-left
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - padding-top
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - padding-right
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - padding-bottom
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - padding-left
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - font-size
+Pass	<h5> (in <article><article><article><article><article><hgroup>) - font-weight
+Pass	<h1> (in <aside>) - display
+Pass	<h1> (in <aside>) - margin-top
+Pass	<h1> (in <aside>) - margin-right
+Pass	<h1> (in <aside>) - margin-bottom
+Pass	<h1> (in <aside>) - margin-left
+Pass	<h1> (in <aside>) - padding-top
+Pass	<h1> (in <aside>) - padding-right
+Pass	<h1> (in <aside>) - padding-bottom
+Pass	<h1> (in <aside>) - padding-left
+Pass	<h1> (in <aside>) - font-size
+Pass	<h1> (in <aside>) - font-weight
+Pass	<h1> (in <aside><aside>) - display
+Pass	<h1> (in <aside><aside>) - margin-top
+Pass	<h1> (in <aside><aside>) - margin-right
+Pass	<h1> (in <aside><aside>) - margin-bottom
+Pass	<h1> (in <aside><aside>) - margin-left
+Pass	<h1> (in <aside><aside>) - padding-top
+Pass	<h1> (in <aside><aside>) - padding-right
+Pass	<h1> (in <aside><aside>) - padding-bottom
+Pass	<h1> (in <aside><aside>) - padding-left
+Pass	<h1> (in <aside><aside>) - font-size
+Pass	<h1> (in <aside><aside>) - font-weight
+Pass	<h1> (in <aside><aside><aside>) - display
+Pass	<h1> (in <aside><aside><aside>) - margin-top
+Pass	<h1> (in <aside><aside><aside>) - margin-right
+Pass	<h1> (in <aside><aside><aside>) - margin-bottom
+Pass	<h1> (in <aside><aside><aside>) - margin-left
+Pass	<h1> (in <aside><aside><aside>) - padding-top
+Pass	<h1> (in <aside><aside><aside>) - padding-right
+Pass	<h1> (in <aside><aside><aside>) - padding-bottom
+Pass	<h1> (in <aside><aside><aside>) - padding-left
+Pass	<h1> (in <aside><aside><aside>) - font-size
+Pass	<h1> (in <aside><aside><aside>) - font-weight
+Pass	<h1> (in <aside><aside><aside><aside>) - display
+Pass	<h1> (in <aside><aside><aside><aside>) - margin-top
+Pass	<h1> (in <aside><aside><aside><aside>) - margin-right
+Pass	<h1> (in <aside><aside><aside><aside>) - margin-bottom
+Pass	<h1> (in <aside><aside><aside><aside>) - margin-left
+Pass	<h1> (in <aside><aside><aside><aside>) - padding-top
+Pass	<h1> (in <aside><aside><aside><aside>) - padding-right
+Pass	<h1> (in <aside><aside><aside><aside>) - padding-bottom
+Pass	<h1> (in <aside><aside><aside><aside>) - padding-left
+Pass	<h1> (in <aside><aside><aside><aside>) - font-size
+Pass	<h1> (in <aside><aside><aside><aside>) - font-weight
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - display
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - margin-top
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - margin-right
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - margin-bottom
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - margin-left
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - padding-top
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - padding-right
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - padding-bottom
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - padding-left
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - font-size
+Pass	<h1> (in <aside><aside><aside><aside><aside>) - font-weight
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - display
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+Pass	<h1> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - display
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+Pass	<h2> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - display
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+Pass	<h3> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - display
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+Pass	<h4> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - display
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-right
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - margin-left
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-top
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-right
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-bottom
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - padding-left
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - font-size
+Pass	<h5> (in <aside><aside><aside><aside><aside><hgroup>) - font-weight
+Pass	<h1> (in <nav>) - display
+Pass	<h1> (in <nav>) - margin-top
+Pass	<h1> (in <nav>) - margin-right
+Pass	<h1> (in <nav>) - margin-bottom
+Pass	<h1> (in <nav>) - margin-left
+Pass	<h1> (in <nav>) - padding-top
+Pass	<h1> (in <nav>) - padding-right
+Pass	<h1> (in <nav>) - padding-bottom
+Pass	<h1> (in <nav>) - padding-left
+Pass	<h1> (in <nav>) - font-size
+Pass	<h1> (in <nav>) - font-weight
+Pass	<h1> (in <nav><nav>) - display
+Pass	<h1> (in <nav><nav>) - margin-top
+Pass	<h1> (in <nav><nav>) - margin-right
+Pass	<h1> (in <nav><nav>) - margin-bottom
+Pass	<h1> (in <nav><nav>) - margin-left
+Pass	<h1> (in <nav><nav>) - padding-top
+Pass	<h1> (in <nav><nav>) - padding-right
+Pass	<h1> (in <nav><nav>) - padding-bottom
+Pass	<h1> (in <nav><nav>) - padding-left
+Pass	<h1> (in <nav><nav>) - font-size
+Pass	<h1> (in <nav><nav>) - font-weight
+Pass	<h1> (in <nav><nav><nav>) - display
+Pass	<h1> (in <nav><nav><nav>) - margin-top
+Pass	<h1> (in <nav><nav><nav>) - margin-right
+Pass	<h1> (in <nav><nav><nav>) - margin-bottom
+Pass	<h1> (in <nav><nav><nav>) - margin-left
+Pass	<h1> (in <nav><nav><nav>) - padding-top
+Pass	<h1> (in <nav><nav><nav>) - padding-right
+Pass	<h1> (in <nav><nav><nav>) - padding-bottom
+Pass	<h1> (in <nav><nav><nav>) - padding-left
+Pass	<h1> (in <nav><nav><nav>) - font-size
+Pass	<h1> (in <nav><nav><nav>) - font-weight
+Pass	<h1> (in <nav><nav><nav><nav>) - display
+Pass	<h1> (in <nav><nav><nav><nav>) - margin-top
+Pass	<h1> (in <nav><nav><nav><nav>) - margin-right
+Pass	<h1> (in <nav><nav><nav><nav>) - margin-bottom
+Pass	<h1> (in <nav><nav><nav><nav>) - margin-left
+Pass	<h1> (in <nav><nav><nav><nav>) - padding-top
+Pass	<h1> (in <nav><nav><nav><nav>) - padding-right
+Pass	<h1> (in <nav><nav><nav><nav>) - padding-bottom
+Pass	<h1> (in <nav><nav><nav><nav>) - padding-left
+Pass	<h1> (in <nav><nav><nav><nav>) - font-size
+Pass	<h1> (in <nav><nav><nav><nav>) - font-weight
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - display
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - margin-top
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - margin-right
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - margin-bottom
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - margin-left
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - padding-top
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - padding-right
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - padding-bottom
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - padding-left
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - font-size
+Pass	<h1> (in <nav><nav><nav><nav><nav>) - font-weight
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - display
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+Pass	<h1> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - display
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+Pass	<h2> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - display
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+Pass	<h3> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - display
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+Pass	<h4> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - display
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-right
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - margin-left
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-top
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-right
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-bottom
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - padding-left
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - font-size
+Pass	<h5> (in <nav><nav><nav><nav><nav><hgroup>) - font-weight
+Pass	<h1> (in <section>) - display
+Pass	<h1> (in <section>) - margin-top
+Pass	<h1> (in <section>) - margin-right
+Pass	<h1> (in <section>) - margin-bottom
+Pass	<h1> (in <section>) - margin-left
+Pass	<h1> (in <section>) - padding-top
+Pass	<h1> (in <section>) - padding-right
+Pass	<h1> (in <section>) - padding-bottom
+Pass	<h1> (in <section>) - padding-left
+Pass	<h1> (in <section>) - font-size
+Pass	<h1> (in <section>) - font-weight
+Pass	<h1> (in <section><section>) - display
+Pass	<h1> (in <section><section>) - margin-top
+Pass	<h1> (in <section><section>) - margin-right
+Pass	<h1> (in <section><section>) - margin-bottom
+Pass	<h1> (in <section><section>) - margin-left
+Pass	<h1> (in <section><section>) - padding-top
+Pass	<h1> (in <section><section>) - padding-right
+Pass	<h1> (in <section><section>) - padding-bottom
+Pass	<h1> (in <section><section>) - padding-left
+Pass	<h1> (in <section><section>) - font-size
+Pass	<h1> (in <section><section>) - font-weight
+Pass	<h1> (in <section><section><section>) - display
+Pass	<h1> (in <section><section><section>) - margin-top
+Pass	<h1> (in <section><section><section>) - margin-right
+Pass	<h1> (in <section><section><section>) - margin-bottom
+Pass	<h1> (in <section><section><section>) - margin-left
+Pass	<h1> (in <section><section><section>) - padding-top
+Pass	<h1> (in <section><section><section>) - padding-right
+Pass	<h1> (in <section><section><section>) - padding-bottom
+Pass	<h1> (in <section><section><section>) - padding-left
+Pass	<h1> (in <section><section><section>) - font-size
+Pass	<h1> (in <section><section><section>) - font-weight
+Pass	<h1> (in <section><section><section><section>) - display
+Pass	<h1> (in <section><section><section><section>) - margin-top
+Pass	<h1> (in <section><section><section><section>) - margin-right
+Pass	<h1> (in <section><section><section><section>) - margin-bottom
+Pass	<h1> (in <section><section><section><section>) - margin-left
+Pass	<h1> (in <section><section><section><section>) - padding-top
+Pass	<h1> (in <section><section><section><section>) - padding-right
+Pass	<h1> (in <section><section><section><section>) - padding-bottom
+Pass	<h1> (in <section><section><section><section>) - padding-left
+Pass	<h1> (in <section><section><section><section>) - font-size
+Pass	<h1> (in <section><section><section><section>) - font-weight
+Pass	<h1> (in <section><section><section><section><section>) - display
+Pass	<h1> (in <section><section><section><section><section>) - margin-top
+Pass	<h1> (in <section><section><section><section><section>) - margin-right
+Pass	<h1> (in <section><section><section><section><section>) - margin-bottom
+Pass	<h1> (in <section><section><section><section><section>) - margin-left
+Pass	<h1> (in <section><section><section><section><section>) - padding-top
+Pass	<h1> (in <section><section><section><section><section>) - padding-right
+Pass	<h1> (in <section><section><section><section><section>) - padding-bottom
+Pass	<h1> (in <section><section><section><section><section>) - padding-left
+Pass	<h1> (in <section><section><section><section><section>) - font-size
+Pass	<h1> (in <section><section><section><section><section>) - font-weight
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - display
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - margin-top
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - margin-right
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - margin-bottom
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - margin-left
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - padding-top
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - padding-right
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - padding-bottom
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - padding-left
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - font-size
+Pass	<h1> (in <section><section><section><section><section><hgroup>) - font-weight
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - display
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - margin-top
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - margin-right
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - margin-bottom
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - margin-left
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - padding-top
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - padding-right
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - padding-bottom
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - padding-left
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - font-size
+Pass	<h2> (in <section><section><section><section><section><hgroup>) - font-weight
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - display
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - margin-top
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - margin-right
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - margin-bottom
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - margin-left
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - padding-top
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - padding-right
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - padding-bottom
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - padding-left
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - font-size
+Pass	<h3> (in <section><section><section><section><section><hgroup>) - font-weight
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - display
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - margin-top
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - margin-right
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - margin-bottom
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - margin-left
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - padding-top
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - padding-right
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - padding-bottom
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - padding-left
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - font-size
+Pass	<h4> (in <section><section><section><section><section><hgroup>) - font-weight
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - display
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - margin-top
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - margin-right
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - margin-bottom
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - margin-left
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - padding-top
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - padding-right
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - padding-bottom
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - padding-left
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - font-size
+Pass	<h5> (in <section><section><section><section><section><hgroup>) - font-weight

--- a/Tests/LibWeb/Text/input/wpt-import/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<title>default styles for h1..h6, hgroup, article, aside, nav, section (no h1 in section UA styles)</title>
+<meta name="viewport" content="width=device-width">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<script src="../../../../html/rendering/support/test-ua-stylesheet.js"></script>
+<link rel="help" href="https://github.com/whatwg/html/issues/7867">
+<style>
+/* Specify this bogus namespace, so the rules in this stylesheet only apply to the `fakeClone`d elements in #refs, not the HTML elements in #tests. */
+@namespace url(urn:not-html);
+
+article, aside, h1, h2, h3, h4, h5, h6, hgroup, nav, section {
+  display: block;
+}
+
+h1 { margin-block: 0.67em; font-size: 2.00em; font-weight: bold; }
+h2 { margin-block: 0.83em; font-size: 1.50em; font-weight: bold; }
+h3 { margin-block: 1.00em; font-size: 1.17em; font-weight: bold; }
+h4 { margin-block: 1.33em; font-size: 1.00em; font-weight: bold; }
+h5 { margin-block: 1.67em; font-size: 0.83em; font-weight: bold; }
+h6 { margin-block: 2.33em; font-size: 0.67em; font-weight: bold; }
+
+</style>
+
+<div id="log"></div>
+
+<div id="tests">
+  <h1></h1>
+  <h2></h2>
+  <h3></h3>
+  <h4></h4>
+  <h5></h5>
+  <h6></h6>
+  <hgroup></hgroup>
+  <article></article>
+  <aside></aside>
+  <nav></nav>
+  <section></section>
+  <article data-skip>
+    <h1></h1>
+    <article data-skip>
+      <h1></h1>
+      <article data-skip>
+        <h1></h1>
+        <article data-skip>
+          <h1></h1>
+          <article data-skip>
+            <h1></h1>
+            <hgroup data-skip>
+             <h1></h1>
+             <h2></h2>
+             <h3></h3>
+             <h4></h4>
+             <h5></h5>
+            </hgroup>
+          </article>
+        </article>
+      </article>
+    </article>
+  </article>
+  <aside data-skip>
+    <h1></h1>
+    <aside data-skip>
+      <h1></h1>
+      <aside data-skip>
+        <h1></h1>
+        <aside data-skip>
+          <h1></h1>
+          <aside data-skip>
+            <h1></h1>
+            <hgroup data-skip>
+             <h1></h1>
+             <h2></h2>
+             <h3></h3>
+             <h4></h4>
+             <h5></h5>
+            </hgroup>
+          </aside>
+        </aside>
+      </aside>
+    </aside>
+  </aside>
+  <nav data-skip>
+    <h1></h1>
+    <nav data-skip>
+      <h1></h1>
+      <nav data-skip>
+        <h1></h1>
+        <nav data-skip>
+          <h1></h1>
+          <nav data-skip>
+            <h1></h1>
+            <hgroup data-skip>
+             <h1></h1>
+             <h2></h2>
+             <h3></h3>
+             <h4></h4>
+             <h5></h5>
+            </hgroup>
+          </nav>
+        </nav>
+      </nav>
+    </nav>
+  </nav>
+  <section data-skip>
+    <h1></h1>
+    <section data-skip>
+      <h1></h1>
+      <section data-skip>
+        <h1></h1>
+        <section data-skip>
+          <h1></h1>
+          <section data-skip>
+            <h1></h1>
+            <hgroup data-skip>
+             <h1></h1>
+             <h2></h2>
+             <h3></h3>
+             <h4></h4>
+             <h5></h5>
+            </hgroup>
+          </section>
+        </section>
+      </section>
+    </section>
+  </section>
+</div>
+
+<div id="refs"></div>
+
+<script>
+  const props = [
+    'display',
+    'margin-top',
+    'margin-right',
+    'margin-bottom',
+    'margin-left',
+    'padding-top',
+    'padding-right',
+    'padding-bottom',
+    'padding-left',
+    'font-size',
+    'font-weight',
+  ];
+  runUAStyleTests(props);
+
+</script>


### PR DESCRIPTION
This change corresponds to: https://github.com/whatwg/html/pull/11102, which hasn't yet been merged, but appears will be merged soon.

The imported WPT test already reflects this change and gets us +72 subtests.