### PR TITLE
Tests/LibJS+Utilities: Enable abench+dns+image+wasm+xml and test-js on Windows

### DIFF
--- a/Libraries/LibDNS/CMakeLists.txt
+++ b/Libraries/LibDNS/CMakeLists.txt
@@ -2,5 +2,5 @@ set(SOURCES
     Message.cpp
 )
 
-ladybird_lib(LibDNS dns)
+ladybird_lib(LibDNS dns EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibDNS PRIVATE LibCore PUBLIC LibCrypto)

--- a/Libraries/LibDNS/Message.h
+++ b/Libraries/LibDNS/Message.h
@@ -11,6 +11,7 @@
 #include <AK/IPv6Address.h>
 #include <AK/RedBlackTree.h>
 #include <AK/Time.h>
+#include <LibDNS/Export.h>
 
 namespace DNS {
 namespace Messages {
@@ -84,7 +85,7 @@ struct Header {
     NetworkOrdered<u16> additional_count;
 };
 
-struct DomainName {
+struct DNS_API DomainName {
     Vector<ByteString> labels;
 
     static DomainName from_string(StringView);
@@ -201,8 +202,8 @@ enum class ResourceType : u16 {
     TA = 32768,      // DNSSEC Trust Authorities "[Sam_Weiler][Deploying DNSSEC Without a Signed Root.  Technical Report 1999-19, Information Networking Institute, Carnegie Mellon University, April 2004.]"
     DLV = 32769,     // DNSSEC Lookaside Validation (OBSOLETE) [RFC8749][RFC4431]
 };
-StringView to_string(ResourceType);
-Optional<ResourceType> resource_type_from_string(StringView);
+DNS_API StringView to_string(ResourceType);
+DNS_API Optional<ResourceType> resource_type_from_string(StringView);
 
 // Listing from IANA https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-2.
 enum class Class : u16 {
@@ -693,7 +694,7 @@ using Record = Variant<
     // TODO: Add more records.
     ByteBuffer>; // Fallback for unknown records.
 
-struct ResourceRecord {
+struct DNS_API ResourceRecord {
     DomainName name;
     ResourceType type;
     Class class_;
@@ -716,7 +717,7 @@ struct ZoneAuthority {
     u32 minimum_ttl;
 };
 
-struct Message {
+struct DNS_API Message {
     Header header;
     Vector<Question> questions;
     Vector<ResourceRecord> answers;

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -286,6 +286,9 @@ endif()
 
 target_link_libraries(LibJS PUBLIC JSClangPlugin)
 
-# TODO: Use lagom_generate_export_header and annotate entire LibJS with export macros
-include(GenerateExportHeader)
-generate_export_header(LibJS EXPORT_MACRO_NAME JS_API EXPORT_FILE_NAME "Export.h")
+if (ENABLE_WINDOWS_CI)
+    # FIXME: Fix address sanitizer stack-overflow error when running test-js.
+    # Even tripling the stack size for this target to 24MB didn't fix it, so it is most likely some ASAN related bug/quirk given test-js passes using the 8MB stack without ASAN
+    # ==9948==ERROR: AddressSanitizer: stack-overflow on address 0x7ffd983a6f47 (pc 0x7ffd983a6f47 bp 0x004e514053e0 sp 0x004e51405348 T0)
+    target_compile_options(LibJS PRIVATE -fno-sanitize=address)
+endif()

--- a/Libraries/LibMedia/Audio/Loader.h
+++ b/Libraries/LibMedia/Audio/Loader.h
@@ -17,6 +17,7 @@
 #include <AK/Stream.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <LibMedia/Export.h>
 
 namespace Audio {
 
@@ -72,7 +73,7 @@ protected:
     NonnullOwnPtr<SeekableStream> m_stream;
 };
 
-class Loader : public RefCounted<Loader> {
+class MEDIA_API Loader : public RefCounted<Loader> {
 public:
     static ErrorOr<NonnullRefPtr<Loader>> create(StringView path);
     static ErrorOr<NonnullRefPtr<Loader>> create(ReadonlyBytes buffer);

--- a/Libraries/LibMedia/Audio/PlaybackStream.h
+++ b/Libraries/LibMedia/Audio/PlaybackStream.h
@@ -12,6 +12,7 @@
 #include <AK/Time.h>
 #include <LibCore/Forward.h>
 #include <LibCore/ThreadedPromise.h>
+#include <LibMedia/Export.h>
 
 namespace Audio {
 
@@ -25,7 +26,7 @@ enum class OutputState {
 //
 // The interface is designed to be simple and robust. All control functions can be called safely from any thread.
 // Timing information provided by the class should allow audio timestamps to be tracked with the best accuracy possible.
-class PlaybackStream : public AtomicRefCounted<PlaybackStream> {
+class MEDIA_API PlaybackStream : public AtomicRefCounted<PlaybackStream> {
 public:
     using AudioDataRequestCallback = Function<ReadonlyBytes(Bytes buffer, PcmSampleFormat format, size_t sample_count)>;
 

--- a/Libraries/LibMedia/Audio/PulseAudioWrappers.h
+++ b/Libraries/LibMedia/Audio/PulseAudioWrappers.h
@@ -12,6 +12,7 @@
 #include <AK/Error.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Time.h>
+#include <LibMedia/Export.h>
 #include <LibThreading/Thread.h>
 #include <pulse/pulseaudio.h>
 
@@ -35,7 +36,7 @@ using PulseAudioDataRequestCallback = Function<ReadonlyBytes(PulseAudioStream&, 
 
 // A wrapper around the PulseAudio main loop and context structs.
 // Generally, only one instance of this should be needed for a single process.
-class PulseAudioContext
+class MEDIA_API PulseAudioContext
     : public AtomicRefCounted<PulseAudioContext>
     , public Weakable<PulseAudioContext> {
 public:

--- a/Libraries/LibMedia/Audio/SampleFormats.h
+++ b/Libraries/LibMedia/Audio/SampleFormats.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Types.h>
+#include <LibMedia/Export.h>
 
 namespace Audio {
 
@@ -21,6 +22,6 @@ enum class PcmSampleFormat : u8 {
 };
 
 // Most of the read code only cares about how many bits to read or write
-u16 pcm_bits_per_sample(PcmSampleFormat format);
+MEDIA_API u16 pcm_bits_per_sample(PcmSampleFormat format);
 
 }

--- a/Libraries/LibMedia/CMakeLists.txt
+++ b/Libraries/LibMedia/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SOURCES
     VideoFrame.cpp
 )
 
-ladybird_lib(LibMedia media)
+ladybird_lib(LibMedia media EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibMedia PRIVATE LibCore LibCrypto LibIPC LibGfx LibThreading LibUnicode)
 
 target_sources(LibMedia PRIVATE

--- a/Libraries/LibMedia/Containers/Matroska/Reader.h
+++ b/Libraries/LibMedia/Containers/Matroska/Reader.h
@@ -12,6 +12,7 @@
 #include <AK/Optional.h>
 #include <LibCore/MappedFile.h>
 #include <LibMedia/DecoderError.h>
+#include <LibMedia/Export.h>
 
 #include "Document.h"
 
@@ -20,7 +21,7 @@ namespace Media::Matroska {
 class SampleIterator;
 class Streamer;
 
-class Reader {
+class MEDIA_API Reader {
 public:
     typedef Function<DecoderErrorOr<IterationDecision>(TrackEntry const&)> TrackEntryCallback;
 
@@ -80,7 +81,7 @@ private:
     bool m_cues_have_been_parsed { false };
 };
 
-class SampleIterator {
+class MEDIA_API SampleIterator {
 public:
     DecoderErrorOr<Block> next_block();
     Cluster const& current_cluster() const { return *m_current_cluster; }

--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.h
@@ -7,13 +7,14 @@
 #pragma once
 
 #include <LibMedia/CodecID.h>
+#include <LibMedia/Export.h>
 #include <LibMedia/VideoDecoder.h>
 
 #include "FFmpegForward.h"
 
 namespace Media::FFmpeg {
 
-class FFmpegVideoDecoder final : public VideoDecoder {
+class MEDIA_API FFmpegVideoDecoder final : public VideoDecoder {
 public:
     static DecoderErrorOr<NonnullOwnPtr<FFmpegVideoDecoder>> try_create(CodecID, ReadonlyBytes codec_initialization_data);
     FFmpegVideoDecoder(AVCodecContext* codec_context, AVPacket* packet, AVFrame* frame);

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -14,6 +14,7 @@
 #include <LibCore/SharedCircularQueue.h>
 #include <LibGfx/Bitmap.h>
 #include <LibMedia/Demuxer.h>
+#include <LibMedia/Export.h>
 #include <LibThreading/ConditionVariable.h>
 #include <LibThreading/Mutex.h>
 #include <LibThreading/Thread.h>
@@ -98,7 +99,7 @@ enum class PlaybackState {
     Stopped,
 };
 
-class PlaybackManager {
+class MEDIA_API PlaybackManager {
     AK_MAKE_NONCOPYABLE(PlaybackManager);
     AK_MAKE_NONMOVABLE(PlaybackManager);
 

--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -13,6 +13,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/StackInfo.h>
 #include <AK/UFixedBigInt.h>
+#include <LibWasm/Export.h>
 #include <LibWasm/Types.h>
 
 namespace Wasm {
@@ -551,7 +552,7 @@ private:
     Vector<Reference> m_references;
 };
 
-class Store {
+class WASM_API Store {
 public:
     Store() = default;
 
@@ -631,7 +632,7 @@ struct HostVisitOps {
     Function<void(ExternallyManagedTrap&)> visit_trap;
 };
 
-class AbstractMachine {
+class WASM_API AbstractMachine {
 public:
     explicit AbstractMachine() = default;
 
@@ -682,7 +683,7 @@ private:
     bool m_should_limit_instruction_count { false };
 };
 
-class Linker {
+class WASM_API Linker {
 public:
     struct Name {
         ByteString module;

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -9,10 +9,11 @@
 #include <AK/StackInfo.h>
 #include <LibWasm/AbstractMachine/Configuration.h>
 #include <LibWasm/AbstractMachine/Interpreter.h>
+#include <LibWasm/Export.h>
 
 namespace Wasm {
 
-struct BytecodeInterpreter final : public Interpreter {
+struct WASM_API BytecodeInterpreter final : public Interpreter {
     explicit BytecodeInterpreter(StackInfo const& stack_info)
         : m_stack_info(stack_info)
     {

--- a/Libraries/LibWasm/CMakeLists.txt
+++ b/Libraries/LibWasm/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     Printer/Printer.cpp
 )
 
+# FIXME: Add Windows support
 if (NOT WIN32)
     list(APPEND SOURCES WASI/Wasi.cpp)
 endif()

--- a/Libraries/LibWasm/CMakeLists.txt
+++ b/Libraries/LibWasm/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT WIN32)
     list(APPEND SOURCES WASI/Wasi.cpp)
 endif()
 
-ladybird_lib(LibWasm wasm)
+ladybird_lib(LibWasm wasm EXPLICIT_SYMBOL_EXPORT)
 target_link_libraries(LibWasm PRIVATE LibCore)
 
 include(wasm_spec_tests)

--- a/Libraries/LibWasm/Printer/Printer.h
+++ b/Libraries/LibWasm/Printer/Printer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWasm/Export.h>
 #include <LibWasm/Types.h>
 
 namespace Wasm {
@@ -16,7 +17,7 @@ class Value;
 ByteString instruction_name(OpCode const& opcode);
 Optional<OpCode> instruction_from_name(StringView name);
 
-struct Printer {
+struct WASM_API Printer {
     explicit Printer(Stream& stream, size_t initial_indent = 0)
         : m_stream(stream)
         , m_indent(initial_indent)

--- a/Libraries/LibWasm/Types.h
+++ b/Libraries/LibWasm/Types.h
@@ -16,6 +16,7 @@
 #include <AK/Variant.h>
 #include <AK/WeakPtr.h>
 #include <LibWasm/Constants.h>
+#include <LibWasm/Export.h>
 #include <LibWasm/Forward.h>
 #include <LibWasm/Opcode.h>
 
@@ -61,7 +62,7 @@ enum class ParseError {
     SectionOutOfOrder,
 };
 
-ByteString parse_error_to_byte_string(ParseError);
+WASM_API ByteString parse_error_to_byte_string(ParseError);
 
 template<typename T>
 using ParseResult = ErrorOr<T, ParseError>;
@@ -1035,7 +1036,7 @@ private:
     Optional<u32> m_count;
 };
 
-class Module : public RefCounted<Module>
+class WASM_API Module : public RefCounted<Module>
     , public Weakable<Module> {
 public:
     enum class ValidationStatus {

--- a/Libraries/LibWasm/Wasi.h
+++ b/Libraries/LibWasm/Wasi.h
@@ -14,6 +14,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibWasm/AbstractMachine/AbstractMachine.h>
+#include <LibWasm/Export.h>
 #include <LibWasm/Forward.h>
 
 namespace Wasm::Wasi::ABI {
@@ -821,7 +822,7 @@ private:
     LittleEndian<Tag> tag;
 };
 
-struct Implementation {
+struct WASM_API Implementation {
     struct MappedPath {
         LexicalPath host_path;
         LexicalPath mapped_path;

--- a/Libraries/LibXML/CMakeLists.txt
+++ b/Libraries/LibXML/CMakeLists.txt
@@ -3,4 +3,4 @@ set(SOURCES
     DOM/Node.cpp
 )
 
-ladybird_lib(LibXML xml)
+ladybird_lib(LibXML xml EXPLICIT_SYMBOL_EXPORT)

--- a/Libraries/LibXML/DOM/Node.h
+++ b/Libraries/LibXML/DOM/Node.h
@@ -11,6 +11,7 @@
 #include <AK/HashMap.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibXML/Export.h>
 #include <LibXML/FundamentalTypes.h>
 
 namespace XML {
@@ -20,7 +21,7 @@ struct Attribute {
     ByteString value;
 };
 
-struct Node {
+struct XML_API Node {
     struct Text {
         StringBuilder builder;
     };

--- a/Libraries/LibXML/Parser/Parser.h
+++ b/Libraries/LibXML/Parser/Parser.h
@@ -17,6 +17,7 @@
 #include <LibXML/DOM/Document.h>
 #include <LibXML/DOM/DocumentTypeDeclaration.h>
 #include <LibXML/DOM/Node.h>
+#include <LibXML/Export.h>
 #include <LibXML/Forward.h>
 
 namespace XML {
@@ -46,7 +47,7 @@ struct Listener {
     virtual void error(ParseError const&) { }
 };
 
-class Parser {
+class XML_API Parser {
 public:
     struct Options {
         bool preserve_cdata { true };

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,10 +1,5 @@
 ladybird_test(test-invalid-unicode-js.cpp LibJS LIBS LibJS LibUnicode)
 ladybird_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
 
-# FIXME: This test is currently not working in the windows-2025 GHA image  due to the Visual Studio version currently being used
-if (WIN32 AND ENABLE_WINDOWS_CI)
-    return()
-endif()
-
 ladybird_testjs_test(test-js.cpp test-js LIBS LibGC)
 set_tests_properties(test-js PROPERTIES ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_PROJECT_ROOT})

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -1,7 +1,10 @@
 if(WIN32)
+    # FIXME: Add support for LibLine on Windows
     lagom_utility(js SOURCES js.cpp LIBS LibCrypto LibJS LibUnicode LibMain LibTextCodec LibGC Threads::Threads)
+    lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibMain)
 else()
     lagom_utility(js SOURCES js.cpp LIBS LibCrypto LibJS LibLine LibUnicode LibMain LibTextCodec LibGC Threads::Threads)
+    lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibLine LibMain)
 endif()
 
 # FIXME: Increase support for building targets on Windows
@@ -34,7 +37,6 @@ if (ASSERT_FAIL_HAS_INT OR EMSCRIPTEN)
     target_compile_definitions(test262-runner PRIVATE ASSERT_FAIL_HAS_INT)
 endif()
 
-lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibLine LibMain)
 lagom_utility(xml SOURCES xml.cpp LIBS LibFileSystem LibMain LibXML LibURL)
 
 if (NOT CMAKE_SKIP_INSTALL_RULES)

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -8,13 +8,13 @@ else()
 endif()
 
 lagom_utility(xml SOURCES xml.cpp LIBS LibFileSystem LibMain LibXML LibURL)
+lagom_utility(abench SOURCES abench.cpp LIBS LibMain LibFileSystem LibMedia)
 
 # FIXME: Increase support for building targets on Windows
 if (WIN32 AND ENABLE_WINDOWS_CI)
     return()
 endif()
 
-lagom_utility(abench SOURCES abench.cpp LIBS LibMain LibFileSystem LibMedia)
 lagom_utility(dns SOURCES dns.cpp LIBS LibDNS LibMain LibTLS LibCrypto)
 
 if (ENABLE_GUI_TARGETS)

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -11,14 +11,15 @@ lagom_utility(xml SOURCES xml.cpp LIBS LibFileSystem LibMain LibXML LibURL)
 lagom_utility(abench SOURCES abench.cpp LIBS LibMain LibFileSystem LibMedia)
 lagom_utility(dns SOURCES dns.cpp LIBS LibDNS LibMain LibTLS LibCrypto)
 
+if (ENABLE_GUI_TARGETS)
+    lagom_utility(image SOURCES image.cpp LIBS LibGfx LibMain)
+endif()
+
 # FIXME: Increase support for building targets on Windows
 if (WIN32 AND ENABLE_WINDOWS_CI)
     return()
 endif()
 
-if (ENABLE_GUI_TARGETS)
-    lagom_utility(image SOURCES image.cpp LIBS LibGfx LibMain)
-endif()
 
 lagom_utility(test262-runner SOURCES test262-runner.cpp LIBS LibJS LibFileSystem LibGC)
 

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -9,13 +9,12 @@ endif()
 
 lagom_utility(xml SOURCES xml.cpp LIBS LibFileSystem LibMain LibXML LibURL)
 lagom_utility(abench SOURCES abench.cpp LIBS LibMain LibFileSystem LibMedia)
+lagom_utility(dns SOURCES dns.cpp LIBS LibDNS LibMain LibTLS LibCrypto)
 
 # FIXME: Increase support for building targets on Windows
 if (WIN32 AND ENABLE_WINDOWS_CI)
     return()
 endif()
-
-lagom_utility(dns SOURCES dns.cpp LIBS LibDNS LibMain LibTLS LibCrypto)
 
 if (ENABLE_GUI_TARGETS)
     lagom_utility(image SOURCES image.cpp LIBS LibGfx LibMain)

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -7,6 +7,8 @@ else()
     lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibLine LibMain)
 endif()
 
+lagom_utility(xml SOURCES xml.cpp LIBS LibFileSystem LibMain LibXML LibURL)
+
 # FIXME: Increase support for building targets on Windows
 if (WIN32 AND ENABLE_WINDOWS_CI)
     return()
@@ -36,8 +38,6 @@ endif()
 if (ASSERT_FAIL_HAS_INT OR EMSCRIPTEN)
     target_compile_definitions(test262-runner PRIVATE ASSERT_FAIL_HAS_INT)
 endif()
-
-lagom_utility(xml SOURCES xml.cpp LIBS LibFileSystem LibMain LibXML LibURL)
 
 if (NOT CMAKE_SKIP_INSTALL_RULES)
     install(TARGETS js COMPONENT js)


### PR DESCRIPTION
If desirable I can file an issue for this for eventual follow-up but I think having test-js running in Windows CI now, despite not having ASAN enabled, is still valuable to catch general LibJS Windows bitrot at CI-time