### PR TITLE
LibWeb: A few Wasm IDL fixes

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 212 tests
 
-38 Pass
-174 Fail
+212 Pass
 Pass	WebAssembly.instantiate(module): Non-object imports argument: null
 Pass	WebAssembly.instantiate(module): Non-object imports argument: true
 Pass	WebAssembly.instantiate(module): Non-object imports argument: ""
@@ -23,93 +22,93 @@ Pass	WebAssembly.instantiate(module): Missing imports argument
 Pass	WebAssembly.instantiate(module): Imports argument with missing property: undefined
 Pass	WebAssembly.instantiate(module): Imports argument with missing property: empty object
 Pass	WebAssembly.instantiate(module): Imports argument with missing property: wrong property
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 1
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 0.1
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: NaN
-Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: object "[object Object]"
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: BigInt
-Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: Number
-Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: BigInt
-Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: BigInt
-Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(module): Importing an i32 mutable global with a primitive value
-Fail	WebAssembly.instantiate(module): Importing an i32 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(module): Importing an i64 mutable global with a primitive value
-Fail	WebAssembly.instantiate(module): Importing an i64 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(module): Importing an f32 mutable global with a primitive value
-Fail	WebAssembly.instantiate(module): Importing an f32 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(module): Importing an f64 mutable global with a primitive value
-Fail	WebAssembly.instantiate(module): Importing an f64 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: 1
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: 0.1
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: NaN
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory.prototype
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: Object.create(WebAssembly.Memory.prototype)
-Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory object (too large)
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: 1
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: 0.1
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: NaN
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table.prototype
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: Object.create(WebAssembly.Table.prototype)
-Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table object (too large)
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 1
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 0.1
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: NaN
+Pass	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: object "[object Object]"
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: BigInt
+Pass	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: Number
+Pass	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: BigInt
+Pass	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: BigInt
+Pass	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(module): Importing an i32 mutable global with a primitive value
+Pass	WebAssembly.instantiate(module): Importing an i32 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(module): Importing an i64 mutable global with a primitive value
+Pass	WebAssembly.instantiate(module): Importing an i64 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(module): Importing an f32 mutable global with a primitive value
+Pass	WebAssembly.instantiate(module): Importing an f32 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(module): Importing an f64 mutable global with a primitive value
+Pass	WebAssembly.instantiate(module): Importing an f64 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: 1
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: 0.1
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: NaN
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory.prototype
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: Object.create(WebAssembly.Memory.prototype)
+Pass	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory object (too large)
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: 1
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: 0.1
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: NaN
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table.prototype
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: Object.create(WebAssembly.Table.prototype)
+Pass	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table object (too large)
 Pass	WebAssembly.instantiate(buffer): Non-object imports argument: null
 Pass	WebAssembly.instantiate(buffer): Non-object imports argument: true
 Pass	WebAssembly.instantiate(buffer): Non-object imports argument: ""
