### PR TITLE
LibWeb/WebSocket: Include the User-Agent header on connection

### DIFF
--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -213,6 +213,8 @@ ErrorOr<void> WebSocket::establish_web_socket_connection(URL::URL const& url_rec
         additional_headers.set("Cookie", cookies.to_byte_string());
     }
 
+    additional_headers.set("User-Agent", ResourceLoader::the().user_agent().to_byte_string());
+
     m_websocket = ResourceLoader::the().request_client().websocket_connect(url_record, origin_string, protocol_byte_strings, {}, additional_headers);
 
     m_websocket->on_open = [weak_this = make_weak_ptr<WebSocket>()] {


### PR DESCRIPTION
This makes the WebSockets on https://pro.kraken.com/app/trade/btc-usd happier, but the page doesn't quite work yet.