### PR TITLE
AK+LibWeb/CSS: Add `lower-greek` counter style

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -492,6 +492,21 @@ String String::bijective_base_from(size_t value, Case target_case, unsigned base
     return MUST(from_utf8(ReadonlyBytes(buffer.data(), i)));
 }
 
+String String::greek_letter_from(size_t value)
+{
+    static StringView const map = "αβγδεζηθικλμνξοπρστυφχψω"sv;
+    static unsigned const base = 24;
+
+    StringBuilder builder;
+    while (value > 0) {
+        value--;
+        builder.append(map.substring_view((value % base) * 2, 2));
+        value /= base;
+    }
+
+    return MUST(builder.to_string_without_validation().reverse());
+}
+
 String String::roman_number_from(size_t value, Case target_case)
 {
     if (value > 3999)

--- a/AK/String.h
+++ b/AK/String.h
@@ -102,6 +102,7 @@ public:
         Lower,
     };
     [[nodiscard]] static String bijective_base_from(size_t value, Case, unsigned base = 26, StringView map = {});
+    [[nodiscard]] static String greek_letter_from(size_t value);
     [[nodiscard]] static String roman_number_from(size_t value, Case);
 
     // Creates a new String by case-transforming this String. Using these methods require linking LibUnicode into your application.

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -138,6 +138,7 @@
     "disclosure-closed",
     "disclosure-open",
     "lower-alpha",
+    "lower-greek",
     "lower-latin",
     "lower-roman",
     "none",

--- a/Libraries/LibWeb/CSS/Keywords.json
+++ b/Libraries/LibWeb/CSS/Keywords.json
@@ -304,6 +304,7 @@
   "local",
   "longer",
   "lower-alpha",
+  "lower-greek",
   "lower-latin",
   "lower-roman",
   "lowercase",

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -79,6 +79,8 @@ static String generate_a_counter_representation(CSSStyleValue const& counter_sty
                 case CounterStyleNameKeyword::UpperAlpha:
                 case CounterStyleNameKeyword::UpperLatin:
                     return String::bijective_base_from(value - 1, String::Case::Upper);
+                case CounterStyleNameKeyword::LowerGreek:
+                    return String::greek_letter_from(value);
                 case CounterStyleNameKeyword::LowerRoman:
                     return String::roman_number_from(value, String::Case::Lower);
                 case CounterStyleNameKeyword::UpperRoman:

--- a/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -52,6 +52,9 @@ Optional<String> ListItemMarkerBox::text() const
             case CSS::CounterStyleNameKeyword::UpperLatin:
                 text = String::bijective_base_from(index - 1, String::Case::Upper);
                 break;
+            case CSS::CounterStyleNameKeyword::LowerGreek:
+                text = String::greek_letter_from(index);
+                break;
             case CSS::CounterStyleNameKeyword::LowerRoman:
                 text = String::roman_number_from(index, String::Case::Lower);
                 break;

--- a/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -108,6 +108,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
         case CSS::CounterStyleNameKeyword::Decimal:
         case CSS::CounterStyleNameKeyword::DecimalLeadingZero:
         case CSS::CounterStyleNameKeyword::LowerAlpha:
+        case CSS::CounterStyleNameKeyword::LowerGreek:
         case CSS::CounterStyleNameKeyword::LowerLatin:
         case CSS::CounterStyleNameKeyword::LowerRoman:
         case CSS::CounterStyleNameKeyword::UpperAlpha:

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/serialize-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/serialize-values.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 687 tests
 
-658 Pass
-29 Fail
+659 Pass
+28 Fail
 Pass	background-attachment: scroll
 Pass	background-attachment: fixed
 Pass	background-attachment: inherit
@@ -468,7 +468,7 @@ Pass	list-style-type: decimal
 Pass	list-style-type: decimal-leading-zero
 Pass	list-style-type: lower-roman
 Pass	list-style-type: upper-roman
-Fail	list-style-type: lower-greek
+Pass	list-style-type: lower-greek
 Pass	list-style-type: lower-latin
 Pass	list-style-type: upper-latin
 Fail	list-style-type: armenian


### PR DESCRIPTION
This PR adds support for `lower-greek` as a counter style.

I implemented a member function `greek_letter_from` in AK's `String` type as it appears that `bijective_base_from` doesn't handle multibyte characters correctly. I wasn't sure, but it may be better to implement a variant of `bijective_base_from` which accepts multibyte characters instead of having a seperate function for greek letters, as it'll allow us to add support for other styles like `georgian`. My only concern with this approach is where we would place the respective alphabets.

The test case for `lower-greek` in `css/cssom/serialize-values.html` passes. 

The test cases in `css/css-counter-styles/lower-greek/` appear to fail, but when testing cases like those in `css/css-counter-styles/upper-roman`, those fail too, so I'm not sure if its important to get these cases passing.