### PR TITLE
UI/AppKit: Implement NSApplicationDelegate::openURLs

### DIFF
--- a/UI/AppKit/Application/ApplicationDelegate.h
+++ b/UI/AppKit/Application/ApplicationDelegate.h
@@ -37,6 +37,10 @@
                              activateTab:(Web::HTML::ActivateTab)activate_tab
                                pageIndex:(u64)page_index;
 
+- (void)createTabGroup:(Vector<URL::URL> const&)urls
+               fromTab:(nullable Tab*)tab
+      activateFirstTab:(Web::HTML::ActivateTab)activate_first_tab;
+
 - (void)setActiveTab:(nonnull Tab*)tab;
 - (nullable Tab*)activeTab;
 

--- a/UI/AppKit/Utilities/Conversions.h
+++ b/UI/AppKit/Utilities/Conversions.h
@@ -14,6 +14,7 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
+#include <LibURL/URL.h>
 
 #import <Cocoa/Cocoa.h>
 
@@ -43,5 +44,7 @@ NSColor* gfx_color_to_ns_color(Gfx::Color);
 Gfx::IntPoint compute_origin_relative_to_window(NSWindow*, Gfx::IntPoint);
 
 NSImage* gfx_bitmap_to_ns_image(Gfx::Bitmap const&);
+
+URL::URL ns_url_to_url(NSURL*);
 
 }

--- a/UI/AppKit/Utilities/Conversions.mm
+++ b/UI/AppKit/Utilities/Conversions.mm
@@ -6,6 +6,7 @@
  */
 
 #include <LibGfx/ImageFormats/PNGWriter.h>
+#include <LibURL/Parser.h>
 
 #import <Utilities/Conversions.h>
 
@@ -146,6 +147,14 @@ NSImage* gfx_bitmap_to_ns_image(Gfx::Bitmap const& bitmap)
                                 length:png.value().size()];
 
     return [[NSImage alloc] initWithData:data];
+}
+
+URL::URL ns_url_to_url(NSURL* url)
+{
+    auto absolute_string = ns_string_to_string([url absoluteString]);
+    auto converted_url = URL::Parser::basic_parse(absolute_string);
+    VERIFY(converted_url.has_value());
+    return converted_url.release_value();
 }
 
 }


### PR DESCRIPTION
When Ladybird is set as the default browser, this method is called to tell us to open URLs from external applications.

This has only been tested when Ladybird is already open, since trying to open Ladybird without using the ladybird.py script crashes at the time of writing, at least on my Macbook.

https://github.com/user-attachments/assets/34933d94-a6e4-4acc-966c-efe7ef5fbc0b