### PR TITLE
LibJS+LibUnicode: Port Intl formatters to UTF-16 strings

### DIFF
--- a/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -1134,7 +1134,7 @@ ByteString time_zone_string(double time)
 
     // Most implementations seem to prefer the long-form display name of the time zone. Not super important, but we may as well match that behavior.
     if (auto name = Unicode::time_zone_display_name(Unicode::default_locale(), tz_name, in_dst, time); name.has_value())
-        tz_name = name.release_value();
+        tz_name = name->to_utf8_but_should_be_ported_to_utf16();
 
     // 10. Return the string-concatenation of offsetString and tzName.
     return ByteString::formatted("{} ({})", offset_string, tz_name);

--- a/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
+++ b/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
@@ -48,17 +48,17 @@ ThrowCompletionOr<Value> CollatorCompareFunction::call()
     // 4. If y is not provided, let y be undefined.
 
     // 5. Let X be ? ToString(x).
-    auto x = TRY(vm.argument(0).to_string(vm));
+    auto x = TRY(vm.argument(0).to_utf16_string(vm));
 
     // 6. Let Y be ? ToString(y).
-    auto y = TRY(vm.argument(1).to_string(vm));
+    auto y = TRY(vm.argument(1).to_utf16_string(vm));
 
     // 7. Return CompareStrings(collator, X, Y).
     return compare_strings(m_collator, x, y);
 }
 
 // 10.3.3.2 CompareStrings ( collator, x, y ), https://tc39.es/ecma402/#sec-collator-comparestrings
-int compare_strings(Collator const& collator, StringView x, StringView y)
+int compare_strings(Collator const& collator, Utf16View const& x, Utf16View const& y)
 {
     auto result = collator.collator().compare(x, y);
 

--- a/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
+++ b/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
@@ -30,6 +30,6 @@ private:
     GC::Ref<Collator> m_collator; // [[Collator]]
 };
 
-int compare_strings(Collator const&, StringView x, StringView y);
+int compare_strings(Collator const&, Utf16View const& x, Utf16View const& y);
 
 }

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -119,11 +119,11 @@ ThrowCompletionOr<Vector<Unicode::DateTimeFormat::Partition>> partition_date_tim
 
 // 11.5.7 FormatDateTime ( dateTimeFormat, x ), https://tc39.es/ecma402/#sec-formatdatetime
 // 15.9.6 FormatDateTime ( dateTimeFormat, x ), https://tc39.es/proposal-temporal/#sec-formatdatetime
-ThrowCompletionOr<String> format_date_time(VM& vm, DateTimeFormat& date_time_format, FormattableDateTime const& time)
+ThrowCompletionOr<Utf16String> format_date_time(VM& vm, DateTimeFormat& date_time_format, FormattableDateTime const& time)
 {
     // 1. Let parts be ? PartitionDateTimePattern(dateTimeFormat, x).
     // 2. Let result be the empty String.
-    String result;
+    Utf16String result;
 
     // NOTE: We short-circuit PartitionDateTimePattern as we do not need individual partitions.
     {
@@ -196,11 +196,11 @@ ThrowCompletionOr<Vector<Unicode::DateTimeFormat::Partition>> partition_date_tim
 
 // 11.5.10 FormatDateTimeRange ( dateTimeFormat, x, y ), https://tc39.es/ecma402/#sec-formatdatetimerange
 // 15.9.9 FormatDateTimeRange ( dateTimeFormat, x, y ), https://tc39.es/proposal-temporal/#sec-formatdatetimerange
-ThrowCompletionOr<String> format_date_time_range(VM& vm, DateTimeFormat& date_time_format, FormattableDateTime const& start, FormattableDateTime const& end)
+ThrowCompletionOr<Utf16String> format_date_time_range(VM& vm, DateTimeFormat& date_time_format, FormattableDateTime const& start, FormattableDateTime const& end)
 {
     // 1. Let parts be ? PartitionDateTimeRangePattern(dateTimeFormat, x, y).
     // 2. Let result be the empty String.
-    String result;
+    Utf16String result;
 
     // NOTE: We short-circuit PartitionDateTimeRangePattern as we do not need individual partitions.
     {

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -137,10 +137,10 @@ struct ValueFormat {
 
 Vector<Unicode::DateTimeFormat::Partition> format_date_time_pattern(ValueFormat const&);
 ThrowCompletionOr<Vector<Unicode::DateTimeFormat::Partition>> partition_date_time_pattern(VM&, DateTimeFormat&, FormattableDateTime const&);
-ThrowCompletionOr<String> format_date_time(VM&, DateTimeFormat&, FormattableDateTime const&);
+ThrowCompletionOr<Utf16String> format_date_time(VM&, DateTimeFormat&, FormattableDateTime const&);
 ThrowCompletionOr<GC::Ref<Array>> format_date_time_to_parts(VM&, DateTimeFormat&, FormattableDateTime const&);
 ThrowCompletionOr<Vector<Unicode::DateTimeFormat::Partition>> partition_date_time_range_pattern(VM&, DateTimeFormat&, FormattableDateTime const& start, FormattableDateTime const& end);
-ThrowCompletionOr<String> format_date_time_range(VM&, DateTimeFormat&, FormattableDateTime const& start, FormattableDateTime const& end);
+ThrowCompletionOr<Utf16String> format_date_time_range(VM&, DateTimeFormat&, FormattableDateTime const& start, FormattableDateTime const& end);
 ThrowCompletionOr<GC::Ref<Array>> format_date_time_range_to_parts(VM&, DateTimeFormat&, FormattableDateTime const& start, FormattableDateTime const& end);
 
 Optional<Unicode::CalendarPattern> get_date_time_format(Unicode::CalendarPattern const& options, OptionRequired, OptionDefaults, OptionInherit);

--- a/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -83,7 +83,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
 
     // 5. Let fields be displayNames.[[Fields]].
     // 6. If fields has a field [[<code>]], return fields.[[<code>]].
-    Optional<String> result;
+    Optional<Utf16String> result;
 
     switch (display_names->type()) {
     case DisplayNames::Type::Language:

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -731,13 +731,13 @@ Vector<DurationFormatPart> list_format_parts(VM& vm, DurationFormat const& durat
     auto list_format = construct_list_format(vm, duration_format, list_format_options);
 
     // 7. Let strings be a new empty List.
-    Vector<String> strings;
+    Vector<Utf16String> strings;
     strings.ensure_capacity(partitioned_parts_list.size());
 
     // 8. For each element parts of partitionedPartsList, do
     for (auto const& parts : partitioned_parts_list) {
         // a. Let string be the empty String.
-        StringBuilder string;
+        StringBuilder string(StringBuilder::Mode::UTF16);
 
         // b. For each Record { [[Type]], [[Value]], [[Unit]] } part in parts, do
         for (auto const& part : parts) {
@@ -746,7 +746,7 @@ Vector<DurationFormatPart> list_format_parts(VM& vm, DurationFormat const& durat
         }
 
         // c. Append string to strings.
-        strings.unchecked_append(MUST(string.to_string()));
+        strings.unchecked_append(string.to_utf16_string());
     }
 
     // 9. Let formattedPartsList be CreatePartsFromList(lf, strings).
@@ -786,7 +786,7 @@ Vector<DurationFormatPart> list_format_parts(VM& vm, DurationFormat const& durat
             VERIFY(list_part.type == "literal"sv);
 
             // ii. Append the Record { [[Type]]: "literal", [[Value]]: listPart.[[Value]], [[Unit]]: empty } to flattenedPartsList.
-            flattened_parts_list.append({ .type = "literal"sv, .value = move(list_part.value), .unit = {} });
+            flattened_parts_list.append({ .type = "literal"sv, .value = list_part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = {} });
         }
     }
 

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -407,7 +407,7 @@ Vector<DurationFormatPart> format_numeric_hours(VM& vm, DurationFormat const& du
 
     for (auto& part : hours_parts) {
         // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: "hour" } to result.
-        result.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = "hour"sv });
+        result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "hour"sv });
     }
 
     // 13. Return result.
@@ -472,7 +472,7 @@ Vector<DurationFormatPart> format_numeric_minutes(VM& vm, DurationFormat const& 
 
     for (auto& part : minutes_parts) {
         // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: "minute" } to result.
-        result.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = "minute"sv });
+        result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "minute"sv });
     }
 
     // 14. Return result.
@@ -560,7 +560,7 @@ Vector<DurationFormatPart> format_numeric_seconds(VM& vm, DurationFormat const& 
 
     for (auto& part : seconds_parts) {
         // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: "second" } to result.
-        result.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = "second"sv });
+        result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "second"sv });
     }
 
     // 18. Return result.
