### PR TITLE
LibWeb/HTML: Only include direction if dirname applies

### DIFF
--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -397,6 +397,7 @@ public:
         Rtl,
     };
     Directionality directionality() const;
+    bool is_auto_directionality_form_associated_element() const;
 
     Optional<FlyString> const& id() const { return m_id; }
     Optional<FlyString> const& name() const { return m_name; }
@@ -553,7 +554,6 @@ private:
     Optional<Directionality> auto_directionality() const;
     Optional<Directionality> contained_text_auto_directionality(bool can_exclude_root) const;
     Directionality parent_directionality() const;
-    bool is_auto_directionality_form_associated_element() const;
 
     QualifiedName m_qualified_name;
     mutable Optional<FlyString> m_html_uppercased_qualified_name;

--- a/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -189,10 +189,10 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
             entry_list.append(TRY(create_entry(realm, name.to_string(), control_as_form_associated_element->value())));
         }
 
-        // 11. If the element has a dirname attribute, and that attribute's value is not the empty string, then:
-        if (auto attribute = control->get_attribute(HTML::AttributeNames::dirname); attribute.has_value() && !attribute.value().is_empty()) {
+        // 11. If the element has a dirname attribute, that attribute's value is not the empty string, and the element is an auto-directionality form-associated element:
+        if (auto attribute = control->get_attribute(HTML::AttributeNames::dirname); attribute.has_value() && !attribute.value().is_empty() && control->is_auto_directionality_form_associated_element()) {
             // 1. Let dirname be the value of the element's dirname attribute.
-            String dirname = attribute.value();
+            String const& dirname = attribute.value();
 
             // 2. Let dir be the string "ltr" if the directionality of the element is 'ltr', and "rtl" otherwise (i.e., when the directionality of the element is 'rtl').
             String dir = MUST((control->directionality() == DOM::Element::Directionality::Ltr) ? String::from_utf8("ltr"sv) : String::from_utf8("rtl"sv));

--- a/Meta/import-wpt-test.py
+++ b/Meta/import-wpt-test.py
@@ -89,6 +89,10 @@ class LinkedResourceFinder(HTMLParser):
             attr_dict = dict(attrs)
             if "rel" in attr_dict and attr_dict["rel"] == "stylesheet":
                 self._resources.append(attr_dict["href"])
+        if tag == "form":
+            attr_dict = dict(attrs)
+            if "action" in attr_dict:
+                self._resources.append(attr_dict["action"])
 
     def handle_endtag(self, tag):
         self._tag_stack_.pop()

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/attributes-common-to-form-controls/dirname-only-if-applies.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/attributes-common-to-form-controls/dirname-only-if-applies.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	Submit input element directionality to FormData, if dirname applies.
+Pass	Submit textarea element directionality to FormData.
+Pass	Submit input element directionality, if dirname applies.
+Pass	Submit textarea element directionality.

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/attributes-common-to-form-controls/dirname-only-if-applies.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/attributes-common-to-form-controls/dirname-only-if-applies.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=utf-8>
+    <title>Submitting element directionality: the dirname attribute</title>
+    <link rel="author" title="Vincent Hilla" href="mailto:vhilla@mozilla.com">
+    <link rel=help href="https://html.spec.whatwg.org/multipage/#submitting-element-directionality:-the-dirname-attribute">
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+    <script src="resources/dirname.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <form action="resources/dirname-iframe.html" method=get target="iframe">
+      <textarea name="textarea" dirname="textarea.dir"></textarea>
+      <p><input id="btn-submit" type=submit name=submit dirname=submit.dir value=Submit></p>
+    </form>
+    <iframe name="iframe"></iframe>
+
+    <script>
+      const types_applies = [
+        "hidden", "text", "search", "tel", "url", "email", "password", "submit"
+      ];
+      const types_not = [
+        "date", "month", "week", "time", "datetime-local", "number", "range", "color", "checkbox",
+        "radio", "file", "image", "reset", "button"
+      ];
+      const types = [...types_applies, ...types_not];
+      let form = document.querySelector("form");
+      for (const type of types) {
+        if (type === "submit") {
+          continue;
+        }
+        let p = document.createElement("p");
+        let lbl = document.createElement("label");
+        let txt = document.createTextNode(type + ": ");
+        let inp = document.createElement("input");
+        inp.type = type;
+        inp.name = type;
+        inp.dirName = type + ".dir";
+        inp.id = "testelement." + type
+        lbl.appendChild(txt);
+        lbl.appendChild(inp);
+        p.appendChild(lbl);
+        form.appendChild(p);
+      }
+      // Avoid continue in https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-form-data-set:attr-fe-dirname
+      document.getElementById("testelement.checkbox").checked = true;
+      document.getElementById("testelement.radio").checked = true;
+
+      function assertInputSubmission(data) {
+        for (const type of types_applies) {
+          assert_equals(data.get(type + ".dir"), "ltr", "Submit ltr for input type=" + type);
+        }
+        for (const type of types_not) {
+          assert_false(data.has(type + ".dir"), "Do not submit dir for input type=" + type);
+        }
+      }
+
+      const submitter = document.getElementById("btn-submit");
+      const data = new FormData(form, submitter);
+      test(function() {
+        assertInputSubmission(data);
+      }, "Submit input element directionality to FormData, if dirname applies.");
+      test(function() {
+        assert_equals(data.get("textarea.dir"), "ltr", "Submit ltr for textarea");
+      }, "Submit textarea element directionality to FormData.");
+
+      submitter.click();
+      const t_inp = async_test("Submit input element directionality, if dirname applies.");
+      onIframeLoadedDone(t_inp, function(params) {
+        assertInputSubmission(params);
+      });
+      const t_ta = async_test("Submit textarea element directionality.");
+      onIframeLoadedDone(t_ta, function(params) {
+        assert_equals(params.get("textarea.dir"), "ltr", "Submit ltr for textarea");
+      });
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/attributes-common-to-form-controls/resources/dirname-iframe.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/attributes-common-to-form-controls/resources/dirname-iframe.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Submitting element directionality: the dirname attribute support</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/attributes-common-to-form-controls/resources/dirname.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/attributes-common-to-form-controls/resources/dirname.js
@@ -1,0 +1,12 @@
+function onIframeLoadedDone(t, cb, selector="iframe") {
+  const iframe = document.querySelector(selector);
+  iframe.addEventListener("load", function() {
+    // The initial about:blank load event can be fired before the form navigation occurs.
+    // See https://github.com/whatwg/html/issues/490 for more information.
+    if(iframe.contentWindow.location.href == "about:blank") { return; }
+
+    const params = new URLSearchParams(iframe.contentWindow.location.search);
+    t.step(() => cb(params))
+    t.done();
+  });
+}


### PR DESCRIPTION
This commit changes form data to only include the direction of auto directionality form associated elements.

This fixes [this test](http://wpt.live/html/semantics/forms/attributes-common-to-form-controls/dirname-only-if-applies.html), but I struggled to import the test. It submits the form in an iframe to check the search parameters, but when running the test from a file, this fails because the iframe is a cross-origin object. Changing the action attribute of the form from `resources/dirname-iframe.html` to `.` allows the test to run, but I am not sure if it is fine to change imported WPT tests.