### PR TITLE
LibWeb/CSS: Support legacy value aliases for the properties that have them

### DIFF
--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -638,8 +638,7 @@
     "auto",
     "none",
     "inter-word",
-    "inter-character",
-    "distribute=inter-character"
+    "inter-character"
   ],
   "text-overflow": [
     "clip",

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -723,6 +723,17 @@ Parser::ParseErrorOr<NonnullRefPtr<CSSStyleValue const>> Parser::parse_css_value
         if (auto parsed_value = parse_text_decoration_line_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
+    case PropertyID::TextJustify:
+        if (auto parsed_value = parse_css_value_for_property(property_id, tokens); parsed_value && !tokens.has_next_token()) {
+            // https://drafts.csswg.org/css-text-3/#valdef-text-justify-distribute
+            // For legacy reasons, UAs must also support the alternate keyword distribute which must compute to
+            // inter-character, thus having the exact same meaning and behavior. UAs may treat this as a legacy value alias.
+            // FIXME: Figure out a generic way of supporting legacy value aliases.
+            if (parsed_value->to_keyword() == Keyword::Distribute)
+                return CSSKeywordValue::create(Keyword::InterCharacter);
+            return parsed_value.release_nonnull();
+        }
+        return ParseError::SyntaxError;
     case PropertyID::TextShadow:
         if (auto parsed_value = parse_shadow_value(tokens, AllowInsetKeyword::No); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -672,6 +672,17 @@ Parser::ParseErrorOr<NonnullRefPtr<CSSStyleValue const>> Parser::parse_css_value
         if (auto parsed_value = parse_overflow_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
+    case PropertyID::OverflowX:
+    case PropertyID::OverflowY:
+        if (auto parsed_value = parse_css_value_for_property(property_id, tokens); parsed_value && !tokens.has_next_token()) {
+            // https://drafts.csswg.org/css-overflow-3/#valdef-overflow-overlay
+            // User agents must also support the overlay keyword as a legacy value alias of auto.
+            // FIXME: Figure out a generic way of supporting legacy value aliases.
+            if (parsed_value->to_keyword() == Keyword::Overlay)
+                return CSSKeywordValue::create(Keyword::Auto);
+            return parsed_value.release_nonnull();
+        }
+        return ParseError::SyntaxError;
     case PropertyID::PlaceContent:
         if (auto parsed_value = parse_place_content_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
@@ -3599,11 +3610,24 @@ RefPtr<CSSStyleValue const> Parser::parse_opacity_value(PropertyID property_id, 
 
 RefPtr<CSSStyleValue const> Parser::parse_overflow_value(TokenStream<ComponentValue>& tokens)
 {
+    // https://drafts.csswg.org/css-overflow-3/#valdef-overflow-overlay
+    // User agents must also support the overlay keyword as a legacy value alias of auto.
+    // FIXME: Figure out a generic way of supporting legacy value aliases.
+    // FIXME: Even better, make parsing the longhands go through their proper parsing routine.
+    auto parse_an_overflow_longhand_value = [this](PropertyID property, auto& tokens) -> RefPtr<CSSStyleValue const> {
+        auto maybe_value = parse_css_value_for_property(property, tokens);
+        if (!maybe_value)
+            return nullptr;
+        if (maybe_value->to_keyword() == Keyword::Overlay)
+            return CSSKeywordValue::create(Keyword::Auto);
+        return maybe_value.release_nonnull();
+    };
+
     auto transaction = tokens.begin_transaction();
-    auto maybe_x_value = parse_css_value_for_property(PropertyID::OverflowX, tokens);
+    auto maybe_x_value = parse_an_overflow_longhand_value(PropertyID::OverflowX, tokens);
     if (!maybe_x_value)
         return nullptr;
-    auto maybe_y_value = parse_css_value_for_property(PropertyID::OverflowY, tokens);
+    auto maybe_y_value = parse_an_overflow_longhand_value(PropertyID::OverflowY, tokens);
     transaction.commit();
     if (maybe_y_value) {
         return ShorthandStyleValue::create(PropertyID::Overflow,

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -3157,6 +3157,9 @@
     "initial": "auto",
     "valid-types": [
       "text-justify"
+    ],
+    "valid-identifiers": [
+      "distribute"
     ]
   },
   "text-overflow": {

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -2643,6 +2643,9 @@
     "initial": "visible",
     "valid-types": [
       "overflow"
+    ],
+    "valid-identifiers": [
+      "overlay"
     ]
   },
   "overflow-y": {
@@ -2651,6 +2654,9 @@
     "initial": "visible",
     "valid-types": [
       "overflow"
+    ],
+    "valid-identifiers": [
+      "overlay"
     ]
   },
   "padding": {

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-overflow/overflow-overlay-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-overflow/overflow-overlay-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+  div {
+      width: 15em;
+      height: 10em;
+      overflow: auto;
+    }
+</style>
+<div>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-overflow/overflow-overlay.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-overflow/overflow-overlay.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/8063">
+<link rel="match" href="../../../../expected/wpt-import/css/css-overflow/overflow-overlay-ref.html">
+<style>
+  div {
+    width: 15em;
+    height: 10em;
+    overflow: overlay;
+  }
+</style>
+<div>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-text/text-justify/distribute-alias.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-text/text-justify/distribute-alias.tentative.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	text-justify: distribute is a parse-time alias of inter-character

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-text/text-justify/distribute-alias.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-text/text-justify/distribute-alias.tentative.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<link rel=author href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel=author href="https://mozilla.org" title="Mozilla">
+<link rel=help href="https://github.com/w3c/csswg-drafts/issues/6156">
+<title>text-justify: distribute is a parse-time alias of inter-character</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+  test(function() {
+    let style = document.createElement("div").style;
+    style.textJustify = "distribute";
+    assert_equals(style.textJustify, "inter-character");
+  });
+</script>


### PR DESCRIPTION
[Legacy value aliases](https://drafts.csswg.org/css-cascade-5/#css-legacy-value-alias) are, for now, keywords that get swapped for other keywords at parse-time. Specifically there are two users of this now, at least according to [webdex](https://dontcallmedom.github.io/webdex/l.html#legacy%20value%20alias%40%40CSS%40dfn):

- `overlay` in `overflow` is an alias for `auto`, also applying to `overflow-x` and `overflow-y`.
- `distribute` in `text-justify` is an alias for `inter-character`.

`overflow: overlay` specifically showed up on bbc.co.uk.

Until there are more uses of this, it doesn't seem worth implementing a proper automatic system to handle them, but I've left some FIXMEs about that.