@@ -129,90 +128,90 @@ Pass	WebAssembly.instantiate(buffer): Missing imports argument
 Pass	WebAssembly.instantiate(buffer): Imports argument with missing property: undefined
 Pass	WebAssembly.instantiate(buffer): Imports argument with missing property: empty object
 Pass	WebAssembly.instantiate(buffer): Imports argument with missing property: wrong property
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: 1
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: 0.1
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: NaN
-Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: object "[object Object]"
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: BigInt
-Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: Number
-Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: BigInt
-Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global.prototype
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: BigInt
-Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
-Fail	WebAssembly.instantiate(buffer): Importing an i32 mutable global with a primitive value
-Fail	WebAssembly.instantiate(buffer): Importing an i32 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(buffer): Importing an i64 mutable global with a primitive value
-Fail	WebAssembly.instantiate(buffer): Importing an i64 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(buffer): Importing an f32 mutable global with a primitive value
-Fail	WebAssembly.instantiate(buffer): Importing an f32 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(buffer): Importing an f64 mutable global with a primitive value
-Fail	WebAssembly.instantiate(buffer): Importing an f64 mutable global with an immutable Global object
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: 1
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: 0.1
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: NaN
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory.prototype
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: Object.create(WebAssembly.Memory.prototype)
-Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory object (too large)
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: undefined
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: null
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: true
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: ""
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: 1
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: 0.1
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: NaN
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: plain object
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table.prototype
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: Object.create(WebAssembly.Table.prototype)
-Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table object (too large)
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: 1
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: 0.1
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: NaN
+Pass	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: object "[object Object]"
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: BigInt
+Pass	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: Number
+Pass	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: BigInt
+Pass	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: BigInt
+Pass	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Pass	WebAssembly.instantiate(buffer): Importing an i32 mutable global with a primitive value
+Pass	WebAssembly.instantiate(buffer): Importing an i32 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(buffer): Importing an i64 mutable global with a primitive value
+Pass	WebAssembly.instantiate(buffer): Importing an i64 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(buffer): Importing an f32 mutable global with a primitive value
+Pass	WebAssembly.instantiate(buffer): Importing an f32 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(buffer): Importing an f64 mutable global with a primitive value
+Pass	WebAssembly.instantiate(buffer): Importing an f64 mutable global with an immutable Global object
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: 1
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: 0.1
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: NaN
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory.prototype
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: Object.create(WebAssembly.Memory.prototype)
+Pass	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory object (too large)
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: undefined
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: null
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: true
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: ""
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: 1
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: 0.1
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: NaN
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: plain object
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table.prototype
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: Object.create(WebAssembly.Table.prototype)
+Pass	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table object (too large)

--- a/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
@@ -2,15 +2,15 @@ Harness status: OK
 
 Found 212 tests
 
-6 Pass
-206 Fail
+18 Pass
+194 Fail
 Pass	WebAssembly.instantiate(module): Non-object imports argument: null
-Fail	WebAssembly.instantiate(module): Non-object imports argument: true
-Fail	WebAssembly.instantiate(module): Non-object imports argument: ""
-Fail	WebAssembly.instantiate(module): Non-object imports argument: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Non-object imports argument: 1
-Fail	WebAssembly.instantiate(module): Non-object imports argument: 0.1
-Fail	WebAssembly.instantiate(module): Non-object imports argument: NaN
+Pass	WebAssembly.instantiate(module): Non-object imports argument: true
+Pass	WebAssembly.instantiate(module): Non-object imports argument: ""
+Pass	WebAssembly.instantiate(module): Non-object imports argument: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Non-object imports argument: 1
+Pass	WebAssembly.instantiate(module): Non-object imports argument: 0.1
+Pass	WebAssembly.instantiate(module): Non-object imports argument: NaN
 Fail	WebAssembly.instantiate(module): Non-object module: undefined
 Fail	WebAssembly.instantiate(module): Non-object module: null
 Fail	WebAssembly.instantiate(module): Non-object module: true
@@ -111,12 +111,12 @@ Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed 
 Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: Object.create(WebAssembly.Table.prototype)
 Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table object (too large)
 Pass	WebAssembly.instantiate(buffer): Non-object imports argument: null
-Fail	WebAssembly.instantiate(buffer): Non-object imports argument: true
-Fail	WebAssembly.instantiate(buffer): Non-object imports argument: ""
-Fail	WebAssembly.instantiate(buffer): Non-object imports argument: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Non-object imports argument: 1
-Fail	WebAssembly.instantiate(buffer): Non-object imports argument: 0.1
-Fail	WebAssembly.instantiate(buffer): Non-object imports argument: NaN
+Pass	WebAssembly.instantiate(buffer): Non-object imports argument: true
+Pass	WebAssembly.instantiate(buffer): Non-object imports argument: ""
+Pass	WebAssembly.instantiate(buffer): Non-object imports argument: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Non-object imports argument: 1
+Pass	WebAssembly.instantiate(buffer): Non-object imports argument: 0.1
+Pass	WebAssembly.instantiate(buffer): Non-object imports argument: NaN
 Fail	WebAssembly.instantiate(buffer): Non-object module: undefined
 Fail	WebAssembly.instantiate(buffer): Non-object module: null
 Fail	WebAssembly.instantiate(buffer): Non-object module: true

