### PR TITLE
LibXML: Add parser hooks for CDATASection and ProcessingInstructions

### DIFF
--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -178,7 +178,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::Navig
             document->completely_finish_loading();
             return;
         }
-        XML::Parser parser(source.value(), { .resolve_external_resource = resolve_xml_resource });
+        XML::Parser parser(source.value(), { .preserve_cdata = true, .preserve_comments = true, .resolve_external_resource = resolve_xml_resource });
         XMLDocumentBuilder builder { document };
         auto result = parser.parse_with_listener(builder);
         if (result.is_error()) {

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/CDATASection.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/Event.h>
+#include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
@@ -260,9 +262,28 @@ void XMLDocumentBuilder::text(StringView data)
 
 void XMLDocumentBuilder::comment(StringView data)
 {
-    if (m_has_error)
+    if (m_has_error || !m_current_node)
         return;
-    MUST(m_document->append_child(m_document->create_comment(MUST(String::from_utf8(data)))));
+
+    MUST(m_current_node->append_child(m_document->create_comment(MUST(String::from_utf8(data)))));
+}
+
+void XMLDocumentBuilder::cdata_section(StringView data)
+{
+    if (m_has_error || !m_current_node)
+        return;
+
+    auto section = MUST(m_document->create_cdata_section(MUST(String::from_utf8(data))));
+    MUST(m_current_node->append_child(section));
+}
+
+void XMLDocumentBuilder::processing_instruction(StringView target, StringView data)
+{
+    if (m_has_error || !m_current_node)
+        return;
+
+    auto processing_instruction = MUST(m_document->create_processing_instruction(MUST(String::from_utf8(target)), MUST(String::from_utf8(data))));
+    MUST(m_current_node->append_child(processing_instruction));
 }
 
 void XMLDocumentBuilder::document_end()

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -36,6 +36,8 @@ private:
     virtual void element_end(XML::Name const& name) override;
     virtual void text(StringView data) override;
     virtual void comment(StringView data) override;
+    virtual void cdata_section(StringView data) override;
+    virtual void processing_instruction(StringView target, StringView data) override;
     virtual void document_end() override;
 
     Optional<FlyString> namespace_for_name(XML::Name const&);

--- a/Libraries/LibXML/Parser/Parser.cpp
+++ b/Libraries/LibXML/Parser/Parser.cpp
@@ -136,6 +136,27 @@ void Parser::append_comment(StringView text, LineTrackingLexer::Position positio
         });
 }
 
+void Parser::append_cdata_section(StringView text, LineTrackingLexer::Position position)
+{
+    if (m_listener) {
+        m_listener->cdata_section(text);
+        return;
+    }
+
+    // FIXME: Non-listener parsing should probably expect a CDATA node as well
+    append_text(text, position);
+}
+
+void Parser::append_processing_instruction(StringView target, StringView data)
+{
+    if (m_listener) {
+        m_listener->processing_instruction(target, data);
+        return;
+    }
+
+    m_processing_instructions.set(target, data);
+}
+
 void Parser::enter_node(Node& node)
 {
     if (m_listener) {
@@ -505,7 +526,8 @@ ErrorOr<void, ParseError> Parser::parse_processing_instruction()
         data = m_lexer.consume_until("?>");
     TRY(expect("?>"sv));
 
-    m_processing_instructions.set(target, data);
+    append_processing_instruction(target, data);
+
     rollback.disarm();
     return {};
 }
@@ -898,7 +920,7 @@ ErrorOr<void, ParseError> Parser::parse_content()
         }
         if (auto result = parse_cdata_section(); !result.is_error()) {
             if (m_options.preserve_cdata)
-                append_text(result.release_value(), m_lexer.position_for(node_start));
+                append_cdata_section(result.release_value(), m_lexer.position_for(node_start));
             goto try_char_data;
         }
         if (auto result = parse_processing_instruction(); !result.is_error())

--- a/Libraries/LibXML/Parser/Parser.h
+++ b/Libraries/LibXML/Parser/Parser.h
@@ -40,6 +40,8 @@ struct Listener {
     virtual void element_start(Name const&, HashMap<Name, ByteString> const&) { }
     virtual void element_end(Name const&) { }
     virtual void text(StringView) { }
+    virtual void cdata_section(StringView) { }
+    virtual void processing_instruction(StringView, StringView) { }
     virtual void comment(StringView) { }
     virtual void error(ParseError const&) { }
 };
@@ -82,6 +84,8 @@ private:
     void append_node(NonnullOwnPtr<Node>);
     void append_text(StringView, LineTrackingLexer::Position);
     void append_comment(StringView, LineTrackingLexer::Position);
+    void append_cdata_section(StringView, LineTrackingLexer::Position);
+    void append_processing_instruction(StringView target, StringView data);
     void enter_node(Node&);
     void leave_node();
 

