### PR TITLE
LibWeb/XHR: Don't construct a String from a String

### DIFF
--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -1289,8 +1289,7 @@ String XMLHttpRequest::response_url()
     if (!m_response->url().has_value())
         return String {};
 
-    auto serialized = m_response->url().value().serialize(URL::ExcludeFragment::Yes);
-    return String::from_utf8_without_validation(serialized.bytes());
+    return m_response->url().value().serialize(URL::ExcludeFragment::Yes);
 }
 
 }


### PR DESCRIPTION
Serializing a URL already returns a String.