### PR TITLE
Meta: Generate correct format for user-variables.cmake

### DIFF
--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -240,9 +240,9 @@ def configure_skia_jemalloc() -> list[str]:
     with open(user_vars_cmake_module, "w") as f:
         f.writelines(
             [
-                f"set(PKGCONFIG {pkg_config})",
-                f"set(GN {gn})",
-                "",
+                f"set(PKGCONFIG {pkg_config})\n",
+                f"set(GN {gn})\n",
+                "\n",
             ]
         )
 


### PR DESCRIPTION
This PR fixes an issue building on Linux aarch64. The script tries to generate the file  Meta/CMake/vcpkg/user-variables.cmake but the generated file is incorrect because missing EOLs. The root cause is that python file.writelines() does not append line separators.