### PR TITLE
LibWeb: Set filename of module scripts to full URL instead of basename

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -713,7 +713,7 @@ void fetch_single_module_script(JS::Realm& realm,
         // 7. If mimeType is a JavaScript MIME type and moduleType is "javascript", then set moduleScript to the result of creating a JavaScript module script given sourceText, moduleMapRealm, response's URL, and options.
         // FIXME: Pass options.
         if (mime_type.has_value() && mime_type->is_javascript() && module_type == "javascript")
-            module_script = JavaScriptModuleScript::create(url.basename(), source_text, module_map_realm, response->url().value_or({})).release_value_but_fixme_should_propagate_errors();
+            module_script = JavaScriptModuleScript::create(url.to_byte_string(), source_text, module_map_realm, response->url().value_or({})).release_value_but_fixme_should_propagate_errors();
 
         // FIXME: 8. If the MIME type essence of mimeType is "text/css" and moduleType is "css", then set moduleScript to the result of creating a CSS module script given sourceText and settingsObject.
         // FIXME: 9. If mimeType is a JSON MIME type and moduleType is "json", then set moduleScript to the result of creating a JSON module script given sourceText and settingsObject.

--- a/Tests/LibWeb/Text/expected/error-stack-must-contain-full-url.txt
+++ b/Tests/LibWeb/Text/expected/error-stack-must-contain-full-url.txt
@@ -1,0 +1,11 @@
+classic: Error
+    at Error
+    at blob:file:///[flaky-uuid-replaced]:3:36
+
+module: Error
+    at Error
+    at blob:file:///[flaky-uuid-replaced]:3:36
+    at <unknown>
+    at <unknown>
+    at <unknown>
+

--- a/Tests/LibWeb/Text/input/error-stack-must-contain-full-url.html
+++ b/Tests/LibWeb/Text/input/error-stack-must-contain-full-url.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="script-container"></div>
+<script>
+    asyncTest(async (done) => {
+        const scriptContainer = document.getElementById("script-container");
+
+        const createScript = (type) => {
+            return new Promise((resolve) => {
+                const scriptSource = `
+                    try {
+                        throw Error();
+                    } catch (e) {
+                        const uuidRegex = /[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+/g;
+                        globalThis.println("${type}: " + e.stack.replace(uuidRegex, "[flaky-uuid-replaced]"));
+                    }
+                `;
+
+                const scriptBlob = new Blob([scriptSource], { type: "text/javascript" });
+                const scriptBlobUrl = URL.createObjectURL(scriptBlob);
+
+                const script = document.createElement("script");
+                script.onload = () => {
+                    resolve();
+                };
+                script.src = scriptBlobUrl;
+
+                if (type !== "classic")
+                    script.type = type;
+
+                scriptContainer.appendChild(script);
+            });
+        };
+
+        const scriptPromises = [
+            createScript("classic"),
+            createScript("module"),
+        ];
+
+        await Promise.all(scriptPromises);
+        done();
+    });
+</script>


### PR DESCRIPTION
Atlassian login gets the base URL for its module scripts by throwing an error and pulling out the current script's URL from error.stack with regex.

Since we only returned a basename for module scripts, it would fail to match and try and use `/` as a base URL (because it does [matched_string] + "/"), which is not a valid base URL.