--- a/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
@@ -1,0 +1,218 @@
+Harness status: OK
+
+Found 212 tests
+
+6 Pass
+206 Fail
+Pass	WebAssembly.instantiate(module): Non-object imports argument: null
+Fail	WebAssembly.instantiate(module): Non-object imports argument: true
+Fail	WebAssembly.instantiate(module): Non-object imports argument: ""
+Fail	WebAssembly.instantiate(module): Non-object imports argument: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Non-object imports argument: 1
+Fail	WebAssembly.instantiate(module): Non-object imports argument: 0.1
+Fail	WebAssembly.instantiate(module): Non-object imports argument: NaN
+Fail	WebAssembly.instantiate(module): Non-object module: undefined
+Fail	WebAssembly.instantiate(module): Non-object module: null
+Fail	WebAssembly.instantiate(module): Non-object module: true
+Fail	WebAssembly.instantiate(module): Non-object module: ""
+Fail	WebAssembly.instantiate(module): Non-object module: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Non-object module: 1
+Fail	WebAssembly.instantiate(module): Non-object module: 0.1
+Fail	WebAssembly.instantiate(module): Non-object module: NaN
+Pass	WebAssembly.instantiate(module): Missing imports argument
+Pass	WebAssembly.instantiate(module): Imports argument with missing property: undefined
+Fail	WebAssembly.instantiate(module): Imports argument with missing property: empty object
+Fail	WebAssembly.instantiate(module): Imports argument with missing property: wrong property
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 1
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 0.1
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: NaN
+Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: object "[object Object]"
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: BigInt
+Fail	WebAssembly.instantiate(module): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: Number
+Fail	WebAssembly.instantiate(module): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: BigInt
+Fail	WebAssembly.instantiate(module): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: BigInt
+Fail	WebAssembly.instantiate(module): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(module): Importing an i32 mutable global with a primitive value
+Fail	WebAssembly.instantiate(module): Importing an i32 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(module): Importing an i64 mutable global with a primitive value
+Fail	WebAssembly.instantiate(module): Importing an i64 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(module): Importing an f32 mutable global with a primitive value
+Fail	WebAssembly.instantiate(module): Importing an f32 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(module): Importing an f64 mutable global with a primitive value
+Fail	WebAssembly.instantiate(module): Importing an f64 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: 1
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: 0.1
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: NaN
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory.prototype
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: Object.create(WebAssembly.Memory.prototype)
+Fail	WebAssembly.instantiate(module): Importing memory with an incorrectly-typed value: WebAssembly.Memory object (too large)
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: 1
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: 0.1
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: NaN
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table.prototype
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: Object.create(WebAssembly.Table.prototype)
+Fail	WebAssembly.instantiate(module): Importing table with an incorrectly-typed value: WebAssembly.Table object (too large)
+Pass	WebAssembly.instantiate(buffer): Non-object imports argument: null
+Fail	WebAssembly.instantiate(buffer): Non-object imports argument: true
+Fail	WebAssembly.instantiate(buffer): Non-object imports argument: ""
+Fail	WebAssembly.instantiate(buffer): Non-object imports argument: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Non-object imports argument: 1
+Fail	WebAssembly.instantiate(buffer): Non-object imports argument: 0.1
+Fail	WebAssembly.instantiate(buffer): Non-object imports argument: NaN
+Fail	WebAssembly.instantiate(buffer): Non-object module: undefined
+Fail	WebAssembly.instantiate(buffer): Non-object module: null
+Fail	WebAssembly.instantiate(buffer): Non-object module: true
+Fail	WebAssembly.instantiate(buffer): Non-object module: ""
+Fail	WebAssembly.instantiate(buffer): Non-object module: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Non-object module: 1
+Fail	WebAssembly.instantiate(buffer): Non-object module: 0.1
+Fail	WebAssembly.instantiate(buffer): Non-object module: NaN
+Pass	WebAssembly.instantiate(buffer): Missing imports argument
+Pass	WebAssembly.instantiate(buffer): Imports argument with missing property: undefined
+Fail	WebAssembly.instantiate(buffer): Imports argument with missing property: empty object
+Fail	WebAssembly.instantiate(buffer): Imports argument with missing property: wrong property
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: 1
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: 0.1
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: NaN
+Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: object "[object Object]"
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: BigInt
+Fail	WebAssembly.instantiate(buffer): Importing an i32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: Number
+Fail	WebAssembly.instantiate(buffer): Importing an i64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: BigInt
+Fail	WebAssembly.instantiate(buffer): Importing an f32 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global.prototype
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: Object.create(WebAssembly.Global.prototype)
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: BigInt
+Fail	WebAssembly.instantiate(buffer): Importing an f64 global with an incorrectly-typed value: WebAssembly.Global object (wrong value type)
+Fail	WebAssembly.instantiate(buffer): Importing an i32 mutable global with a primitive value
+Fail	WebAssembly.instantiate(buffer): Importing an i32 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(buffer): Importing an i64 mutable global with a primitive value
+Fail	WebAssembly.instantiate(buffer): Importing an i64 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(buffer): Importing an f32 mutable global with a primitive value
+Fail	WebAssembly.instantiate(buffer): Importing an f32 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(buffer): Importing an f64 mutable global with a primitive value
+Fail	WebAssembly.instantiate(buffer): Importing an f64 mutable global with an immutable Global object
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: 1
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: 0.1
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: NaN
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory.prototype
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: Object.create(WebAssembly.Memory.prototype)
+Fail	WebAssembly.instantiate(buffer): Importing memory with an incorrectly-typed value: WebAssembly.Memory object (too large)
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: undefined
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: null
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: true
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: ""
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: symbol "Symbol()"
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: 1
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: 0.1
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: NaN
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: plain object
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table.prototype
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: Object.create(WebAssembly.Table.prototype)
+Fail	WebAssembly.instantiate(buffer): Importing table with an incorrectly-typed value: WebAssembly.Table object (too large)

