### PR TITLE
Meta: Update vcpkg, including simdutf for a `Uint8Array.fromBase64` fix

### DIFF
--- a/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
+++ b/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
@@ -49,6 +49,22 @@ describe("errors", () => {
         expect(() => {
             Uint8Array.fromBase64("Zm9vaa=a", { lastChunkHandling: "strict" });
         }).toThrowWithMessage(SyntaxError, "Invalid base64 character");
+
+        expect(() => {
+            Uint8Array.fromBase64("A==");
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
+
+        expect(() => {
+            Uint8Array.fromBase64("A==", { lastChunkHandling: "loose" });
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
+
+        expect(() => {
+            Uint8Array.fromBase64("A==", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
+
+        expect(() => {
+            Uint8Array.fromBase64("A==", { lastChunkHandling: "stop-before-partial" });
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
     });
 
     test("invalid alphabet", () => {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -215,7 +215,7 @@
     },
     {
       "name": "libpng",
-      "version": "1.6.47"
+      "version": "1.6.48#0"
     },
     {
       "name": "libproxy",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -251,7 +251,7 @@
     },
     {
       "name": "simdutf",
-      "version": "7.3.0#0"
+      "version": "7.3.3#0"
     },
     {
       "name": "skia",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -183,7 +183,7 @@
     },
     {
       "name": "dirent",
-      "version": "1.24#0"
+      "version": "1.25#0"
     },
     {
       "name": "fast-float",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "9edc4f5f224efb05f6d277af3ea0f1f0e75fdcb1",
+  "builtin-baseline": "b509a07261b982f35c663bf638aae5f77877d207",
   "dependencies": [
     {
       "name": "angle",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -239,7 +239,7 @@
     },
     {
       "name": "openssl",
-      "version": "3.5.0#1"
+      "version": "3.5.1#0"
     },
     {
       "name": "qtbase",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -259,7 +259,7 @@
     },
     {
       "name": "sqlite3",
-      "version": "3.49.2#0"
+      "version": "3.50.2#0"
     },
     {
       "name": "woff2",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -207,7 +207,7 @@
     },
     {
       "name": "libjpeg-turbo",
-      "version": "3.1.0#0"
+      "version": "3.1.0#2"
     },
     {
       "name": "libjxl",


### PR DESCRIPTION
Updating simdutf for a fix for handling invalid trailing padding characters.

Updated other packages while I'm here since this is a cache-busting change.

test262 diff:
```
Diff Tests:
    test/built-ins/Uint8Array/fromBase64/last-chunk-invalid.js ❌ -> ✅
```