### PR TITLE
LibWeb: Delete `schedule_style_update()` and `schedule_layout_update()`

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -861,24 +861,6 @@ void Document::set_origin(URL::Origin const& origin)
     m_origin = origin;
 }
 
-void Document::schedule_style_update()
-{
-    if (!browsing_context())
-        return;
-
-    // NOTE: Update of the style is a step in HTML event loop processing.
-    HTML::main_thread_event_loop().schedule();
-}
-
-void Document::schedule_layout_update()
-{
-    if (!browsing_context())
-        return;
-
-    // NOTE: Update of the layout is a step in HTML event loop processing.
-    HTML::main_thread_event_loop().schedule();
-}
-
 bool Document::is_child_allowed(Node const& node) const
 {
     switch (node.type()) {
@@ -1238,7 +1220,6 @@ void Document::invalidate_layout_tree(InvalidateLayoutTreeReason reason)
     if (m_layout_root)
         dbgln_if(UPDATE_LAYOUT_DEBUG, "DROP TREE {}", to_string(reason));
     tear_down_layout_tree();
-    schedule_layout_update();
 }
 
 static void propagate_scrollbar_width_to_viewport(Element& root_element, Layout::Viewport& viewport)
@@ -3426,8 +3407,6 @@ void Document::run_the_resize_steps()
         visual_viewport_resize_event->set_is_trusted(true);
         visual_viewport()->dispatch_event(visual_viewport_resize_event);
     }
-
-    schedule_layout_update();
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-view-1/#document-run-the-scroll-steps

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -349,9 +349,6 @@ public:
     Painting::ViewportPaintable const* paintable() const;
     Painting::ViewportPaintable* paintable();
 
-    void schedule_style_update();
-    void schedule_layout_update();
-
     GC::Ref<NodeList> get_elements_by_name(FlyString const&);
 
     GC::Ref<HTMLCollection> applets();

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -442,7 +442,6 @@ void Node::invalidate_style(StyleInvalidationReason reason)
     if (is_document()) {
         auto& document = static_cast<DOM::Document&>(*this);
         document.set_needs_full_style_update(true);
-        document.schedule_style_update();
         return;
     }
 
@@ -493,8 +492,6 @@ void Node::invalidate_style(StyleInvalidationReason reason)
 
     for (auto* ancestor = parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host())
         ancestor->m_child_needs_style_update = true;
-
-    document().schedule_style_update();
 }
 
 void Node::invalidate_style(StyleInvalidationReason reason, Vector<CSS::InvalidationSet::Property> const& properties, StyleInvalidationOptions options)
@@ -558,8 +555,6 @@ void Node::invalidate_style(StyleInvalidationReason reason, Vector<CSS::Invalida
                 invalidate_entire_subtree(*sibling);
         }
     }
-
-    document().schedule_style_update();
 }
 
 String Node::child_text_content() const
@@ -1703,7 +1698,6 @@ void Node::set_needs_style_update(bool value)
                 break;
             ancestor->m_child_needs_style_update = true;
         }
-        document().schedule_style_update();
     }
 }
 


### PR DESCRIPTION
Both functions schedule HTML event loop processing but that's unnecessary, because we schedule a rendering task that checks if style/layout needs an update 60/s anyway.