### PR TITLE
LibWeb: Mark width & height of grid item definite before inside layout

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2073,6 +2073,8 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
         compute_inset(grid_item.box, grid_area_rect.size());
 
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_width()), AvailableSize::make_definite(grid_item.used_values.content_height()));
+        grid_item.used_values.set_has_definite_width(true);
+        grid_item.used_values.set_has_definite_height(true);
         if (auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, available_space_for_children))
             independent_formatting_context->parent_context_did_dimension_child_root_box();
     }

--- a/Tests/LibWeb/Layout/expected/flex/cross-alignment-when-nested-in-gfc.txt
+++ b/Tests/LibWeb/Layout/expected/flex/cross-alignment-when-nested-in-gfc.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (0,0) content-size 800x600 children: not-inline
+      Box <div#Main> at (0,0) content-size 800x600 [GFC] children: not-inline
+        Box <div#MiddleColumn> at (0,0) content-size 800x600 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div.MiddleHeader> at (0,0) content-size 100x100 flex-item [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x600]
+      PaintableBox (Box<DIV>#Main) [0,0 800x600]
+        PaintableBox (Box<DIV>#MiddleColumn) [0,0 800x600]
+          PaintableWithLines (BlockContainer<DIV>.MiddleHeader) [0,0 100x100]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x600] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/cross-alignment-when-nested-in-gfc.html
+++ b/Tests/LibWeb/Layout/input/flex/cross-alignment-when-nested-in-gfc.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html><style>
+    html,body {
+        background-color: #99ba92;
+        height: 100%;
+        width: 100%;
+        margin: 0;
+    }
+    #Main {
+        height: 100%;
+        display: grid;
+        grid-template-rows: 100%;
+    }
+    #MiddleColumn {
+        display: flex;
+        background-color: mediumslateblue;
+    }
+   .MiddleHeader {
+        width: 100px;
+        height: 100px;
+        background: pink;
+    }
+</style><div id="Main"><div id="MiddleColumn"><div class="MiddleHeader"></div></div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/dynamic-grid-flex-abspos.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/dynamic-grid-flex-abspos.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 8 tests
 
-6 Pass
-2 Fail
+8 Pass
 Pass	.relpos 1
 Pass	.relpos 2
 Pass	.relpos 3
-Fail	.relpos 4
+Pass	.relpos 4
 Pass	.relpos 5
 Pass	.relpos 6
 Pass	.relpos 7
-Fail	.relpos 8
+Pass	.relpos 8


### PR DESCRIPTION
FFC expects parent formatting context to mark size as definite if that's the case, because otherwise it cannot figure cross line size correctly. Fixes incorrect alignment when FFC is nested in GFC.

Progress on https://web.telegram.org/a/ layout.