### PR TITLE
LibWeb: Avoid division by zero with small aspect ratios

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1609,6 +1609,8 @@ CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, Avail
 CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpace const& available_space, CSS::Size const& height) const
 {
     if (height.is_auto() && box.has_preferred_aspect_ratio()) {
+        if (*box.preferred_aspect_ratio() == 0)
+            return CSSPixels(0);
         return m_state.get(box).content_width() / *box.preferred_aspect_ratio();
     }
 

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -604,7 +604,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle& node, UsedValues const* co
             if (m_has_definite_width && m_has_definite_height) {
                 // Both width and height are definite.
             } else if (m_has_definite_width) {
-                m_content_height = clamp_to_max_dimension_value(m_content_width / *aspect_ratio);
+                m_content_height = *aspect_ratio == 0 ? 0 : clamp_to_max_dimension_value(m_content_width / *aspect_ratio);
                 m_has_definite_height = true;
             } else if (m_has_definite_height) {
                 m_content_width = clamp_to_max_dimension_value(m_content_height * *aspect_ratio);

--- a/Tests/LibWeb/Text/expected/css/small-aspect-ratio.txt
+++ b/Tests/LibWeb/Text/expected/css/small-aspect-ratio.txt
@@ -1,1 +1,3 @@
 element height: 10px
+element height: 0px
+element height: 0px

--- a/Tests/LibWeb/Text/input/css/small-aspect-ratio.html
+++ b/Tests/LibWeb/Text/input/css/small-aspect-ratio.html
@@ -2,11 +2,18 @@
 <script src="../include.js"></script>
 <script>
     test(() => {
-        const element = document.createElement("div");
-        element.style.width = "100px";
-        element.style.aspectRatio = ".0000000000001 / .00000000000001";
-        document.body.appendChild(element);
-        println(`element height: ${element.clientHeight}px`);
-        element.remove();
+        const smallAspectRatios = [
+            ".0000000000001 / .00000000000001",
+            "1/0.00000000000001",
+            "0.00000000000001/1",
+        ];
+        for (const ratio of smallAspectRatios) {
+            const element = document.createElement("div");
+            element.style.width = "100px";
+            element.style.aspectRatio = ratio;
+            document.body.appendChild(element);
+            println(`element height: ${element.clientHeight}px`);
+            element.remove();
+        }
     });
 </script>


### PR DESCRIPTION
This fixes a crash in http://wpt.live/css/css-sizing/aspect-ratio/small-aspect-ratio-crash.html