### PR TITLE
LibWeb: Ensure image context menu uses the correct image source

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -48,7 +48,6 @@ public:
     }
 
     String alt() const { return get_attribute_value(HTML::AttributeNames::alt); }
-    String src() const { return get_attribute_value(HTML::AttributeNames::src); }
 
     RefPtr<Gfx::ImmutableBitmap> immutable_bitmap() const;
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -547,7 +547,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPix
                 } else if (button == UIEvents::MouseButton::Secondary) {
                     if (is<HTML::HTMLImageElement>(*node)) {
                         auto& image_element = as<HTML::HTMLImageElement>(*node);
-                        auto image_url = image_element.document().encoding_parse_url(image_element.src());
+                        auto image_url = image_element.document().encoding_parse_url(image_element.current_src());
                         if (image_url.has_value()) {
                             Optional<Gfx::Bitmap const*> bitmap;
                             if (image_element.immutable_bitmap())


### PR DESCRIPTION
Previously, the value of the `src` tag would always be used as the image source URL when requesting an image context menu, which may not be correct if an image uses a `srcset` or has a parent picture tag.

Fixes #5689 

Here's a demo of the fixed behavior on: https://jpegxl.info

https://github.com/user-attachments/assets/e0b45a65-7970-4469-be02-65cc83209a8e

As far as I can tell there isn't an easy way to add an automated test for this.
