### PR TITLE
Base: Wrap error URL

### DIFF
--- a/Base/res/ladybird/templates/error.html
+++ b/Base/res/ladybird/templates/error.html
@@ -37,6 +37,7 @@
         h1 {
             margin: 0;
             font-size: 1.5rem;
+            text-wrap: wrap;
         }
         p {
             font-size: 1rem;


### PR DESCRIPTION
Fixes text overlap on error page.

Fix #5730 