### PR TITLE
LibWeb: Correctly round non-integer z-indexes

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -338,7 +338,7 @@ Optional<int> ComputedProperties::z_index() const
         return {};
 
     // Clamp z-index to the range of a signed 32-bit integer for consistency with other engines.
-    auto clamp = [](auto number) -> int {
+    auto clamp = [](long number) -> int {
         if (number >= NumericLimits<int>::max())
             return NumericLimits<int>::max();
         if (number <= NumericLimits<int>::min())
@@ -352,7 +352,8 @@ Optional<int> ComputedProperties::z_index() const
     if (value.is_calculated()) {
         auto maybe_double = value.as_calculated().resolve_number_deprecated({});
         if (maybe_double.has_value()) {
-            return clamp(maybe_double.value());
+            // Round up on half
+            return clamp(floor(maybe_double.value() + 0.5f));
         }
     }
     return {};

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-z-index-fractions-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-z-index-fractions-001.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	testing z-index: calc(2.5 / 2)
+Pass	testing z-index: calc(3 / 2)
+Pass	testing z-index: calc(3.5 / 2)
+Pass	testing z-index: calc(-2.5 / 2)
+Pass	testing z-index: calc(-3 / 2)
+Pass	testing z-index: calc(-3.5 / 2)

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-z-index-fractions-001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-z-index-fractions-001.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+
+  <meta charset="UTF-8">
+
+  <title>CSS Values and Units Test: computed value of 'z-index' when specified with calc() function and fractional values</title>
+
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/">
+  <link rel="help" href="https://www.w3.org/TR/css-values-4/#calc-range">
+
+  <meta content="This test verifies how 2 calc() functions are computed for 'z-index' when involved expressions end up being numbers halfway between adjacent integers." name="assert">
+
+  <script src="../../resources/testharness.js"></script>
+
+  <script src="../../resources/testharnessreport.js"></script>
+
+  <div id="target"></div>
+
+  <script>
+  function startTesting()
+  {
+
+  var targetElement = document.getElementById("target");
+
+    function verifyComputedStyle(property_name, initial_value, specified_value, expected_value)
+    {
+
+    test(function()
+      {
+
+      targetElement.style.setProperty(property_name, initial_value);
+
+      /*
+      The purpose of the initial_value is to act as a fallback
+      value in case the calc() function in the specified value
+      fails or in case it generates an invalid value. Since we
+      are running 2 consecutive tests on the same element,
+      then it is necessary to reset its property to an initial
+      value.
+      */
+
+      targetElement.style.setProperty(property_name, specified_value);
+
+      assert_equals(getComputedStyle(targetElement)[property_name], expected_value);
+
+      }, `testing ${property_name}: ${specified_value}`);
+    }
+
+ /* verifyComputedStyle(property_name, initial_value, specified_value, expected_value) */
+    verifyComputedStyle("z-index", "auto", "calc(2.5 / 2)", "1");
+    verifyComputedStyle("z-index", "auto", "calc(3 / 2)", "2");
+    verifyComputedStyle("z-index", "auto", "calc(3.5 / 2)", "2");
+    verifyComputedStyle("z-index", "auto", "calc(-2.5 / 2)", "-1");
+    verifyComputedStyle("z-index", "auto", "calc(-3 / 2)", "-1");
+    verifyComputedStyle("z-index", "auto", "calc(-3.5 / 2)", "-2");
+  }
+
+  startTesting();
+
+  </script>


### PR DESCRIPTION
Previously we would just cast to an int.

Gains us 3 WPT tests.