### PR TITLE
Tests/LibGfx: Enable file based tests on Windows

### DIFF
--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -1,19 +1,13 @@
 set(TEST_SOURCES
+    BenchmarkJPEGLoader.cpp
     TestColor.cpp
+    TestImageDecoder.cpp
     TestImageWriter.cpp
     TestQuad.cpp
     TestRect.cpp
+    TestWOFF.cpp
+    TestWOFF2.cpp
 )
-
-# FIXME: Address runtime errors for file-based tests on Windows
-if (NOT WIN32)
-    list(APPEND TEST_SOURCES
-        BenchmarkJPEGLoader.cpp
-        TestImageDecoder.cpp
-        TestWOFF.cpp
-        TestWOFF2.cpp
-    )
-endif()
 
 foreach(source IN LISTS TEST_SOURCES)
     ladybird_test("${source}" LibGfx LIBS LibGfx)


### PR DESCRIPTION
This needs the `windows` label applied to test, but I have confirmed `Windows_Sanitizer_CI` passes for me locally