### PR TITLE
LibWeb: Port the document title to UTF-16

### DIFF
--- a/AK/Utf16String.h
+++ b/AK/Utf16String.h
@@ -138,6 +138,8 @@ public:
         return from_string_builder_without_validation(builder);
     }
 
+    static ErrorOr<Utf16String> from_ipc_stream(Stream&, size_t length_in_code_units, bool is_ascii);
+
     Utf16String to_well_formed() const;
     String to_well_formed_utf8() const;
 

--- a/AK/Utf16StringData.h
+++ b/AK/Utf16StringData.h
@@ -34,6 +34,7 @@ public:
     static NonnullRefPtr<Utf16StringData> from_utf16(Utf16View const&);
     static NonnullRefPtr<Utf16StringData> from_utf32(Utf32View const&);
     static NonnullRefPtr<Utf16StringData> from_string_builder(StringBuilder&);
+    static ErrorOr<NonnullRefPtr<Utf16StringData>> from_ipc_stream(Stream&, size_t length_in_code_units, bool is_ascii);
 
     static NonnullRefPtr<Utf16StringData> to_well_formed(Utf16View const&);
 

--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2020, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/JsonValue.h>
 #include <AK/NumericLimits.h>
+#include <AK/Utf16String.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/Proxy.h>
@@ -28,6 +29,15 @@ ErrorOr<String> decode(Decoder& decoder)
 {
     auto length = TRY(decoder.decode_size());
     return String::from_stream(decoder.stream(), length);
+}
+
+template<>
+ErrorOr<Utf16String> decode(Decoder& decoder)
+{
+    auto is_ascii = TRY(decoder.decode<bool>());
+    auto length_in_code_units = TRY(decoder.decode_size());
+
+    return Utf16String::from_ipc_stream(decoder.stream(), length_in_code_units, is_ascii);
 }
 
 template<>

--- a/Libraries/LibIPC/Decoder.h
+++ b/Libraries/LibIPC/Decoder.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -87,6 +87,9 @@ ErrorOr<T> decode(Decoder& decoder)
 
 template<>
 ErrorOr<String> decode(Decoder&);
+
+template<>
+ErrorOr<Utf16String> decode(Decoder&);
 
 template<>
 ErrorOr<ByteString> decode(Decoder&);

--- a/Libraries/LibIPC/Encoder.h
+++ b/Libraries/LibIPC/Encoder.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -86,6 +86,12 @@ ErrorOr<void> encode(Encoder&, String const&);
 
 template<>
 ErrorOr<void> encode(Encoder&, StringView const&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Utf16String const&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Utf16View const&);
 
 template<>
 ErrorOr<void> encode(Encoder&, ByteString const&);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -994,32 +994,32 @@ WebIDL::ExceptionOr<void> Document::set_body(HTML::HTMLElement* new_body)
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#document.title
-String Document::title() const
+Utf16String Document::title() const
 {
-    String value;
+    Utf16String value;
 
     // 1. If the document element is an SVG svg element, then let value be the child text content of the first SVG title
     //    element that is a child of the document element.
     if (auto const* document_element = this->document_element(); is<SVG::SVGElement>(document_element)) {
         if (auto const* title_element = document_element->first_child_of_type<SVG::SVGTitleElement>())
-            value = title_element->child_text_content().to_utf8_but_should_be_ported_to_utf16();
+            value = title_element->child_text_content();
     }
 
     // 2. Otherwise, let value be the child text content of the title element, or the empty string if the title element
     //    is null.
     else if (auto title_element = this->title_element()) {
-        value = title_element->text_content().value_or({}).to_utf8_but_should_be_ported_to_utf16();
+        value = title_element->text_content().value_or({});
     }
 
     // 3. Strip and collapse ASCII whitespace in value.
-    auto title = Infra::strip_and_collapse_whitespace(value).release_value_but_fixme_should_propagate_errors();
+    auto title = Infra::strip_and_collapse_whitespace(value);
 
     // 4. Return value.
     return title;
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#document.title
-WebIDL::ExceptionOr<void> Document::set_title(String const& title)
+WebIDL::ExceptionOr<void> Document::set_title(Utf16String const& title)
 {
     auto* document_element = this->document_element();
 
@@ -1043,7 +1043,7 @@ WebIDL::ExceptionOr<void> Document::set_title(String const& title)
         }
 
         // 3. String replace all with the given value within element.
-        element->string_replace_all(Utf16String::from_utf8(title));
+        element->string_replace_all(title);
     }
 
     // -> If the document element is in the HTML namespace
@@ -1072,7 +1072,7 @@ WebIDL::ExceptionOr<void> Document::set_title(String const& title)
         }
 
         // 4. String replace all with the given value within element.
