### PR TITLE
LibWeb: Add "parallel queue" and allow it as fetch task destination

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -63,7 +63,7 @@ void FetchedDataReceiver::on_data_received(ReadonlyBytes bytes)
     // 3. Queue a fetch task to run the following steps, with fetchParams’s task destination.
     Infrastructure::queue_fetch_task(
         m_fetch_params->controller(),
-        m_fetch_params->task_destination().get<GC::Ref<JS::Object>>(),
+        m_fetch_params->task_destination(),
         GC::create_function(heap(), [this, bytes = MUST(ByteBuffer::copy(bytes))]() mutable {
             HTML::TemporaryExecutionContext execution_context { m_stream->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -46,9 +46,9 @@ public:
 
     [[nodiscard]] GC::Ref<Body> clone(JS::Realm&);
 
-    void fully_read(JS::Realm&, ProcessBodyCallback process_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination) const;
-    void incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination);
-    void incrementally_read_loop(Streams::ReadableStreamDefaultReader& reader, GC::Ref<JS::Object> task_destination, ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error);
+    void fully_read(JS::Realm&, ProcessBodyCallback process_body, ProcessBodyErrorCallback process_body_error, TaskDestination) const;
+    void incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination);
+    void incrementally_read_loop(Streams::ReadableStreamDefaultReader& reader, TaskDestination, ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error);
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 

--- a/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
@@ -61,7 +61,7 @@ void IncrementalReadLoopReadRequest::on_error(JS::Value error)
     }));
 }
 
-IncrementalReadLoopReadRequest::IncrementalReadLoopReadRequest(GC::Ref<Body> body, GC::Ref<Streams::ReadableStreamDefaultReader> reader, GC::Ref<JS::Object> task_destination, Body::ProcessBodyChunkCallback process_body_chunk, Body::ProcessEndOfBodyCallback process_end_of_body, Body::ProcessBodyErrorCallback process_body_error)
+IncrementalReadLoopReadRequest::IncrementalReadLoopReadRequest(GC::Ref<Body> body, GC::Ref<Streams::ReadableStreamDefaultReader> reader, TaskDestination task_destination, Body::ProcessBodyChunkCallback process_body_chunk, Body::ProcessEndOfBodyCallback process_end_of_body, Body::ProcessBodyErrorCallback process_body_error)
     : m_body(body)
     , m_reader(reader)
     , m_task_destination(task_destination)
@@ -76,7 +76,8 @@ void IncrementalReadLoopReadRequest::visit_edges(Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_body);
     visitor.visit(m_reader);
-    visitor.visit(m_task_destination);
+    if (auto* task_destination_object = m_task_destination.get_pointer<GC::Ref<JS::Object>>(); task_destination_object)
+        visitor.visit(*task_destination_object);
     visitor.visit(m_process_body_chunk);
     visitor.visit(m_process_end_of_body);
     visitor.visit(m_process_body_error);

