### PR TITLE
LibWeb: Fix local storage type in Window::local_storage()

### DIFF
--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -477,7 +477,7 @@ WebIDL::ExceptionOr<GC::Ref<Storage>> Window::local_storage()
         return WebIDL::SecurityError::create(realm, "localStorage is not available"_string);
 
     // 4. Let storage be a new Storage object whose map is map.
-    auto storage = Storage::create(realm, Storage::Type::Session, *map);
+    auto storage = Storage::create(realm, Storage::Type::Local, *map);
 
     // 5. Set this's associated Document's local storage holder to storage.
     associated_document.set_local_storage_holder(storage);


### PR DESCRIPTION
The storage type was being incorrectly set to Session instead of Local, apparently because of copying the implementation from `Window::session_storage()`.

Bug introduced in commit https://github.com/LadybirdBrowser/ladybird/commit/2066ed2318eae490e7581a634959637698861e5a