@@ -786,7 +786,7 @@ Vector<DurationFormatPart> list_format_parts(VM& vm, DurationFormat const& durat
             VERIFY(list_part.type == "literal"sv);
 
             // ii. Append the Record { [[Type]]: "literal", [[Value]]: listPart.[[Value]], [[Unit]]: empty } to flattenedPartsList.
-            flattened_parts_list.append({ .type = "literal"sv, .value = list_part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = {} });
+            flattened_parts_list.append({ .type = "literal"sv, .value = move(list_part.value), .unit = {} });
         }
     }
 
@@ -922,7 +922,7 @@ Vector<DurationFormatPart> partition_duration_format_pattern(VM& vm, DurationFor
 
                 for (auto& part : parts) {
                     // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: numberFormatUnit } to list.
-                    list.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = number_format_unit.as_string() });
+                    list.unchecked_append({ .type = part.type, .value = move(part.value), .unit = number_format_unit.as_string() });
                 }
 
                 // 11. Append list to result.

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -407,7 +407,7 @@ Vector<DurationFormatPart> format_numeric_hours(VM& vm, DurationFormat const& du
 
     for (auto& part : hours_parts) {
         // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: "hour" } to result.
-        result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "hour"sv });
+        result.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = "hour"sv });
     }
 
     // 13. Return result.
@@ -472,7 +472,7 @@ Vector<DurationFormatPart> format_numeric_minutes(VM& vm, DurationFormat const& 
 
     for (auto& part : minutes_parts) {
         // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: "minute" } to result.
-        result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "minute"sv });
+        result.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = "minute"sv });
     }
 
     // 14. Return result.
@@ -560,7 +560,7 @@ Vector<DurationFormatPart> format_numeric_seconds(VM& vm, DurationFormat const& 
 
     for (auto& part : seconds_parts) {
         // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: "second" } to result.
-        result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "second"sv });
+        result.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = "second"sv });
     }
 
     // 18. Return result.
@@ -922,7 +922,7 @@ Vector<DurationFormatPart> partition_duration_format_pattern(VM& vm, DurationFor
 
                 for (auto& part : parts) {
                     // a. Append the Record { [[Type]]: part.[[Type]], [[Value]]: part.[[Value]], [[Unit]]: numberFormatUnit } to list.
-                    list.unchecked_append({ .type = part.type, .value = move(part.value), .unit = number_format_unit.as_string() });
+                    list.unchecked_append({ .type = part.type, .value = part.value.to_utf8_but_should_be_ported_to_utf16(), .unit = number_format_unit.as_string() });
                 }
 
                 // 11. Append list to result.

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -82,11 +82,11 @@ public:
     void set_numbering_system(String numbering_system) { m_numbering_system = move(numbering_system); }
     String const& numbering_system() const { return m_numbering_system; }
 
-    void set_hour_minute_separator(String hour_minute_separator) { m_hour_minute_separator = move(hour_minute_separator); }
-    String const& hour_minute_separator() const { return m_hour_minute_separator; }
+    void set_hour_minute_separator(Utf16String hour_minute_separator) { m_hour_minute_separator = move(hour_minute_separator); }
+    Utf16String const& hour_minute_separator() const { return m_hour_minute_separator; }
 
-    void set_minute_second_separator(String minute_second_separator) { m_minute_second_separator = move(minute_second_separator); }
-    String const& minute_second_separator() const { return m_minute_second_separator; }
+    void set_minute_second_separator(Utf16String minute_second_separator) { m_minute_second_separator = move(minute_second_separator); }
+    Utf16String const& minute_second_separator() const { return m_minute_second_separator; }
 
     void set_style(StringView style) { m_style = style_from_string(style); }
     Style style() const { return m_style; }
@@ -129,10 +129,10 @@ public:
 private:
     explicit DurationFormat(Object& prototype);
 
-    String m_locale;                  // [[Locale]]
-    String m_numbering_system;        // [[NumberingSystem]]
-    String m_hour_minute_separator;   // [[HourMinutesSeparator]]
-    String m_minute_second_separator; // [[MinutesSecondsSeparator]]
+    String m_locale;                       // [[Locale]]
+    String m_numbering_system;             // [[NumberingSystem]]
+    Utf16String m_hour_minute_separator;   // [[HourMinutesSeparator]]
+    Utf16String m_minute_second_separator; // [[MinutesSecondsSeparator]]
 
     Style m_style { Style::Long };              // [[Style]]
     DurationUnitOptions m_years_options;        // [[YearsOptions]]
@@ -178,7 +178,7 @@ static constexpr auto duration_instances_components = to_array<DurationInstanceC
 
 struct DurationFormatPart {
     StringView type;
-    String value;
+    Utf16String value;
     StringView unit;
 };
 

--- a/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -35,13 +35,13 @@ ReadonlySpan<ResolutionOptionDescriptor> ListFormat::resolution_option_descripto
 }
 
 // 14.5.2 CreatePartsFromList ( listFormat, list ), https://tc39.es/ecma402/#sec-createpartsfromlist
-Vector<Unicode::ListFormat::Partition> create_parts_from_list(ListFormat const& list_format, ReadonlySpan<String> list)
+Vector<Unicode::ListFormat::Partition> create_parts_from_list(ListFormat const& list_format, ReadonlySpan<Utf16String> list)
 {
     return list_format.formatter().format_to_parts(list);
 }
 
 // 14.5.3 FormatList ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlist
