### PR TITLE
LibWeb: Use scroll state from snapshot while applying clip rectangles

### DIFF
--- a/Libraries/LibWeb/Painting/ClipFrame.cpp
+++ b/Libraries/LibWeb/Painting/ClipFrame.cpp
@@ -16,7 +16,10 @@ void ClipFrame::add_clip_rect(CSSPixelRect rect, BorderRadiiData radii, RefPtr<S
             return;
         }
     }
-    m_clip_rects.append({ rect, radii, move(enclosing_scroll_frame) });
+    Optional<size_t> enclosing_scroll_frame_id;
+    if (enclosing_scroll_frame)
+        enclosing_scroll_frame_id = enclosing_scroll_frame->id();
+    m_clip_rects.append({ rect, radii, move(enclosing_scroll_frame), enclosing_scroll_frame_id });
 }
 
 CSSPixelRect ClipFrame::clip_rect_for_hit_testing() const

--- a/Libraries/LibWeb/Painting/ClipFrame.h
+++ b/Libraries/LibWeb/Painting/ClipFrame.h
@@ -16,6 +16,7 @@ struct ClipRectWithScrollFrame {
     CSSPixelRect rect;
     BorderRadiiData corner_radii;
     RefPtr<ScrollFrame const> enclosing_scroll_frame;
+    Optional<size_t> enclosing_scroll_frame_id;
 };
 
 struct ClipFrame : public AtomicRefCounted<ClipFrame> {

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -75,7 +75,7 @@ private:
     virtual void apply_mask_bitmap(ApplyMaskBitmap const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
 
-    void apply_clip_frame(ClipFrame const&, DevicePixelConverter const&);
+    void apply_clip_frame(ClipFrame const&, ScrollStateSnapshot const&, DevicePixelConverter const&);
     void remove_clip_frame(ClipFrame const&);
 
     Vector<NonnullRefPtr<Gfx::PaintingSurface>, 1> m_surfaces;


### PR DESCRIPTION
Fixes race condition introduced in eed47acb when rendering thread accesses ScrollFrame that could be mutated in the middle of rasterization by the main thread, resulting in broken rendering.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/5553