### PR TITLE
LibWeb: Implement stacking context rules for SVG elements

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -164,7 +164,6 @@ public:
     virtual bool is_shadow_root() const { return false; }
 
     virtual bool requires_svg_container() const { return false; }
-    virtual bool is_svg_container() const { return false; }
     virtual bool is_svg_element() const { return false; }
     virtual bool is_svg_graphics_element() const { return false; }
     virtual bool is_svg_script_element() const { return false; }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -166,12 +166,24 @@ public:
     virtual bool requires_svg_container() const { return false; }
     virtual bool is_svg_element() const { return false; }
     virtual bool is_svg_graphics_element() const { return false; }
+    virtual bool is_svg_container_element() const { return false; }
+
+    virtual bool is_svg_a_element() const { return false; }
+    virtual bool is_svg_clip_path_element() const { return false; }
+    virtual bool is_svg_defs_element() const { return false; }
+    virtual bool is_svg_foreign_object_element() const { return false; }
+    virtual bool is_svg_g_element() const { return false; }
+    virtual bool is_svg_image_element() const { return false; }
+    virtual bool is_svg_marker_element() const { return false; }
+    virtual bool is_svg_mask_element() const { return false; }
+    virtual bool is_svg_pattern_element() const { return false; }
+    virtual bool is_svg_symbol_element() const { return false; }
     virtual bool is_svg_script_element() const { return false; }
     virtual bool is_svg_style_element() const { return false; }
     virtual bool is_svg_svg_element() const { return false; }
+    virtual bool is_svg_switch_element() const { return false; }
+    virtual bool is_svg_unknown_element() const { return false; }
     virtual bool is_svg_use_element() const { return false; }
-    virtual bool is_svg_a_element() const { return false; }
-    virtual bool is_svg_foreign_object_element() const { return false; }
 
     bool in_a_document_tree() const;
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -470,7 +470,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         }
     };
 