--- a/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.h
@@ -17,7 +17,7 @@ class IncrementalReadLoopReadRequest : public Streams::ReadRequest {
     GC_DECLARE_ALLOCATOR(IncrementalReadLoopReadRequest);
 
 public:
-    IncrementalReadLoopReadRequest(GC::Ref<Body>, GC::Ref<Streams::ReadableStreamDefaultReader>, GC::Ref<JS::Object> task_destination, Body::ProcessBodyChunkCallback, Body::ProcessEndOfBodyCallback, Body::ProcessBodyErrorCallback);
+    IncrementalReadLoopReadRequest(GC::Ref<Body>, GC::Ref<Streams::ReadableStreamDefaultReader>, TaskDestination, Body::ProcessBodyChunkCallback, Body::ProcessEndOfBodyCallback, Body::ProcessBodyErrorCallback);
 
     virtual void on_chunk(JS::Value chunk) override;
     virtual void on_close() override;
@@ -28,7 +28,7 @@ private:
 
     GC::Ref<Body> m_body;
     GC::Ref<Streams::ReadableStreamDefaultReader> m_reader;
-    GC::Ref<JS::Object> m_task_destination;
+    TaskDestination m_task_destination;
     Body::ProcessBodyChunkCallback m_process_body_chunk;
     Body::ProcessEndOfBodyCallback m_process_end_of_body;
     Body::ProcessBodyErrorCallback m_process_body_error;

--- a/Libraries/LibWeb/Fetch/Infrastructure/Task.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/Task.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Infrastructure/Task.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
@@ -11,21 +12,25 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#queue-a-fetch-task
-HTML::TaskID queue_fetch_task(JS::Object& task_destination, GC::Ref<GC::Function<void()>> algorithm)
+HTML::TaskID queue_fetch_task(TaskDestination task_destination, GC::Ref<GC::Function<void()>> algorithm)
 {
-    // FIXME: 1. If taskDestination is a parallel queue, then enqueue algorithm to taskDestination.
+    VERIFY(!task_destination.has<Empty>());
+
+    // 1. If taskDestination is a parallel queue, then enqueue algorithm to taskDestination.
+    if (auto* parallel_queue = task_destination.get_pointer<NonnullRefPtr<HTML::ParallelQueue>>())
+        return (*parallel_queue)->enqueue(algorithm);
 
     // 2. Otherwise, queue a global task on the networking task source with taskDestination and algorithm.
-    return HTML::queue_global_task(HTML::Task::Source::Networking, task_destination, algorithm);
+    return HTML::queue_global_task(HTML::Task::Source::Networking, task_destination.get<GC::Ref<JS::Object>>(), algorithm);
 }
 
 // AD-HOC: This overload allows tracking the queued task within the fetch controller so that we may cancel queued tasks
 //         when the spec indicates that we must stop an ongoing fetch.
-HTML::TaskID queue_fetch_task(GC::Ref<FetchController> fetch_controller, JS::Object& task_destination, GC::Ref<GC::Function<void()>> algorithm)
+HTML::TaskID queue_fetch_task(GC::Ref<FetchController> fetch_controller, TaskDestination task_destination, GC::Ref<GC::Function<void()>> algorithm)
 {
     auto fetch_task_id = fetch_controller->next_fetch_task_id();
 
-    auto& heap = task_destination.heap();
+    auto& heap = fetch_controller->heap();
     auto html_task_id = queue_fetch_task(task_destination, GC::create_function(heap, [fetch_controller, fetch_task_id, algorithm]() {
         fetch_controller->fetch_task_complete(fetch_task_id);
         algorithm->function()();

--- a/Libraries/LibWeb/Fetch/Infrastructure/Task.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/Task.h
@@ -14,10 +14,9 @@
 
 namespace Web::Fetch::Infrastructure {
 
-// FIXME: 'or a parallel queue'
-using TaskDestination = Variant<Empty, GC::Ref<JS::Object>>;
+using TaskDestination = Variant<Empty, GC::Ref<JS::Object>, NonnullRefPtr<HTML::ParallelQueue>>;
 
-HTML::TaskID queue_fetch_task(JS::Object&, GC::Ref<GC::Function<void()>>);
-HTML::TaskID queue_fetch_task(GC::Ref<FetchController>, JS::Object&, GC::Ref<GC::Function<void()>>);
+HTML::TaskID queue_fetch_task(TaskDestination, GC::Ref<GC::Function<void()>>);
+HTML::TaskID queue_fetch_task(GC::Ref<FetchController>, TaskDestination, GC::Ref<GC::Function<void()>>);
 
 }

--- a/Libraries/LibWeb/HTML/EventLoop/Task.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.cpp
@@ -77,4 +77,17 @@ UniqueTaskSource::~UniqueTaskSource()
     s_unique_task_source_allocator.deallocate(static_cast<int>(source));
 }
 
+NonnullRefPtr<ParallelQueue> ParallelQueue::create()
+{
+    return adopt_ref(*new (nothrow) ParallelQueue);
+}
+
+TaskID ParallelQueue::enqueue(GC::Ref<GC::Function<void()>> algorithm)
+{
+    auto& event_loop = HTML::main_thread_event_loop();
+    auto task = HTML::Task::create(event_loop.vm(), m_task_source.source, nullptr, algorithm);
+    event_loop.task_queue().add(task);
+    return task->id();
+}
+
 }

--- a/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -116,4 +116,13 @@ struct UniqueTaskSource {
     Task::Source const source;
 };
 
+class ParallelQueue : public RefCounted<ParallelQueue> {
+public:
+    static NonnullRefPtr<ParallelQueue> create();
+    TaskID enqueue(GC::Ref<GC::Function<void()>>);
+
+private:
+    UniqueTaskSource m_task_source;
+};
+
 }


### PR DESCRIPTION
Note that it's not actually executing tasks in parallel, it's still throwing them on the HTML event loop task queue, each with its own unique task source.

This makes our fetch implementation a lot more robust when HTTP caching is enabled, and you can now click links on https://terminal.shop/ without hitting TODO assertions in fetch.

A big step towards enabling HTTP caching by default :)