### PR TITLE
LibWeb: Skip backing store allocation for traversables created for SVG

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -220,6 +220,8 @@ public:
 
     void set_should_show_line_box_borders(bool value) { m_should_show_line_box_borders = value; }
 
+    bool is_svg_page() const { return m_is_svg_page; }
+
     template<typename T>
     bool fast_is() const = delete;
 

--- a/Libraries/LibWeb/Painting/BackingStoreManager.cpp
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.cpp
@@ -143,6 +143,9 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
 
 void BackingStoreManager::resize_backing_stores_if_needed(WindowResizingInProgress window_resize_in_progress)
 {
+    if (!m_navigable->is_top_level_traversable() || m_navigable->is_svg_page())
+        return;
+
     auto viewport_size = m_navigable->page().css_to_device_rect(m_navigable->viewport_rect()).size();
     if (viewport_size.is_empty())
         return;


### PR DESCRIPTION
Recently, we moved the backing store manager into Navigable, which means we now try to allocate a backing store for all navigables, including those corresponding to SVG image documents. This change disables that behavior for all navigables except top-level non-SVG traversables, because otherwise it causes issues when we stop repainting: the browser process was notified about an allocated backing stores that does not correspond to the page, and then all subsequent repaints are ignored until the window is resized.