### PR TITLE
LibWeb: Fix scroll state refresh in cached display list for iframes

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -94,8 +94,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         case DisplayListPlayerType::SkiaCPU: {
             auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
             Painting::DisplayListPlayerSkia display_list_player;
-            Painting::ScrollStateSnapshot scroll_state_snapshot;
-            display_list_player.execute(*display_list, scroll_state_snapshot, painting_surface);
+            display_list_player.execute(*display_list, {}, painting_surface);
             break;
         }
         }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6405,6 +6405,11 @@ void Document::invalidate_display_list()
     }
 }
 
+RefPtr<Painting::DisplayList> Document::cached_display_list() const
+{
+    return m_cached_display_list;
+}
+
 RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig config)
 {
     if (m_cached_display_list && m_cached_display_list_paint_config == config) {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -831,6 +831,7 @@ public:
     void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes);
     void set_needs_display(CSSPixelRect const&, InvalidateDisplayList = InvalidateDisplayList::Yes);
 
+    RefPtr<Painting::DisplayList> cached_display_list() const;
     RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig);
 
     void invalidate_display_list();

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -40,7 +40,9 @@ class DisplayList;
 class DisplayListPlayerSkia;
 class DisplayListRecorder;
 class SVGGradientPaintStyle;
+class ScrollStateSnapshot;
 using PaintStyle = RefPtr<SVGGradientPaintStyle>;
+using ScrollStateSnapshotByDisplayList = HashMap<NonnullRefPtr<DisplayList>, ScrollStateSnapshot>;
 
 }
 

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -67,7 +67,7 @@ void RenderingThread::rendering_thread_loop()
             break;
         }
 
-        m_skia_player->execute(*task->display_list, task->scroll_state_snapshot, task->painting_surface);
+        m_skia_player->execute(*task->display_list, move(task->scroll_state_snapshot_by_display_list), task->painting_surface);
         if (m_exit)
             break;
         m_main_thread_event_loop.deferred_invoke([callback = move(task->callback)] {
@@ -76,10 +76,10 @@ void RenderingThread::rendering_thread_loop()
     }
 }
 
-void RenderingThread::enqueue_rendering_task(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshot&& scroll_state_snapshot, NonnullRefPtr<Gfx::PaintingSurface> painting_surface, Function<void()>&& callback)
+void RenderingThread::enqueue_rendering_task(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshotByDisplayList&& scroll_state_snapshot_by_display_list, NonnullRefPtr<Gfx::PaintingSurface> painting_surface, Function<void()>&& callback)
 {
     Threading::MutexLocker const locker { m_rendering_task_mutex };
-    m_rendering_tasks.enqueue(Task { move(display_list), move(scroll_state_snapshot), move(painting_surface), move(callback) });
+    m_rendering_tasks.enqueue(Task { move(display_list), move(scroll_state_snapshot_by_display_list), move(painting_surface), move(callback) });
     m_rendering_task_ready_wake_condition.signal();
 }
 

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -14,7 +14,6 @@
 #include <LibThreading/Thread.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/Page.h>
-#include <LibWeb/Painting/ScrollState.h>
 
 namespace Web::HTML {
 
@@ -28,7 +27,7 @@ public:
 
     void start(DisplayListPlayerType);
     void set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player);
