### PR TITLE
LibWeb: Do not create an anonymous container for table cells by default

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -83,11 +83,8 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
     if (layout_parent.display().is_inline_outside() && layout_parent.display().is_flow_inside())
         return layout_parent;
 
-    if (layout_parent.display().is_flex_inside()
-        || layout_parent.display().is_grid_inside()
-        || layout_parent.display().is_table_cell()) {
+    if (layout_parent.display().is_flex_inside() || layout_parent.display().is_grid_inside())
         return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
-    }
 
     if (!has_in_flow_block_children(layout_parent) || layout_parent.children_are_inline())
         return layout_parent;

--- a/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
+++ b/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
@@ -13,11 +13,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 204x100 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,10) content-size 200x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (10,10) content-size 200x18 children: inline
-                  frag 0 from TextNode start: 0, length: 15, rect: [10,10 129.296875x18] baseline: 13.796875
-                      "Text at the top"
-                  TextNode <#text>
+              BlockContainer <td> at (10,10) content-size 200x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 15, rect: [10,10 129.296875x18] baseline: 13.796875
+                    "Text at the top"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -35,8 +34,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 204x100]
             PaintableBox (Box<TR>) [8,8 204x100]
               PaintableWithLines (BlockContainer<TD>) [8,8 204x100]
-                PaintableWithLines (BlockContainer(anonymous)) [10,10 200x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
@@ -11,16 +11,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <table.middle> at (15.34375,9) content-size 154.796875x26 table-box [TFC] children: not-inline
               Box <tbody> at (17.34375,11) content-size 150.796875x22 table-row-group children: not-inline
                 Box <tr> at (17.34375,11) content-size 150.796875x22 table-row children: not-inline
-                  BlockContainer <td> at (19.34375,13) content-size 69.59375x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (19.34375,13) content-size 69.59375x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x18] baseline: 13.796875
-                          "2"
-                      TextNode <#text>
-                  BlockContainer <td> at (94.9375,13) content-size 71.203125x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (94.9375,13) content-size 71.203125x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [94.9375,13 9.09375x18] baseline: 13.796875
-                          "3"
-                      TextNode <#text>
+                  BlockContainer <td> at (19.34375,13) content-size 69.59375x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x18] baseline: 13.796875
+                        "2"
+                    TextNode <#text>
+                  BlockContainer <td> at (94.9375,13) content-size 71.203125x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [94.9375,13 9.09375x18] baseline: 13.796875
+                        "3"
+                    TextNode <#text>
           BlockContainer <div.right> at (171.140625,8) content-size 7.75x18 floating [BFC] children: inline
             frag 0 from TextNode start: 0, length: 1, rect: [171.140625,8 7.75x18] baseline: 13.796875
                 "4"
@@ -40,11 +38,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableBox (Box<TBODY>) [17.34375,11 150.796875x22]
                 PaintableBox (Box<TR>) [17.34375,11 150.796875x22]
                   PaintableWithLines (BlockContainer<TD>) [17.34375,11 73.59375x22]
-                    PaintableWithLines (BlockContainer(anonymous)) [19.34375,13 69.59375x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [92.9375,11 75.203125x22]
-                    PaintableWithLines (BlockContainer(anonymous)) [94.9375,13 71.203125x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
           PaintableWithLines (BlockContainer<DIV>.right) [171.140625,8 7.75x18]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,36 784x0]

--- a/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
@@ -5,22 +5,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 27.90625x48 table-box [TFC] children: not-inline
           Box <tbody> at (10,10) content-size 23.90625x44 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 23.90625x20 table-row children: not-inline
-              BlockContainer <td> at (11,11) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
-              BlockContainer <td> at (24.09375,23) content-size 8.8125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (24.09375,23) content-size 8.8125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [24.09375,23 8.8125x18] baseline: 13.796875
-                      "2"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
+              BlockContainer <td> at (24.09375,23) content-size 8.8125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [24.09375,23 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text>
             Box <tr> at (10,32) content-size 23.90625x20 table-row children: not-inline
-              BlockContainer <td> at (11,33) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,33 9.09375x18] baseline: 13.796875
-                      "3"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,33 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text>
             Box <tr> at (10,54) content-size 23.90625x0 table-row children: not-inline
               BlockContainer <(anonymous)> at (10,54) content-size 11.09375x0 table-cell [BFC] children: not-inline
       BlockContainer <(anonymous)> at (8,56) content-size 784x0 children: inline
@@ -34,15 +31,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 23.90625x44]
             PaintableBox (Box<TR>) [10,10 23.90625x20]
               PaintableWithLines (BlockContainer<TD>) [10,10 11.09375x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [23.09375,10 10.8125x44]
-                PaintableWithLines (BlockContainer(anonymous)) [24.09375,23 8.8125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,32 23.90625x20]
               PaintableWithLines (BlockContainer<TD>) [10,32 11.09375x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,54 23.90625x0]
               PaintableWithLines (BlockContainer(anonymous)) [10,54 11.09375x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,56 784x0]

--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -9,25 +9,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 198.328125x50 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25,25) content-size 32.078125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (25,25) content-size 32.078125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x18] baseline: 13.796875
-                      "Top"
-                  TextNode <#text>
+              BlockContainer <td> at (25,25) content-size 32.078125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x18] baseline: 13.796875
+                    "Top"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (89.078125,75) content-size 55.984375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (89.078125,75) content-size 55.984375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [89.078125,75 55.984375x18] baseline: 13.796875
-                      "Bottom"
-                  TextNode <#text>
+              BlockContainer <td> at (89.078125,75) content-size 55.984375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [89.078125,75 55.984375x18] baseline: 13.796875
+                    "Bottom"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (177.0625,25) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (177.0625,25) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (177.0625,25) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -35,11 +32,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,59) content-size 198.328125x50 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (177.0625,75) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (177.0625,75) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,75 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (177.0625,75) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [177.0625,75 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -53,18 +49,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 198.328125x100]
             PaintableBox (Box<TR>) [9,9 198.328125x50]
               PaintableWithLines (BlockContainer<TD>) [9,9 64.078125x100]
-                PaintableWithLines (BlockContainer(anonymous)) [25,25 32.078125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [73.078125,9 87.984375x100]
-                PaintableWithLines (BlockContainer(anonymous)) [89.078125,75 55.984375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [161.0625,9 46.265625x50]
-                PaintableWithLines (BlockContainer(anonymous)) [177.0625,25 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,59 198.328125x50]
               PaintableWithLines (BlockContainer<TD>) [161.0625,59 46.265625x50]
-                PaintableWithLines (BlockContainer(anonymous)) [177.0625,75 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-height.txt
@@ -5,20 +5,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (11,11) content-size 29.15625x20 [BFC] children: not-inline
           Box <(anonymous)> at (11,11) content-size 29.15625x20 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,11) content-size 29.15625x20 table-row children: not-inline
-              BlockContainer <span> at (12,12) content-size 27.15625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (12,12) content-size 27.15625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x18] baseline: 13.796875
-                      "foo"
-                  TextNode <#text>
+              BlockContainer <span> at (12,12) content-size 27.15625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x18] baseline: 13.796875
+                    "foo"
+                TextNode <#text>
       BlockContainer <div> at (11,33) content-size 778x20 children: not-inline
         TableWrapper <(anonymous)> at (11,33) content-size 29.640625x20 [BFC] children: not-inline
           Box <(anonymous)> at (11,33) content-size 29.640625x20 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,33) content-size 29.640625x20 table-row children: not-inline
-              BlockContainer <span> at (12,34) content-size 27.640625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (12,34) content-size 27.640625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [12,34 27.640625x18] baseline: 13.796875
-                      "bar"
-                  TextNode <#text>
+              BlockContainer <span> at (12,34) content-size 27.640625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [12,34 27.640625x18] baseline: 13.796875
+                    "bar"
+                TextNode <#text>
       BlockContainer <(anonymous)> at (10,54) content-size 780x0 children: inline
         TextNode <#text>
 
@@ -30,15 +28,13 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box(anonymous)) [11,11 29.15625x20]
             PaintableBox (Box(anonymous)) [11,11 29.15625x20]
               PaintableWithLines (BlockContainer<SPAN>) [11,11 29.15625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [12,12 27.15625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>) [10,32 780x22]
         PaintableWithLines (TableWrapper(anonymous)) [11,33 29.640625x20]
           PaintableBox (Box(anonymous)) [11,33 29.640625x20]
             PaintableBox (Box(anonymous)) [11,33 29.640625x20]
               PaintableWithLines (BlockContainer<SPAN>) [11,33 29.640625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [12,34 27.640625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [10,54 780x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-margins.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (235.265625,8) content-size 329.46875x18 [BFC] children: not-inline
           Box <div.box> at (235.265625,8) content-size 329.46875x18 table-box [TFC] children: not-inline
             Box <(anonymous)> at (235.265625,8) content-size 329.46875x18 table-row children: not-inline
-              BlockContainer <div.cell> at (235.265625,8) content-size 329.46875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (235.265625,8) content-size 329.46875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 34, rect: [235.265625,8 329.46875x18] baseline: 13.796875
-                      "DaTa DisplaYiNg CSS WeBpaGE ScReEn"
-                  TextNode <#text>
+              BlockContainer <div.cell> at (235.265625,8) content-size 329.46875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 34, rect: [235.265625,8 329.46875x18] baseline: 13.796875
+                    "DaTa DisplaYiNg CSS WeBpaGE ScReEn"
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
@@ -19,8 +18,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<DIV>.box) [235.265625,8 329.46875x18]
             PaintableBox (Box(anonymous)) [235.265625,8 329.46875x18]
               PaintableWithLines (BlockContainer<DIV>.cell) [235.265625,8 329.46875x18]
-                PaintableWithLines (BlockContainer(anonymous)) [235.265625,8 329.46875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -11,11 +11,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 2x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 0x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 0x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 0x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -26,13 +25,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x24]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x24] overflow: [8,8 17.265625x24]
         PaintableBox (Box<TABLE>) [8,8 6x24]
           PaintableBox (Box<TBODY>) [10,10 2x20]
             PaintableBox (Box<TR>) [10,10 2x20]
-              PaintableWithLines (BlockContainer<TD>) [10,10 2x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 0x18] overflow: [11,11 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [10,10 2x20] overflow: [10,10 15.265625x21]
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x40] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -22,11 +22,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,30) content-size 95.171875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,31) content-size 93.171875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,31) content-size 93.171875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,31 73.65625x18] baseline: 13.796875
-                      "Head Cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,31) content-size 93.171875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [11,31 73.65625x18] baseline: 13.796875
+                    "Head Cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -39,11 +38,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,52) content-size 95.171875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,53) content-size 93.171875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,53) content-size 93.171875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,53 70.234375x18] baseline: 13.796875
-                      "Body Cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,53) content-size 93.171875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [11,53 70.234375x18] baseline: 13.796875
+                    "Body Cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -56,11 +54,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,74) content-size 95.171875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,75) content-size 93.171875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,75) content-size 93.171875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,75 93.171875x18] baseline: 13.796875
-                      "Footer Cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,75) content-size 93.171875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 11, rect: [11,75 93.171875x18] baseline: 13.796875
+                    "Footer Cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -83,18 +80,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [10,30 95.171875x20]
             PaintableBox (Box<TR>) [10,30 95.171875x20]
               PaintableWithLines (BlockContainer<TD>) [10,30 95.171875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,31 93.171875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>) [10,52 95.171875x20]
             PaintableBox (Box<TR>) [10,52 95.171875x20]
               PaintableWithLines (BlockContainer<TD>) [10,52 95.171875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,53 93.171875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<TFOOT>) [10,74 95.171875x20]
             PaintableBox (Box<TR>) [10,74 95.171875x20]
               PaintableWithLines (BlockContainer<TD>) [10,74 95.171875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,75 93.171875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,114 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (18,18) content-size 22.265625x26 table-box [TFC] children: not-inline
           Box <tbody> at (20,20) content-size 18.265625x22 table-row-group children: not-inline
             Box <tr> at (20,20) content-size 18.265625x22 table-row children: not-inline
-              BlockContainer <td> at (22,22) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (22,22) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [22,22 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (22,22) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [22,22 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x62]
@@ -19,8 +18,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [20,20 18.265625x22]
             PaintableBox (Box<TR>) [20,20 18.265625x22]
               PaintableWithLines (BlockContainer<TD>) [20,20 18.265625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [22,22 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-attribute.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (13,13) content-size 22.265625x26 table-box [TFC] children: not-inline
           Box <tbody> at (15,15) content-size 18.265625x22 table-row-group children: not-inline
             Box <tr> at (15,15) content-size 18.265625x22 table-row children: not-inline
-              BlockContainer <td> at (17,17) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (17,17) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,17 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (17,17) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [17,17 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
@@ -19,8 +18,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [15,15 18.265625x22]
             PaintableBox (Box<TR>) [15,15 18.265625x22]
               PaintableWithLines (BlockContainer<TD>) [15,15 18.265625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [17,17 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x52] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.horizontal> at (8,8) content-size 784x202 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 161.90625x200] baseline: 14.796875
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 161.90625x200] baseline: 25.296875
         TextNode <#text>
         BlockContainer <table> at (9,9) content-size 161.90625x200 inline-block [BFC] children: not-inline
           BlockContainer <(anonymous)> at (9,9) content-size 161.90625x0 children: inline
@@ -19,25 +19,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,9) content-size 161.90625x40 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,20) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (30,20) content-size 14.265625x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [30,20 14.265625x18] baseline: 13.796875
-                          "A"
-                      TextNode <#text>
+                  BlockContainer <td> at (30,20) content-size 14.265625x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [30,20 14.265625x18] baseline: 13.796875
+                        "A"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,20) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (86.265625,20) content-size 12.546875x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [87.859375,20 9.34375x18] baseline: 13.796875
-                          "B"
-                      TextNode <#text>
+                  BlockContainer <td> at (86.265625,20) content-size 12.546875x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [87.859375,20 9.34375x18] baseline: 13.796875
+                        "B"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,20) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (140.8125,20) content-size 9.09375x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [142.1875,20 6.34375x18] baseline: 13.796875
-                          "1"
-                      TextNode <#text>
+                  BlockContainer <td> at (140.8125,20) content-size 9.09375x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [142.1875,20 6.34375x18] baseline: 13.796875
+                        "1"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -45,25 +42,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,49) content-size 161.90625x40 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,60) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (30,60) content-size 14.265625x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [31.96875,60 10.3125x18] baseline: 13.796875
-                          "C"
-                      TextNode <#text>
+                  BlockContainer <td> at (30,60) content-size 14.265625x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [31.96875,60 10.3125x18] baseline: 13.796875
+                        "C"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,60) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (86.265625,60) content-size 12.546875x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.96875,60 11.140625x18] baseline: 13.796875
-                          "D"
-                      TextNode <#text>
+                  BlockContainer <td> at (86.265625,60) content-size 12.546875x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [86.96875,60 11.140625x18] baseline: 13.796875
+                        "D"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,60) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (140.8125,60) content-size 9.09375x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.953125,60 8.8125x18] baseline: 13.796875
-                          "2"
-                      TextNode <#text>
+                  BlockContainer <td> at (140.8125,60) content-size 9.09375x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [140.953125,60 8.8125x18] baseline: 13.796875
+                        "2"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -71,25 +65,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,89) content-size 161.90625x40 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,100) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (30,100) content-size 14.265625x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [31.203125,100 11.859375x18] baseline: 13.796875
-                          "E"
-                      TextNode <#text>
+                  BlockContainer <td> at (30,100) content-size 14.265625x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [31.203125,100 11.859375x18] baseline: 13.796875
+                        "E"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,100) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (86.265625,100) content-size 12.546875x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.265625,100 12.546875x18] baseline: 13.796875
-                          "F"
-                      TextNode <#text>
+                  BlockContainer <td> at (86.265625,100) content-size 12.546875x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [86.265625,100 12.546875x18] baseline: 13.796875
+                        "F"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,100) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (140.8125,100) content-size 9.09375x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,100 9.09375x18] baseline: 13.796875
-                          "3"
-                      TextNode <#text>
+                  BlockContainer <td> at (140.8125,100) content-size 9.09375x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [140.8125,100 9.09375x18] baseline: 13.796875
+                        "3"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -97,25 +88,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,129) content-size 161.90625x40 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,140) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (30,140) content-size 14.265625x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [30.515625,140 13.234375x18] baseline: 13.796875
-                          "G"
-                      TextNode <#text>
+                  BlockContainer <td> at (30,140) content-size 14.265625x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [30.515625,140 13.234375x18] baseline: 13.796875
+                        "G"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,140) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (86.265625,140) content-size 12.546875x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [86.421875,140 12.234375x18] baseline: 13.796875
-                          "H"
-                      TextNode <#text>
+                  BlockContainer <td> at (86.265625,140) content-size 12.546875x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [86.421875,140 12.234375x18] baseline: 13.796875
+                        "H"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,140) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (140.8125,140) content-size 9.09375x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [141.484375,140 7.75x18] baseline: 13.796875
-                          "4"
-                      TextNode <#text>
+                  BlockContainer <td> at (140.8125,140) content-size 9.09375x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [141.484375,140 7.75x18] baseline: 13.796875
+                        "4"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -123,25 +111,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,169) content-size 161.90625x40 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,180) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (30,180) content-size 14.265625x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [34.828125,180 4.59375x18] baseline: 13.796875
-                          "I"
-                      TextNode <#text>
+                  BlockContainer <td> at (30,180) content-size 14.265625x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [34.828125,180 4.59375x18] baseline: 13.796875
+                        "I"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,180) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (86.265625,180) content-size 12.546875x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [88.078125,180 8.90625x18] baseline: 13.796875
-                          "J"
-                      TextNode <#text>
+                  BlockContainer <td> at (86.265625,180) content-size 12.546875x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [88.078125,180 8.90625x18] baseline: 13.796875
+                        "J"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,180) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                    BlockContainer <(anonymous)> at (140.8125,180) content-size 9.09375x18 children: inline
-                      frag 0 from TextNode start: 0, length: 1, rect: [141.125,180 8.453125x18] baseline: 13.796875
-                          "5"
-                      TextNode <#text>
+                  BlockContainer <td> at (140.8125,180) content-size 9.09375x18 table-cell [BFC] children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [141.125,180 8.453125x18] baseline: 13.796875
+                        "5"
+                    TextNode <#text>
                   BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
