### PR TITLE
LibWeb/HTML: Fix attr cloning in active element reconstruction

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1705,9 +1705,10 @@ Create:
 
     // FIXME: Hold on to the real token!
     auto new_element = insert_html_element(HTMLToken::make_start_tag(entry->element->local_name()));
-    entry->element->for_each_attribute([&](auto& name, auto& value) {
-        new_element->append_attribute(name, value);
-    });
+    // Copy the snapshot of attributes stored in the formatting list entry (see spec step 8)
+    for (auto const& attr : entry->attributes) {
+        new_element->append_attribute(attr.first, attr.second);
+    }
 
     // 9. Replace the entry for entry in the list with an entry for new element.
     m_list_of_active_formatting_elements.entries().at(index).element = new_element;

--- a/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.cpp
+++ b/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.cpp
@@ -20,12 +20,18 @@ void ListOfActiveFormattingElements::visit_edges(JS::Cell::Visitor& visitor)
 void ListOfActiveFormattingElements::add(DOM::Element& element)
 {
     // FIXME: Implement the Noah's Ark clause https://html.spec.whatwg.org/multipage/parsing.html#push-onto-the-list-of-active-formatting-elements
-    m_entries.append({ element });
+    ListOfActiveFormattingElements::Entry entry;
+    entry.element = element;
+    // Take a snapshot of the element's current attributes (names and values)
+    element.for_each_attribute([&](auto& name, auto& value) {
+        entry.attributes.append({ name, value });
+    });
+    m_entries.append(move(entry));
 }
 
 void ListOfActiveFormattingElements::add_marker()
 {
-    m_entries.append({ nullptr });
+    m_entries.append({ nullptr, {} });
 }
 
 bool ListOfActiveFormattingElements::contains(const DOM::Element& element) const
@@ -84,7 +90,7 @@ void ListOfActiveFormattingElements::replace(DOM::Element& to_remove, DOM::Eleme
 
 void ListOfActiveFormattingElements::insert_at(size_t index, DOM::Element& element)
 {
-    m_entries.insert(index, { element });
+    m_entries.insert(index, { element, {} });
 }
 
 }

--- a/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.h
+++ b/Libraries/LibWeb/HTML/Parser/ListOfActiveFormattingElements.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/String.h>
+#include <AK/Vector.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Forward.h>
 
@@ -20,6 +22,7 @@ public:
         bool is_marker() const { return !element; }
 
         GC::Ptr<DOM::Element> element;
+        Vector<std::pair<FlyString, String>> attributes;
     };
 
     bool is_empty() const { return m_entries.is_empty(); }


### PR DESCRIPTION
When reconstructing active formatting elements, the parser was
creating a new element and copying attributes from the live DOM
element in the active formatting elements list.

If a script had modified the attributes of that live element, the
modified attributes were incorrectly carried over to the newly created
element.

This violates the HTML spec, which requires the new element to be
created based on the token that originally created the formatting
element.

Check this line in spec: `each element in the list of active formatting elements is associated with the token for which it was created`

This change fixes the issue by:
1. Storing a snapshot of the element's attributes in the
   ListOfActiveFormattingElements::Entry at the time of creation.
2. Using this stored snapshot during reconstruction instead of the
   live attributes.

This fixes the html5lib test case:
`html/syntax/parsing/html5lib_scripted_adoption01.html`.

There are 2 FIXME (keep real token, noah ark's clause) related to this code that I guess can be fixed in a separate branch. Please let me know if that should be done in this branch itself.

## Master WPT Test results
```
ankk98@fedora:~/repos/ladybird$ ./Meta/WPT.sh run html/syntax/parsing/html5lib_scripted_adoption01.html?run_type=uri
ninja: Entering directory `/home/ankk98/repos/ladybird/Build/release'
ninja: no work to do.
./wpt run -f --browser-version=1.0-e534395243e --processes=24 --binary=/home/ankk98/repos/ladybird/Build/release/bin/Ladybird --webdriver-binary=/home/ankk98/repos/ladybird/Build/release/bin/WebDriver --install-webdriver --webdriver-arg=--force-cpu-painting --no-pause-after-test --install-fonts --webdriver-arg=--headless --webdriver-arg=--certificate=tools/certs/cacert.pem ladybird html/syntax/parsing/html5lib_scripted_adoption01.html?run_type=uri

  ▶ Unexpected subtest result in /html/syntax/parsing/html5lib_scripted_adoption01.html?run_type=uri:
  │ FAIL [expected PASS] html5lib_scripted_adoption01.html 8970fe21b551a270aa74648bb2e8b905edb54522
  │   → assert_equals: expected "#document\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         id=\"B\"\n|         <script>\n|           \"document.getElementById(\"A\").id = \"B\"\"\n|     <b>\n|       id=\"A\"\n|       \"TEXT\"" but got "#document\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         id=\"B\"\n|         <script>\n|           \"document.getElementById(\"A\").id = \"B\"\"\n|     <b>\n|       id=\"B\"\n|       \"TEXT\""
  │ 
  │     at <unknown>
  │     at assert_wrapper (http://web-platform.test:8000/resources/testharness.js:1518:35)
  │     at http://web-platform.test:8000/html/syntax/parsing/test.js:182:29
  │     at <unknown>
  │     at http://web-platform.test:8000/resources/testharness.js:2869:30
  │     at http://web-platform.test:8000/html/syntax/parsing/test.js:178:13
  │     at <unknown>
  └     at <unknown>

Ran 1 tests finished in 0.9 seconds.
  • 0 ran as expected. 0 tests skipped.
  • 1 tests had unexpected subtest results
```

## Branch WPT Test results
```
ankk98@fedora:~/repos/ladybird$ ./Meta/WPT.sh run html/syntax/parsing/html5lib_scripted_adoption01.html?run_type=uri
ninja: Entering directory `/home/ankk98/repos/ladybird/Build/release'
[1291/1291] Linking CXX executable bin/WebDriver
./wpt run -f --browser-version=1.0-1eb4c39d782 --processes=24 --binary=/home/ankk98/repos/ladybird/Build/release/bin/Ladybird --webdriver-binary=/home/ankk98/repos/ladybird/Build/release/bin/WebDriver --install-webdriver --webdriver-arg=--force-cpu-painting --no-pause-after-test --install-fonts --webdriver-arg=--headless --webdriver-arg=--certificate=tools/certs/cacert.pem ladybird html/syntax/parsing/html5lib_scripted_adoption01.html?run_type=uri

Running 1 tests in web-platform-tests

Ran 1 tests finished in 0.9 seconds.
  • 1 ran as expected. 0 tests skipped.
```

## Master Tests Passing
```
ankk98@fedora:~/repos/ladybird$ ./Meta/WPT.sh run html/syntax/parsing > master_results.log 2>&1
ankk98@fedora:~/repos/ladybird$ grep "ran as expected" master_results.log | tail -1
  • 173 ran as expected. 0 tests skipped.
```

## Branch Tests Passing
```
ankk98@fedora:~/repos/ladybird$ ./Meta/WPT.sh run html/syntax/parsing > branch_results.log 2>&1
ankk98@fedora:~/repos/ladybird$ grep "ran as expected" branch_results.log | tail -1
  • 176 ran as expected. 0 tests skipped.
```
