### PR TITLE
LibJS: Throw error when value of local const variable is reassigned

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -882,6 +882,10 @@ void Generator::emit_set_variable(JS::Identifier const& identifier, ScopedOperan
 {
     if (identifier.is_local()) {
         auto local_index = identifier.local_index();
+        if (initialization_mode == Bytecode::Op::BindingInitializationMode::Set && identifier.declaration_kind() == DeclarationKind::Const) {
+            emit<Bytecode::Op::ThrowInvalidAssignToConst>();
+            return;
+        }
         if (value.operand().is_local() && local_index.is_variable() && value.operand().index() == local_index.index) {
             // Moving a local to itself is a no-op.
             return;

--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -144,6 +144,7 @@
     O(ThrowIfNotObject)                \
     O(ThrowIfNullish)                  \
     O(ThrowIfTDZ)                      \
+    O(ThrowInvalidAssignToConst)       \
     O(Typeof)                          \
     O(TypeofBinding)                   \
     O(UnaryMinus)                      \

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -684,6 +684,7 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(ThrowIfNotObject);
             HANDLE_INSTRUCTION(ThrowIfNullish);
             HANDLE_INSTRUCTION(ThrowIfTDZ);
+            HANDLE_INSTRUCTION(ThrowInvalidAssignToConst);
             HANDLE_INSTRUCTION(Typeof);
             HANDLE_INSTRUCTION(TypeofBinding);
             HANDLE_INSTRUCTION(UnaryMinus);
@@ -3049,6 +3050,11 @@ ThrowCompletionOr<void> ThrowIfTDZ::execute_impl(Bytecode::Interpreter& interpre
     return {};
 }
 
+ThrowCompletionOr<void> ThrowInvalidAssignToConst::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    return interpreter.vm().throw_completion<TypeError>(ErrorType::InvalidAssignToConst);
+}
+
 void LeaveLexicalEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& running_execution_context = interpreter.running_execution_context();
@@ -3839,6 +3845,11 @@ ByteString ThrowIfTDZ::to_byte_string_impl(Bytecode::Executable const& executabl
 {
     return ByteString::formatted("ThrowIfTDZ {}",
         format_operand("src"sv, m_src, executable));
+}
+
+ByteString ThrowInvalidAssignToConst::to_byte_string_impl(Bytecode::Executable const&) const
+{
+    return ByteString::formatted("ThrowInvalidAssignToConst");
 }
 
 ByteString EnterUnwindContext::to_byte_string_impl(Bytecode::Executable const&) const

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -2373,6 +2373,17 @@ private:
     Operand m_src;
 };
 
+class ThrowInvalidAssignToConst final : public Instruction {
+public:
+    explicit ThrowInvalidAssignToConst()
+        : Instruction(Type::ThrowInvalidAssignToConst)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+};
+
 class EnterUnwindContext final : public Instruction {
 public:
     constexpr static bool IsTerminator = true;

--- a/Libraries/LibJS/Tests/operators/assignment-operators.js
+++ b/Libraries/LibJS/Tests/operators/assignment-operators.js
@@ -133,3 +133,33 @@ test("evaluation order", () => {
         expect(c.hasBeenCalled).toBeFalse();
     }
 });
+
+test("assignment to local const variable should throw", () => {
+    expect(() => {
+        const i = 1;
+        i++;
+    }).toThrow(Error);
+
+    expect(() => {
+        const i = 1;
+        i += 1;
+    }).toThrow(Error);
+
+    expect(() => {
+        const i = 1;
+        i = 2;
+    }).toThrow(Error);
+
+    let hello;
+    expect(() => {
+        const i = {
+            valueOf() {
+                hello = "hello!";
+                return 1;
+            },
+        };
+        i++;
+    }).toThrow(Error);
+
+    expect(hello).toBe("hello!");
+});


### PR DESCRIPTION
Fixes https://github.com/LadybirdBrowser/ladybird/issues/5683

test262 diff (tests are located in `language/statements/const/syntax/`):
const-invalid-assignment-next-expression-for.js   ❌ -> ✅
const-invalid-assignment-statement-body-for-in.js ❌ -> ✅
const-invalid-assignment-statement-body-for-of.js ❌ -> ✅