### PR TITLE
LibWeb: Improve handling of non-finite values in calcs

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1052,6 +1052,13 @@ static Optional<CalculatedStyleValue::CalculationResult> run_min_or_max_operatio
             if (!consistent_type.has_value())
                 return {};
 
+            // https://drafts.csswg.org/css-values-4/#calc-ieee
+            // Any operation with at least one NaN argument produces NaN.
+            if (isnan(child_value->value()) || isnan(result->value())) {
+                result = CalculatedStyleValue::CalculationResult { AK::NaN<double>, consistent_type };
+                continue;
+            }
+
             if (min_or_max == MinOrMax::Min) {
                 if (child_value->value() < result->value()) {
                     result = CalculatedStyleValue::CalculationResult { child_value->value(), consistent_type };

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1269,6 +1269,11 @@ Optional<CalculatedStyleValue::CalculationResult> ClampCalculationNode::run_oper
     if (!consistent_type.has_value())
         return {};
 
+    // https://drafts.csswg.org/css-values-4/#calc-ieee
+    // Any operation with at least one NaN argument produces NaN.
+    if (isnan(min_result->value()) || isnan(center_result->value()) || isnan(max_result->value()))
+        return CalculatedStyleValue::CalculationResult { AK::NaN<double>, consistent_type.release_value() };
+
     auto chosen_value = max(min_result->value(), min(center_result->value(), max_result->value()));
     return CalculatedStyleValue::CalculationResult { chosen_value, consistent_type.release_value() };
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-catch-divide-by-0.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-catch-divide-by-0.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 21 tests
 
-17 Pass
-4 Fail
+19 Pass
+2 Fail
 Pass	'calc(100px * 0 / 0)' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(100px / 0)' as a specified value should serialize as 'calc(infinity * 1px)'.
 Pass	'calc(100px / (0))' as a specified value should serialize as 'calc(infinity * 1px)'.
@@ -19,9 +19,9 @@ Pass	'calc(1px * max(0/0, 0))' as a specified value should serialize as 'calc(Na
 Pass	'calc(1px * min(0/0, 0))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * max(0/0, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(0/0, 0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * max(0, min(10, 0/0)))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * max(0, min(10, 0/0)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Fail	'calc(1px * clamp(0, 10, 0/0))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * max(0, min(0/0, 10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * max(0, min(0/0, 10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Fail	'calc(1px * clamp(0, 0/0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(-1/0, 0, 1/0))' as a specified value should serialize as 'calc(0px)'.
 Pass	'calc(1px * clamp(-1/0, 1/0, 10))' as a specified value should serialize as 'calc(10px)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-catch-divide-by-0.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-catch-divide-by-0.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 21 tests
 
-19 Pass
-2 Fail
+21 Pass
 Pass	'calc(100px * 0 / 0)' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(100px / 0)' as a specified value should serialize as 'calc(infinity * 1px)'.
 Pass	'calc(100px / (0))' as a specified value should serialize as 'calc(infinity * 1px)'.
@@ -20,8 +19,8 @@ Pass	'calc(1px * min(0/0, 0))' as a specified value should serialize as 'calc(Na
 Pass	'calc(1px * max(0/0, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(0/0, 0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * max(0, min(10, 0/0)))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * clamp(0, 10, 0/0))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * clamp(0, 10, 0/0))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * max(0, min(0/0, 10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * clamp(0, 0/0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * clamp(0, 0/0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(-1/0, 0, 1/0))' as a specified value should serialize as 'calc(0px)'.
 Pass	'calc(1px * clamp(-1/0, 1/0, 10))' as a specified value should serialize as 'calc(10px)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-catch-divide-by-0.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-catch-divide-by-0.txt
@@ -1,0 +1,27 @@
+Harness status: OK
+
+Found 21 tests
+
+17 Pass
+4 Fail
+Pass	'calc(100px * 0 / 0)' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(100px / 0)' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(100px / (0))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(100px / (2 - 2))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(100px / (2 - (-62 + 64)))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(100px * (1 / 0))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(100px * (1 / (0)))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(100px * (1 / (2 - 2)))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(100px * (1 / (2 - (-62 + 64))))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(1px * max(1/0, 0))' as a specified value should serialize as 'calc(infinity * 1px)'.
+Pass	'calc(1px * min(1/0, 0))' as a specified value should serialize as 'calc(0px)'.
+Pass	'calc(1px * max(0/0, 0))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * min(0/0, 0))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * max(0/0, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * clamp(0/0, 0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Fail	'calc(1px * max(0, min(10, 0/0)))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Fail	'calc(1px * clamp(0, 10, 0/0))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Fail	'calc(1px * max(0, min(0/0, 10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Fail	'calc(1px * clamp(0, 0/0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * clamp(-1/0, 0, 1/0))' as a specified value should serialize as 'calc(0px)'.
+Pass	'calc(1px * clamp(-1/0, 1/0, 10))' as a specified value should serialize as 'calc(10px)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 45 tests
 
-24 Pass
-21 Fail
+26 Pass
+19 Fail
 Pass	Property width value 'calc(NaN * 1px)'
 Pass	Property width value 'calc(NaN * 1%)'
 Pass	Property width value 'calc(infinity * 1px)'
@@ -11,11 +11,11 @@ Pass	Property width value 'calc(infinity * 1%)'
 Pass	Property width value 'calc(infinity * 1cm)'
 Pass	Property width value 'calc(NaN * 1rem)'
 Pass	Property width value 'calc(10.135262721212548pc - 199pt / NaN)'
-Fail	Property width value 'max(15px, NaN * 1px)'
+Pass	Property width value 'max(15px, NaN * 1px)'
 Pass	Property width value 'max(NaN * 1px, 15px)'
 Pass	Property width value 'max(-15px, NaN * 1px)'
 Pass	Property width value 'max(NaN * 1px, -15px)'
-Fail	Property width value 'min(15px, NaN * 1px)'
+Pass	Property width value 'min(15px, NaN * 1px)'
 Pass	Property width value 'min(NaN * 1px, 15px)'
 Pass	Property width value 'min(-15px, NaN * 1px)'
 Pass	Property width value 'min(NaN * 1px, -15px)'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 45 tests
 
-33 Pass
-12 Fail
+24 Pass
+21 Fail
 Pass	Property width value 'calc(NaN * 1px)'
 Pass	Property width value 'calc(NaN * 1%)'
 Pass	Property width value 'calc(infinity * 1px)'
@@ -11,11 +11,11 @@ Pass	Property width value 'calc(infinity * 1%)'
 Pass	Property width value 'calc(infinity * 1cm)'
 Pass	Property width value 'calc(NaN * 1rem)'
 Pass	Property width value 'calc(10.135262721212548pc - 199pt / NaN)'
-Pass	Property width value 'max(15px, NaN * 1px)'
+Fail	Property width value 'max(15px, NaN * 1px)'
 Pass	Property width value 'max(NaN * 1px, 15px)'
 Pass	Property width value 'max(-15px, NaN * 1px)'
 Pass	Property width value 'max(NaN * 1px, -15px)'
-Pass	Property width value 'min(15px, NaN * 1px)'
+Fail	Property width value 'min(15px, NaN * 1px)'
 Pass	Property width value 'min(NaN * 1px, 15px)'
 Pass	Property width value 'min(-15px, NaN * 1px)'
 Pass	Property width value 'min(NaN * 1px, -15px)'
@@ -30,13 +30,13 @@ Pass	Property margin-left value 'calc(-infinity * 1%)'
 Pass	Property margin-left value 'calc(max(10000px, 0px) + min(-infinity * 1px, infinity * 1px))'
 Pass	Property margin-left value 'calc(-infinity * 1px - infinity * 1px)'
 Pass	Property margin-left value 'calc(min(-infinity * 1px, 10px))'
-Pass	Property animation-duration value 'calc(NaN * 1s)'
-Pass	Property animation-duration value 'calc(infinity * 1s)'
-Pass	Property animation-duration value 'calc(1 / 0 * 1s)'
-Pass	Property animation-duration value 'calc(max(infinity * 1s, 10s)'
-Pass	Property transition-delay value 'calc(-infinity* 1s)'
-Pass	Property transition-delay value 'calc(max(10000s, 0s) + min(-infinity * 1s, infinity * 1s))'
-Pass	Property transition-delay value 'calc(min(-infinity * 1s, 10s))'
+Fail	Property animation-duration value 'calc(NaN * 1s)'
+Fail	Property animation-duration value 'calc(infinity * 1s)'
+Fail	Property animation-duration value 'calc(1 / 0 * 1s)'
+Fail	Property animation-duration value 'calc(max(infinity * 1s, 10s)'
+Fail	Property transition-delay value 'calc(-infinity* 1s)'
+Fail	Property transition-delay value 'calc(max(10000s, 0s) + min(-infinity * 1s, infinity * 1s))'
+Fail	Property transition-delay value 'calc(min(-infinity * 1s, 10s))'
 Fail	Property rotate(calc(infinity * 1deg)) value expected same with rotate(0deg) in +/-0.0001
 Fail	Property rotate(calc(-infinity * 1deg)) value expected same with rotate(0deg) in +/-0.0001
 Fail	Property rotate(calc(NaN * 1deg)) value expected same with rotate(0deg) in +/-0.0001

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.txt
@@ -1,0 +1,36 @@
+Harness status: OK
+
+Found 30 tests
+
+26 Pass
+4 Fail
+Pass	'rotate(calc(1deg * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1rad * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1turn * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1grad * nan))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * infinity / infinity))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * 0 * infinity))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * (infinity + -infinity)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * (-infinity + infinity)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * (infinity - infinity)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * infinity))' as a specified value should serialize as 'rotate(calc(infinity * 1deg))'.
+Pass	'rotate(calc(1deg * -infinity))' as a specified value should serialize as 'rotate(calc(-infinity * 1deg))'.
+Pass	'rotate(calc(1deg * iNFinIty))' as a specified value should serialize as 'rotate(calc(infinity * 1deg))'.
+Pass	'rotate(calc(1deg * (infinity + infinity)))' as a specified value should serialize as 'rotate(calc(infinity * 1deg))'.
+Pass	'rotate(calc(1deg * (-infinity + -infinity)))' as a specified value should serialize as 'rotate(calc(-infinity * 1deg))'.
+Pass	'rotate(calc(1deg * 1/infinity))' as a specified value should serialize as 'rotate(calc(0deg))'.
+Pass	'rotate(calc(1deg * infinity * infinity))' as a specified value should serialize as 'rotate(calc(infinity * 1deg))'.
+Pass	'rotate(calc(1deg * -infinity * -infinity))' as a specified value should serialize as 'rotate(calc(infinity * 1deg))'.
+Pass	'rotate(calc(1 * max(INFinity*3deg, 0deg)))' as a specified value should serialize as 'rotate(calc(infinity * 1deg))'.
+Pass	'rotate(calc(1 * min(inFInity*4deg, 0deg)))' as a specified value should serialize as 'rotate(calc(0deg))'.
+Pass	'rotate(calc(1 * max(nAn*2deg, 0deg)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1 * min(nan*3deg, 0deg)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1 * clamp(-INFINITY*20deg, 0deg, infiniTY*10deg)))' as a specified value should serialize as 'rotate(calc(0deg))'.
+Pass	'rotate(calc(1deg * max(NaN, min(0,10))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * clamp(NaN, 0, 10)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Fail	'rotate(calc(1deg * max(0, min(10, NaN))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Fail	'rotate(calc(1deg * clamp(0, 10, NaN)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Fail	'rotate(calc(1deg * max(0, min(NaN, 10))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Fail	'rotate(calc(1deg * clamp(0, NaN, 10)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * clamp(-Infinity, 0, infinity)))' as a specified value should serialize as 'rotate(calc(0deg))'.
+Pass	'rotate(calc(1deg * clamp(-inFinity, infinity, 10)))' as a specified value should serialize as 'rotate(calc(10deg))'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 30 tests
 
-26 Pass
-4 Fail
+28 Pass
+2 Fail
 Pass	'rotate(calc(1deg * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1rad * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1turn * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
@@ -28,9 +28,9 @@ Pass	'rotate(calc(1 * min(nan*3deg, 0deg)))' as a specified value should seriali
 Pass	'rotate(calc(1 * clamp(-INFINITY*20deg, 0deg, infiniTY*10deg)))' as a specified value should serialize as 'rotate(calc(0deg))'.
 Pass	'rotate(calc(1deg * max(NaN, min(0,10))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1deg * clamp(NaN, 0, 10)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
-Fail	'rotate(calc(1deg * max(0, min(10, NaN))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * max(0, min(10, NaN))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Fail	'rotate(calc(1deg * clamp(0, 10, NaN)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
-Fail	'rotate(calc(1deg * max(0, min(NaN, 10))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * max(0, min(NaN, 10))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Fail	'rotate(calc(1deg * clamp(0, NaN, 10)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1deg * clamp(-Infinity, 0, infinity)))' as a specified value should serialize as 'rotate(calc(0deg))'.
 Pass	'rotate(calc(1deg * clamp(-inFinity, infinity, 10)))' as a specified value should serialize as 'rotate(calc(10deg))'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 30 tests
 
-28 Pass
-2 Fail
+30 Pass
 Pass	'rotate(calc(1deg * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1rad * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1turn * NaN))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
@@ -29,8 +28,8 @@ Pass	'rotate(calc(1 * clamp(-INFINITY*20deg, 0deg, infiniTY*10deg)))' as a speci
 Pass	'rotate(calc(1deg * max(NaN, min(0,10))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1deg * clamp(NaN, 0, 10)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1deg * max(0, min(10, NaN))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
-Fail	'rotate(calc(1deg * clamp(0, 10, NaN)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * clamp(0, 10, NaN)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1deg * max(0, min(NaN, 10))))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
-Fail	'rotate(calc(1deg * clamp(0, NaN, 10)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
+Pass	'rotate(calc(1deg * clamp(0, NaN, 10)))' as a specified value should serialize as 'rotate(calc(NaN * 1deg))'.
 Pass	'rotate(calc(1deg * clamp(-Infinity, 0, infinity)))' as a specified value should serialize as 'rotate(calc(0deg))'.
 Pass	'rotate(calc(1deg * clamp(-inFinity, infinity, 10)))' as a specified value should serialize as 'rotate(calc(10deg))'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-length.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-length.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 41 tests
 
-37 Pass
-4 Fail
+39 Pass
+2 Fail
 Pass	'calc(1px * NaN)' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1% * NaN)' as a specified value should serialize as 'calc(NaN * 1%)'.
 Pass	'calc(1in * NaN)' as a specified value should serialize as 'calc(NaN * 1px)'.
@@ -36,9 +36,9 @@ Pass	'calc(1 * clamp(-INFINITY*20px, 0px, infiniTY*10px))' as a specified value 
 Pass	'calc(1px * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0px)'.
 Pass	'calc(1px * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10px)'.
 Pass	'calc(1 * min(NaN * 1pt, NaN * 1cm))' as a specified value should serialize as 'calc(NaN * 1px)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-length.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-length.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 41 tests
 
-35 Pass
-6 Fail
+37 Pass
+4 Fail
 Pass	'calc(1px * NaN)' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1% * NaN)' as a specified value should serialize as 'calc(NaN * 1%)'.
 Pass	'calc(1in * NaN)' as a specified value should serialize as 'calc(NaN * 1px)'.
@@ -35,9 +35,9 @@ Pass	'calc(1 * min(nan*3px, 0px))' as a specified value should serialize as 'cal
 Pass	'calc(1 * clamp(-INFINITY*20px, 0px, infiniTY*10px))' as a specified value should serialize as 'calc(0px)'.
 Pass	'calc(1px * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Fail	'calc(1px * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN * 1px)'.
-Fail	'calc(1px * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
+Pass	'calc(1px * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Fail	'calc(1px * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN * 1px)'.
 Pass	'calc(1px * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0px)'.
 Pass	'calc(1px * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10px)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-number.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-number.txt
@@ -1,0 +1,37 @@
+Harness status: OK
+
+Found 31 tests
+
+27 Pass
+4 Fail
+Pass	'calc(NaN)' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(infinity)' as a specified value should serialize as 'calc(infinity)'.
+Pass	'calc(-infinity)' as a specified value should serialize as 'calc(-infinity)'.
+Pass	'calc(1 * NaN)' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * nan)' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * infinity / infinity)' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * 0 * infinity)' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * (infinity + -infinity))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * (-infinity + infinity))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * (infinity - infinity))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * infinity)' as a specified value should serialize as 'calc(infinity)'.
+Pass	'calc(1 * -infinity)' as a specified value should serialize as 'calc(-infinity)'.
+Pass	'calc(1 * iNFinIty)' as a specified value should serialize as 'calc(infinity)'.
+Pass	'calc(1 * (infinity + infinity))' as a specified value should serialize as 'calc(infinity)'.
+Pass	'calc(1 * (-infinity + -infinity))' as a specified value should serialize as 'calc(-infinity)'.
+Pass	'calc(1 * 1/infinity)' as a specified value should serialize as 'calc(0)'.
+Pass	'calc(1 * infinity * infinity)' as a specified value should serialize as 'calc(infinity)'.
+Pass	'calc(1 * -infinity * -infinity)' as a specified value should serialize as 'calc(infinity)'.
+Pass	'calc(1 * max(INFinity*3, 0))' as a specified value should serialize as 'calc(infinity)'.
+Pass	'calc(1 * min(inFInity*4, 0))' as a specified value should serialize as 'calc(0)'.
+Pass	'calc(1 * max(nAn*2, 0))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * min(nan*3, 0))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * clamp(-INFINITY*20, 0, infiniTY*10))' as a specified value should serialize as 'calc(0)'.
+Pass	'calc(1 * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN)'.
+Fail	'calc(1 * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN)'.
+Fail	'calc(1 * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN)'.
+Fail	'calc(1 * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN)'.
+Fail	'calc(1 * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0)'.
+Pass	'calc(1 * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-number.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-number.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 31 tests
 
-29 Pass
-2 Fail
+31 Pass
 Pass	'calc(NaN)' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(infinity)' as a specified value should serialize as 'calc(infinity)'.
 Pass	'calc(-infinity)' as a specified value should serialize as 'calc(-infinity)'.
@@ -30,8 +29,8 @@ Pass	'calc(1 * clamp(-INFINITY*20, 0, infiniTY*10))' as a specified value should
 Pass	'calc(1 * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(1 * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(1 * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN)'.
-Fail	'calc(1 * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(1 * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN)'.
-Fail	'calc(1 * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(1 * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0)'.
 Pass	'calc(1 * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-number.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-number.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 31 tests
 
-27 Pass
-4 Fail
+29 Pass
+2 Fail
 Pass	'calc(NaN)' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(infinity)' as a specified value should serialize as 'calc(infinity)'.
 Pass	'calc(-infinity)' as a specified value should serialize as 'calc(-infinity)'.
@@ -29,9 +29,9 @@ Pass	'calc(1 * min(nan*3, 0))' as a specified value should serialize as 'calc(Na
 Pass	'calc(1 * clamp(-INFINITY*20, 0, infiniTY*10))' as a specified value should serialize as 'calc(0)'.
 Pass	'calc(1 * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(1 * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN)'.
-Fail	'calc(1 * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN)'.
 Fail	'calc(1 * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN)'.
-Fail	'calc(1 * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN)'.
+Pass	'calc(1 * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN)'.
 Fail	'calc(1 * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN)'.
 Pass	'calc(1 * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0)'.
 Pass	'calc(1 * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-time.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-time.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 29 tests
 
-25 Pass
-4 Fail
+27 Pass
+2 Fail
 Pass	'calc(1s * NaN)' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * nan)' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1ms * NaN)' as a specified value should serialize as 'calc(NaN * 1s)'.
@@ -27,9 +27,9 @@ Pass	'calc(1 * min(nan*3s, 0s))' as a specified value should serialize as 'calc(
 Pass	'calc(1 * clamp(-INFINITY*20s, 0s, infiniTY*10s))' as a specified value should serialize as 'calc(0s)'.
 Pass	'calc(1s * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN * 1s)'.
-Fail	'calc(1s * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Fail	'calc(1s * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN * 1s)'.
-Fail	'calc(1s * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Fail	'calc(1s * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0s)'.
 Pass	'calc(1s * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10s)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-time.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-time.txt
@@ -1,0 +1,35 @@
+Harness status: OK
+
+Found 29 tests
+
+25 Pass
+4 Fail
+Pass	'calc(1s * NaN)' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * nan)' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1ms * NaN)' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * infinity / infinity)' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * 0 * infinity)' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * (infinity + -infinity))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * (-infinity + infinity))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * (infinity - infinity))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * infinity)' as a specified value should serialize as 'calc(infinity * 1s)'.
+Pass	'calc(1s * -infinity)' as a specified value should serialize as 'calc(-infinity * 1s)'.
+Pass	'calc(1s * iNFinIty)' as a specified value should serialize as 'calc(infinity * 1s)'.
+Pass	'calc(1s * (infinity + infinity))' as a specified value should serialize as 'calc(infinity * 1s)'.
+Pass	'calc(1s * (-infinity + -infinity))' as a specified value should serialize as 'calc(-infinity * 1s)'.
+Pass	'calc(1s * 1/infinity)' as a specified value should serialize as 'calc(0s)'.
+Pass	'calc(1s * infinity * infinity)' as a specified value should serialize as 'calc(infinity * 1s)'.
+Pass	'calc(1s * -infinity * -infinity)' as a specified value should serialize as 'calc(infinity * 1s)'.
+Pass	'calc(1 * max(INFinity*3s, 0s))' as a specified value should serialize as 'calc(infinity * 1s)'.
+Pass	'calc(1 * min(inFInity*4s, 0s))' as a specified value should serialize as 'calc(0s)'.
+Pass	'calc(1 * max(nAn*2s, 0s))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1 * min(nan*3s, 0s))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1 * clamp(-INFINITY*20s, 0s, infiniTY*10s))' as a specified value should serialize as 'calc(0s)'.
+Pass	'calc(1s * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Fail	'calc(1s * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Fail	'calc(1s * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Fail	'calc(1s * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Fail	'calc(1s * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0s)'.
+Pass	'calc(1s * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10s)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-time.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/calc-infinity-nan-serialize-time.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 29 tests
 
-27 Pass
-2 Fail
+29 Pass
 Pass	'calc(1s * NaN)' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * nan)' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1ms * NaN)' as a specified value should serialize as 'calc(NaN * 1s)'.
@@ -28,8 +27,8 @@ Pass	'calc(1 * clamp(-INFINITY*20s, 0s, infiniTY*10s))' as a specified value sho
 Pass	'calc(1s * max(NaN, min(0,10)))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * clamp(NaN, 0, 10))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * max(0, min(10, NaN)))' as a specified value should serialize as 'calc(NaN * 1s)'.
-Fail	'calc(1s * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * clamp(0, 10, NaN))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * max(0, min(NaN, 10)))' as a specified value should serialize as 'calc(NaN * 1s)'.
-Fail	'calc(1s * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN * 1s)'.
+Pass	'calc(1s * clamp(0, NaN, 10))' as a specified value should serialize as 'calc(NaN * 1s)'.
 Pass	'calc(1s * clamp(-Infinity, 0, infinity))' as a specified value should serialize as 'calc(0s)'.
 Pass	'calc(1s * clamp(-inFinity, infinity, 10))' as a specified value should serialize as 'calc(10s)'.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/round-mod-rem-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/round-mod-rem-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 229 tests
 
-211 Pass
-18 Fail
+215 Pass
+14 Fail
 Pass	round(10,10) should be used-value-equivalent to 10
 Pass	mod(1,1) should be used-value-equivalent to 0
 Pass	rem(1,1) should be used-value-equivalent to 0
@@ -217,18 +217,18 @@ Pass	round(to-zero, 0, -Infinity) should be used-value-equivalent to 0
 Pass	round(to-zero, 4, -Infinity) should be used-value-equivalent to 0
 Pass	round(to-zero, -0, -Infinity) should be used-value-equivalent to calc(-0)
 Pass	round(to-zero, -4, -Infinity) should be used-value-equivalent to calc(-0)
-Fail	round(up, 1, Infinity) should be used-value-equivalent to calc(Infinity)
+Pass	round(up, 1, Infinity) should be used-value-equivalent to calc(Infinity)
 Pass	round(up, 0, Infinity) should be used-value-equivalent to 0
 Pass	round(up, -1, Infinity) should be used-value-equivalent to calc(-0)
-Fail	round(up, 1, -Infinity) should be used-value-equivalent to calc(Infinity)
+Pass	round(up, 1, -Infinity) should be used-value-equivalent to calc(Infinity)
 Pass	round(up, 0, -Infinity) should be used-value-equivalent to 0
 Pass	round(up, -1, -Infinity) should be used-value-equivalent to calc(-0)
 Pass	round(down, 1, Infinity) should be used-value-equivalent to calc(-0)
 Pass	round(down, 0, Infinity) should be used-value-equivalent to 0
-Fail	round(down, -1, Infinity) should be used-value-equivalent to calc(-Infinity)
+Pass	round(down, -1, Infinity) should be used-value-equivalent to calc(-Infinity)
 Pass	round(down, 1, -Infinity) should be used-value-equivalent to calc(-0)
 Pass	round(down, 0, -Infinity) should be used-value-equivalent to 0
-Fail	round(down, -1, -Infinity) should be used-value-equivalent to calc(-Infinity)
+Pass	round(down, -1, -Infinity) should be used-value-equivalent to calc(-Infinity)
 Pass	mod(-0, Infinity) should be used-value-equivalent to calc(NaN)
 Pass	mod(0, -Infinity) should be used-value-equivalent to calc(NaN)
 Pass	mod(-4, Infinity) should be used-value-equivalent to calc(NaN)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signed-zero.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signed-zero.txt
@@ -1,0 +1,168 @@
+Harness status: OK
+
+Found 162 tests
+
+154 Pass
+8 Fail
+Pass	sign(calc(-0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-0)), 1) should be used-value-equivalent to -1
+Pass	sign(calc( 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 0)), 1) should be used-value-equivalent to 1
+Pass	sign(calc(-0 * -1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-0 * -1)), 1) should be used-value-equivalent to 1
+Pass	sign(calc(-0 *  1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-0 *  1)), 1) should be used-value-equivalent to -1
+Pass	sign(calc( 0 * -1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 0 * -1)), 1) should be used-value-equivalent to -1
+Pass	sign(calc( 0 *  1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 0 *  1)), 1) should be used-value-equivalent to 1
+Pass	sign(calc(-1 / -infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-1 / -infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(calc(-1 /  infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-1 /  infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(calc( 1 / -infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 1 / -infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(calc( 1 /  infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 1 /  infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(calc(-0 + -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-0 + -0)), 1) should be used-value-equivalent to -1
+Pass	sign(calc(-0 +  0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-0 +  0)), 1) should be used-value-equivalent to 1
+Pass	sign(calc( 0 + -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 0 + -0)), 1) should be used-value-equivalent to 1
+Pass	sign(calc( 0 +  0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 0 +  0)), 1) should be used-value-equivalent to 1
+Pass	sign(calc(-0 - -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-0 - -0)), 1) should be used-value-equivalent to 1
+Pass	sign(calc(-0 -  0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc(-0 -  0)), 1) should be used-value-equivalent to -1
+Pass	sign(calc( 0 - -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 0 - -0)), 1) should be used-value-equivalent to 1
+Pass	sign(calc( 0 -  0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(calc( 0 -  0)), 1) should be used-value-equivalent to 1
+Pass	sign(min(-0,  0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(min(-0,  0)), 1) should be used-value-equivalent to -1
+Pass	sign(min( 0, -0)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(min( 0, -0)), 1) should be used-value-equivalent to -1
+Pass	sign(max(-0,  0)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(max(-0,  0)), 1) should be used-value-equivalent to 1
+Pass	sign(max( 0, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(max( 0, -0)), 1) should be used-value-equivalent to 1
+Pass	sign(clamp(-0, -1, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(-0, -1, -0)), 1) should be used-value-equivalent to -1
+Pass	sign(clamp(-0, -0, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(-0, -0, -0)), 1) should be used-value-equivalent to -1
+Pass	sign(clamp(-0,  0, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(-0,  0, -0)), 1) should be used-value-equivalent to -1
+Pass	sign(clamp(-0,  1, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(-0,  1, -0)), 1) should be used-value-equivalent to -1
+Pass	sign(clamp(-0, -1, 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(-0, -1, 0)), 1) should be used-value-equivalent to -1
+Pass	sign(clamp(-0, -0, 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(-0, -0, 0)), 1) should be used-value-equivalent to -1
+Pass	sign(clamp(-0,  0, 0)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(clamp(-0,  0, 0)), 1) should be used-value-equivalent to 1
+Pass	sign(clamp(-0,  1, 0)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(clamp(-0,  1, 0)), 1) should be used-value-equivalent to 1
+Pass	sign(clamp(0, -1, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(0, -1, -0)), 1) should be used-value-equivalent to 1
+Pass	sign(clamp(0, -0, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(0, -0, -0)), 1) should be used-value-equivalent to 1
+Pass	sign(clamp(0,  0, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(0,  0, -0)), 1) should be used-value-equivalent to 1
+Pass	sign(clamp(0,  1, -0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(clamp(0,  1, -0)), 1) should be used-value-equivalent to 1
+Pass	sign(round(nearest, -1, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(nearest, -1, infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(round(nearest, -0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(nearest, -0, infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(round(nearest,  0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(nearest,  0, infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(round(nearest,  1, infinity)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(round(nearest,  1, infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(round(up, -1, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(up, -1, infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(round(up, -0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(up, -0, infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(round(up,  0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(up,  0, infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(round(down, -0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(down, -0, infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(round(down,  0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(round(down,  0, infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(round(down,  1, infinity)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(round(down,  1, infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(mod(-1, -1)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(mod(-1, -1)), 1) should be used-value-equivalent to -1
+Pass	sign(mod(-1,  1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(mod(-1,  1)), 1) should be used-value-equivalent to 1
+Pass	sign(mod( 1, -1)) should be used-value-equivalent to 0
+Fail	clamp(-1, 1 / sign(mod( 1, -1)), 1) should be used-value-equivalent to -1
+Pass	sign(mod( 1,  1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(mod( 1,  1)), 1) should be used-value-equivalent to 1
+Pass	sign(rem(-1, -1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(rem(-1, -1)), 1) should be used-value-equivalent to -1
+Pass	sign(rem(-1,  1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(rem(-1,  1)), 1) should be used-value-equivalent to -1
+Pass	sign(rem( 1, -1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(rem( 1, -1)), 1) should be used-value-equivalent to 1
+Pass	sign(rem( 1,  1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(rem( 1,  1)), 1) should be used-value-equivalent to 1
+Pass	sign(asin(-0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(asin(-0)), 1) should be used-value-equivalent to -1
+Pass	sign(asin( 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(asin( 0)), 1) should be used-value-equivalent to 1
+Pass	sign(atan(-0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan(-0)), 1) should be used-value-equivalent to -1
+Pass	sign(atan( 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan( 0)), 1) should be used-value-equivalent to 1
+Pass	sign(atan2(-0, 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2(-0, 0)), 1) should be used-value-equivalent to -1
+Pass	sign(atan2(-0, 1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2(-0, 1)), 1) should be used-value-equivalent to -1
+Pass	sign(atan2(-0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2(-0, infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(atan2(0, 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2(0, 0)), 1) should be used-value-equivalent to 1
+Pass	sign(atan2(0, 1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2(0, 1)), 1) should be used-value-equivalent to 1
+Pass	sign(atan2(0, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2(0, infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(atan2(-1, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2(-1, infinity)), 1) should be used-value-equivalent to -1
+Pass	sign(atan2( 1, infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(atan2( 1, infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(pow(-infinity, -2)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(-infinity, -2)), 1) should be used-value-equivalent to 1
+Pass	sign(pow(-infinity, -1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(-infinity, -1)), 1) should be used-value-equivalent to -1
+Pass	sign(pow(-0, 1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(-0, 1)), 1) should be used-value-equivalent to -1
+Pass	sign(pow(-0, 2)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(-0, 2)), 1) should be used-value-equivalent to 1
+Pass	sign(pow(0, 1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(0, 1)), 1) should be used-value-equivalent to 1
+Pass	sign(pow(0, 2)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(0, 2)), 1) should be used-value-equivalent to 1
+Pass	sign(pow(infinity, -2)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(infinity, -2)), 1) should be used-value-equivalent to 1
+Pass	sign(pow(infinity, -1)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(pow(infinity, -1)), 1) should be used-value-equivalent to 1
+Pass	sign(sqrt(-0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(sqrt(-0)), 1) should be used-value-equivalent to -1
+Pass	sign(sqrt( 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(sqrt( 0)), 1) should be used-value-equivalent to 1
+Pass	sign(hypot(-0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(hypot(-0)), 1) should be used-value-equivalent to 1
+Pass	sign(hypot( 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(hypot( 0)), 1) should be used-value-equivalent to 1
+Pass	sign(exp(-infinity)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(exp(-infinity)), 1) should be used-value-equivalent to 1
+Pass	sign(abs(-0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(abs(-0)), 1) should be used-value-equivalent to 1
+Pass	sign(abs( 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(abs( 0)), 1) should be used-value-equivalent to 1
+Pass	sign(sign(-0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(sign(-0)), 1) should be used-value-equivalent to -1
+Pass	sign(sign( 0)) should be used-value-equivalent to 0
+Pass	clamp(-1, 1 / sign(sign( 0)), 1) should be used-value-equivalent to 1

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signed-zero.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signed-zero.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 162 tests
 
-154 Pass
-8 Fail
+156 Pass
+6 Fail
 Pass	sign(calc(-0)) should be used-value-equivalent to 0
 Pass	clamp(-1, 1 / sign(calc(-0)), 1) should be used-value-equivalent to -1
 Pass	sign(calc( 0)) should be used-value-equivalent to 0
@@ -79,7 +79,7 @@ Pass	clamp(-1, 1 / sign(round(nearest, -0, infinity)), 1) should be used-value-e
 Pass	sign(round(nearest,  0, infinity)) should be used-value-equivalent to 0
 Pass	clamp(-1, 1 / sign(round(nearest,  0, infinity)), 1) should be used-value-equivalent to 1
 Pass	sign(round(nearest,  1, infinity)) should be used-value-equivalent to 0
-Fail	clamp(-1, 1 / sign(round(nearest,  1, infinity)), 1) should be used-value-equivalent to 1
+Pass	clamp(-1, 1 / sign(round(nearest,  1, infinity)), 1) should be used-value-equivalent to 1
 Pass	sign(round(up, -1, infinity)) should be used-value-equivalent to 0
 Pass	clamp(-1, 1 / sign(round(up, -1, infinity)), 1) should be used-value-equivalent to -1
 Pass	sign(round(up, -0, infinity)) should be used-value-equivalent to 0
@@ -91,7 +91,7 @@ Pass	clamp(-1, 1 / sign(round(down, -0, infinity)), 1) should be used-value-equi
 Pass	sign(round(down,  0, infinity)) should be used-value-equivalent to 0
 Pass	clamp(-1, 1 / sign(round(down,  0, infinity)), 1) should be used-value-equivalent to 1
 Pass	sign(round(down,  1, infinity)) should be used-value-equivalent to 0
-Fail	clamp(-1, 1 / sign(round(down,  1, infinity)), 1) should be used-value-equivalent to 1
+Pass	clamp(-1, 1 / sign(round(down,  1, infinity)), 1) should be used-value-equivalent to 1
 Pass	sign(mod(-1, -1)) should be used-value-equivalent to 0
 Fail	clamp(-1, 1 / sign(mod(-1, -1)), 1) should be used-value-equivalent to -1
 Pass	sign(mod(-1,  1)) should be used-value-equivalent to 0

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signs-abs-serialize.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signs-abs-serialize.txt
@@ -1,0 +1,22 @@
+Harness status: OK
+
+Found 16 tests
+
+14 Pass
+2 Fail
+Pass	'scale(abs(1))' as a specified value should serialize as 'scale(calc(1))'.
+Pass	'scale(sign(.1))' as a specified value should serialize as 'scale(calc(1))'.
+Pass	'scale(abs(1 + 2 + 3))' as a specified value should serialize as 'scale(calc(6))'.
+Pass	'scale(sign(1 + 2 + 3))' as a specified value should serialize as 'scale(calc(1))'.
+Pass	'scale(calc(abs(1) + abs(2)))' as a specified value should serialize as 'scale(calc(3))'.
+Pass	'scale(calc(sign(.1) + sign(.2)))' as a specified value should serialize as 'scale(calc(2))'.
+Pass	'scale(calc(1 + abs(1)))' as a specified value should serialize as 'scale(calc(2))'.
+Pass	'scale(calc(sign(.1) + 1))' as a specified value should serialize as 'scale(calc(2))'.
+Pass	'scale(calc(abs(inFinity)))' as a specified value should serialize as 'scale(calc(infinity))'.
+Pass	'scale(calc(abs(infinity)))' as a specified value should serialize as 'scale(calc(infinity))'.
+Pass	'scale(calc(sign(infinity)))' as a specified value should serialize as 'scale(calc(1))'.
+Pass	'scale(abs(infinity))' as a specified value should serialize as 'scale(calc(infinity))'.
+Pass	'scale(calc(abs(-infinity)))' as a specified value should serialize as 'scale(calc(infinity))'.
+Pass	'scale(calc(sign(-1 * infinity)))' as a specified value should serialize as 'scale(calc(-1))'.
+Fail	'scale(calc(sign(-1 * NaN)))' as a specified value should serialize as 'scale(calc(NaN))'.
+Fail	'scale(calc(sign(1 * NaN)))' as a specified value should serialize as 'scale(calc(NaN))'.

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-catch-divide-by-0.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-catch-divide-by-0.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML>
+<title>Zero Division: calc() serialization.</title>
+<link rel="author" title="Seokho Song"  href="mailto:0xdevssh@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/serialize-testcommon.js"></script>
+<div id="target"></div>
+<div id="log"></div>
+<script>
+function test_serialization(t,s, {prop="width"}={}) {
+    test_specified_serialization(prop, t, s)
+}
+
+    //TEST CASE                       |EXPECTED
+var test_map = {
+    "100px * 0 / 0"                   :"calc(NaN * 1px)",
+    "100px / 0"                       :"calc(infinity * 1px)",
+    "100px / (0)"                     :"calc(infinity * 1px)",
+    "100px / (2 - 2)"                 :"calc(infinity * 1px)",
+    "100px / (2 - (-62 + 64))"        :"calc(infinity * 1px)",
+    "100px * (1 / 0)"                 :"calc(infinity * 1px)",
+    "100px * (1 / (0))"               :"calc(infinity * 1px)",
+    "100px * (1 / (2 - 2))"           :"calc(infinity * 1px)",
+    "100px * (1 / (2 - (-62 + 64)))"  :"calc(infinity * 1px)",
+    "1px * max(1/0, 0)"               :"calc(infinity * 1px)",
+    "1px * min(1/0, 0)"               :"calc(0px)",
+    "1px * max(0/0, 0)"               :"calc(NaN * 1px)",
+    "1px * min(0/0, 0)"               :"calc(NaN * 1px)",
+
+    "1px * max(0/0, min(0,10))"       :"calc(NaN * 1px)",
+    "1px * clamp(0/0, 0, 10)"         :"calc(NaN * 1px)",
+
+    "1px * max(0, min(10, 0/0))"      :"calc(NaN * 1px)",
+    "1px * clamp(0, 10, 0/0)"         :"calc(NaN * 1px)",
+
+    "1px * max(0, min(0/0, 10))"      :"calc(NaN * 1px)",
+    "1px * clamp(0, 0/0, 10)"         :"calc(NaN * 1px)",
+
+    "1px * clamp(-1/0, 0, 1/0)"       :"calc(0px)",
+    "1px * clamp(-1/0, 1/0, 10)"      :"calc(10px)",
+};
+for (var exp in test_map) {
+    test_serialization("calc("+exp+")", test_map[exp])
+}
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-computed.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Infinity and NaN: calc() computed value.</title>
+<link rel="author" title="Seokho Song"  href="mailto:0xdevssh@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+const REALLY_LARGE = 1e6;
+const REALLY_LARGE_NEGATIVE = -REALLY_LARGE;
+
+// For <length>
+test_computed_value("width", "calc(NaN * 1px)", "0px");
+test_computed_value("width", "calc(NaN * 1%)", "0px");
+testComputedValueGreaterOrLowerThan("width", "calc(infinity * 1px)", REALLY_LARGE);
+testComputedValueGreaterOrLowerThan("width", "calc(infinity * 1%)", REALLY_LARGE);
+testComputedValueGreaterOrLowerThan("width", "calc(infinity * 1cm)", REALLY_LARGE);
+test_computed_value("width", "calc(NaN * 1rem)", "0px");
+test_computed_value("width", "calc(10.135262721212548pc - 199pt / NaN)", "0px");
+
+test_computed_value("width", "max(15px, NaN * 1px)", "0px");
+test_computed_value("width", "max(NaN * 1px, 15px)", "0px");
+test_computed_value("width", "max(-15px, NaN * 1px)", "0px");
+test_computed_value("width", "max(NaN * 1px, -15px)", "0px");
+test_computed_value("width", "min(15px, NaN * 1px)", "0px");
+test_computed_value("width", "min(NaN * 1px, 15px)", "0px");
+test_computed_value("width", "min(-15px, NaN * 1px)", "0px");
+test_computed_value("width", "min(NaN * 1px, -15px)", "0px");
+
+test_computed_value("width", "calc(infinity * 1px - infinity * 1%)", "0px");
+testComputedValueGreaterOrLowerThan("width", "calc(infinity * 1px + infinity * 1%)", REALLY_LARGE);
+test_computed_value("width", "calc(min(NaN * 1px, infinity * 1px) + max(infinity * 1px, -infinity * 1px))", "0px");
+test_computed_value("width", "calc(infinity * 1px - max(infinity * 1%, 0%))", "0px");
+
+testComputedValueGreaterOrLowerThan("width", "calc(max(infinity * 1px, 10px))", REALLY_LARGE);
+
+testComputedValueGreaterOrLowerThan("margin-left", "calc(-infinity * 1px)", REALLY_LARGE_NEGATIVE);
+testComputedValueGreaterOrLowerThan("margin-left", "calc(min(1px, -infinity * 1%))", REALLY_LARGE_NEGATIVE);
+
+testComputedValueGreaterOrLowerThan("margin-left", "calc(-infinity * 1%)", REALLY_LARGE_NEGATIVE);
+testComputedValueGreaterOrLowerThan("margin-left", "calc(max(10000px, 0px) + min(-infinity * 1px, infinity * 1px))", REALLY_LARGE_NEGATIVE);
+
+testComputedValueGreaterOrLowerThan("margin-left", "calc(-infinity * 1px - infinity * 1px)", REALLY_LARGE_NEGATIVE);
+testComputedValueGreaterOrLowerThan("margin-left", "calc(min(-infinity * 1px, 10px))", REALLY_LARGE_NEGATIVE);
+
+// For <time>
+test_computed_value("animation-duration", "calc(NaN * 1s)", "0s");
+testComputedValueGreaterOrLowerThan("animation-duration", "calc(infinity * 1s)", REALLY_LARGE);
+testComputedValueGreaterOrLowerThan("animation-duration", "calc(1 / 0 * 1s)", REALLY_LARGE);
+testComputedValueGreaterOrLowerThan("animation-duration", "calc(max(infinity * 1s, 10s)", REALLY_LARGE);
+
+testComputedValueGreaterOrLowerThan("transition-delay", "calc(-infinity* 1s)", REALLY_LARGE_NEGATIVE);
+testComputedValueGreaterOrLowerThan("transition-delay", "calc(max(10000s, 0s) + min(-infinity * 1s, infinity * 1s))", REALLY_LARGE_NEGATIVE);
+testComputedValueGreaterOrLowerThan("transition-delay", "calc(min(-infinity * 1s, 10s))", REALLY_LARGE_NEGATIVE);
+
+// For <angle>
+testTransformValuesCloseTo("rotate(calc(infinity * 1deg))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(-infinity * 1deg))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(NaN * 1deg))", 0.0001, "rotate(0deg)");
+
+testTransformValuesCloseTo("rotate(calc(infinity * 1turn))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(-infinity * 1turn))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(NaN * 1turn))", 0.0001, "rotate(0deg)");
+
+testTransformValuesCloseTo("rotate(calc(infinity * 1rad))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(-infinity * 1rad))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(NaN * 1rad))", 0.0001, "rotate(0deg)");
+
+testTransformValuesCloseTo("rotate(calc(infinity * 1grad))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(-infinity * 1grad))", 0.0001, "rotate(0deg)");
+testTransformValuesCloseTo("rotate(calc(NaN * 1grad))", 0.0001, "rotate(0deg)");
+
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-serialize-angle.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<title>Infinity and NaN: calc() serialization for length values.</title>
+<link rel="author" title="Seokho Song"  href="mailto:0xdevssh@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/serialize-testcommon.js"></script>
+<div id="target"></div>
+<div id="log"></div>
+<script>
+function test_serialization(t,s, {prop="transform"}={}) {
+    test_specified_serialization(prop, t, s)
+}
+//TEST CASE                                            | EXPECTED
+var test_map = {
+    "1deg * NaN"                                       :"calc(NaN * 1deg)",
+    "1rad * NaN"                                       :"calc(NaN * 1deg)",
+    "1turn * NaN"                                      :"calc(NaN * 1deg)",
+    "1grad * nan"                                      :"calc(NaN * 1deg)",
+    "1deg * infinity / infinity"                       :"calc(NaN * 1deg)",
+    "1deg * 0 * infinity"                              :"calc(NaN * 1deg)",
+    "1deg * (infinity + -infinity)"                    :"calc(NaN * 1deg)",
+    "1deg * (-infinity + infinity)"                    :"calc(NaN * 1deg)",
+    "1deg * (infinity - infinity)"                     :"calc(NaN * 1deg)",
+    "1deg * infinity"                                  :"calc(infinity * 1deg)",
+    "1deg * -infinity"                                 :"calc(-infinity * 1deg)",
+    "1deg * iNFinIty"                                  :"calc(infinity * 1deg)",
+    "1deg * (infinity + infinity)"                     :"calc(infinity * 1deg)",
+    "1deg * (-infinity + -infinity)"                   :"calc(-infinity * 1deg)",
+    "1deg * 1/infinity"                                :"calc(0deg)",
+    "1deg * infinity * infinity"                       :"calc(infinity * 1deg)",
+    "1deg * -infinity * -infinity"                     :"calc(infinity * 1deg)",
+    "1 * max(INFinity*3deg, 0deg)"                     :"calc(infinity * 1deg)",
+    "1 * min(inFInity*4deg, 0deg)"                     :"calc(0deg)",
+    "1 * max(nAn*2deg, 0deg)"                          :"calc(NaN * 1deg)",
+    "1 * min(nan*3deg, 0deg)"                          :"calc(NaN * 1deg)",
+    "1 * clamp(-INFINITY*20deg, 0deg, infiniTY*10deg)" :"calc(0deg)",
+
+    "1deg * max(NaN, min(0,10))"                       :"calc(NaN * 1deg)",
+    "1deg * clamp(NaN, 0, 10)"                         :"calc(NaN * 1deg)",
+
+    "1deg * max(0, min(10, NaN))"                      :"calc(NaN * 1deg)",
+    "1deg * clamp(0, 10, NaN)"                         :"calc(NaN * 1deg)",
+
+    "1deg * max(0, min(NaN, 10))"                      :"calc(NaN * 1deg)",
+    "1deg * clamp(0, NaN, 10)"                         :"calc(NaN * 1deg)",
+
+    "1deg * clamp(-Infinity, 0, infinity)"             :"calc(0deg)",
+    "1deg * clamp(-inFinity, infinity, 10)"            :"calc(10deg)",
+};
+
+for (var exp in test_map) {
+    test_serialization("rotate(calc("+exp+"))", "rotate("+test_map[exp]+")");
+}
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-serialize-number.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-serialize-number.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<title>Infinity and NaN: calc() serialization for number values.</title>
+<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/serialize-testcommon.js"></script>
+<div id="target"></div>
+<div id="log"></div>
+<script>
+function test_serialization(t,s, {prop="opacity"}={}) {
+    test_specified_serialization(prop, t, s)
+}
+//TEST CASE                                          | EXPECTED
+var test_map = {
+    "NaN"                                         :"calc(NaN)",
+    "infinity"                                    :"calc(infinity)",
+    "-infinity"                                   :"calc(-infinity)",
+    "1 * NaN"                                     :"calc(NaN)",
+    "1 * nan"                                     :"calc(NaN)",
+    "1 * infinity / infinity"                     :"calc(NaN)",
+    "1 * 0 * infinity"                            :"calc(NaN)",
+    "1 * (infinity + -infinity)"                  :"calc(NaN)",
+    "1 * (-infinity + infinity)"                  :"calc(NaN)",
+    "1 * (infinity - infinity)"                   :"calc(NaN)",
+    "1 * infinity"                                :"calc(infinity)",
+    "1 * -infinity"                               :"calc(-infinity)",
+    "1 * iNFinIty"                                :"calc(infinity)",
+    "1 * (infinity + infinity)"                   :"calc(infinity)",
+    "1 * (-infinity + -infinity)"                 :"calc(-infinity)",
+    "1 * 1/infinity"                              :"calc(0)",
+    "1 * infinity * infinity"                     :"calc(infinity)",
+    "1 * -infinity * -infinity"                   :"calc(infinity)",
+    "1 * max(INFinity*3, 0)"                      :"calc(infinity)",
+    "1 * min(inFInity*4, 0)"                      :"calc(0)",
+    "1 * max(nAn*2, 0)"                           :"calc(NaN)",
+    "1 * min(nan*3, 0)"                           :"calc(NaN)",
+    "1 * clamp(-INFINITY*20, 0, infiniTY*10)"     :"calc(0)",
+
+    "1 * max(NaN, min(0,10))"                     :"calc(NaN)",
+    "1 * clamp(NaN, 0, 10)"                       :"calc(NaN)",
+
+    "1 * max(0, min(10, NaN))"                    :"calc(NaN)",
+    "1 * clamp(0, 10, NaN)"                       :"calc(NaN)",
+
+    "1 * max(0, min(NaN, 10))"                    :"calc(NaN)",
+    "1 * clamp(0, NaN, 10)"                       :"calc(NaN)",
+
+    "1 * clamp(-Infinity, 0, infinity)"           :"calc(0)",
+    "1 * clamp(-inFinity, infinity, 10)"          :"calc(10)",
+};
+
+for (var exp in test_map) {
+    test_serialization("calc("+exp+")", test_map[exp]);
+}
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-serialize-time.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/calc-infinity-nan-serialize-time.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<title>Infinity and NaN: calc() serialization for time values.</title>
+<link rel="author" title="Seokho Song"  href="mailto:0xdevssh@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/serialize-testcommon.js"></script>
+<div id="target"></div>
+<div id="log"></div>
+<script>
+function test_serialization(t,s, {prop="animationDuration"}={}) {
+    test_specified_serialization(prop, t, s)
+}
+//TEST CASE                                          | EXPECTED
+var test_map = {
+    "1s * NaN"                                     :"calc(NaN * 1s)",
+    "1s * nan"                                     :"calc(NaN * 1s)",
+    "1ms * NaN"                                     :"calc(NaN * 1s)",
+    "1s * infinity / infinity"                     :"calc(NaN * 1s)",
+    "1s * 0 * infinity"                            :"calc(NaN * 1s)",
+    "1s * (infinity + -infinity)"                  :"calc(NaN * 1s)",
+    "1s * (-infinity + infinity)"                  :"calc(NaN * 1s)",
+    "1s * (infinity - infinity)"                   :"calc(NaN * 1s)",
+    "1s * infinity"                                :"calc(infinity * 1s)",
+    "1s * -infinity"                               :"calc(-infinity * 1s)",
+    "1s * iNFinIty"                                :"calc(infinity * 1s)",
+    "1s * (infinity + infinity)"                   :"calc(infinity * 1s)",
+    "1s * (-infinity + -infinity)"                 :"calc(-infinity * 1s)",
+    "1s * 1/infinity"                              :"calc(0s)",
+    "1s * infinity * infinity"                     :"calc(infinity * 1s)",
+    "1s * -infinity * -infinity"                   :"calc(infinity * 1s)",
+    "1 * max(INFinity*3s, 0s)"                     :"calc(infinity * 1s)",
+    "1 * min(inFInity*4s, 0s)"                     :"calc(0s)",
+    "1 * max(nAn*2s, 0s)"                          :"calc(NaN * 1s)",
+    "1 * min(nan*3s, 0s)"                          :"calc(NaN * 1s)",
+    "1 * clamp(-INFINITY*20s, 0s, infiniTY*10s)"   :"calc(0s)",
+
+    "1s * max(NaN, min(0,10))"                     :"calc(NaN * 1s)",
+    "1s * clamp(NaN, 0, 10)"                       :"calc(NaN * 1s)",
+
+    "1s * max(0, min(10, NaN))"                    :"calc(NaN * 1s)",
+    "1s * clamp(0, 10, NaN)"                       :"calc(NaN * 1s)",
+
+    "1s * max(0, min(NaN, 10))"                    :"calc(NaN * 1s)",
+    "1s * clamp(0, NaN, 10)"                       :"calc(NaN * 1s)",
+
+    "1s * clamp(-Infinity, 0, infinity)"           :"calc(0s)",
+    "1s * clamp(-inFinity, infinity, 10)"          :"calc(10s)",
+};
+
+for (var exp in test_map) {
+    test_serialization("calc("+exp+")", test_map[exp]);
+}
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/signed-zero.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/signed-zero.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Values and Units Test: signed zero</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#math">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-ieee">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<meta name="assert" content="Checks that a bunch of calculations produce the correct zero (+0 or -0)">
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/numeric-testcommon.js"></script>
+<div id="target"></div>
+<script>
+function test_zero(expression, { is_negative }) {
+  test_math_used(`sign(${expression})`, '0', { type: 'integer' });
+  // to test zero sign, make it to negative infinity and clamp it between -1 and 1
+  test_math_used(
+    `clamp(-1, 1 / sign(${expression}), 1)`,
+    (is_negative)? '-1' : '1',
+    { type: 'integer' },
+  );
+}
+
+test_zero('calc(-0)', { is_negative: true });
+test_zero('calc( 0)', { is_negative: false });
+
+test_zero('calc(-0 * -1)', { is_negative: false });
+test_zero('calc(-0 *  1)', { is_negative: true });
+test_zero('calc( 0 * -1)', { is_negative: true });
+test_zero('calc( 0 *  1)', { is_negative: false });
+
+test_zero('calc(-1 / -infinity)', { is_negative: false });
+test_zero('calc(-1 /  infinity)', { is_negative: true });
+test_zero('calc( 1 / -infinity)', { is_negative: true });
+test_zero('calc( 1 /  infinity)', { is_negative: false });
+
+test_zero('calc(-0 + -0)', { is_negative: true });
+test_zero('calc(-0 +  0)', { is_negative: false });
+test_zero('calc( 0 + -0)', { is_negative: false });
+test_zero('calc( 0 +  0)', { is_negative: false });
+
+test_zero('calc(-0 - -0)', { is_negative: false });
+test_zero('calc(-0 -  0)', { is_negative: true });
+test_zero('calc( 0 - -0)', { is_negative: false });
+test_zero('calc( 0 -  0)', { is_negative: false });
+
+test_zero('min(-0,  0)', { is_negative: true });
+test_zero('min( 0, -0)', { is_negative: true });
+
+test_zero('max(-0,  0)', { is_negative: false });
+test_zero('max( 0, -0)', { is_negative: false });
+
+test_zero('clamp(-0, -1, -0)', { is_negative: true });
+test_zero('clamp(-0, -0, -0)', { is_negative: true });
+test_zero('clamp(-0,  0, -0)', { is_negative: true });
+test_zero('clamp(-0,  1, -0)', { is_negative: true });
+
+test_zero('clamp(-0, -1, 0)', { is_negative: true });
+test_zero('clamp(-0, -0, 0)', { is_negative: true });
+test_zero('clamp(-0,  0, 0)', { is_negative: false });
+test_zero('clamp(-0,  1, 0)', { is_negative: false });
+
+test_zero('clamp(0, -1, -0)', { is_negative: false });
+test_zero('clamp(0, -0, -0)', { is_negative: false });
+test_zero('clamp(0,  0, -0)', { is_negative: false });
+test_zero('clamp(0,  1, -0)', { is_negative: false });
+
+test_zero('round(nearest, -1, infinity)', { is_negative: true });
+test_zero('round(nearest, -0, infinity)', { is_negative: true });
+test_zero('round(nearest,  0, infinity)', { is_negative: false });
+test_zero('round(nearest,  1, infinity)', { is_negative: false });
+
+test_zero('round(up, -1, infinity)', { is_negative: true });
+test_zero('round(up, -0, infinity)', { is_negative: true });
+test_zero('round(up,  0, infinity)', { is_negative: false });
+
+test_zero('round(down, -0, infinity)', { is_negative: true });
+test_zero('round(down,  0, infinity)', { is_negative: false });
+test_zero('round(down,  1, infinity)', { is_negative: false });
+
+test_zero('mod(-1, -1)', { is_negative: true });
+test_zero('mod(-1,  1)', { is_negative: false });
+test_zero('mod( 1, -1)', { is_negative: true });
+test_zero('mod( 1,  1)', { is_negative: false });
+
+test_zero('rem(-1, -1)', { is_negative: true });
+test_zero('rem(-1,  1)', { is_negative: true });
+test_zero('rem( 1, -1)', { is_negative: false });
+test_zero('rem( 1,  1)', { is_negative: false });
+
+test_zero('asin(-0)', { is_negative: true });
+test_zero('asin( 0)', { is_negative: false });
+
+test_zero('atan(-0)', { is_negative: true });
+test_zero('atan( 0)', { is_negative: false });
+
+test_zero('atan2(-0, 0)', { is_negative: true });
+test_zero('atan2(-0, 1)', { is_negative: true });
+test_zero('atan2(-0, infinity)', { is_negative: true });
+
+test_zero('atan2(0, 0)', { is_negative: false });
+test_zero('atan2(0, 1)', { is_negative: false });
+test_zero('atan2(0, infinity)', { is_negative: false });
+
+test_zero('atan2(-1, infinity)', { is_negative: true });
+test_zero('atan2( 1, infinity)', { is_negative: false });
+
+test_zero('pow(-infinity, -2)', { is_negative: false });
+test_zero('pow(-infinity, -1)', { is_negative: true });
+
+test_zero('pow(-0, 1)', { is_negative: true });
+test_zero('pow(-0, 2)', { is_negative: false });
+
+test_zero('pow(0, 1)', { is_negative: false });
+test_zero('pow(0, 2)', { is_negative: false });
+
+test_zero('pow(infinity, -2)', { is_negative: false });
+test_zero('pow(infinity, -1)', { is_negative: false });
+
+test_zero('sqrt(-0)', { is_negative: true });
+test_zero('sqrt( 0)', { is_negative: false });
+
+test_zero('hypot(-0)', { is_negative: false });
+test_zero('hypot( 0)', { is_negative: false });
+
+test_zero('exp(-infinity)', { is_negative: false });
+
+test_zero('abs(-0)', { is_negative: false });
+test_zero('abs( 0)', { is_negative: false });
+
+test_zero('sign(-0)', { is_negative: true });
+test_zero('sign( 0)', { is_negative: false });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/signs-abs-serialize.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/signs-abs-serialize.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#sign-funcs">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#numbers">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-serialize">
+<link rel="author" title="Apple Inc">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../support/serialize-testcommon.js"></script>
+<div id=target></div>
+<script>
+function test_serialization(t,s,c) {
+    test_specified_serialization('transform', `scale(${t})`, `scale(calc(${c}))`);
+}
+
+test_serialization(
+    'abs(1)',
+    'calc(1)',
+    '1');
+test_serialization(
+    'sign(.1)',
+    'calc(1)',
+    '1');
+
+test_serialization(
+    'abs(1 + 2 + 3)',
+    'calc(6)',
+    '6');
+test_serialization(
+    'sign(1 + 2 + 3)',
+    'calc(1)',
+    '1');
+
+test_serialization(
+    'calc(abs(1) + abs(2))',
+    'calc(3)',
+    '3');
+test_serialization(
+    'calc(sign(.1) + sign(.2))',
+    'calc(2)',
+    '2');
+
+test_serialization(
+    'calc(1 + abs(1))',
+    'calc(2)',
+    '2');
+test_serialization(
+    'calc(sign(.1) + 1)',
+    'calc(2)',
+    '2');
+
+test_serialization(
+    'calc(abs(inFinity))',
+    'calc(inFinity)',
+    'infinity');
+
+test_serialization(
+    'calc(abs(infinity))',
+    'calc(infinity)',
+    'infinity');
+test_serialization(
+    'calc(sign(infinity))',
+    'calc(1)',
+    '1');
+test_serialization(
+    'abs(infinity)',
+    'calc(infinity)',
+    'infinity');
+
+test_serialization(
+    'calc(abs(-infinity))',
+    'calc(infinity)',
+    'infinity');
+test_serialization(
+    'calc(sign(-1 * infinity))',
+    'calc(-1)',
+    '-1');
+
+test_serialization(
+  'calc(sign(-1 * NaN))',
+  'calc(NaN)',
+  'NaN');
+
+test_serialization(
+  'calc(sign(1 * NaN))',
+  'calc(NaN)',
+  'NaN');
+</script>


### PR DESCRIPTION
This PR improves our handling of `NaN` and `Infinity` in the following CSS functions:
  - `min()`
  - `max()`
  - `round()`
  - `clamp()`

Gains us 30 WPT tests.