--- a/Tests/LibWeb/Text/expected/XHTML/CDATASection-PI-Comment-Nodes.txt
+++ b/Tests/LibWeb/Text/expected/XHTML/CDATASection-PI-Comment-Nodes.txt
@@ -1,0 +1,4 @@
+elem.childNodes.length: 5
+child node 0: [object CDATASection], 4
+child node 1 [object ProcessingInstruction], 7
+child node 2: [object Comment], 8

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/xml-stylesheet-pi-in-doctype.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/xml-stylesheet-pi-in-doctype.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	xml-stylesheet processing instruction in doctype internal subset

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Comment-in-doctype.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Comment-in-doctype.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	XML: Comment in doctype internal subset

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Node-lookupPrefix.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Node-lookupPrefix.txt
@@ -1,0 +1,16 @@
+Harness status: OK
+
+Found 11 tests
+
+11 Pass
+Pass	Node.lookupPrefix
+Pass	Node.lookupPrefix 1
+Pass	Node.lookupPrefix 2
+Pass	Node.lookupPrefix 3
+Pass	Node.lookupPrefix 4
+Pass	Node.lookupPrefix 5
+Pass	Node.lookupPrefix 6
+Pass	Node.lookupPrefix 7
+Pass	Node.lookupPrefix 8
+Pass	Node.lookupPrefix 9
+Pass	Node.lookupPrefix 10

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/ProcessingInstruction-in-doctype.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/ProcessingInstruction-in-doctype.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	XML: Processing instruction in doctype internal subset

--- a/Tests/LibWeb/Text/input/XHTML/CDATASection-PI-Comment-Nodes.xhtml
+++ b/Tests/LibWeb/Text/input/XHTML/CDATASection-PI-Comment-Nodes.xhtml
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<div id="elem"><![CDATA[beep]]><?test test?><!-- I am a comment --><p>Hello</p><p>World</p></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const elem = document.getElementById("elem");
+        println(`elem.childNodes.length: ${elem.childNodes.length}`);
+        println(`child node 0: ${elem.childNodes[0].toString()}, ${elem.childNodes[0].nodeType}`);
+        println(`child node 1 ${elem.childNodes[1].toString()}, ${elem.childNodes[1].nodeType}`);
+        println(`child node 2: ${elem.childNodes[2].toString()}, ${elem.childNodes[2].nodeType}`);
+    });
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
@@ -1,0 +1,17 @@
+<!DOCTYPE html [<?xml-stylesheet href="data:text/css,html{z-index: 1}"?>]>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>xml-stylesheet processing instruction in doctype internal subset</title>
+    <link rel="help" href="https://drafts.csswg.org/cssom/#prolog"/>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      promise_test(async () => {
+        await new Promise(resolve => window.onload = resolve);
+        assert_equals(getComputedStyle(document.documentElement).zIndex, "auto");
+      });
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Comment-in-doctype.xhtml
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Comment-in-doctype.xhtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html [<!--x-->]><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>XML: Comment in doctype internal subset</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        assert_equals(document.documentElement.previousSibling, document.firstChild);
+        assert_equals(document.firstChild.nodeType, Node.DOCUMENT_TYPE_NODE);
+      });
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Node-lookupPrefix.xhtml
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Node-lookupPrefix.xhtml
@@ -1,0 +1,31 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:x="test">
+<head>
+<title>Node.lookupPrefix</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body xmlns:s="test">
+<div id="log"/>
+<x xmlns:t="test"><!--comment--><?test test?>TEST<x/></x>
+<script>
+function lookupPrefix(node, ns, prefix) {
+  test(function() {
+    assert_equals(node.lookupPrefix(ns), prefix)
+  })
+}
+var x = document.getElementsByTagName("x")[0];
+lookupPrefix(document, "test", "x") // XXX add test for when there is no documentElement
+lookupPrefix(document, null, null)
+lookupPrefix(x, "http://www.w3.org/1999/xhtml", null)
+lookupPrefix(x, "something", null)
+lookupPrefix(x, null, null)
+lookupPrefix(x, "test", "t")
+lookupPrefix(x.parentNode, "test", "s")
+lookupPrefix(x.firstChild, "test", "t")
+lookupPrefix(x.childNodes[1], "test", "t")
+lookupPrefix(x.childNodes[2], "test", "t")
+lookupPrefix(x.lastChild, "test", "t")
+x.parentNode.removeChild(x)
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/ProcessingInstruction-in-doctype.xhtml
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/ProcessingInstruction-in-doctype.xhtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html [<?x y?>]><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>XML: Processing instruction in doctype internal subset</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      test(() => {
+        assert_equals(document.documentElement.previousSibling, document.firstChild);
+        assert_equals(document.firstChild.nodeType, Node.DOCUMENT_TYPE_NODE);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This allows listeners to be notified when a CDATASection or
ProcessingInstruction is encountered during parsing. The non-listener
path still has the incorrect behavior of silently treating CDATASection
as Text nodes, but this allows listeners to handle them correctly.

Fixes: https://github.com/LadybirdBrowser/ladybird/issues/840