-    if (dom_node.is_svg_container()) {
+    if (dom_node.is_svg_svg_element()) {
         has_svg_root_change.emplace(context.has_svg_root, true);
     } else if (dom_node.requires_svg_container() && !context.has_svg_root) {
         return;

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.h
@@ -46,8 +46,16 @@ public:
 private:
     SVGClipPathElement(DOM::Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
+    virtual bool is_svg_clip_path_element() const override { return true; }
 
     Optional<ClipPathUnits> m_clip_path_units = {};
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGClipPathElement>() const { return is_svg_clip_path_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGDefsElement.h
+++ b/Libraries/LibWeb/SVG/SVGDefsElement.h
@@ -26,6 +26,14 @@ private:
     SVGDefsElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual bool is_svg_defs_element() const override { return true; }
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGDefsElement>() const { return is_svg_defs_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -302,4 +302,21 @@ GC::Ref<SVGAnimatedLength> SVGElement::svg_animated_length_for_property(CSS::Pro
     return SVGAnimatedLength::create(realm(), make_length(), make_length());
 }
 
+// https://svgwg.org/svg2-draft/struct.html#container-element
+bool SVGElement::is_svg_container_element() const
+{
+    // An element which can have graphics elements and other container elements as child elements.
+    // Specifically: ‘a’, ‘clipPath’, ‘defs’, ‘g’, ‘marker’, ‘mask’, ‘pattern’, ‘svg’, ‘switch’ and ‘symbol’.
+    return is_svg_a_element()
+        || is_svg_clip_path_element()
+        || is_svg_defs_element()
+        || is_svg_g_element()
+        || is_svg_marker_element()
+        || is_svg_mask_element()
+        || is_svg_pattern_element()
+        || is_svg_svg_element()
+        || is_svg_switch_element()
+        || is_svg_symbol_element();
+}
+
 }

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -54,6 +54,7 @@ private:
     virtual GC::Ptr<DOM::EventTarget> global_event_handlers_to_event_target(FlyString const&) override { return *this; }
 
     virtual bool is_svg_element() const final { return true; }
+    virtual bool is_svg_container_element() const override;
 
     GC::Ptr<SVGAnimatedString> m_class_name_animated_string;
 };

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -34,6 +34,9 @@ public:
     virtual bool is_presentational_hint(FlyString const&) const override;
     virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
 
+    bool property_applies_to(CSS::PropertyID) const;
+    bool establishes_a_new_viewport() const;
+
 protected:
     SVGElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/SVG/SVGGElement.h
+++ b/Libraries/LibWeb/SVG/SVGGElement.h
@@ -23,6 +23,14 @@ private:
     SVGGElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual bool is_svg_g_element() const override { return true; }
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGGElement>() const { return is_svg_g_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -49,6 +49,7 @@ protected:
 
 private:
     virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual bool is_svg_image_element() const override { return true; }
     void animate();
 
     GC::Ptr<SVG::SVGAnimatedLength> m_x;
@@ -65,5 +66,12 @@ private:
     GC::Ptr<HTML::SharedResourceRequest> m_resource_request;
     Optional<DOM::DocumentLoadEventDelayer> m_load_event_delayer;
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGImageElement>() const { return is_svg_image_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -48,9 +48,17 @@ public:
 private:
     SVGMaskElement(DOM::Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
+    virtual bool is_svg_mask_element() const override { return true; }
 
     Optional<MaskContentUnits> m_mask_content_units = {};
     Optional<MaskUnits> m_mask_units = {};
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGMaskElement>() const { return is_svg_mask_element(); }
 
 }

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -32,7 +32,6 @@ public:
     virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
 
     virtual bool requires_svg_container() const override { return false; }
-    virtual bool is_svg_container() const override { return true; }
 
     virtual Optional<ViewBox> view_box() const override;
     virtual Optional<PreserveAspectRatio> preserve_aspect_ratio() const override { return m_preserve_aspect_ratio; }

--- a/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -39,3 +39,10 @@ private:
 };
 
 }
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGStyleElement>() const { return is_svg_style_element(); }
+
+}

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -36,6 +36,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual bool is_svg_symbol_element() const override { return true; }
 
     virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
 
@@ -47,5 +48,12 @@ private:
 
     GC::Ptr<SVGAnimatedRect> m_view_box_for_bindings;
 };
+
+}
+
+namespace Web::DOM {
+
+template<>
+inline bool Node::fast_is<SVG::SVGSymbolElement>() const { return is_svg_symbol_element(); }
 
 }

--- a/Tests/LibWeb/Layout/expected/HTMLSelectElement-selected-index.txt
+++ b/Tests/LibWeb/Layout/expected/HTMLSelectElement-selected-index.txt
@@ -27,4 +27,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               SVGPathPaintable (SVGGeometryBox<path>) [79.390625,16.71875 8x4.953125]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x38] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x38] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [75.390625,11 16x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -42,4 +42,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,282 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x290] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x290] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [9,9 300x150] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/css-namespace-universal-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-universal-selector.txt
@@ -22,4 +22,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,332 784x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x340] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x340] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [18,18 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.txt
@@ -11,4 +11,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<rect>) [8,8 100x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
@@ -11,4 +11,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<rect>) [0,0 200x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x100] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x100] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [0,0 200x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
@@ -11,4 +11,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
         SVGPathPaintable (SVGGeometryBox<rect>) [8,8 392x392]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x800] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x800] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x784] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/no-stretch-fit-width-for-item-that-can-resolve-aspect-ratio-through-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/no-stretch-fit-width-for-item-that-can-resolve-aspect-ratio-through-height.txt
@@ -14,4 +14,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<DIV>) [28,8 100x20]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x36] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x36] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 20x20] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.txt
@@ -13,4 +13,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
         SVGPathPaintable (SVGGeometryBox<rect>) [8,8 392x392]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x800] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x800] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x784] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-percentage-max-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-percentage-max-size.txt
