### PR TITLE
LibWeb: Remove XML-derived attribute name validation from DOMStringMap

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -237,6 +237,7 @@ bool is_valid_namespace_prefix(FlyString const& prefix)
     return !prefix.is_empty() && !prefix.code_points().contains_any_of(INVALID_NAMESPACE_PREFIX_CHARACTERS);
 }
 
+// https://dom.spec.whatwg.org/#valid-attribute-local-name
 bool is_valid_attribute_local_name(FlyString const& local_name)
 {
     // A string is a valid attribute local name if its length is at least 1 and it does not contain ASCII whitespace, U+0000 NULL, U+002F (/), U+003D (=), or U+003E (>).

--- a/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -162,7 +162,9 @@ WebIDL::ExceptionOr<void> DOMStringMap::set_value_of_new_named_property(String c
 
     auto data_name = MUST(builder.to_string());
 
-    // FIXME: 4. If name does not match the XML Name production, throw an "InvalidCharacterError" DOMException.
+    // 4. If name is not a valid attribute local name, then throw an "InvalidCharacterError" DOMException.
+    if (!DOM::is_valid_attribute_local_name(data_name))
+        return WebIDL::InvalidCharacterError::create(realm(), "Name is not a valid attribute local name."_string);
 
     // 5. Set an attribute value for the DOMStringMap's associated element using name and value.
     TRY(m_associated_element->set_attribute(data_name, value));


### PR DESCRIPTION
Corresponds to https://github.com/whatwg/html/commit/841fcfdb2c58da244f3c3ae93c3bc9f9ba749bca