### PR TITLE
LibWeb: Ignore zero width when calculating SVG intrinsic aspect ratio

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -172,10 +172,7 @@ Optional<CSSPixelFraction> SVGDecodedImageData::intrinsic_aspect_ratio() const
     // https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS
     auto width = intrinsic_width();
     auto height = intrinsic_height();
-    if (height.has_value() && *height == 0)
-        return {};
-
-    if (width.has_value() && height.has_value())
+    if (width.has_value() && height.has_value() && *width > 0 && *height > 0)
         return *width / *height;
 
     if (auto const& viewbox = m_root_element->view_box(); viewbox.has_value()) {

--- a/Tests/LibWeb/Crash/SVG/zero-width-svg.html
+++ b/Tests/LibWeb/Crash/SVG/zero-width-svg.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='0' height='1'></svg>">


### PR DESCRIPTION
Previously, an SVG with width of zero would have an intrinsic aspect ratio of zero. With this change, if an SVG has a width or height of zero, the intrinsic aspect ratio is determined by the SVG's viewbox.

This fixes crashes in these 2 WPT tests:
* http://wpt.live/css/css-grid/alignment/grid-item-aspect-ratio-stretch-3.html
* http://wpt.live/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-4.html

These tests still fail for reasons beyond the scope of this PR, so they can't be imported.