-String format_list(ListFormat const& list_format, ReadonlySpan<String> list)
+Utf16String format_list(ListFormat const& list_format, ReadonlySpan<Utf16String> list)
 {
     // 1. Let parts be ! CreatePartsFromList(listFormat, list).
     // 2. Let result be the empty String.
@@ -52,7 +52,7 @@ String format_list(ListFormat const& list_format, ReadonlySpan<String> list)
 }
 
 // 14.5.4 FormatListToParts ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlisttoparts
-GC::Ref<Array> format_list_to_parts(VM& vm, ListFormat const& list_format, ReadonlySpan<String> list)
+GC::Ref<Array> format_list_to_parts(VM& vm, ListFormat const& list_format, ReadonlySpan<Utf16String> list)
 {
     auto& realm = *vm.current_realm();
 
@@ -88,19 +88,19 @@ GC::Ref<Array> format_list_to_parts(VM& vm, ListFormat const& list_format, Reado
 }
 
 // 14.5.5 StringListFromIterable ( iterable ), https://tc39.es/ecma402/#sec-createstringlistfromiterable
-ThrowCompletionOr<Vector<String>> string_list_from_iterable(VM& vm, Value iterable)
+ThrowCompletionOr<Vector<Utf16String>> string_list_from_iterable(VM& vm, Value iterable)
 {
     // 1. If iterable is undefined, then
     if (iterable.is_undefined()) {
         // a. Return a new empty List.
-        return Vector<String> {};
+        return Vector<Utf16String> {};
     }
 
     // 2. Let iteratorRecord be ? GetIterator(iterable, sync).
     auto iterator_record = TRY(get_iterator(vm, iterable, IteratorHint::Sync));
 
     // 3. Let list be a new empty List.
-    Vector<String> list;
+    Vector<Utf16String> list;
 
     // 4. Repeat,
     while (true) {
@@ -123,7 +123,7 @@ ThrowCompletionOr<Vector<String>> string_list_from_iterable(VM& vm, Value iterab
         }
 
         // iii. Append next to list.
-        list.append(next->as_string().utf8_string());
+        list.append(next->as_string().utf16_string());
     }
 }
 

--- a/Libraries/LibJS/Runtime/Intl/ListFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/ListFormat.h
@@ -57,9 +57,9 @@ private:
     OwnPtr<Unicode::ListFormat> m_formatter;
 };
 
-Vector<Unicode::ListFormat::Partition> create_parts_from_list(ListFormat const&, ReadonlySpan<String> list);
-String format_list(ListFormat const&, ReadonlySpan<String> list);
-GC::Ref<Array> format_list_to_parts(VM&, ListFormat const&, ReadonlySpan<String> list);
-ThrowCompletionOr<Vector<String>> string_list_from_iterable(VM&, Value iterable);
+Vector<Unicode::ListFormat::Partition> create_parts_from_list(ListFormat const&, ReadonlySpan<Utf16String> list);
+Utf16String format_list(ListFormat const&, ReadonlySpan<Utf16String> list);
+GC::Ref<Array> format_list_to_parts(VM&, ListFormat const&, ReadonlySpan<Utf16String> list);
+ThrowCompletionOr<Vector<Utf16String>> string_list_from_iterable(VM&, Value iterable);
 
 }

--- a/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -152,7 +152,7 @@ Vector<Unicode::NumberFormat::Partition> partition_number_pattern(NumberFormat c
 }
 
 // 16.5.6 FormatNumeric ( numberFormat, x ), https://tc39.es/ecma402/#sec-formatnumber
-String format_numeric(NumberFormat const& number_format, MathematicalValue const& number)
+Utf16String format_numeric(NumberFormat const& number_format, MathematicalValue const& number)
 {
     // 1. Let parts be ? PartitionNumberPattern(numberFormat, x).
     // 2. Let result be the empty String.
@@ -258,7 +258,7 @@ ThrowCompletionOr<Vector<Unicode::NumberFormat::Partition>> partition_number_ran
 }
 
 // 16.5.22 FormatNumericRange ( numberFormat, x, y ), https://tc39.es/ecma402/#sec-formatnumericrange
-ThrowCompletionOr<String> format_numeric_range(VM& vm, NumberFormat const& number_format, MathematicalValue const& start, MathematicalValue const& end)
+ThrowCompletionOr<Utf16String> format_numeric_range(VM& vm, NumberFormat const& number_format, MathematicalValue const& start, MathematicalValue const& end)
 {
     // 1. Let parts be ? PartitionNumberRangePattern(numberFormat, x, y).
     {

--- a/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -182,11 +182,11 @@ private:
 
 int currency_digits(StringView currency);
 Vector<Unicode::NumberFormat::Partition> partition_number_pattern(NumberFormat const&, MathematicalValue const& number);
-String format_numeric(NumberFormat const&, MathematicalValue const& number);
+Utf16String format_numeric(NumberFormat const&, MathematicalValue const& number);
 GC::Ref<Array> format_numeric_to_parts(VM&, NumberFormat const&, MathematicalValue const& number);
 ThrowCompletionOr<MathematicalValue> to_intl_mathematical_value(VM&, Value value);
 ThrowCompletionOr<Vector<Unicode::NumberFormat::Partition>> partition_number_range_pattern(VM&, NumberFormat const&, MathematicalValue const& start, MathematicalValue const& end);
-ThrowCompletionOr<String> format_numeric_range(VM&, NumberFormat const&, MathematicalValue const& start, MathematicalValue const& end);
+ThrowCompletionOr<Utf16String> format_numeric_range(VM&, NumberFormat const&, MathematicalValue const& start, MathematicalValue const& end);
 ThrowCompletionOr<GC::Ref<Array>> format_numeric_range_to_parts(VM&, NumberFormat const&, MathematicalValue const& start, MathematicalValue const& end);
 
 }

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -87,7 +87,7 @@ ThrowCompletionOr<Vector<Unicode::RelativeTimeFormat::Partition>> partition_rela
 }
 
 // 18.5.4 FormatRelativeTime ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-FormatRelativeTime
