### PR TITLE
LibGfx: VulkanContext coverity reports integer_overflow on index

### DIFF
--- a/Libraries/LibGfx/VulkanContext.cpp
+++ b/Libraries/LibGfx/VulkanContext.cpp
@@ -75,12 +75,17 @@ static ErrorOr<VkDevice> create_logical_device(VkPhysicalDevice physical_device)
     queue_families.resize(queue_family_count);
     vkGetPhysicalDeviceQueueFamilyProperties(physical_device, &queue_family_count, queue_families.data());
 
-    int graphics_queue_family_index = -1;
-    for (int i = 0; i < static_cast<int>(queue_families.size()); i++) {
-        if (queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-            graphics_queue_family_index = i;
+    bool graphics_queue_family_found = false;
+    uint32_t graphics_queue_family_index = 0;
+    for (; graphics_queue_family_index < queue_families.size(); ++graphics_queue_family_index) {
+        if (queue_families[graphics_queue_family_index].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            graphics_queue_family_found = true;
             break;
         }
+    }
+
+    if (!graphics_queue_family_found) {
+        return Error::from_string_literal("Graphics queue family not found");
     }
 
     VkDeviceQueueCreateInfo queue_create_info {};


### PR DESCRIPTION
Coverity static analysis reports that the code that scans the queue families for one that has the graphics bit, can be -1 if none are found, which could cause a problem when the -1 (signed) value is used later as an index in a uint32_t (unsigned) variable.

Its not immediately clear how often this could occur, not finding a queue family with the graphics bit, but adding some protecting just in case.

<img width="826" height="484" alt="Screenshot From 2025-07-22 17-08-12" src="https://github.com/user-attachments/assets/b6b60b38-5b11-4739-84c4-c903e03fed4a" />
