### PR TITLE
Meta/curl: Add upstream patch for issue 17917

### DIFF
--- a/Meta/CMake/vcpkg/overlay-ports/curl/curl-issue-17917.patch
+++ b/Meta/CMake/vcpkg/overlay-ports/curl/curl-issue-17917.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/altsvc.c b/lib/altsvc.c
+index 602ef61de..0c443268e 100644
+--- a/lib/altsvc.c
++++ b/lib/altsvc.c
+@@ -487,8 +487,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
+   DEBUGASSERT(asi);
+ 
+   /* initial check for "clear" */
+-  if(!curlx_str_until(&p, &alpn, MAX_ALTSVC_LINE, ';') &&
+-     !curlx_str_single(&p, ';')) {
++  if(!curlx_str_cspn(&p, &alpn, ";\n\r")) {
+     curlx_str_trimblanks(&alpn);
+     /* "clear" is a magic keyword */
+     if(curlx_str_casecompare(&alpn, "clear")) {

--- a/Meta/CMake/vcpkg/overlay-ports/curl/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/curl/portfile.cmake
@@ -9,6 +9,7 @@ vcpkg_from_github(
     PATCHES
         dependencies.patch
         pkgconfig-curl-config.patch
+        curl-issue-17917.patch # FIXME: This is an upstream patch that can be removed when it lands in a stable version. See: https://github.com/curl/curl/issues/17917
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS


### PR DESCRIPTION
See: https://github.com/curl/curl/issues/17917

This allows us to connect to https://developer.mozilla.org/ with HTTP/3 enabled.

Thanks to Tim Ledbetter (https://github.com/tcl3) for finding that we couldn't connect!
