### PR TITLE
LibGfx+LibMedia+LibWeb: Use C++23 multi dimensional subscript operator for Matrix

### DIFF
--- a/Libraries/LibGfx/Matrix.h
+++ b/Libraries/LibGfx/Matrix.h
@@ -62,9 +62,8 @@ public:
     constexpr auto elements() const { return m_elements; }
     constexpr auto elements() { return m_elements; }
 
-    // FIXME: Change to multi-arg operator[] once we upgrade to C++23
-    constexpr auto const& operator()(size_t row, size_t col) const { return m_elements[row][col]; }
-    constexpr auto& operator()(size_t row, size_t col) { return m_elements[row][col]; }
+    constexpr auto const& operator[](size_t row, size_t col) const { return m_elements[row][col]; }
+    constexpr auto& operator[](size_t row, size_t col) { return m_elements[row][col]; }
 
     [[nodiscard]] constexpr Matrix operator*(Matrix const& other) const
     {

--- a/Libraries/LibGfx/Matrix.h
+++ b/Libraries/LibGfx/Matrix.h
@@ -49,7 +49,7 @@ public:
         if (is_constant_evaluated()) {
             for (size_t i = 0; i < N; i++) {
                 for (size_t j = 0; j < N; j++) {
-                    m_elements[i][j] = other.elements()[i][j];
+                    (*this)[i, j] = other[i, j];
                 }
             }
             return *this;
@@ -70,26 +70,26 @@ public:
         Matrix product;
         for (size_t i = 0; i < N; ++i) {
             for (size_t j = 0; j < N; ++j) {
-                auto& element = product.m_elements[i][j];
+                auto& element = product[i, j];
 
                 if constexpr (N == 4) {
-                    element = m_elements[i][0] * other.m_elements[0][j]
-                        + m_elements[i][1] * other.m_elements[1][j]
-                        + m_elements[i][2] * other.m_elements[2][j]
-                        + m_elements[i][3] * other.m_elements[3][j];
+                    element = (*this)[i, 0] * other[0, j]
+                        + (*this)[i, 1] * other[1, j]
+                        + (*this)[i, 2] * other[2, j]
+                        + (*this)[i, 3] * other[3, j];
                 } else if constexpr (N == 3) {
-                    element = m_elements[i][0] * other.m_elements[0][j]
-                        + m_elements[i][1] * other.m_elements[1][j]
-                        + m_elements[i][2] * other.m_elements[2][j];
+                    element = (*this)[i, 0] * other[0, j]
+                        + (*this)[i, 1] * other[1, j]
+                        + (*this)[i, 2] * other[2, j];
                 } else if constexpr (N == 2) {
-                    element = m_elements[i][0] * other.m_elements[0][j]
-                        + m_elements[i][1] * other.m_elements[1][j];
+                    element = (*this)[i, 0] * other[0, j]
+                        + (*this)[i, 1] * other[1, j];
                 } else if constexpr (N == 1) {
-                    element = m_elements[i][0] * other.m_elements[0][j];
+                    element = (*this)[i, 0] * other[0, j];
                 } else {
                     T value {};
                     for (size_t k = 0; k < N; ++k)
-                        value += m_elements[i][k] * other.m_elements[k][j];
+                        value += (*this)[i, k] * other[k, j];
 
                     element = value;
                 }
@@ -104,7 +104,7 @@ public:
         Matrix sum;
         for (size_t i = 0; i < N; ++i) {
             for (size_t j = 0; j < N; ++j)
-                sum.m_elements[i][j] = m_elements[i][j] + other.m_elements[i][j];
+                sum[i, j] = (*this)[i, j] + other[i, j];
         }
         return sum;
     }
@@ -114,7 +114,7 @@ public:
         Matrix division;
         for (size_t i = 0; i < N; ++i) {
             for (size_t j = 0; j < N; ++j)
-                division.m_elements[i][j] = m_elements[i][j] / divisor;
+                division[i, j] = (*this)[i, j] / divisor;
         }
         return division;
     }
@@ -124,7 +124,7 @@ public:
         Matrix scaled;
         for (size_t i = 0; i < N; ++i) {
             for (size_t j = 0; j < N; ++j)
-                scaled.m_elements[i][j] = matrix.m_elements[i][j] * scalar;
+                scaled[i, j] = matrix[i, j] * scalar;
         }
         return scaled;
     }
@@ -143,7 +143,7 @@ public:
         for (size_t i = 0; i < N; ++i) {
             for (size_t j = 0; j < N; ++j) {
                 int sign = (i + j) % 2 == 0 ? 1 : -1;
-                adjugate.m_elements[j][i] = sign * first_minor(i, j);
+                adjugate[j, i] = sign * first_minor(i, j);
             }
         }
         return adjugate;
@@ -152,12 +152,12 @@ public:
     [[nodiscard]] constexpr T determinant() const
     {
         if constexpr (N == 1) {
-            return m_elements[0][0];
+            return (*this)[0, 0];
         } else {
             T result = {};
             int sign = 1;
             for (size_t j = 0; j < N; ++j) {
-                result += sign * m_elements[0][j] * first_minor(0, j);
+                result += sign * (*this)[0, j] * first_minor(0, j);
                 sign *= -1;
             }
             return result;
@@ -179,7 +179,7 @@ public:
                 if (i == skip_row || j == skip_column)
                     continue;
 
-                first_minor.elements()[k / new_size][k % new_size] = m_elements[i][j];
+                first_minor[k / new_size, k % new_size] = (*this)[i, j];
                 ++k;
             }
         }
@@ -193,9 +193,9 @@ public:
         for (size_t i = 0; i < N; ++i) {
             for (size_t j = 0; j < N; ++j) {
                 if (i == j)
-                    result.m_elements[i][j] = 1;
+                    result[i, j] = 1;
                 else
-                    result.m_elements[i][j] = 0;
+                    result[i, j] = 0;
             }
         }
         return result;
@@ -211,7 +211,7 @@ public:
         Matrix result;
         for (size_t i = 0; i < N; ++i) {
             for (size_t j = 0; j < N; ++j)
-                result.m_elements[i][j] = m_elements[j][i];
+                result[i, j] = (*this)[j, i];
         }
         return result;
     }
