### PR TITLE
LibWeb+LibWebView+WebContent+UI: Set the paint interval to the refresh rate of the current screen

### DIFF
--- a/Libraries/LibCore/Timer.cpp
+++ b/Libraries/LibCore/Timer.cpp
@@ -90,6 +90,7 @@ void Timer::timer_event(TimerEvent&)
         if (m_interval_dirty) {
             stop();
             start(m_interval_ms);
+            m_interval_dirty = false;
         }
     }
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -589,6 +589,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     client().async_set_window_handle(m_client_state.page_index, m_client_state.client_handle);
 
     client().async_set_device_pixels_per_css_pixel(m_client_state.page_index, m_device_pixel_ratio);
+    client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
 
     if (auto webdriver_content_ipc_path = Application::browser_options().webdriver_content_ipc_path; webdriver_content_ipc_path.has_value())

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -72,6 +72,7 @@ public:
     void reset_zoom();
     float zoom_level() const { return m_zoom_level; }
     float device_pixel_ratio() const { return m_device_pixel_ratio; }
+    double maximum_frames_per_second() const { return m_maximum_frames_per_second; }
 
     void enqueue_input_event(Web::InputEvent);
     void did_finish_handling_input_event(Badge<WebContentClient>, Web::EventResult event_result);
@@ -288,6 +289,7 @@ protected:
 
     float m_zoom_level { 1.0 };
     float m_device_pixel_ratio { 1.0 };
+    double m_maximum_frames_per_second { 60.0 };
 
     Queue<Web::InputEvent> m_pending_input_events;
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1158,6 +1158,12 @@ void ConnectionFromClient::set_device_pixels_per_css_pixel(u64 page_id, float de
         page->set_device_pixels_per_css_pixel(device_pixels_per_css_pixel);
 }
 
+void ConnectionFromClient::set_maximum_frames_per_second(u64 page_id, double maximum_frames_per_second)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->set_maximum_frames_per_second(maximum_frames_per_second);
+}
+
 void ConnectionFromClient::set_window_position(u64 page_id, Web::DevicePixelPoint position)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -112,6 +112,7 @@ private:
     virtual void set_has_focus(u64 page_id, bool) override;
     virtual void set_is_scripting_enabled(u64 page_id, bool) override;
     virtual void set_device_pixels_per_css_pixel(u64 page_id, float) override;
+    virtual void set_maximum_frames_per_second(u64 page_id, double) override;
     virtual void set_window_position(u64 page_id, Web::DevicePixelPoint) override;
     virtual void set_window_size(u64 page_id, Web::DevicePixelSize) override;
     virtual void did_update_window_rect(u64 page_id) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -55,6 +55,7 @@ public:
     void set_viewport_size(Web::DevicePixelSize const&);
     void set_screen_rects(Vector<Web::DevicePixelRect, 4> const& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index]; }
     void set_device_pixels_per_css_pixel(float device_pixels_per_css_pixel) { m_device_pixels_per_css_pixel = device_pixels_per_css_pixel; }
+    void set_maximum_frames_per_second(u64 maximum_frames_per_second);
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
     void set_preferred_motion(Web::CSS::PreferredMotion);
@@ -186,6 +187,7 @@ private:
     RefPtr<Gfx::PaletteImpl> m_palette_impl;
     Web::DevicePixelRect m_screen_rect;
     float m_device_pixels_per_css_pixel { 1.0f };
+    double m_maximum_frames_per_second { 60.0 };
     u64 m_id { 0 };
     bool m_has_focus { false };
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -99,6 +99,7 @@ endpoint WebContentServer
     set_has_focus(u64 page_id, bool has_focus) =|
     set_is_scripting_enabled(u64 page_id, bool is_scripting_enabled) =|
     set_device_pixels_per_css_pixel(u64 page_id, float device_pixels_per_css_pixel) =|
+    set_maximum_frames_per_second(u64 page_id, double maximum_frames_per_second) =|
 
     set_window_position(u64 page_id, Web::DevicePixelPoint position) =|
     set_window_size(u64 page_id, Web::DevicePixelSize size) =|

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -379,6 +379,14 @@
     }
 }
 
