### PR TITLE
LibWeb: Unbreak SVGFilterElement compilation

### DIFF
--- a/Libraries/LibWeb/SVG/SVGFilterElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFilterElement.cpp
@@ -117,8 +117,7 @@ Optional<Gfx::Filter> SVGFilterElement::gfx_filter()
         } else if (auto* blend_primitive = as_if<SVGFEBlendElement>(node)) {
             auto foreground = resolve_input_filter(blend_primitive->in1()->base_val());
             auto background = resolve_input_filter(blend_primitive->in2()->base_val());
-
-            auto blend_mode = blend_primitive.mode();
+            auto blend_mode = blend_primitive->mode();
 
             root_filter = Gfx::Filter::blend(background, foreground, blend_mode);
             update_result_map(*blend_primitive);


### PR DESCRIPTION
This was caused by an undetected merge conflict.