@@ -223,7 +223,7 @@ public:
         Matrix<U, T> result;
         for (size_t i = 0; i < U; ++i) {
             for (size_t j = 0; j < U; ++j)
-                result.m_elements[i][j] = m_elements[i][j];
+                result[i, j] = (*this)[i, j];
         }
         return result;
     }

--- a/Libraries/LibGfx/Matrix3x3.h
+++ b/Libraries/LibGfx/Matrix3x3.h
@@ -17,11 +17,10 @@ using Matrix3x3 = Matrix<3, T>;
 template<typename T>
 constexpr static Vector3<T> operator*(Matrix3x3<T> const& m, Vector3<T> const& v)
 {
-    auto const& elements = m.elements();
     return Vector3<T>(
-        v.x() * elements[0][0] + v.y() * elements[0][1] + v.z() * elements[0][2],
-        v.x() * elements[1][0] + v.y() * elements[1][1] + v.z() * elements[1][2],
-        v.x() * elements[2][0] + v.y() * elements[2][1] + v.z() * elements[2][2]);
+        v.x() * m[0, 0] + v.y() * m[0, 1] + v.z() * m[0, 2],
+        v.x() * m[1, 0] + v.y() * m[1, 1] + v.z() * m[1, 2],
+        v.x() * m[2, 0] + v.y() * m[2, 1] + v.z() * m[2, 2]);
 }
 
 typedef Matrix3x3<float> FloatMatrix3x3;

--- a/Libraries/LibGfx/Matrix4x4.h
+++ b/Libraries/LibGfx/Matrix4x4.h
@@ -20,12 +20,11 @@ using Matrix4x4 = Matrix<4, T>;
 template<typename T>
 constexpr static Vector4<T> operator*(Matrix4x4<T> const& m, Vector4<T> const& v)
 {
-    auto const& elements = m.elements();
     return Vector4<T>(
-        v.x() * elements[0][0] + v.y() * elements[0][1] + v.z() * elements[0][2] + v.w() * elements[0][3],
-        v.x() * elements[1][0] + v.y() * elements[1][1] + v.z() * elements[1][2] + v.w() * elements[1][3],
-        v.x() * elements[2][0] + v.y() * elements[2][1] + v.z() * elements[2][2] + v.w() * elements[2][3],
-        v.x() * elements[3][0] + v.y() * elements[3][1] + v.z() * elements[3][2] + v.w() * elements[3][3]);
+        v.x() * m[0, 0] + v.y() * m[0, 1] + v.z() * m[0, 2] + v.w() * m[0, 3],
+        v.x() * m[1, 0] + v.y() * m[1, 1] + v.z() * m[1, 2] + v.w() * m[1, 3],
+        v.x() * m[2, 0] + v.y() * m[2, 1] + v.z() * m[2, 2] + v.w() * m[2, 3],
+        v.x() * m[3, 0] + v.y() * m[3, 1] + v.z() * m[3, 2] + v.w() * m[3, 3]);
 }
 
 // FIXME: this is a specific Matrix4x4 * Vector3 interaction that implies W=1; maybe move this out of LibGfx