-ThrowCompletionOr<String> format_relative_time(VM& vm, RelativeTimeFormat& relative_time_format, double value, StringView unit)
+ThrowCompletionOr<Utf16String> format_relative_time(VM& vm, RelativeTimeFormat& relative_time_format, double value, StringView unit)
 {
     // 1. Let parts be ? PartitionRelativeTimePattern(relativeTimeFormat, value, unit).
     auto time_unit = TRY([&]() -> ThrowCompletionOr<Unicode::TimeUnit> {

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -56,7 +56,7 @@ private:
 
 ThrowCompletionOr<Unicode::TimeUnit> singular_relative_time_unit(VM&, StringView unit);
 ThrowCompletionOr<Vector<Unicode::RelativeTimeFormat::Partition>> partition_relative_time_pattern(VM&, RelativeTimeFormat&, double value, StringView unit);
-ThrowCompletionOr<String> format_relative_time(VM&, RelativeTimeFormat&, double value, StringView unit);
+ThrowCompletionOr<Utf16String> format_relative_time(VM&, RelativeTimeFormat&, double value, StringView unit);
 ThrowCompletionOr<GC::Ref<Array>> format_relative_time_to_parts(VM&, RelativeTimeFormat&, double value, StringView unit);
 
 }

--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -538,10 +538,10 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::locale_compare)
     auto object = TRY(require_object_coercible(vm, vm.this_value()));
 
     // 2. Let S be ? ToString(O).
-    auto string = TRY(object.to_string(vm));
+    auto string = TRY(object.to_utf16_string(vm));
 
     // 3. Let thatValue be ? ToString(that).
-    auto that_value = TRY(vm.argument(0).to_string(vm));
+    auto that_value = TRY(vm.argument(0).to_utf16_string(vm));
 
     // 4. Let collator be ? Construct(%Collator%, « locales, options »).
     auto locales = vm.argument(1);

--- a/Libraries/LibUnicode/Collator.cpp
+++ b/Libraries/LibUnicode/Collator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -168,11 +168,14 @@ public:
     {
     }
 
-    virtual Collator::Order compare(StringView lhs, StringView rhs) const override
+    virtual Collator::Order compare(Utf16View const& lhs, Utf16View const& rhs) const override
     {
         UErrorCode status = U_ZERO_ERROR;
 
-        auto result = m_collator->compareUTF8(icu_string_piece(lhs), icu_string_piece(rhs), status);
+        auto lhs_it = icu_string_iterator(lhs);
+        auto rhs_it = icu_string_iterator(rhs);
+
+        auto result = m_collator->compare(lhs_it, rhs_it, status);
         VERIFY(icu_success(status));
 
         switch (result) {

--- a/Libraries/LibUnicode/Collator.h
+++ b/Libraries/LibUnicode/Collator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,7 +53,7 @@ public:
         Equal,
         After,
     };
-    virtual Order compare(StringView, StringView) const = 0;
+    virtual Order compare(Utf16View const&, Utf16View const&) const = 0;
 
     virtual Sensitivity sensitivity() const = 0;
     virtual bool ignore_punctuation() const = 0;

--- a/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -672,13 +672,13 @@ public:
 
     virtual CalendarPattern const& chosen_pattern() const override { return m_pattern; }
 
-    virtual String format(double time) const override
+    virtual Utf16String format(double time) const override
     {
         auto formatted_time = format_impl(time);
         if (!formatted_time.has_value())
             return {};
 
-        return icu_string_to_string(*formatted_time);
+        return icu_string_to_utf16_string(*formatted_time);
     }
 
     virtual Vector<Partition> format_to_parts(double time) const override
@@ -694,7 +694,7 @@ public:
         auto create_partition = [&](i32 field, i32 begin, i32 end) {
             Partition partition;
             partition.type = icu_date_time_format_field_to_string(field);
-            partition.value = icu_string_to_string(formatted_time->tempSubStringBetween(begin, end));
+            partition.value = icu_string_to_utf16_string(formatted_time->tempSubStringBetween(begin, end));
             partition.source = "shared"sv;
             result.append(move(partition));
         };
@@ -717,7 +717,7 @@ public:
         return result;
     }
 
-    virtual String format_range(double start, double end) const override
+    virtual Utf16String format_range(double start, double end) const override
     {
         UErrorCode status = U_ZERO_ERROR;
 
@@ -733,7 +733,7 @@ public:
             return {};
 
         normalize_spaces(formatted_time);
-        return icu_string_to_string(formatted_time);
+        return icu_string_to_utf16_string(formatted_time);
     }
 
     virtual Vector<Partition> format_range_to_parts(double start, double end) const override
@@ -763,7 +763,7 @@ public:
         auto create_partition = [&](i32 field, i32 begin, i32 end) {
             Partition partition;
             partition.type = icu_date_time_format_field_to_string(field);
-            partition.value = icu_string_to_string(formatted_time.tempSubStringBetween(begin, end));
+            partition.value = icu_string_to_utf16_string(formatted_time.tempSubStringBetween(begin, end));
 
             if (start_range.has_value() && start_range->contains(begin))
                 partition.source = "startRange"sv;

--- a/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Libraries/LibUnicode/DateTimeFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,10 +8,10 @@
 
 #include <AK/IterationDecision.h>
 #include <AK/Optional.h>
-#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
+#include <AK/Utf16String.h>
 #include <AK/Vector.h>
 #include <LibUnicode/Forward.h>
 
@@ -151,16 +151,16 @@ public:
 
     struct Partition {
         StringView type;
-        String value;
+        Utf16String value;
         StringView source;
     };
 
     virtual CalendarPattern const& chosen_pattern() const = 0;
 
-    virtual String format(double) const = 0;
+    virtual Utf16String format(double) const = 0;
     virtual Vector<Partition> format_to_parts(double) const = 0;
 
-    virtual String format_range(double, double) const = 0;
+    virtual Utf16String format_range(double, double) const = 0;
     virtual Vector<Partition> format_range_to_parts(double, double) const = 0;
 
 protected:

--- a/Libraries/LibUnicode/DisplayNames.cpp
+++ b/Libraries/LibUnicode/DisplayNames.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,7 +37,7 @@ StringView language_display_to_string(LanguageDisplay language_display)
     }
 }
 
-Optional<String> language_display_name(StringView locale, StringView language, LanguageDisplay display)
+Optional<Utf16String> language_display_name(StringView locale, StringView language, LanguageDisplay display)
 {
     auto locale_data = LocaleData::for_locale(locale);
     if (!locale_data.has_value())
@@ -54,10 +54,10 @@ Optional<String> language_display_name(StringView locale, StringView language, L
     icu::UnicodeString result;
     display_names.localeDisplayName(language_data->locale().getName(), result);
 
-    return icu_string_to_string(result);
+    return icu_string_to_utf16_string(result);
 }
 
-Optional<String> region_display_name(StringView locale, StringView region)
+Optional<Utf16String> region_display_name(StringView locale, StringView region)
 {
     UErrorCode status = U_ZERO_ERROR;
 
@@ -72,10 +72,10 @@ Optional<String> region_display_name(StringView locale, StringView region)
     icu::UnicodeString result;
     locale_data->standard_display_names().regionDisplayName(icu_region.getCountry(), result);
 
-    return icu_string_to_string(result);
+    return icu_string_to_utf16_string(result);
 }
 
-Optional<String> script_display_name(StringView locale, StringView script)
+Optional<Utf16String> script_display_name(StringView locale, StringView script)
 {
     UErrorCode status = U_ZERO_ERROR;
 
@@ -90,10 +90,10 @@ Optional<String> script_display_name(StringView locale, StringView script)
     icu::UnicodeString result;
     locale_data->standard_display_names().scriptDisplayName(icu_script.getScript(), result);
 
-    return icu_string_to_string(result);
+    return icu_string_to_utf16_string(result);
 }
 
-Optional<String> calendar_display_name(StringView locale, StringView calendar)
+Optional<Utf16String> calendar_display_name(StringView locale, StringView calendar)
 {
     auto locale_data = LocaleData::for_locale(locale);
     if (!locale_data.has_value())
@@ -109,7 +109,7 @@ Optional<String> calendar_display_name(StringView locale, StringView calendar)
     icu::UnicodeString result;
     locale_data->standard_display_names().keyValueDisplayName("calendar", ByteString(calendar).characters(), result);
 
-    return icu_string_to_string(result);
+    return icu_string_to_utf16_string(result);
 }
 
 static constexpr UDateTimePatternField icu_date_time_field(StringView field)
@@ -155,7 +155,7 @@ static constexpr UDateTimePGDisplayWidth icu_date_time_style(Style style)
     VERIFY_NOT_REACHED();
 }
 
