### PR TITLE
LibWeb: Skip tree traversal if invalidation set doesn't have properties

### DIFF
--- a/Libraries/LibWeb/CSS/InvalidationSet.h
+++ b/Libraries/LibWeb/CSS/InvalidationSet.h
@@ -51,6 +51,7 @@ public:
     void set_needs_invalidate_pseudo_class(PseudoClass pseudo_class) { m_properties.set({ Property::Type::PseudoClass, pseudo_class }); }
 
     bool is_empty() const;
+    bool has_properties() const { return !m_properties.is_empty(); }
     void for_each_property(Function<IterationDecision(Property const&)> const& callback) const;
 
 private:

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -516,13 +516,17 @@ void Node::invalidate_style(StyleInvalidationReason reason, Vector<CSS::Invalida
     if (invalidation_set.is_empty())
         return;
 
+    if (invalidation_set.needs_invalidate_self()) {
+        set_needs_style_update(true);
+    }
+
     if (invalidation_set.needs_invalidate_whole_subtree()) {
         invalidate_style(reason);
         return;
     }
 
-    if (invalidation_set.needs_invalidate_self()) {
-        set_needs_style_update(true);
+    if (!invalidation_set.has_properties() && !options.invalidate_elements_that_use_css_custom_properties) {
+        return;
     }
 
     auto invalidate_entire_subtree = [&](Node& subtree_root) {


### PR DESCRIPTION
This allows us to skip unnecessary tree traversal to mark style for recalculation when invalidation set only has `InvalidateSelf`.