### PR TITLE
LibRegex+LibJS: Fix non-ASCII unicode regex matching

### DIFF
--- a/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -96,19 +96,10 @@ ErrorOr<String, ParseRegexPatternError> parse_regex_pattern(StringView pattern, 
     auto utf16_pattern = Utf16String::from_utf8(pattern);
     StringBuilder builder;
 
-    // If the Unicode flag is set, append each code point to the pattern. Otherwise, append each
-    // code unit. But unlike the spec, multi-byte code units must be escaped for LibRegex to parse.
+    // FIXME: We need to escape multi-byte code units for LibRegex to parse since the lexer there doesn't handle unicode.
     auto previous_code_unit_was_backslash = false;
-    for (size_t i = 0; i < utf16_pattern.length_in_code_units();) {
-        if (unicode || unicode_sets) {
-            auto code_point = code_point_at(utf16_pattern, i);
-            builder.append_code_point(code_point.code_point);
-            i += code_point.code_unit_count;
-            continue;
-        }
-
+    for (size_t i = 0; i < utf16_pattern.length_in_code_units(); ++i) {
         u16 code_unit = utf16_pattern.code_unit_at(i);
-        ++i;
 
         if (code_unit > 0x7f) {
             // Incorrectly escaping this code unit will result in a wildly different regex than intended

--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
@@ -81,3 +81,19 @@ test("v flag should enable unicode mode", () => {
 test("parsing a large bytestring shouldn't crash", () => {
     RegExp(new Uint8Array(0x40000));
 });
+
+test("Unicode non-ASCII matching", () => {
+    const cases = [
+        { pattern: /é/u, match: "é", expected: ["é"] },
+        { pattern: /é/, match: "é", expected: ["é"] },
+        { pattern: /\u{61}/u, match: "a", expected: ["a"] },
+        { pattern: /\u{61}/, match: "a", expected: null },
+        { pattern: /😄/u, match: "😄", expected: ["😄"] },
+        { pattern: /😄/u, match: "\ud83d", expected: null },
+        { pattern: /😄/, match: "\ud83d", expected: null },
+    ];
+    for (const test of cases) {
+        const result = test.match.match(test.pattern);
+        expect(result).toEqual(test.expected);
+    }
+});

--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -957,7 +957,7 @@ Vector<ByteString> OpCode_Compare::variable_arguments_to_byte_string(Optional<Ma
     Vector<ByteString> result;
 
     size_t offset { state().instruction_position + 3 };
-    RegexStringView const& view = ((input.has_value()) ? input.value().view : StringView {});
+    RegexStringView const& view = input.has_value() ? input.value().view : StringView {};
 
     for (size_t i = 0; i < arguments_count(); ++i) {
         auto compare_type = (CharacterCompareType)m_bytecode->at(offset++);

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -237,7 +237,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
         input.view = view;
         dbgln_if(REGEX_DEBUG, "[match] Starting match with view ({}): _{}_", view.length(), view);
 
-        auto view_length = view.length();
+        auto view_length = view.length_in_code_units();
         size_t view_index = m_pattern->start_offset;
         state.string_position = view_index;
         state.string_position_in_code_units = view_index;


### PR DESCRIPTION
There apparently is a bit of a disconnect between the spec asking us to construct the pattern using code points and LibRegex not being able to swallow those. Whenever we had multi-byte code points in the pattern and tried to match that in unicode mode, we would fail.

Change the parser to encode all non-ASCII code units. Fixes 2 test262 cases in `language/literals/regexp`.