### PR TITLE
LibWeb: Make StyleComputer and FontLoader GC-allocated

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -128,6 +128,7 @@ void CSSStyleSheet::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_namespace_rules);
     visitor.visit(m_import_rules);
     visitor.visit(m_owning_documents_or_shadow_roots);
+    visitor.visit(m_associated_font_loaders);
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylesheet-insertrule

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -91,7 +91,7 @@ public:
     void set_source_text(String);
     Optional<String> source_text(Badge<DOM::Document>) const;
 
-    void add_associated_font_loader(WeakPtr<FontLoader const> font_loader)
+    void add_associated_font_loader(GC::Ref<FontLoader const> font_loader)
     {
         m_associated_font_loaders.append(font_loader);
     }
@@ -126,7 +126,7 @@ private:
     bool m_disallow_modification { false };
     Optional<bool> m_did_match;
 
-    Vector<WeakPtr<FontLoader const>> m_associated_font_loaders;
+    Vector<GC::Ptr<FontLoader const>> m_associated_font_loaders;
 };
 
 }

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -499,7 +499,7 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                 {},                // FIXME: feature_settings
                 {},                // FIXME: variation_settings
             };
-            if (auto loader = style_computer.load_font_face(parsed_font_face, move(on_load)); loader.has_value())
+            if (auto loader = style_computer.load_font_face(parsed_font_face, move(on_load)))
                 loader->start_loading_next_url();
         } else {
             // FIXME: Don't know how to load fonts in workers! They don't have a StyleComputer

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -459,7 +459,7 @@ GC::Ref<Document> Document::create_for_fragment_parsing(JS::Realm& realm)
 Document::Document(JS::Realm& realm, const URL::URL& url, TemporaryDocumentForFragmentParsing temporary_document_for_fragment_parsing)
     : ParentNode(realm, *this, NodeType::DOCUMENT_NODE)
     , m_page(Bindings::principal_host_defined_page(realm))
-    , m_style_computer(make<CSS::StyleComputer>(*this))
+    , m_style_computer(realm.heap().allocate<CSS::StyleComputer>(*this))
     , m_url(url)
     , m_temporary_document_for_fragment_parsing(temporary_document_for_fragment_parsing)
     , m_editing_host_manager(EditingHostManager::create(realm, *this))
@@ -557,7 +557,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_appropriate_template_contents_owner_document);
     visitor.visit(m_pending_parsing_blocking_script);
     visitor.visit(m_history);
-
+    visitor.visit(m_style_computer);
     visitor.visit(m_browsing_context);
 
     visitor.visit(m_applets);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -965,7 +965,7 @@ private:
     void run_csp_initialization() const;
 
     GC::Ref<Page> m_page;
-    OwnPtr<CSS::StyleComputer> m_style_computer;
+    GC::Ptr<CSS::StyleComputer> m_style_computer;
     GC::Ptr<CSS::StyleSheetList> m_style_sheets;
     GC::Ptr<Node> m_active_favicon;
     GC::Ptr<HTML::BrowsingContext> m_browsing_context;


### PR DESCRIPTION
This allows them to keep style sheets alive while loading fonts for them. Fixes some GC crashes seen on the WPT WOFF2 tests after 66a19b85501dad8c0bfc5577b8d0b835877ad0dc stopped FetchRecord leaks from keeping various other things alive.