--- a/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 212 tests
 
-18 Pass
-194 Fail
+38 Pass
+174 Fail
 Pass	WebAssembly.instantiate(module): Non-object imports argument: null
 Pass	WebAssembly.instantiate(module): Non-object imports argument: true
 Pass	WebAssembly.instantiate(module): Non-object imports argument: ""
@@ -11,18 +11,18 @@ Pass	WebAssembly.instantiate(module): Non-object imports argument: symbol "Symbo
 Pass	WebAssembly.instantiate(module): Non-object imports argument: 1
 Pass	WebAssembly.instantiate(module): Non-object imports argument: 0.1
 Pass	WebAssembly.instantiate(module): Non-object imports argument: NaN
-Fail	WebAssembly.instantiate(module): Non-object module: undefined
-Fail	WebAssembly.instantiate(module): Non-object module: null
-Fail	WebAssembly.instantiate(module): Non-object module: true
-Fail	WebAssembly.instantiate(module): Non-object module: ""
-Fail	WebAssembly.instantiate(module): Non-object module: symbol "Symbol()"
-Fail	WebAssembly.instantiate(module): Non-object module: 1
-Fail	WebAssembly.instantiate(module): Non-object module: 0.1
-Fail	WebAssembly.instantiate(module): Non-object module: NaN
+Pass	WebAssembly.instantiate(module): Non-object module: undefined
+Pass	WebAssembly.instantiate(module): Non-object module: null
+Pass	WebAssembly.instantiate(module): Non-object module: true
+Pass	WebAssembly.instantiate(module): Non-object module: ""
+Pass	WebAssembly.instantiate(module): Non-object module: symbol "Symbol()"
+Pass	WebAssembly.instantiate(module): Non-object module: 1
+Pass	WebAssembly.instantiate(module): Non-object module: 0.1
+Pass	WebAssembly.instantiate(module): Non-object module: NaN
 Pass	WebAssembly.instantiate(module): Missing imports argument
 Pass	WebAssembly.instantiate(module): Imports argument with missing property: undefined
