### PR TITLE
LibWeb: Include submitter name and value when constructing FormData

### DIFF
--- a/Libraries/LibWeb/XHR/FormData.cpp
+++ b/Libraries/LibWeb/XHR/FormData.cpp
@@ -43,8 +43,8 @@ WebIDL::ExceptionOr<GC::Ref<FormData>> FormData::construct_impl(JS::Realm& realm
             }
         }
 
-        // 2. Let list be the result of constructing the entry list for form.
-        auto entry_list = TRY(construct_entry_list(realm, *form));
+        // 2. Let list be the result of constructing the entry list for form and submitter.
+        auto entry_list = TRY(construct_entry_list(realm, *form, submitter));
         // 3. If list is null, then throw an "InvalidStateError" DOMException.
         if (!entry_list.has_value())
             return WebIDL::InvalidStateError::create(realm, "Form element does not contain any entries."_string);

--- a/Tests/LibWeb/Text/expected/XHR/FormData-constructor-takes-name-and-value-of-submitter.txt
+++ b/Tests/LibWeb/Text/expected/XHR/FormData-constructor-takes-name-and-value-of-submitter.txt
@@ -1,0 +1,1 @@
+'test-button-name' = 'test-button-value'

--- a/Tests/LibWeb/Text/expected/wpt-import/xhr/formdata/constructor-submitter.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/xhr/formdata/constructor-submitter.txt
@@ -2,14 +2,13 @@ Harness status: OK
 
 Found 9 tests
 
-6 Pass
-3 Fail
+9 Pass
 Pass	FormData construction should allow a null submitter
 Pass	FormData construction should allow an undefined form and an undefined submitter
 Pass	FormData construction should allow an undefined form and a null submitter
 Pass	FormData construction should throw a TypeError if a non-null submitter is not a submit button
 Pass	FormData construction should throw a 'NotFoundError' DOMException if a non-null submitter is not owned by the form
-Fail	The constructed FormData object should contain an in-tree-order entry for a named submit button submitter
+Pass	The constructed FormData object should contain an in-tree-order entry for a named submit button submitter
 Pass	The constructed FormData object should not contain an entry for an unnamed submit button submitter
-Fail	The constructed FormData object should contain in-tree-order entries for an activated Image Button submitter
-Fail	The constructed FormData object should contain in-tree-order entries for an unactivated Image Button submitter
+Pass	The constructed FormData object should contain in-tree-order entries for an activated Image Button submitter
+Pass	The constructed FormData object should contain in-tree-order entries for an unactivated Image Button submitter

--- a/Tests/LibWeb/Text/input/XHR/FormData-constructor-takes-name-and-value-of-submitter.html
+++ b/Tests/LibWeb/Text/input/XHR/FormData-constructor-takes-name-and-value-of-submitter.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<form id="test-form">
+    <button id="test-button" name="test-button-name" value="test-button-value"></button>
+</form>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const testForm = document.getElementById("test-form");
+        const testButton = document.getElementById("test-button");
+        const formData = new FormData(testForm, testButton);
+
+        for (const [name, value] of formData.entries()) {
+            println(`'${name}' = '${value}'`);
+        }
+    });
+</script>


### PR DESCRIPTION
This fixes the SSO buttons on OpenAI's login page giving "Unknown error"