@@ -17,4 +17,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               SVGPathPaintable (SVGGeometryBox<rect>) [8,8 100x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg>.c-ico [8,8 100x100] [children: 1] (z-index: auto)
+   SC for SVGGraphicsBox<use> [8,8 100x100] [children: 1] (z-index: auto)
+    SC for SVGGraphicsBox<symbol>#icon-cart [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/simple-update-inside-svg-subtree.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/simple-update-inside-svg-subtree.txt
@@ -17,4 +17,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableWithLines (InlineNode<set>#set) [8,8 0x18]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x166] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x166] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 300x150] [children: 1] (z-index: auto)
+   SC for SVGGraphicsBox<symbol> [8,8 300x150] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
+++ b/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
@@ -26,4 +26,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               SVGPathPaintable (SVGGeometryBox<path>) [90.109375,16.71875 8x4.953125]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x38] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x38] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [86.109375,11 16x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/svg-preserve-aspect-ratio.txt
@@ -144,4 +144,17 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<circle>) [249,201 160x60]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x274] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x274] [children: 13] (z-index: auto)
+  SC for SVGSVGBox<svg> [9,84 100x50] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [119,84 100x50] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [229,84 100x50] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [339,84 100x50] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [449,84 100x50] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [559,84 100x50] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [669,9 50x125] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [729,9 50x125] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [9,136 50x125] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [69,136 50x125] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [129,136 50x125] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [189,136 50x125] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [249,201 160x60] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg-text-with-percentage-values.txt
+++ b/Tests/LibWeb/Layout/expected/svg-text-with-percentage-values.txt
@@ -29,4 +29,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGTextBox<text>.Rrrrr) [249.828125,56.546875 514.125x106.03125]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x277.328125] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x277.328125] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x261.328125] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg-text-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg-text-with-viewbox.txt
@@ -29,4 +29,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGTextBox<text>.Rrrrr) [226.96875,92.46875 514.125x106.03125]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x277.328125] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x277.328125] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x261.328125] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
+++ b/Tests/LibWeb/Layout/expected/svg-transforms-and-viewboxes.txt
@@ -129,4 +129,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x700]
         SVGPathPaintable (SVGGeometryBox<rect>) [160,560 80x80]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x700] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x700] [children: 7] (z-index: auto)
+  SC for SVGSVGBox<svg> [50,150 200x100] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [258,50 200x200] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [466,50 200x200] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [50,250 200x200] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [258,250 200x200] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [466,250 200x200] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [50,450 200x200] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/abspos-svg-polygon.txt
+++ b/Tests/LibWeb/Layout/expected/svg/abspos-svg-polygon.txt
@@ -14,4 +14,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           SVGPathPaintable (SVGGeometryBox<polygon>) [48,18 120x170]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x216] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x216] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 200x200] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
+++ b/Tests/LibWeb/Layout/expected/svg/dont-stretch-fit-svg-with-indefinite-containing-block-width.txt
@@ -10,4 +10,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,21 0x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x34] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,21 0x0] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/foreignObject-and-mask-with-different-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/foreignObject-and-mask-with-different-viewbox.txt
@@ -18,5 +18,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 808x808]
           PaintableWithLines (BlockContainer<DIV>#lol) [8,8 100x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
-  SC for SVGForeignObjectBox<foreignObject> [8,8 40x40] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 2] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 800x800] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 1] (z-index: auto)
+   SC for SVGForeignObjectBox<foreignObject> [8,8 40x40] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/foreignObject-simple.txt
+++ b/Tests/LibWeb/Layout/expected/svg/foreignObject-simple.txt
@@ -17,4 +17,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x64] [children: 1] (z-index: auto)
-  SC for SVGForeignObjectBox<foreignObject> [8,8 30x30] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 48x48] [children: 1] (z-index: auto)
+   SC for SVGForeignObjectBox<foreignObject> [8,8 30x30] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/foreignObject-with-abspos-descendant.txt
+++ b/Tests/LibWeb/Layout/expected/svg/foreignObject-with-abspos-descendant.txt
@@ -25,4 +25,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x166] [children: 1] (z-index: auto)
-  SC for SVGForeignObjectBox<foreignObject> [8,8 100x200] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 300x150] [children: 1] (z-index: auto)
+   SC for SVGForeignObjectBox<foreignObject> [8,8 100x200] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/foreignObject-with-mask.txt
+++ b/Tests/LibWeb/Layout/expected/svg/foreignObject-with-mask.txt
@@ -26,4 +26,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x64] [children: 1] (z-index: auto)
-  SC for SVGForeignObjectBox<foreignObject> [26,36 40x40] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 48x48] [children: 1] (z-index: auto)
+   SC for SVGForeignObjectBox<foreignObject> [26,36 40x40] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/inline-svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/inline-svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -22,4 +22,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<rect>) [16,21 1x1]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x34] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [16,21 0x0] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/natural-width-from-svg-attributes.txt
+++ b/Tests/LibWeb/Layout/expected/svg/natural-width-from-svg-attributes.txt
@@ -14,4 +14,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,72 128x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x144] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x144] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 64x64] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
+++ b/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
@@ -26,4 +26,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             SVGPathPaintable (SVGGeometryBox<rect>) [34.671875,34.671875 133.328125x133.328125]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x216] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x216] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg>#a [8,8 200x200] [children: 1] (z-index: auto)
+   SC for SVGSVGBox<svg>#b [8,8 200x200] [children: 1] (z-index: auto)
+    SC for SVGSVGBox<svg>#c [8,8 266.671875x266.671875] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
+++ b/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
@@ -31,4 +31,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<rect>) [208,208 200x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x416] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x416] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 400x400] [children: 2] (z-index: auto)
+   SC for SVGGeometryBox<rect> [8,8 200x200] [children: 0] (z-index: auto)
+   SC for SVGGeometryBox<rect> [208,208 200x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-h.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-h.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,172 128x256]
       SVGPathPaintable (SVGGeometryBox<path>) [0,172 128x256]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x600] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-h.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-h.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x600] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-w.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-w.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x256] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-wh.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-wh.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x600] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x256] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-w.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-w.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [336,0 128x256]
       SVGPathPaintable (SVGGeometryBox<path>) [336,0 128x256]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x256] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-wh.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-wh.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [250,0 300x600]
       SVGPathPaintable (SVGGeometryBox<path>) [250,0 300x600]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x600] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone.txt