-Fail	WebAssembly.instantiate(module): Imports argument with missing property: empty object
-Fail	WebAssembly.instantiate(module): Imports argument with missing property: wrong property
+Pass	WebAssembly.instantiate(module): Imports argument with missing property: empty object
+Pass	WebAssembly.instantiate(module): Imports argument with missing property: wrong property
 Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: undefined
 Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: null
 Fail	WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: true
@@ -117,18 +117,18 @@ Pass	WebAssembly.instantiate(buffer): Non-object imports argument: symbol "Symbo
 Pass	WebAssembly.instantiate(buffer): Non-object imports argument: 1
 Pass	WebAssembly.instantiate(buffer): Non-object imports argument: 0.1
 Pass	WebAssembly.instantiate(buffer): Non-object imports argument: NaN
-Fail	WebAssembly.instantiate(buffer): Non-object module: undefined
-Fail	WebAssembly.instantiate(buffer): Non-object module: null
-Fail	WebAssembly.instantiate(buffer): Non-object module: true
-Fail	WebAssembly.instantiate(buffer): Non-object module: ""
-Fail	WebAssembly.instantiate(buffer): Non-object module: symbol "Symbol()"
-Fail	WebAssembly.instantiate(buffer): Non-object module: 1
-Fail	WebAssembly.instantiate(buffer): Non-object module: 0.1
-Fail	WebAssembly.instantiate(buffer): Non-object module: NaN
+Pass	WebAssembly.instantiate(buffer): Non-object module: undefined
+Pass	WebAssembly.instantiate(buffer): Non-object module: null
+Pass	WebAssembly.instantiate(buffer): Non-object module: true
+Pass	WebAssembly.instantiate(buffer): Non-object module: ""
+Pass	WebAssembly.instantiate(buffer): Non-object module: symbol "Symbol()"
+Pass	WebAssembly.instantiate(buffer): Non-object module: 1
+Pass	WebAssembly.instantiate(buffer): Non-object module: 0.1
+Pass	WebAssembly.instantiate(buffer): Non-object module: NaN
 Pass	WebAssembly.instantiate(buffer): Missing imports argument
 Pass	WebAssembly.instantiate(buffer): Imports argument with missing property: undefined
-Fail	WebAssembly.instantiate(buffer): Imports argument with missing property: empty object
-Fail	WebAssembly.instantiate(buffer): Imports argument with missing property: wrong property
+Pass	WebAssembly.instantiate(buffer): Imports argument with missing property: empty object
+Pass	WebAssembly.instantiate(buffer): Imports argument with missing property: wrong property
 Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: undefined
 Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: null
 Fail	WebAssembly.instantiate(buffer): Importing a function with an incorrectly-typed value: true

