### PR TITLE
LibWeb: Respect `letter-spacing` for last glyph of each chunk

### DIFF
--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -117,10 +117,9 @@ NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spaci
         glyph_run.unchecked_append({ position, glyph_info[i].codepoint });
         point += FloatPoint { positions[i].x_advance, positions[i].y_advance } / text_shaping_resolution;
 
-        // don't apply spacing to last glyph
-        // https://drafts.csswg.org/css-text/#example-7880704e
-        if (i != (glyph_count - 1))
-            point.translate_by(letter_spacing, 0);
+        // NOTE: The spec says that we "really should not" apply letter-spacing to the trailing edge of a line but
+        //       other browsers do so we will as well. https://drafts.csswg.org/css-text/#example-7880704e
+        point.translate_by(letter_spacing, 0);
     }
 
     return adopt_ref(*new GlyphRun(move(glyph_run), font, text_type, point.x() - baseline_start.x()));

--- a/Tests/LibWeb/Layout/expected/letter-spacing-end-of-line-001.txt
+++ b/Tests/LibWeb/Layout/expected/letter-spacing-end-of-line-001.txt
@@ -8,10 +8,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,63) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (8,63) content-size 784x55 children: inline
-        frag 0 from TextNode start: 0, length: 1, rect: [93.0625,63 28.03125x55] baseline: 41.890625
+        frag 0 from TextNode start: 0, length: 1, rect: [122.0625,63 28.03125x55] baseline: 41.890625
             "a"
-        BlockContainer <span> at (8,63) content-size 85.0625x55 floating [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 2, rect: [8,63 85.0625x55] baseline: 41.890625
+        BlockContainer <span> at (8,63) content-size 114.0625x55 floating [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 2, rect: [8,63 114.0625x55] baseline: 41.890625
               "aa"
           TextNode <#text>
         TextNode <#text>
@@ -25,7 +25,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,63 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,63 784x55]
-        PaintableWithLines (BlockContainer<SPAN>) [8,63 85.0625x55]
+        PaintableWithLines (BlockContainer<SPAN>) [8,63 114.0625x55]
           TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,118 784x0]

--- a/Tests/LibWeb/Layout/expected/tab-size-letter-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-letter-spacing.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x31 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x15 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x15 children: inline
-        frag 0 from TextNode start: 1, length: 1, rect: [8,8 11.59375x15] baseline: 11.390625
+        frag 0 from TextNode start: 1, length: 1, rect: [8,8 27.59375x15] baseline: 11.390625
             "A"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,23) content-size 784x0 children: inline


### PR DESCRIPTION
Previously we would omit the letter spacing for the end glyph of each chunk in a misguided attempt to conform to the spec's instruction that we "really should not append letter spacing to the right or trailing edge of a line", this behaviour can be removed entirely as other browsers (Firefox, Chrome) don't implement it either.