-        element->string_replace_all(Utf16String::from_utf8(title));
+        element->string_replace_all(title);
     }
 
     // -> Otherwise

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -307,8 +307,8 @@ public:
 
     WebIDL::ExceptionOr<void> set_body(HTML::HTMLElement* new_body);
 
-    String title() const;
-    WebIDL::ExceptionOr<void> set_title(String const&);
+    Utf16String title() const;
+    WebIDL::ExceptionOr<void> set_title(Utf16String const&);
 
     GC::Ptr<HTML::BrowsingContext> browsing_context() { return m_browsing_context; }
     GC::Ptr<HTML::BrowsingContext const> browsing_context() const { return m_browsing_context; }

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -124,7 +124,7 @@ interface Document : Node {
     readonly attribute DOMString lastModified;
     readonly attribute DOMString readyState;
 
-    [CEReactions] attribute DOMString title;
+    [CEReactions] attribute Utf16DOMString title;
 
     readonly attribute boolean hidden;
     readonly attribute DOMString visibilityState;

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -32,7 +32,7 @@ void HTMLTitleElement::children_changed(ChildrenChangedMetadata const* metadata)
     HTMLElement::children_changed(metadata);
     auto navigable = this->navigable();
     if (navigable && navigable->is_traversable()) {
-        navigable->traversable_navigable()->page().client().page_did_change_title(document().title().to_byte_string());
+        navigable->traversable_navigable()->page().client().page_did_change_title(document().title());
     }
 }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -319,7 +319,7 @@ public:
     virtual CSS::PreferredMotion preferred_motion() const = 0;
     virtual Queue<QueuedInputEvent>& input_event_queue() = 0;
     virtual void report_finished_handling_input_event(u64 page_id, EventResult event_was_handled) = 0;
-    virtual void page_did_change_title(ByteString const&) { }
+    virtual void page_did_change_title(Utf16String const&) { }
     virtual void page_did_change_url(URL::URL const&) { }
     virtual void page_did_request_refresh() { }
     virtual void page_did_request_resize_window(Gfx::IntSize) { }

--- a/Libraries/LibWeb/SVG/SVGTitleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTitleElement.cpp
@@ -41,7 +41,7 @@ void SVGTitleElement::children_changed(ChildrenChangedMetadata const* metadata)
     auto* document_element = document().document_element();
 
     if (document_element == parent() && is<SVGElement>(document_element))
-        page.client().page_did_change_title(document().title().to_byte_string());
+        page.client().page_did_change_title(document().title());
 }
 
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -324,7 +324,7 @@ void Application::launch_spare_web_content_process()
         m_spare_web_content_process = web_content_client.release_value();
 
         if (auto process = find_process(m_spare_web_content_process->pid()); process.has_value())
-            process->set_title("(spare)"_string);
+            process->set_title("(spare)"_utf16);
     });
 }
 
@@ -594,7 +594,7 @@ Vector<DevTools::TabDescription> Application::tab_list() const
     Vector<DevTools::TabDescription> tabs;
 
     ViewImplementation::for_each_view([&](ViewImplementation& view) {
-        tabs.empend(view.view_id(), MUST(String::from_byte_string(view.title())), view.url().to_string());
+        tabs.empend(view.view_id(), view.title().to_utf8(), view.url().to_string());
         return IterationDecision::Continue;
     });
 

--- a/Libraries/LibWebView/Process.h
+++ b/Libraries/LibWebView/Process.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/String.h>
+#include <AK/Utf16String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Process.h>
 #include <LibIPC/Connection.h>
@@ -30,8 +30,9 @@ public:
     static ErrorOr<ProcessAndClient<ClientType>> spawn(ProcessType type, Core::ProcessSpawnOptions const& options, ClientArguments&&... client_arguments);
 
     ProcessType type() const { return m_type; }
-    Optional<String> const& title() const { return m_title; }
-    void set_title(Optional<String> title) { m_title = move(title); }
+
+    Optional<Utf16String> const& title() const { return m_title; }
+    void set_title(Optional<Utf16String> title) { m_title = move(title); }
 
     template<typename ConnectionFromClient>
     Optional<ConnectionFromClient&> client()
@@ -60,7 +61,7 @@ private:
 
     Core::Process m_process;
     ProcessType m_type;
-    Optional<String> m_title;
+    Optional<Utf16String> m_title;
     WeakPtr<IPC::ConnectionBase> m_connection;
 };
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -13,6 +13,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/Queue.h>
 #include <AK/String.h>
+#include <AK/Utf16String.h>
 #include <LibCore/Forward.h>
 #include <LibCore/Promise.h>
 #include <LibGfx/Cursor.h>
@@ -45,8 +46,8 @@ public:
     void set_url(Badge<WebContentClient>, URL::URL url) { m_url = move(url); }
     URL::URL const& url() const { return m_url; }
 
