### PR TITLE
LibWeb: Add {,de}serialization + transfer steps for ImageBitmap + a few minor unrelated changes

### DIFF
--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -24,17 +24,18 @@ enum class BitmapFormat {
     RGBA8888,
 };
 
-inline bool is_valid_bitmap_format(unsigned format)
+inline bool is_valid_bitmap_format(u32 const format)
 {
     switch (format) {
-    case (unsigned)BitmapFormat::Invalid:
-    case (unsigned)BitmapFormat::BGRx8888:
-    case (unsigned)BitmapFormat::RGBx8888:
-    case (unsigned)BitmapFormat::BGRA8888:
-    case (unsigned)BitmapFormat::RGBA8888:
+    case static_cast<u32>(BitmapFormat::Invalid):
+    case static_cast<u32>(BitmapFormat::BGRx8888):
+    case static_cast<u32>(BitmapFormat::RGBx8888):
+    case static_cast<u32>(BitmapFormat::BGRA8888):
+    case static_cast<u32>(BitmapFormat::RGBA8888):
         return true;
+    default:
+        return false;
     }
-    return false;
 }
 
 enum class StorageFormat {

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -331,27 +331,12 @@ String HTMLCanvasElement::to_data_url(StringView type, JS::Value js_quality)
 // https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-toblob
 WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackType> callback, StringView type, JS::Value js_quality)
 {
-    // It is possible the canvas doesn't have a associated bitmap so create one
-    allocate_painting_surface_if_needed();
-    auto surface = this->surface();
-    auto size = bitmap_size_for_canvas();
-    if (!surface && !size.is_empty()) {
-        // If the context is not initialized yet, we need to allocate transparent surface for serialization
-        auto skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
-        surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
-    }
-
     // FIXME: 1. If this canvas element's bitmap's origin-clean flag is set to false, then throw a "SecurityError" DOMException.
 
     // 2. Let result be null.
-    RefPtr<Gfx::Bitmap> bitmap_result;
-
     // 3. If this canvas element's bitmap has pixels (i.e., neither its horizontal dimension nor its vertical dimension is zero),
     //    then set result to a copy of this canvas element's bitmap.
-    if (surface) {
-        bitmap_result = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, surface->size()));
-        surface->read_into_bitmap(*bitmap_result);
-    }
+    auto bitmap_result = get_bitmap_from_surface();
 
     Optional<double> quality = js_quality.is_number() ? js_quality.as_double() : Optional<double>();
 
@@ -381,6 +366,26 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackTyp
         });
     }));
     return {};
+}
+
+RefPtr<Gfx::Bitmap> HTMLCanvasElement::get_bitmap_from_surface()
+{
+    // It is possible the canvas doesn't have an associated bitmap so create one
+    allocate_painting_surface_if_needed();
+    auto surface = this->surface();
+    if (auto const size = bitmap_size_for_canvas(); !surface && !size.is_empty()) {
+        // If the context is not initialized yet, we need to allocate transparent surface for serialization
+        auto const skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
+        surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
+    }
+
+    RefPtr<Gfx::Bitmap> bitmap;
+    if (surface) {
+        bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, surface->size()));
+        surface->read_into_bitmap(*bitmap);
+    }
+
+    return bitmap;
 }
 
 void HTMLCanvasElement::present()

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -41,6 +41,7 @@ public:
 
     String to_data_url(StringView type, JS::Value quality);
     WebIDL::ExceptionOr<void> to_blob(GC::Ref<WebIDL::CallbackType> callback, StringView type, JS::Value quality);
+    RefPtr<Gfx::Bitmap> get_bitmap_from_surface();
 
     void present();
 

--- a/Libraries/LibWeb/HTML/ImageBitmap.cpp
+++ b/Libraries/LibWeb/HTML/ImageBitmap.cpp
@@ -7,10 +7,39 @@
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/Bindings/ImageBitmapPrototype.h>
 #include <LibWeb/HTML/ImageBitmap.h>
+#include <LibWeb/HTML/StructuredSerialize.h>
+#include <LibWeb/WebIDL/DOMException.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(ImageBitmap);
+
+[[nodiscard]] static auto create_bitmap_from_bitmap_data(Gfx::BitmapFormat const format, Gfx::AlphaType const alpha_type, u32 const width, u32 const height, u32 const pitch, ByteBuffer data)
+{
+    return Gfx::Bitmap::create_wrapper(format, alpha_type, Gfx::IntSize(width, height), pitch, data.data());
+}
+
+static void serialize_bitmap(HTML::TransferDataEncoder& encoder, Gfx::Bitmap& bitmap)
+{
+    encoder.encode(bitmap.width());
+    encoder.encode(bitmap.height());
+    encoder.encode(bitmap.pitch());
+    encoder.encode(bitmap.format());
+    encoder.encode(bitmap.alpha_type());
+    encoder.encode(ReadonlyBytes { bitmap.scanline_u8(0), bitmap.data_size() });
+}
+
+[[nodiscard]] static WebIDL::ExceptionOr<NonnullRefPtr<Gfx::Bitmap>> deserialize_bitmap(JS::Realm& realm, HTML::TransferDataDecoder& decoder)
+{
+    auto const width = decoder.decode<int>();
+    auto const height = decoder.decode<int>();
+    auto const pitch = decoder.decode<size_t>();
+    auto const format = decoder.decode<Gfx::BitmapFormat>();
+    auto const alpha_type = decoder.decode<Gfx::AlphaType>();
+    auto const data = TRY(decoder.decode_buffer(realm));
+    return TRY_OR_THROW_OOM(realm.vm(), create_bitmap_from_bitmap_data(format, alpha_type, width, height, pitch, data));
+}
 
 GC::Ref<ImageBitmap> ImageBitmap::create(JS::Realm& realm)
 {
@@ -33,17 +62,23 @@ void ImageBitmap::visit_edges(Cell::Visitor& visitor)
     Base::visit_edges(visitor);
 }
 