@@ -16,4 +16,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 128x256]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 128x256]
 
-SC for Viewport<#document> [0,0 800x600] [children: 0] (z-index: auto)
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x256] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-circle-percentage-attr.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-circle-percentage-attr.txt
@@ -13,4 +13,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<circle>) [250,28 300x300]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x366] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x366] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x350] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-different-types-of-opacity.txt
@@ -15,4 +15,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
         SVGPathPaintable (SVGGeometryBox<circle>) [47.203125,47.203125 548.796875x548.796875]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x800] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x800] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x784] [children: 1] (z-index: auto)
+   SC for SVGGeometryBox<circle> [47.203125,47.203125 548.796875x548.796875] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
@@ -12,4 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
         SVGPathPaintable (SVGGeometryBox<rect>) [8,8 784x784]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x800] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x800] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x784] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-foreign-object-with-block-element.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-foreign-object-with-block-element.txt
@@ -19,4 +19,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
-  SC for SVGForeignObjectBox<foreignObject> [8,8 100x100] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 1] (z-index: auto)
+   SC for SVGForeignObjectBox<foreignObject> [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-g-inside-g.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-g-inside-g.txt
@@ -24,4 +24,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             SVGPathPaintable (SVGGeometryBox<rect>) [58,58 10x10]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-g-with-opacity.txt
@@ -22,4 +22,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
           SVGPathPaintable (SVGGeometryBox<circle>) [278.484375,278.484375 399.84375x399.84375]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x800] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x800] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x784] [children: 1] (z-index: auto)
