### PR TITLE
LibWeb: Make ESO "fetch group" weakly reference the fetch records

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1789,9 +1789,9 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             auto& group = http_request->client()->fetch_group();
 
             // 3. Let inflightRecords be the set of fetch records in group whose request’s keepalive is true and done flag is unset.
-            Vector<GC::Ref<Infrastructure::FetchRecord>> in_flight_records;
-            for (auto const& fetch_record : group) {
-                if (fetch_record->request()->keepalive() && !fetch_record->request()->done())
+            GC::RootVector<GC::Ref<Infrastructure::FetchRecord>> in_flight_records(vm.heap());
+            for (auto& fetch_record : group) {
+                if (fetch_record.request()->keepalive() && !fetch_record.request()->done())
                     in_flight_records.append(fetch_record);
             }
 

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchRecord.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchRecord.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Fetch/Infrastructure/FetchRecord.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 
 namespace Web::Fetch::Infrastructure {
 
@@ -36,6 +37,12 @@ void FetchRecord::visit_edges(Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_request);
     visitor.visit(m_fetch_controller);
+}
+
+void FetchRecord::finalize()
+{
+    Base::finalize();
+    m_list_node.remove();
 }
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchRecord.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchRecord.h
@@ -7,12 +7,11 @@
 #pragma once
 
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
-#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#concept-fetch-record
-class FetchRecord : public JS::Cell {
+class FetchRecord final : public JS::Cell {
     GC_CELL(FetchRecord, JS::Cell);
     GC_DECLARE_ALLOCATOR(FetchRecord);
 
@@ -31,6 +30,7 @@ private:
     FetchRecord(GC::Ref<Infrastructure::Request>, GC::Ptr<FetchController>);
 
     virtual void visit_edges(Visitor&) override;
+    virtual void finalize() override;
 
     // https://fetch.spec.whatwg.org/#concept-request
     // A fetch record has an associated request (a request)
@@ -39,6 +39,11 @@ private:
     // https://fetch.spec.whatwg.org/#fetch-controller
     // A fetch record has an associated controller (a fetch controller or null)
     GC::Ptr<FetchController> m_fetch_controller { nullptr };
+
+    IntrusiveListNode<FetchRecord> m_list_node;
+
+public:
+    using List = IntrusiveList<&FetchRecord::m_list_node>;
 };
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -22,7 +22,6 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Headers.h>
 #include <LibWeb/HTML/PolicyContainers.h>
-#include <LibWeb/HTML/Scripting/Environments.h>
 
 namespace Web::Fetch::Infrastructure {
 

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -62,7 +62,6 @@ void EnvironmentSettingsObject::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_responsible_event_loop);
     visitor.visit(m_module_map);
     m_realm_execution_context->visit_edges(visitor);
-    visitor.visit(m_fetch_group);
     visitor.visit(m_storage_manager);
     visitor.visit(m_service_worker_registration_object_map);
     visitor.visit(m_service_worker_object_map);

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -11,6 +11,7 @@
 #include <LibJS/Forward.h>
 #include <LibURL/Origin.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Fetch/Infrastructure/FetchRecord.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Scripting/ModuleMap.h>
@@ -116,7 +117,7 @@ public:
     EventLoop& responsible_event_loop();
 
     // https://fetch.spec.whatwg.org/#concept-fetch-group
-    Vector<GC::Ref<Fetch::Infrastructure::FetchRecord>>& fetch_group() { return m_fetch_group; }
+    auto& fetch_group() { return m_fetch_group; }
 
     SerializedEnvironmentSettingsObject serialize();
 
@@ -146,7 +147,7 @@ private:
 
     // https://fetch.spec.whatwg.org/#concept-fetch-record
     // A fetch group holds an ordered list of fetch records
-    Vector<GC::Ref<Fetch::Infrastructure::FetchRecord>> m_fetch_group;
+    Fetch::Infrastructure::FetchRecord::List m_fetch_group;
 
     // https://storage.spec.whatwg.org/#api
     // Each environment settings object has an associated StorageManager object.


### PR DESCRIPTION
Otherwise we end up holding on to every fetch record indefinitely.

Found by analyzing GC heap graphs on Discord.