### PR TITLE
LibWeb: Unregister Element from all ResizeObservers when it's removed

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -695,6 +695,7 @@ public:
     void register_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, IntersectionObserver::IntersectionObserver&);
     void unregister_intersection_observer(Badge<IntersectionObserver::IntersectionObserver>, IntersectionObserver::IntersectionObserver&);
 
+    auto& resize_observers(Badge<Element>) { return m_resize_observers; }
     void register_resize_observer(Badge<ResizeObserver::ResizeObserver>, ResizeObserver::ResizeObserver&);
     void unregister_resize_observer(Badge<ResizeObserver::ResizeObserver>, ResizeObserver::ResizeObserver&);
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1365,6 +1365,10 @@ void Element::removed_from(Node* old_parent, Node& old_root)
 
     play_or_cancel_animations_after_display_property_change();
     remove_animations_from_timeline();
+
+    for (auto& resize_observer : document().resize_observers({})) {
+        resize_observer.unobserve(*this);
+    }
 }
 
 void Element::moved_from(GC::Ptr<Node> old_parent)


### PR DESCRIPTION
...from DOM tree. Fixes GC leak of ResizeObserver.