### PR TITLE
Fix previous style calculation for CSS transitions on pseudo

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -518,19 +518,11 @@ RefPtr<CSSStyleValue const> CSSStyleProperties::style_value_for_computed_propert
     };
 
     auto get_computed_value = [&element, pseudo_element](PropertyID property_id) -> auto const& {
-        if (pseudo_element.has_value())
-            return element.pseudo_element_computed_properties(pseudo_element.value())->property(property_id);
-        return element.computed_properties()->property(property_id);
+        return element.computed_properties(pseudo_element)->property(property_id);
     };
 
     if (property_is_logical_alias(property_id)) {
-        GC::Ptr<ComputedProperties> computed_properties;
-
-        if (pseudo_element.has_value())
-            computed_properties = element.pseudo_element_computed_properties(pseudo_element.value());
-        else
-            computed_properties = element.computed_properties();
-
+        auto computed_properties = element.computed_properties(pseudo_element);
         return style_value_for_computed_property(
             layout_node,
             map_logical_alias_to_physical_property(property_id, LogicalAliasMappingContext { computed_properties->writing_mode(), computed_properties->direction() }));

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2724,7 +2724,7 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
     // 9. Transition declarations [css-transitions-1]
     // Theoretically this should be part of the cascade, but it works with computed values, which we don't have until now.
     compute_transitioned_properties(computed_style, element, pseudo_element);
-    if (auto previous_style = element.computed_properties(); previous_style) {
+    if (auto previous_style = element.computed_properties(pseudo_element)) {
         start_needed_transitions(*previous_style, computed_style, element, pseudo_element);
     }
 

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -75,9 +75,7 @@ bool AbstractElement::is_before(AbstractElement const& other) const
 
 GC::Ptr<CSS::ComputedProperties const> AbstractElement::computed_properties() const
 {
-    if (m_pseudo_element.has_value())
-        return m_element->pseudo_element_computed_properties(*m_pseudo_element);
-    return m_element->computed_properties();
+    return m_element->computed_properties(m_pseudo_element);
 }
 
 HashMap<FlyString, CSS::StyleProperty> const& AbstractElement::custom_properties() const

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -209,16 +209,13 @@ public:
     GC::Ptr<Layout::NodeWithStyle> layout_node();
     GC::Ptr<Layout::NodeWithStyle const> layout_node() const;
 
-    GC::Ptr<CSS::ComputedProperties> computed_properties() { return m_computed_properties; }
-    GC::Ptr<CSS::ComputedProperties const> computed_properties() const { return m_computed_properties; }
-    void set_computed_properties(GC::Ptr<CSS::ComputedProperties>);
+    GC::Ptr<CSS::ComputedProperties> computed_properties(Optional<CSS::PseudoElement> = {});
+    GC::Ptr<CSS::ComputedProperties const> computed_properties(Optional<CSS::PseudoElement> = {}) const;
+    void set_computed_properties(Optional<CSS::PseudoElement>, GC::Ptr<CSS::ComputedProperties>);
     GC::Ref<CSS::ComputedProperties> resolved_css_values(Optional<CSS::PseudoElement> = {});
 
     [[nodiscard]] GC::Ptr<CSS::CascadedProperties> cascaded_properties(Optional<CSS::PseudoElement>) const;
     void set_cascaded_properties(Optional<CSS::PseudoElement>, GC::Ptr<CSS::CascadedProperties>);
-
-    void set_pseudo_element_computed_properties(CSS::PseudoElement, GC::Ptr<CSS::ComputedProperties>);
-    GC::Ptr<CSS::ComputedProperties> pseudo_element_computed_properties(CSS::PseudoElement);
 
     Optional<PseudoElement&> get_pseudo_element(CSS::PseudoElement) const;
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -187,7 +187,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Ps
 {
     auto& document = element.document();
 
-    auto pseudo_element_style = element.pseudo_element_computed_properties(pseudo_element);
+    auto pseudo_element_style = element.computed_properties(pseudo_element);
     if (!pseudo_element_style)
         return;
 
@@ -726,7 +726,7 @@ void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, GC::Ref
         auto marker_style = style_computer.compute_style(element, CSS::PseudoElement::Marker);
         auto list_item_marker = document.heap().allocate<ListItemMarkerBox>(document, layout_node->computed_values().list_style_type(), layout_node->computed_values().list_style_position(), element, marker_style);
         static_cast<ListItemBox&>(*layout_node).set_marker(list_item_marker);
-        element.set_pseudo_element_computed_properties(CSS::PseudoElement::Marker, marker_style);
+        element.set_computed_properties(CSS::PseudoElement::Marker, marker_style);
         element.set_pseudo_element_node({}, CSS::PseudoElement::Marker, list_item_marker);
         layout_node->prepend_child(*list_item_marker);
         DOM::AbstractElement marker_reference { element, CSS::PseudoElement::Marker };

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -461,13 +461,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
     auto& element = as<Web::DOM::Element>(*node);
     node->document().set_inspected_node(node);
 
-    GC::Ptr<Web::CSS::ComputedProperties> properties;
-    if (pseudo_element.has_value()) {
-        if (auto pseudo_element_node = element.get_pseudo_element_node(*pseudo_element))
-            properties = element.pseudo_element_computed_properties(*pseudo_element);
-    } else {
-        properties = element.computed_properties();
-    }
+    auto properties = element.computed_properties(pseudo_element);
 
     if (!properties) {
         async_did_inspect_dom_node(page_id, { property_type, {} });

--- a/Tests/LibWeb/Text/expected/WebAnimations/transitions/transition-on-pseudo-element.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/transitions/transition-on-pseudo-element.txt
@@ -1,0 +1,1 @@
+running animations count (0) should be zero

--- a/Tests/LibWeb/Text/input/WebAnimations/transitions/transition-on-pseudo-element.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/transitions/transition-on-pseudo-element.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../include.js"></script>
+        <style>
+            .container {
+                display: flex;
+                gap: 2rem;
+                padding: 2rem;
+                font-size: 4rem;
+                flex-wrap: wrap;
+            }
+            .emojiItem_fc7141 {
+                position: relative;
+            }
+            .emojiItem_fc7141:after {
+                border: 3px solid #fde047;
+                content: "";
+                height: 100%;
+                width: 100%;
+                left: 0;
+                opacity: 0;
+                position: absolute;
+                top: 0;
+                z-index: 5;
+                transition: all 1s ease-in-out;
+            }
+        </style>
+    </head>
+    <body class="full-motion">
+        <div id="emojiContainer" class="container">
+            <span class="emojiItem_fc7141">😀</span>
+            <span class="emojiItem_fc7141">😎</span>
+            <span class="emojiItem_fc7141">🚀</span>
+        </div>
+        <script>
+            const container = document.getElementById("emojiContainer");
+            asyncTest(done => {
+                const span = document.createElement("span");
+                span.className = "emojiItem_fc7141";
+                span.textContent = "🌟";
+                container.appendChild(span);
+                requestAnimationFrame(() => {
+                    println(
+                        `running animations count (${
+                            document.getAnimations().length
+                        }) should be zero`
+                    );
+                    done();
+                });
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
...elements. Adds missing pseudo-element type passed into computed
properties getter.

Previously, due to this bug, we were using the element's computed
properties as the previous computed properties for its pseudo-elements.
This caused an excessive number of unintended CSS transitions to run.
The issue was particularly noticeable in Discord's emoji picker, where
each emoji has `::after` pseudo-element. We were incorrectly triggering
transitions on all their properties, resulting in significant
unnecessary work in style computation and animation event dispatching.