-WebIDL::ExceptionOr<void> ImageBitmap::serialization_steps(HTML::TransferDataEncoder&, bool, HTML::SerializationMemory&)
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#the-imagebitmap-interface:serialization-steps
+WebIDL::ExceptionOr<void> ImageBitmap::serialization_steps(HTML::TransferDataEncoder& serialized, bool, HTML::SerializationMemory&)
 {
-    // FIXME: Implement this
-    dbgln("(STUBBED) ImageBitmap::serialization_steps(HTML::TransferDataEncoder&, bool, HTML::SerializationMemory&)");
+    // FIXME: 1. If value's origin-clean flag is not set, then throw a "DataCloneError" DOMException.
+
+    // 2. Set serialized.[[BitmapData]] to a copy of value's bitmap data.
+    serialize_bitmap(serialized, *m_bitmap);
+
     return {};
 }
 
-WebIDL::ExceptionOr<void> ImageBitmap::deserialization_steps(HTML::TransferDataDecoder&, HTML::DeserializationMemory&)
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#the-imagebitmap-interface:deserialization-steps
+WebIDL::ExceptionOr<void> ImageBitmap::deserialization_steps(HTML::TransferDataDecoder& serialized, HTML::DeserializationMemory&)
 {
-    // FIXME: Implement this
-    dbgln("(STUBBED) ImageBitmap::deserialization_steps(ReadonlySpan<u32> const&, size_t&, HTML::DeserializationMemory&)");
+    // 1. Set value's bitmap data to serialized.[[BitmapData]].
+    m_bitmap = TRY(deserialize_bitmap(this->realm(), serialized));
+
     return {};
 }
 

--- a/Libraries/LibWeb/HTML/ImageBitmap.cpp
+++ b/Libraries/LibWeb/HTML/ImageBitmap.cpp
@@ -82,25 +82,32 @@ WebIDL::ExceptionOr<void> ImageBitmap::deserialization_steps(HTML::TransferDataD
     return {};
 }
 
-WebIDL::ExceptionOr<void> ImageBitmap::transfer_steps(HTML::TransferDataEncoder&)
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#the-imagebitmap-interface:transfer-steps
+WebIDL::ExceptionOr<void> ImageBitmap::transfer_steps(HTML::TransferDataEncoder& data_holder)
 {
-    // FIXME: Implement this
-    dbgln("(STUBBED) ImageBitmap::transfer_steps(HTML::TransferDataEncoder&)");
+    // FIXME: 1. If value's origin-clean flag is not set, then throw a "DataCloneError" DOMException.
+
+    // 2. Set dataHolder.[[BitmapData]] to value's bitmap data.
+    serialize_bitmap(data_holder, *m_bitmap);
+
+    // 3. Unset value's bitmap data.
+    m_bitmap = nullptr;
+
     return {};
 }
 
-WebIDL::ExceptionOr<void> ImageBitmap::transfer_receiving_steps(HTML::TransferDataDecoder&)
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#the-imagebitmap-interface:transfer-receiving-steps
+WebIDL::ExceptionOr<void> ImageBitmap::transfer_receiving_steps(HTML::TransferDataDecoder& data_holder)
 {
-    // FIXME: Implement this
-    dbgln("(STUBBED) ImageBitmap::transfer_receiving_steps(HTML::TransferDataDecoder&)");
+    // 1. Set value's bitmap data to dataHolder.[[BitmapData]].
+    m_bitmap = TRY(deserialize_bitmap(this->realm(), data_holder));
+
     return {};
 }
 
 HTML::TransferType ImageBitmap::primary_interface() const
 {
-    // FIXME: Implement this
-    dbgln("(STUBBED) ImageBitmap::primary_interface()");
-    return TransferType::Unknown;
+    return TransferType::ImageBitmap;
 }
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-width

--- a/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -1147,6 +1147,11 @@ static WebIDL::ExceptionOr<GC::Ref<Bindings::PlatformObject>> create_transferred
         TRY(transform_stream->transfer_receiving_steps(decoder));
         return transform_stream;
     }
