### PR TITLE
Fix some SVG use element bugs for cal.com

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -325,4 +325,9 @@ String Internals::dump_display_list()
     return window().associated_document().dump_display_list();
 }
 
+GC::Ptr<DOM::ShadowRoot> Internals::get_shadow_root(GC::Ref<DOM::Element> element)
+{
+    return element->shadow_root();
+}
+
 }

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -66,6 +66,8 @@ public:
 
     String dump_display_list();
 
+    GC::Ptr<DOM::ShadowRoot> get_shadow_root(GC::Ref<DOM::Element>);
+
 private:
     explicit Internals(JS::Realm&);
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -54,4 +54,8 @@ interface Internals {
     readonly attribute boolean headless;
 
     DOMString dumpDisplayList();
+
+    // Returns the shadow root of the element, if it has one, even if it's not normally accessible to JS.
+    ShadowRoot? getShadowRoot(Element element);
+
 };

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -240,6 +240,13 @@ void SVGElement::removed_from(Node* old_parent, Node& old_root)
 {
     Base::removed_from(old_parent, old_root);
 
+    if (auto* shadow_root = as_if<DOM::ShadowRoot>(root())) {
+        // If this element is in a shadow root hosted by a use element,
+        // it already represents a clone and is not itself referenced.
+        if (shadow_root->host() && is<SVGUseElement>(*shadow_root->host()))
+            return;
+    }
+
     remove_from_use_element_that_reference_this();
 }
 

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -36,8 +36,10 @@ void SVGUseElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGUseElement);
     Base::initialize(realm);
 
-    // The shadow tree is open (inspectable by script), but read-only.
-    auto shadow_root = realm.create<DOM::ShadowRoot>(document(), *this, Bindings::ShadowRootMode::Open);
+    // NOTE: The spec says "The shadow tree is open (inspectable by script), but read-only."
+    //       This doesn't actually match other browsers, and there's a spec issue to change it.
+    //       Spec bug: https://github.com/w3c/svgwg/issues/875
+    auto shadow_root = realm.create<DOM::ShadowRoot>(document(), *this, Bindings::ShadowRootMode::Closed);
 
     // The user agent must create a use-element shadow tree whose host is the ‘use’ element itself
     set_shadow_root(shadow_root);

--- a/Tests/LibWeb/Text/expected/Internals/getShadowRoot.txt
+++ b/Tests/LibWeb/Text/expected/Internals/getShadowRoot.txt
@@ -1,0 +1,2 @@
+null
+[object ShadowRoot]

--- a/Tests/LibWeb/Text/expected/SVG/removeChild-on-ancestor-of-use-element.txt
+++ b/Tests/LibWeb/Text/expected/SVG/removeChild-on-ancestor-of-use-element.txt
@@ -1,0 +1,4 @@
+use1 > [object SVGSVGElement] foo
+use2 > [object SVGSVGElement] foo
+no use1
+use2 > [object SVGSVGElement] foo

--- a/Tests/LibWeb/Text/expected/SVG/use-shadowRoot-closed.txt
+++ b/Tests/LibWeb/Text/expected/SVG/use-shadowRoot-closed.txt
@@ -1,0 +1,2 @@
+null
+[object ShadowRoot]

--- a/Tests/LibWeb/Text/input/Internals/getShadowRoot.html
+++ b/Tests/LibWeb/Text/input/Internals/getShadowRoot.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<script src="../include.js"></script>
+<input id="myInput">
+<script>
+    test(() => {
+        println(myInput.shadowRoot);
+        println(internals.getShadowRoot(myInput));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/SVG/removeChild-on-ancestor-of-use-element.html
+++ b/Tests/LibWeb/Text/input/SVG/removeChild-on-ancestor-of-use-element.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<script src="../include.js"></script>
+<div id="svgContainer1">
+<svg><use id="use1" href="#foo" /></svg>
+</div>
+<div id="svgContainer2">
+<svg><use id="use2" href="#foo" /></svg>
+</div>
+<svg id="foo"></svg>
+<script>
+    function check(use) {
+        let sr = internals.getShadowRoot(use);
+        println(use.id + " > " + sr.firstChild + " " + sr.firstChild.id);
+    }
+    asyncTest((done) => {
+        // NOTE: We use setTimeout() here to ensure that the SVG use elements have had their shadow clone trees instantiated.
+        setTimeout(function() {
+            check(use1);
+            check(use2);
+            svgContainer1.remove();
+            // use1 is gone, but use2 should still have children!
+            try {
+                check(use1);
+            } catch (e) {
+                println("no use1");
+            }
+            check(use2);
+            done();
+        }, 10);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/SVG/use-shadowRoot-closed.html
+++ b/Tests/LibWeb/Text/input/SVG/use-shadowRoot-closed.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<script src="../include.js"></script>
+<svg id="foo"></svg>
+<svg><use id="use" href="#foo" /></svg>
+<script>
+    test(() => {
+        println(use.shadowRoot);
+        println(internals.getShadowRoot(use));
+    });
+</script>


### PR DESCRIPTION
See individual commits! Improves https://cal.com/

Before:
<img width="1092" height="848" alt="Screenshot 2025-08-07 at 19 16 22" src="https://github.com/user-attachments/assets/d76c192f-5414-4fc2-b996-26c0876ad53b" />

After:
<img width="1092" height="848" alt="Screenshot 2025-08-07 at 19 13 57" src="https://github.com/user-attachments/assets/e06c200a-847c-4385-aab4-bcf93ab4e2ea" />
