### PR TITLE
LibJS: Create match indices based on code unit length

### DIFF
--- a/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -76,7 +76,7 @@ static ThrowCompletionOr<void> increment_last_index(VM& vm, Object& regexp_objec
 struct Match {
     static Match create(regex::Match const& match)
     {
-        return { match.global_offset, match.global_offset + match.view.length() };
+        return { match.global_offset, match.global_offset + match.view.length_in_code_units() };
     }
 
     size_t start_index { 0 };

--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.hasIndices.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.hasIndices.js
@@ -50,4 +50,8 @@ test("basic functionality", () => {
         var result = regex.exec("let foo").indices;
         expect(result.groups).toEqual({ keyword: [0, 3], id: [4, 7] });
     }
+
+    regex = /🍕/du;
+    expect(regex.hasIndices).toBeTrue();
+    expect(regex.exec("🍕").indices[0]).toEqual([0, 2]);
 });


### PR DESCRIPTION
test262 diff:
```
test/built-ins/RegExp/match-indices/indices-array-unicode-match.js ❌ -> ✅
```