### PR TITLE
LibWeb/CSP: Implement the script-src-elem and script-src-attr directives

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
+    ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceElementDirective.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp
+    ContentSecurityPolicy/Directives/ScriptSourceElementDirective.cpp
     ContentSecurityPolicy/Directives/SerializedDirective.cpp
     ContentSecurityPolicy/Directives/SourceExpression.cpp
     ContentSecurityPolicy/Policy.cpp

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
 
@@ -44,6 +45,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ScriptSrc)
         return heap.allocate<ScriptSourceDirective>(move(name), move(value));
+
+    if (name == Names::ScriptSrcElem)
+        return heap.allocate<ScriptSourceElementDirective>(move(name), move(value));
 
     return heap.allocate<Directive>(move(name), move(value));
 }

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.h>
 
@@ -42,6 +43,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ObjectSrc)
         return heap.allocate<ObjectSourceDirective>(move(name), move(value));
+
+    if (name == Names::ScriptSrcAttr)
+        return heap.allocate<ScriptSourceAttributeDirective>(move(name), move(value));
 
     if (name == Names::ScriptSrc)
         return heap.allocate<ScriptSourceDirective>(move(name), move(value));

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(ScriptSourceAttributeDirective);
+
+ScriptSourceAttributeDirective::ScriptSourceAttributeDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#script-src-attr-inline
+Directive::Result ScriptSourceAttributeDirective::inline_check(GC::Heap&, GC::Ptr<DOM::Element const> element, InlineType type, GC::Ref<Policy const> policy, String const& source) const
+{
+    // 1. Assert: element is not null or type is "navigation".
+    VERIFY(element || type == InlineType::Navigation);
+
+    // 2. Let name be the result of executing § 6.8.2 Get the effective directive for inline checks on type.
+    auto name = get_the_effective_directive_for_inline_checks(type);
+
+    // 3. If the result of executing § 6.8.4 Should fetch directive execute on name, script-src-attr and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ScriptSrcAttr, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 4. If the result of executing § 6.7.3.3 Does element match source list for type and source? on element, this
+    //    directive’s value, type, and source is "Does Not Match", return "Blocked".
+    if (does_element_match_source_list_for_type_and_source(element, value(), type, source) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 5. Return "Allowed".
+    return Result::Allowed;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-script-src-attr
+class ScriptSourceAttributeDirective final : public Directive {
+    GC_CELL(ScriptSourceAttributeDirective, Directive)
+    GC_DECLARE_ALLOCATOR(ScriptSourceAttributeDirective);
+
+public:
+    virtual ~ScriptSourceAttributeDirective() = default;
+
+    virtual Result inline_check(GC::Heap&, GC::Ptr<DOM::Element const>, InlineType, GC::Ref<Policy const>, String const&) const override;
+
+private:
+    ScriptSourceAttributeDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(ScriptSourceElementDirective);
+
+ScriptSourceElementDirective::ScriptSourceElementDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#script-src-elem-pre-request
+Directive::Result ScriptSourceElementDirective::pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, script-src-elem and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ScriptSrcElem, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. Return the result of executing § 6.7.1.1 Script directives pre-request check on request, this directive,
+    //    and policy.
+    return script_directives_pre_request_check(request, *this, policy);
+}
+
+// https://w3c.github.io/webappsec-csp/#script-src-elem-post-request
+Directive::Result ScriptSourceElementDirective::post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const> request, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<Policy const> policy) const
+{
+    // 1. Let name be the result of executing § 6.8.1 Get the effective directive for request on request.
+    auto name = get_the_effective_directive_for_request(request);
+
+    // 2. If the result of executing § 6.8.4 Should fetch directive execute on name, script-src-elem and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ScriptSrcElem, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 3. Return the result of executing § 6.7.1.2 Script directives post-request check on request, response, this
+    //    directive, and policy.
+    return script_directives_post_request_check(request, response, *this, policy);
+}
+
+// https://w3c.github.io/webappsec-csp/#script-src-elem-inline
+Directive::Result ScriptSourceElementDirective::inline_check(GC::Heap&, GC::Ptr<DOM::Element const> element, InlineType type, GC::Ref<Policy const> policy, String const& source) const
+{
+    // 1. Assert: element is not null or type is "navigation".
+    VERIFY(element || type == InlineType::Navigation);
+
+    // 2. Let name be the result of executing § 6.8.2 Get the effective directive for inline checks on type.
+    auto name = get_the_effective_directive_for_inline_checks(type);
+
+    // 3. If the result of executing § 6.8.4 Should fetch directive execute on name, script-src-elem and policy is "No",
+    //    return "Allowed".
+    if (should_fetch_directive_execute(name, Names::ScriptSrcElem, policy) == ShouldExecute::No)
+        return Result::Allowed;
+
+    // 4. If the result of executing § 6.7.3.3 Does element match source list for type and source? on element, this
+    //    directive’s value, type, and source is "Does Not Match", return "Blocked".
+    if (does_element_match_source_list_for_type_and_source(element, value(), type, source) == MatchResult::DoesNotMatch)
+        return Result::Blocked;
+
+    // 5. Return "Allowed".
+    return Result::Allowed;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-script-src-elem
+class ScriptSourceElementDirective final : public Directive {
+    GC_CELL(ScriptSourceElementDirective, Directive)
+    GC_DECLARE_ALLOCATOR(ScriptSourceElementDirective);
+
+public:
+    virtual ~ScriptSourceElementDirective() = default;
+
+    virtual Result pre_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Policy const>) const override;
+    virtual Result post_request_check(GC::Heap&, GC::Ref<Fetch::Infrastructure::Request const>, GC::Ref<Fetch::Infrastructure::Response const>, GC::Ref<Policy const>) const override;
+    virtual Result inline_check(GC::Heap&, GC::Ptr<DOM::Element const>, InlineType, GC::Ref<Policy const>, String const&) const override;
+
+private:
+    ScriptSourceElementDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -139,6 +139,7 @@ class ManifestSourceDirective;
 class MediaSourceDirective;
 class ObjectSourceDirective;
 class ScriptSourceDirective;
+class ScriptSourceElementDirective;
 struct SerializedDirective;
 
 }

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -138,6 +138,7 @@ class ImageSourceDirective;
 class ManifestSourceDirective;
 class MediaSourceDirective;
 class ObjectSourceDirective;
+class ScriptSourceAttributeDirective;
 class ScriptSourceDirective;
 class ScriptSourceElementDirective;
 struct SerializedDirective;


### PR DESCRIPTION
Part 11 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854

With script-src now implemented, these are the two subset directives for it.