### PR TITLE
Base: Stop relying on const-ness not being enforced by LibJS

### DIFF
--- a/Base/res/ladybird/about-pages/settings/search.js
+++ b/Base/res/ladybird/about-pages/settings/search.js
@@ -164,7 +164,7 @@ function addCustomSearchEngine() {
     searchCustomName.classList.remove("error");
     searchCustomURL.classList.remove("error");
 
-    for (const i = 0; i < searchEngine.length; ++i) {
+    for (let i = 0; i < searchEngine.length; ++i) {
         if (searchCustomName.value === searchEngine.item(i).value) {
             searchCustomName.classList.add("error");
             return;


### PR DESCRIPTION
## PR Summary
This PR fixes a runtime issue in `addCustomSearchEngine` by replacing `const` with `let` in a for loop to allow correct iteration and engine name comparison.