### PR TITLE
AK: Use Deducing this for OptionalBase

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -8,7 +8,11 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Concepts.h>
+#include <AK/Forward.h>
 #include <AK/Noncopyable.h>
+#include <AK/Platform.h>
+#include <AK/StdLibExtraDetails.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Traits.h>
 #include <AK/Try.h>
@@ -32,10 +36,17 @@ struct ConditionallyResultType<false, T> {
     using Type = T;
 };
 
+template<typename Self, typename T>
+struct AddConstIfNeeded {
+    using Type = Conditional<IsConst<RemoveReference<Self>> && !IsConst<T>, AddConst<T>, T>;
+};
+
 }
 
 template<auto condition, typename T>
 using ConditionallyResultType = typename Detail::ConditionallyResultType<condition, T>::Type;
+template<typename Self, typename T>
+using AddConstIfNeeded = typename Detail::AddConstIfNeeded<Self, T>::Type;
 
 // NOTE: If you're here because of an internal compiler error in GCC 10.3.0+,
 //       it's because of the following bug:
@@ -52,108 +63,84 @@ struct OptionalNone {
     explicit constexpr OptionalNone() = default;
 };
 
-template<typename T, typename Self = Optional<T>>
-requires(!IsLvalueReference<Self>) class [[nodiscard]] OptionalBase {
+template<typename T>
+requires(!IsLvalueReference<T>)
+class [[nodiscard]] OptionalBase {
 public:
     using ValueType = T;
 
-    template<SameAs<OptionalNone> V>
-    ALWAYS_INLINE constexpr Self& operator=(V)
+    template<typename Self, SameAs<OptionalNone> V>
+    ALWAYS_INLINE constexpr Self& operator=(this Self& self, V)
     {
-        static_cast<Self&>(*this).clear();
-        return static_cast<Self&>(*this);
+        self.clear();
+        return self;
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T* ptr() &
+    template<typename Self>
+    [[nodiscard]] ALWAYS_INLINE constexpr AddConstIfNeeded<Self, T>* ptr(this Self& self)
     {
-        return static_cast<Self&>(*this).has_value() ? __builtin_launder(reinterpret_cast<T*>(&static_cast<Self&>(*this).value())) : nullptr;
+        return self.has_value() ? &self.value() : nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T const* ptr() const&
+    template<typename O = T, typename Fallback = O, typename Self>
+    [[nodiscard]] ALWAYS_INLINE constexpr O value_or(this Self&& self, Fallback&& fallback)
     {
-        return static_cast<Self const&>(*this).has_value() ? __builtin_launder(reinterpret_cast<T const*>(&static_cast<Self const&>(*this).value())) : nullptr;
+        if (self.has_value())
+            return forward<Self>(self).value();
+        return forward<Fallback>(fallback);
     }
 
-    template<typename O = T, typename Fallback = O>
-    [[nodiscard]] ALWAYS_INLINE constexpr O value_or(Fallback const& fallback) const&
+    template<typename Callback, typename O = T, typename Self>
+    [[nodiscard]] ALWAYS_INLINE constexpr O value_or_lazy_evaluated(this Self&& self, Callback callback)
     {
-        if (static_cast<Self const&>(*this).has_value())
-            return static_cast<Self const&>(*this).value();
-        return fallback;
-    }
-
-    template<typename O = T, typename Fallback = O>
-    requires(!IsLvalueReference<O> && !IsRvalueReference<O>)
-    [[nodiscard]] ALWAYS_INLINE constexpr O value_or(Fallback&& fallback) &&
-    {
-        if (static_cast<Self&>(*this).has_value())
-            return move(static_cast<Self&>(*this).value());
-        return move(fallback);
-    }
-
-    template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE constexpr O value_or_lazy_evaluated(Callback callback) const
-    {
-        if (static_cast<Self const&>(*this).has_value())
-            return static_cast<Self const&>(*this).value();
+        if (self.has_value())
+            return forward<Self>(self).value();
         return callback();
     }
 
-    template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE constexpr Optional<O> value_or_lazy_evaluated_optional(Callback callback) const
+    template<typename Callback, typename O = T, typename Self>
+    [[nodiscard]] ALWAYS_INLINE constexpr Optional<O> value_or_lazy_evaluated_optional(this Self&& self, Callback callback)
     {
-        if (static_cast<Self const&>(*this).has_value())
-            return static_cast<Self const&>(*this).value();
+        if (self.has_value())
+            return forward<Self>(self);
         return callback();
     }
 
-    template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<O> try_value_or_lazy_evaluated(Callback callback) const
+    template<typename Callback, typename O = T, typename Self>
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<O> try_value_or_lazy_evaluated(this Self&& self, Callback callback)
     {
-        if (static_cast<Self const&>(*this).has_value())
-            return static_cast<Self const&>(*this).value();
+        if (self.has_value())
+            return forward<Self>(self).value();
         return TRY(callback());
     }
 
-    template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<Optional<O>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    template<typename Callback, typename O = T, typename Self>
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<Optional<O>> try_value_or_lazy_evaluated_optional(this Self&& self, Callback callback)
     {
-        if (static_cast<Self const&>(*this).has_value())
-            return static_cast<Self const&>(*this).value();
+        if (self.has_value())
+            return forward<Self>(self);
         return TRY(callback());
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T const& operator*() const { return static_cast<Self const&>(*this).value(); }
-    [[nodiscard]] ALWAYS_INLINE constexpr T& operator*() { return static_cast<Self&>(*this).value(); }
+    template<typename Self>
+    [[nodiscard]] ALWAYS_INLINE constexpr AddConstIfNeeded<Self, T>& operator*(this Self&& self) { return self.value(); }
+    template<typename Self>
+    ALWAYS_INLINE constexpr AddConstIfNeeded<Self, T>* operator->(this Self&& self) { return &self.value(); }
 
-    ALWAYS_INLINE constexpr T const* operator->() const { return &static_cast<Self const&>(*this).value(); }
-    ALWAYS_INLINE constexpr T* operator->() { return &static_cast<Self&>(*this).value(); }
-
-    template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    template<typename F,
+        typename MappedType = decltype(declval<F>()(declval<T&>())),
+        auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>,
+        typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>,
+        typename Self>
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(this Self&& self, F&& mapper)
     {
         if constexpr (IsErrorOr) {
-            if (static_cast<Self&>(*this).has_value())
-                return OptionalType { TRY(mapper(static_cast<Self&>(*this).value())) };
+            if (self.has_value())
+                return OptionalType { TRY(mapper(forward<Self>(self).value())) };
             return OptionalType {};
         } else {
-            if (static_cast<Self&>(*this).has_value())
-                return OptionalType { mapper(static_cast<Self&>(*this).value()) };
-
-            return OptionalType {};
-        }
-    }
-
-    template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
-    {
-        if constexpr (IsErrorOr) {
-            if (static_cast<Self const&>(*this).has_value())
-                return OptionalType { TRY(mapper(static_cast<Self const&>(*this).value())) };
-            return OptionalType {};
-        } else {
-            if (static_cast<Self const&>(*this).has_value())
-                return OptionalType { mapper(static_cast<Self const&>(*this).value()) };
+            if (self.has_value())
+                return OptionalType { mapper(forward<Self>(self).value()) };
 
             return OptionalType {};
         }
@@ -161,7 +148,7 @@ public:
 };
 
 template<typename T>
-requires(!IsLvalueReference<T>) class [[nodiscard]] Optional<T> : public OptionalBase<T, Optional<T>> {
+requires(!IsLvalueReference<T>) class [[nodiscard]] Optional<T> : public OptionalBase<T> {
     template<typename U>
     friend class Optional;
 
@@ -500,12 +487,12 @@ public:
 
     [[nodiscard]] ALWAYS_INLINE constexpr bool has_value() const { return m_pointer != nullptr; }
 
-    [[nodiscard]] ALWAYS_INLINE RemoveReference<T>* ptr()
+    [[nodiscard]] ALWAYS_INLINE constexpr RemoveReference<T>* ptr()
     {
         return m_pointer;
     }
 
-    [[nodiscard]] ALWAYS_INLINE RemoveReference<T> const* ptr() const
+    [[nodiscard]] ALWAYS_INLINE constexpr RemoveReference<T> const* ptr() const
     {
         return m_pointer;
     }
@@ -546,8 +533,8 @@ public:
     ALWAYS_INLINE constexpr AddConstToReferencedType<T> operator*() const { return value(); }
     ALWAYS_INLINE constexpr T operator*() { return value(); }
 
-    ALWAYS_INLINE RawPtr<AddConst<RemoveReference<T>>> operator->() const { return &value(); }
-    ALWAYS_INLINE RawPtr<RemoveReference<T>> operator->() { return &value(); }
+    ALWAYS_INLINE constexpr RawPtr<AddConst<RemoveReference<T>>> operator->() const { return &value(); }
+    ALWAYS_INLINE constexpr RawPtr<RemoveReference<T>> operator->() { return &value(); }
 
     // Conversion operators from Optional<T&> -> Optional<T>, implicit when T is trivially copyable.
     ALWAYS_INLINE constexpr operator Optional<RemoveCVReference<T>>() const

--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -119,7 +119,7 @@ MatchResult MediaFeature::evaluate(HTML::Window const* window) const
         if (queried_value.is_ratio())
             return as_match_result(!queried_value.ratio().is_degenerate());
         if (queried_value.is_resolution())
-            return as_match_result(queried_value.resolution().resolved(calculation_context).map([](auto& it) { return it.to_dots_per_pixel(); }).value_or(0) != 0);
+            return as_match_result(queried_value.resolution().resolved(calculation_context).map([](auto&& it) { return it.to_dots_per_pixel(); }).value_or(0) != 0);
         if (queried_value.is_ident()) {
             if (media_feature_keyword_is_falsey(m_id, queried_value.ident()))
                 return MatchResult::False;
@@ -245,8 +245,8 @@ MatchResult MediaFeature::compare(HTML::Window const& window, MediaFeatureValue 
     }
 
     if (left.is_resolution()) {
-        auto left_dppx = left.resolution().resolved(calculation_context).map([](auto& it) { return it.to_dots_per_pixel(); }).value_or(0);
-        auto right_dppx = right.resolution().resolved(calculation_context).map([](auto& it) { return it.to_dots_per_pixel(); }).value_or(0);
+        auto left_dppx = left.resolution().resolved(calculation_context).map([](auto&& it) { return it.to_dots_per_pixel(); }).value_or(0);
+        auto right_dppx = right.resolution().resolved(calculation_context).map([](auto&& it) { return it.to_dots_per_pixel(); }).value_or(0);
 
         switch (comparison) {
         case Comparison::Equal:

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1225,7 +1225,7 @@ Optional<Rule> Parser::parse_a_rule(TokenStream<T>& input)
     //    Otherwise, if the next token from input is an <at-keyword-token>,
     //    consume an at-rule from input, and let rule be the return value.
     else if (input.next_token().is(Token::Type::AtKeyword)) {
-        rule = consume_an_at_rule(m_token_stream).map([](auto& it) { return Rule { it }; });
+        rule = consume_an_at_rule(m_token_stream).map([](auto&& it) { return Rule { it }; });
     }
     //    Otherwise, consume a qualified rule from input and let rule be the return value.
     //    If nothing or an invalid rule error was returned, return a syntax error.

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -98,7 +98,7 @@ RefPtr<CSSStyleValue const> Parser::parse_simple_comma_separated_value_list(Prop
 RefPtr<CSSStyleValue const> Parser::parse_css_value_for_property(PropertyID property_id, TokenStream<ComponentValue>& tokens)
 {
     return parse_css_value_for_properties({ &property_id, 1 }, tokens)
-        .map([](auto& it) { return it.style_value; })
+        .map([](auto&& it) { return it.style_value; })
         .value_or(nullptr);
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1258,7 +1258,7 @@ Optional<CalculatedStyleValue::CalculationResult> ClampCalculationNode::run_oper
     if (!max_result.has_value())
         return {};
 
-    auto consistent_type = min_result->type()->consistent_type(center_result->type().value()).map([&](auto& it) { return it.consistent_type(max_result->type().value()); });
+    auto consistent_type = min_result->type()->consistent_type(center_result->type().value()).map([&](auto&& it) { return it.consistent_type(max_result->type().value()); });
     if (!consistent_type.has_value())
         return {};
 

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -529,8 +529,8 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::next_without_lookahead(
         }
 
         CSS::CalculationResolutionContext calculation_context { .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(text_node) };
-        auto letter_spacing = text_node.computed_values().letter_spacing().resolved(calculation_context).map([&](auto& it) { return it.to_px(text_node); }).value_or(0);
-        auto word_spacing = text_node.computed_values().word_spacing().resolved(calculation_context).map([&](auto& it) { return it.to_px(text_node); }).value_or(0);
+        auto letter_spacing = text_node.computed_values().letter_spacing().resolved(calculation_context).map([&](auto&& it) { return it.to_px(text_node); }).value_or(0);
+        auto word_spacing = text_node.computed_values().word_spacing().resolved(calculation_context).map([&](auto&& it) { return it.to_px(text_node); }).value_or(0);
 
         auto x = 0.0f;
         if (chunk.has_breaking_tab) {
@@ -548,7 +548,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::next_without_lookahead(
             tab_width = tab_size.visit(
                 [&](CSS::LengthOrCalculated const& t) -> CSSPixels {
                     return t.resolved(calculation_context)
-                        .map([&](auto& it) { return it.to_px(text_node); })
+                        .map([&](auto&& it) { return it.to_px(text_node); })
                         .value_or(0);
                 },
                 [&](CSS::NumberOrCalculated const& n) -> CSSPixels {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -604,7 +604,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
                         .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(*this),
                     };
                     auto to_px = [&](CSS::LengthOrCalculated const& length) {
-                        return static_cast<float>(length.resolved(context).map([&](auto& it) { return it.to_px(*this).to_double(); }).value_or(0.0));
+                        return static_cast<float>(length.resolved(context).map([&](auto&& it) { return it.to_px(*this).to_double(); }).value_or(0.0));
                     };
                     // The default value for omitted values is missing length values set to 0
                     // and the missing used color is taken from the color property.


### PR DESCRIPTION
This is taken from and akin to
https://github.com/SerenityOS/serenity/pull/25894


----

This greatly reduces the code duplication and is a bit more strict about forwarding