### PR TITLE
LibWeb+LibUnicode+WebContent: Port `DOM:CharacterData` to UTF-16

### DIFF
--- a/AK/Utf16StringBase.h
+++ b/AK/Utf16StringBase.h
@@ -156,6 +156,7 @@ public:
 
     [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return length_in_code_units() == 0uz; }
     [[nodiscard]] ALWAYS_INLINE bool is_ascii() const { return utf16_view().is_ascii(); }
+    [[nodiscard]] ALWAYS_INLINE bool is_ascii_whitespace() const { return utf16_view().is_ascii_whitespace(); }
 
     [[nodiscard]] ALWAYS_INLINE size_t length_in_code_units() const
     {

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -268,7 +268,15 @@ public:
     }
 
     [[nodiscard]] constexpr bool is_empty() const { return length_in_code_units() == 0; }
+
     [[nodiscard]] bool is_ascii() const;
+
+    [[nodiscard]] constexpr bool is_ascii_whitespace() const
+    {
+        if (has_ascii_storage())
+            return all_of(ascii_span(), AK::is_ascii_space);
+        return all_of(utf16_span(), AK::is_ascii_space);
+    }
 
     [[nodiscard]] ALWAYS_INLINE bool validate(AllowLonelySurrogates allow_lonely_surrogates = AllowLonelySurrogates::Yes) const
     {

--- a/Libraries/LibIDL/Types.h
+++ b/Libraries/LibIDL/Types.h
@@ -119,7 +119,7 @@ public:
     // https://webidl.spec.whatwg.org/#idl-symbol
     bool is_symbol() const { return is_plain() && m_name == "symbol"; }
 
-    bool is_string() const { return is_plain() && m_name.is_one_of("ByteString", "CSSOMString", "DOMString", "USVString"); }
+    bool is_string() const { return is_plain() && m_name.is_one_of("ByteString", "CSSOMString", "DOMString", "Utf16DOMString", "USVString"); }
 
     // https://webidl.spec.whatwg.org/#dfn-integer-type
     bool is_integer() const { return is_plain() && m_name.is_one_of("byte", "octet", "short", "unsigned short", "long", "unsigned long", "long long", "unsigned long long"); }

--- a/Libraries/LibUnicode/Segmenter.cpp
+++ b/Libraries/LibUnicode/Segmenter.cpp
@@ -247,7 +247,7 @@ NonnullOwnPtr<Segmenter> Segmenter::create(StringView locale, SegmenterGranulari
     return make<SegmenterImpl>(segmenter.release_nonnull(), segmenter_granularity);
 }
 
-bool Segmenter::should_continue_beyond_word(Utf8View const& word)
+bool Segmenter::should_continue_beyond_word(Utf16View const& word)
 {
     for (auto code_point : word) {
         if (!code_point_has_punctuation_general_category(code_point) && !code_point_has_separator_general_category(code_point))

--- a/Libraries/LibUnicode/Segmenter.h
+++ b/Libraries/LibUnicode/Segmenter.h
@@ -27,7 +27,7 @@ public:
     static NonnullOwnPtr<Segmenter> create(StringView locale, SegmenterGranularity segmenter_granularity);
     virtual ~Segmenter() = default;
 
-    static bool should_continue_beyond_word(Utf8View const&);
+    static bool should_continue_beyond_word(Utf16View const&);
 
     SegmenterGranularity segmenter_granularity() const { return m_segmenter_granularity; }
 

--- a/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -60,9 +60,9 @@ JS::ThrowCompletionOr<GC::Ref<JS::Object>> OptionConstructor::construct(Function
     GC::Ref<HTML::HTMLOptionElement> option_element = as<HTML::HTMLOptionElement>(*element);
 
     // 3. If text is not the empty string, then append to option a new Text node whose data is text.
-    auto text = TRY(text_value.to_string(vm));
+    auto text = TRY(text_value.to_utf16_string(vm));
     if (!text.is_empty()) {
-        auto new_text_node = realm.create<DOM::Text>(document, text);
+        auto new_text_node = realm.create<DOM::Text>(document, move(text));
         MUST(option_element->append_child(*new_text_node));
     }
 

--- a/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
+++ b/Libraries/LibWeb/DOM/AccessibilityTreeNode.cpp
@@ -51,12 +51,11 @@ void AccessibilityTreeNode::serialize_tree_as_json(JsonObjectSerializer<StringBu
         } else {
             VERIFY_NOT_REACHED();
         }
-
     } else if (value()->is_text()) {
         MUST(object.add("type"sv, "text"sv));
 
         auto const* text_node = static_cast<DOM::Text const*>(value().ptr());
-        MUST(object.add("text"sv, text_node->data()));
+        MUST(object.add("text"sv, text_node->data().to_utf8()));
     }
 
     if (value()->has_child_nodes()) {

--- a/Libraries/LibWeb/DOM/CDATASection.cpp
+++ b/Libraries/LibWeb/DOM/CDATASection.cpp
@@ -12,8 +12,8 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(CDATASection);
 
-CDATASection::CDATASection(Document& document, String const& data)
-    : Text(document, NodeType::CDATA_SECTION_NODE, data)
+CDATASection::CDATASection(Document& document, Utf16String data)
+    : Text(document, NodeType::CDATA_SECTION_NODE, move(data))
 {
 }
 

--- a/Libraries/LibWeb/DOM/CDATASection.h
+++ b/Libraries/LibWeb/DOM/CDATASection.h
@@ -22,7 +22,7 @@ public:
     virtual FlyString node_name() const override { return "#cdata-section"_fly_string; }
 
 private:
-    CDATASection(Document&, String const&);
+    CDATASection(Document&, Utf16String);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Libraries/LibWeb/DOM/CharacterData.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/String.h>
+#include <AK/Utf16String.h>
 #include <AK/Utf16View.h>
 #include <LibUnicode/Forward.h>
 #include <LibWeb/DOM/ChildNode.h>
@@ -26,30 +26,27 @@ class CharacterData
 public:
     virtual ~CharacterData() override;
 
-    String const& data() const { return m_data; }
-    void set_data(String const&);
+    Utf16String const& data() const { return m_data; }
+    void set_data(Utf16String const&);
 
-    unsigned length_in_utf16_code_units() const
-    {
-        return AK::utf16_code_unit_length_from_utf8(m_data);
-    }
+    unsigned length_in_utf16_code_units() const { return m_data.length_in_code_units(); }
 
-    WebIDL::ExceptionOr<String> substring_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units) const;
-    WebIDL::ExceptionOr<void> append_data(String const&);
-    WebIDL::ExceptionOr<void> insert_data(size_t offset_in_utf16_code_units, String const&);
+    WebIDL::ExceptionOr<Utf16String> substring_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units) const;
+    WebIDL::ExceptionOr<void> append_data(Utf16View const&);
+    WebIDL::ExceptionOr<void> insert_data(size_t offset_in_utf16_code_units, Utf16View const&);
     WebIDL::ExceptionOr<void> delete_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units);
-    WebIDL::ExceptionOr<void> replace_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units, String const&);
+    WebIDL::ExceptionOr<void> replace_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units, Utf16View const&);
 
     Unicode::Segmenter& grapheme_segmenter() const;
     Unicode::Segmenter& word_segmenter() const;
 
 protected:
-    CharacterData(Document&, NodeType, String const&);
+    CharacterData(Document&, NodeType, Utf16String);
 
     virtual void initialize(JS::Realm&) override;
 
 private:
-    String m_data;
+    Utf16String m_data;
 
     mutable OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;
     mutable OwnPtr<Unicode::Segmenter> m_word_segmenter;

