### PR TITLE
LibWeb/HTML: Return CSSStyleProperties from getComputedStyle()

### DIFF
--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1272,8 +1272,8 @@ Variant<GC::Root<DOM::Event>, Empty> Window::event() const
     return Empty {};
 }
 
-// https://w3c.github.io/csswg-drafts/cssom/#dom-window-getcomputedstyle
-GC::Ref<CSS::CSSStyleDeclaration> Window::get_computed_style(DOM::Element& element, Optional<String> const& pseudo_element) const
+// https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle
+GC::Ref<CSS::CSSStyleProperties> Window::get_computed_style(DOM::Element& element, Optional<String> const& pseudo_element) const
 {
     // 1. Let doc be elt’s node document.
 

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -204,7 +204,7 @@ public:
 
     Variant<GC::Root<DOM::Event>, Empty> event() const;
 
-    [[nodiscard]] GC::Ref<CSS::CSSStyleDeclaration> get_computed_style(DOM::Element&, Optional<String> const& pseudo_element) const;
+    [[nodiscard]] GC::Ref<CSS::CSSStyleProperties> get_computed_style(DOM::Element&, Optional<String> const& pseudo_element) const;
 
     WebIDL::ExceptionOr<GC::Ref<CSS::MediaQueryList>> match_media(String const& query);
     [[nodiscard]] GC::Ref<CSS::Screen> screen();

--- a/Libraries/LibWeb/HTML/Window.idl
+++ b/Libraries/LibWeb/HTML/Window.idl
@@ -71,8 +71,8 @@ interface Window : EventTarget {
     // https://dom.spec.whatwg.org/#interface-window-extensions
     [Replaceable] readonly attribute (Event or undefined) event; // legacy
 
-    // https://w3c.github.io/csswg-drafts/cssom/#extensions-to-the-window-interface
-    [NewObject] CSSStyleDeclaration getComputedStyle(Element elt, optional CSSOMString? pseudoElt);
+    // https://drafts.csswg.org/cssom/#extensions-to-the-window-interface
+    [NewObject] CSSStyleProperties getComputedStyle(Element elt, optional CSSOMString? pseudoElt);
 
     // https://w3c.github.io/csswg-drafts/cssom-view/#extensions-to-the-window-interface
     [NewObject] MediaQueryList matchMedia(CSSOMString query);


### PR DESCRIPTION
Corresponds to https://github.com/w3c/csswg-drafts/commit/94fdd8ab1e7fa6c9ee098cbf1ee22e8f3911636b

Somehow I've already got `CSSStyleProperties` in `ElementCSSInlineStyle.style`, so I'm not sure what happened there.