### PR TITLE
LibWeb/CSS: Specify behavior for OOB CSSStyleDeclaration::item()

### DIFF
--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -33,6 +33,7 @@ size_t CSSDescriptors::length() const
 String CSSDescriptors::item(size_t index) const
 {
     // The item(index) method must return the property name of the CSS declaration at position index.
+    // If there is no indexth object in the collection, then the method must return the empty string.
     if (index >= length())
         return {};
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -137,6 +137,7 @@ size_t CSSStyleProperties::length() const
 String CSSStyleProperties::item(size_t index) const
 {
     // The item(index) method must return the property name of the CSS declaration at position index.
+    // If there is no indexth object in the collection, then the method must return the empty string.
     // FIXME: Include custom properties.
 
     if (index >= length())


### PR DESCRIPTION
Corresponds to https://github.com/w3c/csswg-drafts/commit/56ed462ccd71c8441d5b4221b45a3701cbbc610e

We already did the right thing.