### PR TITLE
LibWeb+WebContent+UI: Remove unused same-origin policy toggle

### DIFF
--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -107,9 +107,6 @@ public:
     CSS::PreferredContrast preferred_contrast() const;
     CSS::PreferredMotion preferred_motion() const;
 
-    bool is_same_origin_policy_enabled() const { return m_same_origin_policy_enabled; }
-    void set_same_origin_policy_enabled(bool b) { m_same_origin_policy_enabled = b; }
-
     bool is_scripting_enabled() const { return m_is_scripting_enabled; }
     void set_is_scripting_enabled(bool b) { m_is_scripting_enabled = b; }
 
@@ -248,9 +245,6 @@ private:
     WeakPtr<HTML::Navigable> m_focused_navigable;
 
     GC::Ptr<HTML::TraversableNavigable> m_top_level_traversable;
-
-    // FIXME: Enable this by default once CORS preflight checks are supported.
-    bool m_same_origin_policy_enabled { false };
 
     bool m_is_scripting_enabled { true };
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -378,11 +378,6 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
         return;
     }
 
-    if (request == "same-origin-policy") {
-        page->page().set_same_origin_policy_enabled(argument == "on");
-        return;
-    }
-
     if (request == "scripting") {
         page->page().set_is_scripting_enabled(argument == "on");
         return;

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -730,9 +730,6 @@
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Block Pop-ups"
                                                 action:@selector(togglePopupBlocking:)
                                          keyEquivalent:@""]];
-    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Enable Same-Origin Policy"
-                                                action:@selector(toggleSameOriginPolicy:)
-                                         keyEquivalent:@""]];
 
     [menu setSubmenu:submenu];
     return menu;

--- a/UI/AppKit/Interface/TabController.h
+++ b/UI/AppKit/Interface/TabController.h
@@ -17,7 +17,6 @@ struct TabSettings {
     BOOL should_show_line_box_borders { NO };
     BOOL scripting_enabled { YES };
     BOOL block_popups { YES };
-    BOOL same_origin_policy_enabled { NO };
     ByteString user_agent_name { "Disabled"sv };
     ByteString navigator_compatibility_mode { "chrome"sv };
 };

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -431,12 +431,6 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     [self debugRequest:"block-pop-ups" argument:block_popups ? "on" : "off"];
 }
 
-- (void)toggleSameOriginPolicy:(id)sender
-{
-    m_settings.same_origin_policy_enabled = !m_settings.same_origin_policy_enabled;
-    [self debugRequest:"same-origin-policy" argument:m_settings.same_origin_policy_enabled ? "on" : "off"];
-}
-
 - (void)setUserAgentSpoof:(NSMenuItem*)sender
 {
     ByteString const user_agent_name = [[sender title] UTF8String];
@@ -673,8 +667,6 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [item setState:m_settings.scripting_enabled ? NSControlStateValueOn : NSControlStateValueOff];
     } else if ([item action] == @selector(togglePopupBlocking:)) {
         [item setState:m_settings.block_popups ? NSControlStateValueOn : NSControlStateValueOff];
-    } else if ([item action] == @selector(toggleSameOriginPolicy:)) {
-        [item setState:m_settings.same_origin_policy_enabled ? NSControlStateValueOn : NSControlStateValueOff];
     } else if ([item action] == @selector(setUserAgentSpoof:)) {
         [item setState:(m_settings.user_agent_name == [[item title] UTF8String]) ? NSControlStateValueOn : NSControlStateValueOff];
     } else if ([item action] == @selector(setNavigatorCompatibilityMode:)) {

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -597,16 +597,6 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         });
     });
 
-    m_enable_same_origin_policy_action = new QAction("Enable Same-Origin Policy", this);
-    m_enable_same_origin_policy_action->setCheckable(true);
-    debug_menu->addAction(m_enable_same_origin_policy_action);
-    QObject::connect(m_enable_same_origin_policy_action, &QAction::triggered, this, [this] {
-        bool state = m_enable_same_origin_policy_action->isChecked();
-        for_each_tab([state](auto& tab) {
-            tab.set_same_origin_policy(state);
-        });
-    });
-
     auto* help_menu = m_hamburger_menu->addMenu("&Help");
     menuBar()->addMenu(help_menu);
 
@@ -852,7 +842,6 @@ void BrowserWindow::initialize_tab(Tab* tab)
     tab->set_scripting(m_enable_scripting_action->isChecked());
     tab->set_content_filtering(m_enable_content_filtering_action->isChecked());
     tab->set_block_popups(m_block_pop_ups_action->isChecked());
-    tab->set_same_origin_policy(m_enable_same_origin_policy_action->isChecked());
     tab->set_user_agent_string(user_agent_string());
     tab->set_navigator_compatibility_mode(navigator_compatibility_mode());
     tab->view().set_preferred_color_scheme(m_preferred_color_scheme);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -208,7 +208,6 @@ private:
     QAction* m_enable_scripting_action { nullptr };
     QAction* m_enable_content_filtering_action { nullptr };
     QAction* m_block_pop_ups_action { nullptr };
-    QAction* m_enable_same_origin_policy_action { nullptr };
 
     ByteString m_user_agent_string {};
     ByteString m_navigator_compatibility_mode {};

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -938,11 +938,6 @@ void Tab::set_line_box_borders(bool enabled)
     debug_request("set-line-box-borders", enabled ? "on" : "off");
 }
 
-void Tab::set_same_origin_policy(bool enabled)
-{
-    debug_request("same-origin-policy", enabled ? "on" : "off");
-}
-
 void Tab::set_scripting(bool enabled)
 {
     debug_request("scripting", enabled ? "on" : "off");

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -82,7 +82,6 @@ public:
 
     void set_block_popups(bool);
     void set_line_box_borders(bool);
-    void set_same_origin_policy(bool);
     void set_scripting(bool);
     void set_content_filtering(bool);
     void set_user_agent_string(ByteString const&);


### PR DESCRIPTION
Page::is_same_origin_policy_enabled is unused, and the original FIXME has been implemented.