### PR TITLE
LibWeb: Avoid accessing opaque origin port during CSP checks

### DIFF
--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
@@ -541,7 +541,7 @@ MatchResult does_url_match_expression_in_origin_with_redirect_count(URL::URL con
             origin_port = origin.port();
         }
 
-        if (origin_host == url.host() && (origin.port() == url.port() || (origin_port == origin_default_port && url.port() == url_default_port))) {
+        if (origin_host == url.host() && (origin_port == url.port() || (origin_port == origin_default_port && url.port() == url_default_port))) {
             // 1. url’s scheme is "https" or "wss"
             if (url.scheme() == "https"sv || url.scheme() == "wss"sv)
                 return MatchResult::Matches;

--- a/Tests/LibWeb/Text/expected/wpt-import/content-security-policy/frame-src/frame-src-self-unique-origin.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/content-security-policy/frame-src/frame-src-self-unique-origin.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Iframe's url must not match with 'self'. It must be blocked.

--- a/Tests/LibWeb/Text/expected/wpt-import/content-security-policy/img-src/img-src-self-unique-origin.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/content-security-policy/img-src/img-src-self-unique-origin.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Image's url must not match with 'self'. Image must be blocked.

--- a/Tests/LibWeb/Text/input/wpt-import/content-security-policy/frame-src/frame-src-self-unique-origin.html
+++ b/Tests/LibWeb/Text/input/wpt-import/content-security-policy/frame-src/frame-src-self-unique-origin.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>frame-src-self-unique-origin</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <p>
+        The origin of an URL is called "unique" when it is considered to be
+        different from every origin, including itself. The origin of a
+        data-url is unique. When the current origin is unique, the CSP source
+        'self' must not match any URL.
+    </p>
+    <script>
+        var iframe = document.createElement("iframe");
+        iframe.src = encodeURI(`data:text/html,
+          <script>
+              /* Add the CSP: frame-src: 'self'. */
+              var meta = document.createElement('meta');
+              meta.httpEquiv = 'Content-Security-Policy';
+              meta.content = "frame-src 'self'";
+              document.getElementsByTagName('head')[0].appendChild(meta);
+
+              /* Notify the parent the iframe has been blocked. */
+              window.addEventListener('securitypolicyviolation', e => {
+                  if (e.originalPolicy == "frame-src 'self'")
+                      window.parent.postMessage('Test PASS', '*');
+              });
+          </scr`+`ipt>
+
+          This iframe should be blocked by CSP:
+          <iframe src='data:text/html,blocked_iframe'></iframe>
+        `);
+        if (window.async_test) {
+            async_test(t => {
+                window.addEventListener("message", e => {
+                    if (e.data == "Test PASS")
+                      t.done();
+                });
+            }, "Iframe's url must not match with 'self'. It must be blocked.");
+        }
+        document.body.appendChild(iframe);
+    </script>
+</body>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/content-security-policy/img-src/img-src-self-unique-origin.html
+++ b/Tests/LibWeb/Text/input/wpt-import/content-security-policy/img-src/img-src-self-unique-origin.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>img-src-self-unique-origin</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+
+<body>
+    <p>
+        The origin of an URL is called "unique" when it is considered to be
+        different from every origin, including itself. The origin of a
+        data-url is unique. When the current origin is unique, the CSP source
+        'self' must not match any URL.
+    </p>
+    <script>
+        var iframe = document.createElement("iframe");
+        iframe.src = encodeURI(`data:text/html,
+          <script>
+              /* Add the CSP: frame-src: 'self'. */
+              var meta = document.createElement('meta');
+              meta.httpEquiv = 'Content-Security-Policy';
+              meta.content = "img-src 'self'";
+              document.getElementsByTagName('head')[0].appendChild(meta);
+
+              /* Notify the parent the image has been blocked. */
+              window.addEventListener('securitypolicyviolation', e => {
+                  if (e.originalPolicy == "img-src 'self'")
+                      window.parent.postMessage('Test PASS', '*');
+              });
+          </scr`+`ipt>
+
+          This image should be blocked by CSP:
+          <img src='data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7'></img>
+        `);
+        if (window.async_test) {
+            async_test(t => {
+                window.addEventListener("message", e => {
+                    if (e.data == "Test PASS")
+                      t.done();
+                });
+            }, "Image's url must not match with 'self'. Image must be blocked.");
+        }
+        document.body.appendChild(iframe);
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This fixes 2 CSP WPT tests, which previously crashed.