### PR TITLE
LibWeb: Remove `scroll_by()` in `update_layout()` to avoid double layout

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1418,11 +1418,6 @@ void Document::update_layout(UpdateLayoutReason reason)
         return TraversalDecision::Continue;
     });
 
-    // Scrolling by zero offset will clamp scroll offset back to valid range if it was out of bounds
-    // after the viewport size change.
-    if (auto window = this->window())
-        window->scroll_by(0, 0);
-
     if constexpr (UPDATE_LAYOUT_DEBUG) {
         dbgln("LAYOUT {} {} µs", to_string(reason), timer.elapsed_time().to_microseconds());
     }


### PR DESCRIPTION
`scroll_by` calls `update_layout`, so using it from within
`update_layout` means we could re-enter `update_layout`. This might
seem fine, since `update_layout` clears the layout invalidation flag
before calling `scroll_by`. However, it turns out that when the document
has running animations that invalidate layout, we actually end up
performing layout twice, because `update_style`, which invalidates
animated properties, is invoked before checking the layout invalidation
flag.

This change deletes `scroll_by(0, 0)` because part of
`LayoutState::commit()` responsible for measuring scrollable overflow
already clamps scroll offsets for all scrollable boxes, so there's no
need to do it once again in `update_layout()`.

Improves performance on Discord when scrolling the emoji selector, as we
now avoid redundant layout passes.
