### PR TITLE
LibWeb/CSP: Implement report-to, report-uri, webrtc and sandbox directives

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -70,6 +70,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/StyleSourceAttributeDirective.cpp
     ContentSecurityPolicy/Directives/StyleSourceDirective.cpp
     ContentSecurityPolicy/Directives/StyleSourceElementDirective.cpp
+    ContentSecurityPolicy/Directives/WebRTCDirective.cpp
     ContentSecurityPolicy/Directives/WorkerSourceDirective.cpp
     ContentSecurityPolicy/Policy.cpp
     ContentSecurityPolicy/PolicyList.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -555,6 +555,7 @@ set(SOURCES
     HTML/PromiseRejectionEvent.cpp
     HTML/RadioNodeList.cpp
     HTML/RenderingThread.cpp
+    HTML/SandboxingFlagSet.cpp
     HTML/Scripting/Agent.cpp
     HTML/Scripting/ClassicScript.cpp
     HTML/Scripting/Environments.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -62,6 +62,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
     ContentSecurityPolicy/Directives/ReportToDirective.cpp
     ContentSecurityPolicy/Directives/ReportUriDirective.cpp
+    ContentSecurityPolicy/Directives/SandboxDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceElementDirective.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
+    ContentSecurityPolicy/Directives/ReportUriDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceElementDirective.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SOURCES
     ContentSecurityPolicy/Directives/MediaSourceDirective.cpp
     ContentSecurityPolicy/Directives/Names.cpp
     ContentSecurityPolicy/Directives/ObjectSourceDirective.cpp
+    ContentSecurityPolicy/Directives/ReportToDirective.cpp
     ContentSecurityPolicy/Directives/ReportUriDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.cpp
     ContentSecurityPolicy/Directives/ScriptSourceDirective.cpp

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ReportToDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/SandboxDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.h>
@@ -76,6 +77,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ReportUri)
         return heap.allocate<ReportUriDirective>(move(name), move(value));
+
+    if (name == Names::Sandbox)
+        return heap.allocate<SandboxDirective>(move(name), move(value));
 
     if (name == Names::ScriptSrcAttr)
         return heap.allocate<ScriptSourceAttributeDirective>(move(name), move(value));

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -28,6 +28,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/StyleSourceAttributeDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/StyleSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/StyleSourceElementDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/WebRTCDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/WorkerSourceDirective.h>
 
 namespace Web::ContentSecurityPolicy::Directives {
@@ -93,6 +94,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::StyleSrcElem)
         return heap.allocate<StyleSourceElementDirective>(move(name), move(value));
+
+    if (name == Names::WebRTC)
+        return heap.allocate<WebRTCDirective>(move(name), move(value));
 
     if (name == Names::WorkerSrc)
         return heap.allocate<WorkerSourceDirective>(move(name), move(value));

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ReportToDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h>
@@ -68,6 +69,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ObjectSrc)
         return heap.allocate<ObjectSourceDirective>(move(name), move(value));
