### PR TITLE
LibWeb: Correctly calculate grid item size while accommodating fr track

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/use-limited-contribution-if-container-has-intrinsic-available-size.txt
+++ b/Tests/LibWeb/Layout/expected/grid/use-limited-contribution-if-container-has-intrinsic-available-size.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 200x100 [GFC] children: not-inline
+      BlockContainer <div.grid-item> at (8,8) content-size 200x100 [BFC] children: not-inline
+        BlockContainer <div.orange-thing> at (8,8) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableBox (Box<BODY>) [8,8 200x100]
+      PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 200x100]
+        PaintableWithLines (BlockContainer<DIV>.orange-thing) [8,8 100x100]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/use-limited-contribution-if-container-has-intrinsic-available-size.html
+++ b/Tests/LibWeb/Layout/input/grid/use-limited-contribution-if-container-has-intrinsic-available-size.html
@@ -1,0 +1,17 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    html { background: white; }
+    body {
+        display: grid;
+        grid-template-rows: minmax(0px, 1fr);
+        width: 200px;
+        height: min-content;
+        background: pink;
+    }   
+    .orange-thing { 
+        background: orange;
+        width: 100px;
+        height: 100px;
+    }   
+</style>
+<body><div class="grid-item"><div class="orange-thing"></div></div>


### PR DESCRIPTION
Implements text from grid layout specification.
Improves layout on https://cal.com/