### PR TITLE
CMake: Update default BUILD_PRESET arg to Release in WPT.sh

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -12,7 +12,7 @@ ensure_ladybird_source_dir
 WPT_SOURCE_DIR=${WPT_SOURCE_DIR:-"${LADYBIRD_SOURCE_DIR}/Tests/LibWeb/WPT/wpt"}
 WPT_REPOSITORY_URL=${WPT_REPOSITORY_URL:-"https://github.com/web-platform-tests/wpt.git"}
 
-BUILD_PRESET=${BUILD_PRESET:-default}
+BUILD_PRESET=${BUILD_PRESET:-Release}
 
 BUILD_DIR=$(get_build_dir "$BUILD_PRESET")
 

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -66,7 +66,7 @@ get_build_dir() {
 
     # Note: Keep in sync with buildDir defaults in CMakePresets.json
     case "$1" in
-        "default")
+        "Release")
             BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/release"
             ;;
         "Debug")


### PR DESCRIPTION
It was renamed from 'default' to 'Release' in https://github.com/LadybirdBrowser/ladybird/pull/4942 but I missed updating this section.