--- a/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/bad-imports.js
+++ b/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/bad-imports.js
@@ -1,0 +1,186 @@
+/**
+ * `t` should be a function that takes at least three arguments:
+ *
+ * - the name of the test;
+ * - the expected error (to be passed to `assert_throws_js`);
+ * - a function that takes a `WasmModuleBuilder` and initializes it;
+ * - (optionally) an options object.
+ *
+ * The function is expected to create a test that checks if instantiating a
+ * module with the result of the `WasmModuleBuilder` and the options object
+ * (if any) yields the correct error.
+ */
+function test_bad_imports(t) {
+  function value_type(type) {
+    switch (type) {
+      case "i32": return kWasmI32;
+      case "i64": return kWasmI64;
+      case "f32": return kWasmF32;
+      case "f64": return kWasmF64;
+      default: throw new TypeError(`Unexpected type ${type}`);
+    }
+  }
+
+  for (const value of [null, true, "", Symbol(), 1, 0.1, NaN]) {
+    t(`Non-object imports argument: ${format_value(value)}`,
+      TypeError,
+      builder => {},
+      value);
+  }
+
+  for (const value of [undefined, null, true, "", Symbol(), 1, 0.1, NaN]) {
+    const imports = {
+      "module": value,
+    };
+    t(`Non-object module: ${format_value(value)}`,
+      TypeError,
+      builder => {
+        builder.addImport("module", "fn", kSig_v_v);
+      },
+      imports);
+  }
+
+  t(`Missing imports argument`,
+    TypeError,
+    builder => {
+      builder.addImport("module", "fn", kSig_v_v);
+    });
+
+  for (const [value, name] of [[undefined, "undefined"], [{}, "empty object"], [{ "module\0": null }, "wrong property"]]) {
+    t(`Imports argument with missing property: ${name}`,
+      TypeError,
+      builder => {
+        builder.addImport("module", "fn", kSig_v_v);
+      },
+      value);
+  }
+
+  for (const value of [undefined, null, true, "", Symbol(), 1, 0.1, NaN, {}]) {
+    t(`Importing a function with an incorrectly-typed value: ${format_value(value)}`,
+      WebAssembly.LinkError,
+      builder => {
+        builder.addImport("module", "fn", kSig_v_v);
+      },
+      {
+        "module": {
+          "fn": value,
+        },
+      });
+  }
+
+  const nonGlobals = [
+    [undefined],
+    [null],
+    [true],
+    [""],
+    [Symbol()],
+    [{}, "plain object"],
+    [WebAssembly.Global, "WebAssembly.Global"],
+    [WebAssembly.Global.prototype, "WebAssembly.Global.prototype"],
+    [Object.create(WebAssembly.Global.prototype), "Object.create(WebAssembly.Global.prototype)"],
+  ];
+
+  for (const type of ["i32", "i64", "f32", "f64"]) {
+    const extendedNonGlobals = nonGlobals.concat([
+      type === "i64" ? [0, "Number"] : [0n, "BigInt"],
+      [new WebAssembly.Global({value: type === "f32" ? "f64" : "f32"}), "WebAssembly.Global object (wrong value type)"],
+    ]);
+    for (const [value, name = format_value(value)] of extendedNonGlobals) {
+      t(`Importing an ${type} global with an incorrectly-typed value: ${name}`,
+        WebAssembly.LinkError,
+        builder => {
+          builder.addImportedGlobal("module", "global", value_type(type));
+        },
+        {
+          "module": {
+            "global": value,
+          },
+        });
+    }
+  }
+
+  for (const type of ["i32", "i64", "f32", "f64"]) {
+    const value = type === "i64" ? 0n : 0;
+    t(`Importing an ${type} mutable global with a primitive value`,
+      WebAssembly.LinkError,
+      builder => {
+        builder.addImportedGlobal("module", "global", value_type(type), true);
+      },
+      {
+        "module": {
+          "global": value,
+        },
+      });
+
+    const global = new WebAssembly.Global({ "value": type }, value);
+    t(`Importing an ${type} mutable global with an immutable Global object`,
+      WebAssembly.LinkError,
+      builder => {
+        builder.addImportedGlobal("module", "global", value_type(type), true);
+      },
+      {
+        "module": {
+          "global": global,
+        },
+      });
+  }
+
+  const nonMemories = [
+    [undefined],
+    [null],
+    [true],
+    [""],
+    [Symbol()],
+    [1],
+    [0.1],
+    [NaN],
+    [{}, "plain object"],
+    [WebAssembly.Memory, "WebAssembly.Memory"],
+    [WebAssembly.Memory.prototype, "WebAssembly.Memory.prototype"],
+    [Object.create(WebAssembly.Memory.prototype), "Object.create(WebAssembly.Memory.prototype)"],
+    [new WebAssembly.Memory({"initial": 256}), "WebAssembly.Memory object (too large)"],
+  ];
+
+  for (const [value, name = format_value(value)] of nonMemories) {
+    t(`Importing memory with an incorrectly-typed value: ${name}`,
+      WebAssembly.LinkError,
+      builder => {
+        builder.addImportedMemory("module", "memory", 0, 128);
+      },
+      {
+        "module": {
+          "memory": value,
+        },
+      });
+  }
+
+  const nonTables = [
+    [undefined],
+    [null],
+    [true],
+    [""],
+    [Symbol()],
+    [1],
+    [0.1],
+    [NaN],
+    [{}, "plain object"],
+    [WebAssembly.Table, "WebAssembly.Table"],
+    [WebAssembly.Table.prototype, "WebAssembly.Table.prototype"],
+    [Object.create(WebAssembly.Table.prototype), "Object.create(WebAssembly.Table.prototype)"],
+    [new WebAssembly.Table({"element": "anyfunc", "initial": 256}), "WebAssembly.Table object (too large)"],
+  ];
+
+  for (const [value, name = format_value(value)] of nonTables) {
+    t(`Importing table with an incorrectly-typed value: ${name}`,
+      WebAssembly.LinkError,
+      builder => {
+        builder.addImportedTable("module", "table", 0, 128);
+      },
+      {
+        "module": {
+          "table": value,
+        },
+      });
+  }
+}
+globalThis.test_bad_imports = test_bad_imports;

