### PR TITLE
LibWeb: Use correct angle type when serializing hue-rotate filter values

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -67,10 +67,10 @@ String FilterValueListStyleValue::to_string(SerializationMode) const
             [&](FilterOperation::HueRotate const& hue_rotate) {
                 builder.append("hue-rotate("sv);
                 hue_rotate.angle.visit(
-                    [&](Angle const& angle) {
+                    [&](AngleOrCalculated const& angle) {
                         builder.append(angle.to_string());
                     },
-                    [&](auto&) {
+                    [&](FilterOperation::HueRotate::Zero const&) {
                         builder.append("0deg"sv);
                     });
             },

--- a/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/filter-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/filter-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 34 tests
 
-22 Pass
-12 Fail
+23 Pass
+11 Fail
 Pass	Property filter value 'none'
 Pass	Property filter value 'blur(100px)'
 Pass	Property filter value 'blur()'
@@ -20,7 +20,7 @@ Fail	Property filter value 'grayscale(calc(50%))'
 Pass	Property filter value 'grayscale(2)'
 Fail	Property filter value 'grayscale(calc(2))'
 Pass	Property filter value 'grayscale()'
-Fail	Property filter value 'hue-rotate(90deg)'
+Pass	Property filter value 'hue-rotate(90deg)'
 Pass	Property filter value 'hue-rotate()'
 Pass	Property filter value 'invert(0)'
 Fail	Property filter value 'invert(100%)'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/filter-parsing-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/filter-parsing-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 39 tests
 
-35 Pass
-4 Fail
+36 Pass
+3 Fail
 Pass	e.style['filter'] = "none" should set the property value
 Pass	e.style['filter'] = "blur(100px)" should set the property value
 Pass	e.style['filter'] = "blur(0)" should set the property value
@@ -25,7 +25,7 @@ Pass	e.style['filter'] = "grayscale(300%)" should set the property value
 Pass	e.style['filter'] = "grayscale(calc(300%))" should set the property value
 Pass	e.style['filter'] = "grayscale(calc(101% * sign(1em - 1px)))" should set the property value
 Pass	e.style['filter'] = "grayscale()" should set the property value
-Fail	e.style['filter'] = "hue-rotate(90deg)" should set the property value
+Pass	e.style['filter'] = "hue-rotate(90deg)" should set the property value
 Pass	e.style['filter'] = "hue-rotate(0)" should set the property value
 Pass	e.style['filter'] = "hue-rotate()" should set the property value
 Pass	e.style['filter'] = "invert(0)" should set the property value


### PR DESCRIPTION
At some point `hue-rotate` was changed to use `AngleOrCalculated` rather than `Angle`, but `Angle` was still being used in a `visit`, which otherwise defaulted to zero. This caused all `hue-rotate` angles to serialize to zero.