--- a/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Libraries/LibWeb/DOM/CharacterData.idl
@@ -5,14 +5,14 @@
 // https://dom.spec.whatwg.org/#characterdata
 [Exposed=Window]
 interface CharacterData : Node {
-    [LegacyNullToEmptyString] attribute DOMString data;
+    [LegacyNullToEmptyString] attribute Utf16DOMString data;
     [ImplementedAs=length_in_utf16_code_units] readonly attribute unsigned long length;
 
-    DOMString substringData(unsigned long offset, unsigned long count);
-    undefined appendData(DOMString data);
-    undefined insertData(unsigned long offset, DOMString data);
+    Utf16DOMString substringData(unsigned long offset, unsigned long count);
+    undefined appendData(Utf16DOMString data);
+    undefined insertData(unsigned long offset, Utf16DOMString data);
     undefined deleteData(unsigned long offset, unsigned long count);
-    undefined replaceData(unsigned long offset, unsigned long count, DOMString data);
+    undefined replaceData(unsigned long offset, unsigned long count, Utf16DOMString data);
 
     // https://dom.spec.whatwg.org/#interface-nondocumenttypechildnode
     readonly attribute Element? previousElementSibling;

--- a/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Libraries/LibWeb/DOM/ChildNode.h
@@ -16,7 +16,7 @@ template<typename NodeType>
 class ChildNode {
 public:
     // https://dom.spec.whatwg.org/#dom-childnode-before
-    WebIDL::ExceptionOr<void> before(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+    WebIDL::ExceptionOr<void> before(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -46,7 +46,7 @@ public:
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-after
-    WebIDL::ExceptionOr<void> after(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+    WebIDL::ExceptionOr<void> after(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -70,7 +70,7 @@ public:
     }
 
     // https://dom.spec.whatwg.org/#dom-childnode-replacewith
-    WebIDL::ExceptionOr<void> replace_with(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+    WebIDL::ExceptionOr<void> replace_with(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -117,7 +117,7 @@ protected:
     ChildNode() = default;
 
 private:
-    GC::Ptr<Node> viable_previous_sibling_for_insertion(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+    GC::Ptr<Node> viable_previous_sibling_for_insertion(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 
@@ -142,7 +142,7 @@ private:
         return nullptr;
     }
 
-    GC::Ptr<Node> viable_next_sibling_for_insertion(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+    GC::Ptr<Node> viable_next_sibling_for_insertion(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
     {
         auto* node = static_cast<NodeType*>(this);
 

--- a/Libraries/LibWeb/DOM/ChildNode.idl
+++ b/Libraries/LibWeb/DOM/ChildNode.idl
@@ -3,8 +3,8 @@
 
 // https://dom.spec.whatwg.org/#childnode
 interface mixin ChildNode {
-    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined before((Node or Utf16DOMString)... nodes);
+    [CEReactions, Unscopable] undefined after((Node or Utf16DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceWith((Node or Utf16DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 };

--- a/Libraries/LibWeb/DOM/Comment.cpp
+++ b/Libraries/LibWeb/DOM/Comment.cpp
@@ -13,16 +13,16 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(Comment);
 
-Comment::Comment(Document& document, String const& data)
-    : CharacterData(document, NodeType::COMMENT_NODE, data)
+Comment::Comment(Document& document, Utf16String data)
+    : CharacterData(document, NodeType::COMMENT_NODE, move(data))
 {
 }
 
 // https://dom.spec.whatwg.org/#dom-comment-comment
-WebIDL::ExceptionOr<GC::Ref<Comment>> Comment::construct_impl(JS::Realm& realm, String const& data)
+WebIDL::ExceptionOr<GC::Ref<Comment>> Comment::construct_impl(JS::Realm& realm, Utf16String data)
 {
     auto& window = as<HTML::Window>(realm.global_object());
-    return realm.create<Comment>(window.associated_document(), data);
+    return realm.create<Comment>(window.associated_document(), move(data));
 }
 
 void Comment::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/DOM/Comment.h
+++ b/Libraries/LibWeb/DOM/Comment.h
@@ -15,13 +15,13 @@ class Comment final : public CharacterData {
     GC_DECLARE_ALLOCATOR(Comment);
 
 public:
-    static WebIDL::ExceptionOr<GC::Ref<Comment>> construct_impl(JS::Realm&, String const& data);
+    static WebIDL::ExceptionOr<GC::Ref<Comment>> construct_impl(JS::Realm&, Utf16String data);
     virtual ~Comment() override = default;
 
     virtual FlyString node_name() const override { return "#comment"_fly_string; }
 
 private:
-    Comment(Document&, String const&);
+    Comment(Document&, Utf16String);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/DOM/Comment.idl
+++ b/Libraries/LibWeb/DOM/Comment.idl
@@ -3,5 +3,5 @@
 // https://dom.spec.whatwg.org/#comment
 [Exposed=Window]
 interface Comment : CharacterData {
-    constructor(optional DOMString data = "");
+    constructor(optional Utf16DOMString data = "");
 };

--- a/Libraries/LibWeb/DOM/DOMImplementation.cpp
+++ b/Libraries/LibWeb/DOM/DOMImplementation.cpp
@@ -90,7 +90,7 @@ WebIDL::ExceptionOr<GC::Ref<XMLDocument>> DOMImplementation::create_document(Opt
 }
 
 // https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
-GC::Ref<Document> DOMImplementation::create_html_document(Optional<String> const& title) const
+GC::Ref<Document> DOMImplementation::create_html_document(Optional<Utf16String> const& title) const
 {
     // 1. Let doc be a new document that is an HTML document.
     auto html_document = HTML::HTMLDocument::create(realm());

--- a/Libraries/LibWeb/DOM/DOMImplementation.h
+++ b/Libraries/LibWeb/DOM/DOMImplementation.h
@@ -22,7 +22,7 @@ public:
     virtual ~DOMImplementation();
 
     WebIDL::ExceptionOr<GC::Ref<XMLDocument>> create_document(Optional<FlyString> const&, String const&, GC::Ptr<DocumentType>) const;
-    GC::Ref<Document> create_html_document(Optional<String> const& title) const;
+    GC::Ref<Document> create_html_document(Optional<Utf16String> const& title) const;
     WebIDL::ExceptionOr<GC::Ref<DocumentType>> create_document_type(String const& name, String const& public_id, String const& system_id);
 
     // https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature

--- a/Libraries/LibWeb/DOM/DOMImplementation.idl
+++ b/Libraries/LibWeb/DOM/DOMImplementation.idl
@@ -6,7 +6,7 @@
 interface DOMImplementation {
     [NewObject] DocumentType createDocumentType(DOMString qualifiedName, DOMString publicId, DOMString systemId);
     [NewObject] XMLDocument createDocument([FlyString] DOMString? namespace, [LegacyNullToEmptyString] DOMString qualifiedName, optional DocumentType? doctype = null);
-    [NewObject] Document createHTMLDocument(optional DOMString title);
+    [NewObject] Document createHTMLDocument(optional Utf16DOMString title);
 
     boolean hasFeature(); // useless; always returns true
 };

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2122,13 +2122,13 @@ GC::Ref<DocumentFragment> Document::create_document_fragment()
     return realm().create<DocumentFragment>(*this);
 }
 
-GC::Ref<Text> Document::create_text_node(String const& data)
+GC::Ref<Text> Document::create_text_node(Utf16String data)
 {
-    return realm().create<Text>(*this, data);
+    return realm().create<Text>(*this, move(data));
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createcdatasection
-WebIDL::ExceptionOr<GC::Ref<CDATASection>> Document::create_cdata_section(String const& data)
+WebIDL::ExceptionOr<GC::Ref<CDATASection>> Document::create_cdata_section(Utf16String data)
 {
     // 1. If this is an HTML document, then throw a "NotSupportedError" DOMException.
     if (is_html_document())
@@ -2139,16 +2139,16 @@ WebIDL::ExceptionOr<GC::Ref<CDATASection>> Document::create_cdata_section(String
         return WebIDL::InvalidCharacterError::create(realm(), "String may not contain ']]>'"_string);
 
     // 3. Return a new CDATASection node with its data set to data and node document set to this.
-    return realm().create<CDATASection>(*this, data);
+    return realm().create<CDATASection>(*this, move(data));
 }
 
-GC::Ref<Comment> Document::create_comment(String const& data)
+GC::Ref<Comment> Document::create_comment(Utf16String data)
 {
-    return realm().create<Comment>(*this, data);
+    return realm().create<Comment>(*this, move(data));
 }
 
 // https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
-WebIDL::ExceptionOr<GC::Ref<ProcessingInstruction>> Document::create_processing_instruction(String const& target, String const& data)
+WebIDL::ExceptionOr<GC::Ref<ProcessingInstruction>> Document::create_processing_instruction(String const& target, Utf16String data)
 {
     // 1. If target does not match the Name production, then throw an "InvalidCharacterError" DOMException.
     if (!is_valid_name(target))
@@ -2159,7 +2159,7 @@ WebIDL::ExceptionOr<GC::Ref<ProcessingInstruction>> Document::create_processing_
         return WebIDL::InvalidCharacterError::create(realm(), "String may not contain '?>'"_string);
 
     // 3. Return a new ProcessingInstruction node, with target set to target, data set to data, and node document set to this.
-    return realm().create<ProcessingInstruction>(*this, data, target);
+    return realm().create<ProcessingInstruction>(*this, move(data), target);
 }
 
 GC::Ref<Range> Document::create_range()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -377,10 +377,10 @@ public:
     WebIDL::ExceptionOr<GC::Ref<Element>> create_element(String const& local_name, Variant<String, ElementCreationOptions> const& options);
     WebIDL::ExceptionOr<GC::Ref<Element>> create_element_ns(Optional<FlyString> const& namespace_, String const& qualified_name, Variant<String, ElementCreationOptions> const& options);
     GC::Ref<DocumentFragment> create_document_fragment();
-    GC::Ref<Text> create_text_node(String const& data);
-    WebIDL::ExceptionOr<GC::Ref<CDATASection>> create_cdata_section(String const& data);
-    GC::Ref<Comment> create_comment(String const& data);
-    WebIDL::ExceptionOr<GC::Ref<ProcessingInstruction>> create_processing_instruction(String const& target, String const& data);
+    GC::Ref<Text> create_text_node(Utf16String data);
+    WebIDL::ExceptionOr<GC::Ref<CDATASection>> create_cdata_section(Utf16String data);
+    GC::Ref<Comment> create_comment(Utf16String data);
+    WebIDL::ExceptionOr<GC::Ref<ProcessingInstruction>> create_processing_instruction(String const& target, Utf16String data);
 
     WebIDL::ExceptionOr<GC::Ref<Attr>> create_attribute(String const& local_name);
     WebIDL::ExceptionOr<GC::Ref<Attr>> create_attribute_ns(Optional<FlyString> const& namespace_, String const& qualified_name);

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -98,10 +98,10 @@ interface Document : Node {
     [CEReactions, NewObject] Element createElement(DOMString tagName, optional (DOMString or ElementCreationOptions) options = {});
     [CEReactions, NewObject] Element createElementNS([FlyString] DOMString? namespace, DOMString qualifiedName, optional (DOMString or ElementCreationOptions) options = {});
     DocumentFragment createDocumentFragment();
-    Text createTextNode(DOMString data);
-    [NewObject] CDATASection createCDATASection(DOMString data);
-    Comment createComment(DOMString data);
-    [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
+    Text createTextNode(Utf16DOMString data);
+    [NewObject] CDATASection createCDATASection(Utf16DOMString data);
+    Comment createComment(Utf16DOMString data);
+    [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, Utf16DOMString data);
 
     [NewObject] Attr createAttribute(DOMString localName);
     [NewObject] Attr createAttributeNS([FlyString] DOMString? namespace, DOMString qualifiedName);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2200,7 +2200,7 @@ WebIDL::ExceptionOr<GC::Ptr<Element>> Element::insert_adjacent_element(String co
 }
 
 // https://dom.spec.whatwg.org/#dom-element-insertadjacenttext
-WebIDL::ExceptionOr<void> Element::insert_adjacent_text(String const& where, String const& data)
+WebIDL::ExceptionOr<void> Element::insert_adjacent_text(String const& where, Utf16String const& data)
 {
     // 1. Let text be a new Text node whose data is data and node document is this’s node document.
     auto text = realm().create<DOM::Text>(document(), data);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -306,7 +306,7 @@ public:
     bool is_actually_disabled() const;
 
     WebIDL::ExceptionOr<GC::Ptr<Element>> insert_adjacent_element(String const& where, GC::Ref<Element> element);
-    WebIDL::ExceptionOr<void> insert_adjacent_text(String const& where, String const& data);
+    WebIDL::ExceptionOr<void> insert_adjacent_text(String const& where, Utf16String const& data);
 
     // https://w3c.github.io/csswg-drafts/cssom-view-1/#dom-element-scrollintoview
     ErrorOr<void> scroll_into_view(Optional<Variant<bool, ScrollIntoViewOptions>> = {});

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -77,7 +77,7 @@ interface Element : Node {
     HTMLCollection getElementsByClassName(DOMString className);
 
     [CEReactions] Element? insertAdjacentElement(DOMString where, Element element); // legacy
-    undefined insertAdjacentText(DOMString where, DOMString data); // legacy
+    undefined insertAdjacentText(DOMString where, Utf16DOMString data); // legacy
 
     // https://dom.spec.whatwg.org/#interface-nondocumenttypechildnode
     readonly attribute Element? nextElementSibling;

--- a/Libraries/LibWeb/DOM/NodeOperations.cpp
+++ b/Libraries/LibWeb/DOM/NodeOperations.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteString.h>
+#include <AK/Utf16String.h>
 #include <AK/Vector.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentFragment.h>
@@ -15,7 +15,7 @@
 namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#converting-nodes-into-a-node
-WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(Vector<Variant<GC::Root<Node>, String>> const& nodes, DOM::Document& document)
+WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes, DOM::Document& document)
 {
     // 1. Let node be null.
     // 2. Replace each string in nodes with a new Text node whose data is the string and node document is document.
@@ -23,11 +23,11 @@ WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(Vector<Variant<G
     // 4. Otherwise, set node to a new DocumentFragment node whose node document is document, and then append each node in nodes, if any, to it.
     // 5. Return node.
 
-    auto potentially_convert_string_to_text_node = [&document](Variant<GC::Root<Node>, String> const& node) -> GC::Ref<Node> {
+    auto potentially_convert_string_to_text_node = [&document](Variant<GC::Root<Node>, Utf16String> const& node) -> GC::Ref<Node> {
         if (node.has<GC::Root<Node>>())
             return *node.get<GC::Root<Node>>();
 
-        return document.realm().create<DOM::Text>(document, node.get<String>());
+        return document.realm().create<DOM::Text>(document, node.get<Utf16String>());
     };
 
     if (nodes.size() == 1)

--- a/Libraries/LibWeb/DOM/NodeOperations.h
+++ b/Libraries/LibWeb/DOM/NodeOperations.h
@@ -13,6 +13,6 @@
 
 namespace Web::DOM {
 
-WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(Vector<Variant<GC::Root<Node>, String>> const& nodes, DOM::Document& document);
+WebIDL::ExceptionOr<GC::Ref<Node>> convert_nodes_to_single_node(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes, DOM::Document& document);
 
 }

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -209,7 +209,7 @@ GC::Ref<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(Optional<FlyStri
 }
 
 // https://dom.spec.whatwg.org/#dom-parentnode-prepend
-WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
@@ -220,7 +220,7 @@ WebIDL::ExceptionOr<void> ParentNode::prepend(Vector<Variant<GC::Root<Node>, Str
     return {};
 }
 
-WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));
@@ -231,7 +231,7 @@ WebIDL::ExceptionOr<void> ParentNode::append(Vector<Variant<GC::Root<Node>, Stri
     return {};
 }
 
-WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<GC::Root<Node>, String>> const& nodes)
+WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes)
 {
     // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
     auto node = TRY(convert_nodes_to_single_node(nodes, document()));

--- a/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Libraries/LibWeb/DOM/ParentNode.h
@@ -32,9 +32,9 @@ public:
     GC::Ref<HTMLCollection> get_elements_by_tag_name(FlyString const&);
     GC::Ref<HTMLCollection> get_elements_by_tag_name_ns(Optional<FlyString>, FlyString const&);
 
-    WebIDL::ExceptionOr<void> prepend(Vector<Variant<GC::Root<Node>, String>> const& nodes);
-    WebIDL::ExceptionOr<void> append(Vector<Variant<GC::Root<Node>, String>> const& nodes);
-    WebIDL::ExceptionOr<void> replace_children(Vector<Variant<GC::Root<Node>, String>> const& nodes);
+    WebIDL::ExceptionOr<void> prepend(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes);
+    WebIDL::ExceptionOr<void> append(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes);
+    WebIDL::ExceptionOr<void> replace_children(Vector<Variant<GC::Root<Node>, Utf16String>> const& nodes);
     WebIDL::ExceptionOr<void> move_before(GC::Ref<Node> node, GC::Ptr<Node> child);
 
     GC::Ref<HTMLCollection> get_elements_by_class_name(StringView);

--- a/Libraries/LibWeb/DOM/ParentNode.idl
+++ b/Libraries/LibWeb/DOM/ParentNode.idl
@@ -8,9 +8,9 @@ interface mixin ParentNode {
     readonly attribute Element? lastElementChild;
     readonly attribute unsigned long childElementCount;
 
-    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
-    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined prepend((Node or Utf16DOMString)... nodes);
+    [CEReactions, Unscopable] undefined append((Node or Utf16DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceChildren((Node or Utf16DOMString)... nodes);
 
     [CEReactions] undefined moveBefore(Node node, Node? child);
 

--- a/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
+++ b/Libraries/LibWeb/DOM/ProcessingInstruction.cpp
@@ -14,8 +14,8 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(ProcessingInstruction);
 
-ProcessingInstruction::ProcessingInstruction(Document& document, String const& data, String const& target)
-    : CharacterData(document, NodeType::PROCESSING_INSTRUCTION_NODE, data)
+ProcessingInstruction::ProcessingInstruction(Document& document, Utf16String data, String const& target)
+    : CharacterData(document, NodeType::PROCESSING_INSTRUCTION_NODE, move(data))
     , m_target(target)
 {
 }

--- a/Libraries/LibWeb/DOM/ProcessingInstruction.h
+++ b/Libraries/LibWeb/DOM/ProcessingInstruction.h
@@ -22,7 +22,7 @@ public:
     String const& target() const { return m_target; }
 
 private:
-    ProcessingInstruction(Document&, String const& data, String const& target);
+    ProcessingInstruction(Document&, Utf16String data, String const& target);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -558,7 +558,7 @@ String Range::to_string() const
     //    then return the substring of that Text node’s data beginning at this’s start offset and ending at this’s end offset.
     if (start_container() == end_container() && is<Text>(*start_container())) {
         auto const& text = static_cast<Text const&>(*start_container());
-        return MUST(text.substring_data(start_offset(), end_offset() - start_offset()));
+        return MUST(text.substring_data(start_offset(), end_offset() - start_offset())).to_utf8_but_should_be_ported_to_utf16();
     }
 
     // 3. If this’s start node is a Text node, then append the substring of that node’s data from this’s start offset until the end to s.
@@ -621,7 +621,7 @@ WebIDL::ExceptionOr<GC::Ref<DocumentFragment>> Range::extract()
         TRY(fragment->append_child(clone));
 
         // 4. Replace data with node original start node, offset original start offset, count original end offset minus original start offset, and data the empty string.
-        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_end_offset - original_start_offset, String {}));
+        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_end_offset - original_start_offset, {}));
 
         // 5. Return fragment.
         return fragment;
@@ -711,7 +711,7 @@ WebIDL::ExceptionOr<GC::Ref<DocumentFragment>> Range::extract()
         TRY(fragment->append_child(clone));
 
         // 4. Replace data with node original start node, offset original start offset, count original start node’s length minus original start offset, and data the empty string.
-        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_start_node->length() - original_start_offset, String {}));
+        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_start_node->length() - original_start_offset, {}));
     }
     // 16. Otherwise, if first partially contained child is not null:
     else if (first_partially_contained_child) {
@@ -749,7 +749,7 @@ WebIDL::ExceptionOr<GC::Ref<DocumentFragment>> Range::extract()
         TRY(fragment->append_child(clone));
 
         // 4. Replace data with node original end node, offset 0, count original end offset, and data the empty string.
-        TRY(as<CharacterData>(*original_end_node).replace_data(0, original_end_offset, String {}));
+        TRY(as<CharacterData>(*original_end_node).replace_data(0, original_end_offset, {}));
     }
     // 19. Otherwise, if last partially contained child is not null:
     else if (last_partially_contained_child) {
@@ -1088,7 +1088,7 @@ WebIDL::ExceptionOr<void> Range::delete_contents()
     // 3. If original start node is original end node and it is a CharacterData node, then replace data with node original start node, offset original start offset,
     //    count original end offset minus original start offset, and data the empty string, and then return.
     if (original_start_node.ptr() == original_end_node.ptr() && is<CharacterData>(*original_start_node)) {
-        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_end_offset - original_start_offset, String {}));
+        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_end_offset - original_start_offset, {}));
         return {};
     }
 
@@ -1123,7 +1123,7 @@ WebIDL::ExceptionOr<void> Range::delete_contents()
 
     // 7. If original start node is a CharacterData node, then replace data with node original start node, offset original start offset, count original start node’s length minus original start offset, data the empty string.
     if (is<CharacterData>(*original_start_node))
-        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_start_node->length() - original_start_offset, String {}));
+        TRY(static_cast<CharacterData&>(*original_start_node).replace_data(original_start_offset, original_start_node->length() - original_start_offset, {}));
 
     // 8. For each node in nodes to remove, in tree order, remove node.
     for (auto& node : nodes_to_remove)
@@ -1131,7 +1131,7 @@ WebIDL::ExceptionOr<void> Range::delete_contents()
 
     // 9. If original end node is a CharacterData node, then replace data with node original end node, offset 0, count original end offset and data the empty string.
     if (is<CharacterData>(*original_end_node))
-        TRY(static_cast<CharacterData&>(*original_end_node).replace_data(0, original_end_offset, String {}));
+        TRY(static_cast<CharacterData&>(*original_end_node).replace_data(0, original_end_offset, {}));
 
     // 10. Set start and end to (new node, new offset).
     TRY(set_start(*new_node, new_offset));

--- a/Libraries/LibWeb/DOM/Text.h
+++ b/Libraries/LibWeb/DOM/Text.h
@@ -22,7 +22,7 @@ class Text
 public:
     virtual ~Text() override = default;
 
-    static WebIDL::ExceptionOr<GC::Ref<Text>> construct_impl(JS::Realm& realm, String const& data);
+    static WebIDL::ExceptionOr<GC::Ref<Text>> construct_impl(JS::Realm& realm, Utf16String data);
 
     // ^Node
     virtual FlyString node_name() const override { return "#text"_fly_string; }
@@ -31,7 +31,7 @@ public:
     void set_max_length(Optional<size_t> max_length) { m_max_length = move(max_length); }
 
     WebIDL::ExceptionOr<GC::Ref<Text>> split_text(size_t offset);
-    String whole_text();
+    Utf16String whole_text();
 
     bool is_password_input() const { return m_is_password_input; }
     void set_is_password_input(Badge<HTML::HTMLInputElement>, bool b) { m_is_password_input = b; }
@@ -39,8 +39,8 @@ public:
     Optional<Element::Directionality> directionality() const;
 
 protected:
-    Text(Document&, String const&);
-    Text(Document&, NodeType, String const&);
+    Text(Document&, Utf16String);
+    Text(Document&, NodeType, Utf16String);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/DOM/Text.idl
+++ b/Libraries/LibWeb/DOM/Text.idl
@@ -5,10 +5,10 @@
 // https://dom.spec.whatwg.org/#text
 [Exposed=Window]
 interface Text : CharacterData {
-    constructor(optional DOMString data = "");
+    constructor(optional Utf16DOMString data = "");
 
     [NewObject] Text splitText(unsigned long offset);
-    readonly attribute DOMString wholeText;
+    readonly attribute Utf16DOMString wholeText;
 };
 
 Text includes Slottable;

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -1367,10 +1367,10 @@ bool command_insert_linebreak_action(DOM::Document& document, Utf16View const&)
     if (auto* text_node = as_if<DOM::Text>(*start_node); text_node) {
         auto resolved_white_space_collapse = resolved_keyword(*start_node, CSS::PropertyID::WhiteSpaceCollapse);
         if (resolved_white_space_collapse.has_value() && first_is_one_of(resolved_white_space_collapse.value(), CSS::Keyword::Preserve, CSS::Keyword::PreserveBreaks)) {
-            MUST(text_node->insert_data(active_range.start_offset(), "\n"_string));
+            MUST(text_node->insert_data(active_range.start_offset(), "\n"_utf16));
             MUST(selection.collapse(start_node, active_range.start_offset() + 1));
             if (selection.range()->start_offset() == start_node->length())
-                MUST(text_node->insert_data(active_range.start_offset(), "\n"_string));
+                MUST(text_node->insert_data(active_range.start_offset(), "\n"_utf16));
             return true;
         }
     }
@@ -1796,7 +1796,7 @@ bool command_insert_text_action(DOM::Document& document, Utf16View const& value)
     // 13. If node is a Text node:
     if (is<DOM::Text>(*node)) {
         // 1. Call insertData(offset, value) on node.
-        MUST(static_cast<DOM::Text&>(*node).insert_data(offset, value.to_utf8_but_should_be_ported_to_utf16()));
+        MUST(static_cast<DOM::Text&>(*node).insert_data(offset, value));
 
         // 2. Call collapse(node, offset) on the context object's selection.
         MUST(selection.collapse(node, offset));
@@ -1812,7 +1812,7 @@ bool command_insert_text_action(DOM::Document& document, Utf16View const& value)
             node->first_child()->remove();
 
         // 2. Let text be the result of calling createTextNode(value) on the context object.
-        auto text = document.create_text_node(value.to_utf8_but_should_be_ported_to_utf16());
+        auto text = document.create_text_node(Utf16String::from_utf16_without_validation(value));
 
         // 3. Call insertNode(text) on the active range.
         MUST(active_range(document)->insert_node(text));

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -566,7 +566,7 @@ void canonicalize_whitespace(DOM::BoundaryPoint boundary, bool fix_collapsed_spa
             if (element != start_node_code_point) {
                 // 1. Call insertData(start offset, element) on start node.
                 auto& start_node_character_data = static_cast<DOM::CharacterData&>(*start_node);
-                MUST(start_node_character_data.insert_data(start_offset, String::from_code_point(element)));
+                MUST(start_node_character_data.insert_data(start_offset, Utf16String::from_code_point(element)));
 
                 // 2. Call deleteData(start offset + 1, 1) on start node.
                 MUST(start_node_character_data.delete_data(start_offset + 1, 1));
@@ -2615,8 +2615,7 @@ bool is_whitespace_node(GC::Ref<DOM::Node> node)
     auto is_tab_lf_cr_or_space = [](u32 codepoint) {
         return codepoint == '\t' || codepoint == '\n' || codepoint == '\r' || codepoint == ' ';
     };
-    auto code_points = character_data.data().code_points();
-    if (all_of(code_points, is_tab_lf_cr_or_space) && (white_space_collapse == CSS::Keyword::Collapse))
+    if (all_of(character_data.data(), is_tab_lf_cr_or_space) && (white_space_collapse == CSS::Keyword::Collapse))
         return true;
 
     // or a Text node whose data consists only of one or more tabs (0x0009), carriage returns
@@ -2626,7 +2625,7 @@ bool is_whitespace_node(GC::Ref<DOM::Node> node)
     auto is_tab_cr_or_space = [](u32 codepoint) {
         return codepoint == '\t' || codepoint == '\r' || codepoint == ' ';
     };
-    if (all_of(code_points, is_tab_cr_or_space) && white_space_collapse == CSS::Keyword::PreserveBreaks)
+    if (all_of(character_data.data(), is_tab_cr_or_space) && white_space_collapse == CSS::Keyword::PreserveBreaks)
         return true;
 
     return false;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -806,7 +806,7 @@ void FormAssociatedTextControlElement::handle_insert(String const& data)
     String data_for_insertion = data;
     // FIXME: Cut by UTF-16 code units instead of raw bytes
     if (auto max_length = text_node->max_length(); max_length.has_value()) {
-        auto remaining_length = *max_length - text_node->data().code_points().length();
+        auto remaining_length = *max_length - text_node->data().length_in_code_points();
         if (remaining_length < data.code_points().length()) {
             data_for_insertion = MUST(data.substring_from_byte_offset(0, remaining_length));
         }
@@ -832,7 +832,7 @@ void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
                 MUST(set_range_text(String {}, selection_start - 1, selection_end, Bindings::SelectionMode::End));
             }
         } else {
-            if (selection_start < text_node->data().code_points().length()) {
+            if (selection_start < text_node->data().length_in_code_points()) {
                 MUST(set_range_text(String {}, selection_start, selection_end + 1, Bindings::SelectionMode::End));
             }
         }
@@ -982,7 +982,7 @@ void FormAssociatedTextControlElement::increment_cursor_position_to_next_word(Co
 
     while (true) {
         if (auto offset = text_node->word_segmenter().next_boundary(m_selection_end); offset.has_value()) {
-            auto word = text_node->data().code_points().substring_view(m_selection_end, *offset - m_selection_end);
+            auto word = text_node->data().substring_view(m_selection_end, *offset - m_selection_end);
             if (collapse == CollapseSelection::Yes) {
                 collapse_selection_to_offset(*offset);
             } else {
@@ -1005,7 +1005,7 @@ void FormAssociatedTextControlElement::decrement_cursor_position_to_previous_wor
 
     while (true) {
         if (auto offset = text_node->word_segmenter().previous_boundary(m_selection_end); offset.has_value()) {
-            auto word = text_node->data().code_points().substring_view(*offset, m_selection_end - *offset);
+            auto word = text_node->data().substring_view(*offset, m_selection_end - *offset);
             if (collapse == CollapseSelection::Yes) {
                 collapse_selection_to_offset(*offset);
             } else {

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -240,7 +240,7 @@ WebIDL::ExceptionOr<void> HTMLElement::set_outer_text(String const& value)
 
     // 5. If fragment has no children, then append a new Text node whose data is the empty string and node document is this's node document to fragment.
     if (!fragment->has_children())
-        MUST(fragment->append_child(document().create_text_node(String {})));
+        MUST(fragment->append_child(document().create_text_node({})));
 
     // 6. Replace this with fragment within this's parent.
     MUST(parent()->replace_child(fragment, *this));
@@ -276,7 +276,7 @@ GC::Ref<DOM::DocumentFragment> HTMLElement::rendered_text_fragment(StringView in
 
         // 2. If text is not the empty string, then append a new Text node whose data is text and node document is document to fragment.
         if (!text.is_empty()) {
-            MUST(fragment->append_child(document().create_text_node(MUST(String::from_utf8(text)))));
+            MUST(fragment->append_child(document().create_text_node(Utf16String::from_utf8(text))));
         }
 
         // 3. While position is not past the end of input, and the code point at position is either U+000A LF or U+000D CR:

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -530,7 +530,7 @@ void HTMLInputElement::did_edit_text_node()
 {
     // An input element's dirty value flag must be set to true whenever the user interacts with the control in a way that changes the value.
     auto old_value = move(m_value);
-    m_value = value_sanitization_algorithm(m_text_node->data());
+    m_value = value_sanitization_algorithm(m_text_node->data().to_utf8_but_should_be_ported_to_utf16());
     m_dirty_value = true;
 
     m_has_uncommitted_changes = true;
@@ -700,7 +700,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value(String const& value)
             relevant_value_was_changed();
 
             if (m_text_node) {
-                m_text_node->set_data(m_value);
+                m_text_node->set_data(Utf16String::from_utf8(m_value));
                 update_placeholder_visibility();
 
                 set_the_selection_range(m_text_node->length(), m_text_node->length());
@@ -819,7 +819,7 @@ void HTMLInputElement::update_button_input_shadow_tree()
             }
         }
 
-        m_text_node->set_data(label.value());
+        m_text_node->set_data(Utf16String::from_utf8(label.value()));
         update_placeholder_visibility();
     }
 }
@@ -827,7 +827,7 @@ void HTMLInputElement::update_button_input_shadow_tree()
 void HTMLInputElement::update_text_input_shadow_tree()
 {
     if (m_text_node) {
-        m_text_node->set_data(m_value);
+        m_text_node->set_data(Utf16String::from_utf8(m_value));
         update_placeholder_visibility();
     }
 }
@@ -1018,7 +1018,7 @@ void HTMLInputElement::create_button_input_shadow_tree()
             label = value();
         }
     }
-    m_text_node = realm().create<DOM::Text>(document(), label.value());
+    m_text_node = realm().create<DOM::Text>(document(), Utf16String::from_utf8(label.value()));
     MUST(text_container->append_child(*m_text_node));
     MUST(shadow_root->append_child(*text_container));
 }
@@ -1053,8 +1053,7 @@ void HTMLInputElement::create_text_input_shadow_tree()
 
     MUST(element->append_child(*m_placeholder_element));
 
-    m_placeholder_text_node = realm().create<DOM::Text>(document(), String {});
-    m_placeholder_text_node->set_data(placeholder());
+    m_placeholder_text_node = realm().create<DOM::Text>(document(), Utf16String::from_utf8(placeholder()));
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
 
     // https://www.w3.org/TR/css-ui-4/#input-rules
@@ -1075,7 +1074,7 @@ void HTMLInputElement::create_text_input_shadow_tree()
     }
     MUST(element->append_child(*m_inner_text_element));
 
-    m_text_node = realm().create<DOM::Text>(document(), move(initial_value));
+    m_text_node = realm().create<DOM::Text>(document(), Utf16String::from_utf8(initial_value));
     handle_readonly_attribute(attribute(HTML::AttributeNames::readonly));
     if (type_state() == TypeAttributeState::Password)
         m_text_node->set_is_password_input({}, true);
@@ -1421,7 +1420,7 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
         }
     } else if (name == HTML::AttributeNames::placeholder) {
         if (m_placeholder_text_node) {
-            m_placeholder_text_node->set_data(placeholder());
+            m_placeholder_text_node->set_data(Utf16String::from_utf8(placeholder()));
             update_placeholder_visibility();
         }
     } else if (name == HTML::AttributeNames::readonly) {
@@ -1771,7 +1770,7 @@ void HTMLInputElement::reset_algorithm()
         relevant_value_was_changed();
 
     if (m_text_node) {
-        m_text_node->set_data(m_value);
+        m_text_node->set_data(Utf16String::from_utf8(m_value));
         update_placeholder_visibility();
     }
 
@@ -1807,7 +1806,7 @@ void HTMLInputElement::clear_algorithm()
         relevant_value_was_changed();
 
     if (m_text_node) {
-        m_text_node->set_data(m_value);
+        m_text_node->set_data(Utf16String::from_utf8(m_value));
         update_placeholder_visibility();
     }
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -191,7 +191,7 @@ void HTMLTextAreaElement::set_value(String const& value)
     //    the text control, unselecting any selected text and resetting the selection direction to "none".
     if (api_value() != old_api_value) {
         if (m_text_node) {
-            m_text_node->set_data(m_raw_value);
+            m_text_node->set_data(Utf16String::from_utf8(m_raw_value));
             update_placeholder_visibility();
 
             set_the_selection_range(m_text_node->length(), m_text_node->length());
@@ -369,14 +369,13 @@ void HTMLTextAreaElement::create_shadow_tree_if_needed()
     m_placeholder_element->set_use_pseudo_element(CSS::PseudoElement::Placeholder);
     MUST(element->append_child(*m_placeholder_element));
 
-    m_placeholder_text_node = realm().create<DOM::Text>(document(), String {});
-    m_placeholder_text_node->set_data(get_attribute_value(HTML::AttributeNames::placeholder));
+    m_placeholder_text_node = realm().create<DOM::Text>(document(), Utf16String::from_utf8(get_attribute_value(HTML::AttributeNames::placeholder)));
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
 
     m_inner_text_element = MUST(DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML));
     MUST(element->append_child(*m_inner_text_element));
 
-    m_text_node = realm().create<DOM::Text>(document(), String {});
+    m_text_node = realm().create<DOM::Text>(document(), Utf16String {});
     handle_readonly_attribute(attribute(HTML::AttributeNames::readonly));
     // NOTE: If `children_changed()` was called before now, `m_raw_value` will hold the text content.
     //       Otherwise, it will get filled in whenever that does get called.
@@ -442,7 +441,7 @@ void HTMLTextAreaElement::form_associated_element_attribute_changed(FlyString co
 {
     if (name == HTML::AttributeNames::placeholder) {
         if (m_placeholder_text_node)
-            m_placeholder_text_node->set_data(value.value_or(String {}));
+            m_placeholder_text_node->set_data(Utf16String::from_utf8(value.value_or(String {})));
     } else if (name == HTML::AttributeNames::readonly) {
         handle_readonly_attribute(value);
     } else if (name == HTML::AttributeNames::maxlength) {
@@ -453,7 +452,7 @@ void HTMLTextAreaElement::form_associated_element_attribute_changed(FlyString co
 void HTMLTextAreaElement::did_edit_text_node()
 {
     VERIFY(m_text_node);
-    set_raw_value(m_text_node->data());
+    set_raw_value(m_text_node->data().to_utf8_but_should_be_ported_to_utf16());
 
     // Any time the user causes the element's raw value to change, the user agent must queue an element task on the user
     // interaction task source given the textarea element to fire an event named input at the textarea element, with the

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2483,11 +2483,11 @@ static String visible_text_in_range(DOM::Range const& range)
     if (range.start_container() == range.end_container() && is<DOM::Text>(*range.start_container())) {
         if (!range.start_container()->layout_node())
             return String {};
-        return MUST(static_cast<DOM::Text const&>(*range.start_container()).data().substring_from_byte_offset(range.start_offset(), range.end_offset() - range.start_offset()));
+        return static_cast<DOM::Text const&>(*range.start_container()).data().substring_view(range.start_offset(), range.end_offset() - range.start_offset()).to_utf8_but_should_be_ported_to_utf16();
     }
 
     if (is<DOM::Text>(*range.start_container()) && range.start_container()->layout_node())
-        builder.append(static_cast<DOM::Text const&>(*range.start_container()).data().bytes_as_string_view().substring_view(range.start_offset()));
+        builder.append(static_cast<DOM::Text const&>(*range.start_container()).data().substring_view(range.start_offset()));
 
     range.for_each_contained([&](GC::Ref<DOM::Node> node) {
         if (is<DOM::Text>(*node) && node->layout_node())
@@ -2496,7 +2496,7 @@ static String visible_text_in_range(DOM::Range const& range)
     });
 
     if (is<DOM::Text>(*range.end_container()) && range.end_container()->layout_node())
-        builder.append(static_cast<DOM::Text const&>(*range.end_container()).data().bytes_as_string_view().substring_view(0, range.end_offset()));
+        builder.append(static_cast<DOM::Text const&>(*range.end_container()).data().substring_view(0, range.end_offset()));
 
     return MUST(builder.to_string());
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -228,7 +228,7 @@ private:
     Vector<HTMLToken> m_pending_table_character_tokens;
 
     GC::Ptr<DOM::Text> m_character_insertion_node;
-    StringBuilder m_character_insertion_builder;
+    StringBuilder m_character_insertion_builder { StringBuilder::Mode::UTF16 };
 } SWIFT_UNSAFE_REFERENCE;
 
 RefPtr<CSS::CSSStyleValue const> parse_dimension_value(StringView);

--- a/Libraries/LibWeb/HTML/XMLSerializer.cpp
+++ b/Libraries/LibWeb/HTML/XMLSerializer.cpp
@@ -754,7 +754,7 @@ static WebIDL::ExceptionOr<String> serialize_comment(DOM::Comment const& comment
         if (comment.data().contains("--"sv))
             return WebIDL::InvalidStateError::create(comment.realm(), "Comment data contains two adjacent hyphens"_string);
 
-        if (comment.data().ends_with('-'))
+        if (comment.data().ends_with("-"sv))
             return WebIDL::InvalidStateError::create(comment.realm(), "Comment data ends with a hyphen"_string);
     }
 
@@ -776,7 +776,7 @@ static WebIDL::ExceptionOr<String> serialize_text(DOM::Text const& text, Require
     // 1. If the require well-formed flag is set (its value is true), and node's data contains characters that are not matched by the XML Char production,
     //    then throw an exception; the serialization of this node's data would not be well-formed.
     if (require_well_formed == RequireWellFormed::Yes) {
-        for (u32 code_point : text.data().code_points()) {
+        for (u32 code_point : text.data()) {
             if (!is_valid_xml_char(code_point))
                 return WebIDL::InvalidStateError::create(text.realm(), "Text contains characters not allowed in XML"_string);
         }
@@ -786,16 +786,16 @@ static WebIDL::ExceptionOr<String> serialize_text(DOM::Text const& text, Require
     auto markup = text.data();
 
     // 3. Replace any occurrences of "&" in markup by "&amp;".
-    markup = MUST(markup.replace("&"sv, "&amp;"sv, ReplaceMode::All));
+    markup = markup.replace("&"sv, "&amp;"sv, ReplaceMode::All);
 
     // 4. Replace any occurrences of "<" in markup by "&lt;".
-    markup = MUST(markup.replace("<"sv, "&lt;"sv, ReplaceMode::All));
+    markup = markup.replace("<"sv, "&lt;"sv, ReplaceMode::All);
 
     // 5. Replace any occurrences of ">" in markup by "&gt;".
-    markup = MUST(markup.replace(">"sv, "&gt;"sv, ReplaceMode::All));
+    markup = markup.replace(">"sv, "&gt;"sv, ReplaceMode::All);
 
     // 6. Return the value of markup.
-    return markup;
+    return markup.to_utf8_but_should_be_ported_to_utf16();
 }
 
 // https://w3c.github.io/DOM-Parsing/#xml-serializing-a-documentfragment-node

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1756,7 +1756,7 @@ bool FormattingContext::can_skip_is_anonymous_text_run(Box& box)
     if (box.is_anonymous() && !box.is_generated() && !box.first_child_of_type<BlockContainer>()) {
         bool contains_only_white_space = true;
         box.for_each_in_subtree([&](auto const& node) {
-            if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().bytes_as_string_view().is_whitespace()) {
+            if (!is<TextNode>(node) || !static_cast<TextNode const&>(node).dom_node().data().is_ascii_whitespace()) {
                 contains_only_white_space = false;
                 return TraversalDecision::Break;
             }

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -322,7 +322,7 @@ String const& TextNode::text_for_rendering() const
 void TextNode::compute_text_for_rendering()
 {
     if (dom_node().is_password_input()) {
-        m_text_for_rendering = MUST(String::repeated('*', dom_node().data().code_points().length()));
+        m_text_for_rendering = MUST(String::repeated('*', dom_node().data().length_in_code_points()));
         return;
     }
 
@@ -332,7 +332,7 @@ void TextNode::compute_text_for_rendering()
     auto const maybe_lang = parent_element ? parent_element->lang() : Optional<String> {};
     auto const lang = maybe_lang.has_value() ? maybe_lang.value() : Optional<StringView> {};
 
-    auto data = apply_text_transform(dom_node().data(), computed_values().text_transform(), lang).release_value_but_fixme_should_propagate_errors();
+    auto data = apply_text_transform(dom_node().data().to_utf8_but_should_be_ported_to_utf16(), computed_values().text_transform(), lang).release_value_but_fixme_should_propagate_errors();
 
     auto data_view = data.bytes_as_string_view();
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -242,7 +242,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Ps
 
         // FIXME: Handle images, and multiple values
         if (new_content.type == CSS::ContentData::Type::String) {
-            auto text = document.realm().create<DOM::Text>(document, new_content.data);
+            auto text = document.realm().create<DOM::Text>(document, Utf16String::from_utf8(new_content.data));
             auto text_node = document.heap().allocate<TextNode>(document, *text);
             text_node->set_generated_for(pseudo_element, element);
 

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -599,12 +599,12 @@ void Selection::move_offset_to_next_word(bool collapse_selection)
     auto& text_node = static_cast<DOM::Text&>(*anchor_node);
     while (true) {
         auto focus_offset = this->focus_offset();
-        if (focus_offset == text_node.data().bytes_as_string_view().length()) {
+        if (focus_offset == text_node.data().length_in_code_units()) {
             return;
         }
 
         if (auto offset = text_node.word_segmenter().next_boundary(focus_offset); offset.has_value()) {
-            auto word = text_node.data().code_points().substring_view(focus_offset, *offset - focus_offset);
+            auto word = text_node.data().substring_view(focus_offset, *offset - focus_offset);
             if (collapse_selection) {
                 MUST(collapse(anchor_node, *offset));
                 m_document->reset_cursor_blink_cycle();
@@ -629,7 +629,7 @@ void Selection::move_offset_to_previous_word(bool collapse_selection)
     while (true) {
         auto focus_offset = this->focus_offset();
         if (auto offset = text_node.word_segmenter().previous_boundary(focus_offset); offset.has_value()) {
-            auto word = text_node.data().code_points().unicode_substring_view(*offset, focus_offset - *offset);
+            auto word = text_node.data().substring_view(*offset, focus_offset - *offset);
             if (collapse_selection) {
                 MUST(collapse(anchor_node, *offset));
                 m_document->reset_cursor_blink_cycle();

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -234,6 +234,11 @@ JS::ThrowCompletionOr<String> to_string(JS::VM& vm, JS::Value value)
     return value.to_string(vm);
 }
 
+JS::ThrowCompletionOr<Utf16String> to_utf16_string(JS::VM& vm, JS::Value value)
+{
+    return value.to_utf16_string(vm);
+}
+
 JS::ThrowCompletionOr<String> to_usv_string(JS::VM& vm, JS::Value value)
 {
     return value.to_well_formed_string(vm);

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -23,6 +23,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source);
 JS::Completion call_user_object_operation(CallbackType& callback, String const& operation_name, Optional<JS::Value> this_argument, ReadonlySpan<JS::Value> args);
 
 JS::ThrowCompletionOr<String> to_string(JS::VM&, JS::Value);
+JS::ThrowCompletionOr<Utf16String> to_utf16_string(JS::VM&, JS::Value);
 JS::ThrowCompletionOr<String> to_usv_string(JS::VM&, JS::Value);
 JS::ThrowCompletionOr<String> to_byte_string(JS::VM&, JS::Value);
 

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -245,18 +245,16 @@ void XMLDocumentBuilder::text(StringView data)
 {
     if (m_has_error)
         return;
-    auto last = m_current_node->last_child();
-    if (last && last->is_text()) {
+
+    if (auto* last = m_current_node->last_child(); last && last->is_text()) {
         auto& text_node = static_cast<DOM::Text&>(*last);
-        text_builder.append(text_node.data());
-        text_builder.append(data);
-        text_node.set_data(MUST(text_builder.to_string()));
-        text_builder.clear();
-    } else {
-        if (!data.is_empty()) {
-            auto node = m_document->create_text_node(MUST(String::from_utf8(data)));
-            MUST(m_current_node->append_child(node));
-        }
+        m_text_builder.append(text_node.data());
+        m_text_builder.append(data);
+        text_node.set_data(m_text_builder.to_utf16_string());
+        m_text_builder.clear();
+    } else if (!data.is_empty()) {
+        auto node = m_document->create_text_node(Utf16String::from_utf8(data));
+        MUST(m_current_node->append_child(node));
     }
 }
 
@@ -265,7 +263,7 @@ void XMLDocumentBuilder::comment(StringView data)
     if (m_has_error || !m_current_node)
         return;
 
-    MUST(m_current_node->append_child(m_document->create_comment(MUST(String::from_utf8(data)))));
+    MUST(m_current_node->append_child(m_document->create_comment(Utf16String::from_utf8(data))));
 }
 
 void XMLDocumentBuilder::cdata_section(StringView data)
@@ -273,7 +271,7 @@ void XMLDocumentBuilder::cdata_section(StringView data)
     if (m_has_error || !m_current_node)
         return;
 
-    auto section = MUST(m_document->create_cdata_section(MUST(String::from_utf8(data))));
+    auto section = MUST(m_document->create_cdata_section(Utf16String::from_utf8(data)));
     MUST(m_current_node->append_child(section));
 }
 
@@ -282,7 +280,7 @@ void XMLDocumentBuilder::processing_instruction(StringView target, StringView da
     if (m_has_error || !m_current_node)
         return;
 
-    auto processing_instruction = MUST(m_document->create_processing_instruction(MUST(String::from_utf8(target)), MUST(String::from_utf8(data))));
+    auto processing_instruction = MUST(m_document->create_processing_instruction(MUST(String::from_utf8(target)), Utf16String::from_utf8(data)));
     MUST(m_current_node->append_child(processing_instruction));
 }
 

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -47,7 +47,7 @@ private:
     GC::Ptr<DOM::Node> m_current_node;
     XMLScriptingSupport m_scripting_support { XMLScriptingSupport::Enabled };
     bool m_has_error { false };
-    StringBuilder text_builder;
+    StringBuilder m_text_builder { StringBuilder::Mode::UTF16 };
 
     struct NamespaceAndPrefix {
         FlyString ns;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -650,7 +650,7 @@ void ConnectionFromClient::get_dom_node_inner_html(u64 page_id, Web::UniqueNodeI
         html = element.inner_html().release_value_but_fixme_should_propagate_errors();
     } else if (dom_node->is_text() || dom_node->is_comment()) {
         auto const& character_data = static_cast<Web::DOM::CharacterData const&>(*dom_node);
-        html = character_data.data();
+        html = character_data.data().to_utf8_but_should_be_ported_to_utf16();
     } else {
         return;
     }
@@ -671,7 +671,7 @@ void ConnectionFromClient::get_dom_node_outer_html(u64 page_id, Web::UniqueNodeI
         html = element.outer_html().release_value_but_fixme_should_propagate_errors();
     } else if (dom_node->is_text() || dom_node->is_comment()) {
         auto const& character_data = static_cast<Web::DOM::CharacterData const&>(*dom_node);
-        html = character_data.data();
+        html = character_data.data().to_utf8_but_should_be_ported_to_utf16();
     } else {
         return;
     }
@@ -692,7 +692,7 @@ void ConnectionFromClient::set_dom_node_outer_html(u64 page_id, Web::UniqueNodeI
         element.set_outer_html(html).release_value_but_fixme_should_propagate_errors();
     } else if (dom_node->is_text() || dom_node->is_comment()) {
         auto& character_data = static_cast<Web::DOM::CharacterData&>(*dom_node);
-        character_data.set_data(html);
+        character_data.set_data(Utf16String::from_utf8(html));
     } else {
         async_did_finish_editing_dom_node(page_id, {});
         return;
@@ -710,7 +710,7 @@ void ConnectionFromClient::set_dom_node_text(u64 page_id, Web::UniqueNodeID node
     }
 
     auto& character_data = static_cast<Web::DOM::CharacterData&>(*dom_node);
-    character_data.set_data(text);
+    character_data.set_data(Utf16String::from_utf8(text));
 
     async_did_finish_editing_dom_node(page_id, character_data.unique_id());
 }
@@ -804,7 +804,7 @@ void ConnectionFromClient::create_child_text_node(u64 page_id, Web::UniqueNodeID
         return;
     }
 
-    auto text_node = dom_node->realm().create<Web::DOM::Text>(dom_node->document(), "text"_string);
+    auto text_node = dom_node->realm().create<Web::DOM::Text>(dom_node->document(), "text"_utf16);
     dom_node->append_child(text_node).release_value_but_fixme_should_propagate_errors();
 
     async_did_finish_editing_dom_node(page_id, text_node->unique_id());

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -667,7 +667,7 @@ void PageClient::page_did_mutate_dom(FlyString const& type, Web::DOM::Node const
         mutation = WebView::AttributeMutation { *attribute_name, element.attribute(*attribute_name) };
     } else if (type == Web::DOM::MutationType::characterData) {
         auto const& character_data = as<Web::DOM::CharacterData>(target);
-        mutation = WebView::CharacterDataMutation { character_data.data() };
+        mutation = WebView::CharacterDataMutation { character_data.data().to_utf8_but_should_be_ported_to_utf16() };
     } else if (type == Web::DOM::MutationType::childList) {
         Vector<Web::UniqueNodeID> added;
         added.ensure_capacity(added_nodes.length());

--- a/Tests/AK/TestUtf16View.cpp
+++ b/Tests/AK/TestUtf16View.cpp
@@ -341,6 +341,22 @@ TEST_CASE(is_ascii)
     EXPECT(!u"The quick (“brown”) fox can’t jump 32.3 feet, right?"sv.is_ascii());
 }
 
+TEST_CASE(is_ascii_whitespace)
+{
+    EXPECT(Utf16View {}.is_ascii_whitespace());
+    EXPECT(u" "sv.is_ascii_whitespace());
+    EXPECT(u"\t"sv.is_ascii_whitespace());
+    EXPECT(u"\r"sv.is_ascii_whitespace());
+    EXPECT(u"\n"sv.is_ascii_whitespace());
+    EXPECT(u" \t\r\n\v "sv.is_ascii_whitespace());
+
+    EXPECT(!u"a"sv.is_ascii_whitespace());
+    EXPECT(!u"😀"sv.is_ascii_whitespace());
+    EXPECT(!u"\u00a0"sv.is_ascii_whitespace());
+    EXPECT(!u"\ufeff"sv.is_ascii_whitespace());
+    EXPECT(!u"  \t \u00a0 \ufeff  "sv.is_ascii_whitespace());
+}
+
 TEST_CASE(to_ascii_lowercase)
 {
     EXPECT_EQ(u""sv.to_ascii_lowercase(), u""sv);


### PR DESCRIPTION
This replaces the underlying storage of `CharacterData` with `Utf16String` and deals with the fallout.