-Optional<String> date_time_field_display_name(StringView locale, StringView field, Style style)
+Optional<Utf16String> date_time_field_display_name(StringView locale, StringView field, Style style)
 {
     auto locale_data = LocaleData::for_locale(locale);
     if (!locale_data.has_value())
@@ -167,10 +167,10 @@ Optional<String> date_time_field_display_name(StringView locale, StringView fiel
     icu::UnicodeString result;
     result = locale_data->date_time_pattern_generator().getFieldDisplayName(icu_field, icu_style);
 
-    return icu_string_to_string(result);
+    return icu_string_to_utf16_string(result);
 }
 
-Optional<String> time_zone_display_name(StringView locale, StringView time_zone_identifier, TimeZoneOffset::InDST in_dst, double time)
+Optional<Utf16String> time_zone_display_name(StringView locale, StringView time_zone_identifier, TimeZoneOffset::InDST in_dst, double time)
 {
     auto locale_data = LocaleData::for_locale(locale);
     if (!locale_data.has_value())
@@ -183,7 +183,7 @@ Optional<String> time_zone_display_name(StringView locale, StringView time_zone_
     if (static_cast<bool>(time_zone_name.isBogus()))
         return {};
 
-    return icu_string_to_string(time_zone_name);
+    return icu_string_to_utf16_string(time_zone_name);
 }
 
 static constexpr Array<UChar, 4> icu_currency_code(StringView currency)
@@ -212,7 +212,7 @@ static constexpr UCurrNameStyle icu_currency_style(Style style)
     VERIFY_NOT_REACHED();
 }
 
-Optional<String> currency_display_name(StringView locale, StringView currency, Style style)
+Optional<Utf16String> currency_display_name(StringView locale, StringView currency, Style style)
 {
     UErrorCode status = U_ZERO_ERROR;
 
@@ -230,10 +230,10 @@ Optional<String> currency_display_name(StringView locale, StringView currency, S
     if ((status == U_USING_DEFAULT_WARNING) && (result == icu_currency.data()))
         return {};
 
-    return icu_string_to_string(result, length);
+    return icu_string_to_utf16_string(result, length);
 }
 
-Optional<String> currency_numeric_display_name(StringView locale, StringView currency)
+Optional<Utf16String> currency_numeric_display_name(StringView locale, StringView currency)
 {
     UErrorCode status = U_ZERO_ERROR;
 
@@ -251,7 +251,7 @@ Optional<String> currency_numeric_display_name(StringView locale, StringView cur
     if ((status == U_USING_DEFAULT_WARNING) && (result == icu_currency.data()))
         return {};
 
-    return icu_string_to_string(result, length);
+    return icu_string_to_utf16_string(result, length);
 }
 
 }

--- a/Libraries/LibUnicode/DisplayNames.h
+++ b/Libraries/LibUnicode/DisplayNames.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <AK/Optional.h>
-#include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Utf16String.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/TimeZone.h>
 
@@ -22,13 +22,13 @@ enum class LanguageDisplay {
 LanguageDisplay language_display_from_string(StringView language_display);
 StringView language_display_to_string(LanguageDisplay language_display);
 
-Optional<String> language_display_name(StringView locale, StringView language, LanguageDisplay);
-Optional<String> region_display_name(StringView locale, StringView region);
-Optional<String> script_display_name(StringView locale, StringView script);
-Optional<String> calendar_display_name(StringView locale, StringView calendar);
-Optional<String> date_time_field_display_name(StringView locale, StringView field, Style);
-Optional<String> time_zone_display_name(StringView locale, StringView time_zone_identifier, TimeZoneOffset::InDST, double time);
-Optional<String> currency_display_name(StringView locale, StringView currency, Style);
-Optional<String> currency_numeric_display_name(StringView locale, StringView currency);
+Optional<Utf16String> language_display_name(StringView locale, StringView language, LanguageDisplay);
+Optional<Utf16String> region_display_name(StringView locale, StringView region);
+Optional<Utf16String> script_display_name(StringView locale, StringView script);
+Optional<Utf16String> calendar_display_name(StringView locale, StringView calendar);
+Optional<Utf16String> date_time_field_display_name(StringView locale, StringView field, Style);
+Optional<Utf16String> time_zone_display_name(StringView locale, StringView time_zone_identifier, TimeZoneOffset::InDST, double time);
+Optional<Utf16String> currency_display_name(StringView locale, StringView currency, Style);
+Optional<Utf16String> currency_numeric_display_name(StringView locale, StringView currency);
 
 }

--- a/Libraries/LibUnicode/DurationFormat.cpp
+++ b/Libraries/LibUnicode/DurationFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -72,12 +72,12 @@ DigitalFormat digital_format(StringView locale)
     digital_format.uses_two_digit_hours = hours.length() == 2;
 
     auto hours_minutes_separator = lexer.consume_while(is_not_ascii_digit);
-    digital_format.hours_minutes_separator = MUST(String::from_utf8(hours_minutes_separator));
+    digital_format.hours_minutes_separator = Utf16String::from_utf8(hours_minutes_separator);
 
     lexer.ignore_while(is_ascii_digit);
 
     auto minutes_seconds_separator = lexer.consume_while(is_not_ascii_digit);
-    digital_format.minutes_seconds_separator = MUST(String::from_utf8(minutes_seconds_separator));
+    digital_format.minutes_seconds_separator = Utf16String::from_utf8(minutes_seconds_separator);
 
     locale_data->set_digital_format(move(digital_format));
     return *locale_data->digital_format();

--- a/Libraries/LibUnicode/DurationFormat.h
+++ b/Libraries/LibUnicode/DurationFormat.h
@@ -1,18 +1,18 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/String.h>
+#include <AK/Utf16String.h>
 
 namespace Unicode {
 
 struct DigitalFormat {
-    String hours_minutes_separator { ":"_string };
-    String minutes_seconds_separator { ":"_string };
+    Utf16String hours_minutes_separator { ":"_utf16 };
+    Utf16String minutes_seconds_separator { ":"_utf16 };
     bool uses_two_digit_hours { false };
 };
 

--- a/Libraries/LibUnicode/ICU.cpp
+++ b/Libraries/LibUnicode/ICU.cpp
@@ -162,6 +162,11 @@ String icu_string_to_string(UChar const* string, i32 length)
     return MUST(Utf16View { string, static_cast<size_t>(length) }.to_utf8());
 }
 
+Utf16String icu_string_to_utf16_string(icu::UnicodeString const& string)
+{
+    return Utf16String::from_utf16_without_validation({ string.getBuffer(), static_cast<size_t>(string.length()) });
+}
+
 UCharIterator icu_string_iterator(Utf16View const& string)
 {
     UCharIterator iterator;

--- a/Libraries/LibUnicode/ICU.cpp
+++ b/Libraries/LibUnicode/ICU.cpp
@@ -164,7 +164,12 @@ String icu_string_to_string(UChar const* string, i32 length)
 
 Utf16String icu_string_to_utf16_string(icu::UnicodeString const& string)
 {
-    return Utf16String::from_utf16_without_validation({ string.getBuffer(), static_cast<size_t>(string.length()) });
+    return icu_string_to_utf16_string(string.getBuffer(), string.length());
+}
+
+Utf16String icu_string_to_utf16_string(UChar const* string, i32 length)
+{
+    return Utf16String::from_utf16_without_validation({ string, static_cast<size_t>(length) });
 }
 
 UCharIterator icu_string_iterator(Utf16View const& string)

--- a/Libraries/LibUnicode/ICU.cpp
+++ b/Libraries/LibUnicode/ICU.cpp
@@ -169,6 +169,11 @@ Utf16String icu_string_to_utf16_string(UChar const* string, i32 length)
     return Utf16String::from_utf16_without_validation({ string, static_cast<size_t>(length) });
 }
 
+Utf16View icu_string_to_utf16_view(icu::UnicodeString const& string)
+{
+    return { string.getBuffer(), static_cast<size_t>(string.length()) };
+}
+
 UCharIterator icu_string_iterator(Utf16View const& string)
 {
     UCharIterator iterator;

--- a/Libraries/LibUnicode/ICU.cpp
+++ b/Libraries/LibUnicode/ICU.cpp
@@ -138,16 +138,13 @@ TimeZoneData::TimeZoneData(NonnullOwnPtr<icu::TimeZone> time_zone)
 {
 }
 
-Vector<icu::UnicodeString> icu_string_list(ReadonlySpan<String> strings)
+Vector<icu::UnicodeString> icu_string_list(ReadonlySpan<Utf16String> strings)
 {
     Vector<icu::UnicodeString> result;
     result.ensure_capacity(strings.size());
 
-    for (auto const& string : strings) {
-        auto view = string.bytes_as_string_view();
-        icu::UnicodeString icu_string(view.characters_without_null_termination(), static_cast<i32>(view.length()));
-        result.unchecked_append(move(icu_string));
-    }
+    for (auto const& string : strings)
+        result.unchecked_append(icu_string(string));
 
     return result;
 }

--- a/Libraries/LibUnicode/ICU.cpp
+++ b/Libraries/LibUnicode/ICU.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -160,6 +160,18 @@ String icu_string_to_string(icu::UnicodeString const& string)
 String icu_string_to_string(UChar const* string, i32 length)
 {
     return MUST(Utf16View { string, static_cast<size_t>(length) }.to_utf8());
+}
+
+UCharIterator icu_string_iterator(Utf16View const& string)
+{
+    UCharIterator iterator;
+
+    if (string.has_ascii_storage())
+        uiter_setUTF8(&iterator, string.ascii_span().data(), static_cast<i32>(string.length_in_code_units()));
+    else
+        uiter_setString(&iterator, string.utf16_span().data(), static_cast<i32>(string.length_in_code_units()));
+
+    return iterator;
 }
 
 }

--- a/Libraries/LibUnicode/ICU.h
+++ b/Libraries/LibUnicode/ICU.h
@@ -16,6 +16,7 @@
 #include <unicode/locid.h>
 #include <unicode/strenum.h>
 #include <unicode/stringpiece.h>
+#include <unicode/uiter.h>
 #include <unicode/uloc.h>
 #include <unicode/unistr.h>
 #include <unicode/utypes.h>
@@ -101,6 +102,8 @@ Vector<icu::UnicodeString> icu_string_list(ReadonlySpan<String> strings);
 
 String icu_string_to_string(icu::UnicodeString const& string);
 String icu_string_to_string(UChar const*, i32 length);
+
+UCharIterator icu_string_iterator(Utf16View const&);
 
 template<typename Filter>
 Vector<String> icu_string_enumeration_to_list(OwnPtr<icu::StringEnumeration> enumeration, char const* bcp47_keyword, Filter&& filter)

--- a/Libraries/LibUnicode/ICU.h
+++ b/Libraries/LibUnicode/ICU.h
@@ -10,6 +10,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Utf16String.h>
 #include <AK/Vector.h>
 #include <LibUnicode/DurationFormat.h>
 
@@ -102,6 +103,8 @@ Vector<icu::UnicodeString> icu_string_list(ReadonlySpan<String> strings);
 
 String icu_string_to_string(icu::UnicodeString const& string);
 String icu_string_to_string(UChar const*, i32 length);
+
+Utf16String icu_string_to_utf16_string(icu::UnicodeString const& string);
 
 UCharIterator icu_string_iterator(Utf16View const&);
 

--- a/Libraries/LibUnicode/ICU.h
+++ b/Libraries/LibUnicode/ICU.h
@@ -116,6 +116,8 @@ String icu_string_to_string(UChar const*, i32 length);
 Utf16String icu_string_to_utf16_string(icu::UnicodeString const& string);
 Utf16String icu_string_to_utf16_string(UChar const*, i32 length);
 
+Utf16View icu_string_to_utf16_view(icu::UnicodeString const& string);
+
 UCharIterator icu_string_iterator(Utf16View const&);
 
 template<typename Filter>

--- a/Libraries/LibUnicode/ICU.h
+++ b/Libraries/LibUnicode/ICU.h
@@ -99,7 +99,16 @@ ALWAYS_INLINE icu::UnicodeString icu_string(StringView string)
     return icu::UnicodeString::fromUTF8(icu_string_piece(string));
 }
 
-Vector<icu::UnicodeString> icu_string_list(ReadonlySpan<String> strings);
+// If the Utf16View has ASCII storage, this creates an owned icu::UnicodeString. Otherwise, the icu::UnicodeString is
+// unowned (i.e. it is effectively a view).
+ALWAYS_INLINE icu::UnicodeString icu_string(Utf16View const& string)
+{
+    if (string.has_ascii_storage())
+        return icu::UnicodeString::fromUTF8(icu_string_piece(string.bytes()));
+    return { false, string.utf16_span().data(), static_cast<i32>(string.length_in_code_units()) };
+}
+
+Vector<icu::UnicodeString> icu_string_list(ReadonlySpan<Utf16String> strings);
 
 String icu_string_to_string(icu::UnicodeString const& string);
 String icu_string_to_string(UChar const*, i32 length);

--- a/Libraries/LibUnicode/ICU.h
+++ b/Libraries/LibUnicode/ICU.h
@@ -105,6 +105,7 @@ String icu_string_to_string(icu::UnicodeString const& string);
 String icu_string_to_string(UChar const*, i32 length);
 
 Utf16String icu_string_to_utf16_string(icu::UnicodeString const& string);
+Utf16String icu_string_to_utf16_string(UChar const*, i32 length);
 
 UCharIterator icu_string_iterator(Utf16View const&);
 

--- a/Libraries/LibUnicode/ListFormat.cpp
+++ b/Libraries/LibUnicode/ListFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -82,7 +82,7 @@ public:
 
     virtual ~ListFormatImpl() override = default;
 
-    virtual String format(ReadonlySpan<String> list) const override
+    virtual Utf16String format(ReadonlySpan<Utf16String> list) const override
     {
         UErrorCode status = U_ZERO_ERROR;
 
@@ -94,10 +94,10 @@ public:
         if (icu_failure(status))
             return {};
 
-        return icu_string_to_string(formatted_string);
+        return icu_string_to_utf16_string(formatted_string);
     }
 
-    virtual Vector<Partition> format_to_parts(ReadonlySpan<String> list) const override
+    virtual Vector<Partition> format_to_parts(ReadonlySpan<Utf16String> list) const override
     {
         UErrorCode status = U_ZERO_ERROR;
 
@@ -118,14 +118,14 @@ public:
             auto type = icu_list_format_field_to_string(position.getField());
             auto part = formatted_string.tempSubStringBetween(position.getStart(), position.getLimit());
 
-            result.empend(type, icu_string_to_string(part));
+            result.empend(type, icu_string_to_utf16_string(part));
         }
 
         return result;
     }
 
 private:
