### PR TITLE
LibWeb/HTML: Sanitize email input with multiple attribute

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -56,7 +56,7 @@ private:                                                                        
     {                                                                                                                                                                       \
         ElementBaseClass::attribute_changed(name, old_value, value, namespace_);                                                                                            \
         form_node_attribute_changed(name, value);                                                                                                                           \
-        form_associated_element_attribute_changed(name, value, namespace_);                                                                                                 \
+        form_associated_element_attribute_changed(name, old_value, value, namespace_);                                                                                      \
     }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#selection-direction
@@ -152,7 +152,7 @@ protected:
     virtual void form_associated_element_was_inserted() { }
     virtual void form_associated_element_was_removed(DOM::Node*) { }
     virtual void form_associated_element_was_moved(GC::Ptr<DOM::Node>) { }
-    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) { }
+    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&) { }
 
     void form_node_was_inserted();
     void form_node_was_removed();

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -80,7 +80,7 @@ WebIDL::ExceptionOr<void> HTMLButtonElement::set_type_for_bindings(String const&
     return set_attribute(HTML::AttributeNames::type, type);
 }
 
-void HTMLButtonElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const& namespace_)
+void HTMLButtonElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     PopoverInvokerElement::associated_attribute_changed(name, value, namespace_);
 }

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -42,7 +42,7 @@ public:
     String type_for_bindings() const;
     WebIDL::ExceptionOr<void> set_type_for_bindings(String const&);
 
-    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     bool will_validate();
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -134,7 +134,7 @@ void HTMLImageElement::apply_presentational_hints(GC::Ref<CSS::CascadedPropertie
     });
 }
 
-void HTMLImageElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
+void HTMLImageElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::crossorigin) {
         m_cors_setting = cors_setting_attribute_from_keyword(value);

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -38,7 +38,7 @@ class HTMLImageElement final
 public:
     virtual ~HTMLImageElement() override;
 
-    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     Optional<String> alternative_text() const override
     {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -195,7 +195,7 @@ public:
     virtual void clear_algorithm() override;
 
     virtual void form_associated_element_was_inserted() override;
-    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -91,7 +91,7 @@ bool HTMLObjectElement::will_validate()
     return false;
 }
 
-void HTMLObjectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<FlyString> const&)
+void HTMLObjectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&)
 {
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element
     // Whenever one of the following conditions occur:

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -33,7 +33,7 @@ class HTMLObjectElement final
 public:
     virtual ~HTMLObjectElement() override;
 
-    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual void form_associated_element_was_removed(DOM::Node*) override;
 
     String data() const;

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -32,7 +32,7 @@ void HTMLOutputElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_html_for);
 }
 
-void HTMLOutputElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
+void HTMLOutputElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::for_) {
         if (m_html_for)

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -65,7 +65,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor& visitor) override;
 
-    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     GC::Ptr<DOM::DOMTokenList> m_html_for;
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -574,7 +574,7 @@ void HTMLSelectElement::form_associated_element_was_inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLSelectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
+void HTMLSelectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::multiple) {
         // If the multiple attribute is absent then update the selectedness of the option elements.

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -98,7 +98,7 @@ public:
     virtual void activation_behavior(DOM::Event const&) override;
 
     virtual void form_associated_element_was_inserted() override;
-    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void did_select_item(Optional<u32> const& id);
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -438,7 +438,7 @@ void HTMLTextAreaElement::children_changed(ChildrenChangedMetadata const* metada
     }
 }
 
-void HTMLTextAreaElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
+void HTMLTextAreaElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::placeholder) {
         if (m_placeholder_text_node)

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -70,7 +70,7 @@ public:
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;
 
     virtual void form_associated_element_was_inserted() override;
-    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual void children_changed(ChildrenChangedMetadata const*) override;
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-patternMismatch.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-patternMismatch.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 85 tests
 
-69 Pass
-16 Fail
+71 Pass
+14 Fail
 Pass	[INPUT in TEXT status] The pattern attribute is not set
 Pass	[INPUT in TEXT status] The value attibute is empty string
 Pass	[INPUT in TEXT status] The value attribute matches the pattern attribute
@@ -80,12 +80,12 @@ Pass	[INPUT in EMAIL status] The pattern attribute is not set, if multiple is pr
 Pass	[INPUT in EMAIL status] The value attibute is empty string, if multiple is present
 Pass	[INPUT in EMAIL status] The value attribute matches the pattern attribute, if multiple is present
 Pass	[INPUT in EMAIL status] The value(ABC) in unicode attribute matches the pattern attribute, if multiple is present
-Fail	[INPUT in EMAIL status] The value attribute mismatches the pattern attribute, if multiple is present
-Fail	[INPUT in EMAIL status] The value attribute mismatches the pattern attribute even when a subset matches, if multiple is present
+Pass	[INPUT in EMAIL status] The value attribute mismatches the pattern attribute, if multiple is present
+Pass	[INPUT in EMAIL status] The value attribute mismatches the pattern attribute even when a subset matches, if multiple is present
 Pass	[INPUT in EMAIL status] Invalid regular expression gets ignored, if multiple is present
 Pass	[INPUT in EMAIL status] Invalid `v` regular expression gets ignored, if multiple is present
 Pass	[INPUT in EMAIL status] The pattern attribute tries to escape a group, if multiple is present
-Pass	[INPUT in EMAIL status] The pattern attribute uses Unicode features, if multiple is present
+Fail	[INPUT in EMAIL status] The pattern attribute uses Unicode features, if multiple is present
 Pass	[INPUT in EMAIL status] The value attribute matches JavaScript-specific regular expression, if multiple is present
 Fail	[INPUT in EMAIL status] The value attribute mismatches JavaScript-specific regular expression, if multiple is present
-Fail	[INPUT in EMAIL status] Commas should be stripped from regex input, if multiple is present
+Pass	[INPUT in EMAIL status] Commas should be stripped from regex input, if multiple is present

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/email.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/email.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 8 tests
 
-5 Pass
-3 Fail
+8 Pass
 Pass	single_email doesn't have the multiple attribute
 Pass	value should be sanitized: strip line breaks
 Pass	Email address validity
-Fail	When the multiple attribute is removed, the user agent must run the value sanitization algorithm
+Pass	When the multiple attribute is removed, the user agent must run the value sanitization algorithm
 Pass	multiple_email has the multiple attribute
-Fail	run the value sanitization algorithm after setting a new value
+Pass	run the value sanitization algorithm after setting a new value
 Pass	valid value is a set of valid email addresses separated by a single ','
-Fail	When the multiple attribute is set, the user agent must run the value sanitization algorithm
+Pass	When the multiple attribute is set, the user agent must run the value sanitization algorithm


### PR DESCRIPTION
This implements the missing part of the value sanitization algorithm for email inputs with the multiple attribute.