+- (void)broadcastDisplayRefreshRateChange
+{
+    for (TabController* controller in self.managed_tabs) {
+        auto* tab = (Tab*)[controller window];
+        [[tab web_view] handleDisplayRefreshRateChange];
+    }
+}
+
 - (void)clearHistory:(id)sender
 {
     for (TabController* controller in self.managed_tabs) {
@@ -781,6 +789,11 @@
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication*)sender
 {
     return YES;
+}
+
+- (void)applicationDidChangeScreenParameters:(NSNotification*)notification
+{
+    [self broadcastDisplayRefreshRateChange];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem*)item

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -70,6 +70,7 @@
 
 - (void)handleResize;
 - (void)handleDevicePixelRatioChange;
+- (void)handleDisplayRefreshRateChange;
 - (void)handleVisibility:(BOOL)is_visible;
 
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme;

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -131,8 +131,9 @@ struct HideCursor {
 
         // This returns device pixel ratio of the screen the window is opened in
         auto device_pixel_ratio = [[NSScreen mainScreen] backingScaleFactor];
+        auto maximum_frames_per_second = [[NSScreen mainScreen] maximumFramesPerSecond];
 
-        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, [delegate preferredColorScheme], [delegate preferredContrast], [delegate preferredMotion]));
+        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, maximum_frames_per_second, [delegate preferredColorScheme], [delegate preferredContrast], [delegate preferredMotion]));
         [self setWebViewCallbacks];
 
         auto* area = [[NSTrackingArea alloc] initWithRect:[self bounds]
@@ -210,6 +211,11 @@ struct HideCursor {
     m_web_view_bridge->set_device_pixel_ratio([[self window] backingScaleFactor]);
     [self updateViewportRect];
     [self updateStatusLabelPosition];
+}
+
+- (void)handleDisplayRefreshRateChange
+{
+    m_web_view_bridge->set_maximum_frames_per_second([[[self window] screen] maximumFramesPerSecond]);
 }
 
 - (void)handleVisibility:(BOOL)is_visible

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -20,18 +20,19 @@ static T scale_for_device(T size, float device_pixel_ratio)
     return size.template to_type<float>().scaled(device_pixel_ratio).template to_type<int>();
 }
 
-ErrorOr<NonnullOwnPtr<WebViewBridge>> WebViewBridge::create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast, Web::CSS::PreferredMotion preferred_motion)
+ErrorOr<NonnullOwnPtr<WebViewBridge>> WebViewBridge::create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, u64 maximum_frames_per_second, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast, Web::CSS::PreferredMotion preferred_motion)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) WebViewBridge(move(screen_rects), device_pixel_ratio, preferred_color_scheme, preferred_contrast, preferred_motion));
+    return adopt_nonnull_own_or_enomem(new (nothrow) WebViewBridge(move(screen_rects), device_pixel_ratio, maximum_frames_per_second, preferred_color_scheme, preferred_contrast, preferred_motion));
 }
 
-WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast, Web::CSS::PreferredMotion preferred_motion)
+WebViewBridge::WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, u64 maximum_frames_per_second, Web::CSS::PreferredColorScheme preferred_color_scheme, Web::CSS::PreferredContrast preferred_contrast, Web::CSS::PreferredMotion preferred_motion)
     : m_screen_rects(move(screen_rects))
     , m_preferred_color_scheme(preferred_color_scheme)
     , m_preferred_contrast(preferred_contrast)
     , m_preferred_motion(preferred_motion)
 {
     m_device_pixel_ratio = device_pixel_ratio;
+    m_maximum_frames_per_second = static_cast<double>(maximum_frames_per_second);
 }
 
 WebViewBridge::~WebViewBridge() = default;
@@ -48,6 +49,12 @@ void WebViewBridge::set_viewport_rect(Gfx::IntRect viewport_rect)
     m_viewport_size = viewport_rect.size();
 
     handle_resize();
