### PR TITLE
LibWebView: Don't provide autocomplete suggestions for file:// URLs

### DIFF
--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -18,6 +18,8 @@
 
 namespace WebView {
 
+static constexpr auto file_url_prefix = "file://"sv;
+
 static constexpr auto builtin_autocomplete_engines = to_array<AutocompleteEngine>({
     { "DuckDuckGo"sv, "https://duckduckgo.com/ac/?q={}"sv },
     { "Google"sv, "https://www.google.com/complete/search?client=chrome&q={}"sv },
@@ -46,7 +48,8 @@ void Autocomplete::query_autocomplete_engine(String query)
         m_request.clear();
     }
 
-    if (query.bytes_as_string_view().trim_whitespace().is_empty()) {
+    auto trimmed_query = query.bytes_as_string_view().trim_whitespace();
+    if (trimmed_query.is_empty() || trimmed_query.starts_with(file_url_prefix)) {
         invoke_autocomplete_query_complete({});
         return;
     }


### PR DESCRIPTION
 ## Summary
  This PR fixes #5493 by preventing autocomplete suggestions when typing file:// URLs in the address bar.

  ## Changes
  - Added a check to return early with empty suggestions when the query starts with "file://"

## Testing
  - Typing "file://" or any file URL (e.g., "file:///home/user") shows no suggestions
  - Regular URLs continue to show autocomplete suggestions as normal

  Fixes #5493