### PR TITLE
LibWeb: Fix size computation for elements with max-width and max-height

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -583,10 +583,9 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
         CSSPixels w = used_width;
         CSSPixels h = tentative_height_for_replaced_element(box, computed_height, available_space);
         used_width = solve_replaced_size_constraint(w, h, box, available_space).width();
-        return used_width;
     }
 
-    // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
+    // 2. If the tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.width)) {
         auto const& computed_max_width = box.computed_values().max_width();
@@ -661,7 +660,6 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
         CSSPixels w = tentative_width_for_replaced_element(box, computed_width, available_space);
         CSSPixels h = used_height;
         used_height = solve_replaced_size_constraint(w, h, box, available_space).height();
-        return used_height;
     }
 
     // 2. If this tentative height is greater than 'max-height', the rules above are applied again,

--- a/Tests/LibWeb/Layout/expected/image-with-max-width-and-max-height.txt
+++ b/Tests/LibWeb/Layout/expected/image-with-max-width-and-max-height.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x70 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x52 children: inline
+      frag 0 from ImageBox start: 0, length: 0, rect: [11,11 66.65625x50] baseline: 52
+      ImageBox <img> at (11,11) content-size 66.65625x50 children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x54]
+      ImagePaintable (ImageBox<IMG>) [10,10 68.65625x52]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x70] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/image-with-max-width-and-max-height.html
+++ b/Tests/LibWeb/Layout/input/image-with-max-width-and-max-height.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><style>
+* { border: 1px solid black; }
+body { background: #444; }
+img {
+    max-height: 50px;
+    max-width: 100px;
+}
+</style><img src="data:image/gif;base64,R0lGODdhgALgAYAAAP///////ywAAAAAgALgAQAC/oSPqcvtD6OctNqLs968+w+G4kiW5omm6sq27gvH8kzX9o3n+s73/g8MCofEovGITCqXzKbzCY1Kp9Sq9YrNarfcrvcLDovH5LL5jE6r1+y2+w2Py+f0uv2Oz+v3/L7/DxgoOEhYaHiImKi4yNjo+AgZKTlJWWl5iZmpucnZ6fkJGio6SlpqeoqaqrrK2ur6ChsrO0tba3uLm6u7y9vr+wscLDxMXGx8jJysvMzc7PwMHS09TV1tfY2drb3N3e39DR4uPk5ebn6Onq6+zt7u/g4fLz9PX29/j5+vv8/f7/8PMKDAgQQLGjyIMKHChQwbOnwIMaLEiRQrWryIMaPG/o0cO3r8CDKkyJEkS5o8iTKlypUsW7p8CTOmzJk0a9q8iTOnzp08e/r8CTSo0KFEixo9ijSp0qVMmzp9CjWq1KlUq1q9ijWr1q1cu3r9Cjas2LFky5o9izat2rVs27p9Czeu3Ll069q9izev3r18+/r9Cziw4MGECxs+jDix4sWMGzt+DDmy5MmUK1u+jDmz5s2cO3v+DDq06NGkS5s+jTq16tWsW7t+DTu27Nm0a9u+jTu37t28e/v+DTy48OHEixs/jjy58uXMmzt/Dj269OnUq1u/jj279u3cu3v/Dj68+PHky5s/jz69+vXs27t/Dz++/Pn069u/jz+//v38/vv7/w9ggAIOSGCBBh6IYIIKLshggw4+CGGEEk5IYYUWXohhhhpuyGGHHn4IYogijkhiiSaeiGKKKq7IYosuvghjjDLOSGONNt6IY4467shjjz7+CGSQQg5JZJFGHolkkkouyWSTTj4JZZRSTklllVZeiWWWWm7JZZdefglmmGKOSWaZZp6JZppqrslmm26+CWeccs5JZ5123olnnnruyWeffv4JaKCCDkpooYYeimiiii7KaKOOPgpppJJOSmmlll6Kaaaabsppp55+Cmqooo5Kaqmmnopqqqquymqrrr4Ka6yyzkprrbbeimuuuu7Ka6++/gpssMIOS2yxxh6LYWyyyi7LbLPOPgtttNJOS2211l6Lbbbabsttt95+C2644o5Lbrnmnotuuuquy2677r4Lb7zyzktvvfbei2+++u7Lb7/+/gtwwAIPTHDBBh+McMIKL8xwww4/DHHEEk/MUAEAOw==" />


### PR DESCRIPTION
The specification [1] indicates that the tentative used width and height should be computed first, and if they exceed the `max-width` or `max-height`, the rules should be applied again using the computed values of `max-width` and `max-height`.

The only required change to follow the spec is to remove the early `return` statements, in both `compute_width_for_replaced_element` and `compute_height_for_replaced_element`.

Fixes #5100.

[1] https://www.w3.org/TR/CSS22/visudet.html#min-max-widths