+   SC for SVGGraphicsBox<g> [121.671875,121.671875 556.65625x556.65625] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-inline-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-inline-block.txt
@@ -18,4 +18,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x50]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x66] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x66] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x50] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg-with-xy.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg-with-xy.txt
@@ -26,4 +26,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           SVGPathPaintable (SVGGeometryBox<rect>) [217.5,32.5 101x101]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x166] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x166] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 300x150] [children: 2] (z-index: auto)
+   SC for SVGSVGBox<svg> [18,8 300x150] [children: 0] (z-index: auto)
+   SC for SVGSVGBox<svg> [208,23 300x150] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -17,4 +17,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             SVGPathPaintable (SVGGeometryBox<rect>) [8,8 24x24]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x40] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x40] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 24x24] [children: 1] (z-index: auto)
+   SC for SVGSVGBox<svg> [8,8 24x24] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
@@ -15,4 +15,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<rect>) [34,86 150x50]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x170] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x170] [children: 2] (z-index: auto)
+  SC for SVGSVGBox<svg> [9,9 100x50] [children: 0] (z-index: auto)
+  SC for SVGSVGBox<svg> [9,61 200x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-line-with-percentage-values.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-line-with-percentage-values.txt
@@ -23,4 +23,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<line>) [523.484375,6.046875 3.921875x395.921875]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x408] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x408] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x392] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
@@ -12,4 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<path>) [8,10 100x48]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-nested-svg-display-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-nested-svg-display-block.txt
@@ -15,4 +15,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             SVGPathPaintable (SVGGeometryBox<rect>) [8,13 25x15]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x66] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x66] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg>#outer [8,8 50x50] [children: 1] (z-index: auto)
+   SC for SVGSVGBox<svg>#inner [8,8 25x25] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
@@ -12,4 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<path>) [28,28 60x60]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -29,4 +29,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               SVGPathPaintable (SVGGeometryBox<path>) [92.375,26.75 131.25x112.15625]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x166] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x166] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 300x150] [children: 1] (z-index: auto)
+   SC for SVGGraphicsBox<use> [8,8 300x150] [children: 1] (z-index: auto)
+    SC for SVGGraphicsBox<symbol>#braces [8,8 300x150] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
@@ -17,4 +17,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           SVGGraphicsPaintable (SVGGraphicsBox<symbol>#myid) [8,8 300x150]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x166] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x166] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 300x150] [children: 1] (z-index: auto)
+   SC for SVGGraphicsBox<use> [8,8 300x150] [children: 1] (z-index: auto)
+    SC for SVGGraphicsBox<symbol>#myid [8,8 300x150] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-viewbox-zero-width.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-viewbox-zero-width.txt
@@ -10,4 +10,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x166] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x166] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 300x150] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
@@ -12,4 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<rect>) [29,29 60x60]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [9,9 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
@@ -11,4 +11,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
         SVGPathPaintable (SVGGeometryBox<rect>) [8,8 784x784]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x800] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x800] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x784] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-sized-viewBox.txt
@@ -15,4 +15,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -13,4 +13,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGTextBox<text>) [8,8 0x0]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x166] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x166] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 300x150] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/use-honor-outer-viewBox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/use-honor-outer-viewBox.txt
@@ -21,4 +21,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             SVGPathPaintable (SVGGeometryBox<rect>) [9,9 50x50]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x118] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x118] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg>#outer [9,9 100x100] [children: 1] (z-index: auto)
+   SC for SVGGraphicsBox<use> [9,9 100x100] [children: 1] (z-index: auto)
+    SC for SVGSVGBox<svg>#whee [9,9 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/treat-intrinsic-sizing-keywords-as-auto-when-aspect-ratio-cant-be-resolved.txt
+++ b/Tests/LibWeb/Layout/expected/treat-intrinsic-sizing-keywords-as-auto-when-aspect-ratio-cant-be-resolved.txt
@@ -12,4 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]
         SVGPathPaintable (SVGGeometryBox<rect>) [8,8 392x392]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x800] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x800] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 784x784] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/zero-height-replaced-box-with-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/zero-height-replaced-box-with-aspect-ratio.txt
@@ -12,4 +12,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/zero-size-replaced-box-with-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/zero-size-replaced-box-with-aspect-ratio.txt
@@ -13,4 +13,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 1] (z-index: auto)
+  SC for SVGSVGBox<svg> [8,8 100x100] [children: 0] (z-index: auto)


### PR DESCRIPTION
This is an attempt at solving #5494 which didn't work, but seems useful on its own.

`Screenshot/input/svg-foreign-object-mask.html` failed for me locally on macOS because of some minor edge-pixel differences. I've left it as-is to see how it goes for other OSes as maybe it needs fuzzy-matching.