-    Optional<icu::FormattedList> format_list_impl(ReadonlySpan<String> list) const
+    Optional<icu::FormattedList> format_list_impl(ReadonlySpan<Utf16String> list) const
     {
         UErrorCode status = U_ZERO_ERROR;
 

--- a/Libraries/LibUnicode/ListFormat.h
+++ b/Libraries/LibUnicode/ListFormat.h
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/String.h>
+#include <AK/Utf16String.h>
 #include <AK/Vector.h>
 #include <LibUnicode/Locale.h>
 
@@ -27,11 +27,11 @@ public:
 
     struct Partition {
         StringView type;
-        String value;
+        Utf16String value;
     };
 
-    virtual String format(ReadonlySpan<String> list) const = 0;
-    virtual Vector<Partition> format_to_parts(ReadonlySpan<String> list) const = 0;
+    virtual Utf16String format(ReadonlySpan<Utf16String> list) const = 0;
+    virtual Vector<Partition> format_to_parts(ReadonlySpan<Utf16String> list) const = 0;
 
 protected:
     ListFormat() = default;

--- a/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Libraries/LibUnicode/NumberFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -601,7 +601,7 @@ public:
 
     virtual ~NumberFormatImpl() override = default;
 
-    virtual String format(Value const& value) const override
+    virtual Utf16String format(Value const& value) const override
     {
         UErrorCode status = U_ZERO_ERROR;
 
@@ -613,7 +613,7 @@ public:
         if (icu_failure(status))
             return {};
 
-        return icu_string_to_string(result);
+        return icu_string_to_utf16_string(result);
     }
 
     virtual Vector<Partition> format_to_parts(Value const& value) const override
@@ -625,7 +625,7 @@ public:
         return format_to_parts_impl(formatted, value, value);
     }
 
