### PR TITLE
LibWeb: Use GC::Ptr for BrowsingContext pointer saved in Document

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -544,6 +544,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_inspected_node);
     visitor.visit(m_highlighted_node);
     visitor.visit(m_active_favicon);
+    visitor.visit(m_browsing_context);
     visitor.visit(m_focused_element);
     visitor.visit(m_active_element);
     visitor.visit(m_target_element);
@@ -4239,7 +4240,7 @@ GC::Ptr<HTML::HTMLParser> Document::active_parser()
     return m_parser;
 }
 
-void Document::set_browsing_context(HTML::BrowsingContext* browsing_context)
+void Document::set_browsing_context(GC::Ptr<HTML::BrowsingContext> browsing_context)
 {
     m_browsing_context = browsing_context;
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -308,10 +308,10 @@ public:
     String title() const;
     WebIDL::ExceptionOr<void> set_title(String const&);
 
-    HTML::BrowsingContext* browsing_context() { return m_browsing_context.ptr(); }
-    HTML::BrowsingContext const* browsing_context() const { return m_browsing_context.ptr(); }
+    GC::Ptr<HTML::BrowsingContext> browsing_context() { return m_browsing_context; }
+    GC::Ptr<HTML::BrowsingContext const> browsing_context() const { return m_browsing_context; }
 
-    void set_browsing_context(HTML::BrowsingContext*);
+    void set_browsing_context(GC::Ptr<HTML::BrowsingContext>);
 
     Page& page();
     Page const& page() const;
@@ -960,7 +960,7 @@ private:
     OwnPtr<CSS::StyleComputer> m_style_computer;
     GC::Ptr<CSS::StyleSheetList> m_style_sheets;
     GC::Ptr<Node> m_active_favicon;
-    WeakPtr<HTML::BrowsingContext> m_browsing_context;
+    GC::Ptr<HTML::BrowsingContext> m_browsing_context;
     URL::URL m_url;
     mutable OwnPtr<ElementByIdMap> m_element_by_id;
 

--- a/Libraries/LibWeb/HTML/BarProp.cpp
+++ b/Libraries/LibWeb/HTML/BarProp.cpp
@@ -28,7 +28,7 @@ bool BarProp::visible() const
 {
     // 1. Let browsingContext be this's relevant global object's browsing context.
     auto& global_object = HTML::relevant_global_object(*this);
-    auto* browsing_context = as<HTML::Window>(global_object).associated_document().browsing_context();
+    auto browsing_context = as<HTML::Window>(global_object).associated_document().browsing_context();
 
     // 2. If browsingContext is null, then return true.
     if (!browsing_context) {

--- a/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -16,8 +16,7 @@
 
 namespace Web::HTML {
 
-class BrowsingContext final : public JS::Cell
-    , public Weakable<BrowsingContext> {
+class BrowsingContext final : public JS::Cell {
     GC_CELL(BrowsingContext, JS::Cell);
     GC_DECLARE_ALLOCATOR(BrowsingContext);
 

--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -129,7 +129,7 @@ static CSSPixelPoint get_parent_offset(HTML::BrowsingContext const& browsing_con
     // 4. If parent navigable is not null:
     if (parent_navigable && parent_navigable->active_document() && parent_navigable->active_document()->browsing_context()) {
         // 1. Let parent context be parent navigable's document's browsing context.
-        auto* parent_context = parent_navigable->active_document()->browsing_context();
+        auto parent_context = parent_navigable->active_document()->browsing_context();
 
         // 2. Let (parentOffsetLeft, parentOffsetTop) be result of get parent offset of parent context.
         auto parent_offset = get_parent_offset(*parent_context);


### PR DESCRIPTION
Likely we forgot to update `WeakPtr` to `GC::Ptr` after converting `BrowsingContext` to GC-allocated object.