### PR TITLE
LibWeb: Return base Document for non-HTML parses

### DIFF
--- a/Libraries/LibWeb/HTML/DOMParser.cpp
+++ b/Libraries/LibWeb/HTML/DOMParser.cpp
@@ -56,7 +56,7 @@ GC::Ref<DOM::Document> DOMParser::parse_from_string(StringView string, Bindings:
         document->parse_html_from_a_string(string);
     } else {
         // -> Otherwise
-        document = DOM::XMLDocument::create(realm(), associated_document.url());
+        document = DOM::Document::create(realm(), associated_document.url());
         document->set_content_type(Bindings::idl_enum_to_string(type));
         document->set_document_type(DOM::Document::Type::XML);
 

--- a/Tests/LibWeb/Text/expected/DOM/DOMParser-xml-document.txt
+++ b/Tests/LibWeb/Text/expected/DOM/DOMParser-xml-document.txt
@@ -1,1 +1,1 @@
-XMLDocument
+Document

--- a/Tests/LibWeb/Text/expected/wpt-import/domparsing/DOMParser-parseFromString-xml.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domparsing/DOMParser-parseFromString-xml.txt
@@ -1,0 +1,25 @@
+Harness status: OK
+
+Found 20 tests
+
+20 Pass
+Pass	Should parse correctly in type text/xml
+Pass	XMLDocument interface for correctly parsed document with type text/xml
+Pass	Should return an error document for XML wellformedness errors in type text/xml
+Pass	XMLDocument interface for incorrectly parsed document with type text/xml
+Pass	scripting must be disabled with type text/xml
+Pass	Should parse correctly in type application/xml
+Pass	XMLDocument interface for correctly parsed document with type application/xml
+Pass	Should return an error document for XML wellformedness errors in type application/xml
+Pass	XMLDocument interface for incorrectly parsed document with type application/xml
+Pass	scripting must be disabled with type application/xml
+Pass	Should parse correctly in type application/xhtml+xml
+Pass	XMLDocument interface for correctly parsed document with type application/xhtml+xml
+Pass	Should return an error document for XML wellformedness errors in type application/xhtml+xml
+Pass	XMLDocument interface for incorrectly parsed document with type application/xhtml+xml
+Pass	scripting must be disabled with type application/xhtml+xml
+Pass	Should parse correctly in type image/svg+xml
+Pass	XMLDocument interface for correctly parsed document with type image/svg+xml
+Pass	Should return an error document for XML wellformedness errors in type image/svg+xml
+Pass	XMLDocument interface for incorrectly parsed document with type image/svg+xml
+Pass	scripting must be disabled with type image/svg+xml

--- a/Tests/LibWeb/Text/input/wpt-import/domparsing/DOMParser-parseFromString-xml.html
+++ b/Tests/LibWeb/Text/input/wpt-import/domparsing/DOMParser-parseFromString-xml.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<title>DOMParser</title>
+<link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+function checkMetadata(doc, contentType) {
+  assert_true(doc instanceof Document, "Should be Document");
+  assert_equals(doc.URL, document.URL, "URL");
+  assert_equals(doc.documentURI, document.URL, "documentURI");
+  assert_equals(doc.baseURI, document.URL, "baseURI");
+  assert_equals(doc.characterSet, "UTF-8", "characterSet");
+  assert_equals(doc.charset, "UTF-8", "charset");
+  assert_equals(doc.inputEncoding, "UTF-8", "inputEncoding");
+  assert_equals(doc.contentType, contentType, "contentType");
+  assert_equals(doc.location, null, "location");
+}
+
+var allowedTypes = ["text/xml", "application/xml", "application/xhtml+xml", "image/svg+xml"];
+
+allowedTypes.forEach(function(type) {
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo/>", type);
+    assert_true(doc instanceof Document, "Should be Document");
+    checkMetadata(doc, type);
+    assert_equals(doc.documentElement.namespaceURI, null);
+    assert_equals(doc.documentElement.localName, "foo");
+    assert_equals(doc.documentElement.tagName, "foo");
+  }, "Should parse correctly in type " + type);
+
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo/>", type);
+    assert_false(doc instanceof XMLDocument, "Should not be XMLDocument");
+  }, "XMLDocument interface for correctly parsed document with type " + type);
+
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo>", type);
+    checkMetadata(doc, type);
+    assert_equals(doc.documentElement.namespaceURI, "http://www.mozilla.org/newlayout/xml/parsererror.xml");
+    assert_equals(doc.documentElement.localName, "parsererror");
+    assert_equals(doc.documentElement.tagName, "parsererror");
+  }, "Should return an error document for XML wellformedness errors in type " + type);
+
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString("<foo>", type);
+    assert_false(doc instanceof XMLDocument, "Should not be XMLDocument");
+  }, "XMLDocument interface for incorrectly parsed document with type " + type);
+
+  test(function() {
+    var p = new DOMParser();
+    var doc = p.parseFromString(`
+      <html>
+        <head></head>
+        <body>
+          <script>document.x = 5;<\/script>
+          <noscript><p>test1</p><p>test2</p></noscript>
+        </body>
+      </html>`
+    , type);
+
+    assert_equals(doc.x, undefined, "script must not be executed on the inner document");
+    assert_equals(document.x, undefined, "script must not be executed on the outer document");
+
+    const body = doc.documentElement.children[1];
+    assert_equals(body.localName, "body");
+    assert_equals(body.children[1].localName, "noscript");
+    assert_equals(body.children[1].children.length, 2);
+    assert_equals(body.children[1].children[0].localName, "p");
+    assert_equals(body.children[1].children[1].localName, "p");
+  }, "scripting must be disabled with type " + type);
+});
+</script>


### PR DESCRIPTION
The HTML specification does not explicitly require a specific return type for parseFromString(),
but according to Web Platform TestsDOMParser-parseFromString.html, the expected return value for
XML MIME types is a Document—not an XMLDocument.