### PR TITLE
LibWeb: Move `Transformation::to_matrix` to new CSV resolve methods

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -3798,7 +3798,9 @@ RefPtr<CSSStyleValue const> Parser::parse_calculated_value(ComponentValue const&
                 // The scale family of functions treats percentages as numbers.
                 if (function.name.is_one_of_ignoring_ascii_case(
                         "scale"sv, "scalex"sv, "scaley"sv, "scalez"sv, "scale3d"sv)) {
-                    return CalculationContext { .percentages_resolve_as = ValueType::Number };
+                    // NOTE: Resolving percentages as numbers isn't supported by the spec and we instead expect the
+                    //       caller to handle the resolved value being a percentage.
+                    return CalculationContext {};
                 }
                 // FIXME: Add other functions that provide a context for resolving values
                 return {};

--- a/Libraries/LibWeb/CSS/Transformation.cpp
+++ b/Libraries/LibWeb/CSS/Transformation.cpp
@@ -43,7 +43,7 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
                         return length.absolute_length_to_px().to_float();
                 }
                 if (value.is_calculated() && value.calculated()->resolves_to_length()) {
-                    if (auto const& resolved = value.calculated()->resolve_length_deprecated(context); resolved->is_absolute())
+                    if (auto const& resolved = value.calculated()->resolve_length(context); resolved.has_value() && resolved->is_absolute())
                         return resolved->absolute_length_to_px().to_float();
                 }
                 return Error::from_string_literal("Transform contains non absolute units");
@@ -55,9 +55,11 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
                     return value.percentage().as_fraction();
                 if (value.is_calculated()) {
                     if (value.calculated()->resolves_to_number())
-                        return value.calculated()->resolve_number_deprecated(context).value();
+                        if (auto resolved_number = value.calculated()->resolve_number(context); resolved_number.has_value())
+                            return resolved_number.value();
                     if (value.calculated()->resolves_to_percentage())
-                        return value.calculated()->resolve_percentage_deprecated(context)->as_fraction();
+                        if (auto resolved_percentage = value.calculated()->resolve_percentage(context); resolved_percentage.has_value())
+                            return resolved_percentage->as_fraction();
                 }
                 return Error::from_string_literal("Transform contains non absolute units");
             });

--- a/Tests/LibWeb/Text/expected/wpt-import/css/geometry/DOMMatrix-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/geometry/DOMMatrix-001.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 138 tests
 
-132 Pass
-6 Fail
+134 Pass
+4 Fail
 Pass	new DOMMatrix()
 Pass	new DOMMatrix(undefined)
 Pass	new DOMMatrix(new DOMMatrix())
@@ -47,7 +47,7 @@ Pass	new DOMMatrix("translateX(5vi)")
 Pass	new DOMMatrix("translateX(5vmin)")
 Pass	new DOMMatrix("translateX(5vmax)")
 Pass	new DOMMatrix("translateX(5%)")
-Fail	new DOMMatrix("translateX(calc(10px * sign(1em - 10px)))")
+Pass	new DOMMatrix("translateX(calc(10px * sign(1em - 10px)))")
 Pass	new DOMMatrix("translateX(calc(10px * sibling-index()))")
 Pass	new DOMMatrix("rotate(5)")
 Pass	new DOMMatrix("rotate(5, 5, 5)")
@@ -116,7 +116,7 @@ Pass	new DOMMatrixReadOnly("translateX(5vi)")
 Pass	new DOMMatrixReadOnly("translateX(5vmin)")
 Pass	new DOMMatrixReadOnly("translateX(5vmax)")
 Pass	new DOMMatrixReadOnly("translateX(5%)")
-Fail	new DOMMatrixReadOnly("translateX(calc(10px * sign(1em - 10px)))")
+Pass	new DOMMatrixReadOnly("translateX(calc(10px * sign(1em - 10px)))")
 Pass	new DOMMatrixReadOnly("translateX(calc(10px * sibling-index()))")
 Pass	new DOMMatrixReadOnly("rotate(5)")
 Pass	new DOMMatrixReadOnly("rotate(5, 5, 5)")


### PR DESCRIPTION
This gains us 2 WPT passes as we now correctly disallow relative lengths in more places in the `DOMMatrix` constructor.