### PR TITLE
LibWeb: Convert Editing API internals to UTF-16

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -228,6 +228,14 @@ public:
         return TypedTransfer<T>::compare(data(), other.data(), other.size());
     }
 
+    [[nodiscard]] constexpr bool ends_with(ReadonlySpan<T> other) const
+    {
+        if (size() < other.size())
+            return false;
+
+        return TypedTransfer<T>::compare(offset_pointer(size() - other.size()), other.data(), other.size());
+    }
+
     [[nodiscard]] constexpr size_t matching_prefix_length(ReadonlySpan<T> other) const
     {
         auto maximum_length = min(size(), other.size());

--- a/AK/StringConversions.cpp
+++ b/AK/StringConversions.cpp
@@ -71,7 +71,7 @@ Optional<ParseFirstNumberResult<T>> parse_first_number(Utf16View const& string, 
     if (string.has_ascii_storage())
         return parse_first_number<T>(string.bytes(), trim_whitespace, base);
 
-    auto trimmed_string = trim_whitespace == TrimWhitespace::Yes ? string.trim_whitespace() : string;
+    auto trimmed_string = trim_whitespace == TrimWhitespace::Yes ? string.trim_ascii_whitespace() : string;
     return from_chars<char16_t, T>(trimmed_string.utf16_span().data(), trimmed_string.length_in_code_units(), base);
 }
 
@@ -107,7 +107,7 @@ Optional<T> parse_number(Utf16View const& string, TrimWhitespace trim_whitespace
     if (string.has_ascii_storage())
         return parse_number<T>(string.bytes(), trim_whitespace, base);
 
-    auto trimmed_string = trim_whitespace == TrimWhitespace::Yes ? string.trim_whitespace() : string;
+    auto trimmed_string = trim_whitespace == TrimWhitespace::Yes ? string.trim_ascii_whitespace() : string;
 
     auto result = parse_first_number<T>(trimmed_string, TrimWhitespace::No, base);
     if (!result.has_value())

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -56,7 +56,7 @@ public:
 
     static bool compare(T const* a, T const* b, size_t count)
     {
-        if (count == 0)
+        if (count == 0 || a == b)
             return true;
 
         if constexpr (Traits<T>::is_trivial())

--- a/AK/Utf16StringBase.h
+++ b/AK/Utf16StringBase.h
@@ -220,6 +220,7 @@ public:
     [[nodiscard]] ALWAYS_INLINE bool contains(Utf16View const& needle) const { return find_code_unit_offset(needle).has_value(); }
 
     [[nodiscard]] ALWAYS_INLINE bool starts_with(Utf16View const& needle) const { return utf16_view().starts_with(needle); }
+    [[nodiscard]] ALWAYS_INLINE bool ends_with(Utf16View const& needle) const { return utf16_view().ends_with(needle); }
 
     // This is primarily interesting to unit tests.
     [[nodiscard]] constexpr bool has_short_ascii_storage() const

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -381,7 +381,7 @@ public:
         return substring_view(substring_start, substring_length);
     }
 
-    [[nodiscard]] constexpr Utf16View trim_whitespace(TrimMode mode = TrimMode::Both) const
+    [[nodiscard]] constexpr Utf16View trim_ascii_whitespace(TrimMode mode = TrimMode::Both) const
     {
         static constexpr Utf16View white_space { u" \n\t\v\f\r", 6uz };
         return trim(white_space, mode);

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -463,17 +463,10 @@ public:
         if (needle.length_in_code_units() > length_in_code_units())
             return false;
 
-        if (has_ascii_storage() && needle.has_ascii_storage()) {
-            if (m_string.ascii == needle.m_string.ascii)
-                return true;
+        if (has_ascii_storage() && needle.has_ascii_storage())
             return ascii_span().starts_with(needle.ascii_span());
-        }
-
-        if (!has_ascii_storage() && !needle.has_ascii_storage()) {
-            if (m_string.utf16 == needle.m_string.utf16)
-                return true;
+        if (!has_ascii_storage() && !needle.has_ascii_storage())
             return utf16_span().starts_with(needle.utf16_span());
-        }
 
         for (auto this_it = begin(), needle_it = needle.begin(); needle_it != needle.end(); ++needle_it, ++this_it) {
             if (*this_it != *needle_it)

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -456,24 +456,24 @@ public:
 
     [[nodiscard]] constexpr bool starts_with(Utf16View const& needle) const
     {
-        if (needle.is_empty())
+        auto needle_length = needle.length_in_code_units();
+        if (needle_length == 0)
             return true;
-        if (is_empty())
-            return false;
-        if (needle.length_in_code_units() > length_in_code_units())
+        if (is_empty() || needle_length > length_in_code_units())
             return false;
 
-        if (has_ascii_storage() && needle.has_ascii_storage())
-            return ascii_span().starts_with(needle.ascii_span());
-        if (!has_ascii_storage() && !needle.has_ascii_storage())
-            return utf16_span().starts_with(needle.utf16_span());
+        return substring_view(0, needle_length) == needle;
+    }
 
-        for (auto this_it = begin(), needle_it = needle.begin(); needle_it != needle.end(); ++needle_it, ++this_it) {
-            if (*this_it != *needle_it)
-                return false;
-        }
+    [[nodiscard]] constexpr bool ends_with(Utf16View const& needle) const
+    {
+        auto needle_length = needle.length_in_code_units();
+        if (needle_length == 0)
+            return true;
+        if (is_empty() || needle_length > length_in_code_units())
+            return false;
 
-        return true;
+        return substring_view(length_in_code_units() - needle_length, needle_length) == needle;
     }
 
     // https://infra.spec.whatwg.org/#code-unit-less-than

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -510,7 +510,7 @@ private:
     } m_string { .ascii = nullptr };
 
     // Just like Utf16StringData, we store whether this string has ASCII or UTF-16 storage by setting the most
-    // significant bit of m_code_unit_length for UTF-16 storage.
+    // significant bit of m_length_in_code_units for UTF-16 storage.
     size_t m_length_in_code_units { 0 };
     mutable size_t m_length_in_code_points { NumericLimits<size_t>::max() };
 };

--- a/Libraries/LibGfx/Color.cpp
+++ b/Libraries/LibGfx/Color.cpp
@@ -11,6 +11,7 @@
 #include <AK/Optional.h>
 #include <AK/StringConversions.h>
 #include <AK/Swift.h>
+#include <AK/Utf16View.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
 #include <LibIPC/Decoder.h>
@@ -365,6 +366,11 @@ Optional<Color> Color::from_string(StringView string)
         return color;
 
     return {};
+}
+
+Optional<Color> Color::from_utf16_string(Utf16View const& string)
+{
+    return from_string(string.to_utf8_but_should_be_ported_to_utf16());
 }
 
 Vector<Color> Color::shades(u32 steps, float max) const

--- a/Libraries/LibGfx/Color.h
+++ b/Libraries/LibGfx/Color.h
@@ -491,6 +491,7 @@ public:
     ByteString to_byte_string() const;
     ByteString to_byte_string_without_alpha() const;
     static Optional<Color> from_string(StringView);
+    static Optional<Color> from_utf16_string(Utf16View const&);
     static Optional<Color> from_named_css_color_string(StringView);
 
     constexpr HSV to_hsv() const

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -869,8 +869,8 @@ public:
     void reset_command_state_overrides() { m_command_state_override.clear(); }
 
     // https://w3c.github.io/editing/docs/execCommand/#value-override
-    Optional<String const&> command_value_override(FlyString const& command) const { return m_command_value_override.get(command); }
-    void set_command_value_override(FlyString const& command, String const& value);
+    Optional<Utf16String const&> command_value_override(FlyString const& command) const { return m_command_value_override.get(command); }
+    void set_command_value_override(FlyString const& command, Utf16String const& value);
     void clear_command_value_override(FlyString const& command);
     void reset_command_value_overrides() { m_command_value_override.clear(); }
 
@@ -1255,7 +1255,7 @@ private:
     HashMap<FlyString, bool> m_command_state_override;
 
     // https://w3c.github.io/editing/docs/execCommand/#value-override
-    HashMap<FlyString, String> m_command_value_override;
+    HashMap<FlyString, Utf16String> m_command_value_override;
 
     // https://html.spec.whatwg.org/multipage/webstorage.html#session-storage-holder
     // A Document object has an associated session storage holder, which is null or a Storage object. It is initially null.

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -512,7 +512,7 @@ enum class FontSizeMode : u8 {
 bool command_font_size_action(DOM::Document& document, Utf16View const& value)
 {
     // 1. Strip leading and trailing whitespace from value.
-    auto resulting_value = value.trim_whitespace();
+    auto resulting_value = value.trim_ascii_whitespace();
 
     // 2. If value is not a valid floating point number, and would not be a valid floating point number if a single
     //    leading "+" character were stripped, return false.

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -1744,7 +1744,7 @@ bool command_insert_text_action(DOM::Document& document, String const& value)
     if (value.code_points().length() > 1) {
         // 1. For each code unit el in value, take the action for the insertText command, with value equal to el.
         for (auto el : value.code_points())
-            command_insert_text_action(document, String::from_code_point(el));
+            take_the_action_for_command(document, CommandNames::insertText, String::from_code_point(el));
 
         // 2. Return true.
         return true;
@@ -1756,7 +1756,7 @@ bool command_insert_text_action(DOM::Document& document, String const& value)
 
     // 5. If value is a newline (U+000A), take the action for the insertParagraph command and return true.
     if (value == "\n"sv) {
-        command_insert_paragraph_action(document, {});
+        take_the_action_for_command(document, CommandNames::insertParagraph, {});
         return true;
     }
 

--- a/Libraries/LibWeb/Editing/Commands.h
+++ b/Libraries/LibWeb/Editing/Commands.h
@@ -13,17 +13,17 @@ namespace Web::Editing {
 // https://w3c.github.io/editing/docs/execCommand/#properties-of-commands
 struct CommandDefinition {
     FlyString const& command;
-    Function<bool(DOM::Document&, String const&)> action {};
+    Function<bool(DOM::Document&, Utf16View const&)> action {};
     Function<bool(DOM::Document const&)> indeterminate {};
     Function<bool(DOM::Document const&)> state {};
-    Function<String(DOM::Document const&)> value {};
+    Function<Utf16String(DOM::Document const&)> value {};
     Optional<CSS::PropertyID> relevant_css_property {};
 
     // https://w3c.github.io/editing/docs/execCommand/#preserves-overrides
     bool preserves_overrides { false };
 
     // https://w3c.github.io/editing/docs/execCommand/#inline-command-activated-values
-    Vector<StringView> inline_activated_values {};
+    Vector<Utf16View> inline_activated_values {};
 
     // https://w3c.github.io/editing/docs/execCommand/#dfn-map-an-edit-command-to-input-type-value
     FlyString mapped_value {};
@@ -32,62 +32,62 @@ struct CommandDefinition {
 Optional<CommandDefinition const&> find_command_definition(FlyString const&);
 
 // Command implementations
-bool command_back_color_action(DOM::Document&, String const&);
-bool command_bold_action(DOM::Document&, String const&);
-bool command_create_link_action(DOM::Document&, String const&);
-bool command_default_paragraph_separator_action(DOM::Document&, String const&);
-String command_default_paragraph_separator_value(DOM::Document const&);
-bool command_delete_action(DOM::Document&, String const&);
-bool command_font_name_action(DOM::Document&, String const&);
-bool command_font_size_action(DOM::Document&, String const&);
-String command_font_size_value(DOM::Document const&);
-bool command_fore_color_action(DOM::Document&, String const&);
-bool command_format_block_action(DOM::Document&, String const&);
+bool command_back_color_action(DOM::Document&, Utf16View const&);
+bool command_bold_action(DOM::Document&, Utf16View const&);
+bool command_create_link_action(DOM::Document&, Utf16View const&);
+bool command_default_paragraph_separator_action(DOM::Document&, Utf16View const&);
+Utf16String command_default_paragraph_separator_value(DOM::Document const&);
+bool command_delete_action(DOM::Document&, Utf16View const&);
+bool command_font_name_action(DOM::Document&, Utf16View const&);
+bool command_font_size_action(DOM::Document&, Utf16View const&);
+Utf16String command_font_size_value(DOM::Document const&);
+bool command_fore_color_action(DOM::Document&, Utf16View const&);
+bool command_format_block_action(DOM::Document&, Utf16View const&);
 bool command_format_block_indeterminate(DOM::Document const&);
-String command_format_block_value(DOM::Document const&);
-bool command_forward_delete_action(DOM::Document&, String const&);
-bool command_indent_action(DOM::Document&, String const&);
-bool command_insert_horizontal_rule_action(DOM::Document&, String const&);
-bool command_insert_html_action(DOM::Document&, String const&);
-bool command_insert_image_action(DOM::Document&, String const&);
-bool command_insert_linebreak_action(DOM::Document&, String const&);
-bool command_insert_ordered_list_action(DOM::Document&, String const&);
+Utf16String command_format_block_value(DOM::Document const&);
+bool command_forward_delete_action(DOM::Document&, Utf16View const&);
+bool command_indent_action(DOM::Document&, Utf16View const&);
+bool command_insert_horizontal_rule_action(DOM::Document&, Utf16View const&);
+bool command_insert_html_action(DOM::Document&, Utf16View const&);
+bool command_insert_image_action(DOM::Document&, Utf16View const&);
+bool command_insert_linebreak_action(DOM::Document&, Utf16View const&);
+bool command_insert_ordered_list_action(DOM::Document&, Utf16View const&);
 bool command_insert_ordered_list_indeterminate(DOM::Document const&);
 bool command_insert_ordered_list_state(DOM::Document const&);
-bool command_insert_paragraph_action(DOM::Document&, String const&);
-bool command_insert_text_action(DOM::Document&, String const&);
-bool command_insert_unordered_list_action(DOM::Document&, String const&);
+bool command_insert_paragraph_action(DOM::Document&, Utf16View const&);
+bool command_insert_text_action(DOM::Document&, Utf16View const&);
+bool command_insert_unordered_list_action(DOM::Document&, Utf16View const&);
 bool command_insert_unordered_list_indeterminate(DOM::Document const&);
 bool command_insert_unordered_list_state(DOM::Document const&);
-bool command_italic_action(DOM::Document&, String const&);
-bool command_justify_center_action(DOM::Document&, String const&);
+bool command_italic_action(DOM::Document&, Utf16View const&);
+bool command_justify_center_action(DOM::Document&, Utf16View const&);
 bool command_justify_center_indeterminate(DOM::Document const&);
 bool command_justify_center_state(DOM::Document const&);
-String command_justify_center_value(DOM::Document const&);
-bool command_justify_full_action(DOM::Document&, String const&);
+Utf16String command_justify_center_value(DOM::Document const&);
+bool command_justify_full_action(DOM::Document&, Utf16View const&);
 bool command_justify_full_indeterminate(DOM::Document const&);
 bool command_justify_full_state(DOM::Document const&);
-String command_justify_full_value(DOM::Document const&);
-bool command_justify_left_action(DOM::Document&, String const&);
+Utf16String command_justify_full_value(DOM::Document const&);
+bool command_justify_left_action(DOM::Document&, Utf16View const&);
 bool command_justify_left_indeterminate(DOM::Document const&);
 bool command_justify_left_state(DOM::Document const&);
-String command_justify_left_value(DOM::Document const&);
-bool command_justify_right_action(DOM::Document&, String const&);
+Utf16String command_justify_left_value(DOM::Document const&);
+bool command_justify_right_action(DOM::Document&, Utf16View const&);
 bool command_justify_right_indeterminate(DOM::Document const&);
 bool command_justify_right_state(DOM::Document const&);
-String command_justify_right_value(DOM::Document const&);
-bool command_outdent_action(DOM::Document&, String const&);
-bool command_remove_format_action(DOM::Document&, String const&);
-bool command_select_all_action(DOM::Document&, String const&);
-bool command_strikethrough_action(DOM::Document&, String const&);
-bool command_style_with_css_action(DOM::Document&, String const&);
+Utf16String command_justify_right_value(DOM::Document const&);
+bool command_outdent_action(DOM::Document&, Utf16View const&);
+bool command_remove_format_action(DOM::Document&, Utf16View const&);
+bool command_select_all_action(DOM::Document&, Utf16View const&);
+bool command_strikethrough_action(DOM::Document&, Utf16View const&);
+bool command_style_with_css_action(DOM::Document&, Utf16View const&);
 bool command_style_with_css_state(DOM::Document const&);
-bool command_subscript_action(DOM::Document&, String const&);
+bool command_subscript_action(DOM::Document&, Utf16View const&);
 bool command_subscript_indeterminate(DOM::Document const&);
-bool command_superscript_action(DOM::Document&, String const&);
+bool command_superscript_action(DOM::Document&, Utf16View const&);
 bool command_superscript_indeterminate(DOM::Document const&);
-bool command_underline_action(DOM::Document&, String const&);
-bool command_unlink_action(DOM::Document&, String const&);
-bool command_use_css_action(DOM::Document&, String const&);
+bool command_underline_action(DOM::Document&, Utf16View const&);
+bool command_unlink_action(DOM::Document&, Utf16View const&);
+bool command_use_css_action(DOM::Document&, Utf16View const&);
 
 }

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -121,7 +121,7 @@ void autolink(DOM::BoundaryPoint point)
     //    characters.
 
     // FIXME: 4. If some substring of search is an autolinkable URL:
-    String href;
+    Utf16String href;
     if (false) {
         // FIXME: 1. While there is no substring of node's data ending at end offset that is an autolinkable URL, decrement end
         //    offset.
@@ -267,7 +267,7 @@ GC::Ptr<DOM::Node> block_node_of_node(GC::Ref<DOM::Node> input_node)
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#canonical-space-sequence
-String canonical_space_sequence(u32 length, bool non_breaking_start, bool non_breaking_end)
+Utf16String canonical_space_sequence(size_t length, bool non_breaking_start, bool non_breaking_end)
 {
     auto n = length;
 
@@ -278,14 +278,14 @@ String canonical_space_sequence(u32 length, bool non_breaking_start, bool non_br
     // 2. If n is one and both non-breaking start and non-breaking end are false, return a single
     //    space (U+0020).
     if (n == 1 && !non_breaking_start && !non_breaking_end)
-        return " "_string;
+        return " "_utf16;
 
     // 3. If n is one, return a single non-breaking space (U+00A0).
     if (n == 1)
-        return "\u00A0"_string;
+        return "\u00A0"_utf16;
 
     // 4. Let buffer be the empty string.
-    StringBuilder buffer;
+    StringBuilder buffer { StringBuilder::Mode::UTF16 };
 
     // 5. If non-breaking start is true, let repeated pair be U+00A0 U+0020. Otherwise, let it be
     //    U+0020 U+00A0.
@@ -338,7 +338,7 @@ String canonical_space_sequence(u32 length, bool non_breaking_start, bool non_br
         buffer.append(non_breaking_end ? "\u00A0"sv : " "sv);
 
     // 9. Return buffer.
-    return MUST(buffer.to_string());
+    return buffer.to_utf16_string();
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#canonicalize-whitespace
@@ -530,6 +530,7 @@ void canonicalize_whitespace(DOM::BoundaryPoint boundary, bool fix_collapsed_spa
         length,
         (start_offset == 0 && follows_a_line_break(start_node)) || length > 1,
         end_offset == end_node->length() && precedes_a_line_break(end_node));
+    auto replacement_whitespace_view = replacement_whitespace.utf16_view();
 
     // 10. While (start node, start offset) is before (end node, end offset):
     while (true) {
@@ -555,10 +556,8 @@ void canonicalize_whitespace(DOM::BoundaryPoint boundary, bool fix_collapsed_spa
         else {
             // 1. Remove the first code unit from replacement whitespace, and let element be that
             //    code unit.
-            // FIXME: Find a way to get code points directly from the UTF-8 string
-            auto replacement_whitespace_utf16 = Utf16String::from_utf8(replacement_whitespace);
-            replacement_whitespace = MUST(replacement_whitespace_utf16.substring_view(1).to_utf8());
-            auto element = replacement_whitespace_utf16.code_point_at(0);
+            auto element = replacement_whitespace_view.code_unit_at(0);
+            replacement_whitespace_view = replacement_whitespace_view.substring_view(1);
 
             // 2. If element is not the same as the start offsetth code unit of start node's data:
             auto start_node_data = Utf16String::from_utf8(*start_node->text_content());
@@ -1135,7 +1134,7 @@ GC::Ptr<DOM::Node> editing_host_of_node(GC::Ref<DOM::Node> node)
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#effective-command-value
-Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString const& command)
+Optional<Utf16String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString const& command)
 {
     VERIFY(node);
 
@@ -1159,7 +1158,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
             return {};
 
         // 3. Return the value of node's href attribute.
-        return node_as_element()->get_attribute_value(HTML::AttributeNames::href);
+        return Utf16String::from_utf8_without_validation(node_as_element()->get_attribute_value(HTML::AttributeNames::href));
     }
 
     // 4. If command is "backColor" or "hiliteColor":
@@ -1182,7 +1181,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
         auto resolved_value = resolved_background_color();
         if (!resolved_value.has_value())
             return {};
-        return resolved_value.value()->to_string(CSS::SerializationMode::ResolvedValue);
+        return Utf16String::from_utf8_without_validation(resolved_value.value()->to_string(CSS::SerializationMode::ResolvedValue));
     }
 
     // 5. If command is "subscript" or "superscript":
@@ -1209,15 +1208,15 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
 
         // 3. If affected by subscript and affected by superscript are both true, return the string "mixed".
         if (affected_by_subscript && affected_by_superscript)
-            return "mixed"_string;
+            return "mixed"_utf16;
 
         // 4. If affected by subscript is true, return "subscript".
         if (affected_by_subscript)
-            return "subscript"_string;
+            return "subscript"_utf16;
 
         // 5. If affected by superscript is true, return "superscript".
         if (affected_by_superscript)
-            return "superscript"_string;
+            return "superscript"_utf16;
 
         // 6. Return null.
         return {};
@@ -1230,7 +1229,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
         do {
             auto text_decoration_line = resolved_value(*node, CSS::PropertyID::TextDecorationLine);
             if (text_decoration_line.has_value() && value_contains_keyword(text_decoration_line.value(), CSS::Keyword::LineThrough))
-                return "line-through"_string;
+                return "line-through"_utf16;
             inclusive_ancestor = inclusive_ancestor->parent();
         } while (inclusive_ancestor);
 
@@ -1244,7 +1243,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
         do {
             auto text_decoration_line = resolved_value(*node, CSS::PropertyID::TextDecorationLine);
             if (text_decoration_line.has_value() && value_contains_keyword(text_decoration_line.value(), CSS::Keyword::Underline))
-                return "underline"_string;
+                return "underline"_utf16;
             inclusive_ancestor = inclusive_ancestor->parent();
         } while (inclusive_ancestor);
 
@@ -1258,7 +1257,7 @@ Optional<String> effective_command_value(GC::Ptr<DOM::Node> node, FlyString cons
     auto optional_value = resolved_value(*node, command_definition.relevant_css_property.value());
     if (!optional_value.has_value())
         return {};
-    return optional_value.value()->to_string(CSS::SerializationMode::ResolvedValue);
+    return Utf16String::from_utf8_without_validation(optional_value.value()->to_string(CSS::SerializationMode::ResolvedValue));
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#first-equivalent-point
@@ -1390,7 +1389,7 @@ bool follows_a_line_break(GC::Ref<DOM::Node> node)
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#force-the-value
-void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional<String> new_value)
+void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional<Utf16View const&> new_value)
 {
     // 1. Let command be the current command.
 
@@ -1403,14 +1402,17 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
         return;
 
     // 4. If node is an allowed child of "span":
+    auto new_value_string = new_value.map([](Utf16View const& view) {
+        return Utf16String::from_utf16_without_validation(view);
+    });
     if (is_allowed_child_of_node(node, HTML::TagNames::span)) {
         // 1. Reorder modifiable descendants of node's previousSibling.
         if (node->previous_sibling())
-            reorder_modifiable_descendants(*node->previous_sibling(), command, new_value);
+            reorder_modifiable_descendants(*node->previous_sibling(), command, new_value_string);
 
         // 2. Reorder modifiable descendants of node's nextSibling.
         if (node->next_sibling())
-            reorder_modifiable_descendants(*node->next_sibling(), command, new_value);
+            reorder_modifiable_descendants(*node->next_sibling(), command, new_value_string);
 
         // 3. Wrap the one-node list consisting of node, with sibling criteria returning true for a simple modifiable
         //    element whose specified command value is equivalent to new value and whose effective command value is
@@ -1420,7 +1422,7 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
             [&](GC::Ref<DOM::Node> sibling) {
                 return is_simple_modifiable_element(sibling)
                     && specified_command_value(static_cast<DOM::Element&>(*sibling), command) == new_value
-                    && values_are_loosely_equivalent(command, effective_command_value(sibling, command), new_value);
+                    && values_are_loosely_equivalent(command, effective_command_value(sibling, command), new_value_string);
             },
             [] -> GC::Ptr<DOM::Node> { return {}; });
     }
@@ -1430,7 +1432,7 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
         return;
 
     // 6. If the effective command value of command is loosely equivalent to new value on node, abort this algorithm.
-    if (values_are_loosely_equivalent(command, effective_command_value(node, command), new_value))
+    if (values_are_loosely_equivalent(command, effective_command_value(node, command), new_value_string))
         return;
 
     // 7. If node is not an allowed child of "span":
@@ -1440,8 +1442,8 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
         Vector<GC::Ref<DOM::Node>> children;
         node->for_each_child([&](GC::Ref<DOM::Node> child) {
             if (is<DOM::Element>(*child)) {
-                auto const& child_specified_value = specified_command_value(static_cast<DOM::Element&>(*child), command);
-                if (child_specified_value.has_value() && !values_are_equivalent(command, child_specified_value.value(), new_value))
+                auto const child_specified_value = specified_command_value(static_cast<DOM::Element&>(*child), command);
+                if (child_specified_value.has_value() && !values_are_equivalent(command, child_specified_value.value(), new_value_string))
                     return IterationDecision::Continue;
             }
 
@@ -1459,7 +1461,7 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
     }
 
     // 8. If the effective command value of command is loosely equivalent to new value on node, abort this algorithm.
-    if (values_are_loosely_equivalent(command, effective_command_value(node, command), new_value))
+    if (values_are_loosely_equivalent(command, effective_command_value(node, command), new_value_string))
         return;
 
     // 9. Let new parent be null.
@@ -1491,7 +1493,7 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
         // 5.  If command is "foreColor", and new value is fully opaque with red, green, and blue components in the
         //     range 0 to 255:
         if (command == CommandNames::foreColor) {
-            auto new_value_color = Color::from_string(new_value.value());
+            auto new_value_color = Color::from_utf16_string(new_value.value());
             if (new_value_color->alpha() == NumericLimits<u8>::max()) {
                 // 1. Let new parent be the result of calling createElement("font") on the ownerDocument of node.
                 new_parent = MUST(DOM::create_element(document, HTML::TagNames::font, Namespace::HTML));
@@ -1506,7 +1508,7 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
         //    ownerDocument of node, then set the face attribute of new parent to new value.
         if (command == CommandNames::fontName) {
             new_parent = MUST(DOM::create_element(document, HTML::TagNames::font, Namespace::HTML));
-            MUST(new_parent->set_attribute(HTML::AttributeNames::face, new_value.value()));
+            MUST(new_parent->set_attribute(HTML::AttributeNames::face, new_value.value().to_utf8_but_should_be_ported_to_utf16()));
         }
     }
 
@@ -1516,7 +1518,7 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
         new_parent = MUST(DOM::create_element(document, HTML::TagNames::a, Namespace::HTML));
 
         // 2. Set the href attribute of new parent to new value.
-        MUST(new_parent->set_attribute(HTML::AttributeNames::href, new_value.value()));
+        MUST(new_parent->set_attribute(HTML::AttributeNames::href, new_value.value().to_utf8_but_should_be_ported_to_utf16()));
 
         // 3. Let ancestor be node's parent.
         GC::Ptr<DOM::Node> ancestor = node->parent();
@@ -1573,11 +1575,11 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
     // 17. If the effective command value of command for new parent is not loosely equivalent to new value, and the
     //     relevant CSS property for command is not null, set that CSS property of new parent to new value (if the new
     //     value would be valid).
-    if (!values_are_loosely_equivalent(command, effective_command_value(new_parent, command), new_value)) {
+    if (!values_are_loosely_equivalent(command, effective_command_value(new_parent, command), new_value_string)) {
         auto const& command_definition = find_command_definition(command);
         if (command_definition->relevant_css_property.has_value()) {
             auto inline_style = new_parent->style_for_bindings();
-            MUST(inline_style->set_property(command_definition->relevant_css_property.value(), new_value.value()));
+            MUST(inline_style->set_property(command_definition->relevant_css_property.value(), new_value.value().to_utf8_but_should_be_ported_to_utf16()));
         }
     }
 
@@ -1603,7 +1605,8 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
 
     // 21. If node is an Element and the effective command value of command for node is not loosely equivalent to new
     //     value:
-    if (is<DOM::Element>(*node) && !values_are_loosely_equivalent(command, effective_command_value(node, command), new_value)) {
+    if (is<DOM::Element>(*node)
+        && !values_are_loosely_equivalent(command, effective_command_value(node, command), new_value_string)) {
         // 1. Insert node into the parent of new parent before new parent, preserving ranges.
         move_node_preserving_ranges(node, *new_parent->parent(), new_parent->index());
 
@@ -1616,7 +1619,7 @@ void force_the_value(GC::Ref<DOM::Node> node, FlyString const& command, Optional
         node->for_each_child([&](GC::Ref<DOM::Node> child) {
             if (is<DOM::Element>(*child)) {
                 auto child_value = specified_command_value(static_cast<DOM::Element&>(*child), command);
-                if (child_value.has_value() && !values_are_equivalent(command, child_value.value(), new_value))
+                if (child_value.has_value() && !values_are_equivalent(command, child_value.value(), new_value_string))
                     return IterationDecision::Continue;
             }
 
@@ -2769,34 +2772,34 @@ DOM::BoundaryPoint last_equivalent_point(DOM::BoundaryPoint boundary_point)
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#legacy-font-size-for
-String legacy_font_size(int pixel_size)
+Utf16String legacy_font_size(int pixel_size)
 {
     // 1. Let returned size be 1.
-    auto returned_size = 1;
+    int returned_size = 1;
 
     // 2. While returned size is less than 7:
     while (returned_size < 7) {
         // 1. Let lower bound be the resolved value of "font-size" in pixels of a font element whose size attribute is
         //    set to returned size.
-        auto lower_bound = font_size_to_pixel_size(MUST(String::formatted("{}", returned_size))).to_float();
+        auto lower_bound = font_size_to_pixel_size(Utf16String::number(returned_size)).to_float();
 
         // 2. Let upper bound be the resolved value of "font-size" in pixels of a font element whose size attribute is
         //    set to one plus returned size.
-        auto upper_bound = font_size_to_pixel_size(MUST(String::formatted("{}", returned_size + 1))).to_float();
+        auto upper_bound = font_size_to_pixel_size(Utf16String::number(returned_size + 1)).to_float();
 
         // 3. Let average be the average of upper bound and lower bound.
         auto average = (lower_bound + upper_bound) / 2;
 
         // 4. If pixel size is less than average, return the one-code unit string consisting of the digit returned size.
         if (pixel_size < average)
-            return MUST(String::formatted("{}", returned_size));
+            return Utf16String::number(returned_size);
 
         // 5. Add one to returned size.
         ++returned_size;
     }
 
     // 3. Return "7".
-    return "7"_string;
+    return "7"_utf16;
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#preserving-ranges
@@ -3153,7 +3156,7 @@ Optional<DOM::BoundaryPoint> previous_equivalent_point(DOM::BoundaryPoint bounda
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#push-down-values
-void push_down_values(FlyString const& command, GC::Ref<DOM::Node> node, Optional<String> new_value)
+void push_down_values(FlyString const& command, GC::Ref<DOM::Node> node, Optional<Utf16String const&> new_value)
 {
     // 1. Let command be the current command.
 
@@ -3237,7 +3240,10 @@ void push_down_values(FlyString const& command, GC::Ref<DOM::Node> node, Optiona
                 continue;
 
             // 4. Force the value of child, with command as in this algorithm and new value equal to propagated value.
-            force_the_value(*child, command, propagated_value);
+            force_the_value(
+                *child,
+                command,
+                propagated_value.map([](Utf16String const& string) { return string.utf16_view(); }));
         }
     }
 }
@@ -3304,7 +3310,7 @@ Vector<RecordedOverride> record_current_states_and_values(DOM::Document const& d
     // 6. For each command in the list "fontName", "foreColor", "hiliteColor", in order: add (command, command's value)
     //    to overrides.
     for (auto const& command : { CommandNames::fontName, CommandNames::foreColor, CommandNames::hiliteColor })
-        overrides.empend(command, MUST(node->document().query_command_value(command)));
+        overrides.empend(command, Utf16String::from_utf8_without_validation(MUST(node->document().query_command_value(command))));
 
     // 7. Add ("fontSize", node's effective command value for "fontSize") to overrides.
     effective_value = effective_command_value(node, CommandNames::fontSize);
@@ -3438,7 +3444,7 @@ void remove_node_preserving_its_descendants(GC::Ref<DOM::Node> node)
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#reorder-modifiable-descendants
-void reorder_modifiable_descendants(GC::Ref<DOM::Node> node, FlyString const& command, Optional<String> new_value)
+void reorder_modifiable_descendants(GC::Ref<DOM::Node> node, FlyString const& command, Optional<Utf16String const&> new_value)
 {
     // 1. Let candidate equal node.
     GC::Ptr<DOM::Node> candidate = node;
@@ -3495,9 +3501,9 @@ void restore_states_and_values(DOM::Document& document, Vector<RecordedOverride>
             // 2. Otherwise, if override is a string, and command is neither "createLink" nor "fontSize", and
             //    queryCommandValue(command) returns something not equivalent to override, take the action for command,
             //    with value equal to override.
-            else if (override.value.has<String>() && !override.command.is_one_of(CommandNames::createLink, CommandNames::fontSize)
-                && MUST(document.query_command_value(override.command)) != override.value.get<String>()) {
-                take_the_action_for_command(document, override.command, override.value.get<String>());
+            else if (override.value.has<Utf16String>() && !override.command.is_one_of(CommandNames::createLink, CommandNames::fontSize)
+                && MUST(document.query_command_value(override.command)) != override.value.get<Utf16String>()) {
+                take_the_action_for_command(document, override.command, override.value.get<Utf16String>());
             }
 
             // 3. Otherwise, if override is a string; and command is "createLink"; and either there is a value override
@@ -3505,31 +3511,31 @@ void restore_states_and_values(DOM::Document& document, Vector<RecordedOverride>
             //    node's effective command value for "createLink" is not equal to override: take the action for
             //    "createLink", with value equal to override.
             else if (auto value_override = document.command_value_override(CommandNames::createLink);
-                override.value.has<String>() && override.command == CommandNames::createLink
-                && ((value_override.has_value() && value_override.value() != override.value.get<String>())
+                override.value.has<Utf16String>() && override.command == CommandNames::createLink
+                && ((value_override.has_value() && value_override.value() != override.value.get<Utf16String>())
                     || (!value_override.has_value()
-                        && effective_command_value(node, CommandNames::createLink) != override.value.get<String>()))) {
-                take_the_action_for_command(document, CommandNames::createLink, override.value.get<String>());
+                        && effective_command_value(node, CommandNames::createLink) != override.value.get<Utf16String>()))) {
+                take_the_action_for_command(document, CommandNames::createLink, override.value.get<Utf16String>());
             }
 
             // 4. Otherwise, if override is a string; and command is "fontSize"; and either there is a value override
             //    for "fontSize" that is not equal to override, or there is no value override for "fontSize" and node's
             //    effective command value for "fontSize" is not loosely equivalent to override:
             else if (auto value_override = document.command_value_override(CommandNames::fontSize);
-                override.value.has<String>() && override.command == CommandNames::fontSize
-                && ((value_override.has_value() && value_override.value() != override.value.get<String>())
+                override.value.has<Utf16String>() && override.command == CommandNames::fontSize
+                && ((value_override.has_value() && value_override.value() != override.value.get<Utf16String>())
                     || (!value_override.has_value()
                         && !values_are_loosely_equivalent(
                             CommandNames::fontSize,
                             effective_command_value(node, CommandNames::fontSize),
-                            override.value.get<String>())))) {
+                            override.value.get<Utf16String>())))) {
                 // 1. Convert override to an integer number of pixels, and set override to the legacy font size for the
                 //    result.
-                auto override_pixel_size = font_size_to_pixel_size(override.value.get<String>());
+                auto override_pixel_size = font_size_to_pixel_size(override.value.get<Utf16String>());
                 override.value = legacy_font_size(override_pixel_size.to_int());
 
                 // 2. Take the action for "fontSize", with value equal to override.
-                take_the_action_for_command(document, CommandNames::fontSize, override.value.get<String>());
+                take_the_action_for_command(document, CommandNames::fontSize, override.value.get<Utf16String>());
             }
 
             // 5. Otherwise, continue this loop from the beginning.
@@ -3550,7 +3556,7 @@ void restore_states_and_values(DOM::Document& document, Vector<RecordedOverride>
             // 2. If override is a string, set the value override for command to override.
             override.value.visit(
                 [&](bool value) { document.set_command_state_override(override.command, value); },
-                [&](String const& value) { document.set_command_value_override(override.command, value); });
+                [&](Utf16String const& value) { document.set_command_value_override(override.command, value); });
         }
     }
 }
@@ -3559,7 +3565,7 @@ void restore_states_and_values(DOM::Document& document, Vector<RecordedOverride>
 void restore_the_values_of_nodes(Vector<RecordedNodeValue> const& values)
 {
     // 1. For each (node, command, value) triple in values:
-    for (auto& recorded_node_value : values) {
+    for (auto const& recorded_node_value : values) {
         auto node = recorded_node_value.node;
         auto const& command = recorded_node_value.command;
         auto value = recorded_node_value.specified_command_value;
@@ -3585,7 +3591,7 @@ void restore_the_values_of_nodes(Vector<RecordedNodeValue> const& values)
         //    node.
         else if ((is<DOM::Element>(ancestor.ptr()) && specified_command_value(static_cast<DOM::Element&>(*ancestor), command) != value)
             || (!is<DOM::Element>(ancestor.ptr()) && value.has_value())) {
-            force_the_value(node, command, value);
+            force_the_value(node, command, value->utf16_view());
         }
     }
 }
@@ -3706,8 +3712,12 @@ SelectionsListState selections_list_state(DOM::Document const& document)
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#set-the-selection's-value
-void set_the_selections_value(DOM::Document& document, FlyString const& command, Optional<String> new_value)
+void set_the_selections_value(DOM::Document& document, FlyString const& command, Optional<Utf16View const&> new_value)
 {
+    auto new_value_string = new_value.map([](Utf16View const& view) {
+        return Utf16String::from_utf16_without_validation(view);
+    });
+
     // 1. Let command be the current command.
 
     // 2. If there is no formattable node effectively contained in the active range:
@@ -3743,7 +3753,7 @@ void set_the_selections_value(DOM::Document& document, FlyString const& command,
 
         // 5. Otherwise, if command is "createLink" or it has a value specified, set the value override to new value.
         else if (command == CommandNames::createLink || !MUST(document.query_command_value(CommandNames::createLink)).is_empty()) {
-            document.set_command_value_override(command, new_value.value());
+            document.set_command_value_override(command, *new_value_string);
         }
 
         // 6. Abort these steps.
@@ -3789,7 +3799,7 @@ void set_the_selections_value(DOM::Document& document, FlyString const& command,
     // 8. For each node in node list:
     for (auto node : node_list) {
         // 1. Push down values on node.
-        push_down_values(command, node, new_value);
+        push_down_values(command, node, new_value_string);
 
         // 2. If node is an allowed child of "span", force the value of node.
         if (is_allowed_child_of_node(node, HTML::TagNames::span))
@@ -3831,7 +3841,7 @@ GC::Ref<DOM::Element> set_the_tag_name(GC::Ref<DOM::Element> element, FlyString 
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#specified-command-value
-Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyString const& command)
+Optional<Utf16String> specified_command_value(GC::Ref<DOM::Element> element, FlyString const& command)
 {
     // 1. If command is "backColor" or "hiliteColor" and the Element's display property does not have resolved value
     //    "inline", return null.
@@ -3846,7 +3856,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
         // 1. If element is an a element and has an href attribute, return the value of that attribute.
         auto href_attribute = element->get_attribute(HTML::AttributeNames::href);
         if (href_attribute.has_value())
-            return href_attribute.release_value();
+            return Utf16String::from_utf8_without_validation(href_attribute.release_value());
 
         // 2. Return null.
         return {};
@@ -3856,11 +3866,11 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
     if (command.is_one_of(CommandNames::subscript, CommandNames::superscript)) {
         // 1. If element is a sup, return "superscript".
         if (element->local_name() == HTML::TagNames::sup)
-            return "superscript"_string;
+            return "superscript"_utf16;
 
         // 2. If element is a sub, return "subscript".
         if (element->local_name() == HTML::TagNames::sub)
-            return "subscript"_string;
+            return "subscript"_utf16;
 
         // 3. Return null.
         return {};
@@ -3874,7 +3884,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
             // 1. If element's style attribute sets "text-decoration" to a value containing "line-through", return
             //    "line-through".
             if (value_contains_keyword(text_decoration_style.value(), CSS::Keyword::LineThrough))
-                return "line-through"_string;
+                return "line-through"_utf16;
 
             // 2. Return null.
             return {};
@@ -3883,7 +3893,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
 
     // 5. If command is "strikethrough" and element is an s or strike element, return "line-through".
     if (command == CommandNames::strikethrough && element->local_name().is_one_of(HTML::TagNames::s, HTML::TagNames::strike))
-        return "line-through"_string;
+        return "line-through"_utf16;
 
     // 6. If command is "underline", and element has a style attribute set, and that attribute sets "text-decoration":
     if (command == CommandNames::underline) {
@@ -3891,7 +3901,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
         if (text_decoration_style.has_value()) {
             // 1. If element's style attribute sets "text-decoration" to a value containing "underline", return "underline".
             if (value_contains_keyword(text_decoration_style.value(), CSS::Keyword::Underline))
-                return "underline"_string;
+                return "underline"_utf16;
 
             // 2. Return null.
             return {};
@@ -3900,7 +3910,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
 
     // 7. If command is "underline" and element is a u element, return "underline".
     if (command == CommandNames::underline && element->local_name() == HTML::TagNames::u)
-        return "underline"_string;
+        return "underline"_utf16;
 
     // 8. Let property be the relevant CSS property for command.
     auto property = find_command_definition(command)->relevant_css_property;
@@ -3915,7 +3925,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
     if (auto inline_style = element->inline_style()) {
         auto value = inline_style->get_property_value(string_from_property_id(property.value()));
         if (!value.is_empty())
-            return value;
+            return Utf16String::from_utf8_without_validation(value);
     }
 
     // 11. If element is a font element that has an attribute whose effect is to create a presentational hint for
@@ -3927,7 +3937,7 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
         font_element.apply_presentational_hints(cascaded_properties);
         auto property_value = cascaded_properties->property(property.value());
         if (property_value)
-            return property_value->to_string(CSS::SerializationMode::Normal);
+            return Utf16String::from_utf8_without_validation(property_value->to_string(CSS::SerializationMode::Normal));
     }
 
     // 12. If element is in the following list, and property is equal to the CSS property name listed for it, return the
@@ -3935,9 +3945,9 @@ Optional<String> specified_command_value(GC::Ref<DOM::Element> element, FlyStrin
     //     * b, strong: font-weight: "bold"
     //     * i, em: font-style: "italic"
     if (element->local_name().is_one_of(HTML::TagNames::b, HTML::TagNames::strong) && *property == CSS::PropertyID::FontWeight)
-        return "bold"_string;
+        return "bold"_utf16;
     if (element->local_name().is_one_of(HTML::TagNames::i, HTML::TagNames::em) && *property == CSS::PropertyID::FontStyle)
-        return "italic"_string;
+        return "italic"_utf16;
 
     // 13. Return null.
     return {};
@@ -4349,7 +4359,7 @@ void toggle_lists(DOM::Document& document, FlyString const& tag_name)
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#equivalent-values
-bool values_are_equivalent(FlyString const& command, Optional<String> a, Optional<String> b)
+bool values_are_equivalent(FlyString const& command, Optional<Utf16String const&> a, Optional<Utf16String const&> b)
 {
     // Two quantities are equivalent values for a command if either both are null,
     if (!a.has_value() && !b.has_value())
@@ -4363,8 +4373,8 @@ bool values_are_equivalent(FlyString const& command, Optional<String> a, Optiona
     if (command.is_one_of(CommandNames::backColor, CommandNames::foreColor, CommandNames::hiliteColor)) {
         // Either both strings are valid CSS colors and have the same red, green, blue, and alpha components, or neither
         // string is a valid CSS color.
-        auto a_color = Color::from_string(a.value());
-        auto b_color = Color::from_string(b.value());
+        auto a_color = Color::from_utf16_string(a.value());
+        auto b_color = Color::from_utf16_string(b.value());
         if (a_color.has_value())
             return a_color == b_color;
         return !a_color.has_value() && !b_color.has_value();
@@ -4388,7 +4398,7 @@ bool values_are_equivalent(FlyString const& command, Optional<String> a, Optiona
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#loosely-equivalent-values
-bool values_are_loosely_equivalent(FlyString const& command, Optional<String> a, Optional<String> b)
+bool values_are_loosely_equivalent(FlyString const& command, Optional<Utf16String const&> a, Optional<Utf16String const&> b)
 {
     // Two quantities are loosely equivalent values for a command if either they are equivalent values for the command,
     if (values_are_equivalent(command, a, b))
@@ -4398,9 +4408,9 @@ bool values_are_loosely_equivalent(FlyString const& command, Optional<String> a,
     // "x-large", "xx-large", or "xxx-large"; and the other quantity is the resolved value of "font-size" on a font
     // element whose size attribute has the corresponding value set ("1" through "7" respectively).
     if (command == CommandNames::fontSize && a.has_value() && b.has_value()) {
-        static constexpr Array named_quantities { "x-small"sv, "small"sv, "medium"sv, "large"sv, "x-large"sv,
-            "xx-large"sv, "xxx-large"sv };
-        static constexpr Array size_quantities { "1"sv, "2"sv, "3"sv, "4"sv, "5"sv, "6"sv, "7"sv };
+        static constexpr Array<Utf16View, 7> named_quantities { "x-small"sv, "small"sv, "medium"sv, "large"sv,
+            "x-large"sv, "xx-large"sv, "xxx-large"sv };
+        static constexpr Array<Utf16View, 7> size_quantities { "1"sv, "2"sv, "3"sv, "4"sv, "5"sv, "6"sv, "7"sv };
         static_assert(named_quantities.size() == size_quantities.size());
 
         auto a_index = named_quantities.first_index_of(a.value())
@@ -4614,21 +4624,21 @@ GC::Ptr<DOM::Node> first_formattable_node_effectively_contained(GC::Ptr<DOM::Ran
     return node;
 }
 
-CSSPixels font_size_to_pixel_size(StringView font_size)
+CSSPixels font_size_to_pixel_size(Utf16View const& font_size)
 {
     // If the font size ends in 'px', interpret the preceding as a number and return it.
-    if (font_size.length() >= 2 && font_size.substring_view(font_size.length() - 2).equals_ignoring_ascii_case("px"sv)) {
-        auto optional_number = font_size.substring_view(0, font_size.length() - 2).to_number<float>();
+    if (font_size.ends_with("px"sv)) {
+        auto optional_number = font_size.substring_view(0, font_size.length_in_code_units() - 2).to_number<float>();
         if (optional_number.has_value())
             return CSSPixels::nearest_value_for(optional_number.value());
     }
 
     // Try to map the font size directly to a keyword (e.g. medium or x-large)
-    auto keyword = CSS::keyword_from_string(font_size);
+    auto keyword = CSS::keyword_from_string(font_size.to_utf8_but_should_be_ported_to_utf16());
 
     // If that failed, try to interpret it as a legacy font size (e.g. 1 through 7)
     if (!keyword.has_value())
-        keyword = HTML::HTMLFontElement::parse_legacy_font_size(font_size);
+        keyword = HTML::HTMLFontElement::parse_legacy_font_size(font_size.to_utf8_but_should_be_ported_to_utf16());
 
     // If that also failed, give up
     auto pixel_size = CSS::StyleComputer::default_user_font_size();
@@ -4680,22 +4690,22 @@ bool is_heading(FlyString const& local_name)
         HTML::TagNames::h6);
 }
 
-String justify_alignment_to_string(JustifyAlignment alignment)
+Utf16String justify_alignment_to_string(JustifyAlignment alignment)
 {
     switch (alignment) {
     case JustifyAlignment::Center:
-        return "center"_string;
+        return "center"_utf16;
     case JustifyAlignment::Justify:
-        return "justify"_string;
+        return "justify"_utf16;
     case JustifyAlignment::Left:
-        return "left"_string;
+        return "left"_utf16;
     case JustifyAlignment::Right:
-        return "right"_string;
+        return "right"_utf16;
     }
     VERIFY_NOT_REACHED();
 }
 
-Array<StringView, 7> named_font_sizes()
+Array<Utf16View, 7> named_font_sizes()
 {
     return { "x-small"sv, "small"sv, "medium"sv, "large"sv, "x-large"sv, "xx-large"sv, "xxx-large"sv };
 }
@@ -4747,7 +4757,7 @@ Optional<NonnullRefPtr<CSS::CSSStyleValue const>> resolved_value(GC::Ref<DOM::No
     return optional_style_property.value().value;
 }
 
-void take_the_action_for_command(DOM::Document& document, FlyString const& command, String const& value)
+void take_the_action_for_command(DOM::Document& document, FlyString const& command, Utf16View const& value)
 {
     auto const& command_definition = find_command_definition(command);
     command_definition->action(document, value);

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.h
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.h
@@ -17,13 +17,13 @@ namespace Web::Editing {
 struct RecordedNodeValue {
     GC::Ref<DOM::Node> node;
     FlyString command;
-    Optional<String> specified_command_value;
+    Optional<Utf16String> specified_command_value;
 };
 
 // https://w3c.github.io/editing/docs/execCommand/#record-current-states-and-values
 struct RecordedOverride {
     FlyString command;
-    Variant<String, bool> value;
+    Variant<Utf16String, bool> value;
 };
 
 // https://w3c.github.io/editing/docs/execCommand/#selection's-list-state
@@ -54,17 +54,17 @@ JustifyAlignment alignment_value_of_node(GC::Ptr<DOM::Node>);
 void autolink(DOM::BoundaryPoint);
 GC::Ref<DOM::Range> block_extend_a_range(GC::Ref<DOM::Range>);
 GC::Ptr<DOM::Node> block_node_of_node(GC::Ref<DOM::Node>);
-String canonical_space_sequence(u32 length, bool non_breaking_start, bool non_breaking_end);
+Utf16String canonical_space_sequence(size_t length, bool non_breaking_start, bool non_breaking_end);
 void canonicalize_whitespace(DOM::BoundaryPoint, bool fix_collapsed_space = true);
 Vector<GC::Ref<DOM::Node>> clear_the_value(FlyString const&, GC::Ref<DOM::Element>);
 void delete_the_selection(Selection&, bool block_merging = true, bool strip_wrappers = true,
     Selection::Direction direction = Selection::Direction::Forwards);
 GC::Ptr<DOM::Node> editing_host_of_node(GC::Ref<DOM::Node>);
-Optional<String> effective_command_value(GC::Ptr<DOM::Node>, FlyString const& command);
+Optional<Utf16String> effective_command_value(GC::Ptr<DOM::Node>, FlyString const& command);
 DOM::BoundaryPoint first_equivalent_point(DOM::BoundaryPoint);
 void fix_disallowed_ancestors_of_node(GC::Ref<DOM::Node>);
 bool follows_a_line_break(GC::Ref<DOM::Node>);
-void force_the_value(GC::Ref<DOM::Node>, FlyString const&, Optional<String>);
+void force_the_value(GC::Ref<DOM::Node>, FlyString const&, Optional<Utf16View const&>);
 void indent(Vector<GC::Ref<DOM::Node>>);
 bool is_allowed_child_of_node(Variant<GC::Ref<DOM::Node>, FlyString> child, Variant<GC::Ref<DOM::Node>, FlyString> parent);
 bool is_block_boundary_point(DOM::BoundaryPoint);
@@ -96,14 +96,14 @@ bool is_visible_node(GC::Ref<DOM::Node>);
 bool is_whitespace_node(GC::Ref<DOM::Node>);
 void justify_the_selection(DOM::Document&, JustifyAlignment);
 DOM::BoundaryPoint last_equivalent_point(DOM::BoundaryPoint);
-String legacy_font_size(int);
+Utf16String legacy_font_size(int);
 void move_node_preserving_ranges(GC::Ref<DOM::Node>, GC::Ref<DOM::Node> new_parent, u32 new_index);
 Optional<DOM::BoundaryPoint> next_equivalent_point(DOM::BoundaryPoint);
 void normalize_sublists_in_node(GC::Ref<DOM::Node>);
 void outdent(GC::Ref<DOM::Node>);
 bool precedes_a_line_break(GC::Ref<DOM::Node>);
 Optional<DOM::BoundaryPoint> previous_equivalent_point(DOM::BoundaryPoint);
-void push_down_values(FlyString const&, GC::Ref<DOM::Node>, Optional<String>);
+void push_down_values(FlyString const&, GC::Ref<DOM::Node>, Optional<Utf16String const&>);
 Vector<RecordedOverride> record_current_overrides(DOM::Document const&);
 Vector<RecordedOverride> record_current_states_and_values(DOM::Document const&);
 Vector<RecordedNodeValue> record_the_values_of_nodes(Vector<GC::Ref<DOM::Node>> const&);
@@ -111,33 +111,33 @@ void remove_extraneous_line_breaks_at_the_end_of_node(GC::Ref<DOM::Node>);
 void remove_extraneous_line_breaks_before_node(GC::Ref<DOM::Node>);
 void remove_extraneous_line_breaks_from_a_node(GC::Ref<DOM::Node>);
 void remove_node_preserving_its_descendants(GC::Ref<DOM::Node>);
-void reorder_modifiable_descendants(GC::Ref<DOM::Node>, FlyString const&, Optional<String>);
+void reorder_modifiable_descendants(GC::Ref<DOM::Node>, FlyString const&, Optional<Utf16String const&>);
 void restore_states_and_values(DOM::Document&, Vector<RecordedOverride> const&);
 void restore_the_values_of_nodes(Vector<RecordedNodeValue> const&);
 SelectionsListState selections_list_state(DOM::Document const&);
-void set_the_selections_value(DOM::Document&, FlyString const&, Optional<String>);
+void set_the_selections_value(DOM::Document&, FlyString const&, Optional<Utf16View const&>);
 GC::Ref<DOM::Element> set_the_tag_name(GC::Ref<DOM::Element>, FlyString const&);
-Optional<String> specified_command_value(GC::Ref<DOM::Element>, FlyString const& command);
+Optional<Utf16String> specified_command_value(GC::Ref<DOM::Element>, FlyString const& command);
 void split_the_parent_of_nodes(Vector<GC::Ref<DOM::Node>> const&);
 void toggle_lists(DOM::Document&, FlyString const&);
-bool values_are_equivalent(FlyString const&, Optional<String>, Optional<String>);
-bool values_are_loosely_equivalent(FlyString const&, Optional<String>, Optional<String>);
+bool values_are_equivalent(FlyString const&, Optional<Utf16String const&>, Optional<Utf16String const&>);
+bool values_are_loosely_equivalent(FlyString const&, Optional<Utf16String const&>, Optional<Utf16String const&>);
 GC::Ptr<DOM::Node> wrap(Vector<GC::Ref<DOM::Node>>, Function<bool(GC::Ref<DOM::Node>)> sibling_criteria, Function<GC::Ptr<DOM::Node>()> new_parent_instructions);
 
 // Utility methods:
 
 GC::Ptr<DOM::Node> first_formattable_node_effectively_contained(GC::Ptr<DOM::Range>);
-CSSPixels font_size_to_pixel_size(StringView);
+CSSPixels font_size_to_pixel_size(Utf16View const&);
 void for_each_node_effectively_contained_in_range(GC::Ptr<DOM::Range>, Function<TraversalDecision(GC::Ref<DOM::Node>)>);
 bool has_visible_children(GC::Ref<DOM::Node>);
 bool is_heading(FlyString const&);
-String justify_alignment_to_string(JustifyAlignment);
-Array<StringView, 7> named_font_sizes();
+Utf16String justify_alignment_to_string(JustifyAlignment);
+Array<Utf16View, 7> named_font_sizes();
 Optional<NonnullRefPtr<CSS::CSSStyleValue const>> property_in_style_attribute(GC::Ref<DOM::Element>, CSS::PropertyID);
 Optional<CSS::Display> resolved_display(GC::Ref<DOM::Node>);
 Optional<CSS::Keyword> resolved_keyword(GC::Ref<DOM::Node>, CSS::PropertyID);
 Optional<NonnullRefPtr<CSS::CSSStyleValue const>> resolved_value(GC::Ref<DOM::Node>, CSS::PropertyID);
-void take_the_action_for_command(DOM::Document&, FlyString const&, String const&);
+void take_the_action_for_command(DOM::Document&, FlyString const&, Utf16View const&);
 bool value_contains_keyword(CSS::CSSStyleValue const&, CSS::Keyword);
 
 }

--- a/Tests/AK/TestSpan.cpp
+++ b/Tests/AK/TestSpan.cpp
@@ -152,6 +152,22 @@ TEST_CASE(starts_with)
     EXPECT(bytes.starts_with(hey_bytes_u8));
 }
 
+TEST_CASE(ends_with)
+{
+    char const* str = "HeyFriends!";
+    ReadonlyBytes bytes { str, strlen(str) };
+    char const* str_friends = "Friends!";
+    ReadonlyBytes friends_bytes { str_friends, strlen(str_friends) };
+    EXPECT(bytes.ends_with(friends_bytes));
+    char const* str_nah = "Nah";
+    ReadonlyBytes nah_bytes { str_nah, strlen(str_nah) };
+    EXPECT(!bytes.ends_with(nah_bytes));
+
+    u8 const dse_array[3] = { 'd', 's', '!' };
+    ReadonlyBytes dse_bytes_u8 { dse_array, 3 };
+    EXPECT(bytes.ends_with(dse_bytes_u8));
+}
+
 TEST_CASE(contains_slow)
 {
     Vector<String> list { "abc"_string, "def"_string, "ghi"_string };

--- a/Tests/AK/TestUtf16View.cpp
+++ b/Tests/AK/TestUtf16View.cpp
@@ -568,6 +568,32 @@ TEST_CASE(starts_with)
     EXPECT(!emoji.starts_with(u"🙃"sv));
 }
 
+TEST_CASE(ends_with)
+{
+    EXPECT(Utf16View {}.ends_with(u""sv));
+    EXPECT(!Utf16View {}.ends_with(u" "sv));
+
+    EXPECT(u"a"sv.ends_with(u""sv));
+    EXPECT(u"a"sv.ends_with(u"a"sv));
+    EXPECT(!u"a"sv.ends_with(u"b"sv));
+    EXPECT(!u"a"sv.ends_with(u"ab"sv));
+
+    EXPECT(u"abc"sv.ends_with(u""sv));
+    EXPECT(u"abc"sv.ends_with(u"c"sv));
+    EXPECT(u"abc"sv.ends_with(u"bc"sv));
+    EXPECT(u"abc"sv.ends_with(u"abc"sv));
+    EXPECT(!u"abc"sv.ends_with(u"b"sv));
+    EXPECT(!u"abc"sv.ends_with(u"ab"sv));
+
+    auto emoji = u"😀🙃"sv;
+
+    EXPECT(emoji.ends_with(u""sv));
+    EXPECT(emoji.ends_with(u"🙃"sv));
+    EXPECT(emoji.ends_with(u"😀🙃"sv));
+    EXPECT(!emoji.ends_with(u"a"sv));
+    EXPECT(!emoji.ends_with(u"😀"sv));
+}
+
 TEST_CASE(find_code_unit_offset)
 {
     auto conversion_result = Utf16String::from_utf8("😀foo😀bar"sv);

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-insertText.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-insertText.txt
@@ -1,2 +1,5 @@
 input triggered
-foobazbar
+#text 6 - #text 6
+input triggered
+#text 8 - #text 8
+foobaz🙂bar

--- a/Tests/LibWeb/Text/input/Editing/execCommand-insertText.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-insertText.html
@@ -3,17 +3,29 @@
 <div contenteditable="true">foobar</div>
 <script>
     test(() => {
+        const selection = getSelection();
+        const reportSelection = () => {
+            if (selection.rangeCount === 0) {
+                println('No range.');
+                return;
+            }
+            const range = selection.getRangeAt(0);
+            println(`${range.startContainer.nodeName} ${range.startOffset} - ${range.endContainer.nodeName} ${range.endOffset}`);
+        };
+
         var divElm = document.querySelector('div');
         divElm.addEventListener('input', (e) => println('input triggered'));
 
         // Put cursor between 'foo' and 'bar'
-        var range = document.createRange();
-        getSelection().addRange(range);
-        range.setStart(divElm.childNodes[0], 3);
-        range.setEnd(divElm.childNodes[0], 3);
+        selection.setBaseAndExtent(divElm.childNodes[0], 3, divElm.childNodes[0], 3);
 
         // Insert text
         document.execCommand('insertText', false, 'baz');
+        reportSelection();
+
+        // Insert Unicode
+        document.execCommand('insertText', false, '🙂');
+        reportSelection();
 
         println(divElm.innerHTML);
     });


### PR DESCRIPTION
Both sides of the Editing internals now have to deal with some awkward converting between UTF-8 and UTF-16, but the upside is that it immediately exposed an issue with the `insertText` command: instead of dealing with code units, it was iterating over code points causing the selection to be updated only once instead of twice. This resulted in the final selection potentially ending up in between a surrogate pair.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/5547 (pasting/typing surrogate pairs).