### PR TITLE
LibWeb: Use ConservativeVector for recorded node values in Editing API

### DIFF
--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -240,7 +240,7 @@ bool command_delete_action(DOM::Document& document, Utf16String const&)
 
         // 3. Record the values of the one-node list consisting of node, and let values be the
         //    result.
-        auto values = record_the_values_of_nodes({ *node });
+        auto values = record_the_values_of_nodes(document.heap(), { *node });
 
         // 4. Split the parent of the one-node list consisting of node.
         split_the_parent_of_nodes({ *node });
@@ -666,7 +666,7 @@ bool command_format_block_action(DOM::Document& document, Utf16String const& val
     });
 
     // 7. Record the values of node list, and let values be the result.
-    auto values = record_the_values_of_nodes(node_list);
+    auto values = record_the_values_of_nodes(document.heap(), node_list);
 
     // 8. For each node in node list, while node is the descendant of an editable HTML element in the same editing host,
     //    whose local name is a formattable block name, and which is not the ancestor of a prohibited paragraph child,
@@ -714,7 +714,7 @@ bool command_format_block_action(DOM::Document& document, Utf16String const& val
             });
 
             // 2. Record the values of sublist, and let values be the result.
-            auto values = record_the_values_of_nodes(sublist);
+            auto values = record_the_values_of_nodes(document.heap(), sublist);
 
             // 3. Remove the first member of node list from its parent, preserving its descendants.
             remove_node_preserving_its_descendants(node_list.first());
@@ -2141,7 +2141,7 @@ bool command_outdent_action(DOM::Document& document, Utf16String const&)
             sublist.append(node_list.take_first());
 
         // 6. Record the values of sublist, and let values be the result.
-        auto values = record_the_values_of_nodes(sublist);
+        auto values = record_the_values_of_nodes(document.heap(), sublist);
 
         // 7. Split the parent of sublist.
         split_the_parent_of_nodes(sublist);

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.h
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.h
@@ -106,7 +106,7 @@ Optional<DOM::BoundaryPoint> previous_equivalent_point(DOM::BoundaryPoint);
 void push_down_values(FlyString const&, GC::Ref<DOM::Node>, Optional<Utf16String const&>);
 Vector<RecordedOverride> record_current_overrides(DOM::Document const&);
 Vector<RecordedOverride> record_current_states_and_values(DOM::Document const&);
-Vector<RecordedNodeValue> record_the_values_of_nodes(Vector<GC::Ref<DOM::Node>> const&);
+GC::ConservativeVector<RecordedNodeValue> record_the_values_of_nodes(GC::Heap&, Vector<GC::Ref<DOM::Node>> const&);
 void remove_extraneous_line_breaks_at_the_end_of_node(GC::Ref<DOM::Node>);
 void remove_extraneous_line_breaks_before_node(GC::Ref<DOM::Node>);
 void remove_extraneous_line_breaks_from_a_node(GC::Ref<DOM::Node>);


### PR DESCRIPTION
The `RecordedNodeValue` struct contains a `GC::Ref` to a DOM node, which might disappear as a result of a garbage collection. For example, during the "outdent" command, we record nodes, split the parent of those nodes potentially resulting in all kinds of DOM changes, and then try to restore the nodes' values. This caused a crash in the `editing/run/outdent.html` WPT subtests.

By returning a `ConservativeVector`, we make sure the `GC::Ref` gets marked during sweeps and nodes do not suddenly disappear.

CC @kalenikaliaksandr @tcl3 