### PR TITLE
LibWeb: Remove extraneous trailing '/' from service worker script scope

### DIFF
--- a/Libraries/LibWeb/ServiceWorker/Job.cpp
+++ b/Libraries/LibWeb/ServiceWorker/Job.cpp
@@ -289,10 +289,7 @@ static void update(JS::VM& vm, GC::Ref<Job> job)
             auto join_paths_with_slash = [](URL::URL const& url) -> ByteString {
                 StringBuilder builder;
                 builder.append('/');
-                for (auto const& component : url.paths()) {
-                    builder.append(component);
-                    builder.append('/');
-                }
+                builder.join('/', url.paths());
                 return builder.to_byte_string();
             };
 


### PR DESCRIPTION
The spec language specifies 'Set maxScopeString to "/", followed by the strings in XXXX’s path (including empty strings), separated from each other by "/"': That is, adjacent components are separated by a '/', but the last component does not get a trailing '/'.

This resulted in the generated scope string ending with '//' in some cases, incorrectly tripping the 'Service-Worker-Allowed' security check.

Found this while investigating some unrelated WPT failures.