-    void set_title(Badge<WebContentClient>, ByteString title) { m_title = move(title); }
-    ByteString const& title() const { return m_title; }
+    void set_title(Badge<WebContentClient>, Utf16String title) { m_title = move(title); }
+    Utf16String const& title() const { return m_title; }
 
     String const& handle() const { return m_client_state.client_handle; }
 
@@ -181,7 +182,7 @@ public:
     Function<void()> on_link_unhover;
     Function<void(URL::URL const&, ByteString const& target, unsigned modifiers)> on_link_click;
     Function<void(URL::URL const&, ByteString const& target, unsigned modifiers)> on_link_middle_click;
-    Function<void(ByteString const&)> on_title_change;
+    Function<void(Utf16String const&)> on_title_change;
     Function<void(URL::URL const&)> on_url_change;
     Function<void(URL::URL const&, bool)> on_load_start;
     Function<void(URL::URL const&)> on_load_finish;
@@ -285,7 +286,7 @@ protected:
     } m_client_state;
 
     URL::URL m_url;
-    ByteString m_title;
+    Utf16String m_title;
 
     float m_zoom_level { 1.0 };
     float m_device_pixel_ratio { 1.0 };

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -170,17 +170,19 @@ void WebContentClient::did_request_cursor_change(u64 page_id, Gfx::Cursor cursor
     }
 }
 
