### PR TITLE
LibWeb/CSS: Set style sheet for children of ContentStyleValue

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.cpp
@@ -19,4 +19,12 @@ String ContentStyleValue::to_string(SerializationMode mode) const
     return m_properties.content->to_string(mode);
 }
 
+void ContentStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
+{
+    Base::set_style_sheet(style_sheet);
+    const_cast<StyleValueList&>(*m_properties.content).set_style_sheet(style_sheet);
+    if (m_properties.alt_text)
+        const_cast<StyleValueList&>(*m_properties.alt_text).set_style_sheet(style_sheet);
+}
+
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
@@ -29,6 +29,8 @@ public:
 
     bool properties_equal(ContentStyleValue const& other) const { return m_properties == other.m_properties; }
 
+    virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
+
 private:
     ContentStyleValue(ValueComparingNonnullRefPtr<StyleValueList const> content, ValueComparingRefPtr<StyleValueList const> alt_text)
         : StyleValueWithDefaultOperators(Type::Content)

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
@@ -40,14 +40,14 @@ public:
 
     Separator separator() const { return m_properties.separator; }
 
+    virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
+
 private:
     StyleValueList(StyleValueVector&& values, Separator separator)
         : StyleValueWithDefaultOperators(Type::ValueList)
         , m_properties { .separator = separator, .values = move(values) }
     {
     }
-
-    virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
 
     struct Properties {
         Separator separator;


### PR DESCRIPTION
Without this, any relative url()s in the `content` property don't know what style sheet they are in, which makes them load relative to the document instead.

Progress on https://www.w3.org/Style/CSS/all-properties.en.html :

## Before
<img width="1332" height="714" alt="Screenshot_20250804_142040" src="https://github.com/user-attachments/assets/d2f170e8-c857-4c21-bc75-31e6b5abd8e5" />

## After
<img width="1332" height="714" alt="Screenshot_20250804_142005" src="https://github.com/user-attachments/assets/5913fe07-6f9c-49b5-a3c5-aea1e56b7878" />