--- a/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../wasm/jsapi/wasm-module-builder.js"></script>
+<script src="../../../wasm/jsapi/bad-imports.js"></script>
+<div id=log></div>
+<script src="../../../wasm/jsapi/constructor/instantiate-bad-imports.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/constructor/instantiate-bad-imports.any.js
@@ -1,0 +1,22 @@
+// META: global=window,dedicatedworker,jsshell,shadowrealm
+// META: script=/wasm/jsapi/wasm-module-builder.js
+// META: script=/wasm/jsapi/bad-imports.js
+
+test_bad_imports((name, error, build, ...arguments) => {
+  promise_test(t => {
+    const builder = new WasmModuleBuilder();
+    build(builder);
+    const buffer = builder.toBuffer();
+    const module = new WebAssembly.Module(buffer);
+    return promise_rejects_js(t, error, WebAssembly.instantiate(module, ...arguments));
+  }, `WebAssembly.instantiate(module): ${name}`);
+});
+
+test_bad_imports((name, error, build, ...arguments) => {
+  promise_test(t => {
+    const builder = new WasmModuleBuilder();
+    build(builder);
+    const buffer = builder.toBuffer();
+    return promise_rejects_js(t, error, WebAssembly.instantiate(buffer, ...arguments));
+  }, `WebAssembly.instantiate(buffer): ${name}`);
+});


### PR DESCRIPTION
Fixes ~1000 WPT tests in `/wasm`. Full comparison log here:
[wasm.txt](https://github.com/user-attachments/files/21327822/wasm.txt)

Also causes ~30 "regressions" in `/wasm`. These were actually incorrectly passing previously:
```
  ▶ Unexpected subtest result in /wasm/core/data.wast.js.html:
  │ FAIL [expected PASS] #53 Test that a WebAssembly module is uninstantiable
  │   → assert_true: expected link error, observed LinkError: Data segment attempted to write to out-of-bounds memory (0) in memory of size 0
    at Error
    at assert_uninstantiable (http://web-platform.test:8000/wasm/core/js/harness/async_index.js:372:15)
    at data_wast_js (http://web-platform.test:8000/wasm/core/js/data.wast.js:85:22)
    at http://web-platform.test:8000/wasm/core/js/data.wast.js:186:3
```

(Despite the "expected link error" text, the test is expecting a `RuntimeError`):
https://github.com/web-platform-tests/wpt/blob/6b2239ddd085f1945d5e41406baff9df57f7a42a/wasm/core/js/harness/async_index.js#L378-L379

Before this change, `LinkError` and `RuntimeError` were both just `Error`. Thus, `LinkError() instanceof RuntimeError` would be true and the test "passed". It now correctly fails.
