### PR TITLE
test-web: Add an option to randomize the test order

### DIFF
--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -38,6 +38,7 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     args_parser.add_option(dump_gc_graph, "Dump GC graph", "dump-gc-graph", 'G');
     args_parser.add_option(test_dry_run, "List the tests that would be run, without running them", "dry-run");
     args_parser.add_option(rebaseline, "Rebaseline any executed layout or text tests", "rebaseline");
+    args_parser.add_option(shuffle, "Shuffle the order of tests before running them", "shuffle", 's');
     args_parser.add_option(per_test_timeout_in_seconds, "Per-test timeout (default: 30)", "per-test-timeout", 't', "seconds");
 
     args_parser.add_option(Core::ArgsParser::Option {

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -40,6 +40,7 @@ public:
 
     bool test_dry_run { false };
     bool rebaseline { false };
+    bool shuffle { false };
 
     int per_test_timeout_in_seconds { 30 };
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -612,6 +612,9 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         return is_support_file || !match_glob;
     });
 
+    if (app.shuffle)
+        shuffle(tests);
+
     if (app.test_dry_run) {
         outln("Found {} tests...", tests.size());
 


### PR DESCRIPTION
My intention was to use this to find flakes that depend on the order tests are executed. I wasn't able to find any instances of this, but the option still seems like it may be useful.