### PR TITLE
UI: Inform WebContent when the mouse leaves the WebView widget

### DIFF
--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -137,7 +137,7 @@ struct HideCursor {
         [self setWebViewCallbacks];
 
         auto* area = [[NSTrackingArea alloc] initWithRect:[self bounds]
-                                                  options:NSTrackingActiveInKeyWindow | NSTrackingInVisibleRect | NSTrackingMouseMoved
+                                                  options:NSTrackingActiveInKeyWindow | NSTrackingInVisibleRect | NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved
                                                     owner:self
                                                  userInfo:nil];
         [self addTrackingArea:area];
@@ -1572,6 +1572,14 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     // The origin of a NSScrollView is the lower-left corner, with the y-axis extending upwards. Instead,
     // we want the origin to be the top-left corner, with the y-axis extending downward.
     return YES;
+}
+
+- (void)mouseExited:(NSEvent*)event
+{
+    static constexpr Web::DevicePixelPoint point { NumericLimits<Web::DevicePixels::Type>::max(), NumericLimits<Web::DevicePixels::Type>::max() };
+
+    Web::MouseEvent mouse_event { Web::MouseEvent::Type::MouseMove, point, point, Web::UIEvents::MouseButton::None, Web::UIEvents::MouseButton::None, Web::UIEvents::KeyModifier::Mod_None, 0, 0, nullptr };
+    m_web_view_bridge->enqueue_input_event(move(mouse_event));
 }
 
 - (void)mouseMoved:(NSEvent*)event

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -402,6 +402,16 @@ QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery) const
     return QVariant();
 }
 
+void WebContentView::leaveEvent(QEvent* event)
+{
+    static constexpr QPointF point { NumericLimits<qreal>::max(), NumericLimits<qreal>::max() };
+
+    QMouseEvent mouse_event { QEvent::Type::MouseMove, point, point, Qt::MouseButton::NoButton, Qt::MouseButton::NoButton, Qt::KeyboardModifier::NoModifier };
+    enqueue_native_event(Web::MouseEvent::Type::MouseMove, mouse_event);
+
+    QWidget::leaveEvent(event);
+}
+
 void WebContentView::mouseMoveEvent(QMouseEvent* event)
 {
     if (!m_tooltip_override) {

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -59,6 +59,7 @@ public:
 
     virtual void paintEvent(QPaintEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;
+    virtual void leaveEvent(QEvent* event) override;
     virtual void mouseMoveEvent(QMouseEvent*) override;
     virtual void mousePressEvent(QMouseEvent*) override;
     virtual void mouseReleaseEvent(QMouseEvent*) override;


### PR DESCRIPTION
Previously, when the mouse left the WebView, the currently hovered node would remain hovered (including the scroll bar). This felt a bit awkward and is not how other browsers behave.

Before:

https://github.com/user-attachments/assets/35b223fa-5958-4299-9e6f-06aa95cddf8c

After:

https://github.com/user-attachments/assets/f7e7af43-46f5-40b4-a3ef-a534f975ee86

(Note this doesn't trigger while the mouse is pressed down, so you can still click-and-drag the scroll bar outside of the view).