### PR TITLE
LibWeb: Start implementing Credential Management APIs

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SOURCES
     Cookie/ParsedCookie.cpp
     CredentialManagement/Credential.cpp
     CredentialManagement/CredentialsContainer.cpp
+    CredentialManagement/CredentialUserData.cpp
     CredentialManagement/FederatedCredential.cpp
     CredentialManagement/PasswordCredential.cpp
     Crypto/Crypto.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -75,6 +75,7 @@ set(SOURCES
     CredentialManagement/CredentialUserData.cpp
     CredentialManagement/FederatedCredential.cpp
     CredentialManagement/PasswordCredential.cpp
+    CredentialManagement/PasswordCredentialOperations.cpp
     Crypto/Crypto.cpp
     Crypto/CryptoAlgorithms.cpp
     Crypto/CryptoBindings.cpp

--- a/Libraries/LibWeb/CredentialManagement/Credential.h
+++ b/Libraries/LibWeb/CredentialManagement/Credential.h
@@ -26,8 +26,6 @@ public:
     virtual ~Credential() override;
 
     String const& id() { return m_id; }
-    String const& name() { return m_name; }
-    String const& icon_url() { return m_icon_url; }
 
     virtual String type() = 0;
 
@@ -36,8 +34,6 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
     String m_id;
-    String m_name;
-    String m_icon_url;
 };
 
 struct CredentialData {

--- a/Libraries/LibWeb/CredentialManagement/CredentialUserData.cpp
+++ b/Libraries/LibWeb/CredentialManagement/CredentialUserData.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CredentialManagement/CredentialUserData.h>
+
+namespace Web::CredentialManagement {
+
+String const& CredentialUserData::name()
+{
+    return m_name;
+}
+
+String const& CredentialUserData::icon_url()
+{
+    return m_icon_url;
+}
+
+}

--- a/Libraries/LibWeb/CredentialManagement/CredentialUserData.h
+++ b/Libraries/LibWeb/CredentialManagement/CredentialUserData.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Web::CredentialManagement {
+
+class CredentialUserData {
+public:
+    virtual ~CredentialUserData() = default;
+
+    String const& name();
+    String const& icon_url();
+
+protected:
+    CredentialUserData() = default;
+
+    String m_name;
+    String m_icon_url;
+};
+
+}

--- a/Libraries/LibWeb/CredentialManagement/FederatedCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/FederatedCredential.h
@@ -10,10 +10,13 @@
 #include <LibWeb/Bindings/FederatedCredentialPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CredentialManagement/Credential.h>
+#include <LibWeb/CredentialManagement/CredentialUserData.h>
 
 namespace Web::CredentialManagement {
 
-class FederatedCredential final : public Credential {
+class FederatedCredential final
+    : public Credential
+    , public CredentialUserData {
     WEB_PLATFORM_OBJECT(FederatedCredential, Credential);
     GC_DECLARE_ALLOCATOR(FederatedCredential);
 

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.cpp
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.cpp
@@ -5,35 +5,43 @@
  */
 
 #include <LibWeb/CredentialManagement/PasswordCredential.h>
+#include <LibWeb/CredentialManagement/PasswordCredentialOperations.h>
 
 namespace Web::CredentialManagement {
 
 GC_DEFINE_ALLOCATOR(PasswordCredential);
 
-GC::Ref<PasswordCredential> PasswordCredential::create(JS::Realm& realm)
-{
-    return realm.create<PasswordCredential>(realm);
-}
-
 // https://www.w3.org/TR/credential-management-1/#dom-passwordcredential-passwordcredential
-WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> PasswordCredential::construct_impl(JS::Realm& realm, HTML::HTMLFormElement const&)
+WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> PasswordCredential::construct_impl(JS::Realm& realm, GC::Ptr<HTML::HTMLFormElement> form)
 {
-    return realm.vm().throw_completion<JS::InternalError>(JS::ErrorType::NotImplemented, "construct"sv);
+    // 1. Let origin be the current settings object's origin.
+    auto origin = HTML::current_principal_settings_object().origin();
+
+    // 2. Let r be the result of executing Create a PasswordCredential from an HTMLFormElement given form and origin.
+    // 3. If r is an exception, throw r. Otherwise, return r.
+    return create_password_credential(realm, form, origin);
 }
 
 // https://www.w3.org/TR/credential-management-1/#dom-passwordcredential-passwordcredential-data
-WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> PasswordCredential::construct_impl(JS::Realm& realm, PasswordCredentialData const&)
+WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> PasswordCredential::construct_impl(JS::Realm& realm, PasswordCredentialData const& options)
 {
-    return realm.vm().throw_completion<JS::InternalError>(JS::ErrorType::NotImplemented, "construct"sv);
+    // 1. Let r be the result of executing Create a PasswordCredential from PasswordCredentialData on data.
+    // 2. If r is an exception, throw r.
+    return create_password_credential(realm, options);
 }
 
 PasswordCredential::~PasswordCredential()
 {
 }
 
-PasswordCredential::PasswordCredential(JS::Realm& realm)
+PasswordCredential::PasswordCredential(JS::Realm& realm, PasswordCredentialData const& data)
     : Credential(realm)
+    , m_password(data.password)
+    , m_origin(data.origin)
 {
+    m_id = data.id;
+    m_icon_url = data.icon_url.value_or(String {});
+    m_name = data.name.value_or(String {});
 }
 
 void PasswordCredential::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
@@ -10,11 +10,14 @@
 #include <LibWeb/Bindings/PasswordCredentialPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/CredentialManagement/Credential.h>
+#include <LibWeb/CredentialManagement/CredentialUserData.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
 
 namespace Web::CredentialManagement {
 
-class PasswordCredential final : public Credential {
+class PasswordCredential final
+    : public Credential
+    , public CredentialUserData {
     WEB_PLATFORM_OBJECT(PasswordCredential, Credential);
     GC_DECLARE_ALLOCATOR(PasswordCredential);
 

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
@@ -22,9 +22,8 @@ class PasswordCredential final
     GC_DECLARE_ALLOCATOR(PasswordCredential);
 
 public:
-    [[nodiscard]] static GC::Ref<PasswordCredential> create(JS::Realm&);
-    static WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> construct_impl(JS::Realm&, HTML::HTMLFormElement const&);
-    static WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> construct_impl(JS::Realm&, PasswordCredentialData const&);
+    [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> construct_impl(JS::Realm&, GC::Ptr<HTML::HTMLFormElement>);
+    [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> construct_impl(JS::Realm&, PasswordCredentialData const&);
 
     virtual ~PasswordCredential() override;
 
@@ -34,7 +33,7 @@ public:
     String type() override { return "password"_string; }
 
 private:
-    explicit PasswordCredential(JS::Realm&);
+    explicit PasswordCredential(JS::Realm&, PasswordCredentialData const&);
     virtual void initialize(JS::Realm&) override;
 
     // TODO: Use Core::SecretString when it comes back

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
@@ -29,6 +29,7 @@ public:
     virtual ~PasswordCredential() override;
 
     String const& password() { return m_password; }
+    String const& origin() { return m_origin; }
 
     String type() override { return "password"_string; }
 
@@ -38,6 +39,9 @@ private:
 
     // TODO: Use Core::SecretString when it comes back
     String m_password;
+
+    // https://www.w3.org/TR/credential-management-1/#dom-credential-origin-slot
+    String m_origin;
 };
 
 struct PasswordCredentialData : CredentialData {

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.idl
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.idl
@@ -15,7 +15,7 @@ partial dictionary CredentialRequestOptions {
 dictionary PasswordCredentialData : CredentialData {
     USVString name;
     USVString iconURL;
-    required USVString origin;
+    // FIXME: required USVString origin;
     required USVString password;
 };
 

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredentialOperations.cpp
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredentialOperations.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CredentialManagement/PasswordCredentialOperations.h>
+#include <LibWeb/HTML/HTMLFormElement.h>
+#include <LibWeb/XHR/FormData.h>
+
+namespace Web::CredentialManagement {
+
+// https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement
+WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> create_password_credential(JS::Realm& realm, GC::Ptr<HTML::HTMLFormElement> const form, URL::Origin const& origin)
+{
+    // 1. Let data be a new PasswordCredentialData dictionary.
+    PasswordCredentialData data;
+
+    // 2. Set data’s origin member’s value to origin’s value.
+    data.origin = origin.serialize();
+
+    // 3. Let formData be the result of executing the FormData constructor on form.
+    auto form_data = TRY(XHR::FormData::construct_impl(realm, form));
+
+    // 4. Let elements be a list of all the submittable elements whose form owner is form, in tree order.
+    auto elements = form->get_submittable_elements();
+
+    // 5. Let newPasswordObserved be false.
+    bool new_password_observed = false;
+
+    // 6. For each field in elements, run the following steps:
+    for (auto const& field : elements) {
+        dbgln("field->name(): {}", field->name());
+        // 1. If field does not have an autocomplete attribute, then skip to the next field.
+        if (auto attr = field->attribute(HTML::AttributeNames::autocomplete); !attr.has_value() || attr->is_empty())
+            continue;
+
+        // 2. Let name be the value of field’s name attribute.
+        // 3. If formData’s has() method returns false when executed on name, then skip to the next field.
+        auto name = field->attribute(HTML::AttributeNames::name);
+        if (!name.has_value() || !form_data->has(name.value()))
+            continue;
+
+        // 4. If field’s autocomplete attribute’s value contains one or more autofill detail tokens (tokens), then:
+        if (auto tokens = field->attribute(HTML::AttributeNames::autocomplete); tokens.has_value()) {
+            // 1. For each token in tokens:
+            for (auto& token : MUST(tokens->split(' '))) {
+                // 1. If token is an ASCII case-insensitive match for one of the following strings, run the associated steps:
+                //    - "new-password"
+                //       Set data’s password member’s value to the result of executing formData’s get() method on name,
+                //       and newPasswordObserved to true.
+                if (token.equals_ignoring_ascii_case("new-password"sv)) {
+                    if (auto password = form_data->get(name.value()); password.has<String>()) {
+                        data.password = password.get<String>();
+                        new_password_observed = true;
+                    }
+                }
+                //    - "current-password"
+                //       If newPasswordObserved is false, set data’s password member’s value to the result of executing
+                //       formData’s get() method on name.
+                //       Note: By checking that newPasswordObserved is false, new-password fields take precedence over
+                //             current-password fields.
+                if (!new_password_observed && token.equals_ignoring_ascii_case("current-password"sv)) {
+                    if (auto password = form_data->get(name.value()); password.has<String>())
+                        data.password = password.get<String>();
+                }
+                //    - "photo"
+                //      Set data’s iconURL member’s value to the result of executing formData’s get() method on name.
+                if (token.equals_ignoring_ascii_case("photo"sv)) {
+                    if (auto photo = form_data->get(name.value()); photo.has<String>())
+                        data.icon_url = photo.get<String>();
+                }
+                //    - "name"
+                //    - "nickname"
+                //      Set data’s name member’s value to the result of executing formData’s get() method on name.
+                if (token.equals_ignoring_ascii_case("name"sv)) {
+                    if (auto name_ = form_data->get(name.value()); name_.has<String>())
+                        data.name = name_.get<String>();
+                }
+                if (token.equals_ignoring_ascii_case("nickname"sv)) {
+                    if (auto nickname = form_data->get(name.value()); nickname.has<String>())
+                        data.name = nickname.get<String>();
+                }
+                //    - "username"
+                //      Set data’s id member’s value to the result of executing formData’s get() method on name.
+                if (token.equals_ignoring_ascii_case("username"sv)) {
+                    if (auto username = form_data->get(name.value()); username.has<String>()) {
+                        auto id = username.get<String>();
+                        dbgln("username: {}", id);
+                        data.id = id;
+                    }
+                }
+            }
+        }
+    }
+
+    dbgln("Done iterating over tokens");
+
+    // 7. Let c be the result of executing Create a PasswordCredential from PasswordCredentialData on data.
+    //    If that threw an exception, rethrow that exception.
+    // 8. Assert: c is a PasswordCredential.
+    // 9. Return c.
+    return create_password_credential(realm, data);
+}
+
+// https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata
+WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> create_password_credential(JS::Realm& realm, PasswordCredentialData const& data)
+{
+    // 1. Let c be a new PasswordCredential object.
+    // 2. If any of the following are the empty string, throw a TypeError exception:
+    //    - data’s id member’s value
+    //    - data’s origin member’s value
+    //    - data’s password member’s value
+    // FIXME: Unsure if origin should at all be part of PasswordCredentialData. Chromium source code does not have the origin member.
+    if (data.id.is_empty())
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "'id' must not be empty."sv };
+    if (data.password.is_empty())
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "'password' must not be empty."sv };
+
+    // 3. Set c’s properties as follows:
+    //    - password
+    //      - data’s password member’s value
+    //    - id
+    //      - data’s id member’s value
+    //    - iconUrl
+    //      - data’s iconURL member’s value
+    //    - name
+    //      - data’s name member’s value
+    //    - [[origin]]
+    //      - data’s origin member’s value.
+    // 4. Return c.
+    return realm.create<PasswordCredential>(realm, data);
+}
+
+}

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredentialOperations.h
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredentialOperations.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025, Kenneth Myhra <kennethmyhra@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CredentialManagement/PasswordCredential.h>
+
+namespace Web::CredentialManagement {
+
+WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> create_password_credential(JS::Realm& realm, GC::Ptr<HTML::HTMLFormElement> const, URL::Origin const& origin);
+WebIDL::ExceptionOr<GC::Ref<PasswordCredential>> create_password_credential(JS::Realm& realm, PasswordCredentialData const&);
+
+}

--- a/Tests/LibWeb/Text/expected/CredentialManagement/PasswordCredential-ctors.txt
+++ b/Tests/LibWeb/Text/expected/CredentialManagement/PasswordCredential-ctors.txt
@@ -1,0 +1,18 @@
+cred instanceof PasswordCredential: true
+id: staplemachine@example.com
+password: correcthorsebatterystaple
+name: Staple Machine
+iconURL: http://example.com/images/horse.png
+cred instanceof PasswordCredential: true
+id: staplemachine@example.com
+password: correctstaplehorsecinema
+name: Staple Machine
+iconURL: http://example.com/images/horse.png
+cred instanceof PasswordCredential: true
+id: staplemachine@example.com
+password: correctstaplehorsecinema
+cred instanceof PasswordCredential: true
+id: staplemachine@example.com
+password: correcthorsebatterystaple
+name: StapleNick
+iconURL: http://example.com/images/horse.png

--- a/Tests/LibWeb/Text/input/CredentialManagement/PasswordCredential-ctors.html
+++ b/Tests/LibWeb/Text/input/CredentialManagement/PasswordCredential-ctors.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<form id="loginForm">
+    <input type="text" name="username" autocomplete="username" value="staplemachine@example.com" required>
+    <input type="password" name="password" autocomplete="current-password" value="correctstaplehorsecinema" required>
+    <input type="text" name="name" autocomplete="name" value="Staple Machine" required>
+    <input type="text" name="photo" autocomplete="photo" value="http://example.com/images/horse.png" required>
+</form>
+<form id="changePasswordForm">
+    <input type="text" name="username" autocomplete="username" value="staplemachine@example.com" required>
+    <input type="password" name="password" autocomplete="new-password" value="correctstaplehorsecinema" required>
+    <input type="password" name="password" autocomplete="current-password" value="correcthorsebatterystaple" required>
+</form>
+<form id="loginFormWithNick">
+    <input type="text" name="username" autocomplete="username" value="staplemachine@example.com" required>
+    <input type="password" name="password" autocomplete="current-password" value="correcthorsebatterystaple" required>
+    <input type="text" name="name" autocomplete="nickname" value="StapleNick" required>
+    <input type="text" name="photo" autocomplete="photo" value="http://example.com/images/horse.png" required>
+</form>
+<script>
+test(() => {
+    const data = {
+        id: 'staplemachine@example.com',
+        password: 'correcthorsebatterystaple',
+        name: 'Staple Machine',
+        iconURL: 'http://example.com/images/horse.png',
+    };
+    let cred = new PasswordCredential(data);
+    println(`cred instanceof PasswordCredential: ${cred instanceof PasswordCredential}`)
+    println(`id: ${cred.id}`, cred.id);
+    println(`password: ${cred.password}`, cred.password);
+    println(`name: ${cred.name}`, cred.name);
+    println(`iconURL: ${cred.iconURL}`, cred.iconURL);
+
+    let form = document.getElementById('loginForm');
+    cred = new PasswordCredential(form);
+    println(`cred instanceof PasswordCredential: ${cred instanceof PasswordCredential}`)
+    println(`id: ${cred.id}`, cred.id);
+    println(`password: ${cred.password}`, cred.password);
+    println(`name: ${cred.name}`, cred.name);
+    println(`iconURL: ${cred.iconURL}`, cred.iconURL);
+
+    form = document.getElementById('changePasswordForm');
+    cred = new PasswordCredential(form);
+    println(`cred instanceof PasswordCredential: ${cred instanceof PasswordCredential}`)
+    println(`id: ${cred.id}`, cred.id);
+    println(`password: ${cred.password}`, cred.password);
+
+    form = document.getElementById('loginFormWithNick');
+    cred = new PasswordCredential(form);
+    println(`cred instanceof PasswordCredential: ${cred instanceof PasswordCredential}`)
+    println(`id: ${cred.id}`, cred.id);
+    println(`password: ${cred.password}`, cred.password);
+    println(`name: ${cred.name}`, cred.name);
+    println(`iconURL: ${cred.iconURL}`, cred.iconURL);
+});
+</script>


### PR DESCRIPTION
This implements the following AOs:
- [Create a PasswordCredential from PasswordCredentialData.](https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata)
- [Create a PasswordCredential from an HTMLFormElement.](https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement)

Which corresponds to these PasswordCredential ctors:
- constructor(PasswordCredentialData)
- constructor(HTMLFormElement)

The commits contains more information about the individual changes.