### PR TITLE
LibWeb/HTML: Fix SVG script element unclosed in parser

### DIFF
--- a/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -69,6 +69,10 @@ void SVGScriptElement::process_the_script_element()
     if (m_already_processed || !in_a_document_tree())
         return;
 
+    // This prevents execution of scripts that were implicitly closed by end of SVG context
+    if (!m_properly_closed)
+        return;
+
     // https://svgwg.org/svg2-draft/interact.html#ScriptElement
     // Before attempting to execute the ‘script’ element the resolved media type value for ‘type’ must be inspected.
     // If the SVG user agent does not support the scripting language then the ‘script’ element must not be executed.

--- a/Libraries/LibWeb/SVG/SVGScriptElement.h
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.h
@@ -23,6 +23,7 @@ public:
 
     void set_parser_inserted(Badge<HTML::HTMLParser>) { m_parser_inserted = true; }
     void set_source_line_number(Badge<HTML::HTMLParser>, size_t source_line_number) { m_source_line_number = source_line_number; }
+    void set_properly_closed(Badge<HTML::HTMLParser>) { m_properly_closed = true; }
 
     virtual void inserted() override;
     virtual void children_changed(ChildrenChangedMetadata const*) override;
@@ -40,6 +41,7 @@ private:
 
     bool m_already_processed { false };
     bool m_parser_inserted { false };
+    bool m_properly_closed { false };
 
     GC::Ptr<HTML::ClassicScript> m_script;
 


### PR DESCRIPTION
- Mark SVG script elements as parser-inserted upon insertion.
- Ensure self-closing SVG script elements are properly closed.
- Update end tag handling for proper SVG script closure.
- Prevent execution of improperly closed SVG scripts.

Fix #5688

Tested using:
`./Meta/WPT.sh run html/syntax/parsing/unclosed-svg-script.html`

I am new here, trying to make my first contribution. Please let me know if any changes are needed.
