### PR TITLE
LibWeb: Handle flood-opacity closer to spec

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -830,6 +830,10 @@ RefPtr<CSSStyleValue const> CSSStyleProperties::style_value_for_computed_propert
         auto opacity = layout_node.computed_values().stroke_opacity();
         return NumberStyleValue::create(opacity);
     }
+    case PropertyID::FloodOpacity: {
+        auto opacity = layout_node.computed_values().flood_opacity();
+        return NumberStyleValue::create(opacity);
+    }
     case PropertyID::OutlineWidth: {
         auto outline_width = layout_node.computed_values().outline_width();
         return LengthStyleValue::create(outline_width);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -662,6 +662,7 @@ Parser::ParseErrorOr<NonnullRefPtr<CSSStyleValue const>> Parser::parse_css_value
         return ParseError::SyntaxError;
     case PropertyID::Opacity:
     case PropertyID::FillOpacity:
+    case PropertyID::FloodOpacity:
     case PropertyID::StopOpacity:
     case PropertyID::StrokeOpacity:
         if (auto parsed_value = parse_opacity_value(property_id, tokens); parsed_value && !tokens.has_next_token())

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1561,7 +1561,8 @@
     "inherited": false,
     "initial": "1",
     "valid-types": [
-      "number [0,1]"
+      "number [-∞,∞]",
+      "percentage [-∞,∞]"
     ]
   },
   "font": {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -671,6 +671,9 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     if (computed_style.filter().has_filters())
         computed_values.set_filter(resolve_filter(computed_style.filter()));
 
+    computed_values.set_flood_color(computed_style.flood_color(*this));
+    computed_values.set_flood_opacity(computed_style.flood_opacity());
+
     computed_values.set_justify_content(computed_style.justify_content());
     computed_values.set_justify_items(computed_style.justify_items());
     computed_values.set_justify_self(computed_style.justify_self());

--- a/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/flood-opacity-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/flood-opacity-computed.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 8 tests
+
+6 Pass
+2 Fail
+Pass	Property flood-opacity value '-1'
+Pass	Property flood-opacity value '0.5'
+Pass	Property flood-opacity value '3'
+Pass	Property flood-opacity value '-100%'
+Pass	Property flood-opacity value '50%'
+Pass	Property flood-opacity value '300%'
+Fail	Property flood-opacity value 'calc(0.5 * sign(10em - 1px))'
+Fail	Property flood-opacity value 'calc(50% * sign(10em - 1px))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/flood-opacity-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/flood-opacity-valid.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 7 tests
+
+7 Pass
+Pass	e.style['flood-opacity'] = "-1" should set the property value
+Pass	e.style['flood-opacity'] = "0.5" should set the property value
+Pass	e.style['flood-opacity'] = "3" should set the property value
+Pass	e.style['flood-opacity'] = "-100%" should set the property value
+Pass	e.style['flood-opacity'] = "50%" should set the property value
+Pass	e.style['flood-opacity'] = "300%" should set the property value
+Pass	e.style['flood-opacity'] = "calc(0.5 * sign(10em - 1px))" should set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/flood-opacity-computed.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/flood-opacity-computed.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>Filter Effects Module Level 1: getComputedStyle().floodOpacity</title>
+  <metadata>
+    <h:link rel="help" href="https://drafts.fxtf.org/filter-effects/#propdef-flood-opacity"/>
+    <h:meta name="assert" content="flood-opacity computed value is clamped to the range [0,1]."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/computed-testcommon.js"/>
+  <script><![CDATA[
+
+test_computed_value("flood-opacity", "-1", "0");
+test_computed_value("flood-opacity", "0.5");
+test_computed_value("flood-opacity", "3", "1");
+test_computed_value("flood-opacity", "-100%", "0");
+test_computed_value("flood-opacity", "50%", "0.5");
+test_computed_value("flood-opacity", "300%", "1");
+test_computed_value("flood-opacity", "calc(0.5 * sign(10em - 1px))", "0.5");
+test_computed_value("flood-opacity", "calc(50% * sign(10em - 1px))", "0.5");
+
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/flood-opacity-valid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/flood-opacity-valid.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>Filter Effects Module Level 1: parsing flood-opacity with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://drafts.fxtf.org/filter-effects/#propdef-flood-opacity"/>
+    <h:meta name="assert" content="flood-opacity supports the full grammar 'alpha-value'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("flood-opacity", "-1");
+test_valid_value("flood-opacity", "0.5");
+test_valid_value("flood-opacity", "3");
+test_valid_value("flood-opacity", "-100%", "-1");
+test_valid_value("flood-opacity", "50%", "0.5");
+test_valid_value("flood-opacity", "300%", "3");
+test_valid_value("flood-opacity", "calc(0.5 * sign(10em - 1px))");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
We now do the proper thing in terms of:
  - Allowing percentages
  - Returning the computed value in getComputedStyle
  - Handling values out of the [0,1] range

Gains us 13 WPT passes in the imported tests.