@@ -165,54 +150,39 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableBox (Box<TBODY>) [9,9 161.90625x200]
                 PaintableBox (Box<TR>) [9,9 161.90625x40]
                   PaintableWithLines (BlockContainer<TD>) [9,9 56.265625x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [30,20 14.265625x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,9 54.546875x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,20 12.546875x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,9 51.09375x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,20 9.09375x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,49 161.90625x40]
                   PaintableWithLines (BlockContainer<TD>) [9,49 56.265625x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [30,60 14.265625x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,49 54.546875x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,60 12.546875x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,49 51.09375x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,60 9.09375x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,89 161.90625x40]
                   PaintableWithLines (BlockContainer<TD>) [9,89 56.265625x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [30,100 14.265625x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,89 54.546875x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,100 12.546875x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,89 51.09375x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,100 9.09375x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,129 161.90625x40]
                   PaintableWithLines (BlockContainer<TD>) [9,129 56.265625x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [30,140 14.265625x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,129 54.546875x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,140 12.546875x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,129 51.09375x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,140 9.09375x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,169 161.90625x40]
                   PaintableWithLines (BlockContainer<TD>) [9,169 56.265625x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [30,180 14.265625x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,169 54.546875x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,180 12.546875x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,169 51.09375x40]
-                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,180 9.09375x18]
-                      TextPaintable (TextNode<#text>)
+                    TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
                 PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
               PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -11,25 +11,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 172.671875x44 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,21) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (29,21) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (29,21) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td.td-thick-border> at (89.265625,21) content-size 9.859375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (89.265625,21) content-size 9.859375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [89.265625,21 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td.td-thick-border> at (89.265625,21) content-size 9.859375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [89.265625,21 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (145.125,20) content-size 14.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (145.125,20) content-size 14.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (145.125,20) content-size 14.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -37,25 +34,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,52) content-size 172.671875x44 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,65) content-size 16.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (29,65) content-size 16.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,65 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (29,65) content-size 16.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [29,65 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,66) content-size 11.859375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.265625,66) content-size 11.859375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,66 11.859375x18] baseline: 13.796875
-                      "E"
-                  TextNode <#text>
+              BlockContainer <td> at (87.265625,66) content-size 11.859375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,66 11.859375x18] baseline: 13.796875
+                    "E"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td.td-thick-border> at (145.125,65) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (145.125,65) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,65 12.546875x18] baseline: 13.796875
-                      "F"
-                  TextNode <#text>
+              BlockContainer <td.td-thick-border> at (145.125,65) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [145.125,65 12.546875x18] baseline: 13.796875
+                    "F"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -71,24 +65,18 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 172.671875x88]
             PaintableBox (Box<TR>) [8,8 172.671875x44]
               PaintableWithLines (BlockContainer<TD>) [8,8 58.265625x44]
-                PaintableWithLines (BlockContainer(anonymous)) [29,21 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>.td-thick-border) [66.265625,8 55.859375x44]
-                PaintableWithLines (BlockContainer(anonymous)) [89.265625,21 9.859375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [122.125,8 58.546875x44]
-                PaintableWithLines (BlockContainer(anonymous)) [145.125,20 14.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,52 172.671875x44]
               PaintableWithLines (BlockContainer<TD>) [8,52 58.265625x44]
-                PaintableWithLines (BlockContainer(anonymous)) [29,65 16.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,52 55.859375x44]
-                PaintableWithLines (BlockContainer(anonymous)) [87.265625,66 11.859375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>.td-thick-border) [122.125,52 58.546875x44]
-                PaintableWithLines (BlockContainer(anonymous)) [145.125,65 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x104] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -19,11 +19,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 60.265625x42 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,21) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,21) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (31,21) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -31,11 +30,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,50) content-size 60.265625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,61) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,61) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,61 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (31,61) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,61 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,11 +41,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,90) content-size 60.265625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,101) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,101) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,101 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (31,101) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,101 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -55,11 +52,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,130) content-size 60.265625x42 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,141) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,141) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,141 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (31,141) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,141 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -79,20 +75,16 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 60.265625x164]
             PaintableBox (Box<TR>) [8,8 60.265625x42]
               PaintableWithLines (BlockContainer<TD>) [8,8 60.265625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [31,21 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,50 60.265625x40]
               PaintableWithLines (BlockContainer<TD>) [8,50 60.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [31,61 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,90 60.265625x40]
               PaintableWithLines (BlockContainer<TD>) [8,90 60.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [31,101 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,130 60.265625x42]
               PaintableWithLines (BlockContainer<TD>) [8,130 60.265625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [31,141 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,172 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -11,18 +11,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr.td-thick-border> at (8,8) content-size 114.8125x44 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,21) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,21) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (31,21) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,21) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.265625,21) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (87.265625,21) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -30,18 +28,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,52) content-size 114.8125x44 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,65) content-size 16.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (29,65) content-size 16.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,65 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (29,65) content-size 16.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [29,65 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,65) content-size 14.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.265625,65) content-size 14.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,65 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (87.265625,65) content-size 14.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,65 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -49,18 +45,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr.td-thick-border> at (8,96) content-size 114.8125x44 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,109) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,109) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,109 11.859375x18] baseline: 13.796875
-                      "E"
-                  TextNode <#text>
+              BlockContainer <td> at (31,109) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,109 11.859375x18] baseline: 13.796875
+                    "E"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,109) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.265625,109) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,109 12.546875x18] baseline: 13.796875
-                      "F"
-                  TextNode <#text>
+              BlockContainer <td> at (87.265625,109) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,109 12.546875x18] baseline: 13.796875
+                    "F"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -76,25 +70,19 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 114.8125x132]
             PaintableBox (Box<TR>.td-thick-border) [8,8 114.8125x44]
               PaintableWithLines (BlockContainer<TD>) [8,8 58.265625x44]
-                PaintableWithLines (BlockContainer(anonymous)) [31,21 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,8 56.546875x44]
-                PaintableWithLines (BlockContainer(anonymous)) [87.265625,21 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,52 114.8125x44]
               PaintableWithLines (BlockContainer<TD>) [8,52 58.265625x44]
-                PaintableWithLines (BlockContainer(anonymous)) [29,65 16.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,52 56.546875x44]
-                PaintableWithLines (BlockContainer(anonymous)) [87.265625,65 14.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>.td-thick-border) [8,96 114.8125x44]
               PaintableWithLines (BlockContainer<TD>) [8,96 58.265625x44]
-                PaintableWithLines (BlockContainer(anonymous)) [31,109 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,96 56.546875x44]
-                PaintableWithLines (BlockContainer(anonymous)) [87.265625,109 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x148] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -9,18 +9,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (8,8) content-size 113.40625x42 table-row children: not-inline
-              BlockContainer <td> at (29,19) content-size 16.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (29,19) content-size 16.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x18] baseline: 13.796875
-                      "0"
-                  TextNode <#text>
+              BlockContainer <td> at (29,19) content-size 16.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x18] baseline: 13.796875
+                    "0"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,19) content-size 13.140625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.265625,19) content-size 13.140625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
+              BlockContainer <td> at (87.265625,19) content-size 13.140625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -31,18 +29,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,50) content-size 113.40625x42 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,63) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,63) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,63 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (31,63) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,63 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,63) content-size 11.140625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.265625,63) content-size 11.140625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,63 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (87.265625,63) content-size 11.140625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,63 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -50,18 +46,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,92) content-size 113.40625x42 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,103) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (31,103) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [31,103 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (31,103) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [31,103 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,103) content-size 11.140625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.265625,103) content-size 11.140625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,103 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (87.265625,103) content-size 11.140625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,103 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -77,26 +71,20 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [8,8 113.40625x42]
             PaintableBox (Box<TR>) [8,8 113.40625x42]
               PaintableWithLines (BlockContainer<TD>) [8,8 58.265625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [29,19 16.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,8 55.140625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [87.265625,19 13.140625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>.thick-border) [8,50 113.40625x84]
             PaintableBox (Box<TR>) [8,50 113.40625x42]
               PaintableWithLines (BlockContainer<TD>) [8,50 58.265625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [31,63 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,50 55.140625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [87.265625,63 11.140625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,92 113.40625x42]
               PaintableWithLines (BlockContainer<TD>) [8,92 58.265625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [31,103 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,92 55.140625x42]
-                PaintableWithLines (BlockContainer(anonymous)) [87.265625,103 11.140625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x142] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
@@ -19,32 +19,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 53.0625x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,9) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (9,9) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [9,9 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (9,9) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [9,9 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25.265625,9) content-size 9.34375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (25.265625,9) content-size 9.34375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [25.265625,9 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (25.265625,9) content-size 9.34375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [25.265625,9 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (36.609375,9) content-size 10.3125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (36.609375,9) content-size 10.3125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [36.609375,9 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (36.609375,9) content-size 10.3125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [36.609375,9 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (48.921875,9) content-size 11.140625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (48.921875,9) content-size 11.140625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [48.921875,9 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (48.921875,9) content-size 11.140625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [48.921875,9 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -63,17 +59,13 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 53.0625x20]
             PaintableBox (Box<TR>) [8,8 53.0625x20]
               PaintableWithLines (BlockContainer<TD>) [8,8 16.265625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [9,9 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [24.265625,8 11.34375x20]
-                PaintableWithLines (BlockContainer(anonymous)) [25.265625,9 9.34375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [35.609375,8 12.3125x20]
-                PaintableWithLines (BlockContainer(anonymous)) [36.609375,9 10.3125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [47.921875,8 13.140625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [48.921875,9 11.140625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -9,18 +9,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (33,23) content-size 93.609375x48 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (48,38) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (48,38) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [48,38 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (48,38) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [48,38 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (102.265625,38) content-size 9.34375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (102.265625,38) content-size 9.34375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [102.265625,38 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (102.265625,38) content-size 9.34375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [102.265625,38 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,11 +32,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [33,23 93.609375x48]
             PaintableBox (Box<TR>) [33,23 93.609375x48]
               PaintableWithLines (BlockContainer<TD>) [33,23 44.265625x48]
-                PaintableWithLines (BlockContainer(anonymous)) [48,38 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [87.265625,23 39.34375x48]
-                PaintableWithLines (BlockContainer(anonymous)) [102.265625,38 9.34375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x94] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -15,25 +15,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,19) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,30) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,30) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (50,30) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,30) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,30) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,18 +38,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,69) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,80) content-size 88.8125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,80) content-size 88.8125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [89.25,80 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (50,80) content-size 88.8125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [89.25,80 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,80) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,80) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,80 8.8125x18] baseline: 13.796875
-                      "2"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,80) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [200.953125,80 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -60,25 +55,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,119) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,130) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,130) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,130 11.859375x18] baseline: 13.796875
-                      "E"
-                  TextNode <#text>
+              BlockContainer <td> at (50,130) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [51.203125,130 11.859375x18] baseline: 13.796875
+                    "E"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,130) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,130) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,130 12.546875x18] baseline: 13.796875
-                      "F"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,130) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,130 12.546875x18] baseline: 13.796875
+                    "F"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,130) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,130) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,130 9.09375x18] baseline: 13.796875
-                      "3"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,130) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,130 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -86,25 +78,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,169) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,180) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,180) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,180 13.234375x18] baseline: 13.796875
-                      "G"
-                  TextNode <#text>
+              BlockContainer <td> at (50,180) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [50.515625,180 13.234375x18] baseline: 13.796875
+                    "G"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,180) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,180) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,180 12.234375x18] baseline: 13.796875
-                      "H"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,180) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.421875,180 12.234375x18] baseline: 13.796875
+                    "H"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,180) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,180) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,180 7.75x18] baseline: 13.796875
-                      "4"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,180) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [201.484375,180 7.75x18] baseline: 13.796875
+                    "4"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -112,25 +101,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,219) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,230) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,230) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,230 4.59375x18] baseline: 13.796875
-                      "I"
-                  TextNode <#text>
+              BlockContainer <td> at (50,230) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [54.828125,230 4.59375x18] baseline: 13.796875
+                    "I"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,230) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,230) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,230 8.90625x18] baseline: 13.796875
-                      "J"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,230) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [128.078125,230 8.90625x18] baseline: 13.796875
+                    "J"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,230) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,230) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,230 8.453125x18] baseline: 13.796875
-                      "5"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,230) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [201.125,230 8.453125x18] baseline: 13.796875
+                    "5"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -150,51 +136,37 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [29,19 201.90625x240]
             PaintableBox (Box<TR>) [29,19 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,30 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,30 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,30 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,69 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,69 130.8125x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,80 88.8125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,69 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,80 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,119 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,119 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,130 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,119 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,130 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,119 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,130 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,169 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,169 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,180 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,169 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,180 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,169 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,180 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,219 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,219 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,230 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,219 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,230 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,219 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,230 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,270 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -15,25 +15,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,19) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,55) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,55) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,55 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (50,55) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [50,55 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,30) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,30) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,18 +38,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,69) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,80) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,80) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,80 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,80) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.96875,80 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,80) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,80) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,80 8.8125x18] baseline: 13.796875
-                      "2"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,80) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [200.953125,80 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -60,25 +55,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,119) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,130) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,130) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,130 11.859375x18] baseline: 13.796875
-                      "E"
-                  TextNode <#text>
+              BlockContainer <td> at (50,130) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [51.203125,130 11.859375x18] baseline: 13.796875
+                    "E"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,130) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,130) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,130 12.546875x18] baseline: 13.796875
-                      "F"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,130) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,130 12.546875x18] baseline: 13.796875
+                    "F"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,130) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,130) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,130 9.09375x18] baseline: 13.796875
-                      "3"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,130) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,130 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -86,25 +78,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,169) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,180) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,180) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,180 13.234375x18] baseline: 13.796875
-                      "G"
-                  TextNode <#text>
+              BlockContainer <td> at (50,180) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [50.515625,180 13.234375x18] baseline: 13.796875
+                    "G"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,180) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,180) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,180 12.234375x18] baseline: 13.796875
-                      "H"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,180) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.421875,180 12.234375x18] baseline: 13.796875
+                    "H"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,180) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,180) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,180 7.75x18] baseline: 13.796875
-                      "4"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,180) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [201.484375,180 7.75x18] baseline: 13.796875
+                    "4"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -112,25 +101,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,219) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,230) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,230) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,230 4.59375x18] baseline: 13.796875
-                      "I"
-                  TextNode <#text>
+              BlockContainer <td> at (50,230) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [54.828125,230 4.59375x18] baseline: 13.796875
+                    "I"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,230) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,230) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,230 8.90625x18] baseline: 13.796875
-                      "J"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,230) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [128.078125,230 8.90625x18] baseline: 13.796875
+                    "J"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,230) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,230) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,230 8.453125x18] baseline: 13.796875
-                      "5"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,230) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [201.125,230 8.453125x18] baseline: 13.796875
+                    "5"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -150,51 +136,37 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [29,19 201.90625x240]
             PaintableBox (Box<TR>) [29,19 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x90]
