### PR TITLE
Meta: Enable the zstd feature for curl

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -21,7 +21,8 @@
         "http2",
         "http3",
         "openssl",
-        "websockets"
+        "websockets",
+        "zstd"
       ]
     },
     {


### PR DESCRIPTION
This content encoding is used by Facebook.

For example:

```
> GET /rsrc.php/v5/yj/l/0,cross/VNfVTw9fSM1.css HTTP/3
Host: static.xx.fbcdn.net
Accept-Encoding: deflate, gzip, br, zstd
Alt-Used: (nil):0
User-Agent: Mozilla/5.0 (macOS; AArch64) Ladybird/1.0
Accept: text/css,*/*;q=0.1
Accept-Language: en
Sec-Fetch-Dest: style
Sec-Fetch-Mode: cors
Origin: https://www.facebook.com
Sec-Fetch-Site: cross-site
Referer: https://www.facebook.com/
```

The response (with some headers removed for brevity):
```
< HTTP/3 200
< content-encoding: zstd
< content-type: text/css; charset=utf-8
< last-modified: Mon, 01 Jan 2001 08:00:00 GMT
< expires: Fri, 10 Jul 2026 07:47:17 GMT
< cache-control: public,max-age=31536000,immutable
< content-length: 7448
< date: Fri, 11 Jul 2025 11:52:03 GMT
< access-control-allow-origin: https://www.facebook.com
* Added alt-svc: static.xx.fbcdn.net:443 over h3
< alt-svc: h3=":443"; ma=86400
< priority: u=3,i
<
```