### PR TITLE
LibWeb: Honor box-sizing for block-level replaced element widths

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -432,13 +432,14 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
         margin_right = zero_value;
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.set_content_width(compute_width_for_replaced_element(box, available_space));
+    auto width = compute_width_for_replaced_element(box, available_space);
     box_state.margin_left = margin_left.to_px(box);
     box_state.margin_right = margin_right.to_px(box);
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
     box_state.padding_left = padding_left;
     box_state.padding_right = padding_right;
+    box_state.set_content_width(calculate_inner_width(box, available_space.width, CSS::Size::make_px(width)));
 }
 
 void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/img-as-block-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/img-as-block-with-box-sizing-border-box.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x416 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 400x400 floating [BFC] children: not-inline
+      ImageBox <img> at (58,8) content-size 300x400 children: not-inline
+      BlockContainer <(anonymous)> at (8,408) content-size 400x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x416]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 400x400]
+      ImagePaintable (ImageBox<IMG>) [8,8 400x400]
+      PaintableWithLines (BlockContainer(anonymous)) [8,408 400x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x416] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/img-as-block-with-box-sizing-border-box.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/img-as-block-with-box-sizing-border-box.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body {
+        float: left;
+    }
+    img {
+        display: block;
+        padding-left: 50px;
+        padding-right: 50px;
+        width: 400px;
+        height: 400px;
+        box-sizing: border-box;
+      }
+</style><body><img src="../400.png" />


### PR DESCRIPTION
Before this change, we were always behaving as if box-sizing were content-box for block-level replaced element widths.

This fixes the squishy logo (top left of the page) on https://videolan.org/

Before:
<img width="1332" height="788" alt="Screenshot 2025-07-14 at 10 20 28" src="https://github.com/user-attachments/assets/4e362c23-5453-4651-9667-ac00e90f6190" />

After:
<img width="1332" height="788" alt="Screenshot 2025-07-14 at 10 20 44" src="https://github.com/user-attachments/assets/f735528e-923b-4381-93fc-aeaf1b1fc7d4" />