-    void enqueue_rendering_task(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshot&&, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
+    void enqueue_rendering_task(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshotByDisplayList&&, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
 private:
     void rendering_thread_loop();
@@ -44,7 +43,7 @@ private:
 
     struct Task {
         NonnullRefPtr<Painting::DisplayList> display_list;
-        Painting::ScrollStateSnapshot scroll_state_snapshot;
+        Painting::ScrollStateSnapshotByDisplayList scroll_state_snapshot_by_display_list;
         NonnullRefPtr<Gfx::PaintingSurface> painting_surface;
         Function<void()> callback;
     };

--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -416,7 +416,6 @@ struct AddMask {
 
 struct PaintNestedDisplayList {
     RefPtr<DisplayList> display_list;
-    ScrollStateSnapshot scroll_state_snapshot;
     Gfx::IntRect rect;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -15,23 +15,24 @@
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibWeb/CSS/Enums.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Painting/ClipFrame.h>
 #include <LibWeb/Painting/Command.h>
 #include <LibWeb/Painting/ScrollState.h>
 
 namespace Web::Painting {
 
-class DisplayList;
-
 class DisplayListPlayer {
 public:
     virtual ~DisplayListPlayer() = default;
 
-    void execute(DisplayList&, ScrollStateSnapshot const&, RefPtr<Gfx::PaintingSurface>);
+    void execute(DisplayList&, ScrollStateSnapshotByDisplayList&&, RefPtr<Gfx::PaintingSurface>);
 
 protected:
     Gfx::PaintingSurface& surface() const { return m_surfaces.last(); }
     void execute_impl(DisplayList&, ScrollStateSnapshot const& scroll_state, RefPtr<Gfx::PaintingSurface>);
+
+    ScrollStateSnapshotByDisplayList m_scroll_state_snapshots_by_display_list;
 
 private:
     virtual void flush() = 0;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -991,7 +991,8 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
 {
     auto& canvas = surface().canvas();
     canvas.translate(command.rect.x(), command.rect.y());
-    execute_impl(*command.display_list, command.scroll_state_snapshot, {});
+    ScrollStateSnapshot scroll_state_snapshot = m_scroll_state_snapshots_by_display_list.get(*command.display_list).value_or({});
+    execute_impl(*command.display_list, scroll_state_snapshot, {});
 }
 
 void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -29,9 +29,9 @@ DisplayListRecorder::~DisplayListRecorder() = default;
         m_command_list.append(__VA_ARGS__, _scroll_frame_id, _clip_frame); \
     } while (false)
 
-void DisplayListRecorder::paint_nested_display_list(RefPtr<DisplayList> display_list, ScrollStateSnapshot&& scroll_state_snapshot, Gfx::IntRect rect)
+void DisplayListRecorder::paint_nested_display_list(RefPtr<DisplayList> display_list, Gfx::IntRect rect)
 {
-    APPEND(PaintNestedDisplayList { move(display_list), move(scroll_state_snapshot), rect });
+    APPEND(PaintNestedDisplayList { move(display_list), rect });
 }
 
 void DisplayListRecorder::add_rounded_rect_clip(CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -130,7 +130,7 @@ public:
     void push_stacking_context(PushStackingContextParams params);
     void pop_stacking_context();
 
-    void paint_nested_display_list(RefPtr<DisplayList> display_list, ScrollStateSnapshot&&, Gfx::IntRect rect);
+    void paint_nested_display_list(RefPtr<DisplayList> display_list, Gfx::IntRect rect);
 
     void add_rounded_rect_clip(CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip);
     void add_mask(RefPtr<DisplayList> display_list, Gfx::IntRect rect);
@@ -158,7 +158,7 @@ public:
     DisplayListRecorder(DisplayList&);
     ~DisplayListRecorder();
 
-    DisplayList& display_list() { return m_command_list; }
+    DisplayList const& display_list() const { return m_command_list; }
 
     int m_save_nesting_level { 0 };
 

--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
@@ -60,8 +60,7 @@ void NavigableContainerViewportPaintable::paint(PaintContext& context, PaintPhas
         paint_config.paint_overlay = context.should_paint_overlay();
         paint_config.should_show_line_box_borders = context.should_show_line_box_borders();
         auto display_list = const_cast<DOM::Document*>(hosted_document)->record_display_list(paint_config);
-        auto scroll_state_snapshot = hosted_document->paintable()->scroll_state().snapshot();
-        context.display_list_recorder().paint_nested_display_list(display_list, move(scroll_state_snapshot), context.enclosing_device_rect(absolute_rect).to_type<int>());
+        context.display_list_recorder().paint_nested_display_list(display_list, context.enclosing_device_rect(absolute_rect).to_type<int>());
 
         context.display_list_recorder().restore();
 

--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.h
@@ -16,6 +16,8 @@ class NavigableContainerViewportPaintable final : public PaintableBox {
     GC_DECLARE_ALLOCATOR(NavigableContainerViewportPaintable);
 
 public:
+    virtual bool is_navigable_container_viewport_paintable() const override { return true; }
+
     static GC::Ref<NavigableContainerViewportPaintable> create(Layout::NavigableContainerViewport const&);
 
     virtual void paint(PaintContext&, PaintPhase) const override;
@@ -25,5 +27,8 @@ public:
 private:
     NavigableContainerViewportPaintable(Layout::NavigableContainerViewport const&);
 };
+
+template<>
+inline bool Paintable::fast_is<NavigableContainerViewportPaintable>() const { return is_navigable_container_viewport_paintable(); }
 
 }

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -112,6 +112,7 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
+    [[nodiscard]] virtual bool is_navigable_container_viewport_paintable() const { return false; }
     [[nodiscard]] virtual bool is_paintable_box() const { return false; }
     [[nodiscard]] virtual bool is_paintable_with_lines() const { return false; }
     [[nodiscard]] virtual bool is_svg_paintable() const { return false; }

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -100,8 +100,7 @@ RefPtr<Gfx::ImmutableBitmap> SVGMaskable::calculate_mask_of_svg(PaintContext& co
         StackingContext::paint_svg(paint_context, paintable, PaintPhase::Foreground);
         auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*mask_bitmap);
         DisplayListPlayerSkia display_list_player;
-        ScrollStateSnapshot scroll_state_snapshot;
-        display_list_player.execute(display_list, scroll_state_snapshot, painting_surface);
+        display_list_player.execute(display_list, {}, painting_surface);
         return mask_bitmap;
     };
     RefPtr<Gfx::Bitmap> mask_bitmap = {};

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -114,8 +114,7 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
     case DisplayListPlayerType::SkiaCPU: {
         auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
         Painting::DisplayListPlayerSkia display_list_player;
-        Painting::ScrollStateSnapshot scroll_state_snapshot;
-        display_list_player.execute(*display_list, scroll_state_snapshot, painting_surface);
+        display_list_player.execute(*display_list, {}, painting_surface);
         break;
     }
     default:


### PR DESCRIPTION
6507d23 introduced a bug when snapshot for iframe is saved in `PaintNestedDisplayList` and, since display lists are immutable, it's not possible to update before the next repaint.

This change fixes the issue by moving `ScrollStateSnapshot` for nested display lists from `PaintNestedDisplayList` to `HashMap<NonnullRefPtr<DisplayList>, ScrollStateSnapshot>` that is placed into pending rendering task, making it possible to update snapshots for all display lists before the next repaint.

This change doesn't have a test because it's really hard to make a ref test that will specifically check scenario when scroll offset of an iframe is advanced after display list is cached. We already have `Tests/LibWeb/Ref/input/scroll-iframe.html` but unfortunately it did not catch this bug.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/5486