### PR TITLE
Tests: Improve fuzzy test reports

### DIFF
--- a/Tests/LibWeb/test-web/Fuzzy.cpp
+++ b/Tests/LibWeb/test-web/Fuzzy.cpp
@@ -13,7 +13,7 @@
 namespace TestWeb {
 
 // https://web-platform-tests.org/writing-tests/reftests.html#fuzzy-matching
-bool fuzzy_screenshot_match(URL::URL const& reference, Gfx::Bitmap const& bitmap_a, Gfx::Bitmap const& bitmap_b,
+bool fuzzy_screenshot_match(URL::URL const& test_url, URL::URL const& reference, Gfx::Bitmap const& bitmap_a, Gfx::Bitmap const& bitmap_b,
     Vector<FuzzyMatch> const& fuzzy_matches)
 {
     // If the bitmaps are identical, we don't perform fuzzy matching.
@@ -28,18 +28,18 @@ bool fuzzy_screenshot_match(URL::URL const& reference, Gfx::Bitmap const& bitmap
         return true;
     });
     if (!fuzzy_match.has_value()) {
-        warnln("Screenshot mismatch: pixel error count {}, with maximum error {}. (No fuzzy config defined)", diff.pixel_error_count, diff.maximum_error);
+        warnln("{}: Screenshot mismatch: pixel error count {}, with maximum error {}. (No fuzzy config defined)", test_url, diff.pixel_error_count, diff.maximum_error);
         return false;
     }
 
     // Apply fuzzy matching.
     auto color_error_matches = fuzzy_match->color_value_error.contains(diff.maximum_error);
     if (!color_error_matches)
-        warnln("Fuzzy mismatch: maximum error {} is outside {}", diff.maximum_error, fuzzy_match->color_value_error);
+        warnln("{}: Fuzzy mismatch: maximum error {} is outside {}", test_url, diff.maximum_error, fuzzy_match->color_value_error);
 
     auto pixel_error_matches = fuzzy_match->pixel_error_count.contains(diff.pixel_error_count);
     if (!pixel_error_matches)
-        warnln("Fuzzy mismatch: pixel error count {} is outside {}", diff.pixel_error_count, fuzzy_match->pixel_error_count);
+        warnln("{}: Fuzzy mismatch: pixel error count {} is outside {}", test_url, diff.pixel_error_count, fuzzy_match->pixel_error_count);
 
     return color_error_matches && pixel_error_matches;
 }

--- a/Tests/LibWeb/test-web/Fuzzy.cpp
+++ b/Tests/LibWeb/test-web/Fuzzy.cpp
@@ -27,8 +27,10 @@ bool fuzzy_screenshot_match(URL::URL const& reference, Gfx::Bitmap const& bitmap
             return fuzzy_match.reference.value().equals(reference);
         return true;
     });
-    if (!fuzzy_match.has_value())
-        return diff.identical;
+    if (!fuzzy_match.has_value()) {
+        warnln("Screenshot mismatch: pixel error count {}, with maximum error {}. (No fuzzy config defined)", diff.pixel_error_count, diff.maximum_error);
+        return false;
+    }
 
     // Apply fuzzy matching.
     auto color_error_matches = fuzzy_match->color_value_error.contains(diff.maximum_error);

--- a/Tests/LibWeb/test-web/Fuzzy.cpp
+++ b/Tests/LibWeb/test-web/Fuzzy.cpp
@@ -79,7 +79,7 @@ ErrorOr<FuzzyMatch> parse_fuzzy_match(Optional<URL::URL const&> reference, Strin
     Optional<FuzzyRange> color_value_error;
     Optional<FuzzyRange> pixel_error_count;
     for (auto [i, config_part] : enumerate(config_parts)) {
-        auto named_parts = MUST(config_part.split_limit('=', 2));
+        auto named_parts = MUST(MUST(config_part.trim_ascii_whitespace()).split_limit('=', 2));
         if (named_parts.is_empty())
             return Error::from_string_view("Fuzzy configuration value cannot be empty"sv);
 

--- a/Tests/LibWeb/test-web/Fuzzy.h
+++ b/Tests/LibWeb/test-web/Fuzzy.h
@@ -28,7 +28,7 @@ struct FuzzyMatch {
     FuzzyRange pixel_error_count;
 };
 
-bool fuzzy_screenshot_match(URL::URL const& reference, Gfx::Bitmap const&, Gfx::Bitmap const&, Vector<FuzzyMatch> const&);
+bool fuzzy_screenshot_match(URL::URL const& test_url, URL::URL const& reference, Gfx::Bitmap const&, Gfx::Bitmap const&, Vector<FuzzyMatch> const&);
 ErrorOr<FuzzyMatch> parse_fuzzy_match(Optional<URL::URL const&> reference, String const&);
 ErrorOr<FuzzyRange> parse_fuzzy_range(String const&);
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -455,7 +455,7 @@ static void run_ref_test(TestWebView& view, Test& test, URL::URL const& url, int
             auto content = fuzzy_configuration.get_string("content"sv).release_value();
             auto fuzzy_match_or_error = parse_fuzzy_match(reference_url, content);
             if (fuzzy_match_or_error.is_error()) {
-                warnln("Failed to parse fuzzy configuration '{}' (reference: {})", content, reference_url);
+                warnln("Failed to parse fuzzy configuration '{}' (reference: {}): {}", content, reference_url, fuzzy_match_or_error.error());
                 continue;
             }
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -369,7 +369,7 @@ static void run_ref_test(TestWebView& view, Test& test, URL::URL const& url, int
         VERIFY(test.ref_test_expectation_type.has_value());
         auto should_match = test.ref_test_expectation_type == RefTestExpectationType::Match;
         auto screenshot_matches = fuzzy_screenshot_match(
-            view.url(), *test.actual_screenshot, *test.expectation_screenshot, test.fuzzy_matches);
+            url, view.url(), *test.actual_screenshot, *test.expectation_screenshot, test.fuzzy_matches);
         if (should_match == screenshot_matches)
             return TestResult::Pass;
 


### PR DESCRIPTION
Main thing here is to report the fuzzy difference even if we're not doing a fuzzy test, so that we can more easily know what the configuration should be.