### PR TITLE
Meta: Add `WPT.sh bisect` for finding WPT regressions automatically

### DIFF
--- a/Meta/wpt-bisect-helper.sh
+++ b/Meta/wpt-bisect-helper.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# An exit code of 255 tells git to stop bisecting immediately.
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <log_file> [test paths...]"
+    exit 255
+fi
+
+baseline_log_file="$1"
+if [ ! -f "${baseline_log_file}" ]; then
+    echo "Baseline log file '${baseline_log_file}' does not exist."
+    exit 255
+fi
+shift
+
+WPT_SCRIPT_PATH=${WPT_SCRIPT_PATH:-"$(dirname "$0")/WPT.sh"}
+
+pushd "${LADYBIRD_SOURCE_DIR}" > /dev/null || exit 255
+    trap "exit 255" INT TERM
+    if ! ./Meta/ladybird.py rebuild WebDriver; then
+        # When going back over many commits rebuilds may be flaky. Let's try again before skipping this commit.
+        if ! ./Meta/ladybird.py rebuild WebDriver; then
+            echo "Build failed twice in a row, skipping this commit."
+            exit 125
+        fi
+    fi
+
+    current_commit="$(git rev-parse HEAD)"
+
+    # If comparing to the baseline has no unexpected results this commit is bad, because we create the basseline from
+    # the given bad commit.
+    if "${WPT_SCRIPT_PATH}" compare "${baseline_log_file}" "${@}"; then
+        echo "Commit ${current_commit} is bad."
+        exit 1
+    fi
+    trap - INT TERM
+popd > /dev/null || exit 255
+
+echo "Commit ${current_commit} is good."
+exit 0


### PR DESCRIPTION
This PR adds the a `bisect` command to `WPT.sh`. The command takes a bad commit ref, a good commit ref and a list of tests. For example, if we know the test `http://wpt.live/css/css-variables/variable-exponential-blowup.html` crashes on `master` but is OK on commit `43778e9493`, then we can run:
```sh
./Meta/WPT.sh bisect master 43778e9493 css/css-variables/variable-exponential-blowup.html
```

The command will first create a baseline log file and bisect based on whether it encounters results that differ from the baseline. It should finish when it gets to the first commit where the test results differ from the baseline.

If the build fails at any point, it will first be retried, then the bisect script will skip the commit where the build is broken.

The biggest limitation of the script currently is that it relies on `ladybird.py` from the repository. Therefore, it can't bisect commits before that file existed. In theory we should be able to get round this by copying the necessary build files elsewhere before starting to bisect, but I wasn't able to get this to work.