### PR TITLE
RequestServer+LibWebSocket: Drain underlying socket and resulting frames

### DIFF
--- a/Libraries/LibWebSocket/WebSocket.h
+++ b/Libraries/LibWebSocket/WebSocket.h
@@ -89,7 +89,7 @@ private:
     void send_client_handshake();
     void read_server_handshake();
 
-    void read_frame();
+    ErrorOr<void> read_frame();
     void send_frame(OpCode, ReadonlyBytes, bool is_final);
 
     void notify_open();

--- a/Services/RequestServer/WebSocketImplCurl.h
+++ b/Services/RequestServer/WebSocketImplCurl.h
@@ -34,6 +34,8 @@ public:
 private:
     explicit WebSocketImplCurl(CURLM*);
 
+    void read_from_socket();
+
     CURLM* m_multi_handle { nullptr };
     CURL* m_easy_handle { nullptr };
     RefPtr<Core::Notifier> m_read_notifier;


### PR DESCRIPTION
`curl_easy_recv` must be called in a loop until it returns EAGAIN, because it may cache data, but only activate the read notifier once.

Additionally, the data received can contain multiple WebSocket frames and only activate the notifier once, so we have to keep reading frames until there isn't enough data.

We also have to do this immediately after connecting a WebSocket, since the server may immediately send data when the WebSocket opens and before we create the read notifier.

This makes Discord login faster and more reliable, and makes Discord activities start loading.