@@ -33,11 +32,10 @@ constexpr static Vector4<T> operator*(Matrix4x4<T> const& m, Vector4<T> const& v
 template<typename T>
 constexpr static Vector3<T> transform_point(Matrix4x4<T> const& m, Vector3<T> const& p)
 {
-    auto const& elements = m.elements();
     return Vector3<T>(
-        p.x() * elements[0][0] + p.y() * elements[0][1] + p.z() * elements[0][2] + elements[0][3],
-        p.x() * elements[1][0] + p.y() * elements[1][1] + p.z() * elements[1][2] + elements[1][3],
-        p.x() * elements[2][0] + p.y() * elements[2][1] + p.z() * elements[2][2] + elements[2][3]);
+        p.x() * m[0, 0] + p.y() * m[0, 1] + p.z() * m[0, 2] + m[0, 3],
+        p.x() * m[1, 0] + p.y() * m[1, 1] + p.z() * m[1, 2] + m[1, 3],
+        p.x() * m[2, 0] + p.y() * m[2, 1] + p.z() * m[2, 2] + m[2, 3]);
 }
 
 template<typename T>
@@ -78,10 +76,9 @@ constexpr static Matrix4x4<T> rotation_matrix(Vector3<T> const& axis, T angle)
 }
 
 template<typename T>
-Gfx::AffineTransform extract_2d_affine_transform(Matrix4x4<T> const& matrix)
+Gfx::AffineTransform extract_2d_affine_transform(Matrix4x4<T> const& m)
 {
-    auto* m = matrix.elements();
-    return Gfx::AffineTransform(m[0][0], m[1][0], m[0][1], m[1][1], m[0][3], m[1][3]);
+    return Gfx::AffineTransform(m[0, 0], m[1, 0], m[0, 1], m[1, 1], m[0, 3], m[1, 3]);
 }
 
 typedef Matrix4x4<float> FloatMatrix4x4;

