### PR TITLE
LibWeb: Implement the `path()` `<basic-shape>`

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -816,6 +816,7 @@ set(SOURCES
     Streams/WritableStreamOperations.cpp
     SVG/AttributeNames.cpp
     SVG/AttributeParser.cpp
+    SVG/Path.cpp
     SVG/SVGAElement.cpp
     SVG/SVGAnimatedEnumeration.cpp
     SVG/SVGAnimatedLength.cpp

--- a/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,6 +13,7 @@
 #include <LibWeb/CSS/LengthBox.h>
 #include <LibWeb/CSS/PercentageOr.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
+#include <LibWeb/SVG/AttributeParser.h>
 
 namespace Web::CSS {
 
@@ -89,8 +91,19 @@ struct Polygon {
     Vector<Point> points;
 };
 
-// FIXME: Implement path(). See: https://www.w3.org/TR/css-shapes-1/#basic-shape-functions
-using BasicShape = Variant<Inset, Xywh, Rect, Circle, Ellipse, Polygon>;
+// https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-path
+struct Path {
+    Gfx::Path to_path(CSSPixelRect reference_box, Layout::Node const&) const;
+    String to_string(SerializationMode) const;
+
+    bool operator==(Path const&) const = default;
+
+    Gfx::WindingRule fill_rule;
+    SVG::Path path_instructions;
+};
+
+// https://www.w3.org/TR/css-shapes-1/#basic-shape-functions
+using BasicShape = Variant<Inset, Xywh, Rect, Circle, Ellipse, Polygon, Path>;
 
 class BasicShapeStyleValue : public StyleValueWithDefaultOperators<BasicShapeStyleValue> {
 public:

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -969,6 +969,7 @@ struct StorageEndpoint;
 
 namespace Web::SVG {
 
+class Path;
 class SVGAnimatedEnumeration;
 class SVGAnimatedLength;
 class SVGAnimatedRect;

--- a/Libraries/LibWeb/HTML/Path2D.cpp
+++ b/Libraries/LibWeb/HTML/Path2D.cpp
@@ -11,7 +11,7 @@
 #include <LibWeb/Geometry/DOMMatrix.h>
 #include <LibWeb/HTML/Path2D.h>
 #include <LibWeb/SVG/AttributeParser.h>
-#include <LibWeb/SVG/SVGPathElement.h>
+#include <LibWeb/SVG/Path.h>
 
 namespace Web::HTML {
 
@@ -41,7 +41,7 @@ Path2D::Path2D(JS::Realm& realm, Optional<Variant<GC::Root<Path2D>, String>> con
 
     // 4. Let svgPath be the result of parsing and interpreting path according to SVG 2's rules for path data. [SVG]
     auto path_instructions = SVG::AttributeParser::parse_path_data(path->get<String>());
-    auto svg_path = SVG::path_from_path_instructions(path_instructions);
+    auto svg_path = path_instructions.to_gfx_path();
 
     if (!svg_path.is_empty()) {
         // 5. Let (x, y) be the last point in svgPath.

--- a/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -26,7 +26,7 @@ Optional<Vector<Transform>> AttributeParser::parse_transform(StringView input)
     return parser.parse_transform();
 }
 
-Vector<PathInstruction> AttributeParser::parse_path_data(StringView input)
+Path AttributeParser::parse_path_data(StringView input)
 {
     AttributeParser parser { input };
     parser.parse_whitespace();
@@ -37,9 +37,9 @@ Vector<PathInstruction> AttributeParser::parse_path_data(StringView input)
     }
     if (!parser.m_instructions.is_empty() && parser.m_instructions[0].type != PathInstructionType::Move) {
         // Invalid. "A path data segment (if there is one) must begin with a "moveto" command."
-        return {};
+        return Path { {} };
     }
-    return parser.m_instructions;
+    return Path { parser.m_instructions };
 }
 
 Optional<float> AttributeParser::parse_coordinate(StringView input)

--- a/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Libraries/LibWeb/SVG/AttributeParser.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
- * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,28 +12,9 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibGfx/Point.h>
+#include <LibWeb/SVG/Path.h>
 
 namespace Web::SVG {
-
-enum class PathInstructionType {
-    Move,
-    ClosePath,
-    Line,
-    HorizontalLine,
-    VerticalLine,
-    Curve,
-    SmoothCurve,
-    QuadraticBezierCurve,
-    SmoothQuadraticBezierCurve,
-    EllipticalArc,
-    Invalid,
-};
-
-struct PathInstruction {
-    PathInstructionType type;
-    bool absolute;
-    Vector<float> data;
-};
 
 struct Transform {
     struct Translate {
@@ -154,7 +135,7 @@ public:
     static Optional<NumberPercentage> parse_number_percentage(StringView input);
     static Optional<float> parse_positive_length(StringView input);
     static Vector<Gfx::FloatPoint> parse_points(StringView input);
-    static Vector<PathInstruction> parse_path_data(StringView input);
+    static Path parse_path_data(StringView input);
     static Optional<Vector<Transform>> parse_transform(StringView input);
     static Optional<PreserveAspectRatio> parse_preserve_aspect_ratio(StringView input);
     static Optional<SVGUnits> parse_units(StringView input);

--- a/Libraries/LibWeb/SVG/Path.cpp
+++ b/Libraries/LibWeb/SVG/Path.cpp
@@ -8,10 +8,53 @@
 
 #include <AK/Debug.h>
 #include <AK/Span.h>
+#include <AK/String.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/SVG/Path.h>
 
 namespace Web::SVG {
+
+void PathInstruction::serialize(StringBuilder& builder) const
+{
+    switch (type) {
+    case PathInstructionType::Move:
+        builder.append(absolute ? 'M' : 'm');
+        break;
+    case PathInstructionType::ClosePath:
+        // NB: This is always canonicalized as Z, not z.
+        builder.append('Z');
+        break;
+    case PathInstructionType::Line:
+        builder.append(absolute ? 'L' : 'l');
+        break;
+    case PathInstructionType::HorizontalLine:
+        builder.append(absolute ? 'H' : 'h');
+        break;
+    case PathInstructionType::VerticalLine:
+        builder.append(absolute ? 'V' : 'v');
+        break;
+    case PathInstructionType::Curve:
+        builder.append(absolute ? 'C' : 'c');
+        break;
+    case PathInstructionType::SmoothCurve:
+        builder.append(absolute ? 'S' : 's');
+        break;
+    case PathInstructionType::QuadraticBezierCurve:
+        builder.append(absolute ? 'Q' : 'q');
+        break;
+    case PathInstructionType::SmoothQuadraticBezierCurve:
+        builder.append(absolute ? 'T' : 't');
+        break;
+    case PathInstructionType::EllipticalArc:
+        builder.append(absolute ? 'A' : 'a');
+        break;
+    case PathInstructionType::Invalid:
+        break;
+    }
+
+    for (auto const& value : data)
+        builder.appendff(" {}", value);
+}
 
 void PathInstruction::dump() const
 {
@@ -243,6 +286,21 @@ Gfx::Path Path::to_gfx_path() const
     }
 
     return path;
+}
+
+String Path::serialize() const
+{
+    StringBuilder builder;
+    bool first = true;
+    for (auto const& instruction : m_instructions) {
+        if (first) {
+            first = false;
+        } else {
+            builder.append(' ');
+        }
+        instruction.serialize(builder);
+    }
+    return builder.to_string_without_validation();
 }
 
 }

--- a/Libraries/LibWeb/SVG/Path.cpp
+++ b/Libraries/LibWeb/SVG/Path.cpp
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <AK/Span.h>
+#include <LibGfx/Path.h>
+#include <LibWeb/SVG/Path.h>
+
+namespace Web::SVG {
+
+void PathInstruction::dump() const
+{
+    switch (type) {
+    case PathInstructionType::Move:
+        dbgln("Move (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); i += 2)
+            dbgln("    x={}, y={}", data[i], data[i + 1]);
+        break;
+    case PathInstructionType::ClosePath:
+        dbgln("ClosePath (absolute={})", absolute);
+        break;
+    case PathInstructionType::Line:
+        dbgln("Line (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); i += 2)
+            dbgln("    x={}, y={}", data[i], data[i + 1]);
+        break;
+    case PathInstructionType::HorizontalLine:
+        dbgln("HorizontalLine (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); ++i)
+            dbgln("    x={}", data[i]);
+        break;
+    case PathInstructionType::VerticalLine:
+        dbgln("VerticalLine (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); ++i)
+            dbgln("    y={}", data[i]);
+        break;
+    case PathInstructionType::Curve:
+        dbgln("Curve (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); i += 6)
+            dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3], data[i + 4], data[i + 5]);
+        break;
+    case PathInstructionType::SmoothCurve:
+        dbgln("SmoothCurve (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); i += 4)
+            dbgln("    (x2={}, y2={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3]);
+        break;
+    case PathInstructionType::QuadraticBezierCurve:
+        dbgln("QuadraticBezierCurve (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); i += 4)
+            dbgln("    (x1={}, y1={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3]);
+        break;
+    case PathInstructionType::SmoothQuadraticBezierCurve:
+        dbgln("SmoothQuadraticBezierCurve (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); i += 2)
+            dbgln("    x={}, y={}", data[i], data[i + 1]);
+        break;
+    case PathInstructionType::EllipticalArc:
+        dbgln("EllipticalArc (absolute={})", absolute);
+        for (size_t i = 0; i < data.size(); i += 7)
+            dbgln("    (rx={}, ry={}) x-axis-rotation={}, large-arc-flag={}, sweep-flag={}, (x={}, y={})",
+                data[i],
+                data[i + 1],
+                data[i + 2],
+                data[i + 3],
+                data[i + 4],
+                data[i + 5],
+                data[i + 6]);
+        break;
+    case PathInstructionType::Invalid:
+        dbgln("Invalid");
+        break;
+    }
+}
+
+Gfx::Path Path::to_gfx_path() const
+{
+    Gfx::Path path;
+    Optional<Gfx::FloatPoint> previous_control_point;
+    PathInstructionType last_instruction = PathInstructionType::Invalid;
+
+    for (auto& instruction : m_instructions) {
+        // If the first path element uses relative coordinates, we treat them as absolute by making them relative to (0, 0).
+        auto last_point = path.last_point();
+
+        auto& absolute = instruction.absolute;
+        auto& data = instruction.data;
+
+        if constexpr (PATH_DEBUG) {
+            instruction.dump();
+        }
+
+        bool clear_last_control_point = true;
+
+        switch (instruction.type) {
+        case PathInstructionType::Move: {
+            Gfx::FloatPoint point = { data[0], data[1] };
+            if (absolute) {
+                path.move_to(point);
+            } else {
+                path.move_to(point + last_point);
+            }
+            break;
+        }
+        case PathInstructionType::ClosePath:
+            path.close();
+            break;
+        case PathInstructionType::Line: {
+            Gfx::FloatPoint point = { data[0], data[1] };
+            if (absolute) {
+                path.line_to(point);
+            } else {
+                path.line_to(point + last_point);
+            }
+            break;
+        }
+        case PathInstructionType::HorizontalLine: {
+            if (absolute)
+                path.line_to(Gfx::FloatPoint { data[0], last_point.y() });
+            else
+                path.line_to(Gfx::FloatPoint { data[0] + last_point.x(), last_point.y() });
+            break;
+        }
+        case PathInstructionType::VerticalLine: {
+            if (absolute)
+                path.line_to(Gfx::FloatPoint { last_point.x(), data[0] });
+            else
+                path.line_to(Gfx::FloatPoint { last_point.x(), data[0] + last_point.y() });
+            break;
+        }
+        case PathInstructionType::EllipticalArc: {
+            double rx = data[0];
+            double ry = data[1];
+            double x_axis_rotation = AK::to_radians(static_cast<double>(data[2]));
+            double large_arc_flag = data[3];
+            double sweep_flag = data[4];
+
+            Gfx::FloatPoint next_point;
+
+            if (absolute)
+                next_point = { data[5], data[6] };
+            else
+                next_point = { data[5] + last_point.x(), data[6] + last_point.y() };
+
+            path.elliptical_arc_to(next_point, { rx, ry }, x_axis_rotation, large_arc_flag != 0, sweep_flag != 0);
+            break;
+        }
+        case PathInstructionType::QuadraticBezierCurve: {
+            clear_last_control_point = false;
+
+            Gfx::FloatPoint through = { data[0], data[1] };
+            Gfx::FloatPoint point = { data[2], data[3] };
+
+            if (absolute) {
+                path.quadratic_bezier_curve_to(through, point);
+                previous_control_point = through;
+            } else {
+                auto control_point = through + last_point;
+                path.quadratic_bezier_curve_to(control_point, point + last_point);
+                previous_control_point = control_point;
+            }
+            break;
+        }
+        case PathInstructionType::SmoothQuadraticBezierCurve: {
+            clear_last_control_point = false;
+
+            if (!previous_control_point.has_value()
+                || ((last_instruction != PathInstructionType::QuadraticBezierCurve) && (last_instruction != PathInstructionType::SmoothQuadraticBezierCurve))) {
+                previous_control_point = last_point;
+            }
+
+            auto dx_end_control = last_point.dx_relative_to(previous_control_point.value());
+            auto dy_end_control = last_point.dy_relative_to(previous_control_point.value());
+            auto control_point = Gfx::FloatPoint { last_point.x() + dx_end_control, last_point.y() + dy_end_control };
+
+            Gfx::FloatPoint end_point = { data[0], data[1] };
+
+            if (absolute) {
+                path.quadratic_bezier_curve_to(control_point, end_point);
+            } else {
+                path.quadratic_bezier_curve_to(control_point, end_point + last_point);
+            }
+
+            previous_control_point = control_point;
+            break;
+        }
+
+        case PathInstructionType::Curve: {
+            clear_last_control_point = false;
+
+            Gfx::FloatPoint c1 = { data[0], data[1] };
+            Gfx::FloatPoint c2 = { data[2], data[3] };
+            Gfx::FloatPoint p2 = { data[4], data[5] };
+            if (!absolute) {
+                p2 += last_point;
+                c1 += last_point;
+                c2 += last_point;
+            }
+            path.cubic_bezier_curve_to(c1, c2, p2);
+
+            previous_control_point = c2;
+            break;
+        }
+
+        case PathInstructionType::SmoothCurve: {
+            clear_last_control_point = false;
+
+            if (!previous_control_point.has_value()
+                || ((last_instruction != PathInstructionType::Curve) && (last_instruction != PathInstructionType::SmoothCurve))) {
+                previous_control_point = last_point;
+            }
+
+            // 9.5.2. Reflected control points https://svgwg.org/svg2-draft/paths.html#ReflectedControlPoints
+            // If the current point is (curx, cury) and the final control point of the previous path segment is (oldx2, oldy2),
+            // then the reflected point (i.e., (newx1, newy1), the first control point of the current path segment) is:
+            // (newx1, newy1) = (curx - (oldx2 - curx), cury - (oldy2 - cury))
+            auto reflected_previous_control_x = last_point.x() - previous_control_point.value().dx_relative_to(last_point);
+            auto reflected_previous_control_y = last_point.y() - previous_control_point.value().dy_relative_to(last_point);
+            Gfx::FloatPoint c1 = Gfx::FloatPoint { reflected_previous_control_x, reflected_previous_control_y };
+            Gfx::FloatPoint c2 = { data[0], data[1] };
+            Gfx::FloatPoint p2 = { data[2], data[3] };
+            if (!absolute) {
+                p2 += last_point;
+                c2 += last_point;
+            }
+            path.cubic_bezier_curve_to(c1, c2, p2);
+
+            previous_control_point = c2;
+            break;
+        }
+        case PathInstructionType::Invalid:
+            VERIFY_NOT_REACHED();
+        }
+
+        if (clear_last_control_point) {
+            previous_control_point = Gfx::FloatPoint {};
+        }
+        last_instruction = instruction.type;
+    }
+
+    return path;
+}
+
+}

--- a/Libraries/LibWeb/SVG/Path.h
+++ b/Libraries/LibWeb/SVG/Path.h
@@ -36,6 +36,8 @@ struct PathInstruction {
 
     bool operator==(PathInstruction const&) const = default;
 
+    void serialize(StringBuilder&) const;
+
     void dump() const;
 };
 
@@ -50,6 +52,7 @@ public:
     ReadonlySpan<PathInstruction> instructions() const { return m_instructions; }
 
     [[nodiscard]] Gfx::Path to_gfx_path() const;
+    String serialize() const;
 
     bool operator==(Path const&) const = default;
 

--- a/Libraries/LibWeb/SVG/Path.h
+++ b/Libraries/LibWeb/SVG/Path.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Span.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibGfx/Forward.h>
+
+namespace Web::SVG {
+
+enum class PathInstructionType : u8 {
+    Move,
+    ClosePath,
+    Line,
+    HorizontalLine,
+    VerticalLine,
+    Curve,
+    SmoothCurve,
+    QuadraticBezierCurve,
+    SmoothQuadraticBezierCurve,
+    EllipticalArc,
+    Invalid,
+};
+
+struct PathInstruction {
+    PathInstructionType type;
+    bool absolute;
+    Vector<float> data;
+
+    bool operator==(PathInstruction const&) const = default;
+
+    void dump() const;
+};
+
+class Path {
+public:
+    Path() = default;
+
+    explicit Path(Vector<PathInstruction> instructions)
+        : m_instructions(move(instructions))
+    {
+    }
+    ReadonlySpan<PathInstruction> instructions() const { return m_instructions; }
+
+    [[nodiscard]] Gfx::Path to_gfx_path() const;
+
+    bool operator==(Path const&) const = default;
+
+private:
+    Vector<PathInstruction> m_instructions;
+};
+
+}

--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/Optional.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/Bindings/SVGPathElementPrototype.h>
@@ -16,74 +15,6 @@
 namespace Web::SVG {
 
 GC_DEFINE_ALLOCATOR(SVGPathElement);
-
-[[maybe_unused]] static void print_instruction(PathInstruction const& instruction)
-{
-    VERIFY(PATH_DEBUG);
-
-    auto& data = instruction.data;
-
-    switch (instruction.type) {
-    case PathInstructionType::Move:
-        dbgln("Move (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); i += 2)
-            dbgln("    x={}, y={}", data[i], data[i + 1]);
-        break;
-    case PathInstructionType::ClosePath:
-        dbgln("ClosePath (absolute={})", instruction.absolute);
-        break;
-    case PathInstructionType::Line:
-        dbgln("Line (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); i += 2)
-            dbgln("    x={}, y={}", data[i], data[i + 1]);
-        break;
-    case PathInstructionType::HorizontalLine:
-        dbgln("HorizontalLine (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); ++i)
-            dbgln("    x={}", data[i]);
-        break;
-    case PathInstructionType::VerticalLine:
-        dbgln("VerticalLine (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); ++i)
-            dbgln("    y={}", data[i]);
-        break;
-    case PathInstructionType::Curve:
-        dbgln("Curve (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); i += 6)
-            dbgln("    (x1={}, y1={}, x2={}, y2={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3], data[i + 4], data[i + 5]);
-        break;
-    case PathInstructionType::SmoothCurve:
-        dbgln("SmoothCurve (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); i += 4)
-            dbgln("    (x2={}, y2={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3]);
-        break;
-    case PathInstructionType::QuadraticBezierCurve:
-        dbgln("QuadraticBezierCurve (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); i += 4)
-            dbgln("    (x1={}, y1={}), (x={}, y={})", data[i], data[i + 1], data[i + 2], data[i + 3]);
-        break;
-    case PathInstructionType::SmoothQuadraticBezierCurve:
-        dbgln("SmoothQuadraticBezierCurve (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); i += 2)
-            dbgln("    x={}, y={}", data[i], data[i + 1]);
-        break;
-    case PathInstructionType::EllipticalArc:
-        dbgln("EllipticalArc (absolute={})", instruction.absolute);
-        for (size_t i = 0; i < data.size(); i += 7)
-            dbgln("    (rx={}, ry={}) x-axis-rotation={}, large-arc-flag={}, sweep-flag={}, (x={}, y={})",
-                data[i],
-                data[i + 1],
-                data[i + 2],
-                data[i + 3],
-                data[i + 4],
-                data[i + 5],
-                data[i + 6]);
-        break;
-    case PathInstructionType::Invalid:
-        dbgln("Invalid");
-        break;
-    }
-}
 
 SVGPathElement::SVGPathElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGeometryElement(document, move(qualified_name))
@@ -101,180 +32,12 @@ void SVGPathElement::attribute_changed(FlyString const& name, Optional<String> c
     Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == "d")
-        m_instructions = AttributeParser::parse_path_data(value.value_or(String {}));
-}
-
-Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction> instructions)
-{
-    Gfx::Path path;
-    Optional<Gfx::FloatPoint> previous_control_point;
-    PathInstructionType last_instruction = PathInstructionType::Invalid;
-
-    for (auto& instruction : instructions) {
-        // If the first path element uses relative coordinates, we treat them as absolute by making them relative to (0, 0).
-        auto last_point = path.last_point();
-
-        auto& absolute = instruction.absolute;
-        auto& data = instruction.data;
-
-        if constexpr (PATH_DEBUG) {
-            print_instruction(instruction);
-        }
-
-        bool clear_last_control_point = true;
-
-        switch (instruction.type) {
-        case PathInstructionType::Move: {
-            Gfx::FloatPoint point = { data[0], data[1] };
-            if (absolute) {
-                path.move_to(point);
-            } else {
-                path.move_to(point + last_point);
-            }
-            break;
-        }
-        case PathInstructionType::ClosePath:
-            path.close();
-            break;
-        case PathInstructionType::Line: {
-            Gfx::FloatPoint point = { data[0], data[1] };
-            if (absolute) {
-                path.line_to(point);
-            } else {
-                path.line_to(point + last_point);
-            }
-            break;
-        }
-        case PathInstructionType::HorizontalLine: {
-            if (absolute)
-                path.line_to(Gfx::FloatPoint { data[0], last_point.y() });
-            else
-                path.line_to(Gfx::FloatPoint { data[0] + last_point.x(), last_point.y() });
-            break;
-        }
-        case PathInstructionType::VerticalLine: {
-            if (absolute)
-                path.line_to(Gfx::FloatPoint { last_point.x(), data[0] });
-            else
-                path.line_to(Gfx::FloatPoint { last_point.x(), data[0] + last_point.y() });
-            break;
-        }
-        case PathInstructionType::EllipticalArc: {
-            double rx = data[0];
-            double ry = data[1];
-            double x_axis_rotation = AK::to_radians(static_cast<double>(data[2]));
-            double large_arc_flag = data[3];
-            double sweep_flag = data[4];
-
-            Gfx::FloatPoint next_point;
-
-            if (absolute)
-                next_point = { data[5], data[6] };
-            else
-                next_point = { data[5] + last_point.x(), data[6] + last_point.y() };
-
-            path.elliptical_arc_to(next_point, { rx, ry }, x_axis_rotation, large_arc_flag != 0, sweep_flag != 0);
-            break;
-        }
-        case PathInstructionType::QuadraticBezierCurve: {
-            clear_last_control_point = false;
-
-            Gfx::FloatPoint through = { data[0], data[1] };
-            Gfx::FloatPoint point = { data[2], data[3] };
-
-            if (absolute) {
-                path.quadratic_bezier_curve_to(through, point);
-                previous_control_point = through;
-            } else {
-                auto control_point = through + last_point;
-                path.quadratic_bezier_curve_to(control_point, point + last_point);
-                previous_control_point = control_point;
-            }
-            break;
-        }
-        case PathInstructionType::SmoothQuadraticBezierCurve: {
-            clear_last_control_point = false;
-
-            if (!previous_control_point.has_value()
-                || ((last_instruction != PathInstructionType::QuadraticBezierCurve) && (last_instruction != PathInstructionType::SmoothQuadraticBezierCurve))) {
-                previous_control_point = last_point;
-            }
-
-            auto dx_end_control = last_point.dx_relative_to(previous_control_point.value());
-            auto dy_end_control = last_point.dy_relative_to(previous_control_point.value());
-            auto control_point = Gfx::FloatPoint { last_point.x() + dx_end_control, last_point.y() + dy_end_control };
-
-            Gfx::FloatPoint end_point = { data[0], data[1] };
-
-            if (absolute) {
-                path.quadratic_bezier_curve_to(control_point, end_point);
-            } else {
-                path.quadratic_bezier_curve_to(control_point, end_point + last_point);
-            }
-
-            previous_control_point = control_point;
-            break;
-        }
-
-        case PathInstructionType::Curve: {
-            clear_last_control_point = false;
-
-            Gfx::FloatPoint c1 = { data[0], data[1] };
-            Gfx::FloatPoint c2 = { data[2], data[3] };
-            Gfx::FloatPoint p2 = { data[4], data[5] };
-            if (!absolute) {
-                p2 += last_point;
-                c1 += last_point;
-                c2 += last_point;
-            }
-            path.cubic_bezier_curve_to(c1, c2, p2);
-
-            previous_control_point = c2;
-            break;
-        }
-
-        case PathInstructionType::SmoothCurve: {
-            clear_last_control_point = false;
-
-            if (!previous_control_point.has_value()
-                || ((last_instruction != PathInstructionType::Curve) && (last_instruction != PathInstructionType::SmoothCurve))) {
-                previous_control_point = last_point;
-            }
-
-            // 9.5.2. Reflected control points https://svgwg.org/svg2-draft/paths.html#ReflectedControlPoints
-            // If the current point is (curx, cury) and the final control point of the previous path segment is (oldx2, oldy2),
-            // then the reflected point (i.e., (newx1, newy1), the first control point of the current path segment) is:
-            // (newx1, newy1) = (curx - (oldx2 - curx), cury - (oldy2 - cury))
-            auto reflected_previous_control_x = last_point.x() - previous_control_point.value().dx_relative_to(last_point);
-            auto reflected_previous_control_y = last_point.y() - previous_control_point.value().dy_relative_to(last_point);
-            Gfx::FloatPoint c1 = Gfx::FloatPoint { reflected_previous_control_x, reflected_previous_control_y };
-            Gfx::FloatPoint c2 = { data[0], data[1] };
-            Gfx::FloatPoint p2 = { data[2], data[3] };
-            if (!absolute) {
-                p2 += last_point;
-                c2 += last_point;
-            }
-            path.cubic_bezier_curve_to(c1, c2, p2);
-
-            previous_control_point = c2;
-            break;
-        }
-        case PathInstructionType::Invalid:
-            VERIFY_NOT_REACHED();
-        }
-
-        if (clear_last_control_point) {
-            previous_control_point = Gfx::FloatPoint {};
-        }
-        last_instruction = instruction.type;
-    }
-
-    return path;
+        m_path = AttributeParser::parse_path_data(value.value_or(String {}));
 }
 
 Gfx::Path SVGPathElement::get_path(CSSPixelSize)
 {
-    return path_from_path_instructions(m_instructions);
+    return m_path.to_gfx_path();
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -6,9 +6,7 @@
 
 #pragma once
 
-#include <LibGfx/Bitmap.h>
-#include <LibWeb/HTML/HTMLElement.h>
-#include <LibWeb/SVG/AttributeParser.h>
+#include <LibWeb/SVG/Path.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 
 namespace Web::SVG {
@@ -29,9 +27,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    Vector<PathInstruction> m_instructions;
+    Path m_path {};
 };
-
-[[nodiscard]] Gfx::Path path_from_path_instructions(ReadonlySpan<PathInstruction>);
 
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-computed.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Fail
+Fail	Property clip-path value 'path(nonzero, 'M10,10h80v80h-80zM25,25h50v50h-50z')'
+Fail	Property clip-path value 'path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')'
+Fail	Property clip-path value 'path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-computed.txt
@@ -2,7 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-3 Fail
-Fail	Property clip-path value 'path(nonzero, 'M10,10h80v80h-80zM25,25h50v50h-50z')'
-Fail	Property clip-path value 'path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')'
-Fail	Property clip-path value 'path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')'
+3 Pass
+Pass	Property clip-path value 'path(nonzero, 'M10,10h80v80h-80zM25,25h50v50h-50z')'
+Pass	Property clip-path value 'path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')'
+Pass	Property clip-path value 'path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-invalid.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	e.style['clip-path'] = "path(evenodd, 'not-a-path')" should not set the property value
+Pass	e.style['clip-path'] = "path(badfillrule, 'M10,10')" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-valid.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Fail
+Fail	e.style['clip-path'] = "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')" should set the property value
+Fail	e.style['clip-path'] = "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-shapes/shape-functions/path-function-valid.txt
@@ -2,6 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	e.style['clip-path'] = "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')" should set the property value
-Fail	e.style['clip-path'] = "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')" should set the property value
+2 Pass
+Pass	e.style['clip-path'] = "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')" should set the property value
+Pass	e.style['clip-path'] = "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')" should set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-shapes/shape-functions/path-function-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-shapes/shape-functions/path-function-computed.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Shapes Module Level 1: the computed value of the path() function</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-path">
+<meta name="assert" content="Tests parsing of the path() function">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("clip-path", "path(nonzero, 'M10,10h80v80h-80zM25,25h50v50h-50z')", "path(\"M 10 10 h 80 v 80 h -80 Z M 25 25 h 50 v 50 h -50 Z\")");
+test_computed_value("clip-path", "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')", "path(evenodd, \"M 10 10 h 80 v 80 h -80 Z M 25 25 h 50 v 50 h -50 Z\")");
+test_computed_value("clip-path", "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')", "path(evenodd, \"M 10 10 h 80 v 80 h -80 Z M 25 25 h 50 v 50 h -50\")");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-shapes/shape-functions/path-function-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-shapes/shape-functions/path-function-invalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Shapes Module Level 1: parsing the path() function</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-path">
+<meta name="assert" content="Tests parsing of the path() function">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("clip-path", "path(evenodd, 'not-a-path')");
+test_invalid_value("clip-path", "path(badfillrule, 'M10,10')");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-shapes/shape-functions/path-function-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-shapes/shape-functions/path-function-valid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Shapes Module Level 1: parsing the path() function</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-path">
+<meta name="assert" content="Tests parsing of the path() function">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("clip-path", "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50z')", "path(evenodd, \"M 10 10 h 80 v 80 h -80 Z M 25 25 h 50 v 50 h -50 Z\")");
+test_valid_value("clip-path", "path(evenodd, 'M10,10h80v80h-80zM25,25h50v50h-50')", "path(evenodd, \"M 10 10 h 80 v 80 h -80 Z M 25 25 h 50 v 50 h -50\")");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This lets authors specify a shape (such as a `clip-path`) using an SVG path string.

<img width="737" height="535" alt="Screenshot_20250717_170028" src="https://github.com/user-attachments/assets/fc6d30a6-6ded-4af8-afb2-8834d1596700" />

WPT has 3 ref-tests for this. 2 of them fail because we don't render `<clipPath>` properly, and the third seemed to not apply `clip-path` to a `<g>` element? Needs more investigation.