-    virtual String format_range(Value const& start, Value const& end) const override
+    virtual Utf16String format_range(Value const& start, Value const& end) const override
     {
         UErrorCode status = U_ZERO_ERROR;
 
@@ -637,7 +637,7 @@ public:
         if (icu_failure(status))
             return {};
 
-        return icu_string_to_string(result);
+        return icu_string_to_utf16_string(result);
     }
 
     virtual Vector<Partition> format_range_to_parts(Value const& start, Value const& end) const override
@@ -830,7 +830,7 @@ private:
             auto value = formatted_number.tempSubStringBetween(range.start, range.end);
 
             Partition partition;
-            partition.value = icu_string_to_string(value);
+            partition.value = icu_string_to_utf16_string(value);
             apply_to_partition(partition, range.field, range.start);
 
             result.unchecked_append(move(partition));

--- a/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Libraries/LibUnicode/NumberFormat.cpp
@@ -671,7 +671,7 @@ public:
         if (icu_failure(status))
             return PluralCategory::Other;
 
-        return plural_category_from_string(icu_string_to_string(result));
+        return plural_category_from_string(icu_string_to_utf16_view(result));
     }
 
     virtual PluralCategory select_plural_range(double start, double end) const override
@@ -694,7 +694,7 @@ public:
         if (icu_failure(status))
             return PluralCategory::Other;
 
-        return plural_category_from_string(icu_string_to_string(result));
+        return plural_category_from_string(icu_string_to_utf16_view(result));
     }
 
     virtual Vector<PluralCategory> available_plural_categories() const override
@@ -710,7 +710,7 @@ public:
 
         while (true) {
             i32 length = 0;
-            auto const* category = keywords->next(&length, status);
+            auto const* category = keywords->unext(&length, status);
 
             if (icu_failure(status) || category == nullptr)
                 break;

--- a/Libraries/LibUnicode/NumberFormat.h
+++ b/Libraries/LibUnicode/NumberFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Utf16String.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibUnicode/Forward.h>
@@ -149,16 +150,16 @@ public:
 
     struct Partition {
         StringView type;
-        String value;
+        Utf16String value;
         StringView source;
     };
 
     using Value = Variant<double, String>;
 
-    virtual String format(Value const&) const = 0;
+    virtual Utf16String format(Value const&) const = 0;
     virtual Vector<Partition> format_to_parts(Value const&) const = 0;
 
-    virtual String format_range(Value const&, Value const&) const = 0;
+    virtual Utf16String format_range(Value const&, Value const&) const = 0;
     virtual Vector<Partition> format_range_to_parts(Value const&, Value const&) const = 0;
 
     virtual void create_plural_rules(PluralForm) = 0;

--- a/Libraries/LibUnicode/PluralRules.cpp
+++ b/Libraries/LibUnicode/PluralRules.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,7 +28,7 @@ StringView plural_form_to_string(PluralForm plural_form)
     VERIFY_NOT_REACHED();
 }
 
-PluralCategory plural_category_from_string(StringView category)
+PluralCategory plural_category_from_string(Utf16View const& category)
 {
     if (category == "other"sv)
         return PluralCategory::Other;
@@ -49,7 +49,7 @@ PluralCategory plural_category_from_string(StringView category)
     VERIFY_NOT_REACHED();
 }
 