-                PaintableWithLines (BlockContainer(anonymous)) [50,55 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,30 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,30 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,69 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [105.265625,69 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,80 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,69 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,80 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,119 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,119 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,130 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,119 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,130 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,119 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,130 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,169 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,169 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,180 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,169 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,180 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,169 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,180 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,219 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,219 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,230 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,219 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,230 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,219 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,230 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,270 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -16,11 +16,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (127.59375,10) content-size 474.234375x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (128.59375,11) content-size 472.234375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (128.59375,11) content-size 472.234375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (128.59375,11) content-size 472.234375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,8 +42,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [127.59375,10 474.234375x20]
             PaintableBox (Box<TR>) [127.59375,10 474.234375x20]
               PaintableWithLines (BlockContainer<TD>) [127.59375,10 474.234375x20]
-                PaintableWithLines (BlockContainer(anonymous)) [128.59375,11 472.234375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>.right) [603.828125,8 188.15625x18]
         TextPaintable (TextNode<#text>)
 

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -15,25 +15,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,19) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,30) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,30) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (50,30) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,30) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,30) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,25 +38,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,69) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,80) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,80) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.96875,80 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (50,80) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [51.96875,80 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,80) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,80) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,80 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,80) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.96875,80 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,80) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,80) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,80 8.8125x18] baseline: 13.796875
-                      "2"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,80) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [200.953125,80 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -67,25 +61,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,119) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,130) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,130) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,130 11.859375x18] baseline: 13.796875
-                      "E"
-                  TextNode <#text>
+              BlockContainer <td> at (50,130) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [51.203125,130 11.859375x18] baseline: 13.796875
+                    "E"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,130) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,130) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,130 12.546875x18] baseline: 13.796875
-                      "F"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,130) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,130 12.546875x18] baseline: 13.796875
+                    "F"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,130) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,130) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,130 9.09375x18] baseline: 13.796875
-                      "3"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,130) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,130 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -93,25 +84,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,169) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,180) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,180) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,180 13.234375x18] baseline: 13.796875
-                      "G"
-                  TextNode <#text>
+              BlockContainer <td> at (50,180) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [50.515625,180 13.234375x18] baseline: 13.796875
+                    "G"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,180) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,180) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,180 12.234375x18] baseline: 13.796875
-                      "H"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,180) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [126.421875,180 12.234375x18] baseline: 13.796875
+                    "H"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,180) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,180) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,180 7.75x18] baseline: 13.796875
-                      "4"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,180) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [201.484375,180 7.75x18] baseline: 13.796875
+                    "4"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -119,25 +107,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,219) content-size 201.90625x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,230) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (50,230) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,230 4.59375x18] baseline: 13.796875
-                      "I"
-                  TextNode <#text>
+              BlockContainer <td> at (50,230) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [54.828125,230 4.59375x18] baseline: 13.796875
+                    "I"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,230) content-size 12.546875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (126.265625,230) content-size 12.546875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,230 8.90625x18] baseline: 13.796875
-                      "J"
-                  TextNode <#text>
+              BlockContainer <td> at (126.265625,230) content-size 12.546875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [128.078125,230 8.90625x18] baseline: 13.796875
+                    "J"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,230) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (200.8125,230) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,230 8.453125x18] baseline: 13.796875
-                      "5"
-                  TextNode <#text>
+              BlockContainer <td> at (200.8125,230) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [201.125,230 8.453125x18] baseline: 13.796875
+                    "5"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -157,54 +142,39 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [29,19 201.90625x240]
             PaintableBox (Box<TR>) [29,19 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,30 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,30 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,30 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,69 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,69 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,80 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,69 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,80 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,69 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,80 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,119 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,119 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,130 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,119 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,130 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,119 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,130 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,169 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,169 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,180 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,169 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,180 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,169 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,180 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,219 201.90625x40]
               PaintableWithLines (BlockContainer<TD>) [29,219 56.265625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [50,230 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,219 54.546875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [126.265625,230 12.546875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,219 51.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [200.8125,230 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,270 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -9,18 +9,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 168.296875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 82.015625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,13) content-size 82.015625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x18] baseline: 13.796875
-                      "Firstname"
-                  TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 82.015625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x18] baseline: 13.796875
+                    "Firstname"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,13) content-size 76.28125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (101.015625,13) content-size 76.28125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x18] baseline: 13.796875
-                      "Lastname"
-                  TextNode <#text>
+              BlockContainer <td> at (101.015625,13) content-size 76.28125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x18] baseline: 13.796875
+                    "Lastname"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -28,18 +26,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,35) content-size 168.296875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,37) content-size 82.015625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,37) content-size 82.015625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 5, rect: [13,37 44.65625x18] baseline: 13.796875
-                      "Peter"
-                  TextNode <#text>
+              BlockContainer <td> at (13,37) content-size 82.015625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [13,37 44.65625x18] baseline: 13.796875
+                    "Peter"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,37) content-size 76.28125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (101.015625,37) content-size 76.28125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,37 53.671875x18] baseline: 13.796875
-                      "Griffin"
-                  TextNode <#text>
+              BlockContainer <td> at (101.015625,37) content-size 76.28125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [101.015625,37 53.671875x18] baseline: 13.796875
+                    "Griffin"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -47,18 +43,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,59) content-size 168.296875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,61) content-size 82.015625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,61) content-size 82.015625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [13,61 35.125x18] baseline: 13.796875
-                      "Lois"
-                  TextNode <#text>
+              BlockContainer <td> at (13,61) content-size 82.015625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [13,61 35.125x18] baseline: 13.796875
+                    "Lois"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,61) content-size 76.28125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (101.015625,61) content-size 76.28125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,61 53.671875x18] baseline: 13.796875
-                      "Griffin"
-                  TextNode <#text>
+              BlockContainer <td> at (101.015625,61) content-size 76.28125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [101.015625,61 53.671875x18] baseline: 13.796875
+                    "Griffin"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -74,18 +68,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,84) content-size 164.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,85) content-size 82.015625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (9,85) content-size 82.015625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 9, rect: [9,85 82.015625x18] baseline: 13.796875
-                      "Firstname"
-                  TextNode <#text>
+              BlockContainer <td> at (9,85) content-size 82.015625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [9,85 82.015625x18] baseline: 13.796875
+                    "Firstname"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,85) content-size 76.28125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (95.015625,85) content-size 76.28125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [95.015625,85 76.28125x18] baseline: 13.796875
-                      "Lastname"
-                  TextNode <#text>
+              BlockContainer <td> at (95.015625,85) content-size 76.28125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [95.015625,85 76.28125x18] baseline: 13.796875
+                    "Lastname"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -93,18 +85,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,105) content-size 164.296875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,107) content-size 82.015625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (9,107) content-size 82.015625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 5, rect: [9,107 44.65625x18] baseline: 13.796875
-                      "Peter"
-                  TextNode <#text>
+              BlockContainer <td> at (9,107) content-size 82.015625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [9,107 44.65625x18] baseline: 13.796875
+                    "Peter"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,107) content-size 76.28125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (95.015625,107) content-size 76.28125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,107 53.671875x18] baseline: 13.796875
-                      "Griffin"
-                  TextNode <#text>
+              BlockContainer <td> at (95.015625,107) content-size 76.28125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [95.015625,107 53.671875x18] baseline: 13.796875
+                    "Griffin"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -112,18 +102,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,127) content-size 164.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,129) content-size 82.015625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (9,129) content-size 82.015625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [9,129 35.125x18] baseline: 13.796875
-                      "Lois"
-                  TextNode <#text>
+              BlockContainer <td> at (9,129) content-size 82.015625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [9,129 35.125x18] baseline: 13.796875
+                    "Lois"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,129) content-size 76.28125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (95.015625,129) content-size 76.28125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,129 53.671875x18] baseline: 13.796875
-                      "Griffin"
-                  TextNode <#text>
+              BlockContainer <td> at (95.015625,129) content-size 76.28125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [95.015625,129 53.671875x18] baseline: 13.796875
+                    "Griffin"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -138,18 +126,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.border-black> at (8,148) content-size 160.296875x19 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,148) content-size 82.015625x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,148) content-size 82.015625x18 children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [8,148 82.015625x18] baseline: 13.796875
-                    "Firstname"
-                TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (8,148) content-size 82.015625x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 9, rect: [8,148 82.015625x18] baseline: 13.796875
+                  "Firstname"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,148) content-size 76.28125x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (92.015625,148) content-size 76.28125x18 children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [92.015625,148 76.28125x18] baseline: 13.796875
-                    "Lastname"
-                TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (92.015625,148) content-size 76.28125x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 8, rect: [92.015625,148 76.28125x18] baseline: 13.796875
+                  "Lastname"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -157,18 +143,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.border-black> at (8,167) content-size 160.296875x20 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,168) content-size 82.015625x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,168) content-size 82.015625x18 children: inline
-                frag 0 from TextNode start: 0, length: 5, rect: [8,168 44.65625x18] baseline: 13.796875
-                    "Peter"
-                TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (8,168) content-size 82.015625x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [8,168 44.65625x18] baseline: 13.796875
+                  "Peter"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,168) content-size 76.28125x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (92.015625,168) content-size 76.28125x18 children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,168 53.671875x18] baseline: 13.796875
-                    "Griffin"
-                TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (92.015625,168) content-size 76.28125x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 7, rect: [92.015625,168 53.671875x18] baseline: 13.796875
+                  "Griffin"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -176,18 +160,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.border-black> at (8,187) content-size 160.296875x19 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,188) content-size 82.015625x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,188) content-size 82.015625x18 children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [8,188 35.125x18] baseline: 13.796875
-                    "Lois"
-                TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (8,188) content-size 82.015625x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 4, rect: [8,188 35.125x18] baseline: 13.796875
+                  "Lois"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,188) content-size 76.28125x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (92.015625,188) content-size 76.28125x18 children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,188 53.671875x18] baseline: 13.796875
-                    "Griffin"
-                TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (92.015625,188) content-size 76.28125x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 7, rect: [92.015625,188 53.671875x18] baseline: 13.796875
+                  "Griffin"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -202,18 +184,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.thick-border-black> at (8,206) content-size 168.296875x23 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,206) content-size 82.015625x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,206) content-size 82.015625x18 children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [8,206 82.015625x18] baseline: 13.796875
-                    "Firstname"
-                TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (8,206) content-size 82.015625x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 9, rect: [8,206 82.015625x18] baseline: 13.796875
+                  "Firstname"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,206) content-size 76.28125x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (100.015625,206) content-size 76.28125x18 children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [100.015625,206 76.28125x18] baseline: 13.796875
-                    "Lastname"
-                TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,206) content-size 76.28125x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 8, rect: [100.015625,206 76.28125x18] baseline: 13.796875
+                  "Lastname"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -221,18 +201,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.thick-border-black> at (8,229) content-size 168.296875x28 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,234) content-size 82.015625x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,234) content-size 82.015625x18 children: inline
-                frag 0 from TextNode start: 0, length: 5, rect: [8,234 44.65625x18] baseline: 13.796875
-                    "Peter"
-                TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (8,234) content-size 82.015625x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [8,234 44.65625x18] baseline: 13.796875
+                  "Peter"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,234) content-size 76.28125x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (100.015625,234) content-size 76.28125x18 children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,234 53.671875x18] baseline: 13.796875
-                    "Griffin"
-                TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,234) content-size 76.28125x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 7, rect: [100.015625,234 53.671875x18] baseline: 13.796875
+                  "Griffin"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -240,18 +218,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.thick-border-black> at (8,257) content-size 168.296875x23 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,262) content-size 82.015625x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,262) content-size 82.015625x18 children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [8,262 35.125x18] baseline: 13.796875
-                    "Lois"
-                TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (8,262) content-size 82.015625x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 4, rect: [8,262 35.125x18] baseline: 13.796875
+                  "Lois"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,262) content-size 76.28125x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (100.015625,262) content-size 76.28125x18 children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,262 53.671875x18] baseline: 13.796875
-                    "Griffin"
-                TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,262) content-size 76.28125x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 7, rect: [100.015625,262 53.671875x18] baseline: 13.796875
+                  "Griffin"
+              TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -267,98 +243,74 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 168.296875x70]
             PaintableBox (Box<TR>) [11,11 168.296875x22]
               PaintableWithLines (BlockContainer<TD>) [11,11 86.015625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,13 82.015625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,11 80.28125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [101.015625,13 76.28125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [11,35 168.296875x22]
               PaintableWithLines (BlockContainer<TD>) [11,35 86.015625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,37 82.015625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,35 80.28125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [101.015625,37 76.28125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [11,59 168.296875x22]
               PaintableWithLines (BlockContainer<TD>) [11,59 86.015625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,61 82.015625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,59 80.28125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [101.015625,61 76.28125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,84 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,84 164.296875x64]
         PaintableBox (Box<TABLE>.table-border-black) [8,84 164.296875x64]
           PaintableBox (Box<TBODY>) [8,84 164.296875x64]
             PaintableBox (Box<TR>) [8,84 164.296875x21]
               PaintableWithLines (BlockContainer<TD>) [8,84 85.015625x21]
-                PaintableWithLines (BlockContainer(anonymous)) [9,85 82.015625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [93.015625,84 79.28125x21]
-                PaintableWithLines (BlockContainer(anonymous)) [95.015625,85 76.28125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,105 164.296875x22]
               PaintableWithLines (BlockContainer<TD>) [8,105 85.015625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [9,107 82.015625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [93.015625,105 79.28125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [95.015625,107 76.28125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,127 164.296875x21]
               PaintableWithLines (BlockContainer<TD>) [8,127 85.015625x21]
-                PaintableWithLines (BlockContainer(anonymous)) [9,129 82.015625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [93.015625,127 79.28125x21]
-                PaintableWithLines (BlockContainer(anonymous)) [95.015625,129 76.28125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,148 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,148 160.296875x58]
         PaintableBox (Box<DIV>.table.border-black) [8,148 160.296875x58]
           PaintableBox (Box<DIV>.table-row.border-black) [8,148 160.296875x19]
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,148 83.015625x19]
-              PaintableWithLines (BlockContainer(anonymous)) [8,148 82.015625x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [91.015625,148 77.28125x19]
-              PaintableWithLines (BlockContainer(anonymous)) [92.015625,148 76.28125x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.border-black) [8,167 160.296875x20]
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,167 83.015625x20]
-              PaintableWithLines (BlockContainer(anonymous)) [8,168 82.015625x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [91.015625,167 77.28125x20]
-              PaintableWithLines (BlockContainer(anonymous)) [92.015625,168 76.28125x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.border-black) [8,187 160.296875x19]
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,187 83.015625x19]
-              PaintableWithLines (BlockContainer(anonymous)) [8,188 82.015625x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [91.015625,187 77.28125x19]
-              PaintableWithLines (BlockContainer(anonymous)) [92.015625,188 76.28125x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,206 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,206 168.296875x74]
         PaintableBox (Box<DIV>.table.thick-border-black) [8,206 168.296875x74]
           PaintableBox (Box<DIV>.table-row.thick-border-black) [8,206 168.296875x23]
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,206 87.015625x23]
-              PaintableWithLines (BlockContainer(anonymous)) [8,206 82.015625x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,206 81.28125x23]
-              PaintableWithLines (BlockContainer(anonymous)) [100.015625,206 76.28125x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.thick-border-black) [8,229 168.296875x28]
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,229 87.015625x28]
-              PaintableWithLines (BlockContainer(anonymous)) [8,234 82.015625x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,229 81.28125x28]
-              PaintableWithLines (BlockContainer(anonymous)) [100.015625,234 76.28125x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.thick-border-black) [8,257 168.296875x23]
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,257 87.015625x23]
-              PaintableWithLines (BlockContainer(anonymous)) [8,262 82.015625x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,257 81.28125x23]
-              PaintableWithLines (BlockContainer(anonymous)) [100.015625,262 76.28125x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,280 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -19,11 +19,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 95.171875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 93.171875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 93.171875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x18] baseline: 13.796875
-                      "Head Cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 93.171875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x18] baseline: 13.796875
+                    "Head Cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,11 +35,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,32) content-size 95.171875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 93.171875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 93.171875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 9, rect: [11,33 70.234375x18] baseline: 13.796875
-                      "Body Cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 93.171875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [11,33 70.234375x18] baseline: 13.796875
+                    "Body Cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -53,11 +51,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,54) content-size 95.171875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,55) content-size 93.171875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,55) content-size 93.171875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 11, rect: [11,55 93.171875x18] baseline: 13.796875
-                      "Footer Cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,55) content-size 93.171875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 11, rect: [11,55 93.171875x18] baseline: 13.796875
+                    "Footer Cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -78,18 +75,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [10,10 95.171875x20]
             PaintableBox (Box<TR>) [10,10 95.171875x20]
               PaintableWithLines (BlockContainer<TD>) [10,10 95.171875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 93.171875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>) [10,32 95.171875x20]
             PaintableBox (Box<TR>) [10,32 95.171875x20]
               PaintableWithLines (BlockContainer<TD>) [10,32 95.171875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 93.171875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<TFOOT>) [10,54 95.171875x20]
             PaintableBox (Box<TR>) [10,54 95.171875x20]
               PaintableWithLines (BlockContainer<TD>) [10,54 95.171875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,55 93.171875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,94 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -14,25 +14,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               Box <tr> at (10,10) content-size 76x20 table-row children: not-inline
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (11,11) content-size 17.828125x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (11,11) content-size 17.828125x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x18] baseline: 13.796875
-                        "A"
-                    TextNode <#text>
+                BlockContainer <td> at (11,11) content-size 17.828125x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x18] baseline: 13.796875
+                      "A"
+                  TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (32.828125,11) content-size 11.828125x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (32.828125,11) content-size 11.828125x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [32.828125,11 9.34375x18] baseline: 13.796875
-                        "B"
-                    TextNode <#text>
+                BlockContainer <td> at (32.828125,11) content-size 11.828125x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [32.828125,11 9.34375x18] baseline: 13.796875
+                      "B"
+                  TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (48.65625,11) content-size 36.34375x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (48.65625,11) content-size 36.34375x18 children: inline
-                    frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x18] baseline: 13.796875
-                        "C D"
-                    TextNode <#text>
+                BlockContainer <td> at (48.65625,11) content-size 36.34375x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x18] baseline: 13.796875
+                      "C D"
+                  TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -52,14 +49,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [10,10 76x20]
               PaintableBox (Box<TR>) [10,10 76x20]
                 PaintableWithLines (BlockContainer<TD>) [10,10 19.828125x20]
-                  PaintableWithLines (BlockContainer(anonymous)) [11,11 17.828125x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [31.828125,10 13.828125x20]
-                  PaintableWithLines (BlockContainer(anonymous)) [32.828125,11 11.828125x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [47.65625,10 38.34375x20]
-                  PaintableWithLines (BlockContainer(anonymous)) [48.65625,11 36.34375x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [8,32 80x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -11,25 +11,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 780x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 300.640625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 300.640625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [154.1875,11 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 300.640625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [154.1875,11 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (315.640625,11) content-size 168.71875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (315.640625,11) content-size 168.71875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [395.328125,11 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <th> at (315.640625,11) content-size 168.71875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [395.328125,11 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (488.359375,11) content-size 300.640625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (488.359375,11) content-size 300.640625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [623.953125,11 29.453125x18] baseline: 13.796875
-                      "C D"
-                  TextNode <#text>
+              BlockContainer <th> at (488.359375,11) content-size 300.640625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [623.953125,11 29.453125x18] baseline: 13.796875
+                    "C D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -37,25 +34,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,32) content-size 780x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 300.640625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 300.640625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [155.390625,33 11.859375x18] baseline: 13.796875
-                      "E"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 300.640625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [155.390625,33 11.859375x18] baseline: 13.796875
+                    "E"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (315.640625,33) content-size 168.71875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (315.640625,33) content-size 168.71875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [393.71875,33 12.546875x18] baseline: 13.796875
-                      "F"
-                  TextNode <#text>
+              BlockContainer <td> at (315.640625,33) content-size 168.71875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [393.71875,33 12.546875x18] baseline: 13.796875
+                    "F"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (488.359375,33) content-size 300.640625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (488.359375,33) content-size 300.640625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [632.0625,33 13.234375x18] baseline: 13.796875
-                      "G"
-                  TextNode <#text>
+              BlockContainer <td> at (488.359375,33) content-size 300.640625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [632.0625,33 13.234375x18] baseline: 13.796875
+                    "G"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -71,24 +65,18 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 780x42]
             PaintableBox (Box<TR>) [10,10 780x20]
               PaintableWithLines (BlockContainer<TH>) [10,10 302.640625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 300.640625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [314.640625,10 170.71875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [315.640625,11 168.71875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [487.359375,10 302.640625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [488.359375,11 300.640625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,32 780x20]
               PaintableWithLines (BlockContainer<TD>) [10,32 302.640625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 300.640625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [314.640625,32 170.71875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [315.640625,33 168.71875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [487.359375,32 302.640625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [488.359375,33 300.640625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -9,25 +9,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 93.359375x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,19) content-size 8.453125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (19,19) content-size 8.453125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
+              BlockContainer <td> at (19,19) content-size 8.453125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (49.453125,19) content-size 8.8125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (49.453125,19) content-size 8.8125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [49.453125,19 8.8125x18] baseline: 13.796875
-                      "2"
-                  TextNode <#text>
+              BlockContainer <td> at (49.453125,19) content-size 8.8125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [49.453125,19 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (80.265625,19) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (80.265625,19) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x18] baseline: 13.796875
-                      "3"
-                  TextNode <#text>
+              BlockContainer <td> at (80.265625,19) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <(anonymous)> at (101.359375,28) content-size 0x0 table-cell [BFC] children: not-inline
@@ -36,18 +33,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,48) content-size 93.359375x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,59) content-size 8.453125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (19,59) content-size 8.453125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,59 7.75x18] baseline: 13.796875
-                      "4"
-                  TextNode <#text>
+              BlockContainer <td> at (19,59) content-size 8.453125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [19,59 7.75x18] baseline: 13.796875
+                    "4"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (49.453125,79) content-size 40.90625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (49.453125,79) content-size 40.90625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [49.453125,79 24.046875x18] baseline: 13.796875
-                      "6-9"
-                  TextNode <#text>
+              BlockContainer <td> at (49.453125,79) content-size 40.90625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [49.453125,79 24.046875x18] baseline: 13.796875
+                    "6-9"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -55,11 +50,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,88) content-size 93.359375x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,99) content-size 8.453125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (19,99) content-size 8.453125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [19,99 8.453125x18] baseline: 13.796875
-                      "5"
-                  TextNode <#text>
+              BlockContainer <td> at (19,99) content-size 8.453125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [19,99 8.453125x18] baseline: 13.796875
+                    "5"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -73,26 +67,20 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 93.359375x120]
             PaintableBox (Box<TR>) [8,8 93.359375x40]
               PaintableWithLines (BlockContainer<TD>) [8,8 30.453125x40]
-                PaintableWithLines (BlockContainer(anonymous)) [19,19 8.453125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [38.453125,8 30.8125x40]
-                PaintableWithLines (BlockContainer(anonymous)) [49.453125,19 8.8125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [69.265625,8 31.09375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [80.265625,19 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer(anonymous)) [100.359375,8 1x40]
             PaintableBox (Box<TR>) [8,48 93.359375x40]
               PaintableWithLines (BlockContainer<TD>) [8,48 30.453125x40]
-                PaintableWithLines (BlockContainer(anonymous)) [19,59 8.453125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [38.453125,48 62.90625x80]
-                PaintableWithLines (BlockContainer(anonymous)) [49.453125,79 40.90625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,88 93.359375x40]
               PaintableWithLines (BlockContainer<TD>) [8,88 30.453125x40]
-                PaintableWithLines (BlockContainer(anonymous)) [19,99 8.453125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x136] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
@@ -9,11 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 23.90625x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 6.8125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 6.8125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 6.8125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <(anonymous)> at (20.8125,20) content-size 0x0 table-cell [BFC] children: not-inline
@@ -23,18 +22,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,32) content-size 23.90625x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 8.8125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 8.8125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,33 8.8125x18] baseline: 13.796875
-                      "2"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 8.8125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,33 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (23.8125,33) content-size 9.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (23.8125,33) content-size 9.09375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [23.8125,33 9.09375x18] baseline: 13.796875
-                      "3"
-                  TextNode <#text>
+              BlockContainer <td> at (23.8125,33) content-size 9.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [23.8125,33 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -52,17 +49,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 23.90625x42]
             PaintableBox (Box<TR>) [10,10 23.90625x20]
               PaintableWithLines (BlockContainer<TD>) [10,10 8.8125x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 6.8125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer(anonymous)) [20.8125,10 0x20]
               PaintableWithLines (BlockContainer(anonymous)) [22.8125,10 11.09375x20]
             PaintableBox (Box<TR>) [10,32 23.90625x20]
               PaintableWithLines (BlockContainer<TD>) [10,32 10.8125x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 8.8125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [22.8125,32 11.09375x20]
-                PaintableWithLines (BlockContainer(anonymous)) [23.8125,33 9.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,54 784x18]
         TextPaintable (TextNode<#text>)
 

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -9,25 +9,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 418x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 79.59375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 79.59375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [43.65625,11 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 79.59375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [43.65625,11 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.59375,11) content-size 157.328125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (94.59375,11) content-size 157.328125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [168.578125,11 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (94.59375,11) content-size 157.328125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [168.578125,11 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (255.921875,11) content-size 169.078125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (255.921875,11) content-size 169.078125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [335.296875,11 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (255.921875,11) content-size 169.078125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [335.296875,11 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -35,18 +32,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 418x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 79.59375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 79.59375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [45.21875,33 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 79.59375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [45.21875,33 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.59375,33) content-size 330.40625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (94.59375,33) content-size 330.40625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [253.859375,33 11.859375x18] baseline: 13.796875
-                      "E"
-                  TextNode <#text>
+              BlockContainer <td> at (94.59375,33) content-size 330.40625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [253.859375,33 11.859375x18] baseline: 13.796875
+                    "E"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -60,21 +55,16 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 418x44]
             PaintableBox (Box<TR>) [9,9 418x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 83.59375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 79.59375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [92.59375,9 161.328125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [94.59375,11 157.328125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [253.921875,9 173.078125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [255.921875,11 169.078125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 418x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 83.59375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 79.59375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [92.59375,31 334.40625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [94.59375,33 330.40625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -9,18 +9,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 208x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 180x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 180x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [93.859375,11 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 180x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [93.859375,11 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (195,11) content-size 20x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (195,11) content-size 20x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [200.328125,11 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (195,11) content-size 20x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [200.328125,11 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -28,11 +26,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 208x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 204x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 204x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [107.84375,33 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 204x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [107.84375,33 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -46,15 +43,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 208x44]
             PaintableBox (Box<TR>) [9,9 208x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 184x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 180x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [193,9 24x22]
-                PaintableWithLines (BlockContainer(anonymous)) [195,11 20x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 208x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 208x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 204x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -13,18 +13,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 37.3125x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 17.5625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 17.5625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [12.640625,11 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 17.5625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [12.640625,11 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (32.5625,11) content-size 11.75x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (32.5625,11) content-size 11.75x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.765625,11 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (32.5625,11) content-size 11.75x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [33.765625,11 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,11 +30,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 37.3125x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 33.3125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 33.3125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [11,33 33.3125x18] baseline: 13.796875
-                      "CDE"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 33.3125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [11,33 33.3125x18] baseline: 13.796875
+                    "CDE"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -54,15 +51,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 37.3125x44]
             PaintableBox (Box<TR>) [9,9 37.3125x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 21.5625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 17.5625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [30.5625,9 15.75x22]
-                PaintableWithLines (BlockContainer(anonymous)) [32.5625,11 11.75x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 37.3125x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 37.3125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 33.3125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,54 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
@@ -13,25 +13,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x18] baseline: 13.796875
-                      "Header 1"
-                  TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x18] baseline: 13.796875
+                    "Header 1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (85.046875,11) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,11) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x18] baseline: 13.796875
-                      "Header 2"
-                  TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x18] baseline: 13.796875
+                    "Header 2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (161.5625,11) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,11) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x18] baseline: 13.796875
-                      "Header 3"
-                  TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x18] baseline: 13.796875
+                    "Header 3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -39,11 +36,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 223.359375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 223.359375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [101.75,33 41.84375x18] baseline: 13.796875
-                      "Cell 1"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 223.359375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [101.75,33 41.84375x18] baseline: 13.796875
+                    "Cell 1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -51,11 +47,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,53) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,55) content-size 223.359375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,55) content-size 223.359375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [100.515625,55 44.3125x18] baseline: 13.796875
-                      "Cell 2"
-                  TextNode <#text>
+              BlockContainer <td> at (11,55) content-size 223.359375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [100.515625,55 44.3125x18] baseline: 13.796875
+                    "Cell 2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -63,25 +58,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,75) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,77) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,77) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [23.71875,77 44.59375x18] baseline: 13.796875
-                      "Cell 3"
-                  TextNode <#text>
+              BlockContainer <td> at (11,77) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [23.71875,77 44.59375x18] baseline: 13.796875
+                    "Cell 3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,77) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,77) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [99.671875,77 43.25x18] baseline: 13.796875
-                      "Cell 4"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,77) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [99.671875,77 43.25x18] baseline: 13.796875
+                    "Cell 4"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,77) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,77) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [175.984375,77 43.953125x18] baseline: 13.796875
-                      "Cell 5"
-                  TextNode <#text>
+              BlockContainer <td> at (161.5625,77) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [175.984375,77 43.953125x18] baseline: 13.796875
+                    "Cell 5"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -99,32 +91,24 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 227.359375x88]
             PaintableBox (Box<TR>) [9,9 227.359375x22]
               PaintableWithLines (BlockContainer<TH>) [9,9 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [83.046875,9 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,11 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [159.5625,9 76.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,11 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 227.359375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 223.359375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,53 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,53 227.359375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,55 223.359375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,75 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,75 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,77 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,75 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,77 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,75 76.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,77 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,98 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -9,21 +9,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 778x110 table-row children: not-inline
               BlockContainer <td.mbox-image> at (12,41) content-size 50x50 table-cell [BFC] children: not-inline
                 BlockContainer <div.mbox-image-div> at (12,41) content-size 50x50 children: not-inline
-              BlockContainer <td.mbox-text> at (66,12) content-size 722x108 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (66,12) content-size 722x108 children: inline
-                  frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x18] baseline: 13.796875
-                      "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"
-                  frag 1 from TextNode start: 86, length: 84, rect: [66,30 695.5625x18] baseline: 13.796875
-                      "against the wall. They receive a call from their assistant who expresses frustration"
-                  frag 2 from TextNode start: 171, length: 85, rect: [66,48 703.125x18] baseline: 13.796875
-                      "over a packed waiting room and the lawyer's lack of clients. The lawyer then looks at"
-                  frag 3 from TextNode start: 257, length: 81, rect: [66,66 695.90625x18] baseline: 13.796875
-                      "some papers from a large envelope, which turn out to be divorce papers from their"
-                  frag 4 from TextNode start: 339, length: 84, rect: [66,84 670.515625x18] baseline: 13.796875
-                      "significant other. Finally, the lawyer instructs their assistant to send in the next"
-                  frag 5 from TextNode start: 424, length: 7, rect: [66,102 47.21875x18] baseline: 13.796875
-                      "client."
-                  TextNode <#text>
+              BlockContainer <td.mbox-text> at (66,12) content-size 722x108 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x18] baseline: 13.796875
+                    "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"
+                frag 1 from TextNode start: 86, length: 84, rect: [66,30 695.5625x18] baseline: 13.796875
+                    "against the wall. They receive a call from their assistant who expresses frustration"
+                frag 2 from TextNode start: 171, length: 85, rect: [66,48 703.125x18] baseline: 13.796875
+                    "over a packed waiting room and the lawyer's lack of clients. The lawyer then looks at"
+                frag 3 from TextNode start: 257, length: 81, rect: [66,66 695.90625x18] baseline: 13.796875
+                    "some papers from a large envelope, which turn out to be divorce papers from their"
+                frag 4 from TextNode start: 339, length: 84, rect: [66,84 670.515625x18] baseline: 13.796875
+                    "significant other. Finally, the lawyer instructs their assistant to send in the next"
+                frag 5 from TextNode start: 424, length: 7, rect: [66,102 47.21875x18] baseline: 13.796875
+                    "client."
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x132]
@@ -35,8 +34,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableWithLines (BlockContainer<TD>.mbox-image) [11,11 52x110]
                 PaintableWithLines (BlockContainer<DIV>.mbox-image-div) [12,41 50x50]
               PaintableWithLines (BlockContainer<TD>.mbox-text) [65,11 724x110]
-                PaintableWithLines (BlockContainer(anonymous)) [66,12 722x108]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x132] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
@@ -9,32 +9,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 62.4375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 62.4375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 62.4375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (77.4375,11) content-size 62.4375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (77.4375,11) content-size 62.4375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [77.4375,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (77.4375,11) content-size 62.4375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (143.875,11) content-size 128.890625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (143.875,11) content-size 128.890625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [143.875,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (143.875,11) content-size 128.890625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [143.875,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (276.765625,11) content-size 328.234375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (276.765625,11) content-size 328.234375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (276.765625,11) content-size 328.234375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,32 +38,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 598x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 62.4375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 62.4375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 62.4375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (77.4375,33) content-size 62.4375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (77.4375,33) content-size 62.4375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [77.4375,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (77.4375,33) content-size 62.4375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (143.875,33) content-size 128.890625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (143.875,33) content-size 128.890625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [143.875,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (143.875,33) content-size 128.890625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [143.875,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (276.765625,33) content-size 328.234375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (276.765625,33) content-size 328.234375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [276.765625,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (276.765625,33) content-size 328.234375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -81,30 +73,22 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x44]
             PaintableBox (Box<TR>) [9,9 598x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 66.4375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 62.4375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [75.4375,9 66.4375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [77.4375,11 62.4375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [141.875,9 132.890625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [143.875,11 128.890625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [274.765625,9 332.234375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [276.765625,11 328.234375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 598x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 66.4375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 62.4375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [75.4375,31 66.4375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [77.4375,33 62.4375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [141.875,31 132.890625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [143.875,33 128.890625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [274.765625,31 332.234375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [276.765625,33 328.234375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -9,32 +9,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 597.96875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 95.65625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 95.65625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 95.65625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (110.65625,11) content-size 95.65625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (110.65625,11) content-size 95.65625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (110.65625,11) content-size 95.65625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (210.3125,11) content-size 95.65625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (210.3125,11) content-size 95.65625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (210.3125,11) content-size 95.65625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (309.96875,11) content-size 295x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (309.96875,11) content-size 295x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (309.96875,11) content-size 295x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,32 +38,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 597.96875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 95.65625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 95.65625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 95.65625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (110.65625,33) content-size 95.65625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (110.65625,33) content-size 95.65625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (110.65625,33) content-size 95.65625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (210.3125,33) content-size 95.65625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (210.3125,33) content-size 95.65625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (210.3125,33) content-size 95.65625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (309.96875,33) content-size 295x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (309.96875,33) content-size 295x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (309.96875,33) content-size 295x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -81,30 +73,22 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 597.96875x44]
             PaintableBox (Box<TR>) [9,9 597.96875x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 99.65625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 95.65625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [108.65625,9 99.65625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [110.65625,11 95.65625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [208.3125,9 99.65625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [210.3125,11 95.65625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [307.96875,9 299x22]
-                PaintableWithLines (BlockContainer(anonymous)) [309.96875,11 295x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 597.96875x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 99.65625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 95.65625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [108.65625,31 99.65625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [110.65625,33 95.65625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [208.3125,31 99.65625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [210.3125,33 95.65625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [307.96875,31 299x22]
-                PaintableWithLines (BlockContainer(anonymous)) [309.96875,33 295x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
@@ -9,32 +9,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 58.578125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 58.578125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 58.578125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (73.578125,11) content-size 58.578125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (73.578125,11) content-size 58.578125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [73.578125,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (73.578125,11) content-size 58.578125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [73.578125,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (136.15625,11) content-size 116.53125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (136.15625,11) content-size 116.53125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [136.15625,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (136.15625,11) content-size 116.53125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [136.15625,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (256.6875,11) content-size 348.3125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (256.6875,11) content-size 348.3125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [256.6875,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (256.6875,11) content-size 348.3125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [256.6875,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,32 +38,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 598x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 58.578125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 58.578125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 58.578125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (73.578125,33) content-size 58.578125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (73.578125,33) content-size 58.578125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [73.578125,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (73.578125,33) content-size 58.578125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [73.578125,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (136.15625,33) content-size 116.53125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (136.15625,33) content-size 116.53125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [136.15625,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (136.15625,33) content-size 116.53125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [136.15625,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (256.6875,33) content-size 348.3125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (256.6875,33) content-size 348.3125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [256.6875,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (256.6875,33) content-size 348.3125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [256.6875,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -81,30 +73,22 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x44]
             PaintableBox (Box<TR>) [9,9 598x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 62.578125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 58.578125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [71.578125,9 62.578125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [73.578125,11 58.578125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [134.15625,9 120.53125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [136.15625,11 116.53125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [254.6875,9 352.3125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [256.6875,11 348.3125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 598x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 62.578125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 58.578125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [71.578125,31 62.578125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [73.578125,33 58.578125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [134.15625,31 120.53125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [136.15625,33 116.53125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [254.6875,31 352.3125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [256.6875,33 348.3125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
@@ -9,34 +9,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,20) content-size 94x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,20) content-size 94x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,20 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,20) content-size 94x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,20 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (109,20) content-size 94x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (109,20) content-size 94x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [109,20 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (109,20) content-size 94x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [109,20 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (207,11) content-size 94x36 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (207,11) content-size 94x36 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [207,11 60.890625x18] baseline: 13.796875
-                      "A table"
-                  frag 1 from TextNode start: 8, length: 4, rect: [207,29 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (207,11) content-size 94x36 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [207,11 60.890625x18] baseline: 13.796875
+                    "A table"
+                frag 1 from TextNode start: 8, length: 4, rect: [207,29 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (305,20) content-size 300x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (305,20) content-size 300x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [305,20 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (305,20) content-size 300x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [305,20 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -44,34 +40,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,49) content-size 598x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,60) content-size 94x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,60) content-size 94x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,60 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,60) content-size 94x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,60 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (109,60) content-size 94x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (109,60) content-size 94x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [109,60 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (109,60) content-size 94x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [109,60 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (207,51) content-size 94x36 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (207,51) content-size 94x36 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [207,51 60.890625x18] baseline: 13.796875
-                      "A table"
-                  frag 1 from TextNode start: 8, length: 4, rect: [207,69 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (207,51) content-size 94x36 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [207,51 60.890625x18] baseline: 13.796875
+                    "A table"
+                frag 1 from TextNode start: 8, length: 4, rect: [207,69 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (305,60) content-size 300x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (305,60) content-size 300x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [305,60 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (305,60) content-size 300x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [305,60 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -85,30 +77,22 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x80]
             PaintableBox (Box<TR>) [9,9 598x40]
               PaintableWithLines (BlockContainer<TD>) [9,9 98x40]
-                PaintableWithLines (BlockContainer(anonymous)) [11,20 94x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [107,9 98x40]
-                PaintableWithLines (BlockContainer(anonymous)) [109,20 94x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [205,9 98x40]
-                PaintableWithLines (BlockContainer(anonymous)) [207,11 94x36]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [303,9 304x40]
-                PaintableWithLines (BlockContainer(anonymous)) [305,20 300x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,49 598x40]
               PaintableWithLines (BlockContainer<TD>) [9,49 98x40]
-                PaintableWithLines (BlockContainer(anonymous)) [11,60 94x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [107,49 98x40]
-                PaintableWithLines (BlockContainer(anonymous)) [109,60 94x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [205,49 98x40]
-                PaintableWithLines (BlockContainer(anonymous)) [207,51 94x36]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [303,49 304x40]
-                PaintableWithLines (BlockContainer(anonymous)) [305,60 300x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x98] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
@@ -9,32 +9,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (160.5,11) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (160.5,11) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [160.5,11 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (160.5,11) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [160.5,11 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (310,11) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (310,11) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [310,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (310,11) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [310,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (459.5,11) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (459.5,11) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [459.5,11 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (459.5,11) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [459.5,11 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,32 +38,28 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 598x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (160.5,33) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (160.5,33) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [160.5,33 26.078125x18] baseline: 13.796875
-                      "cell"
-                  TextNode <#text>
+              BlockContainer <td> at (160.5,33) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [160.5,33 26.078125x18] baseline: 13.796875
+                    "cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (310,33) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (310,33) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [310,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (310,33) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [310,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (459.5,33) content-size 145.5x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (459.5,33) content-size 145.5x18 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [459.5,33 94.96875x18] baseline: 13.796875
-                      "A table cell"
-                  TextNode <#text>
+              BlockContainer <td> at (459.5,33) content-size 145.5x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [459.5,33 94.96875x18] baseline: 13.796875
+                    "A table cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -81,30 +73,22 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x44]
             PaintableBox (Box<TR>) [9,9 598x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [158.5,9 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [160.5,11 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [308,9 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [310,11 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [457.5,9 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [459.5,11 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 598x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [158.5,31 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [160.5,33 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [308,31 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [310,33 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [457.5,31 149.5x22]
-                PaintableWithLines (BlockContainer(anonymous)) [459.5,33 145.5x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x62] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -5,13 +5,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (108,8) content-size 584x36 [BFC] children: not-inline
           Box <div.box> at (108,8) content-size 584x36 table-box [TFC] children: not-inline
             Box <(anonymous)> at (108,8) content-size 584x36 table-row children: not-inline
-              BlockContainer <div.cell> at (108,8) content-size 584x36 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (108,8) content-size 584x36 children: inline
-                  frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x18] baseline: 13.796875
-                      "DaTa DisplaYiNg CSS WeBpaGE ScReEn OF aR AddITioN COmmOnLY"
-                  frag 1 from TextNode start: 59, length: 40, rect: [108,26 399.9375x18] baseline: 13.796875
-                      "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
-                  TextNode <#text>
+              BlockContainer <div.cell> at (108,8) content-size 584x36 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x18] baseline: 13.796875
+                    "DaTa DisplaYiNg CSS WeBpaGE ScReEn OF aR AddITioN COmmOnLY"
+                frag 1 from TextNode start: 59, length: 40, rect: [108,26 399.9375x18] baseline: 13.796875
+                    "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
@@ -21,8 +20,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<DIV>.box) [108,8 584x36]
             PaintableBox (Box(anonymous)) [108,8 584x36]
               PaintableWithLines (BlockContainer<DIV>.cell) [108,8 584x36]
-                PaintableWithLines (BlockContainer(anonymous)) [108,8 584x36]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x52] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (11,11) content-size 41.78125x20 [BFC] children: not-inline
           Box <(anonymous)> at (11,11) content-size 41.78125x20 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,11) content-size 41.78125x20 table-row children: not-inline
-              BlockContainer <div.cell> at (12,12) content-size 39.78125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (12,12) content-size 39.78125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x18] baseline: 13.796875
-                      "Hello"
-                  TextNode <#text>
+              BlockContainer <div.cell> at (12,12) content-size 39.78125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x18] baseline: 13.796875
+                    "Hello"
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]
@@ -19,8 +18,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box(anonymous)) [11,11 41.78125x20]
             PaintableBox (Box(anonymous)) [11,11 41.78125x20]
               PaintableWithLines (BlockContainer<DIV>.cell) [11,11 41.78125x20]
-                PaintableWithLines (BlockContainer(anonymous)) [12,12 39.78125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [1,1 798x40] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -1,33 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x64 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x48 children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x46] baseline: 14.796875
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x46] baseline: 15.296875
       BlockContainer <table> at (9,9) content-size 135.984375x46 inline-block [BFC] children: not-inline
         TableWrapper <(anonymous)> at (9,9) content-size 135.984375x46 inline-block [BFC] children: not-inline
           Box <(anonymous)> at (9,9) content-size 135.984375x46 inline-table table-box [TFC] children: not-inline
             Box <tbody> at (11,11) content-size 131.984375x42 table-row-group children: not-inline
               Box <tr> at (11,11) content-size 131.984375x20 table-row children: not-inline
-                BlockContainer <td> at (12,12) content-size 87.90625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (12,12) content-size 87.90625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 2, rect: [12,12 15.734375x18] baseline: 13.796875
-                        "ID"
-                    TextNode <#text>
-                BlockContainer <td> at (103.90625,12) content-size 38.078125x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (103.90625,12) content-size 38.078125x18 children: inline
-                    frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x18] baseline: 13.796875
-                        "null"
-                    TextNode <#text>
+                BlockContainer <td> at (12,12) content-size 87.90625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 2, rect: [12,12 15.734375x18] baseline: 13.796875
+                      "ID"
+                  TextNode <#text>
+                BlockContainer <td> at (103.90625,12) content-size 38.078125x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x18] baseline: 13.796875
+                      "null"
+                  TextNode <#text>
               Box <tr> at (11,33) content-size 131.984375x20 table-row children: not-inline
-                BlockContainer <td> at (12,34) content-size 87.90625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (12,34) content-size 87.90625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 11, rect: [12,34 87.90625x18] baseline: 13.796875
-                        "Is Selected"
-                    TextNode <#text>
-                BlockContainer <td> at (103.90625,34) content-size 38.078125x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (103.90625,34) content-size 38.078125x18 children: inline
-                    frag 0 from TextNode start: 0, length: 5, rect: [103.90625,34 38.078125x18] baseline: 13.796875
-                        "false"
-                    TextNode <#text>
+                BlockContainer <td> at (12,34) content-size 87.90625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 11, rect: [12,34 87.90625x18] baseline: 13.796875
+                      "Is Selected"
+                  TextNode <#text>
+                BlockContainer <td> at (103.90625,34) content-size 38.078125x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [103.90625,34 38.078125x18] baseline: 13.796875
+                      "false"
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x64]
@@ -38,18 +34,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [11,11 131.984375x42]
               PaintableBox (Box<TR>) [11,11 131.984375x20]
                 PaintableWithLines (BlockContainer<TD>) [11,11 89.90625x20]
-                  PaintableWithLines (BlockContainer(anonymous)) [12,12 87.90625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [102.90625,11 40.078125x20]
-                  PaintableWithLines (BlockContainer(anonymous)) [103.90625,12 38.078125x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
               PaintableBox (Box<TR>) [11,33 131.984375x20]
                 PaintableWithLines (BlockContainer<TD>) [11,33 89.90625x20]
-                  PaintableWithLines (BlockContainer(anonymous)) [12,34 87.90625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [102.90625,33 40.078125x20]
-                  PaintableWithLines (BlockContainer(anonymous)) [103.90625,34 38.078125x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x64] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
+++ b/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 37.609375x24 table-box [TFC] children: not-inline
           Box <tbody> at (10,10) content-size 33.609375x20 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 33.609375x20 table-row children: not-inline
-              BlockContainer <td.ab> at (11,11) content-size 31.609375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 31.609375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [11,11 31.609375x18] baseline: 13.796875
-                      "A B"
-                  TextNode <#text>
+              BlockContainer <td.ab> at (11,11) content-size 31.609375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [11,11 31.609375x18] baseline: 13.796875
+                    "A B"
+                TextNode <#text>
       BlockContainer <(anonymous)> at (8,32) content-size 784x0 children: inline
         TextNode <#text>
 
@@ -21,8 +20,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 33.609375x20]
             PaintableBox (Box<TR>) [10,10 33.609375x20]
               PaintableWithLines (BlockContainer<TD>.ab) [10,10 33.609375x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 31.609375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,32 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
@@ -11,29 +11,26 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 61x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,19) content-size 14.296875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (10,19) content-size 14.296875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [10,19 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (10,19) content-size 14.296875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [10,19 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (28.296875,10) content-size 20.40625x36 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (28.296875,10) content-size 20.40625x36 children: inline
-                  frag 0 from TextNode start: 1, length: 1, rect: [28.296875,10 9.34375x18] baseline: 13.796875
-                      "B"
-                  frag 1 from TextNode start: 0, length: 1, rect: [28.296875,28 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
-                  BreakNode <br>
-                  TextNode <#text>
+              BlockContainer <td> at (28.296875,10) content-size 20.40625x36 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 1, length: 1, rect: [28.296875,10 9.34375x18] baseline: 13.796875
+                    "B"
+                frag 1 from TextNode start: 0, length: 1, rect: [28.296875,28 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
+                BreakNode <br>
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (52.703125,19) content-size 14.296875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (52.703125,19) content-size 14.296875x18 children: inline
-                  frag 0 from TextNode start: 1, length: 1, rect: [52.703125,19 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (52.703125,19) content-size 14.296875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 1, length: 1, rect: [52.703125,19 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -49,15 +46,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 61x40]
             PaintableBox (Box<TR>) [8,8 61x40]
               PaintableWithLines (BlockContainer<TD>) [8,8 18.296875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [10,19 14.296875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [26.296875,8 24.40625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [28.296875,10 20.40625x36]
-                  TextPaintable (TextNode<#text>)
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [50.703125,8 18.296875x40]
-                PaintableWithLines (BlockContainer(anonymous)) [52.703125,19 14.296875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x56] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -21,18 +21,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (12,46) content-size 55.046875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,48) content-size 21.25x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (14,48) content-size 21.25x18 children: inline
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,48 20.609375x18] baseline: 13.796875
-                      "A1"
-                  TextNode <#text>
+              BlockContainer <td> at (14,48) content-size 21.25x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [14,48 20.609375x18] baseline: 13.796875
+                    "A1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,48) content-size 23.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (41.25,48) content-size 23.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,48 23.078125x18] baseline: 13.796875
-                      "A2"
-                  TextNode <#text>
+              BlockContainer <td> at (41.25,48) content-size 23.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,48 23.078125x18] baseline: 13.796875
+                    "A2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -45,18 +43,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (12,70) content-size 55.046875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,72) content-size 21.25x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (14,72) content-size 21.25x18 children: inline
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,72 15.6875x18] baseline: 13.796875
-                      "B1"
-                  TextNode <#text>
+              BlockContainer <td> at (14,72) content-size 21.25x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [14,72 15.6875x18] baseline: 13.796875
+                    "B1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,72) content-size 23.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (41.25,72) content-size 23.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,72 18.15625x18] baseline: 13.796875
-                      "B2"
-                  TextNode <#text>
+              BlockContainer <td> at (41.25,72) content-size 23.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,72 18.15625x18] baseline: 13.796875
+                    "B2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -69,18 +65,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (12,94) content-size 55.046875x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,96) content-size 21.25x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (14,96) content-size 21.25x18 children: inline
-                  frag 0 from TextNode start: 0, length: 2, rect: [14,96 18.890625x18] baseline: 13.796875
-                      "F1"
-                  TextNode <#text>
+              BlockContainer <td> at (14,96) content-size 21.25x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [14,96 18.890625x18] baseline: 13.796875
+                    "F1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,96) content-size 23.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (41.25,96) content-size 23.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,96 21.359375x18] baseline: 13.796875
-                      "F2"
-                  TextNode <#text>
+              BlockContainer <td> at (41.25,96) content-size 23.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,96 21.359375x18] baseline: 13.796875
+                    "F2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -101,27 +95,21 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [12,46 55.046875x22]
             PaintableBox (Box<TR>) [12,46 55.046875x22]
               PaintableWithLines (BlockContainer<TD>) [12,46 25.25x22]
-                PaintableWithLines (BlockContainer(anonymous)) [14,48 21.25x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,46 27.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [41.25,48 23.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>) [12,70 55.046875x22]
             PaintableBox (Box<TR>) [12,70 55.046875x22]
               PaintableWithLines (BlockContainer<TD>) [12,70 25.25x22]
-                PaintableWithLines (BlockContainer(anonymous)) [14,72 21.25x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,70 27.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [41.25,72 23.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<TFOOT>) [12,94 55.046875x22]
             PaintableBox (Box<TR>) [12,94 55.046875x22]
               PaintableWithLines (BlockContainer<TD>) [12,94 25.25x22]
-                PaintableWithLines (BlockContainer(anonymous)) [14,96 21.25x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,94 27.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [41.25,96 23.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,156 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
@@ -6,30 +6,26 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table> at (9,9) content-size 98x120 table-box [TFC] children: not-inline
             Box <tbody> at (9,9) content-size 98x120 table-row-group children: not-inline
               Box <tr> at (9,9) content-size 98x40 table-row children: not-inline
-                BlockContainer <td> at (20,20) content-size 30.5625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (20,20) content-size 30.5625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x18] baseline: 13.796875
-                        "A"
-                    TextNode <#text>
-                BlockContainer <td> at (72.5625,20) content-size 23.4375x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (72.5625,20) content-size 23.4375x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x18] baseline: 13.796875
-                        "B"
-                    TextNode <#text>
+                BlockContainer <td> at (20,20) content-size 30.5625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x18] baseline: 13.796875
+                      "A"
+                  TextNode <#text>
+                BlockContainer <td> at (72.5625,20) content-size 23.4375x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x18] baseline: 13.796875
+                      "B"
+                  TextNode <#text>
               Box <tr> at (9,49) content-size 98x40 table-row children: not-inline
-                BlockContainer <td> at (20,60) content-size 30.5625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (20,60) content-size 30.5625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,60 14.265625x18] baseline: 13.796875
-                        "A"
-                    TextNode <#text>
+                BlockContainer <td> at (20,60) content-size 30.5625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,60 14.265625x18] baseline: 13.796875
+                      "A"
+                  TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,69.5) content-size 21.71875x0 table-cell [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (84.28125,69) content-size 21.71875x0 table-cell [BFC] children: not-inline
               Box <tr> at (9,89) content-size 98x40 table-row children: not-inline
-                BlockContainer <td> at (20,100) content-size 30.5625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (20,100) content-size 30.5625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,100 14.265625x18] baseline: 13.796875
-                        "A"
-                    TextNode <#text>
+                BlockContainer <td> at (20,100) content-size 30.5625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,100 14.265625x18] baseline: 13.796875
+                      "A"
+                  TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,108.5) content-size 21.71875x0 table-cell [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (84.28125,108.5) content-size 21.71875x0 table-cell [BFC] children: not-inline
 
@@ -42,21 +38,17 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [9,9 98x120]
               PaintableBox (Box<TR>) [9,9 98x40]
                 PaintableWithLines (BlockContainer<TD>) [9,9 52.5625x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [20,20 30.5625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [61.5625,9 45.4375x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [72.5625,20 23.4375x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
               PaintableBox (Box<TR>) [9,49 98x40]
                 PaintableWithLines (BlockContainer<TD>) [9,49 52.5625x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [20,60 30.5625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,49 22.71875x40]
                 PaintableWithLines (BlockContainer(anonymous)) [84.28125,49 22.71875x40]
               PaintableBox (Box<TR>) [9,89 98x40]
                 PaintableWithLines (BlockContainer<TD>) [9,89 52.5625x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [20,100 30.5625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,89 22.71875x40]
                 PaintableWithLines (BlockContainer(anonymous)) [84.28125,89 22.71875x40]
 

--- a/Tests/LibWeb/Layout/expected/table/missing-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells.txt
@@ -6,29 +6,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table> at (9,9) content-size 98x120 table-box [TFC] children: not-inline
             Box <tbody> at (9,9) content-size 98x120 table-row-group children: not-inline
               Box <tr> at (9,9) content-size 98x40 table-row children: not-inline
-                BlockContainer <td> at (20,20) content-size 30.5625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (20,20) content-size 30.5625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x18] baseline: 13.796875
-                        "A"
-                    TextNode <#text>
-                BlockContainer <td> at (72.5625,20) content-size 23.4375x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (72.5625,20) content-size 23.4375x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x18] baseline: 13.796875
-                        "B"
-                    TextNode <#text>
+                BlockContainer <td> at (20,20) content-size 30.5625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x18] baseline: 13.796875
+                      "A"
+                  TextNode <#text>
+                BlockContainer <td> at (72.5625,20) content-size 23.4375x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x18] baseline: 13.796875
+                      "B"
+                  TextNode <#text>
               Box <tr> at (9,49) content-size 98x40 table-row children: not-inline
-                BlockContainer <td> at (20,60) content-size 30.5625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (20,60) content-size 30.5625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,60 14.265625x18] baseline: 13.796875
-                        "A"
-                    TextNode <#text>
+                BlockContainer <td> at (20,60) content-size 30.5625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,60 14.265625x18] baseline: 13.796875
+                      "A"
+                  TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,69.5) content-size 43.4375x0 table-cell [BFC] children: not-inline
               Box <tr> at (9,89) content-size 98x40 table-row children: not-inline
-                BlockContainer <td> at (20,100) content-size 30.5625x18 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (20,100) content-size 30.5625x18 children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [20,100 14.265625x18] baseline: 13.796875
-                        "A"
-                    TextNode <#text>
+                BlockContainer <td> at (20,100) content-size 30.5625x18 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,100 14.265625x18] baseline: 13.796875
+                      "A"
+                  TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,108.5) content-size 43.4375x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
@@ -40,20 +36,16 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [9,9 98x120]
               PaintableBox (Box<TR>) [9,9 98x40]
                 PaintableWithLines (BlockContainer<TD>) [9,9 52.5625x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [20,20 30.5625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [61.5625,9 45.4375x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [72.5625,20 23.4375x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
               PaintableBox (Box<TR>) [9,49 98x40]
                 PaintableWithLines (BlockContainer<TD>) [9,49 52.5625x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [20,60 30.5625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,49 45.4375x40]
               PaintableBox (Box<TR>) [9,89 98x40]
                 PaintableWithLines (BlockContainer<TD>) [9,89 52.5625x40]
-                  PaintableWithLines (BlockContainer(anonymous)) [20,100 30.5625x18]
-                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,89 45.4375x40]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -7,21 +7,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           Box <tbody> at (11,11) content-size 75.4375x64 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 75.4375x22 table-row children: not-inline
-              BlockContainer <td> at (13,13) content-size 71.4375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,13) content-size 71.4375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x18] baseline: 13.796875
-                      "*"
-                  TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 71.4375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x18] baseline: 13.796875
+                    "*"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (11,35) content-size 75.4375x40 table-row children: not-inline
-              BlockContainer <td> at (13,37) content-size 71.4375x36 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,37) content-size 71.4375x36 children: inline
-                  frag 0 from TextNode start: 0, length: 9, rect: [13,37 71.4375x18] baseline: 13.796875
-                      "*********"
-                  frag 1 from TextNode start: 10, length: 8, rect: [13,55 63.5625x18] baseline: 13.796875
-                      "***** **"
-                  TextNode <#text>
+              BlockContainer <td> at (13,37) content-size 71.4375x36 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [13,37 71.4375x18] baseline: 13.796875
+                    "*********"
+                frag 1 from TextNode start: 10, length: 8, rect: [13,55 63.5625x18] baseline: 13.796875
+                    "***** **"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,78) content-size 784x0 children: inline
@@ -35,12 +33,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 75.4375x64]
             PaintableBox (Box<TR>) [11,11 75.4375x22]
               PaintableWithLines (BlockContainer<TD>) [11,11 75.4375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,13 71.4375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [11,35 75.4375x40]
               PaintableWithLines (BlockContainer<TD>) [11,35 75.4375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [13,37 71.4375x36]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,78 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
@@ -10,11 +10,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (159.890625,13) content-size 43.109375x202 table-box [TFC] children: not-inline
                     Box <tbody> at (161.890625,15) content-size 39.109375x198 table-row-group children: not-inline
                       Box <tr> at (161.890625,15) content-size 39.109375x198 table-row children: not-inline
-                        BlockContainer <td> at (162.890625,105) content-size 37.109375x18 table-cell [BFC] children: not-inline
-                          BlockContainer <(anonymous)> at (162.890625,105) content-size 37.109375x18 children: inline
-                            frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105 37.109375x18] baseline: 13.796875
-                                "right"
-                            TextNode <#text>
+                        BlockContainer <td> at (162.890625,105) content-size 37.109375x18 table-cell [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105 37.109375x18] baseline: 13.796875
+                              "right"
+                          TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x228]
@@ -29,8 +28,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [161.890625,15 39.109375x198]
                       PaintableBox (Box<TR>) [161.890625,15 39.109375x198]
                         PaintableWithLines (BlockContainer<TD>) [161.890625,15 39.109375x198]
-                          PaintableWithLines (BlockContainer(anonymous)) [162.890625,105 37.109375x18]
-                            TextPaintable (TextNode<#text>)
+                          TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x228] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -15,11 +15,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (15,15) content-size 101.828125x55 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25,33.5) content-size 11.5625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (25,33.5) content-size 11.5625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [25,33.5 11.5625x18] baseline: 13.796875
-                      "X"
-                  TextNode <#text>
+              BlockContainer <td> at (25,33.5) content-size 11.5625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [25,33.5 11.5625x18] baseline: 13.796875
+                    "X"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (58.5625,25) content-size 48.265625x92 table-cell [BFC] children: not-inline
@@ -35,11 +34,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (65.5625,32) content-size 34.265625x38 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (75.5625,42) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                          BlockContainer <(anonymous)> at (75.5625,42) content-size 14.265625x18 children: inline
-                            frag 0 from TextNode start: 0, length: 1, rect: [75.5625,42 14.265625x18] baseline: 13.796875
-                                "A"
-                            TextNode <#text>
+                        BlockContainer <td> at (75.5625,42) content-size 14.265625x18 table-cell [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 1, rect: [75.5625,42 14.265625x18] baseline: 13.796875
+                              "A"
+                          TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -47,11 +45,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (65.5625,72) content-size 34.265625x38 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (75.5625,82) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                          BlockContainer <(anonymous)> at (75.5625,82) content-size 14.265625x18 children: inline
-                            frag 0 from TextNode start: 0, length: 1, rect: [75.5625,82 9.34375x18] baseline: 13.796875
-                                "B"
-                            TextNode <#text>
+                        BlockContainer <td> at (75.5625,82) content-size 14.265625x18 table-cell [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 1, rect: [75.5625,82 9.34375x18] baseline: 13.796875
+                              "B"
+                          TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -67,11 +64,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (15,72) content-size 101.828125x55 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25,90.5) content-size 11.5625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (25,90.5) content-size 11.5625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [25,90.5 11.09375x18] baseline: 13.796875
-                      "Y"
-                  TextNode <#text>
+              BlockContainer <td> at (25,90.5) content-size 11.5625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [25,90.5 11.09375x18] baseline: 13.796875
+                    "Y"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -91,8 +87,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [15,15 101.828125x112]
             PaintableBox (Box<TR>) [15,15 101.828125x55]
               PaintableWithLines (BlockContainer<TD>) [15,15 31.5625x55]
-                PaintableWithLines (BlockContainer(anonymous)) [25,33.5 11.5625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [48.5625,15 68.265625x112]
                 PaintableWithLines (BlockContainer(anonymous)) [58.5625,25 48.265625x0]
                 PaintableWithLines (TableWrapper(anonymous)) [58.5625,25 48.265625x92]
@@ -100,17 +95,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [65.5625,32 34.265625x78]
                       PaintableBox (Box<TR>) [65.5625,32 34.265625x38]
                         PaintableWithLines (BlockContainer<TD>) [65.5625,32 34.265625x38]
-                          PaintableWithLines (BlockContainer(anonymous)) [75.5625,42 14.265625x18]
-                            TextPaintable (TextNode<#text>)
+                          TextPaintable (TextNode<#text>)
                       PaintableBox (Box<TR>) [65.5625,72 34.265625x38]
                         PaintableWithLines (BlockContainer<TD>) [65.5625,72 34.265625x38]
-                          PaintableWithLines (BlockContainer(anonymous)) [75.5625,82 14.265625x18]
-                            TextPaintable (TextNode<#text>)
+                          TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [58.5625,117 48.265625x0]
             PaintableBox (Box<TR>) [15,72 101.828125x55]
               PaintableWithLines (BlockContainer<TD>) [15,72 31.5625x55]
-                PaintableWithLines (BlockContainer(anonymous)) [25,90.5 11.5625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,134 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -11,25 +11,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 92x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 14.40625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 14.40625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [11.0625,11 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 14.40625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11.0625,11 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29.40625,11) content-size 51.1875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (29.40625,11) content-size 51.1875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [50.328125,11 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (29.40625,11) content-size 51.1875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [50.328125,11 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (84.59375,11) content-size 14.40625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (84.59375,11) content-size 14.40625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [86.640625,11 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (84.59375,11) content-size 14.40625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [86.640625,11 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -45,14 +42,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 92x22]
             PaintableBox (Box<TR>) [9,9 92x22]
               PaintableWithLines (BlockContainer<TD>) [9,9 18.40625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 14.40625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [27.40625,9 55.1875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [29.40625,11 51.1875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [82.59375,9 18.40625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [84.59375,11 14.40625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x40] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
@@ -12,11 +12,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <table.inner> at (12,12) content-size 192x24 table-box [TFC] children: not-inline
                         Box <tbody> at (14,14) content-size 188x20 table-row-group children: not-inline
                           Box <tr> at (14,14) content-size 188x20 table-row children: not-inline
-                            BlockContainer <td> at (15,15) content-size 186x18 table-cell [BFC] children: not-inline
-                              BlockContainer <(anonymous)> at (15,15) content-size 186x18 children: inline
-                                frag 0 from TextNode start: 0, length: 3, rect: [15,15 36.53125x18] baseline: 13.796875
-                                    "A A"
-                                TextNode <#text>
+                            BlockContainer <td> at (15,15) content-size 186x18 table-cell [BFC] children: inline
+                              frag 0 from TextNode start: 0, length: 3, rect: [15,15 36.53125x18] baseline: 13.796875
+                                  "A A"
+                              TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
@@ -33,8 +32,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                         PaintableBox (Box<TBODY>) [14,14 188x20]
                           PaintableBox (Box<TR>) [14,14 188x20]
                             PaintableWithLines (BlockContainer<TD>) [14,14 188x20]
-                              PaintableWithLines (BlockContainer(anonymous)) [15,15 186x18]
-                                TextPaintable (TextNode<#text>)
+                              TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x48] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
@@ -9,25 +9,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 119x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,10) content-size 31.703125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (10,10) content-size 31.703125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [10,10 31.609375x18] baseline: 13.796875
-                      "A B"
-                  TextNode <#text>
+              BlockContainer <td> at (10,10) content-size 31.703125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [10,10 31.609375x18] baseline: 13.796875
+                    "A B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (45.703125,10) content-size 43.59375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (45.703125,10) content-size 43.59375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [45.703125,10 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (45.703125,10) content-size 43.59375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [45.703125,10 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (93.296875,10) content-size 31.703125x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (93.296875,10) content-size 31.703125x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [93.296875,10 11.140625x18] baseline: 13.796875
-                      "D"
-                  TextNode <#text>
+              BlockContainer <td> at (93.296875,10) content-size 31.703125x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [93.296875,10 11.140625x18] baseline: 13.796875
+                    "D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,14 +38,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 119x22]
             PaintableBox (Box<TR>) [8,8 119x22]
               PaintableWithLines (BlockContainer<TD>) [8,8 35.703125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [10,10 31.703125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [43.703125,8 47.59375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [45.703125,10 43.59375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [91.296875,8 35.703125x22]
-                PaintableWithLines (BlockContainer(anonymous)) [93.296875,10 31.703125x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x38] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -12,14 +12,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <td> at (11,15) content-size 0x0 table-cell [BFC] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (16,12) content-size 37.21875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (16,12) content-size 37.21875x18 children: inline
+              BlockContainer <td> at (16,12) content-size 37.21875x18 table-cell [BFC] children: inline
+                TextNode <#text>
+                InlineNode <a>
+                  frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x18] baseline: 13.796875
+                      "Test"
                   TextNode <#text>
-                  InlineNode <a>
-                    frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x18] baseline: 13.796875
-                        "Test"
-                    TextNode <#text>
-                  TextNode <#text>
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,9 +41,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TR>) [10,10 45.21875x10]
               PaintableWithLines (BlockContainer<TD>) [10,10 2x10]
               PaintableWithLines (BlockContainer<TD>) [14,10 41.21875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [16,12 37.21875x18]
-                  PaintableWithLines (InlineNode<A>) [16,12 37.21875x18]
-                    TextPaintable (TextNode<#text>)
+                PaintableWithLines (InlineNode<A>) [16,12 37.21875x18]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,22 45.21875x10]
               PaintableWithLines (BlockContainer<TD>) [10,22 2x10]
 

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -15,11 +15,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 69.828125x55 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,29.5) content-size 11.5625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (17,29.5) content-size 11.5625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,29.5 11.5625x18] baseline: 13.796875
-                      "X"
-                  TextNode <#text>
+              BlockContainer <td> at (17,29.5) content-size 11.5625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [17,29.5 11.5625x18] baseline: 13.796875
+                    "X"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (42.5625,17) content-size 32.265625x100 table-cell [BFC] children: not-inline
@@ -35,11 +34,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (45.5625,20) content-size 26.265625x30 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,26) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                          BlockContainer <(anonymous)> at (51.5625,26) content-size 14.265625x18 children: inline
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x18] baseline: 13.796875
-                                "A"
-                            TextNode <#text>
+                        BlockContainer <td> at (51.5625,26) content-size 14.265625x18 table-cell [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x18] baseline: 13.796875
+                              "A"
+                          TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -47,11 +45,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (45.5625,52) content-size 26.265625x30 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,58) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                          BlockContainer <(anonymous)> at (51.5625,58) content-size 14.265625x18 children: inline
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,58 9.34375x18] baseline: 13.796875
-                                "B"
-                            TextNode <#text>
+                        BlockContainer <td> at (51.5625,58) content-size 14.265625x18 table-cell [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,58 9.34375x18] baseline: 13.796875
+                              "B"
+                          TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -59,11 +56,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (45.5625,84) content-size 26.265625x30 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,90) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                          BlockContainer <(anonymous)> at (51.5625,90) content-size 14.265625x18 children: inline
-                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,90 10.3125x18] baseline: 13.796875
-                                "C"
-                            TextNode <#text>
+                        BlockContainer <td> at (51.5625,90) content-size 14.265625x18 table-cell [BFC] children: inline
+                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,90 10.3125x18] baseline: 13.796875
+                              "C"
+                          TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -79,11 +75,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,68) content-size 69.828125x55 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,86.5) content-size 11.5625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (17,86.5) content-size 11.5625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [17,86.5 11.09375x18] baseline: 13.796875
-                      "Y"
-                  TextNode <#text>
+              BlockContainer <td> at (17,86.5) content-size 11.5625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [17,86.5 11.09375x18] baseline: 13.796875
+                    "Y"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -103,8 +98,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 69.828125x112]
             PaintableBox (Box<TR>) [11,11 69.828125x55]
               PaintableWithLines (BlockContainer<TD>) [11,11 23.5625x55]
-                PaintableWithLines (BlockContainer(anonymous)) [17,29.5 11.5625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [36.5625,11 44.265625x112]
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,17 32.265625x0]
                 PaintableWithLines (TableWrapper(anonymous)) [42.5625,17 32.265625x100]
@@ -112,21 +106,17 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [45.5625,20 26.265625x94]
                       PaintableBox (Box<TR>) [45.5625,20 26.265625x30]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,20 26.265625x30]
-                          PaintableWithLines (BlockContainer(anonymous)) [51.5625,26 14.265625x18]
-                            TextPaintable (TextNode<#text>)
+                          TextPaintable (TextNode<#text>)
                       PaintableBox (Box<TR>) [45.5625,52 26.265625x30]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,52 26.265625x30]
-                          PaintableWithLines (BlockContainer(anonymous)) [51.5625,58 14.265625x18]
-                            TextPaintable (TextNode<#text>)
+                          TextPaintable (TextNode<#text>)
                       PaintableBox (Box<TR>) [45.5625,84 26.265625x30]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,84 26.265625x30]
-                          PaintableWithLines (BlockContainer(anonymous)) [51.5625,90 14.265625x18]
-                            TextPaintable (TextNode<#text>)
+                          TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,117 32.265625x0]
             PaintableBox (Box<TR>) [11,68 69.828125x55]
               PaintableWithLines (BlockContainer<TD>) [11,68 23.5625x55]
-                PaintableWithLines (BlockContainer(anonymous)) [17,86.5 11.5625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,126 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
@@ -4,17 +4,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
           Box <div.row.a> at (8,8) content-size 200x150 table-row children: not-inline
-            BlockContainer <div.cell> at (8,8) content-size 200x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,8) content-size 200x18 children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x18] baseline: 13.796875
-                    "a"
-                TextNode <#text>
+            BlockContainer <div.cell> at (8,8) content-size 200x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x18] baseline: 13.796875
+                  "a"
+              TextNode <#text>
           Box <div.row.b> at (8,158) content-size 200x150 table-row children: not-inline
-            BlockContainer <div.cell> at (8,158) content-size 200x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,158) content-size 200x18 children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x18] baseline: 13.796875
-                    "b"
-                TextNode <#text>
+            BlockContainer <div.cell> at (8,158) content-size 200x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x18] baseline: 13.796875
+                  "b"
+              TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
@@ -23,12 +21,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<DIV>.table) [8,8 200x300]
           PaintableBox (Box<DIV>.row.a) [8,8 200x150]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x150]
-              PaintableWithLines (BlockContainer(anonymous)) [8,8 200x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.row.b) [8,158 200x150]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,158 200x150]
-              PaintableWithLines (BlockContainer(anonymous)) [8,158 200x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x316] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
@@ -4,17 +4,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
           Box <div.row.a> at (8,8) content-size 200x100 table-row children: not-inline
-            BlockContainer <div.cell> at (8,8) content-size 200x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,8) content-size 200x18 children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x18] baseline: 13.796875
-                    "a"
-                TextNode <#text>
+            BlockContainer <div.cell> at (8,8) content-size 200x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x18] baseline: 13.796875
+                  "a"
+              TextNode <#text>
           Box <div.row.b> at (8,108) content-size 200x200 table-row children: not-inline
-            BlockContainer <div.cell> at (8,108) content-size 200x18 table-cell [BFC] children: not-inline
-              BlockContainer <(anonymous)> at (8,108) content-size 200x18 children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x18] baseline: 13.796875
-                    "b"
-                TextNode <#text>
+            BlockContainer <div.cell> at (8,108) content-size 200x18 table-cell [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x18] baseline: 13.796875
+                  "b"
+              TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
@@ -23,12 +21,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<DIV>.table) [8,8 200x300]
           PaintableBox (Box<DIV>.row.a) [8,8 200x100]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x100]
-              PaintableWithLines (BlockContainer(anonymous)) [8,8 200x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.row.b) [8,108 200x200]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,108 200x200]
-              PaintableWithLines (BlockContainer(anonymous)) [8,108 200x18]
-                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x316] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
@@ -13,25 +13,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x18] baseline: 13.796875
-                      "Header 1"
-                  TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x18] baseline: 13.796875
+                    "Header 1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (85.046875,11) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,11) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x18] baseline: 13.796875
-                      "Header 2"
-                  TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x18] baseline: 13.796875
+                    "Header 2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (161.5625,11) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,11) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x18] baseline: 13.796875
-                      "Header 3"
-                  TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x18] baseline: 13.796875
+                    "Header 3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -39,25 +36,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,31) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,33) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,33) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [25.09375,33 41.84375x18] baseline: 13.796875
-                      "Cell 1"
-                  TextNode <#text>
+              BlockContainer <td> at (11,33) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [25.09375,33 41.84375x18] baseline: 13.796875
+                    "Cell 1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,33) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,33) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [99.140625,33 44.3125x18] baseline: 13.796875
-                      "Cell 2"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,33) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [99.140625,33 44.3125x18] baseline: 13.796875
+                    "Cell 2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,44) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,44) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [175.65625,44 44.59375x18] baseline: 13.796875
-                      "Cell 3"
-                  TextNode <#text>
+              BlockContainer <td> at (161.5625,44) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [175.65625,44 44.59375x18] baseline: 13.796875
+                    "Cell 3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,18 +59,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,53) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,55) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,55) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [24.390625,55 43.25x18] baseline: 13.796875
-                      "Cell 4"
-                  TextNode <#text>
+              BlockContainer <td> at (11,55) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [24.390625,55 43.25x18] baseline: 13.796875
+                    "Cell 4"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,55) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,55) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [99.328125,55 43.953125x18] baseline: 13.796875
-                      "Cell 5"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,55) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [99.328125,55 43.953125x18] baseline: 13.796875
+                    "Cell 5"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -84,25 +76,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,75) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,77) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,77) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [23.90625,77 44.234375x18] baseline: 13.796875
-                      "Cell 6"
-                  TextNode <#text>
+              BlockContainer <td> at (11,77) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [23.90625,77 44.234375x18] baseline: 13.796875
+                    "Cell 6"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,77) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,77) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [99.1875,77 44.21875x18] baseline: 13.796875
-                      "Cell 7"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,77) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [99.1875,77 44.21875x18] baseline: 13.796875
+                    "Cell 7"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,77) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,77) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [175.46875,77 44.984375x18] baseline: 13.796875
-                      "Cell 8"
-                  TextNode <#text>
+              BlockContainer <td> at (161.5625,77) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [175.46875,77 44.984375x18] baseline: 13.796875
+                    "Cell 8"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -110,25 +99,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,97) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,99) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,99) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [23.859375,99 44.328125x18] baseline: 13.796875
-                      "Cell 9"
-                  TextNode <#text>
+              BlockContainer <td> at (11,99) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [23.859375,99 44.328125x18] baseline: 13.796875
+                    "Cell 9"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,99) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,99) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.578125,99 51.4375x18] baseline: 13.796875
-                      "Cell 10"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,99) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [95.578125,99 51.4375x18] baseline: 13.796875
+                    "Cell 10"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,110) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,110) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [173.859375,110 48.1875x18] baseline: 13.796875
-                      "Cell 11"
-                  TextNode <#text>
+              BlockContainer <td> at (161.5625,110) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [173.859375,110 48.1875x18] baseline: 13.796875
+                    "Cell 11"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -136,18 +122,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,119) content-size 227.359375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,121) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,121) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [20.6875,121 50.65625x18] baseline: 13.796875
-                      "Cell 12"
-                  TextNode <#text>
+              BlockContainer <td> at (11,121) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [20.6875,121 50.65625x18] baseline: 13.796875
+                    "Cell 12"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,121) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,121) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 7, rect: [95.828125,121 50.9375x18] baseline: 13.796875
-                      "Cell 13"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,121) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [95.828125,121 50.9375x18] baseline: 13.796875
+                    "Cell 13"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -165,58 +149,42 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 227.359375x132]
             PaintableBox (Box<TR>) [9,9 227.359375x22]
               PaintableWithLines (BlockContainer<TH>) [9,9 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [83.046875,9 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,11 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [159.5625,9 76.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,11 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,31 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,31 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,33 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,31 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,33 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,31 76.796875x44]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,44 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,53 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,53 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,55 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,53 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,55 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,75 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,75 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,77 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,75 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,77 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,75 76.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,77 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,97 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,97 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,99 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,97 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,99 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,97 76.796875x44]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,110 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,119 227.359375x22]
               PaintableWithLines (BlockContainer<TD>) [9,119 74.046875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [11,121 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,119 76.515625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,121 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,142 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -13,25 +13,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 225.359375x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x18] baseline: 13.796875
-                      "Header 1"
-                  TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x18] baseline: 13.796875
+                    "Header 1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (85.046875,11) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,11) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x18] baseline: 13.796875
-                      "Header 2"
-                  TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x18] baseline: 13.796875
+                    "Header 2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (161.5625,11) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,11) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x18] baseline: 13.796875
-                      "Header 3"
-                  TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x18] baseline: 13.796875
+                    "Header 3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -39,25 +36,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,32) content-size 225.359375x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,44) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,44) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 5, rect: [11,44 49.609375x18] baseline: 13.796875
-                      "Row 1"
-                  TextNode <#text>
+              BlockContainer <td> at (11,44) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [11,44 49.609375x18] baseline: 13.796875
+                    "Row 1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,33) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,33) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,33 41.84375x18] baseline: 13.796875
-                      "Cell 1"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,33) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,33 41.84375x18] baseline: 13.796875
+                    "Cell 1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,33) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,33) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,33 44.3125x18] baseline: 13.796875
-                      "Cell 2"
-                  TextNode <#text>
+              BlockContainer <td> at (161.5625,33) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,33 44.3125x18] baseline: 13.796875
+                    "Cell 2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,18 +59,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,54) content-size 225.359375x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,55) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,55) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,55 44.59375x18] baseline: 13.796875
-                      "Cell 3"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,55) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,55 44.59375x18] baseline: 13.796875
+                    "Cell 3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,55) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,55) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,55 43.25x18] baseline: 13.796875
-                      "Cell 4"
-                  TextNode <#text>
+              BlockContainer <td> at (161.5625,55) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,55 43.25x18] baseline: 13.796875
+                    "Cell 4"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -84,25 +76,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,76) content-size 225.359375x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,77) content-size 70.046875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,77) content-size 70.046875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 5, rect: [11,77 52.078125x18] baseline: 13.796875
-                      "Row 2"
-                  TextNode <#text>
+              BlockContainer <td> at (11,77) content-size 70.046875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [11,77 52.078125x18] baseline: 13.796875
+                    "Row 2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,77) content-size 72.515625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.046875,77) content-size 72.515625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,77 43.953125x18] baseline: 13.796875
-                      "Cell 5"
-                  TextNode <#text>
+              BlockContainer <td> at (85.046875,77) content-size 72.515625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,77 43.953125x18] baseline: 13.796875
+                    "Cell 5"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,77) content-size 72.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (161.5625,77) content-size 72.796875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,77 44.234375x18] baseline: 13.796875
-                      "Cell 6"
-                  TextNode <#text>
+              BlockContainer <td> at (161.5625,77) content-size 72.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,77 44.234375x18] baseline: 13.796875
+                    "Cell 6"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -120,41 +109,30 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 225.359375x86]
             PaintableBox (Box<TR>) [10,10 225.359375x20]
               PaintableWithLines (BlockContainer<TH>) [10,10 72.046875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [84.046875,10 74.515625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,11 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [160.5625,10 74.796875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,11 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,32 225.359375x20]
               PaintableWithLines (BlockContainer<TD>) [10,32 72.046875x42]
-                PaintableWithLines (BlockContainer(anonymous)) [11,44 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [84.046875,32 74.515625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,33 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,32 74.796875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,33 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,54 225.359375x20]
               PaintableWithLines (BlockContainer<TD>) [84.046875,54 74.515625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,55 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,54 74.796875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,55 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,76 225.359375x20]
               PaintableWithLines (BlockContainer<TD>) [10,76 72.046875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,77 70.046875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [84.046875,76 74.515625x20]
-                PaintableWithLines (BlockContainer(anonymous)) [85.046875,77 72.515625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,76 74.796875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [161.5625,77 72.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,98 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
@@ -6,9 +6,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table> at (200,8) content-size 392x104 table-box [TFC] children: not-inline
             Box <tbody> at (202,10) content-size 388x100 table-row-group children: not-inline
               Box <tr> at (202,10) content-size 388x100 table-row children: not-inline
-                BlockContainer <td> at (203,60) content-size 386x0 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (203,60) content-size 386x0 children: inline
-                    TextNode <#text>
+                BlockContainer <td> at (203,60) content-size 386x0 table-cell [BFC] children: inline
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x120]
@@ -19,7 +18,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [202,10 388x100]
               PaintableBox (Box<TR>) [202,10 388x100]
                 PaintableWithLines (BlockContainer<TD>) [202,10 388x100]
-                  PaintableWithLines (BlockContainer(anonymous)) [203,60 386x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x120] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -9,25 +9,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 95.984375x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 19x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,13) content-size 19x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 19x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (38,13) content-size 41.984375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (38,13) content-size 41.984375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [38,13 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (38,13) content-size 41.984375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [38,13 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.984375,13) content-size 19x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (85.984375,13) content-size 19x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (85.984375,13) content-size 19x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,14 +38,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 95.984375x22]
             PaintableBox (Box<TR>) [11,11 95.984375x22]
               PaintableWithLines (BlockContainer<TD>) [11,11 23x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,13 19x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [36,11 45.984375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [38,13 41.984375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.984375,11 23x22]
-                PaintableWithLines (BlockContainer(anonymous)) [85.984375,13 19x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x44] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (109,101) content-size 87.34375x202 table-box [TFC] children: not-inline
           Box <tbody> at (111,103) content-size 83.34375x198 table-row-group children: not-inline
             Box <tr> at (111,103) content-size 83.34375x198 table-row children: not-inline
-              BlockContainer <td> at (112,193) content-size 81.34375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (112,193) content-size 81.34375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 10, rect: [112,193 81.34375x18] baseline: 13.796875
-                      "off-center"
-                  TextNode <#text>
+              BlockContainer <td> at (112,193) content-size 81.34375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 10, rect: [112,193 81.34375x18] baseline: 13.796875
+                    "off-center"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -21,8 +20,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [111,103 83.34375x198]
             PaintableBox (Box<TR>) [111,103 83.34375x198]
               PaintableWithLines (BlockContainer<TD>) [111,103 83.34375x198]
-                PaintableWithLines (BlockContainer(anonymous)) [112,193 81.34375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x404] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/table-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (371.1875,9) content-size 57.625x202 table-box [TFC] children: not-inline
           Box <tbody> at (373.1875,11) content-size 53.625x198 table-row-group children: not-inline
             Box <tr> at (373.1875,11) content-size 53.625x198 table-row children: not-inline
-              BlockContainer <td> at (374.1875,101) content-size 51.625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (374.1875,101) content-size 51.625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101 51.625x18] baseline: 13.796875
-                      "center"
-                  TextNode <#text>
+              BlockContainer <td> at (374.1875,101) content-size 51.625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101 51.625x18] baseline: 13.796875
+                    "center"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -21,8 +20,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [373.1875,11 53.625x198]
             PaintableBox (Box<TR>) [373.1875,11 53.625x198]
               PaintableWithLines (BlockContainer<TD>) [373.1875,11 53.625x198]
-                PaintableWithLines (BlockContainer(anonymous)) [374.1875,101 51.625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
@@ -5,21 +5,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 496.1875x202 table-box [TFC] children: not-inline
           Box <tbody> at (11,11) content-size 492.1875x198 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 492.1875x198 table-row children: not-inline
-              BlockContainer <td> at (71,71) content-size 26.640625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (71,71) content-size 26.640625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x18] baseline: 13.796875
-                      "top"
-                  TextNode <#text>
-              BlockContainer <td> at (219.640625,101) content-size 45.4375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (219.640625,101) content-size 45.4375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [219.640625,101 45.4375x18] baseline: 13.796875
-                      "middle"
-                  TextNode <#text>
-              BlockContainer <td> at (387.078125,131) content-size 56.109375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (387.078125,131) content-size 56.109375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [387.078125,131 56.109375x18] baseline: 13.796875
-                      "bottom"
-                  TextNode <#text>
+              BlockContainer <td> at (71,71) content-size 26.640625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x18] baseline: 13.796875
+                    "top"
+                TextNode <#text>
+              BlockContainer <td> at (219.640625,101) content-size 45.4375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [219.640625,101 45.4375x18] baseline: 13.796875
+                    "middle"
+                TextNode <#text>
+              BlockContainer <td> at (387.078125,131) content-size 56.109375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [387.078125,131 56.109375x18] baseline: 13.796875
+                    "bottom"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -31,14 +28,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 492.1875x198]
             PaintableBox (Box<TR>) [11,11 492.1875x198]
               PaintableWithLines (BlockContainer<TD>) [11,11 146.640625x198]
-                PaintableWithLines (BlockContainer(anonymous)) [71,71 26.640625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.640625,11 165.4375x198]
-                PaintableWithLines (BlockContainer(anonymous)) [219.640625,101 45.4375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [327.078125,11 176.109375x198]
-                PaintableWithLines (BlockContainer(anonymous)) [387.078125,131 56.109375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -9,25 +9,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 101.421875x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,20) content-size 9.59375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (20,20) content-size 9.59375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x18] baseline: 13.796875
-                      "0"
-                  TextNode <#text>
+              BlockContainer <td> at (20,20) content-size 9.59375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x18] baseline: 13.796875
+                    "0"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (51.59375,40) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (51.59375,40) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,40 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (51.59375,40) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [51.59375,40 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.859375,60) content-size 11.5625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.859375,60) content-size 11.5625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,60 11.5625x18] baseline: 13.796875
-                      "X"
-                  TextNode <#text>
+              BlockContainer <td> at (87.859375,60) content-size 11.5625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.859375,60 11.5625x18] baseline: 13.796875
+                    "X"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -35,11 +32,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,49) content-size 101.421875x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,60) content-size 9.59375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (20,60) content-size 9.59375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,60 6.34375x18] baseline: 13.796875
-                      "1"
-                  TextNode <#text>
+              BlockContainer <td> at (20,60) content-size 9.59375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [20,60 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -47,18 +43,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,89) content-size 101.421875x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,100) content-size 9.59375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (20,100) content-size 9.59375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,100 8.8125x18] baseline: 13.796875
-                      "2"
-                  TextNode <#text>
+              BlockContainer <td> at (20,100) content-size 9.59375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [20,100 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (51.59375,120) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (51.59375,120) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,120 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (51.59375,120) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [51.59375,120 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -66,18 +60,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,129) content-size 101.421875x40 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,140) content-size 9.59375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (20,140) content-size 9.59375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,140 9.09375x18] baseline: 13.796875
-                      "3"
-                  TextNode <#text>
+              BlockContainer <td> at (20,140) content-size 9.59375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [20,140 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.859375,140) content-size 11.5625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (87.859375,140) content-size 11.5625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,140 10.3125x18] baseline: 13.796875
-                      "C"
-                  TextNode <#text>
+              BlockContainer <td> at (87.859375,140) content-size 11.5625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [87.859375,140 10.3125x18] baseline: 13.796875
+                    "C"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -93,32 +85,24 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 101.421875x160]
             PaintableBox (Box<TR>) [9,9 101.421875x40]
               PaintableWithLines (BlockContainer<TD>) [9,9 31.59375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [20,20 9.59375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [40.59375,9 36.265625x80]
-                PaintableWithLines (BlockContainer(anonymous)) [51.59375,40 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [76.859375,9 33.5625x120]
-                PaintableWithLines (BlockContainer(anonymous)) [87.859375,60 11.5625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,49 101.421875x40]
               PaintableWithLines (BlockContainer<TD>) [9,49 31.59375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [20,60 9.59375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,89 101.421875x40]
               PaintableWithLines (BlockContainer<TD>) [9,89 31.59375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [20,100 9.59375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [40.59375,89 36.265625x80]
-                PaintableWithLines (BlockContainer(anonymous)) [51.59375,120 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,129 101.421875x40]
               PaintableWithLines (BlockContainer<TD>) [9,129 31.59375x40]
-                PaintableWithLines (BlockContainer(anonymous)) [20,140 9.59375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [76.859375,129 33.5625x40]
-                PaintableWithLines (BlockContainer(anonymous)) [87.859375,140 11.5625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,170 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -5,21 +5,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 142.1875x202 table-box [TFC] children: not-inline
           Box <tbody> at (11,11) content-size 138.1875x198 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 138.1875x198 table-row children: not-inline
-              BlockContainer <td> at (12,12) content-size 26.640625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (12,12) content-size 26.640625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x18] baseline: 13.796875
-                      "top"
-                  TextNode <#text>
-              BlockContainer <td> at (42.640625,101) content-size 45.4375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (42.640625,101) content-size 45.4375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [42.640625,101 45.4375x18] baseline: 13.796875
-                      "middle"
-                  TextNode <#text>
-              BlockContainer <td> at (92.078125,190) content-size 56.109375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (92.078125,190) content-size 56.109375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [92.078125,190 56.109375x18] baseline: 13.796875
-                      "bottom"
-                  TextNode <#text>
+              BlockContainer <td> at (12,12) content-size 26.640625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x18] baseline: 13.796875
+                    "top"
+                TextNode <#text>
+              BlockContainer <td> at (42.640625,101) content-size 45.4375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [42.640625,101 45.4375x18] baseline: 13.796875
+                    "middle"
+                TextNode <#text>
+              BlockContainer <td> at (92.078125,190) content-size 56.109375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [92.078125,190 56.109375x18] baseline: 13.796875
+                    "bottom"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -31,14 +28,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 138.1875x198]
             PaintableBox (Box<TR>) [11,11 138.1875x198]
               PaintableWithLines (BlockContainer<TD>) [11,11 28.640625x198]
-                PaintableWithLines (BlockContainer(anonymous)) [12,12 26.640625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [41.640625,11 47.4375x198]
-                PaintableWithLines (BlockContainer(anonymous)) [42.640625,101 45.4375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [91.078125,11 58.109375x198]
-                PaintableWithLines (BlockContainer(anonymous)) [92.078125,190 56.109375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -15,11 +15,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,38) content-size 56.46875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,39) content-size 54.46875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,39) content-size 54.46875x18 children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [11,39 27.5x18] baseline: 13.796875
-                      "Cell"
-                  TextNode <#text>
+              BlockContainer <td> at (11,39) content-size 54.46875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,39 27.5x18] baseline: 13.796875
+                    "Cell"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -35,8 +34,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,38 56.46875x20]
             PaintableBox (Box<TR>) [10,38 56.46875x20]
               PaintableWithLines (BlockContainer<TD>) [10,38 56.46875x20]
-                PaintableWithLines (BlockContainer(anonymous)) [11,39 54.46875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x106] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-baseline.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-baseline.txt
@@ -7,29 +7,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           Box <tbody> at (9,9) content-size 613.65625x100 table-row-group children: not-inline
             Box <tr> at (9,9) content-size 613.65625x50 table-row children: not-inline
-              BlockContainer <td> at (11,11) content-size 349.90625x46 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,11) content-size 349.90625x46 children: inline
-                  frag 0 from TextNode start: 0, length: 13, rect: [11,11 273.984375x46] baseline: 35
-                      "Text baseline"
-                  TextNode <#text>
-              BlockContainer <td.small-text> at (364.90625,37) content-size 255.75x12 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (364.90625,37) content-size 255.75x12 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [364.90625,37 62.28125x12] baseline: 9
-                      "Smaller text"
-                  TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 349.90625x46 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 13, rect: [11,11 273.984375x46] baseline: 35
+                    "Text baseline"
+                TextNode <#text>
+              BlockContainer <td.small-text> at (364.90625,37) content-size 255.75x12 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [364.90625,37 62.28125x12] baseline: 9
+                    "Smaller text"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (9,59) content-size 613.65625x50 table-row children: not-inline
-              BlockContainer <td> at (11,61) content-size 349.90625x46 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,61) content-size 349.90625x46 children: inline
-                  frag 0 from TextNode start: 0, length: 16, rect: [11,61 349.90625x46] baseline: 35
-                      "Another baseline"
-                  TextNode <#text>
-              BlockContainer <td> at (364.90625,61) content-size 255.75x46 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (364.90625,61) content-size 255.75x46 children: inline
-                  frag 0 from TextNode start: 0, length: 12, rect: [364.90625,61 255.75x46] baseline: 35
-                      "Regular text"
-                  TextNode <#text>
+              BlockContainer <td> at (11,61) content-size 349.90625x46 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 16, rect: [11,61 349.90625x46] baseline: 35
+                    "Another baseline"
+                TextNode <#text>
+              BlockContainer <td> at (364.90625,61) content-size 255.75x46 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 12, rect: [364.90625,61 255.75x46] baseline: 35
+                    "Regular text"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,110) content-size 784x0 children: inline
@@ -43,18 +39,14 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 613.65625x100]
             PaintableBox (Box<TR>) [9,9 613.65625x50]
               PaintableWithLines (BlockContainer<TD>) [9,9 353.90625x50]
-                PaintableWithLines (BlockContainer(anonymous)) [11,11 349.90625x46]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>.small-text) [362.90625,9 259.75x50]
-                PaintableWithLines (BlockContainer(anonymous)) [364.90625,37 255.75x12]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,59 613.65625x50]
               PaintableWithLines (BlockContainer<TD>) [9,59 353.90625x50]
-                PaintableWithLines (BlockContainer(anonymous)) [11,61 349.90625x46]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [362.90625,59 259.75x50]
-                PaintableWithLines (BlockContainer(anonymous)) [364.90625,61 255.75x46]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,110 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-td-vs-div.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-td-vs-div.txt
@@ -5,11 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 42.84375x104 table-box [TFC] children: not-inline
           Box <tbody> at (10,10) content-size 38.84375x100 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 38.84375x100 table-row children: not-inline
-              BlockContainer <td> at (11,51) content-size 36.84375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (11,51) content-size 36.84375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 5, rect: [11,51 36.84375x18] baseline: 13.796875
-                      "hello"
-                  TextNode <#text>
+              BlockContainer <td> at (11,51) content-size 36.84375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [11,51 36.84375x18] baseline: 13.796875
+                    "hello"
+                TextNode <#text>
       BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (8,112) content-size 784x100 children: inline
@@ -27,8 +26,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 38.84375x100]
             PaintableBox (Box<TR>) [10,10 38.84375x100]
               PaintableWithLines (BlockContainer<TD>) [10,10 38.84375x100]
-                PaintableWithLines (BlockContainer(anonymous)) [11,51 36.84375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,112 784x100]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-vs-top.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-vs-top.txt
@@ -1,34 +1,32 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x135 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x119 children: not-inline
-      BlockContainer <main> at (8,8) content-size 784x119 children: not-inline
-        TableWrapper <(anonymous)> at (8,8) content-size 346.5x119 [BFC] children: not-inline
-          Box <table> at (8,8) content-size 346.5x119 table-box [TFC] children: not-inline
-            Box <tbody> at (10,10) content-size 342.5x115 table-row-group children: not-inline
-              Box <tr> at (10,10) content-size 342.5x115 table-row children: not-inline
-                BlockContainer <td> at (10,10) content-size 342.5x115 table-cell [BFC] children: not-inline
-                  BlockContainer <(anonymous)> at (10,10) content-size 342.5x115 children: inline
-                    frag 0 from TextNode start: 0, length: 3, rect: [10,10 169.734375x115] baseline: 87.484375
-                        "foo"
+  BlockContainer <html> at (0,0) content-size 800x138 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x122 children: not-inline
+      BlockContainer <main> at (8,8) content-size 784x122 children: not-inline
+        TableWrapper <(anonymous)> at (8,8) content-size 346.5x122 [BFC] children: not-inline
+          Box <table> at (8,8) content-size 346.5x122 table-box [TFC] children: not-inline
+            Box <tbody> at (10,10) content-size 342.5x118 table-row-group children: not-inline
+              Box <tr> at (10,10) content-size 342.5x118 table-row children: not-inline
+                BlockContainer <td> at (10,10) content-size 342.5x118 table-cell [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [10,13 169.734375x115] baseline: 87.484375
+                      "foo"
+                  TextNode <#text>
+                  InlineNode <span>
+                    frag 0 from TextNode start: 0, length: 3, rect: [179.734375,10 172.765625x115] baseline: 87.484375
+                        "bar"
                     TextNode <#text>
-                    InlineNode <span>
-                      frag 0 from TextNode start: 0, length: 3, rect: [179.734375,10 172.765625x115] baseline: 87.484375
-                          "bar"
-                      TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x135]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x119]
-      PaintableWithLines (BlockContainer<MAIN>) [8,8 784x119]
-        PaintableWithLines (TableWrapper(anonymous)) [8,8 346.5x119]
-          PaintableBox (Box<TABLE>) [8,8 346.5x119]
-            PaintableBox (Box<TBODY>) [10,10 342.5x115]
-              PaintableBox (Box<TR>) [10,10 342.5x115]
-                PaintableWithLines (BlockContainer<TD>) [10,10 342.5x115]
-                  PaintableWithLines (BlockContainer(anonymous)) [10,10 342.5x115]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x138]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x122]
+      PaintableWithLines (BlockContainer<MAIN>) [8,8 784x122]
+        PaintableWithLines (TableWrapper(anonymous)) [8,8 346.5x122]
+          PaintableBox (Box<TABLE>) [8,8 346.5x122]
+            PaintableBox (Box<TBODY>) [10,10 342.5x118]
+              PaintableBox (Box<TR>) [10,10 342.5x118]
+                PaintableWithLines (BlockContainer<TD>) [10,10 342.5x118]
+                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (InlineNode<SPAN>) [179.734375,10 172.765625x115]
                     TextPaintable (TextNode<#text>)
-                    PaintableWithLines (InlineNode<SPAN>) [179.734375,10 172.765625x115]
-                      TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x135] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x138] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -14,18 +14,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 414x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 46x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,13) content-size 46x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 46x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (65,13) content-size 358x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (65,13) content-size 358x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [65,13 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (65,13) content-size 358x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [65,13 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -39,11 +37,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 414x22]
             PaintableBox (Box<TR>) [11,11 414x22]
               PaintableWithLines (BlockContainer<TD>) [11,11 50x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,13 46x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [63,11 362x22]
-                PaintableWithLines (BlockContainer(anonymous)) [65,13 358x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x44] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -14,18 +14,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 414x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,13) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (33.265625,13) content-size 389.734375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (33.265625,13) content-size 389.734375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (33.265625,13) content-size 389.734375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -39,11 +37,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 414x22]
             PaintableBox (Box<TR>) [11,11 414x22]
               PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,13 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [33.265625,13 389.734375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x44] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -9,18 +9,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 414x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 14.265625x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (13,13) content-size 14.265625x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 14.265625x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (33.265625,13) content-size 389.734375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (33.265625,13) content-size 389.734375x18 children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (33.265625,13) content-size 389.734375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,11 +32,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 414x22]
             PaintableBox (Box<TR>) [11,11 414x22]
               PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x22]
-                PaintableWithLines (BlockContainer(anonymous)) [13,13 14.265625x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [33.265625,13 389.734375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x44] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -11,25 +11,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 784x22 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,10) content-size 216.09375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (10,10) content-size 216.09375x18 children: inline
-                  frag 0 from TextNode start: 1, length: 1, rect: [10,10 14.265625x18] baseline: 13.796875
-                      "A"
-                  TextNode <#text>
+              BlockContainer <td> at (10,10) content-size 216.09375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 1, length: 1, rect: [10,10 14.265625x18] baseline: 13.796875
+                    "A"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (230.09375,10) content-size 156.796875x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (230.09375,10) content-size 156.796875x18 children: inline
-                  frag 0 from TextNode start: 1, length: 1, rect: [230.09375,10 9.34375x18] baseline: 13.796875
-                      "B"
-                  TextNode <#text>
+              BlockContainer <td> at (230.09375,10) content-size 156.796875x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 1, length: 1, rect: [230.09375,10 9.34375x18] baseline: 13.796875
+                    "B"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (390.890625,10) content-size 399.109375x18 table-cell [BFC] children: not-inline
-                BlockContainer <(anonymous)> at (390.890625,10) content-size 399.109375x18 children: inline
-                  frag 0 from TextNode start: 1, length: 3, rect: [390.890625,10 29.453125x18] baseline: 13.796875
-                      "C D"
-                  TextNode <#text>
+              BlockContainer <td> at (390.890625,10) content-size 399.109375x18 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 1, length: 3, rect: [390.890625,10 29.453125x18] baseline: 13.796875
+                    "C D"
+                TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -45,14 +42,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 784x22]
             PaintableBox (Box<TR>) [8,8 784x22]
               PaintableWithLines (BlockContainer<TD>) [8,8 220.09375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [10,10 216.09375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [228.09375,8 160.796875x22]
-                PaintableWithLines (BlockContainer(anonymous)) [230.09375,10 156.796875x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [388.890625,8 403.109375x22]
-                PaintableWithLines (BlockContainer(anonymous)) [390.890625,10 399.109375x18]
-                  TextPaintable (TextNode<#text>)
+                TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x38] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/zero_percent_width_nested_table.txt
+++ b/Tests/LibWeb/Layout/expected/zero_percent_width_nested_table.txt
@@ -10,9 +10,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (11,11) content-size 6x6 table-box [TFC] children: not-inline
                     Box <tbody> at (13,13) content-size 2x2 table-row-group children: not-inline
                       Box <tr> at (13,13) content-size 2x2 table-row children: not-inline
-                        BlockContainer <td> at (14,14) content-size 0x0 table-cell [BFC] children: not-inline
-                          BlockContainer <(anonymous)> at (14,14) content-size 0x0 children: inline
-                            TextNode <#text>
+                        BlockContainer <td> at (14,14) content-size 0x0 table-cell [BFC] children: inline
+                          TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x28]
@@ -27,7 +26,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [13,13 2x2]
                       PaintableBox (Box<TR>) [13,13 2x2]
                         PaintableWithLines (BlockContainer<TD>) [13,13 2x2]
-                          PaintableWithLines (BlockContainer(anonymous)) [14,14 0x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x28] [children: 0] (z-index: auto)


### PR DESCRIPTION
We were always creating an anonymous container for the inline contents of table cells, but the layout node we spawn for the table cells themselves already is capable of dealing with inline nodes. Regular logic should kick in for dealing with the block/inline node invariant.