--- a/Libraries/LibMedia/Color/ColorConverter.cpp
+++ b/Libraries/LibMedia/Color/ColorConverter.cpp
@@ -131,17 +131,17 @@ DecoderErrorOr<ColorConverter> ColorConverter::create(u8 bit_depth, CodingIndepe
 
     // Expand color primaries matrix with identity elements.
     FloatMatrix4x4 color_primaries_matrix_4x4 = {
-        color_primaries_matrix.elements()[0][0],
-        color_primaries_matrix.elements()[0][1],
-        color_primaries_matrix.elements()[0][2],
+        color_primaries_matrix[0, 0],
+        color_primaries_matrix[0, 1],
+        color_primaries_matrix[0, 2],
         0.0f, // y
-        color_primaries_matrix.elements()[1][0],
-        color_primaries_matrix.elements()[1][1],
-        color_primaries_matrix.elements()[1][2],
+        color_primaries_matrix[1, 0],
+        color_primaries_matrix[1, 1],
+        color_primaries_matrix[1, 2],
         0.0f, // u
-        color_primaries_matrix.elements()[2][0],
-        color_primaries_matrix.elements()[2][1],
-        color_primaries_matrix.elements()[2][2],
+        color_primaries_matrix[2, 0],
+        color_primaries_matrix[2, 1],
+        color_primaries_matrix[2, 2],
         0.0f, // v
         0.0f,
         0.0f,

--- a/Libraries/LibMedia/Color/ColorPrimaries.cpp
+++ b/Libraries/LibMedia/Color/ColorPrimaries.cpp
@@ -39,7 +39,7 @@ ALWAYS_INLINE constexpr FloatMatrix3x3 primaries_matrix(FloatVector2 red, FloatV
 
 ALWAYS_INLINE constexpr FloatVector3 matrix_row(FloatMatrix3x3 matrix, size_t row)
 {
-    return { matrix.elements()[row][0], matrix.elements()[row][1], matrix.elements()[row][2] };
+    return { matrix[row, 0], matrix[row, 1], matrix[row, 2] };
 }
 
 ALWAYS_INLINE constexpr FloatMatrix3x3 generate_rgb_to_xyz_matrix(FloatVector2 red_xy, FloatVector2 green_xy, FloatVector2 blue_xy, FloatVector2 white_xy)

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -720,18 +720,18 @@ RefPtr<CSSStyleValue const> CSSStyleProperties::style_value_for_computed_propert
             // and m33, m44 are equal to 1.
             // NB: We only care about 4x4 matrices here.
             // NB: Our elements are 0-indexed not 1-indexed, and in the opposite order.
-            if (matrix.elements()[0][2] != 0     // m31
-                || matrix.elements()[1][2] != 0  // m32
-                || matrix.elements()[2][0] != 0  // m13
-                || matrix.elements()[2][1] != 0  // m23
-                || matrix.elements()[2][3] != 0  // m43
-                || matrix.elements()[3][0] != 0  // m14
-                || matrix.elements()[3][1] != 0  // m24
-                || matrix.elements()[3][2] != 0) // m34
+            if (matrix[0, 2] != 0     // m31
+                || matrix[1, 2] != 0  // m32
+                || matrix[2, 0] != 0  // m13
+                || matrix[2, 1] != 0  // m23
+                || matrix[2, 3] != 0  // m43
+                || matrix[3, 0] != 0  // m14
+                || matrix[3, 1] != 0  // m24
+                || matrix[3, 2] != 0) // m34
                 return false;
 
-            if (matrix.elements()[2][2] != 1     // m33
-                || matrix.elements()[3][3] != 1) // m44
+            if (matrix[2, 2] != 1     // m33
+                || matrix[3, 3] != 1) // m44
                 return false;
 
             return true;
@@ -742,12 +742,12 @@ RefPtr<CSSStyleValue const> CSSStyleProperties::style_value_for_computed_propert
         //        Serialize transform to a <matrix()> function.
         if (is_2d_matrix(transform)) {
             StyleValueVector parameters {
-                NumberStyleValue::create(transform.elements()[0][0]),
-                NumberStyleValue::create(transform.elements()[1][0]),
-                NumberStyleValue::create(transform.elements()[0][1]),
-                NumberStyleValue::create(transform.elements()[1][1]),
-                NumberStyleValue::create(transform.elements()[0][3]),
-                NumberStyleValue::create(transform.elements()[1][3]),
+                NumberStyleValue::create(transform[0, 0]),
+                NumberStyleValue::create(transform[1, 0]),
+                NumberStyleValue::create(transform[0, 1]),
+                NumberStyleValue::create(transform[1, 1]),
+                NumberStyleValue::create(transform[0, 3]),
+                NumberStyleValue::create(transform[1, 3]),
             };
             return TransformationStyleValue::create(PropertyID::Transform, TransformFunction::Matrix, move(parameters));
         }
@@ -755,22 +755,22 @@ RefPtr<CSSStyleValue const> CSSStyleProperties::style_value_for_computed_propert
         //        Serialize transform to a <matrix3d()> function.
         else {
             StyleValueVector parameters {
-                NumberStyleValue::create(transform.elements()[0][0]),
-                NumberStyleValue::create(transform.elements()[1][0]),
-                NumberStyleValue::create(transform.elements()[2][0]),
-                NumberStyleValue::create(transform.elements()[3][0]),
-                NumberStyleValue::create(transform.elements()[0][1]),
-                NumberStyleValue::create(transform.elements()[1][1]),
-                NumberStyleValue::create(transform.elements()[2][1]),
-                NumberStyleValue::create(transform.elements()[3][1]),
-                NumberStyleValue::create(transform.elements()[0][2]),
-                NumberStyleValue::create(transform.elements()[1][2]),
-                NumberStyleValue::create(transform.elements()[2][2]),
-                NumberStyleValue::create(transform.elements()[3][2]),
-                NumberStyleValue::create(transform.elements()[0][3]),
-                NumberStyleValue::create(transform.elements()[1][3]),
-                NumberStyleValue::create(transform.elements()[2][3]),
-                NumberStyleValue::create(transform.elements()[3][3]),
+                NumberStyleValue::create(transform[0, 0]),
+                NumberStyleValue::create(transform[1, 0]),
+                NumberStyleValue::create(transform[2, 0]),
+                NumberStyleValue::create(transform[3, 0]),
+                NumberStyleValue::create(transform[0, 1]),
+                NumberStyleValue::create(transform[1, 1]),
+                NumberStyleValue::create(transform[2, 1]),
+                NumberStyleValue::create(transform[3, 1]),
+                NumberStyleValue::create(transform[0, 2]),
+                NumberStyleValue::create(transform[1, 2]),
+                NumberStyleValue::create(transform[2, 2]),
+                NumberStyleValue::create(transform[3, 2]),
+                NumberStyleValue::create(transform[0, 3]),
+                NumberStyleValue::create(transform[1, 3]),
+                NumberStyleValue::create(transform[2, 3]),
+                NumberStyleValue::create(transform[3, 3]),
             };
             return TransformationStyleValue::create(PropertyID::Transform, TransformFunction::Matrix3d, move(parameters));
         }

--- a/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -38,20 +38,20 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::construct_impl(JS::Realm& rea
 
         // 2. Parse init into an abstract matrix, and let matrix and 2dTransform be the result. If the result is failure, then throw a "SyntaxError" DOMException.
         auto result = TRY(parse_dom_matrix_init_string(realm, init_value.get<String>()));
-        auto* elements = result.matrix.elements();
+        auto& m = result.matrix;
 
         // If 2dTransform is true
         if (result.is_2d_transform) {
             // Return the result of invoking create a 2d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers, the values being the elements m11, m12, m21, m22, m41 and m42 of matrix.
-            return realm.create<DOMMatrix>(realm, elements[0][0], elements[1][0], elements[0][1], elements[1][1], elements[0][3], elements[1][3]);
+            return realm.create<DOMMatrix>(realm, m[0, 0], m[1, 0], m[0, 1], m[1, 1], m[0, 3], m[1, 3]);
         }
 
         // Otherwise, return the result of invoking create a 3d matrix of type DOMMatrixReadOnly or DOMMatrix as appropriate, with a sequence of numbers, the values being the 16 elements of matrix.
         return realm.create<DOMMatrix>(realm,
-            elements[0][0], elements[1][0], elements[2][0], elements[3][0],
-            elements[0][1], elements[1][1], elements[2][1], elements[3][1],
-            elements[0][2], elements[1][2], elements[2][2], elements[3][2],
-            elements[0][3], elements[1][3], elements[2][3], elements[3][3]);
+            m[0, 0], m[1, 0], m[2, 0], m[3, 0],
+            m[0, 1], m[1, 1], m[2, 1], m[3, 1],
+            m[0, 2], m[1, 2], m[2, 2], m[3, 2],
+            m[0, 3], m[1, 3], m[2, 3], m[3, 3]);
     }
 
     auto const& double_sequence = init_value.get<Vector<double>>();
@@ -212,21 +212,21 @@ WebIDL::ExceptionOr<GC::Ref<DOMMatrix>> DOMMatrix::from_float64_array(JS::VM& vm
 void DOMMatrix::set_m11(double value)
 {
     // For the DOMMatrix interface, setting the m11 or the a attribute must set the m11 element to the new value.
-    m_matrix.elements()[0][0] = value;
+    m_matrix[0, 0] = value;
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m12
 void DOMMatrix::set_m12(double value)
 {
     // For the DOMMatrix interface, setting the m12 or the b attribute must set the m12 element to the new value.
-    m_matrix.elements()[1][0] = value;
+    m_matrix[1, 0] = value;
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m13
 void DOMMatrix::set_m13(double value)
 {
     // For the DOMMatrix interface, setting the m13 attribute must set the m13 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[2][0] = value;
+    m_matrix[2, 0] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -235,7 +235,7 @@ void DOMMatrix::set_m13(double value)
 void DOMMatrix::set_m14(double value)
 {
     // For the DOMMatrix interface, setting the m14 attribute must set the m14 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[3][0] = value;
+    m_matrix[3, 0] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -244,21 +244,21 @@ void DOMMatrix::set_m14(double value)
 void DOMMatrix::set_m21(double value)
 {
     // For the DOMMatrix interface, setting the m21 or the c attribute must set the m21 element to the new value.
-    m_matrix.elements()[0][1] = value;
+    m_matrix[0, 1] = value;
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m22
 void DOMMatrix::set_m22(double value)
 {
     // For the DOMMatrix interface, setting the m22 or the d attribute must set the m22 element to the new value.
-    m_matrix.elements()[1][1] = value;
+    m_matrix[1, 1] = value;
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m23
 void DOMMatrix::set_m23(double value)
 {
     // For the DOMMatrix interface, setting the m23 attribute must set the m23 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[2][1] = value;
+    m_matrix[2, 1] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -267,7 +267,7 @@ void DOMMatrix::set_m23(double value)
 void DOMMatrix::set_m24(double value)
 {
     // For the DOMMatrix interface, setting the m24 attribute must set the m24 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[3][1] = value;
+    m_matrix[3, 1] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -276,7 +276,7 @@ void DOMMatrix::set_m24(double value)
 void DOMMatrix::set_m31(double value)
 {
     // For the DOMMatrix interface, setting the m31 attribute must set the m31 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[0][2] = value;
+    m_matrix[0, 2] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -285,7 +285,7 @@ void DOMMatrix::set_m31(double value)
 void DOMMatrix::set_m32(double value)
 {
     // For the DOMMatrix interface, setting the m32 attribute must set the m32 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[1][2] = value;
+    m_matrix[1, 2] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -294,7 +294,7 @@ void DOMMatrix::set_m32(double value)
 void DOMMatrix::set_m33(double value)
 {
     // For the DOMMatrix interface, setting the m33 attribute must set the m33 element to the new value and, if the new value is not 1, set is 2D to false.
-    m_matrix.elements()[2][2] = value;
+    m_matrix[2, 2] = value;
     if (value != 1.0)
         m_is_2d = false;
 }
@@ -303,7 +303,7 @@ void DOMMatrix::set_m33(double value)
 void DOMMatrix::set_m34(double value)
 {
     // For the DOMMatrix interface, setting the m34 attribute must set the m34 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[3][2] = value;
+    m_matrix[3, 2] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -312,21 +312,21 @@ void DOMMatrix::set_m34(double value)
 void DOMMatrix::set_m41(double value)
 {
     // For the DOMMatrix interface, setting the m41 or the e attribute must set the m41 element to the new value.
-    m_matrix.elements()[0][3] = value;
+    m_matrix[0, 3] = value;
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m42
 void DOMMatrix::set_m42(double value)
 {
     // For the DOMMatrix interface, setting the m42 or the f attribute must set the m42 element to the new value.
-    m_matrix.elements()[1][3] = value;
+    m_matrix[1, 3] = value;
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrixreadonly-m43
 void DOMMatrix::set_m43(double value)
 {
     // For the DOMMatrix interface, setting the m43 attribute must set the m43 element to the new value and, if the new value is not 0 or -0, set is 2D to false.
-    m_matrix.elements()[2][3] = value;
+    m_matrix[2, 3] = value;
     if (value != 0.0 && value != -0.0)
         m_is_2d = false;
 }
@@ -335,7 +335,7 @@ void DOMMatrix::set_m43(double value)
 void DOMMatrix::set_m44(double value)
 {
     // For the DOMMatrix interface, setting the m44 attribute must set the m44 element to the new value and, if the new value is not 1, set is 2D to false.
-    m_matrix.elements()[3][3] = value;
+    m_matrix[3, 3] = value;
     if (value != 1.0)
         m_is_2d = false;
 }
@@ -581,7 +581,7 @@ GC::Ref<DOMMatrix> DOMMatrix::invert_self()
     if (!is_invertible) {
         for (u8 i = 0; i < 4; i++) {
             for (u8 j = 0; j < 4; j++)
-                m_matrix.elements()[j][i] = NAN;
+                m_matrix[j, i] = NAN;
         }
         m_is_2d = false;
     }

--- a/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -992,7 +992,7 @@ WebIDL::ExceptionOr<ParsedMatrix> parse_dom_matrix_init_string(JS::Realm& realm,
         static_cast<double>(matrix[0, 0]), static_cast<double>(matrix[0, 1]), static_cast<double>(matrix[0, 2]), static_cast<double>(matrix[0, 3]),
         static_cast<double>(matrix[1, 0]), static_cast<double>(matrix[1, 1]), static_cast<double>(matrix[1, 2]), static_cast<double>(matrix[1, 3]),
         static_cast<double>(matrix[2, 0]), static_cast<double>(matrix[2, 1]), static_cast<double>(matrix[2, 2]), static_cast<double>(matrix[2, 3]),
-        static_cast<double>(matrix[3, 0]), static_cast<double>(matrix[3, 1]), static_cast<double>(matrix[3, 2]), static_cast<float>(matrix[3, 3])
+        static_cast<double>(matrix[3, 0]), static_cast<double>(matrix[3, 1]), static_cast<double>(matrix[3, 2]), static_cast<double>(matrix[3, 3])
     };
     return ParsedMatrix { double_matrix, is_2d_transform };
 }

--- a/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
+++ b/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.h
@@ -67,22 +67,22 @@ public:
     static WebIDL::ExceptionOr<GC::Ref<DOMMatrixReadOnly>> from_float64_array(JS::VM&, GC::Root<WebIDL::BufferSource> const& array64);
 
     // https://drafts.fxtf.org/geometry/#dommatrix-attributes
-    double m11() const { return m_matrix.elements()[0][0]; }
-    double m12() const { return m_matrix.elements()[1][0]; }
-    double m13() const { return m_matrix.elements()[2][0]; }
-    double m14() const { return m_matrix.elements()[3][0]; }
-    double m21() const { return m_matrix.elements()[0][1]; }
-    double m22() const { return m_matrix.elements()[1][1]; }
-    double m23() const { return m_matrix.elements()[2][1]; }
-    double m24() const { return m_matrix.elements()[3][1]; }
-    double m31() const { return m_matrix.elements()[0][2]; }
-    double m32() const { return m_matrix.elements()[1][2]; }
-    double m33() const { return m_matrix.elements()[2][2]; }
-    double m34() const { return m_matrix.elements()[3][2]; }
-    double m41() const { return m_matrix.elements()[0][3]; }
-    double m42() const { return m_matrix.elements()[1][3]; }
-    double m43() const { return m_matrix.elements()[2][3]; }
-    double m44() const { return m_matrix.elements()[3][3]; }
+    double m11() const { return m_matrix[0, 0]; }
+    double m12() const { return m_matrix[1, 0]; }
+    double m13() const { return m_matrix[2, 0]; }
+    double m14() const { return m_matrix[3, 0]; }
+    double m21() const { return m_matrix[0, 1]; }
+    double m22() const { return m_matrix[1, 1]; }
+    double m23() const { return m_matrix[2, 1]; }
+    double m24() const { return m_matrix[3, 1]; }
+    double m31() const { return m_matrix[0, 2]; }
+    double m32() const { return m_matrix[1, 2]; }
+    double m33() const { return m_matrix[2, 2]; }
+    double m34() const { return m_matrix[3, 2]; }
+    double m41() const { return m_matrix[0, 3]; }
+    double m42() const { return m_matrix[1, 3]; }
+    double m43() const { return m_matrix[2, 3]; }
+    double m44() const { return m_matrix[3, 3]; }
 
     double a() const { return m11(); }
     double b() const { return m12(); }

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -31,10 +31,9 @@ Layout::SVGSVGBox const& SVGSVGPaintable::layout_box() const
 
 static Gfx::FloatMatrix4x4 matrix_with_scaled_translation(Gfx::FloatMatrix4x4 matrix, float scale)
 {
-    auto* m = matrix.elements();
-    m[0][3] *= scale;
-    m[1][3] *= scale;
-    m[2][3] *= scale;
+    matrix[0, 3] *= scale;
+    matrix[1, 3] *= scale;
+    matrix[2, 3] *= scale;
     return matrix;
 }
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -293,10 +293,9 @@ Gfx::AffineTransform StackingContext::affine_transform_matrix() const
 
 static Gfx::FloatMatrix4x4 matrix_with_scaled_translation(Gfx::FloatMatrix4x4 matrix, float scale)
 {
-    auto* m = matrix.elements();
-    m[0][3] *= scale;
-    m[1][3] *= scale;
-    m[2][3] *= scale;
+    matrix[0, 3] *= scale;
+    matrix[1, 3] *= scale;
+    matrix[2, 3] *= scale;
     return matrix;
 }
 


### PR DESCRIPTION
- Resolves the FIXME comment and produces cleaner code.
- I've changed `m_elements[i][j]` in `Matrix` to `(*this)[i, j]` for consistency, although you might think it's better style to just use `m_elements[i][j]`.