### PR TITLE
CI: Add nightly flatpak workflow 

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (Windows)
 
 on:
   pull_request:

--- a/.github/workflows/flatpak-template.yml
+++ b/.github/workflows/flatpak-template.yml
@@ -1,0 +1,30 @@
+name: Flatpak Build
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner_labels:
+        required: true
+        type: string
+
+jobs:
+  flatpak:
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.9
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: Ladybird.flatpak
+          manifest-path: Meta/CMake/flatpak/org.ladybird.Ladybird.json
+          cache: 'true'
+          arch: ${{ inputs.arch }}
+          # Note: default cache key is 'flatpak-builder-${arch}-${sha256(manifestPath)}'
+          upload-artifact: 'true'

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -77,3 +77,22 @@ jobs:
       arch: ${{ matrix.arch }}
       build_preset: ${{ matrix.build_preset }}
       clang_plugins: ${{ matrix.clang_plugins }}
+
+  flatpak:
+    if: github.repository == 'LadybirdBrowser/ladybird'
+    name: Flatpak ${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ 'x86_64' ]
+        runner_labels: [ '["blacksmith-8vcpu-ubuntu-2404"]' ]
+
+        include:
+          - arch: 'aarch64'
+            runner_labels: '["blacksmith-8vcpu-ubuntu-2404-arm"]'
+
+    secrets: inherit
+    uses: ./.github/workflows/flatpak-template.yml
+    with:
+      arch: ${{ matrix.arch }}
+      runner_labels: ${{ matrix.runner_labels }}


### PR DESCRIPTION
This will build both aarch64 and x86_64 flatpaks nightly. The test jobs
I did with the default GitHub runners took ~1h30m for aarch64 and
~2h30m for x86_64, but this will hopefully improve over time as the
cache is built up. And be better time-wise on the blacksmith runners.

Disk space is a large concern with these flatpak builds. A naive script
on my local machine showed that we needed a max of 10.3 GiB of free
space for the x86_64 build, with clang as the compiler. For some reason,
building with default gcc 14 uses more disk space than that, bumping
up against the default 14 GiB free space limit guaranteed by GitHub for
their default runners.


Here's a link to a successful build on my fork, albeit with a slightly different workflow file (no workflow call, gh standard runners, etc)

https://github.com/ADKaster/ladybird-browser/actions/runs/16479144268/job/46588527361