### PR TITLE
LibWeb/CSS: Support `inherit` custom properties on `:root`

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3087,6 +3087,15 @@ void StyleComputer::unload_fonts_from_sheet(CSSStyleSheet& sheet)
     }
 }
 
+static NonnullRefPtr<CSSStyleValue const> custom_property_initial_value(FlyString const& name)
+{
+    // FIXME: Look-up initial value for registered properties. (@property)
+    (void)name;
+
+    // For non-registered properties, the initial value is the guaranteed-invalid value.
+    return GuaranteedInvalidStyleValue::create();
+}
+
 NonnullRefPtr<CSSStyleValue const> StyleComputer::compute_value_of_custom_property(DOM::AbstractElement abstract_element, FlyString const& name, Optional<Parser::GuardedSubstitutionContexts&> guarded_contexts)
 {
     // https://drafts.csswg.org/css-variables/#propdef-
@@ -3094,19 +3103,17 @@ NonnullRefPtr<CSSStyleValue const> StyleComputer::compute_value_of_custom_proper
     // FIXME: These should probably be part of ComputedProperties.
 
     auto value = abstract_element.get_custom_property(name);
-    if (!value)
-        return GuaranteedInvalidStyleValue::create();
-
-    // Initial value is the guaranteed-invalid value.
-    if (value->is_initial())
-        return GuaranteedInvalidStyleValue::create();
+    if (!value || value->is_initial())
+        return custom_property_initial_value(name);
 
     // Unset is the same as inherit for inherited properties, and by default all custom properties are inherited.
-    // FIXME: Update handling of css-wide keywords once we support @property properly.
+    // FIXME: Support non-inherited registered custom properties.
     if (value->is_inherit() || value->is_unset()) {
+        if (!abstract_element.parent_element())
+            return custom_property_initial_value(name);
         auto inherited_value = DOM::AbstractElement { const_cast<DOM::Element&>(*abstract_element.parent_element()) }.get_custom_property(name);
         if (!inherited_value)
-            return GuaranteedInvalidStyleValue::create();
+            return custom_property_initial_value(name);
         return inherited_value.release_nonnull();
     }
 

--- a/Tests/LibWeb/Text/expected/css/custom-property-unset-on-root.txt
+++ b/Tests/LibWeb/Text/expected/css/custom-property-unset-on-root.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/css/custom-property-unset-on-root.html
+++ b/Tests/LibWeb/Text/input/css/custom-property-unset-on-root.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        --example: unset;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println("PASS! (Didn't crash)");
+    });
+</script>


### PR DESCRIPTION
Make sure we have a parent element before trying to look at it!

I've also pulled out a stub function for getting a custom property's initial value, so that there's only one place to change once we support `@property` more.

Fixes #5407.