+    case TransferType::ImageBitmap: {
+        auto image_bitmap = target_realm.create<ImageBitmap>(target_realm);
+        TRY(image_bitmap->transfer_receiving_steps(decoder));
+        return image_bitmap;
+    }
     case TransferType::ArrayBuffer:
     case TransferType::ResizableArrayBuffer:
     case TransferType::Unknown:

--- a/Libraries/LibWeb/HTML/StructuredSerializeTypes.h
+++ b/Libraries/LibWeb/HTML/StructuredSerializeTypes.h
@@ -44,6 +44,7 @@ enum class TransferType : u8 {
     ReadableStream = 4,
     WritableStream = 5,
     TransformStream = 6,
+    ImageBitmap = 7,
 };
 
 }

--- a/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -83,7 +83,7 @@ void ReadableByteStreamController::initialize(JS::Realm& realm)
 WebIDL::ExceptionOr<void> ReadableByteStreamController::enqueue(GC::Root<WebIDL::ArrayBufferView>& chunk)
 {
     // 1. If chunk.[[ByteLength]] is 0, throw a TypeError exception.
-    // 2. If chunk.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is 0, throw a TypeError exception.
+    // 2. If chunk.[[ViewedArrayBuffer]].[[ByteLength]] is 0, throw a TypeError exception.
     if (chunk->byte_length() == 0 || chunk->viewed_array_buffer()->byte_length() == 0)
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Cannot enqueue chunk with byte length of zero"sv };
 

--- a/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
@@ -2,7 +2,7 @@ Blob              [Success]: [object ImageBitmap]
 ImageData         [Success]: [object ImageBitmap]
 HTMLImageElement  [ Error ]: InvalidStateError: image argument is not usable
 SVGImageElement   [ Error ]: InvalidStateError: image argument is not usable
-HTMLCanvasElement [ Error ]: Error: Not Implemented: createImageBitmap() for HTMLCanvasElement
+HTMLCanvasElement [Success]: [object ImageBitmap]
 ImageBitmap       [ Error ]: TypeError: No union types matched
 OffscreenCanvas   [ Error ]: Error: Not Implemented: createImageBitmap() for OffscreenCanvas
 HTMLVideoElement  [ Error ]: InvalidStateError: image argument is not usable

--- a/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 150 tests
 
-141 Pass
-9 Fail
+147 Pass
+3 Fail
 Pass	primitive undefined
 Pass	primitive null
 Pass	primitive true
@@ -126,12 +126,12 @@ Pass	Object with non-enumerable property
 Pass	Object with non-writable property
 Pass	Object with non-configurable property
 Pass	Object with a getter that throws
-Fail	ImageBitmap 1x1 transparent black
-Fail	ImageBitmap 1x1 non-transparent non-black
-Fail	Array ImageBitmap object, ImageBitmap 1x1 transparent black
-Fail	Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
-Fail	Object ImageBitmap object, ImageBitmap 1x1 transparent black
-Fail	Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
+Pass	ImageBitmap 1x1 transparent black
+Pass	ImageBitmap 1x1 non-transparent non-black
+Pass	Array ImageBitmap object, ImageBitmap 1x1 transparent black
+Pass	Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
+Pass	Object ImageBitmap object, ImageBitmap 1x1 transparent black
+Pass	Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
 Pass	ObjectPrototype must lose its exotic-ness when cloned
 Pass	Serializing a non-serializable platform object fails
 Pass	An object whose interface is deleted from the global must still deserialize

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/structured-clone/structured-clone.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/structured-clone/structured-clone.any.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 150 tests
 
-141 Pass
-9 Fail
+147 Pass
+3 Fail
 Pass	primitive undefined
 Pass	primitive null
 Pass	primitive true
@@ -126,12 +126,12 @@ Pass	Object with non-enumerable property
 Pass	Object with non-writable property
 Pass	Object with non-configurable property
 Pass	Object with a getter that throws
-Fail	ImageBitmap 1x1 transparent black
-Fail	ImageBitmap 1x1 non-transparent non-black
-Fail	Array ImageBitmap object, ImageBitmap 1x1 transparent black
-Fail	Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
-Fail	Object ImageBitmap object, ImageBitmap 1x1 transparent black
-Fail	Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
+Pass	ImageBitmap 1x1 transparent black
+Pass	ImageBitmap 1x1 non-transparent non-black
+Pass	Array ImageBitmap object, ImageBitmap 1x1 transparent black
+Pass	Array ImageBitmap object, ImageBitmap 1x1 transparent non-black
+Pass	Object ImageBitmap object, ImageBitmap 1x1 transparent black
+Pass	Object ImageBitmap object, ImageBitmap 1x1 transparent non-black
 Pass	ObjectPrototype must lose its exotic-ness when cloned
 Pass	Serializing a non-serializable platform object fails
 Pass	An object whose interface is deleted from the global must still deserialize


### PR DESCRIPTION
This is the last remaining `[Serializable]` IDL.

To make {,de}serialization of `ImageBitmap` work we also had to add support for creating an `ImageBitmap` from a `HTMLCanvasElement` in `WindowOrWorkerGlobalScopeMixin::create_image_bitmap_impl()`.

The two first commits are unrelated to the main change.