### PR TITLE
LibWeb: Add indentation to display list dumps

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -99,14 +99,20 @@ struct DrawRepeatedImmutableBitmap {
 };
 
 struct Save {
+    static constexpr int nesting_level_change = 1;
+
     void dump(StringBuilder&) const;
 };
 
 struct SaveLayer {
+    static constexpr int nesting_level_change = 1;
+
     void dump(StringBuilder&) const;
 };
 
 struct Restore {
+    static constexpr int nesting_level_change = -1;
+
     void dump(StringBuilder&) const;
 };
 
@@ -127,6 +133,8 @@ struct AddClipRect {
 };
 
 struct PushStackingContext {
+    static constexpr int nesting_level_change = 1;
+
     float opacity;
     Gfx::CompositingAndBlendingOperator compositing_and_blending_operator;
     bool isolate;
@@ -145,6 +153,8 @@ struct PushStackingContext {
 };
 
 struct PopStackingContext {
+    static constexpr int nesting_level_change = -1;
+
     void dump(StringBuilder&) const;
 };
 
@@ -445,16 +455,22 @@ struct PaintScrollBar {
 };
 
 struct ApplyOpacity {
+    static constexpr int nesting_level_change = 1;
+
     float opacity;
     void dump(StringBuilder&) const;
 };
 
 struct ApplyCompositeAndBlendingOperator {
+    static constexpr int nesting_level_change = 1;
+
     Gfx::CompositingAndBlendingOperator compositing_and_blending_operator;
     void dump(StringBuilder&) const;
 };
 
 struct ApplyFilter {
+    static constexpr int nesting_level_change = 1;
+
     Gfx::Filter filter;
     void dump(StringBuilder&) const;
 };

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -455,6 +455,7 @@ struct PaintScrollBar {
 };
 
 struct ApplyOpacity {
+    // Implementation of this item does saveLayer(), so we need to increment the nesting level.
     static constexpr int nesting_level_change = 1;
 
     float opacity;
@@ -462,6 +463,7 @@ struct ApplyOpacity {
 };
 
 struct ApplyCompositeAndBlendingOperator {
+    // Implementation of this item does saveLayer(), so we need to increment the nesting level.
     static constexpr int nesting_level_change = 1;
 
     Gfx::CompositingAndBlendingOperator compositing_and_blending_operator;
@@ -469,6 +471,7 @@ struct ApplyCompositeAndBlendingOperator {
 };
 
 struct ApplyFilter {
+    // Implementation of this item does saveLayer(), so we need to increment the nesting level.
     static constexpr int nesting_level_change = 1;
 
     Gfx::Filter filter;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -462,7 +462,7 @@ void DisplayListRecorder::apply_opacity(float opacity)
 void DisplayListRecorder::apply_compositing_and_blending_operator(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator)
 {
     // Implementation of this item does saveLayer(), so we need to increment the nesting level.
-    m_save_nesting_level++;
+    ++m_save_nesting_level;
     APPEND(ApplyCompositeAndBlendingOperator { .compositing_and_blending_operator = compositing_and_blending_operator });
 }
 

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -1,10 +1,10 @@
 SaveLayer
-PushStackingContext opacity=1 isolate=false has_clip_path=false transform=[1 0 0 1 0 0]
-PushStackingContext opacity=1 isolate=false has_clip_path=false transform=[1 0 0 1 0 0]
-FillPathUsingColor
-FillRect rect=[10,10 300x150] color=rgb(240, 128, 128)
-DrawGlyphRun rect=[10,10 38x18] translation=[10,23.796875] color=rgb(0, 0, 0) scale=1
-PopStackingContext
-PopStackingContext
+  PushStackingContext opacity=1 isolate=false has_clip_path=false transform=[1 0 0 1 0 0]
+    PushStackingContext opacity=1 isolate=false has_clip_path=false transform=[1 0 0 1 0 0]
+      FillPathUsingColor
+      FillRect rect=[10,10 300x150] color=rgb(240, 128, 128)
+      DrawGlyphRun rect=[10,10 38x18] translation=[10,23.796875] color=rgb(0, 0, 0) scale=1
+    PopStackingContext
+  PopStackingContext
 Restore
 


### PR DESCRIPTION
Output display list dumps with an indentation level to show balanced commands. It makes it much easier to see what is happening between e.g. PushStackingContext and PopStackingContext, or SaveLayer and Restore.