+}
+
+void WebViewBridge::set_maximum_frames_per_second(u64 maximum_frames_per_second)
+{
+    m_maximum_frames_per_second = static_cast<double>(maximum_frames_per_second);
+    client().async_set_maximum_frames_per_second(m_client_state.page_index, maximum_frames_per_second);
 }
 
 void WebViewBridge::update_palette()

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.h
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.h
@@ -20,7 +20,7 @@ namespace Ladybird {
 
 class WebViewBridge final : public WebView::ViewImplementation {
 public:
-    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
+    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, u64 maximum_frames_per_second, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
     virtual ~WebViewBridge() override;
 
     virtual void initialize_client(CreateNewClient = CreateNewClient::Yes) override;
@@ -31,6 +31,8 @@ public:
     float inverse_device_pixel_ratio() const { return 1.0f / m_device_pixel_ratio; }
 
     void set_viewport_rect(Gfx::IntRect);
+
+    void set_maximum_frames_per_second(u64 maximum_frames_per_second);
 
     void update_palette();
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
@@ -50,7 +52,7 @@ public:
     Function<void()> on_zoom_level_changed;
 
 private:
-    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
+    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, u64 maximum_frames_per_second, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
 
     virtual void update_zoom() override;
     virtual Web::DevicePixelSize viewport_size() const override;

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -660,6 +660,11 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     [[[self tab] web_view] handleDevicePixelRatioChange];
 }
 
+- (void)windowDidChangeScreen:(NSNotification*)notification
+{
+    [[[self tab] web_view] handleDisplayRefreshRateChange];
+}
+
 - (BOOL)validateMenuItem:(NSMenuItem*)item
 {
     if ([item action] == @selector(toggleLineBoxBorders:)) {

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -100,8 +100,11 @@ public:
 
     Tab* current_tab() const { return m_current_tab; }
 
+    double refresh_rate() const { return m_refresh_rate; }
+
 public slots:
     void device_pixel_ratio_changed(qreal dpi);
+    void refresh_rate_changed(qreal refresh_rate);
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon const& icon);
     void tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState);
@@ -174,6 +177,7 @@ private:
 
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };
+    double m_refresh_rate { 60.0 };
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme;
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -56,7 +56,11 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_layout->setSpacing(0);
     m_layout->setContentsMargins(0, 0, 0, 0);
 
-    m_view = new WebContentView(this, parent_client, page_index);
+    auto view_initial_state = WebContentViewInitialState {
+        .maximum_frames_per_second = window->refresh_rate(),
+    };
+
+    m_view = new WebContentView(this, parent_client, page_index, AK::move(view_initial_state));
     m_find_in_page = new FindInPageWidget(this, m_view);
     m_find_in_page->setVisible(false);
     m_toolbar = new QToolBar(this);

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -47,7 +47,7 @@ namespace Ladybird {
 
 bool is_using_dark_system_theme(QWidget&);
 
-WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
+WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index, WebContentViewInitialState initial_state)
     : QWidget(window)
 {
     m_client_state.client = parent_client;
@@ -60,6 +60,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     setFocusPolicy(Qt::FocusPolicy::StrongFocus);
 
     m_device_pixel_ratio = devicePixelRatio();
+    m_maximum_frames_per_second = initial_state.maximum_frames_per_second;
 
     QObject::connect(qGuiApp, &QGuiApplication::screenRemoved, [this](QScreen*) {
         update_screen_rects();
@@ -536,6 +537,12 @@ void WebContentView::set_device_pixel_ratio(double device_pixel_ratio)
     client().async_set_device_pixels_per_css_pixel(m_client_state.page_index, m_device_pixel_ratio * m_zoom_level);
     update_viewport_size();
     handle_resize();
+}
+
+void WebContentView::set_maximum_frames_per_second(double maximum_frames_per_second)
+{
+    m_maximum_frames_per_second = maximum_frames_per_second;
+    client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
 }
 
 void WebContentView::update_viewport_size()

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -43,12 +43,16 @@ namespace Ladybird {
 
 class Tab;
 
+struct WebContentViewInitialState {
+    double maximum_frames_per_second { 60.0 };
+};
+
 class WebContentView final
     : public QWidget
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:
-    WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0);
+    WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0, WebContentViewInitialState initial_state = {});
     virtual ~WebContentView() override;
 
     Function<String(const URL::URL&, Web::HTML::ActivateTab)> on_tab_open_request;
@@ -76,6 +80,7 @@ public:
 
     void set_viewport_rect(Gfx::IntRect);
     void set_device_pixel_ratio(double);
+    void set_maximum_frames_per_second(double);
 
     enum class PaletteMode {
         Default,


### PR DESCRIPTION
This allows us to paint web content at, for example, 120 FPS. This affects all painting, whether it's scrolling or driving a WebGL application with requestAnimationFrame.

https://github.com/user-attachments/assets/7a44cada-17ad-4974-a223-4ee1fc72078d