-StringView plural_category_to_string(PluralCategory category)
+Utf16View plural_category_to_string(PluralCategory category)
 {
     switch (category) {
     case PluralCategory::Other:

--- a/Libraries/LibUnicode/PluralRules.h
+++ b/Libraries/LibUnicode/PluralRules.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/StringView.h>
+#include <AK/Utf16View.h>
 
 namespace Unicode {
 
@@ -30,7 +31,7 @@ enum class PluralCategory {
     ExactlyZero,
     ExactlyOne,
 };
-PluralCategory plural_category_from_string(StringView);
-StringView plural_category_to_string(PluralCategory);
+PluralCategory plural_category_from_string(Utf16View const&);
+Utf16View plural_category_to_string(PluralCategory);
 
 }

--- a/Libraries/LibUnicode/RelativeTimeFormat.cpp
+++ b/Libraries/LibUnicode/RelativeTimeFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -142,7 +142,7 @@ public:
 
     virtual ~RelativeTimeFormatImpl() override = default;
 
-    virtual String format(double time, TimeUnit unit, NumericDisplay numeric_display) const override
+    virtual Utf16String format(double time, TimeUnit unit, NumericDisplay numeric_display) const override
     {
         UErrorCode status = U_ZERO_ERROR;
 
@@ -152,7 +152,7 @@ public:
         if (icu_failure(status))
             return {};
 
-        return icu_string_to_string(formatted_time);
+        return icu_string_to_utf16_string(formatted_time);
     }
 
     virtual Vector<Partition> format_to_parts(double time, TimeUnit unit, NumericDisplay numeric_display) const override
@@ -172,7 +172,7 @@ public:
         auto create_partition = [&](i32 field, i32 begin, i32 end, bool is_unit) {
             Partition partition;
             partition.type = icu_relative_time_format_field_to_string(field);
-            partition.value = icu_string_to_string(formatted_time.tempSubStringBetween(begin, end));
+            partition.value = icu_string_to_utf16_string(formatted_time.tempSubStringBetween(begin, end));
             if (is_unit)
                 partition.unit = unit_string;
             result.append(move(partition));

--- a/Libraries/LibUnicode/RelativeTimeFormat.h
+++ b/Libraries/LibUnicode/RelativeTimeFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +10,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Utf16String.h>
 #include <AK/Vector.h>
 #include <LibUnicode/Forward.h>
 
@@ -43,11 +44,11 @@ public:
 
     struct Partition {
         StringView type;
-        String value;
+        Utf16String value;
         StringView unit;
     };
 
-    virtual String format(double, TimeUnit, NumericDisplay) const = 0;
+    virtual Utf16String format(double, TimeUnit, NumericDisplay) const = 0;
     virtual Vector<Partition> format_to_parts(double, TimeUnit, NumericDisplay) const = 0;
 
 protected:

--- a/Tests/LibUnicode/TestDisplayNames.cpp
+++ b/Tests/LibUnicode/TestDisplayNames.cpp
@@ -13,21 +13,21 @@ TEST_CASE(locale_mappings_en)
 {
     auto language = Unicode::language_display_name("en"sv, "en"sv, Unicode::LanguageDisplay::Standard);
     EXPECT(language.has_value());
-    EXPECT_EQ(*language, "English"sv);
+    EXPECT_EQ(*language, u"English"sv);
 
     language = Unicode::language_display_name("en"sv, "i-definitely-don't-exist"sv, Unicode::LanguageDisplay::Standard);
     EXPECT(!language.has_value());
 
     auto territory = Unicode::region_display_name("en"sv, "US"sv);
     EXPECT(territory.has_value());
-    EXPECT_EQ(*territory, "United States"sv);
+    EXPECT_EQ(*territory, u"United States"sv);
 
     territory = Unicode::region_display_name("en"sv, "i-definitely-don't-exist"sv);
     EXPECT(!territory.has_value());
 
     auto script = Unicode::script_display_name("en"sv, "Latn"sv);
     EXPECT(script.has_value());
-    EXPECT_EQ(*script, "Latin"sv);
+    EXPECT_EQ(*script, u"Latin"sv);
 
     script = Unicode::script_display_name("en"sv, "i-definitely-don't-exist"sv);
     EXPECT(!script.has_value());
@@ -37,21 +37,21 @@ TEST_CASE(locale_mappings_fr)
 {
     auto language = Unicode::language_display_name("fr"sv, "en"sv, Unicode::LanguageDisplay::Standard);
     EXPECT(language.has_value());
-    EXPECT_EQ(*language, "anglais"sv);
+    EXPECT_EQ(*language, u"anglais"sv);
 
     language = Unicode::language_display_name("fr"sv, "i-definitely-don't-exist"sv, Unicode::LanguageDisplay::Standard);
     EXPECT(!language.has_value());
 
     auto territory = Unicode::region_display_name("fr"sv, "US"sv);
     EXPECT(territory.has_value());
-    EXPECT_EQ(*territory, "États-Unis"sv);
+    EXPECT_EQ(*territory, u"États-Unis"sv);
 
     territory = Unicode::region_display_name("fr"sv, "i-definitely-don't-exist"sv);
     EXPECT(!territory.has_value());
 
     auto script = Unicode::script_display_name("fr"sv, "Latn"sv);
     EXPECT(script.has_value());
-    EXPECT_EQ(*script, "latin"sv);
+    EXPECT_EQ(*script, u"latin"sv);
 
     script = Unicode::script_display_name("fr"sv, "i-definitely-don't-exist"sv);
     EXPECT(!script.has_value());
@@ -61,21 +61,21 @@ TEST_CASE(locale_mappings_root)
 {
     auto language = Unicode::language_display_name("und"sv, "en"sv, Unicode::LanguageDisplay::Standard);
     EXPECT(language.has_value());
-    EXPECT_EQ(*language, "en"sv);
+    EXPECT_EQ(*language, u"en"sv);
 
     language = Unicode::language_display_name("und"sv, "i-definitely-don't-exist"sv, Unicode::LanguageDisplay::Standard);
     EXPECT(!language.has_value());
 
     auto territory = Unicode::region_display_name("und"sv, "US"sv);
     EXPECT(territory.has_value());
-    EXPECT_EQ(*territory, "US"sv);
+    EXPECT_EQ(*territory, u"US"sv);
 
     territory = Unicode::region_display_name("und"sv, "i-definitely-don't-exist"sv);
     EXPECT(!territory.has_value());
 
     auto script = Unicode::script_display_name("und"sv, "Latn"sv);
     EXPECT(script.has_value());
-    EXPECT_EQ(*script, "Latn"sv);
+    EXPECT_EQ(*script, u"Latn"sv);
 
     script = Unicode::script_display_name("und"sv, "i-definitely-don't-exist"sv);
     EXPECT(!script.has_value());


### PR DESCRIPTION
`icu::UnicodeString` is UTF-16, so these lend themselves well to port to UTF-16 right away.