### PR TITLE
LibWeb: Do not use namespace in interface names

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -5169,7 +5169,7 @@ void @constructor_class@::initialize(JS::Realm& realm)
 
     generator.append(R"~~~(
     define_direct_property(vm.names.length, JS::Value(@constructor.length@), JS::Attribute::Configurable);
-    define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, "@namespaced_name@"_string), JS::Attribute::Configurable);
+    define_direct_property(vm.names.name, JS::PrimitiveString::create(vm, "@name@"_string), JS::Attribute::Configurable);
     define_direct_property(vm.names.prototype, &ensure_web_prototype<@prototype_class@>(realm, "@namespaced_name@"_fly_string), 0);
 
 )~~~");

--- a/Tests/LibWeb/Text/expected/Wasm/WebAssembly-instantiate.txt
+++ b/Tests/LibWeb/Text/expected/Wasm/WebAssembly-instantiate.txt
@@ -47,6 +47,6 @@ DataView
 -------------
 Hello from wasm!!!!!!
 -------------
-WebAssembly.Module
+Module
 -------------
 Hello from wasm!!!!!!

--- a/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/global/constructor.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/global/constructor.any.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 60 tests
 
-59 Pass
-1 Fail
-Fail	name
+60 Pass
+Pass	name
 Pass	length
 Pass	No arguments
 Pass	Calling


### PR DESCRIPTION
Gives us 20 additional WPT subtest passes in `wasm/jsapi`.