### PR TITLE
Tests: Fix calculation of elapsed time in tests

### DIFF
--- a/Libraries/LibTest/TestSuite.cpp
+++ b/Libraries/LibTest/TestSuite.cpp
@@ -255,7 +255,7 @@ int TestSuite::run(Vector<NonnullRefPtr<TestCase>> const& tests)
     }
 
     auto const runtime = m_test_time + m_bench_time;
-    auto const elapsed = global_timer.elapsed() - runtime;
+    auto const elapsed = global_timer.elapsed();
 
     dbgln("Finished {} tests and {} benchmarks in {}ms ({}ms tests, {}ms benchmarks, {}ms other).",
         test_count,


### PR DESCRIPTION
We were already taking the "elapsed" part of the global timer, by subtracting the known runtime from that we always ended up with 0 milliseconds.

CC @ttrssreal 