### PR TITLE
LibWeb/HTML: Improve data structure of named character reference data

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/Entities.cpp
+++ b/Libraries/LibWeb/HTML/Parser/Entities.cpp
@@ -4,26 +4,96 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringView.h>
+#include <AK/Assertions.h>
+#include <AK/BuiltinWrappers.h>
+#include <AK/CharacterTypes.h>
 #include <LibWeb/HTML/Parser/Entities.h>
 #include <LibWeb/HTML/Parser/NamedCharacterReferences.h>
 
 namespace Web::HTML {
 
+static u8 ascii_alphabetic_to_index(u8 c)
+{
+    ASSERT(AK::is_ascii_alpha(c));
+    return c <= 'Z' ? (c - 'A') : (c - 'a' + 26);
+}
+
 bool NamedCharacterReferenceMatcher::try_consume_ascii_char(u8 c)
 {
-    auto child_index = named_character_reference_child_index(m_node_index);
-    auto maybe_updated_index = named_character_reference_find_sibling_and_update_unique_index(child_index, c, m_pending_unique_index);
-    if (!maybe_updated_index.has_value())
-        return false;
-    m_overconsumed_code_points++;
-    m_node_index = maybe_updated_index.value();
-    if (currently_matches()) {
-        m_last_matched_unique_index = m_pending_unique_index;
-        m_ends_with_semicolon = c == ';';
-        m_overconsumed_code_points = 0;
+    switch (m_search_state_tag) {
+    case NamedCharacterReferenceMatcher::SearchStateTag::Init: {
+        if (!AK::is_ascii_alpha(c))
+            return false;
+        auto index = ascii_alphabetic_to_index(c);
+        m_search_state_tag = NamedCharacterReferenceMatcher::SearchStateTag::FirstToSecondLayer;
+        m_search_state = { .first_to_second_layer = g_named_character_reference_first_to_second_layer[index] };
+        m_pending_unique_index = g_named_character_reference_first_layer[index].number;
+        m_overconsumed_code_points++;
+        return true;
     }
-    return true;
+    case NamedCharacterReferenceMatcher::SearchStateTag::FirstToSecondLayer: {
+        if (!AK::is_ascii_alpha(c))
+            return false;
+        auto bit_index = ascii_alphabetic_to_index(c);
+        if (((1ull << bit_index) & m_search_state.first_to_second_layer.mask) == 0)
+            return false;
+
+        // Get the second layer node by re-using the first_to_second_layer.mask.
+        // For example, if the first character is 'n' and the second character is 'o':
+        //
+        // This is the first_to_second_layer.mask when the first character is 'n':
+        // 0001111110110110111111111100001000100000100001000000
+        //            └ bit_index of 'o'
+        //
+        // Create a mask where all of the less significant bits than the
+        // bit index of the current character ('o') are set:
+        // 0000000000001111111111111111111111111111111111111111
+        //            └ bit_index of 'o'
+        //
+        // Bitwise AND this new mask with the first_to_second_layer.mask
+        // to get only the set bits less significant than the bit index of the
+        // current character:
+        // 0000000000000110111111111100001000100000100001000000
+        //
+        // Take the popcount of this to get the index of the node within the
+        // second layer. In this case, there are 16 bits set, so the index
+        // of 'o' in the second layer is first_to_second_layer.second_layer_offset + 16.
+        u64 mask = (1ull << bit_index) - 1;
+        u8 char_index = AK::popcount(m_search_state.first_to_second_layer.mask & mask);
+        auto const& node = g_named_character_reference_second_layer[m_search_state.first_to_second_layer.second_layer_offset + char_index];
+
+        m_pending_unique_index += node.number;
+        m_overconsumed_code_points++;
+        if (node.end_of_word) {
+            m_pending_unique_index++;
+            m_last_matched_unique_index = m_pending_unique_index;
+            m_ends_with_semicolon = c == ';';
+            m_overconsumed_code_points = 0;
+        }
+        m_search_state_tag = NamedCharacterReferenceMatcher::SearchStateTag::DafsaChildren;
+        m_search_state = { .dafsa_children = { &g_named_character_reference_nodes[node.child_index], node.children_len } };
+        return true;
+    }
+    case NamedCharacterReferenceMatcher::SearchStateTag::DafsaChildren: {
+        for (auto const& node : m_search_state.dafsa_children) {
+            if (node.character == c) {
+                m_pending_unique_index += node.number;
+                m_overconsumed_code_points++;
+                if (node.end_of_word) {
+                    m_pending_unique_index++;
+                    m_last_matched_unique_index = m_pending_unique_index;
+                    m_ends_with_semicolon = c == ';';
+                    m_overconsumed_code_points = 0;
+                }
+                m_search_state = { .dafsa_children = { &g_named_character_reference_nodes[node.child_index], node.children_len } };
+                return true;
+            }
+        }
+        return false;
+    }
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
 }


### PR DESCRIPTION
This is part 2 of my follow-ups to https://github.com/LadybirdBrowser/ladybird/pull/3011 and what I subsequently wrote about in [Slightly better named character reference tokenization than Chrome, Safari, and Firefox](https://www.ryanliptak.com/blog/better-named-character-reference-tokenization/) (part 1 was https://github.com/LadybirdBrowser/ladybird/pull/5297).

For those that have read the article, this implementation is mostly what's described in the [DAFSA with first-two-character acceleration](https://www.ryanliptak.com/blog/better-named-character-reference-tokenization/#dafsa-with-first-two-character-acceleration) section, but I've since figured out a way to avoid the additional 8 KiB of data.

---

Introduces a few ad-hoc modifications to the DAFSA aimed to increase performance while keeping the data size small.

- The 'first layer' of nodes is extracted out and replaced with a lookup table. This turns the search for the first character from O(n) to O (1), and doesn't increase the data size because all first characters in the set of named character references have the values 'a'-'z'/'A'-'Z', so a lookup array of exactly 52 elements can be used. The lookup table stores the cumulative "number" fields that would be calculated by a linear scan that matches a given node, thus allowing the unique index to be built-up as normal with a O(1) search instead of a linear scan.
- The 'second layer' of nodes is also extracted out and searches of the second layer are done using a bit field of 52 bits (the set bits of the bit field depend on the first character's value), where each set bit corresponds to one of 'a'-'z'/'A'-'Z' (similar to the first layer, the second layer can only contain ASCII alphabetic characters). The bit field is then re-used (along with an offset) to get the index into the array of second layer nodes. This technique ultimately allows for storing the minimum number of nodes in the second layer, and therefore only increasing the size of the data by the size of the 'first to second layer link' info which is 52 * 8 = 416 bytes.
- After the second layer, the rest of the data is stored using a mostly-normal DAFSA, but there are still a few differences:
   - The "number" field is cumulative, in the same way that the first/second layer store a cumulative "number" field. This cuts down slightly on the amount of work done during the search of a list of children, and we can get away with it because the cumulative "number" fields of the remaining nodes in the DAFSA (after the first and second layer nodes were extracted out) happens to require few enough bits that we can store the cumulative version while staying under our 32-bit budget.
   - Instead of storing a 'last sibling' flag to denote the end of a list of children, the length of each node's list of children is stored. Again, this is mostly done just because there are enough bits available to do so while keeping the DAFSA node within 32 bits.
   - Note: Together, these modifications open up the possibility of using a binary search instead of a linear search over the children, but due to the consistently small lengths of the lists of children in the remaining DAFSA, a linear search actually seems to be the better option.

The new data size is 24,724 bytes, up from 24,412 bytes (+312 overall; -104 from the 52 first layer nodes going from 4-bytes to 2-bytes, and +416 from the addition of the 'first to second layer link' data).

In terms of raw matching speed (outside the context of the tokenizer), this provides about a 1.72x speedup.

In very named-character-reference-heavy tokenizer benchmarks, this provides about a 1.05x speedup (the effect of named character reference matching speed is diluted when benchmarking the tokenizer).

Additionally, fixes the size of the named character reference data when targeting Windows.

---

Benchmark code: https://github.com/squeek502/ladybird/commit/bcbf6155c16bfe72898f843f129b882ac45d8740

Raw matching speed (outside the context of the tokenizer):

```
Benchmark 1 (43 runs): ./Build/release/bin/BenchMatcher old
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           116ms ± 2.02ms     113ms …  121ms          0 ( 0%)        0%
  peak_rss           4.50MB ± 69.4KB    4.33MB … 4.59MB          0 ( 0%)        0%
  cpu_cycles          475M  ± 5.98M      468M  …  493M           1 ( 2%)        0%
  instructions        998M  ± 66.7       998M  …  998M           7 (16%)        0%
  cache_references   6.14M  ± 78.5K     5.99M  … 6.51M           1 ( 2%)        0%
  cache_misses       22.4K  ± 6.26K     20.3K  … 62.2K           1 ( 2%)        0%
  branch_misses      6.03M  ± 19.6K     5.98M  … 6.05M           0 ( 0%)        0%
Benchmark 2 (75 runs): ./Build/release/bin/BenchMatcher new
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          67.4ms ± 1.27ms    65.0ms … 69.8ms          0 ( 0%)        ⚡- 42.2% ±  0.5%
  peak_rss           4.51MB ± 64.3KB    4.46MB … 4.59MB          0 ( 0%)          +  0.1% ±  0.6%
  cpu_cycles          269M  ± 1.29M      266M  …  273M           1 ( 1%)        ⚡- 43.5% ±  0.3%
  instructions        478M  ± 76.7       478M  …  478M           0 ( 0%)        ⚡- 52.1% ±  0.0%
  cache_references   6.04M  ± 41.4K     5.97M  … 6.19M           2 ( 3%)        ⚡-  1.7% ±  0.4%
  cache_misses       21.2K  ±  570      20.2K  … 22.7K           3 ( 4%)          -  5.4% ±  6.4%
  branch_misses      4.18M  ± 11.4K     4.16M  … 4.21M           0 ( 0%)        ⚡- 30.7% ±  0.1%
```

Tokenizing a file with tens of thousands of valid/invalid named character references:

```
Benchmark 1 (54 runs): ./Build/release/bin/BenchHTMLTokenizer old
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          93.9ms ± 7.29ms    89.9ms …  145ms          1 ( 2%)        0%
  peak_rss           82.0MB ±  125KB    81.7MB … 82.3MB          3 ( 6%)        0%
  cpu_cycles          167M  ±  794K      166M  …  170M           3 ( 6%)        0%
  instructions        344M  ± 8.38K      344M  …  344M           0 ( 0%)        0%
  cache_references   8.35M  ± 86.0K     8.17M  … 8.70M           4 ( 7%)        0%
  cache_misses        421K  ± 22.8K      408K  …  580K           1 ( 2%)        0%
  branch_misses       554K  ± 1.87K      551K  …  558K           0 ( 0%)        0%
Benchmark 2 (57 runs): ./Build/release/bin/BenchHTMLTokenizer new
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          88.9ms ± 1.59ms    85.8ms … 91.2ms          0 ( 0%)        ⚡-  5.3% ±  2.1%
  peak_rss           82.0MB ±  109KB    81.7MB … 82.2MB          2 ( 4%)          -  0.1% ±  0.1%
  cpu_cycles          153M  ±  544K      152M  …  155M           0 ( 0%)        ⚡-  8.4% ±  0.2%
  instructions        314M  ± 5.62K      314M  …  314M           3 ( 5%)        ⚡-  8.9% ±  0.0%
  cache_references   8.33M  ± 76.8K     8.17M  … 8.46M           0 ( 0%)          -  0.3% ±  0.4%
  cache_misses        418K  ± 5.38K      406K  …  429K           0 ( 0%)          -  0.8% ±  1.5%
  branch_misses       441K  ± 1.58K      437K  …  446K           2 ( 4%)        ⚡- 20.5% ±  0.1%
```

Tokenizing a file with 30,000 randomly chosen valid named character references:

```
Benchmark 1 (126 runs): ./Build/release/bin/BenchHTMLTokenizer old all-valid
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          39.6ms ±  969us    37.1ms … 42.4ms          7 ( 6%)        0%
  peak_rss           57.8MB ±  100KB    57.5MB … 57.9MB          0 ( 0%)        0%
  cpu_cycles         81.3M  ±  531K     80.6M  … 84.7M           1 ( 1%)        0%
  instructions        138M  ± 6.27K      138M  …  138M           2 ( 2%)        0%
  cache_references   3.67M  ± 35.8K     3.60M  … 3.79M           7 ( 6%)        0%
  cache_misses        382K  ± 9.62K      367K  …  428K           1 ( 1%)        0%
  branch_misses       321K  ± 1.24K      318K  …  324K           0 ( 0%)        0%
Benchmark 2 (134 runs): ./Build/release/bin/BenchHTMLTokenizer new all-valid
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          37.5ms ±  952us    35.1ms … 39.1ms         15 (11%)        ⚡-  5.2% ±  0.6%
  peak_rss           57.7MB ± 91.8KB    57.4MB … 57.9MB          3 ( 2%)          -  0.1% ±  0.0%
  cpu_cycles         72.8M  ±  438K     72.2M  … 74.1M           1 ( 1%)        ⚡- 10.5% ±  0.1%
  instructions        119M  ± 5.74K      119M  …  119M           2 ( 1%)        ⚡- 13.9% ±  0.0%
  cache_references   3.67M  ± 41.5K     3.60M  … 3.95M           4 ( 3%)          -  0.2% ±  0.3%
  cache_misses        381K  ± 9.54K      366K  …  412K           4 ( 3%)          -  0.3% ±  0.6%
  branch_misses       261K  ± 4.57K      258K  …  311K           1 ( 1%)        ⚡- 18.6% ±  0.3%
```

Tokenizing a file with nothing but 30,000 `&supsetneqq;` named character references:

```
Benchmark 1 (124 runs): ./Build/release/bin/BenchHTMLTokenizer old gecko-worst-case
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          40.4ms ±  989us    38.6ms … 42.2ms          0 ( 0%)        0%
  peak_rss           57.3MB ± 90.9KB    57.0MB … 57.5MB         45 (36%)        0%
  cpu_cycles         89.2M  ±  414K     87.9M  … 90.2M           8 ( 6%)        0%
  instructions        176M  ± 8.57K      176M  …  176M           4 ( 3%)        0%
  cache_references   3.44M  ± 46.9K     3.36M  … 3.88M           9 ( 7%)        0%
  cache_misses        375K  ± 4.80K      364K  …  395K           3 ( 2%)        0%
  branch_misses       159K  ± 1.18K      157K  …  163K           2 ( 2%)        0%
Benchmark 2 (133 runs): ./Build/release/bin/BenchHTMLTokenizer new gecko-worst-case
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          37.5ms ±  994us    35.5ms … 40.0ms          1 ( 1%)        ⚡-  7.2% ±  0.6%
  peak_rss           57.2MB ± 93.2KB    57.0MB … 57.4MB          0 ( 0%)          -  0.1% ±  0.0%
  cpu_cycles         76.7M  ±  486K     75.5M  … 78.7M           8 ( 6%)        ⚡- 14.0% ±  0.1%
  instructions        141M  ± 7.64K      141M  …  141M           5 ( 4%)        ⚡- 20.1% ±  0.0%
  cache_references   3.44M  ± 44.5K     3.35M  … 3.74M          10 ( 8%)          +  0.0% ±  0.3%
  cache_misses        376K  ± 7.28K      363K  …  419K           6 ( 5%)          +  0.2% ±  0.4%
  branch_misses       161K  ± 5.67K      159K  …  225K           1 ( 1%)          +  1.2% ±  0.6%
```

Tokenizing a file with nothing but 30,000 invalid `&cz` named character references (a named character reference that can be rejected from the first two characters alone, something that was the worst-case for the old implementation when compared against Gecko/Blink/WebKit):

```
Benchmark 1 (88 runs): ./Build/release/bin/BenchHTMLTokenizer old ladybird-worst-case
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          56.8ms ± 1.09ms    55.0ms … 58.6ms          0 ( 0%)        0%
  peak_rss           65.7MB ± 91.5KB    65.5MB … 65.9MB          0 ( 0%)        0%
  cpu_cycles         95.8M  ±  400K     94.9M  … 96.8M           0 ( 0%)        0%
  instructions        191M  ± 5.64K      191M  …  191M           3 ( 3%)        0%
  cache_references   5.43M  ± 31.2K     5.35M  … 5.57M           2 ( 2%)        0%
  cache_misses        394K  ± 6.43K      382K  …  416K           3 ( 3%)        0%
  branch_misses       169K  ± 1.16K      167K  …  173K           1 ( 1%)        0%
Benchmark 2 (92 runs): ./Build/release/bin/BenchHTMLTokenizer new ladybird-worst-case
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          54.7ms ± 1.10ms    52.9ms … 56.8ms          0 ( 0%)        ⚡-  3.7% ±  0.6%
  peak_rss           65.7MB ± 99.2KB    65.4MB … 65.9MB          3 ( 3%)          -  0.1% ±  0.0%
  cpu_cycles         89.2M  ±  466K     88.3M  … 90.2M           0 ( 0%)        ⚡-  6.9% ±  0.1%
  instructions        171M  ± 4.56K      171M  …  171M           0 ( 0%)        ⚡- 10.2% ±  0.0%
  cache_references   5.43M  ± 25.8K     5.37M  … 5.50M           0 ( 0%)          +  0.0% ±  0.2%
  cache_misses        391K  ± 5.24K      381K  …  410K           2 ( 2%)          -  0.7% ±  0.4%
  branch_misses       171K  ±  831       168K  …  173K           3 ( 3%)          +  0.8% ±  0.2%
```

(results come from [`poop`](https://github.com/andrewrk/poop) for anyone curious)