### PR TITLE
LibWeb: Implement validationMessage for elements that used it

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -58,6 +58,28 @@ GC::Ref<ValidityState const> FormAssociatedElement::validity() const
     return realm.create<ValidityState>(realm, *this);
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+String FormAssociatedElement::validation_message()
+{
+    // 1. If this element is not a candidate for constraint validation
+    // or if this element satisfies its constraints, then return the empty string.
+    if (!is_candidate_for_constraint_validation() || satisfies_its_constraints()) {
+        return {};
+    }
+
+    // 2. Return a suitably localized message that the user agent would show the user
+    // if this were the only form control with a validity constraint problem. If the user agent would not
+    // actually show a textual message in such a situation (e.g., it would show a graphical cue instead),
+    // then return a suitably localized message that expresses (one or more of) the validity constraint(s) that the control
+    // does not satisfy. If the element is a candidate for constraint validation and is suffering from a custom error,
+    // then the custom validity error message should be present in the return value.
+    if (suffering_from_a_custom_error()) {
+        return m_custom_validity_error_message;
+    }
+
+    return format_validation_message();
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity
 void FormAssociatedElement::set_custom_validity(String& error)
 {

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -142,6 +142,9 @@ public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
     GC::Ref<ValidityState const> validity() const;
 
+    virtual String format_validation_message() { return {}; }
+    String validation_message();
+
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity
     void set_custom_validity(String& error);
 

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -280,6 +280,19 @@ bool HTMLButtonElement::will_validate()
     return is_candidate_for_constraint_validation();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+String HTMLButtonElement::format_validation_message()
+{
+    if (suffering_from_being_missing()) {
+        return "Please input a value."_string;
+    }
+    if (suffering_from_bad_input()) {
+        return "Please input a valid value."_string;
+    }
+
+    return {};
+}
+
 bool HTMLButtonElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -45,6 +45,7 @@ public:
     virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     bool will_validate();
+    virtual String format_validation_message() override;
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-button-element

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -30,7 +30,7 @@ interface HTMLButtonElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
     [FIXME] boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
@@ -16,7 +16,7 @@ interface HTMLFieldSetElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     [FIXME, SameObject] readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
     [FIXME] boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2855,6 +2855,59 @@ WebIDL::ExceptionOr<bool> HTMLInputElement::report_validity()
     return report_validity_steps();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+String HTMLInputElement::format_validation_message()
+{
+    if (suffering_from_being_missing()) {
+        return "Please input a value."_string;
+    }
+    if (suffering_from_a_type_mismatch()) {
+        switch (type_state()) {
+        case TypeAttributeState::Color:
+            return "Please input a valid color. (#rrggbb)"_string;
+        case TypeAttributeState::Date:
+            return "Please input a valid date. (yy-mm-dd)"_string;
+        case TypeAttributeState::Email:
+            return "Please input a valid email. (username@example.com)"_string;
+        case TypeAttributeState::Number:
+        case TypeAttributeState::Range:
+            return "Please input a valid number."_string;
+        case TypeAttributeState::Password:
+            return "Please input a valid password."_string;
+        case TypeAttributeState::Month:
+            return "Please input a valid month."_string;
+        case TypeAttributeState::Week:
+            return "Please input a valid week."_string;
+        case TypeAttributeState::Telephone:
+            return "Please input a valid phone number."_string;
+        case TypeAttributeState::URL:
+            return "Please input a valid URL. (https://example.com)"_string;
+        default:
+            return "Please input a valid value."_string;
+        }
+    }
+    if (suffering_from_a_pattern_mismatch() || suffering_from_bad_input()) {
+        return "Please input a valid value."_string;
+    }
+    if (suffering_from_being_too_long()) {
+        return MUST(String::formatted("Please limit your character count to {} characters.", max_length()));
+    }
+    if (suffering_from_being_too_short()) {
+        return MUST(String::formatted("Please increase your character count to {} characters.", min_length()));
+    }
+    if (suffering_from_an_underflow()) {
+        return MUST(String::formatted("Please select a number at or above {}.", min()));
+    }
+    if (suffering_from_an_overflow()) {
+        return MUST(String::formatted("Please select a number at or below {}.", max()));
+    }
+    if (suffering_from_a_step_mismatch()) {
+        return "Please input a valid number."_string;
+    }
+
+    return {};
+}
+
 Optional<ARIA::Role> HTMLInputElement::default_role() const
 {
     // http://wpt.live/html-aam/roles-dynamic-switch.tentative.window.html "Disconnected <input type=checkbox switch>"

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -161,6 +161,7 @@ public:
     bool will_validate();
     WebIDL::ExceptionOr<bool> check_validity();
     WebIDL::ExceptionOr<bool> report_validity();
+    virtual String format_validation_message() override;
 
     WebIDL::ExceptionOr<void> show_picker();
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -54,7 +54,7 @@ interface HTMLInputElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -20,7 +20,7 @@ interface HTMLObjectElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
     [FIXME] boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.idl
@@ -17,7 +17,7 @@ interface HTMLOutputElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
     [FIXME] boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -710,6 +710,19 @@ bool HTMLSelectElement::report_validity()
     return report_validity_steps();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+String HTMLSelectElement::format_validation_message()
+{
+    if (suffering_from_being_missing()) {
+        return "Please input a value."_string;
+    }
+    if (suffering_from_bad_input()) {
+        return "Please input a valid value."_string;
+    }
+
+    return {};
+}
+
 bool HTMLSelectElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -64,6 +64,7 @@ public:
     bool will_validate();
     bool check_validity();
     bool report_validity();
+    virtual String format_validation_message() override;
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-select-element

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -33,7 +33,7 @@ interface HTMLSelectElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -251,6 +251,25 @@ bool HTMLTextAreaElement::report_validity()
     return report_validity_steps();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+String HTMLTextAreaElement::format_validation_message()
+{
+    if (suffering_from_being_missing()) {
+        return "Please input a value."_string;
+    }
+    if (suffering_from_being_too_long()) {
+        return MUST(String::formatted("Please limit your character count to {} characters.", max_length()));
+    }
+    if (suffering_from_being_too_short()) {
+        return MUST(String::formatted("Please increase your character count to {} characters.", min_length()));
+    }
+    if (suffering_from_bad_input()) {
+        return "Please input a valid value."_string;
+    }
+
+    return {};
+}
+
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength
 WebIDL::Long HTMLTextAreaElement::max_length() const
 {

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -100,6 +100,7 @@ public:
     bool will_validate();
     bool check_validity();
     bool report_validity();
+    virtual String format_validation_message() override;
 
     WebIDL::Long max_length() const;
     WebIDL::ExceptionOr<void> set_max_length(WebIDL::Long);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
@@ -28,7 +28,7 @@ interface HTMLTextAreaElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	[input]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[input]  The validity.customError must be false if the custom validity error message is empty
+Pass	[button]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[button]  The validity.customError must be false if the custom validity error message is empty
+Pass	[select]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[select]  The validity.customError must be false if the custom validity error message is empty
+Pass	[textarea]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[textarea]  The validity.customError must be false if the custom validity error message is empty

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-valueMissing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-valueMissing.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 78 tests
 
-46 Pass
-32 Fail
+47 Pass
+31 Fail
 Pass	[INPUT in TEXT status] The required attribute is not set
 Pass	[INPUT in TEXT status] The value is not empty and required is true
 Fail	[INPUT in TEXT status] The value is empty and required is true
@@ -81,4 +81,4 @@ Pass	[select]  Selected the option with value equals to empty
 Pass	[textarea]  The required attribute is not set
 Pass	[textarea]  The value is not empty
 Fail	[textarea]  The value is empty
-Fail	validationMessage should return empty string when willValidate is false and valueMissing is true
+Pass	validationMessage should return empty string when willValidate is false and valueMissing is true

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-button-element/button-validationmessage.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-button-element/button-validationmessage.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Forms

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-fieldset-element/fieldset-validationmessage.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-fieldset-element/fieldset-validationmessage.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Forms

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/input-validationmessage.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/input-validationmessage.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Forms

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-output-element/output-validity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-output-element/output-validity.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	:valid and :invalid pseudo-class on output element

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The constraint validation API Test: element.validity.customError</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-validitystate-customerror">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-constraint-validation-api">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<script src="support/validator.js"></script>
+<div id="log"></div>
+<script>
+var testElements = [
+    {
+      tag: "input",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    },
+    {
+      tag: "button",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    },
+    {
+      tag: "select",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    },
+    {
+      tag: "textarea",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    }
+  ]
+
+  validator.run_test(testElements, "customError");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-button-element/button-validationmessage.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-button-element/button-validationmessage.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>Forms</title>
+  <script src="../../../../resources/testharness.js"></script>
+  <script src="../../../../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <p>
+    <h3>button_validationMessage</h3>
+  </p>
+
+  <hr>
+
+  <div id="log"></div>
+
+  <form method="post"
+      enctype="application/x-www-form-urlencoded"
+      action=""
+      id="input_form">
+    <p><button id='button_id'>button</button></p>
+  </form>
+  <script>
+
+    var button = document.getElementById("button_id");
+
+    if (typeof(button.validationMessage) == "string") {
+      test(function() {
+        assert_equals(button.validationMessage, "", "validationMessage attribute is not correct.");
+      });
+    } else {
+      test(function() {
+        assert_unreached("validationMessage attribute is not exist.");
+      });
+    }
+
+  </script>
+
+ </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-fieldset-element/fieldset-validationmessage.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-fieldset-element/fieldset-validationmessage.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>Forms</title>
+  <script src="../../../../resources/testharness.js"></script>
+  <script src="../../../../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <p>
+    <h3>FieldSet_validationMessage</h3>
+  </p>
+
+  <hr>
+
+  <div id="log"></div>
+
+  <form method="post"
+      enctype="application/x-www-form-urlencoded"
+      action=""
+      id="input_form">
+    <fieldset id="input_field">
+     </fieldset>
+  </form>
+  <script>
+
+    var field = document.getElementById("input_field");
+
+    if (typeof(field.validationMessage) == "string") {
+      test(function() {
+        assert_equals(field.validationMessage, "", "validationMessage attribute is not correct.");
+      });
+    } else {
+      test(function() {
+        assert_unreached("validationMessage attribute is not exist.");
+      });
+    }
+
+  </script>
+
+ </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/input-validationmessage.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/input-validationmessage.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>Forms</title>
+  <script src="../../../../resources/testharness.js"></script>
+  <script src="../../../../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <p>
+    <h3>input_validationMessage</h3>
+  </p>
+
+  <hr>
+
+  <div id="log"></div>
+
+  <form method="post"
+      enctype="application/x-www-form-urlencoded"
+      action=""
+      id="input_form">
+    <p><input type='hidden' id='input_text'></p>
+  </form>
+  <script>
+
+    var input = document.getElementById("input_text");
+
+    if (typeof(input.validationMessage) == "string") {
+      test(function() {
+        assert_equals(input.validationMessage, "", "validationMessage attribute is not correct.");
+      });
+    } else {
+      test(function() {
+        assert_unreached("validationMessage attribute is not exist.");
+      });
+    }
+
+  </script>
+
+ </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-output-element/output-validity.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-output-element/output-validity.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<title>:valid and :invalid pseudo-class on output element</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<output id='output_test'></output>
+
+<script>
+
+test(() => {
+  let output = document.getElementById("output_test");
+  assert_false(output.matches(":valid"), "should not match :valid pseudo-class");
+  assert_false(output.matches(":invalid"), "should not match :invalid pseudo-class");
+
+  output.setCustomValidity("custom error");
+  assert_equals(output.validationMessage, "", "should not have a validation message");
+  assert_true(output.validity.customError, "should have a custom error");
+  assert_false(output.validity.valid, "should not be valid with a custom error");
+  assert_false(output.matches(":valid"), "should still not match :valid pseudo-class");
+  assert_false(output.matches(":invalid"), "should still not match :invalid pseudo-class");
+}, ":valid and :invalid pseudo-class on output element")
+
+</script>


### PR DESCRIPTION
HTML Elements with the field validationMessage are now handled to contain the correct message when retrieved.