### PR TITLE
LibWeb: Check parent node exists before checking its type

### DIFF
--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -232,7 +232,7 @@ void XMLDocumentBuilder::element_end(const XML::Name& name)
     };
 
     auto* parent = m_current_node->parent_node();
-    if (parent->is_document_fragment()) {
+    if (parent && parent->is_document_fragment()) {
         auto template_parent_node = m_template_node_stack.take_last();
         parent = template_parent_node.ptr();
     }

--- a/Tests/LibWeb/Crash/DOM/xhtml-namespace-change.xhtml
+++ b/Tests/LibWeb/Crash/DOM/xhtml-namespace-change.xhtml
@@ -1,0 +1,7 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><script>
+    var newRoot = document.createElementNS("http://www.w3.org/2000/svg", "test");
+    document.removeChild(document.documentElement);
+    document.appendChild(newRoot);
+</script></head>
+</html>


### PR DESCRIPTION
This adds a null check that I missed in #5429. This caused a crash in: http://wpt.live/dom/nodes/Document-createElement-namespace.html. Not all subtests behaved correctly when this test was imported, so I extracted the part that caused the crash into a crash test instead.