-void WebContentClient::did_change_title(u64 page_id, ByteString title)
+void WebContentClient::did_change_title(u64 page_id, Utf16String title)
 {
     if (auto process = WebView::Application::the().find_process(m_process_handle.pid); process.has_value())
-        process->set_title(MUST(String::from_byte_string(title)));
+        process->set_title(title);
 
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        auto title_or_url = title.is_empty() ? view->url().to_byte_string() : title;
-        view->set_title({}, title_or_url);
+        if (title.is_empty())
+            title = Utf16String::from_utf8(view->url().serialize());
+
+        view->set_title({}, title);
 
         if (view->on_title_change)
-            view->on_title_change(title_or_url);
+            view->on_title_change(title);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -64,7 +64,7 @@ private:
     virtual void did_finish_loading(u64 page_id, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;
     virtual void did_request_cursor_change(u64 page_id, Gfx::Cursor) override;
-    virtual void did_change_title(u64 page_id, ByteString) override;
+    virtual void did_change_title(u64 page_id, Utf16String) override;
     virtual void did_change_url(u64 page_id, URL::URL) override;
     virtual void did_request_tooltip_override(u64 page_id, Gfx::IntPoint, ByteString) override;
     virtual void did_stop_tooltip_override(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -224,7 +224,7 @@ void PageClient::page_did_request_cursor_change(Gfx::Cursor const& cursor)
     client().async_did_request_cursor_change(m_id, cursor);
 }
 
-void PageClient::page_did_change_title(ByteString const& title)
+void PageClient::page_did_change_title(Utf16String const& title)
 {
     client().async_did_change_title(m_id, title);
 }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -111,7 +111,7 @@ private:
     virtual Web::CSS::PreferredContrast preferred_contrast() const override { return m_preferred_contrast; }
     virtual Web::CSS::PreferredMotion preferred_motion() const override { return m_preferred_motion; }
     virtual void page_did_request_cursor_change(Gfx::Cursor const&) override;
-    virtual void page_did_change_title(ByteString const&) override;
+    virtual void page_did_change_title(Utf16String const&) override;
     virtual void page_did_change_url(URL::URL const&) override;
     virtual void page_did_request_refresh() override;
     virtual void page_did_request_resize_window(Gfx::IntSize) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -34,7 +34,7 @@ endpoint WebContentClient
     did_request_refresh(u64 page_id) =|
     did_paint(u64 page_id, Gfx::IntRect content_rect, i32 bitmap_id) =|
     did_request_cursor_change(u64 page_id, Gfx::Cursor cursor) =|
-    did_change_title(u64 page_id, ByteString title) =|
+    did_change_title(u64 page_id, Utf16String title) =|
     did_change_url(u64 page_id, URL::URL url) =|
     did_request_tooltip_override(u64 page_id, Gfx::IntPoint position, ByteString title) =|
     did_stop_tooltip_override(u64 page_id) =|

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -522,7 +522,7 @@ Messages::WebDriverClient::GetTitleResponse WebDriverConnection::get_title()
     // 2. Handle any user prompts and return its value if it is an error.
     handle_any_user_prompts([this]() {
         // 3. Let title be the initial value of the title IDL attribute of the current top-level browsing context's active document.
-        auto title = current_top_level_browsing_context()->active_document()->title();
+        auto title = current_top_level_browsing_context()->active_document()->title().to_utf8();
 
         // 4. Return success with data title.
         async_driver_execution_complete({ move(title) });

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -39,7 +39,7 @@
 - (void)onBackNavigationEnabled:(BOOL)back_enabled
        forwardNavigationEnabled:(BOOL)forward_enabled;
 
-- (void)onTitleChange:(ByteString const&)title;
+- (void)onTitleChange:(Utf16String const&)title;
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;
 - (void)onAudioPlayStateChange:(Web::HTML::AudioPlayState)play_state;
 

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteString.h>
 #include <AK/String.h>
 #include <LibCore/Resource.h>
 #include <LibGfx/ShareableBitmap.h>
@@ -293,11 +292,9 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
                          forwardNavigationEnabled:forward_enabled];
 }
 
-- (void)onTitleChange:(ByteString const&)title
+- (void)onTitleChange:(Utf16String const&)title
 {
-    [[self tabController] onTitleChange:title];
-
-    self.title = Ladybird::string_to_ns_string(title);
+    self.title = Ladybird::utf16_string_to_ns_string(title);
     [self updateTabTitleAndFavicon];
 }
 

--- a/UI/AppKit/Interface/TabController.h
+++ b/UI/AppKit/Interface/TabController.h
@@ -36,8 +36,6 @@ struct TabSettings {
 - (void)onBackNavigationEnabled:(BOOL)back_enabled
        forwardNavigationEnabled:(BOOL)forward_enabled;
 
-- (void)onTitleChange:(ByteString const&)title;
-
 - (void)onCreateNewTab;
 
 - (void)navigateBack:(id)sender;

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -55,8 +55,6 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 {
     u64 m_page_index;
 
-    ByteString m_title;
-
     TabSettings m_settings;
 
     OwnPtr<WebView::Autocomplete> m_autocomplete;
@@ -178,11 +176,6 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     m_can_navigate_back = back_enabled;
     m_can_navigate_forward = forward_enabled;
     [self updateNavigationButtonStates];
-}
-
-- (void)onTitleChange:(ByteString const&)title
-{
-    m_title = title;
 }
 
 - (void)onCreateNewTab

--- a/UI/AppKit/Utilities/Conversions.h
+++ b/UI/AppKit/Utilities/Conversions.h
@@ -9,6 +9,7 @@
 #include <AK/ByteString.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Utf16String.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Point.h>
@@ -20,8 +21,12 @@
 namespace Ladybird {
 
 String ns_string_to_string(NSString*);
-ByteString ns_string_to_byte_string(NSString*);
 NSString* string_to_ns_string(StringView);
+
+Utf16String ns_string_to_utf16_string(NSString*);
+NSString* utf16_string_to_ns_string(Utf16View const&);
+
+ByteString ns_string_to_byte_string(NSString*);
 
 ByteString ns_data_to_string(NSData*);
 NSData* string_to_ns_data(StringView);

--- a/UI/Qt/StringUtils.cpp
+++ b/UI/Qt/StringUtils.cpp
@@ -29,6 +29,18 @@ QString qstring_from_ak_string(StringView ak_string)
     return QString::fromUtf8(ak_string.characters_without_null_termination(), static_cast<qsizetype>(ak_string.length()));
 }
 
+Utf16String utf16_string_from_qstring(QString const& string)
+{
+    return Utf16String::from_utf16({ reinterpret_cast<char16_t const*>(string.utf16()), static_cast<size_t>(string.size()) });
+}
+
+QString qstring_from_utf16_string(Utf16View const& string)
+{
+    if (string.has_ascii_storage())
+        return qstring_from_ak_string(string.bytes());
+    return QString::fromUtf16(string.utf16_span().data(), static_cast<qsizetype>(string.length_in_code_units()));
+}
+
 QByteArray qbytearray_from_ak_string(StringView ak_string)
 {
     return { ak_string.characters_without_null_termination(), static_cast<qsizetype>(ak_string.length()) };

--- a/UI/Qt/StringUtils.h
+++ b/UI/Qt/StringUtils.h
@@ -11,6 +11,7 @@
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Utf16String.h>
 #include <LibURL/URL.h>
 
 #include <QByteArray>
@@ -22,6 +23,10 @@ AK::ByteString ak_byte_string_from_qbytearray(QByteArray const&);
 
 String ak_string_from_qstring(QString const&);
 QString qstring_from_ak_string(StringView);
+
+Utf16String utf16_string_from_qstring(QString const&);
+QString qstring_from_utf16_string(Utf16View const&);
+
 QByteArray qbytearray_from_ak_string(StringView);
 
 Optional<URL::URL> ak_url_from_qstring(QString const&);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -162,8 +162,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
 
     view().on_title_change = [this](auto const& title) {
-        m_title = qstring_from_ak_string(title);
-
+        m_title = qstring_from_utf16_string(title);
         emit title_changed(tab_index(), m_title);
     };
 


### PR DESCRIPTION
Mostly just to get the IPC hooks out of the way.