### PR TITLE
LibWeb: Always parse calc() inside CSS color functions consistently

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -3842,6 +3842,12 @@ RefPtr<CSSStyleValue const> Parser::parse_calculated_value(ComponentValue const&
                     //       caller to handle the resolved value being a percentage.
                     return CalculationContext {};
                 }
+                if (function.name.is_one_of_ignoring_ascii_case(
+                        "rgb"sv, "rgba"sv, "hsl"sv, "hsla"sv,
+                        "hwb"sv, "lab"sv, "lch"sv, "oklab"sv, "oklch"sv,
+                        "color"sv)) {
+                    return CalculationContext {};
+                }
                 // FIXME: Add other functions that provide a context for resolving values
                 return {};
             },

--- a/Tests/LibWeb/Ref/expected/css/gradient-calc-inside-stop-color-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/gradient-calc-inside-stop-color-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<style>
+    div {
+        background-image: linear-gradient(to right, red, rgb(0 255 0));
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <div></div>
+</body>

--- a/Tests/LibWeb/Ref/input/css/gradient-calc-inside-stop-color.html
+++ b/Tests/LibWeb/Ref/input/css/gradient-calc-inside-stop-color.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<link rel="match" href="../../expected/css/gradient-calc-inside-stop-color-ref.html" />
+<style>
+    div {
+        background-image: linear-gradient(to right, red, rgb(0 calc(100%) 0));
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <div></div>
+</body>


### PR DESCRIPTION
Before this change, calc() would resolve to different types depending on the nearest containing value context. This meant that rgb(calc(), ...) by itself worked correctly due to fallbacks, but rgb(calc(), ...) inside e.g a linear-gradient would create a calc() value that resolves to a length, which subsequently got rejected by the color value parser.

Fixing this makes various little gradients show up on Discord.

Before:
<img width="1863" height="1014" alt="before" src="https://github.com/user-attachments/assets/f900b1f8-a38f-4a24-a518-8a2394918db1" />

After:
<img width="1860" height="1010" alt="after" src="https://github.com/user-attachments/assets/dad99ceb-1422-4b2c-9a6f-e0b15e5fbcb9" />