+
+    if (name == Names::ReportTo)
+        return heap.allocate<ReportToDirective>(move(name), move(value));
 
     if (name == Names::ReportUri)
         return heap.allocate<ReportUriDirective>(move(name), move(value));

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveFactory.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/ContentSecurityPolicy/Directives/MediaSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Names.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ObjectSourceDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceAttributeDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceDirective.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/ScriptSourceElementDirective.h>
@@ -67,6 +68,9 @@ GC::Ref<Directive> create_directive(GC::Heap& heap, String name, Vector<String> 
 
     if (name == Names::ObjectSrc)
         return heap.allocate<ObjectSourceDirective>(move(name), move(value));
+
+    if (name == Names::ReportUri)
+        return heap.allocate<ReportUriDirective>(move(name), move(value));
 
     if (name == Names::ScriptSrcAttr)
         return heap.allocate<ScriptSourceAttributeDirective>(move(name), move(value));

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportToDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportToDirective.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/ReportToDirective.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(ReportToDirective);
+
+ReportToDirective::ReportToDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportToDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportToDirective.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-report-to
+class ReportToDirective final : public Directive {
+    GC_CELL(ReportToDirective, Directive)
+    GC_DECLARE_ALLOCATOR(ReportToDirective);
+
+public:
+    virtual ~ReportToDirective() = default;
+
+private:
+    ReportToDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(ReportUriDirective);
+
+ReportUriDirective::ReportUriDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/ReportUriDirective.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-report-uri
+class ReportUriDirective final : public Directive {
+    GC_CELL(ReportUriDirective, Directive)
+    GC_DECLARE_ALLOCATOR(ReportUriDirective);
+
+public:
+    virtual ~ReportUriDirective() = default;
+
+private:
+    ReportUriDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/SandboxDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/SandboxDirective.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/SandboxDirective.h>
+#include <LibWeb/ContentSecurityPolicy/Policy.h>
+#include <LibWeb/HTML/SandboxingFlagSet.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(SandboxDirective);
+
+SandboxDirective::SandboxDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#sandbox-init
+Directive::Result SandboxDirective::initialization(Variant<GC::Ref<DOM::Document const>, GC::Ref<HTML::WorkerGlobalScope const>> context, GC::Ref<Policy const> policy) const
+{
+    // 1. If policy’s disposition is not "enforce", or context is not a WorkerGlobalScope, then abort this algorithm.
+    // FIXME: File spec issue that this step doesn't specify the return value. It must be allowed, because Document
+    //        asserts that the result of this algorithm is Allowed.
+    if (policy->disposition() != Policy::Disposition::Enforce || !context.has<GC::Ref<HTML::WorkerGlobalScope const>>())
+        return Result::Allowed;
+
+    // 2. Let sandboxing flag set be a new sandboxing flag set.
+    // 3. Parse a sandboxing directive using this directive’s value as the input, and sandboxing flag set as the output.
+    // FIXME: File spec issue that "parse a sandboxing directive" does not accept a set of tokens.
+    auto sandboxing_flag_set = HTML::parse_a_sandboxing_directive(value());
+
+    // 4. If sandboxing flag set contains either the sandboxed scripts browsing context flag or the sandboxed origin
+    //    browsing context flag flags, return "Blocked".
+    // Spec Note: This will need to change if we allow Workers to be sandboxed into unique origins, which seems like a
+    //            pretty reasonable thing to do.
+    if (has_flag(sandboxing_flag_set, HTML::SandboxingFlagSet::SandboxedScripts) || has_flag(sandboxing_flag_set, HTML::SandboxingFlagSet::SandboxedOrigin))
+        return Result::Blocked;
+
+    // 5. Return "Allowed".
+    return Result::Allowed;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/SandboxDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/SandboxDirective.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-sandbox
+class SandboxDirective final : public Directive {
+    GC_CELL(SandboxDirective, Directive)
+    GC_DECLARE_ALLOCATOR(SandboxDirective);
+
+public:
+    virtual ~SandboxDirective() = default;
+
+    [[nodiscard]] virtual Result initialization(Variant<GC::Ref<DOM::Document const>, GC::Ref<HTML::WorkerGlobalScope const>>, GC::Ref<Policy const>) const override;
+
+private:
+    SandboxDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/WebRTCDirective.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/WebRTCDirective.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ContentSecurityPolicy/Directives/WebRTCDirective.h>
+#include <LibWeb/Infra/Strings.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+GC_DEFINE_ALLOCATOR(WebRTCDirective);
+
+WebRTCDirective::WebRTCDirective(String name, Vector<String> value)
+    : Directive(move(name), move(value))
+{
+}
+
+// https://w3c.github.io/webappsec-csp/#webrtc-pre-connect
+Directive::Result WebRTCDirective::webrtc_pre_connect_check(GC::Ref<Policy const>) const
+{
+    // 1. If this directive’s value contains a single item which is an ASCII case-insensitive match for the string
+    //    "'allow'", return "Allowed".
+    if (value().size() == 1 && value().first().equals_ignoring_ascii_case("'allow'"sv))
+        return Result::Allowed;
+
+    // 2. Return "Blocked".
+    return Result::Blocked;
+}
+
+}

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/WebRTCDirective.h
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/WebRTCDirective.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+
+namespace Web::ContentSecurityPolicy::Directives {
+
+// https://w3c.github.io/webappsec-csp/#directive-webrtc
+class WebRTCDirective final : public Directive {
+    GC_CELL(WebRTCDirective, Directive)
+    GC_DECLARE_ALLOCATOR(WebRTCDirective);
+
+public:
+    virtual ~WebRTCDirective() = default;
+
+    [[nodiscard]] virtual Result webrtc_pre_connect_check(GC::Ref<Policy const>) const override;
+
+private:
+    WebRTCDirective(String name, Vector<String> value);
+};
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -151,6 +151,7 @@ class MediaSourceDirective;
 class ObjectSourceDirective;
 class ReportToDirective;
 class ReportUriDirective;
+class SandboxDirective;
 class ScriptSourceAttributeDirective;
 class ScriptSourceDirective;
 class ScriptSourceElementDirective;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -149,6 +149,7 @@ class ImageSourceDirective;
 class ManifestSourceDirective;
 class MediaSourceDirective;
 class ObjectSourceDirective;
+class ReportToDirective;
 class ReportUriDirective;
 class ScriptSourceAttributeDirective;
 class ScriptSourceDirective;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -157,6 +157,7 @@ class ScriptSourceElementDirective;
 class StyleSourceAttributeDirective;
 class StyleSourceDirective;
 class StyleSourceElementDirective;
+class WebRTCDirective;
 class WorkerSourceDirective;
 struct SerializedDirective;
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -149,6 +149,7 @@ class ImageSourceDirective;
 class ManifestSourceDirective;
 class MediaSourceDirective;
 class ObjectSourceDirective;
+class ReportUriDirective;
 class ScriptSourceAttributeDirective;
 class ScriptSourceDirective;
 class ScriptSourceElementDirective;

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -33,6 +33,8 @@ public:
 
     GC::Ref<DOM::DOMTokenList> sandbox();
 
+    SandboxingFlagSet iframe_sandboxing_flag_set() const { return m_iframe_sandboxing_flag_set; }
+
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
@@ -64,6 +66,9 @@ private:
     Optional<HighResolutionTime::DOMHighResTimeStamp> m_pending_resource_start_time = {};
 
     GC::Ptr<DOM::DOMTokenList> m_sandbox;
+
+    // https://html.spec.whatwg.org/multipage/browsers.html#iframe-sandboxing-flag-set
+    SandboxingFlagSet m_iframe_sandboxing_flag_set {};
 };
 
 void run_iframe_load_event_steps(HTML::HTMLIFrameElement&);

--- a/Libraries/LibWeb/HTML/SandboxingFlagSet.cpp
+++ b/Libraries/LibWeb/HTML/SandboxingFlagSet.cpp
@@ -10,11 +10,24 @@
 namespace Web::HTML {
 
 //  https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive
-SandboxingFlagSet parse_a_sandboxing_directive(String const& input)
+SandboxingFlagSet parse_a_sandboxing_directive(Variant<String, Vector<String>> input)
 {
     // 1. Split input on ASCII whitespace, to obtain tokens.
-    auto lowercase_input = input.to_ascii_lowercase();
-    auto tokens = lowercase_input.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
+    Vector<String> tokens;
+    if (input.has<String>()) {
+        auto lowercase_input = input.get<String>().to_ascii_lowercase();
+        auto token_views = lowercase_input.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
+        tokens.ensure_capacity(token_views.size());
+        for (auto token : token_views) {
+            tokens.unchecked_append(MUST(String::from_utf8(token)));
+        }
+    } else {
+        auto const& pre_parsed_tokens = input.get<Vector<String>>();
+        tokens.ensure_capacity(pre_parsed_tokens.size());
+        for (auto const& token : pre_parsed_tokens) {
+            tokens.unchecked_append(token.to_ascii_lowercase());
+        }
+    }
 
     // 2. Let output be empty.
     SandboxingFlagSet output {};

--- a/Libraries/LibWeb/HTML/SandboxingFlagSet.cpp
+++ b/Libraries/LibWeb/HTML/SandboxingFlagSet.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/SandboxingFlagSet.h>
+#include <LibWeb/Infra/CharacterTypes.h>
+
+namespace Web::HTML {
+
+//  https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive
+SandboxingFlagSet parse_a_sandboxing_directive(String const& input)
+{
+    // 1. Split input on ASCII whitespace, to obtain tokens.
+    auto lowercase_input = input.to_ascii_lowercase();
+    auto tokens = lowercase_input.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
+
+    // 2. Let output be empty.
+    SandboxingFlagSet output {};
+
+    // 3. Add the following flags to output:
+    // - The sandboxed navigation browsing context flag.
+    output |= SandboxingFlagSet::SandboxedNavigation;
+
+    // - The sandboxed auxiliary navigation browsing context flag, unless tokens contains the allow-popups keyword.
+    if (!tokens.contains_slow("allow-popups"sv))
+        output |= SandboxingFlagSet::SandboxedAuxiliaryNavigation;
+
+    // - The sandboxed top-level navigation without user activation browsing context flag, unless tokens contains the
+    //   allow-top-navigation keyword.
+    if (!tokens.contains_slow("allow-top-navigation"sv))
+        output |= SandboxingFlagSet::SandboxedTopLevelNavigationWithoutUserActivation;
+
+    // - The sandboxed top-level navigation with user activation browsing context flag, unless tokens contains either
+    //   the allow-top-navigation-by-user-activation keyword or the allow-top-navigation keyword.
+    // Spec Note: This means that if the allow-top-navigation is present, the allow-top-navigation-by-user-activation
+    //            keyword will have no effect. For this reason, specifying both is a document conformance error.
+    if (!tokens.contains_slow("allow-top-navigation"sv) && !tokens.contains_slow("allow-top-navigation-by-user-activation"sv))
+        output |= SandboxingFlagSet::SandboxedTopLevelNavigationWithUserActivation;
+
+    // - The sandboxed origin browsing context flag, unless the tokens contains the allow-same-origin keyword.
+    // Spec Note: The allow-same-origin keyword is intended for two cases.
+    //
+    //            First, it can be used to allow content from the same site to be sandboxed to disable scripting,
+    //            while still allowing access to the DOM of the sandboxed content.
+    //
+    //            Second, it can be used to embed content from a third-party site, sandboxed to prevent that site from
+    //            opening popups, etc, without preventing the embedded page from communicating back to its originating
+    //            site, using the database APIs to store data, etc.
+    if (!tokens.contains_slow("allow-same-origin"sv))
+        output |= SandboxingFlagSet::SandboxedOrigin;
+
+    // - The sandboxed forms browsing context flag, unless tokens contains the allow-forms keyword.
+    if (!tokens.contains_slow("allow-forms"sv))
+        output |= SandboxingFlagSet::SandboxedForms;
+
+    // - The sandboxed pointer lock browsing context flag, unless tokens contains the allow-pointer-lock keyword.
+    if (!tokens.contains_slow("allow-pointer-lock"sv))
+        output |= SandboxingFlagSet::SandboxedPointerLock;
+
+    // - The sandboxed scripts browsing context flag, unless tokens contains the allow-scripts keyword.
+    // - The sandboxed automatic features browsing context flag, unless tokens contains the allow-scripts keyword
+    //   (defined above).
+    // Spec Note: This flag is relaxed by the same keyword as scripts, because when scripts are enabled these features
+    //            are trivially possible anyway, and it would be unfortunate to force authors to use script to do them
+    //            when sandboxed rather than allowing them to use the declarative features.
+    if (!tokens.contains_slow("allow-scripts"sv)) {
+        output |= SandboxingFlagSet::SandboxedScripts;
+        output |= SandboxingFlagSet::SandboxedAutomaticFeatures;
+    }
+
+    // - The sandboxed document.domain browsing context flag.
+    output |= SandboxingFlagSet::SandboxedDocumentDomain;
+
+    // - The sandbox propagates to auxiliary browsing contexts flag, unless tokens contains the
+    //   allow-popups-to-escape-sandbox keyword.
+    if (!tokens.contains_slow("allow-popups-to-escape-sandbox"sv))
+        output |= SandboxingFlagSet::SandboxPropagatesToAuxiliaryBrowsingContexts;
+
+    // - The sandboxed modals flag, unless tokens contains the allow-modals keyword.
+    if (!tokens.contains_slow("allow-modals"sv))
+        output |= SandboxingFlagSet::SandboxedModals;
+
+    // - The sandboxed orientation lock browsing context flag, unless tokens contains the allow-orientation-lock
+    //   keyword.
+    if (!tokens.contains_slow("allow-orientation-lock"sv))
+        output |= SandboxingFlagSet::SandboxedOrientationLock;
+
+    // - The sandboxed presentation browsing context flag, unless tokens contains the allow-presentation keyword.
+    if (!tokens.contains_slow("allow-presentation"sv))
+        output |= SandboxingFlagSet::SandboxedPresentation;
+
+    // - The sandboxed downloads browsing context flag, unless tokens contains the allow-downloads keyword.
+    if (!tokens.contains_slow("allow-downloads"sv))
+        output |= SandboxingFlagSet::SandboxedDownloads;
+
+    // - The sandboxed custom protocols navigation browsing context flag, unless tokens contains either the
+    //   allow-top-navigation-to-custom-protocols keyword, the allow-popups keyword, or the allow-top-navigation
+    //   keyword.
+    if (!tokens.contains_slow("allow-top-navigation-to-custom-protocols"sv) && !tokens.contains_slow("allow-popups"sv) && !tokens.contains_slow("allow-top-navigation"sv))
+        output |= SandboxingFlagSet::SandboxedCustomProtocols;
+
+    return output;
+}
+
+}

--- a/Libraries/LibWeb/HTML/SandboxingFlagSet.h
+++ b/Libraries/LibWeb/HTML/SandboxingFlagSet.h
@@ -36,6 +36,6 @@ enum class SandboxingFlagSet {
 AK_ENUM_BITWISE_OPERATORS(SandboxingFlagSet);
 inline bool is_empty(SandboxingFlagSet s) { return (to_underlying(s) & 0x1FFU) == 0; }
 
-SandboxingFlagSet parse_a_sandboxing_directive(String const& input);
+SandboxingFlagSet parse_a_sandboxing_directive(Variant<String, Vector<String>> input);
 
 }

--- a/Libraries/LibWeb/HTML/SandboxingFlagSet.h
+++ b/Libraries/LibWeb/HTML/SandboxingFlagSet.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/EnumBits.h>
+#include <AK/String.h>
 #include <AK/Types.h>
 
 namespace Web::HTML {
@@ -34,5 +35,7 @@ enum class SandboxingFlagSet {
 
 AK_ENUM_BITWISE_OPERATORS(SandboxingFlagSet);
 inline bool is_empty(SandboxingFlagSet s) { return (to_underlying(s) & 0x1FFU) == 0; }
+
+SandboxingFlagSet parse_a_sandboxing_directive(String const& input);
 
 }

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -293,7 +293,9 @@ bool is_scripting_enabled(JS::Realm const& realm)
     if (!document.page().is_scripting_enabled())
         return false;
 
-    // FIXME: Either settings's global object is not a Window object, or settings's global object's associated Document's active sandboxing flag set does not have its sandboxed scripts browsing context flag set.
+    // Either settings's global object is not a Window object, or settings's global object's associated Document's active sandboxing flag set does not have its sandboxed scripts browsing context flag set.
+    if (has_flag(document.active_sandboxing_flag_set(), SandboxingFlagSet::SandboxedScripts))
+        return false;
 
     return true;
 }

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/browsers/sandboxing/sandbox-parse-noscript-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/browsers/sandboxing/sandbox-parse-noscript-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>noscript parsing when sandbox disables scripting</title>
+<iframe srcdoc="PASS" sandbox></iframe>
+<iframe srcdoc="PASS" sandbox></iframe>
+<iframe srcdoc="P<b>AS</b>S" sandbox></iframe>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/browsers/sandboxing/noscript-iframe.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/browsers/sandboxing/noscript-iframe.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<noscript>PASS</noscript>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/browsers/sandboxing/sandbox-parse-noscript.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/browsers/sandboxing/sandbox-parse-noscript.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>noscript parsing when sandbox disables scripting</title>
+<link rel=match href=../../../../../expected/wpt-import//html/browsers/sandboxing/sandbox-parse-noscript-ref.html>
+<iframe srcdoc="<noscript>PASS</noscript>" sandbox></iframe>
+<iframe src="noscript-iframe.html" sandbox></iframe>
+<iframe srcdoc="<noscript>P<b>AS</b>S</noscript>" sandbox></iframe>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -320,3 +320,16 @@ Text/input/wpt-import/webaudio/the-audio-api/the-periodicwave-interface/periodic
 ; https://github.com/LadybirdBrowser/ladybird/issues/5333
 Text/input/wpt-import/webaudio/the-audio-api/the-audionode-interface/audionode-disconnect.html
 Text/input/wpt-import/webaudio/the-audio-api/the-audionode-interface/audionode-disconnect-audioparam.html
+
+; Currently always timeout
+Text/input/wpt-import/html/browsers/sandboxing/inner-iframe.html
+Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-response.html
+Text/input/wpt-import/html/browsers/sandboxing/sandbox-javascript-window-open.html
+Text/input/wpt-import/html/browsers/sandboxing/sandbox-initial-empty-document-toward-same-origin.html
+Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-scripts-via-unsandboxed-popup.tentative.html
+Text/input/wpt-import/html/browsers/sandboxing/sandbox-document-open.html
+Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-required-csp.html
+Text/input/wpt-import/html/browsers/sandboxing/sandbox-navigation-timing.tentative.html
+
+; Not a ref test, but a subfile of the sandbox-parse-noscript ref test
+Ref/input/wpt-import/html/browsers/sandboxing/noscript-iframe.html

--- a/Tests/LibWeb/Text/expected/wpt-import/fetch/api/cors/sandboxed-iframe.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/fetch/api/cors/sandboxed-iframe.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	CORS with sandboxed iframe

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-allow-same-origin.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-allow-same-origin.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	DOM access in sandbox='allow-same-origin' iframe is allowed

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-allow-scripts.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-allow-scripts.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Running script from sandbox='allow-scripts' iframe is allowed

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-disallow-popups.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-disallow-popups.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	window.open in sandbox iframe

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-disallow-same-origin.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-disallow-same-origin.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Access to sandbox iframe is disallowed

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-disallow-scripts.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-disallow-scripts.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Running script from sandbox iframe is disallowed

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-document-open-mutation.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-document-open-mutation.window.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	Using document.open() against a document from a different window must not mutate the other window's sandbox flags

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-frame.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-frame.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Inherit sandbox flags from the initiator's frame

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-response.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-response.txt
@@ -1,0 +1,6 @@
+Harness status: Timeout
+
+Found 1 tests
+
+1 Timeout
+Timeout	Inherit sandbox flags from the initiator's response

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-navigation-timing.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-navigation-timing.tentative.txt
@@ -1,0 +1,6 @@
+Harness status: Timeout
+
+Found 1 tests
+
+1 Timeout
+Timeout	setting sandbox attribute should not affect current document in iframe

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-new-execution-context.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-new-execution-context.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	iframe with sandbox should load with new execution context

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-window-open-srcdoc.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/sandboxing/sandbox-window-open-srcdoc.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	window.open('about:srcdoc') from sandboxed srcdoc doesn't crash.

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-iframe-element/sandbox-ascii-case-insensitive.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-iframe-element/sandbox-ascii-case-insensitive.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
+2 Pass
 Pass	iframe 'sandbox' ASCII case insensitive, allow-same-orİgin
-Fail	iframe 'sandbox' ASCII case insensitive, allow-ſcripts
+Pass	iframe 'sandbox' ASCII case insensitive, allow-ſcripts

--- a/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/inhead-noscript-head.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/inhead-noscript-head.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	When the scripting flag is disabled, a head start tag in "in head noscript" mode should be ignored
+1 Pass
+Pass	When the scripting flag is disabled, a head start tag in "in head noscript" mode should be ignored

--- a/Tests/LibWeb/Text/input/wpt-import/common/utils.js
+++ b/Tests/LibWeb/Text/input/wpt-import/common/utils.js
@@ -1,0 +1,98 @@
+/**
+ * Create an absolute URL from `options` and defaulting unspecified properties to `window.location`.
+ * @param {Object} options - a `Location`-like object
+ * @param {string} options.hostname
+ * @param {string} options.subdomain - prepend subdomain to the hostname
+ * @param {string} options.port
+ * @param {string} options.path
+ * @param {string} options.query
+ * @param {string} options.hash
+ * @returns {string}
+ */
+function make_absolute_url(options) {
+    var loc = window.location;
+    var protocol = get(options, "protocol", loc.protocol);
+    if (protocol[protocol.length - 1] != ":") {
+        protocol += ":";
+    }
+
+    var hostname = get(options, "hostname", loc.hostname);
+
+    var subdomain = get(options, "subdomain");
+    if (subdomain) {
+        hostname = subdomain + "." + hostname;
+    }
+
+    var port = get(options, "port", loc.port)
+    var path = get(options, "path", loc.pathname);
+    var query = get(options, "query", loc.search);
+    var hash = get(options, "hash", loc.hash)
+
+    var url = protocol + "//" + hostname;
+    if (port) {
+        url += ":" + port;
+    }
+
+    if (path[0] != "/") {
+        url += "/";
+    }
+    url += path;
+    if (query) {
+        if (query[0] != "?") {
+            url += "?";
+        }
+        url += query;
+    }
+    if (hash) {
+        if (hash[0] != "#") {
+            url += "#";
+        }
+        url += hash;
+    }
+    return url;
+}
+
+/** @private */
+function get(obj, name, default_val) {
+    if (obj.hasOwnProperty(name)) {
+        return obj[name];
+    }
+    return default_val;
+}
+
+/**
+ * Generate a new UUID.
+ * @returns {string}
+ */
+function token() {
+    var uuid = [to_hex(rand_int(32), 8),
+                to_hex(rand_int(16), 4),
+                to_hex(0x4000 | rand_int(12), 4),
+                to_hex(0x8000 | rand_int(14), 4),
+                to_hex(rand_int(48), 12)].join("-")
+    return uuid;
+}
+
+/** @private */
+function rand_int(bits) {
+    if (bits < 1 || bits > 53) {
+        throw new TypeError();
+    } else {
+        if (bits >= 1 && bits <= 30) {
+            return 0 | ((1 << bits) * Math.random());
+        } else {
+            var high = (0 | ((1 << (bits - 30)) * Math.random())) * (1 << 30);
+            var low = 0 | ((1 << 30) * Math.random());
+            return  high + low;
+        }
+    }
+}
+
+/** @private */
+function to_hex(x, length) {
+    var rv = x.toString(16);
+    while (rv.length < length) {
+        rv = "0" + rv;
+    }
+    return rv;
+}

--- a/Tests/LibWeb/Text/input/wpt-import/fetch/api/cors/sandboxed-iframe.html
+++ b/Tests/LibWeb/Text/input/wpt-import/fetch/api/cors/sandboxed-iframe.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<iframe sandbox="allow-scripts" src="../resources/sandboxed-iframe.html"></iframe>
+<script>
+promise_test(async (t) => {
+  const message = await new Promise((resolve) => {
+    window.addEventListener('message', e => resolve(e.data));
+  });
+  assert_equals(message, 'PASS');
+}, 'CORS with sandboxed iframe');
+</script>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/fetch/api/resources/sandboxed-iframe.html
+++ b/Tests/LibWeb/Text/input/wpt-import/fetch/api/resources/sandboxed-iframe.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<script>
+async function no_cors_should_be_rejected() {
+  let thrown = false;
+  try {
+    const resp = await fetch('top.txt');
+  } catch (e) {
+    thrown = true;
+  }
+  if (!thrown) {
+    throw Error('fetching "top.txt" should be rejected.');
+  }
+}
+
+async function null_origin_should_be_accepted() {
+  const url = 'top.txt?pipe=header(access-control-allow-origin,null)|' +
+              'header(cache-control,no-store)';
+  const resp = await fetch(url);
+}
+
+async function test() {
+  try {
+    await no_cors_should_be_rejected();
+    await null_origin_should_be_accepted();
+    parent.postMessage('PASS', '*');
+  } catch (e) {
+    parent.postMessage(e.message, '*');
+  }
+}
+
+test();
+</script>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/inner-iframe.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/inner-iframe.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <script>
+    window.onload = function() {
+      top.calledFromIframe();
+    }
+  </script>
+  </head>
+  <body>
+    <div id="inner">foo</div>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-allow-same-origin.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-allow-same-origin.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>DOM access in sandbox="allow-same-origin" iframe</title>
+    <link rel="author" title="Kinuko Yasuda" href="mailto:kinuko@chromium.org">
+    <link rel="help" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#sandboxing">
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <h1>DOM access in sandbox="allow-same-origin" iframe</h1>
+    <script type="text/javascript">
+      var t = async_test("DOM access in sandbox='allow-same-origin' iframe is allowed")
+      var called = 0;
+      function calledFromIframe() {
+        called++;
+      }
+      function loaded() {
+        assert_equals(document.getElementById('sandboxedframe').contentWindow.document.getElementById('inner').innerHTML, 'foo');
+        assert_equals(called, 0);
+        t.done();
+      }
+    </script>
+
+    <iframe src="../../../html/browsers/sandboxing/inner-iframe.html" style="visibility:hidden;display:none" sandbox="allow-same-origin" id="sandboxedframe" onload="loaded();"></iframe>
+
+    <div id="log"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-allow-scripts.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-allow-scripts.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Script execution in sandbox="allow-scripts" iframe</title>
+    <link rel="author" title="Kinuko Yasuda" href="mailto:kinuko@chromium.org">
+    <link rel="help" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#sandboxing">
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <h1>Script execution in sandbox="allow-scripts" iframe</h1>
+    <script type="text/javascript">
+      var t = async_test("Running script from sandbox='allow-scripts' iframe is allowed")
+      var called = 0;
+      function calledFromIframe() {
+        called++;
+      }
+      function loaded() {
+        assert_equals(called, 1);
+        t.done();
+      }
+    </script>
+
+    <iframe src="../../../html/browsers/sandboxing/inner-iframe.html" style="visibility:hidden;display:none" sandbox="allow-scripts allow-same-origin" id="sandboxedframe" onload="loaded();"></iframe>
+
+    <div id="log"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-popups.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-popups.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>window.open in sandbox iframe</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../common/utils.js"></script>
+<body>
+<script>
+setup({single_test: true});
+// check that the popup's URL is not loaded
+const uuid = token();
+async function assert_popup_not_loaded() {
+  const response = await fetch(`/fetch/api/resources/stash-take.py?key=${uuid}`);
+  assert_equals(await response.json(), null); // is "loaded" if it loads
+}
+
+// check for message from the iframe
+window.onmessage = e => {
+  assert_equals(e.data, 'null', 'return value of window.open (stringified)');
+  step_timeout(async () => {
+    await assert_popup_not_loaded();
+    done();
+  }, 1000);
+};
+const iframe = document.createElement('iframe');
+iframe.sandbox = 'allow-scripts';
+iframe.srcdoc = `
+  <script>
+    let result;
+    try {
+      result = window.open('/fetch/api/resources/stash-put.py?key=${uuid}&value=loaded', '_blank');
+    } catch(ex) {
+      result = ex;
+    }
+    parent.postMessage(String(result), '*');
+  <\/script>
+`;
+document.body.appendChild(iframe);
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-same-origin.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-same-origin.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Access to sandbox iframe</title>
+    <link rel="author" title="Kinuko Yasuda" href="mailto:kinuko@chromium.org">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#sandboxed-origin-browsing-context-flag">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#integration-with-idl">
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <h1>Access to sandbox iframe</h1>
+    <script type="text/javascript">
+      var t = async_test("Access to sandbox iframe is disallowed")
+      var called = 0;
+      function calledFromIframe() {
+        called++;
+      }
+      function loaded() {
+        t.step(() => {
+          assert_throws_dom("SecurityError", () => {
+            document.getElementById('sandboxedframe').contentWindow.document;
+          });
+          assert_equals(called, 0);
+          t.done();
+        });
+      }
+    </script>
+
+    <iframe src="../../../html/browsers/sandboxing/inner-iframe.html" style="visibility:hidden;display:none" sandbox id="sandboxedframe" onload="loaded();"></iframe>
+  </body>
+
+    <div id="log"></div>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-scripts-via-unsandboxed-popup.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-scripts-via-unsandboxed-popup.tentative.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+  <script>
+    async_test(t => {
+      let i = document.createElement('iframe');
+      i.sandbox = "allow-same-origin allow-popups allow-popups-to-escape-sandbox";
+      i.srcdoc = `<a target='_blank' rel='opener'
+                     href="javascript:window.opener.top.postMessage('FAIL', '*');">Click me!</a>
+                  <a target='_blank' rel='opener'
+                     href="./resources/post-done-to-opener.html">Click me next!</a>`;
+
+      i.onload = _ => {
+        // Since the frame is sandboxed, but allow-same-origin, we can reach into it to grab the
+        // anchor element to click. We'll click the `javascript:` URL first, then pop up a new
+        // window that posts `DONE`.
+        //
+        // TODO(mkwst): This feels like a race, but it's one that we consistently win when I'm
+        // running the test locally 10,000 times. Good enough!™
+        i.contentDocument.body.querySelectorAll('a')[0].click();
+        i.contentDocument.body.querySelectorAll('a')[1].click();
+      };
+      document.body.appendChild(i);
+
+      window.addEventListener('message', t.step_func(e => {
+        assert_not_equals(e.data, "FAIL");
+        if (e.data == "DONE")
+          t.done();
+      }));
+    }, "Sandboxed => unsandboxed popup");
+  </script>
+</body>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-scripts.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-disallow-scripts.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Script execution in sandbox iframe</title>
+    <link rel="author" title="Kinuko Yasuda" href="mailto:kinuko@chromium.org">
+    <link rel="help" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#sandboxing">
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <h1>Script execution in sandbox iframe</h1>
+    <script type="text/javascript">
+      var t = async_test("Running script from sandbox iframe is disallowed")
+      var called = 0;
+      function calledFromIframe() {
+        called++;
+      }
+      function loaded() {
+        assert_equals(called, 0);
+        t.done();
+      }
+    </script>
+
+    <iframe src="../../../html/browsers/sandboxing/inner-iframe.html" style="visibility:hidden;display:none" sandbox id="sandboxedframe" onload="loaded();"></iframe>
+
+    <div id="log"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-document-open-mutation.window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-document-open-mutation.window.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../../html/browsers/sandboxing/sandbox-document-open-mutation.window.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-document-open-mutation.window.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-document-open-mutation.window.js
@@ -1,0 +1,37 @@
+// Return whether the current context is sandboxed or not. The implementation do
+// not matter much, but might have to change over time depending on what side
+// effect sandbox flag have. Feel free to update as needed.
+const is_sandboxed = () => {
+  try {
+    document.domain = document.domain;
+    return "not sandboxed";
+  } catch (error) {
+    return "sandboxed";
+  }
+};
+
+promise_test(async test => {
+  const message = new Promise(r => window.addEventListener("message", r));
+
+  const iframe_unsandboxed = document.createElement("iframe");
+  document.body.appendChild(iframe_unsandboxed);
+
+  const iframe_sandboxed = document.createElement("iframe");
+  iframe_sandboxed.sandbox = "allow-same-origin allow-scripts";
+  document.body.appendChild(iframe_sandboxed);
+
+  iframe_sandboxed.srcdoc = `
+    <script>
+      parent.frames[0].document.write(\`
+        <script>
+          const is_sandboxed = ${is_sandboxed};
+          window.parent.postMessage(is_sandboxed(), '*');
+        </scr\`+\`ipt>
+      \`);
+      parent.frames[0].document.close();
+    </scr`+`ipt>
+  `;
+  assert_equals((await message).data, "not sandboxed");
+
+}, "Using document.open() against a document from a different window must not" +
+   " mutate the other window's sandbox flags");

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-document-open.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-document-open.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>
+  Check sandbox-flags aren't lost after using document.open().
+</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async test => {
+  let message = new Promise(resolve =>
+    window.addEventListener("message", event => resolve(event.data))
+  );
+
+  let iframe = document.createElement("iframe");
+  iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  iframe.setAttribute("src", "./resources/document-open.html")
+  document.body.appendChild(iframe);
+
+  assert_equals(await message, "document-domain-is-disallowed");
+}, "document.open()");
+
+promise_test(async test => {
+  let iframe = document.createElement("iframe");
+  iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  iframe.setAttribute("src", "/common/blank.html");
+  let loaded = new Promise(resolve => iframe.onload = resolve);
+  document.body.appendChild(iframe);
+  await loaded;
+
+  let message = new Promise(resolve =>
+    window.addEventListener("message", event => resolve(event.data))
+  );
+
+  iframe.contentDocument.write(`
+    <script>
+      try {
+        document.domain = document.domain;
+        parent.postMessage('document-domain-is-allowed', '*');
+      } catch (error) {
+        parent.postMessage('document-domain-is-disallowed', '*');
+      }
+    </sc`+`ript>
+  `);
+
+  assert_equals(await message, "document-domain-is-disallowed");
+}, "other_document.open()");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-frame.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-frame.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Inherit sandbox flags from the initiator's frame</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+<script>
+// Check sandbox flags are properly inherited when a document initiate a
+// navigation inside another frame that it doesn't own directly.
+
+// This check the sandbox flags defined by the frame. See also the other test
+// about sandbox flags defined by the response (e.g. CSP sandbox):
+// => sandbox-inherited-from-initiators-response.html
+
+// Return a promise, resolving when |element| triggers |event_name| event.
+let future = (element, event_name) => {
+  return new Promise(resolve => {
+    element.addEventListener(event_name, event => resolve(event))
+  });
+};
+
+promise_test(async test => {
+  const iframe_1 = document.createElement("iframe");
+  const iframe_2 = document.createElement("iframe");
+
+  iframe_1.id = "iframe_1";
+  iframe_2.id = "iframe_2";
+
+  const iframe_1_script = encodeURI(`
+    <script>
+      try {
+        document.domain = document.domain;
+        parent.postMessage("not sandboxed", "*");
+      } catch (exception) {
+        parent.postMessage("sandboxed", "*");
+      }
+    </scr`+`ipt>
+  `);
+
+  const iframe_2_script = `
+    <script>
+      const iframe_1 = parent.document.querySelector("#iframe_1");
+      iframe_1.src = "data:text/html,${iframe_1_script}";
+    </scr`+`ipt>
+  `;
+
+  iframe_2.sandbox = "allow-scripts allow-same-origin";
+  iframe_2.srcdoc = iframe_2_script;
+
+  // Insert |iframe_1|. It will load the initial empty document, with no sandbox
+  // flags.
+  const iframe_1_load_1 = future(iframe_1, "load");
+  document.body.appendChild(iframe_1);
+  await iframe_1_load_1;
+
+  // Insert |iframe_2|. It will load with sandbox flags. It will make |iframe_1|
+  // to navigate toward a data-url, which should inherit the sandbox flags.
+  const iframe_1_reply = future(window, "message");
+  document.body.appendChild(iframe_2);
+  const result = await iframe_1_reply;
+
+  assert_equals("sandboxed", result.data);
+})
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-response.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-initiator-response.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Inherit sandbox flags from the initiator's response</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+<script>
+// Check sandbox flags are properly inherited when a document initiate a
+// navigation inside another frame that it doesn't own directly.
+
+// This check the sandbox flags defined by the response (e.g. CSP sandbox). See
+// also the other test about sandbox flags inherited from the frame.
+// => sandbox-inherited-from-initiators-frame.html
+
+// Return a promise, resolving when |element| triggers |event_name| event.
+let future = (element, event_name) => {
+  return new Promise(resolve => {
+    element.addEventListener(event_name, event => resolve(event))
+  });
+};
+
+promise_test(async test => {
+  const iframe_1 = document.createElement("iframe");
+  const iframe_2 = document.createElement("iframe");
+
+  iframe_1.id = "iframe_1";
+  iframe_2.id = "iframe_2";
+
+  iframe_2.src =
+    "./resources/sandbox-inherited-from-initiator-response-helper.html";
+
+  // Insert |iframe_1|. It will load the initial empty document, with no sandbox
+  // flags.
+  const iframe_1_load_1 = future(iframe_1, "load");
+  document.body.appendChild(iframe_1);
+  await iframe_1_load_1;
+
+  // Insert |iframe_2|. It will load with sandbox flags. It will make |iframe_1|
+  // to navigate toward a data-url, which should inherit the sandbox flags.
+  const iframe_1_reply = future(window, "message");
+  document.body.appendChild(iframe_2);
+  const result = await iframe_1_reply;
+
+  assert_equals("sandboxed", result.data);
+})
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-required-csp.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-inherited-from-required-csp.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Inherit sandbox from CSP embedded enforcement</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../common/get-host-info.sub.js"></script>
+<body>
+<script>
+// Check sandbox flags are properly defined when its parent requires them and
+// the child allows it.
+
+const same_origin = get_host_info().HTTP_ORIGIN;
+const cross_origin = get_host_info().HTTP_REMOTE_ORIGIN;
+const check_sandbox_url =
+  "/html/browsers/sandboxing/resources/check-sandbox-flags.html?pipe=";
+const allow_csp_from_star = "|header(Allow-CSP-From,*)";
+
+// Return a promise, resolving when |element| triggers |event_name| event.
+const future = (element, event_name, source) => {
+  return new Promise(resolve => {
+    element.addEventListener(event_name, event => {
+      if (!source || source.contentWindow == event.source)
+        resolve(event)
+    })
+  });
+};
+
+const check_sandbox_script = `
+<script>
+  try {
+    document.domain = document.domain;
+    parent.postMessage("document-domain-is-allowed", "*");
+  } catch (exception) {
+    parent.postMessage("document-domain-is-disallowed", "*");
+  }
+</scr`+`ipt>
+`;
+
+const sandbox_policy = "sandbox allow-scripts allow-same-origin";
+
+// Test using the modern async/await primitives are easier to read/write.
+// However they run sequentially, contrary to async_test. This is the parallel
+// version, to avoid timing out.
+let promise_test_parallel = (promise, description) => {
+  async_test(test => {
+    promise(test)
+    .then(() => {test.done();})
+    .catch(test.step_func(error => { throw error; }));
+  }, description);
+};
+
+promise_test_parallel(async test => {
+  const iframe = document.createElement("iframe");
+  iframe.csp = sandbox_policy;
+
+  // The <iframe> immediately hosts the initial empty document after being
+  // appended into the DOM. It will, as long as its 'src' isn't loaded. That's
+  // why a page do not load is being used.
+  iframe.src = "/fetch/api/resources/infinite-slow-response.py";
+  document.body.appendChild(iframe);
+
+  const iframe_reply = future(window, "message", iframe);
+  iframe.contentDocument.write(check_sandbox_script);
+  const result = await iframe_reply;
+  iframe.remove();
+
+  assert_equals(result.data, "document-domain-is-disallowed");
+}, "initial empty document");
+
+promise_test_parallel(async test => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "data:text/html,dummy";
+
+  const iframe_load_1 = future(iframe, "load");
+  document.body.appendChild(iframe);
+  await iframe_load_1;
+
+  const iframe_load_2 = future(iframe, "load");
+  iframe.csp = sandbox_policy;
+  iframe.src = "about:blank";
+  await iframe_load_2;
+
+  const iframe_reply = future(window, "message", iframe);
+  iframe.contentDocument.write(check_sandbox_script);
+  const result = await iframe_reply;
+
+  assert_equals(result.data, "document-domain-is-disallowed");
+}, "about:blank");
+
+promise_test_parallel(async test => {
+  const iframe = document.createElement("iframe");
+  iframe.csp = sandbox_policy;
+  iframe.src =
+    `data:text/html,${encodeURI(check_sandbox_script)}`;
+
+  const iframe_reply = future(window, "message", iframe);
+  document.body.appendChild(iframe);
+  const result = await iframe_reply;
+
+  assert_equals(result.data, "document-domain-is-disallowed");
+}, "data-url");
+
+promise_test_parallel(async test => {
+  const iframe = document.createElement("iframe");
+  iframe.csp = sandbox_policy;
+  iframe.srcdoc = check_sandbox_script;
+
+  const iframe_reply = future(window, "message", iframe);
+  document.body.appendChild(iframe);
+  const result = await iframe_reply;
+
+  assert_equals(result.data, "document-domain-is-disallowed");
+}, "srcdoc");
+
+promise_test_parallel(async test => {
+  const iframe = document.createElement("iframe");
+  iframe.csp = sandbox_policy;
+
+  const blob = new Blob([check_sandbox_script], { type: "text/html" });
+
+  iframe.src = URL.createObjectURL(blob);
+
+  const iframe_reply = future(window, "message", iframe);
+  document.body.appendChild(iframe);
+  const result = await iframe_reply;
+
+  assert_equals(result.data, "document-domain-is-disallowed");
+}, "blob URL");
+
+promise_test_parallel(async test => {
+  const iframe = document.createElement("iframe");
+  iframe.csp = sandbox_policy;
+  iframe.src = same_origin + check_sandbox_url + allow_csp_from_star;
+
+  const iframe_reply = future(window, "message", iframe);
+  document.body.appendChild(iframe);
+  const result = await iframe_reply;
+
+  assert_equals(result.data, "document-domain-is-disallowed");
+}, "same-origin");
+
+promise_test_parallel(async test => {
+  const iframe = document.createElement("iframe");
+  iframe.csp = sandbox_policy;
+  iframe.src = cross_origin + check_sandbox_url + allow_csp_from_star;
+
+  const iframe_reply = future(window, "message", iframe);
+  document.body.appendChild(iframe);
+  const result = await iframe_reply;
+
+  assert_equals(result.data, "document-domain-is-disallowed");
+}, "cross-origin");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-initial-empty-document-toward-same-origin.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-initial-empty-document-toward-same-origin.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>
+  Check sandbox-flags inheritance in case of javascript window reuse.
+</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async test => {
+  let message = new Promise(resolve =>
+    window.addEventListener("message", event => resolve(event.data))
+  );
+
+  // Create an initial empty document in the iframe, sandboxed. It will attempt
+  // to load a slow page, but won't have time.
+  let iframe = document.createElement("iframe");
+  iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  iframe.src = "/fetch/api/resources/infinite-slow-response.py";
+  document.body.appendChild(iframe);
+
+  // Remove sandbox flags. This should apply to documents committed from
+  // navigations started after this instruction.
+  iframe.removeAttribute("sandbox");
+  iframe.src = "./resources/check-sandbox-flags.html";
+
+  // The window is reused, but the new sandbox flags should be used.
+  assert_equals(await message, "document-domain-is-allowed");
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-javascript-window-open.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-javascript-window-open.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>window.open in sandbox iframe</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../common/utils.js"></script>
+<body>
+<script>
+promise_test(async test => {
+  let message = new Promise(resolve => {
+    window.addEventListener("message", event => resolve(event.data));
+  });
+  let iframe = document.createElement("iframe");
+  iframe.sandbox = "allow-scripts allow-popups allow-same-origin";
+  iframe.src = "./resources/sandbox-javascript-window-open.html";
+  document.body.appendChild(iframe);
+  assert_equals(await message, "disallow-document-domain");
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-navigation-timing.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-navigation-timing.tentative.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sandbox Navigation Timing</title>
+<script src=../../../resources/testharness.js></script>
+<script src=../../../resources/testharnessreport.js></script>
+<html></html>
+<script>
+  const sandboxUrl = location.pathname.substring(0, location.pathname.lastIndexOf('/') + 1) + 'sandbox-navigation-timing-iframe.tentative.html';
+  async_test(t => {
+    const iframe = document.createElement('iframe');
+    iframe.src = sandboxUrl;
+    document.body.appendChild(iframe); // Navigation starts; value of sandbox flags locked on.
+    // This should not affect the sandbox value used for both about:blank document
+    // and the final document in iframe.
+    iframe.sandbox = 'allow-scripts';
+    const iframeAboutBlankDocument = iframe.contentDocument;
+
+    iframe.onload = t.step_func(() => {
+      const iframeAboutBlankContents = iframeAboutBlankDocument.querySelectorAll('body');
+      assert_equals(iframeAboutBlankContents[0].tagName, "BODY",
+        "about:blank document's contents should still be accessible");
+
+      iframe.contentWindow.postMessage("is iframe sandboxed?", "*");
+    });
+    window.onmessage = t.step_func_done(e => {
+      assert_equals(e.data.result, 'iframe not sandboxed');
+    });
+  }, 'setting sandbox attribute should not affect current document in iframe');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-new-execution-context.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-new-execution-context.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Reuse of iframe about:blank document execution context</title>
+    <link rel="author" title="Dan Clark" href="mailto:daniec@microsoft.com">
+    <link rel="help" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#sandboxing">
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <h1>Reuse of iframe about:blank document execution context in sandbox="allow-scripts" iframe</h1>
+    <script type="text/javascript">
+      async_test(t => {
+        let iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        let iframeAboutBlankDocument = iframe.contentDocument;
+        assert_equals(iframeAboutBlankDocument.URL, "about:blank");
+
+        iframe.sandbox = "allow-scripts";
+        iframe.src = './sandbox-new-execution-context-iframe.html';
+
+        iframe.onload = t.step_func_done(() => {
+          assert_equals(iframe.contentDocument, null,
+            "New document in sandboxed iframe should have opaque origin");
+
+          assert_equals(Object.getPrototypeOf(iframeAboutBlankDocument).changeFromSandboxedIframe, undefined,
+            "Sandboxed iframe contents should not have been able to mess with type system of about:blank document");
+
+          let iframeAboutBlankContents = iframeAboutBlankDocument.querySelectorAll('body');
+          assert_equals(iframeAboutBlankContents[0].tagName, "BODY",
+            "about:blank document's contents should still be accessible");
+        });
+      },"iframe with sandbox should load with new execution context");
+    </script>
+    <div id="log"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-window-open-srcdoc.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/sandboxing/sandbox-window-open-srcdoc.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>window.open("about:srcdoc") from a sandboxed iframe</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+<script>
+// Check what happens when executing window.open("about:srcdoc") from a
+// sandboxed iframe. Srcdoc can't be loaded in the main frame. It should
+// result in an error page. The error page should be cross-origin with the
+// opener.
+//
+// This test covers an interesting edge case. A main frame should inherit
+// sandbox flags. However the document loaded is an internal error page. This
+// might trigger some assertions, especially if the implementation wrongly
+// applies the sandbox flags of the opener to the internal error page document.
+//
+// This test is mainly a coverage test. It passes if it doesn't crash.
+async_test(test => {
+  let iframe = document.createElement("iframe");
+  iframe.sandbox = "allow-scripts allow-popups allow-same-origin";
+  iframe.srcdoc = `
+    <script>
+      let w = window.open();
+      onunload = () => w.close();
+
+      let notify = () => {
+        try {
+          w.origin; // Will fail after navigating to about:srcdoc.
+          parent.postMessage("pending", "*");
+        } catch (e) {
+          parent.postMessage("done", "*");
+        };
+      };
+
+      addEventListener("message", notify);
+      notify();
+
+      w.location = "about:srcdoc"; // Error page.
+    </scr`+`ipt>
+  `;
+
+  let closed = false;
+  addEventListener("message", event => {
+    closed = (event.data === "done");
+    iframe.contentWindow.postMessage("ping","*");
+  });
+
+  document.body.appendChild(iframe);
+  test.step_wait_func_done(()=>closed);
+}, "window.open('about:srcdoc') from sandboxed srcdoc doesn't crash.");
+</script>


### PR DESCRIPTION
Part 15 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854

The final part of splitting up Part 14 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854!
The report-to, report-uri and webrtc are simple directives, with the main complexity of this part coming from the sandbox directive. Since it shares the same sandbox 