### PR TITLE
LibWeb: Avoid float intrusions for BFCs, FFCs and GFCs

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -968,7 +968,7 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
     CSSPixels available_width_within_containing_block = available_space.width.to_px_or_zero();
 
     if ((!m_left_floats.current_boxes.is_empty() || !m_right_floats.current_boxes.is_empty())
-        && creates_block_formatting_context(child_box)) {
+        && box_should_avoid_floats_because_it_establishes_fc(child_box)) {
         auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_state, root());
         auto space_and_containing_margin = space_used_and_containing_margin_for_floats(box_in_root_rect.y());
         available_width_within_containing_block -= space_and_containing_margin.left_used_space + space_and_containing_margin.right_used_space;

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -5,11 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "InlineFormattingContext.h"
 #include <AK/QuickSort.h>
 #include <AK/StdLibExtras.h>
-#include <LibWeb/Layout/BlockContainer.h>
-#include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/FlexFormattingContext.h>
 #include <LibWeb/Layout/ReplacedBox.h>

--- a/Tests/LibWeb/Layout/expected/flex/flex-container-avoids-float-intrusions.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-container-avoids-float-intrusions.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x108 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
+      BlockContainer <div#a> at (8,8) content-size 100x100 floating [BFC] children: not-inline
+      Box <div#b> at (108,8) content-size 684x50 flex-container(row) [FFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,58) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x108]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50] overflow: [8,8 784x100]
+      PaintableWithLines (BlockContainer<DIV>#a) [8,8 100x100]
+      PaintableBox (Box<DIV>#b) [108,8 684x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,58 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x108] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/flex-container-avoids-float-intrusions.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-container-avoids-float-intrusions.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+#a {
+    background: green;
+    float: left;
+    height: 100px;
+    width: 100px;
+}
+#b {
+    background: red;
+    display: flex;
+    height: 50px;
+}
+</style><div id="a"></div><div id="b"></div>


### PR DESCRIPTION
We were only avoiding float intrusions for BFCs, but FFCs and GFCs should also accommodate for any floats present.

Work towards https://github.com/LadybirdBrowser/ladybird/issues/4136.