### PR TITLE
LibWeb: Align with parts of the Fetch specification steps

### DIFF
--- a/Libraries/LibWeb/ContentSecurityPolicy/Violation.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Violation.cpp
@@ -421,9 +421,9 @@ void Violation::report_a_violation(JS::Realm& realm)
                         auto& environment_settings_object = Bindings::principal_host_defined_environment_settings_object(HTML::principal_realm(realm));
                         request->set_origin(environment_settings_object.origin());
 
-                        // window
-                        //    "no-window"
-                        request->set_window(Fetch::Infrastructure::Request::Window::NoWindow);
+                        // traversable for user prompts
+                        //    "no-traversable"
+                        request->set_traversable_for_user_prompts(Fetch::Infrastructure::Request::TraversableForUserPrompts::NoTraversable);
 
                         // client
                         //    violation's global object's relevant settings object

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2325,11 +2325,11 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> nonstandard_resource_loader_file_o
     if (request->buffer_policy() == Infrastructure::Request::BufferPolicy::DoNotBufferResponse) {
         HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
-        // 12. Let stream be a new ReadableStream.
+        // 10. Let stream be a new ReadableStream.
         auto stream = realm.create<Streams::ReadableStream>(realm);
         auto fetched_data_receiver = realm.create<FetchedDataReceiver>(fetch_params, stream);
 
-        // 10. Let pullAlgorithm be the followings steps:
+        // 11. Let pullAlgorithm be the following steps:
         auto pull_algorithm = GC::create_function(realm.heap(), [&realm, fetched_data_receiver]() {
             // 1. Let promise be a new promise.
             auto promise = WebIDL::create_promise(realm);
@@ -2342,7 +2342,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> nonstandard_resource_loader_file_o
             return promise;
         });
 
-        // 11. Let cancelAlgorithm be an algorithm that aborts fetchParams’s controller with reason, given reason.
+        // 12. Let cancelAlgorithm be an algorithm that aborts fetchParams’s controller with reason, given reason.
         auto cancel_algorithm = GC::create_function(realm.heap(), [&realm, &fetch_params](JS::Value reason) {
             fetch_params.controller()->abort(realm, reason);
             return WebIDL::create_resolved_promise(realm, JS::js_undefined());

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -84,7 +84,6 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
     dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'fetch' with: request @ {}", &request);
 
     auto& vm = realm.vm();
-    auto& heap = vm.heap();
 
     // 1. Assert: request’s mode is "navigate" or processEarlyHintsResponse is null.
     VERIFY(request.mode() == Infrastructure::Request::Mode::Navigate || !algorithms.process_early_hints_response());
@@ -95,7 +94,10 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
     // 3. Let crossOriginIsolatedCapability be false.
     auto cross_origin_isolated_capability = HTML::CanUseCrossOriginIsolatedAPIs::No;
 
-    // 4. If request’s client is non-null, then:
+    // 4. Populate request from client given request.
+    populate_request_from_client(realm, request);
+
+    // 5. If request’s client is non-null, then:
     if (request.client() != nullptr) {
         // 1. Set taskDestination to request’s client’s global object.
         task_destination = GC::Ref { request.client()->global_object() };
@@ -104,11 +106,11 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
         cross_origin_isolated_capability = request.client()->cross_origin_isolated_capability();
     }
 
-    // 5. If useParallelQueue is true, then set taskDestination to the result of starting a new parallel queue.
+    // 6. If useParallelQueue is true, then set taskDestination to the result of starting a new parallel queue.
     if (use_parallel_queue == UseParallelQueue::Yes)
         task_destination = HTML::ParallelQueue::create();
 
-    // 6. Let timingInfo be a new fetch timing info whose start time and post-redirect start time are the coarsened
+    // 7. Let timingInfo be a new fetch timing info whose start time and post-redirect start time are the coarsened
     //    shared current time given crossOriginIsolatedCapability, and render-blocking is set to request’s
     //    render-blocking.
     auto timing_info = Infrastructure::FetchTimingInfo::create(vm);
@@ -117,7 +119,7 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
     timing_info->set_post_redirect_start_time(now);
     timing_info->set_render_blocking(request.render_blocking());
 
-    // 7. Let fetchParams be a new fetch params whose request is request, timing info is timingInfo, process request
+    // 8. Let fetchParams be a new fetch params whose request is request, timing info is timingInfo, process request
     //    body chunk length is processRequestBodyChunkLength, process request end-of-body is processRequestEndOfBody,
     //    process early hints response is processEarlyHintsResponse, process response is processResponse, process
     //    response consume body is processResponseConsumeBody, process response end-of-body is processResponseEndOfBody,
@@ -127,34 +129,18 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
     fetch_params->set_task_destination(task_destination);
     fetch_params->set_cross_origin_isolated_capability(cross_origin_isolated_capability);
 
-    // 8. If request’s body is a byte sequence, then set request’s body to request’s body as a body.
+    // 9. If request’s body is a byte sequence, then set request’s body to request’s body as a body.
     if (auto const* buffer = request.body().get_pointer<ByteBuffer>())
         request.set_body(Infrastructure::byte_sequence_as_body(realm, buffer->bytes()));
 
-    // 9. If request’s window is "client", then set request’s window to request’s client, if request’s client’s global
-    //    object is a Window object; otherwise "no-window".
-    auto const* window = request.traversable_for_user_prompts().get_pointer<Infrastructure::Request::TraversableForUserPrompts>();
-    if (window && *window == Infrastructure::Request::TraversableForUserPrompts::Client) {
-        if (is<HTML::Window>(request.client()->global_object())) {
-            request.set_traversable_for_user_prompts(request.client());
-        } else {
-            request.set_traversable_for_user_prompts(Infrastructure::Request::TraversableForUserPrompts::NoTraversable);
-        }
-    }
-
-    // 10. If request’s origin is "client", then set request’s origin to request’s client’s origin.
-    auto const* origin = request.origin().get_pointer<Infrastructure::Request::Origin>();
-    if (origin && *origin == Infrastructure::Request::Origin::Client)
-        request.set_origin(request.client()->origin());
-
-    // 11. If all of the following conditions are true:
+    // 10. If all of the following conditions are true:
     if (
         // - request’s URL’s scheme is an HTTP(S) scheme
         Infrastructure::is_http_or_https_scheme(request.url().scheme())
         // - request’s mode is "same-origin", "cors", or "no-cors"
         && (request.mode() == Infrastructure::Request::Mode::SameOrigin || request.mode() == Infrastructure::Request::Mode::CORS || request.mode() == Infrastructure::Request::Mode::NoCORS)
-        // - request’s window is an environment settings object
-        && request.traversable_for_user_prompts().has<GC::Ptr<HTML::EnvironmentSettingsObject>>()
+        // - request’s client is not null, and request’s client’s global object is a Window object
+        && request.client() && is<HTML::Window>(request.client()->global_object())
         // - request’s method is `GET`
         && StringView { request.method() }.equals_ignoring_ascii_case("GET"sv)
         // - request’s unsafe-request flag is not set or request’s header list is empty
@@ -180,20 +166,7 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
             fetch_params->set_preloaded_response_candidate(Infrastructure::FetchParams::PreloadedResponseCandidatePendingTag {});
     }
 
-    // 12. If request’s policy container is "client", then:
-    auto const* policy_container = request.policy_container().get_pointer<Infrastructure::Request::PolicyContainer>();
-    if (policy_container) {
-        VERIFY(*policy_container == Infrastructure::Request::PolicyContainer::Client);
-        // 1. If request’s client is non-null, then set request’s policy container to a clone of request’s client’s
-        //    policy container.
-        if (request.client() != nullptr)
-            request.set_policy_container(request.client()->policy_container()->clone(heap));
-        // 2. Otherwise, set request’s policy container to a new policy container.
-        else
-            request.set_policy_container(heap.allocate<HTML::PolicyContainer>(heap));
-    }
-
-    // 13. If request’s header list does not contain `Accept`, then:
+    // 11. If request’s header list does not contain `Accept`, then:
     if (!request.header_list()->contains("Accept"sv.bytes())) {
         // 1. Let value be `*/*`.
         auto value = "*/*"sv;
@@ -240,7 +213,7 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
         request.header_list()->append(move(header));
     }
 
-    // 14. If request’s header list does not contain `Accept-Language`, then user agents should append
+    // 12. If request’s header list does not contain `Accept-Language`, then user agents should append
     //     (`Accept-Language, an appropriate header value) to request’s header list.
     if (!request.header_list()->contains("Accept-Language"sv.bytes())) {
         StringBuilder accept_language;
@@ -250,24 +223,25 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
         request.header_list()->append(move(header));
     }
 
-    // 15. If request’s priority is null, then use request’s initiator, destination, and render-blocking appropriately
-    //     in setting request’s priority to a user-agent-defined object.
+    // 13. If request’s internal priority is null, then use request’s priority, initiator, destination, and
+    //     render-blocking in an implementation-defined manner to set request’s internal priority to an
+    //     implementation-defined object.
     // NOTE: The user-agent-defined object could encompass stream weight and dependency for HTTP/2, and equivalent
     //       information used to prioritize dispatch and processing of HTTP/1 fetches.
 
-    // 16. If request is a subresource request, then:
+    // 14. If request is a subresource request, then:
     if (request.is_subresource_request()) {
         // 1. Let record be a new fetch record whose request is request and controller is fetchParams’s controller.
         auto record = Infrastructure::FetchRecord::create(vm, request, fetch_params->controller());
 
-        // 2. Append record to request’s client’s fetch group list of fetch records.
+        // 2. Append record to request’s client’s fetch group’s fetch records.
         request.client()->fetch_group().append(record);
     }
 
-    // 17. Run main fetch given fetchParams.
+    // 15. Run main fetch given fetchParams.
     (void)TRY(main_fetch(realm, fetch_params));
 
-    // 18. Return fetchParams’s controller.
+    // 16. Return fetchParams’s controller.
     return fetch_params->controller();
 }
 

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -40,6 +40,7 @@ ENUMERATE_BOOL_PARAMS
 
 WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm&, Infrastructure::Request&, Infrastructure::FetchAlgorithms const&, UseParallelQueue use_parallel_queue = UseParallelQueue::No);
 WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm&, Infrastructure::FetchParams const&, Recursive recursive = Recursive::No);
+void populate_request_from_client(JS::Realm const&, Infrastructure::Request&);
 void fetch_response_handover(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm&, Infrastructure::FetchParams const&);
 WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm&, Infrastructure::FetchParams const&, MakeCORSPreflight make_cors_preflight = MakeCORSPreflight::No);

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Fetch/Fetching/PendingResponse.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+#include <LibWeb/HTML/TraversableNavigable.h>
 
 namespace Web::Fetch::Infrastructure {
 
@@ -32,8 +33,9 @@ void Request::visit_edges(JS::Cell::Visitor& visitor)
         [&](GC::Ref<Body>& body) { visitor.visit(body); },
         [](auto&) {});
     visitor.visit(m_reserved_client);
-    m_window.visit(
+    m_traversable_for_user_prompts.visit(
         [&](GC::Ptr<HTML::EnvironmentSettingsObject> const& value) { visitor.visit(value); },
+        [&](GC::Ptr<HTML::TraversableNavigable> const& value) { visitor.visit(value); },
         [](auto const&) {});
     visitor.visit(m_pending_responses);
     m_policy_container.visit(
@@ -226,7 +228,7 @@ GC::Ref<Request> Request::clone(JS::Realm& realm) const
     new_request->set_client(m_client);
     new_request->set_reserved_client(m_reserved_client);
     new_request->set_replaces_client_id(m_replaces_client_id);
-    new_request->set_window(m_window);
+    new_request->set_traversable_for_user_prompts(m_traversable_for_user_prompts);
     new_request->set_keepalive(m_keepalive);
     new_request->set_initiator_type(m_initiator_type);
     new_request->set_service_workers_mode(m_service_workers_mode);

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -147,8 +147,8 @@ public:
         None,
     };
 
-    enum class Window {
-        NoWindow,
+    enum class TraversableForUserPrompts {
+        NoTraversable,
         Client,
     };
 
@@ -173,7 +173,7 @@ public:
     using PolicyContainerType = Variant<PolicyContainer, GC::Ref<HTML::PolicyContainer>>;
     using ReferrerType = Variant<Referrer, URL::URL>;
     using ReservedClientType = GC::Ptr<HTML::Environment>;
-    using WindowType = Variant<Window, GC::Ptr<HTML::EnvironmentSettingsObject>>;
+    using TraversableForUserPromptsType = Variant<TraversableForUserPrompts, GC::Ptr<HTML::EnvironmentSettingsObject>, GC::Ptr<HTML::TraversableNavigable>>;
 
     [[nodiscard]] static GC::Ref<Request> create(JS::VM&);
 
@@ -204,8 +204,8 @@ public:
     [[nodiscard]] String const& replaces_client_id() const { return m_replaces_client_id; }
     void set_replaces_client_id(String replaces_client_id) { m_replaces_client_id = move(replaces_client_id); }
 
-    [[nodiscard]] WindowType const& window() const { return m_window; }
-    void set_window(WindowType window) { m_window = move(window); }
+    [[nodiscard]] TraversableForUserPromptsType const& traversable_for_user_prompts() const { return m_traversable_for_user_prompts; }
+    void set_traversable_for_user_prompts(TraversableForUserPromptsType traversable_for_user_prompts) { m_traversable_for_user_prompts = move(traversable_for_user_prompts); }
 
     [[nodiscard]] bool keepalive() const { return m_keepalive; }
     void set_keepalive(bool keepalive) { m_keepalive = keepalive; }
@@ -373,9 +373,9 @@ private:
     String m_replaces_client_id;
 
     // https://fetch.spec.whatwg.org/#concept-request-window
-    // A request has an associated window ("no-window", "client", or an environment settings object whose global object
-    // is a Window object). Unless stated otherwise it is "client".
-    WindowType m_window { Window::Client };
+    // A request has an associated traversable for user prompts, that is "no-traversable", "client", or a traversable
+    // navigable. Unless stated otherwise it is "client".
+    TraversableForUserPromptsType m_traversable_for_user_prompts { TraversableForUserPrompts::Client };
 
     // https://fetch.spec.whatwg.org/#request-keepalive-flag
     // A request has an associated boolean keepalive. Unless stated otherwise it is false.

--- a/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Libraries/LibWeb/Fetch/Request.cpp
@@ -153,23 +153,24 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
     // 7. Let origin be this’s relevant settings object’s origin.
     auto const& origin = HTML::relevant_settings_object(*request_object).origin();
 
-    // 8. Let window be "client".
-    auto window = Infrastructure::Request::WindowType { Infrastructure::Request::Window::Client };
+    // 8. Let traversableForUserPrompts be "client".
+    auto traversable_for_user_prompts = Infrastructure::Request::TraversableForUserPromptsType { Infrastructure::Request::TraversableForUserPrompts::Client };
 
-    // 9. If request’s window is an environment settings object and its origin is same origin with origin, then set window to request’s window.
-    if (input_request->window().has<GC::Ptr<HTML::EnvironmentSettingsObject>>()) {
-        auto eso = input_request->window().get<GC::Ptr<HTML::EnvironmentSettingsObject>>();
+    // 9. If request’s traversable for user prompts is an environment settings object and its origin is same origin with
+    //    origin, then set traversableForUserPrompts to request’s traversable for user prompts.
+    if (input_request->traversable_for_user_prompts().has<GC::Ptr<HTML::EnvironmentSettingsObject>>()) {
+        auto eso = input_request->traversable_for_user_prompts().get<GC::Ptr<HTML::EnvironmentSettingsObject>>();
         if (eso->origin().is_same_origin(origin))
-            window = input_request->window();
+            traversable_for_user_prompts = input_request->traversable_for_user_prompts();
     }
 
     // 10. If init["window"] exists and is non-null, then throw a TypeError.
     if (init.window.has_value() && !init.window->is_null())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "The 'window' property must be omitted or null"sv };
 
-    // 11. If init["window"] exists, then set window to "no-window".
+    // 11. If init["window"] exists, then set traversableForUserPrompts to "no-traversable".
     if (init.window.has_value())
-        window = Infrastructure::Request::Window::NoWindow;
+        traversable_for_user_prompts = Infrastructure::Request::TraversableForUserPrompts::NoTraversable;
 
     // 12. Set request to a new request with the following properties:
     // NOTE: This is done at the beginning as the 'this' value Request object
@@ -199,9 +200,9 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
     //     This’s relevant settings object.
     request->set_client(&HTML::relevant_settings_object(*request_object));
 
-    // window
-    //     window.
-    request->set_window(window);
+    // traversable for user prompts
+    //     traversableForUserPrompts.
+    request->set_traversable_for_user_prompts(traversable_for_user_prompts);
 
     // priority
     //     request’s priority.


### PR DESCRIPTION
This pulls in a few changes from the Fetch spec:

LibWeb: Define stream variable before using it:
- https://github.com/whatwg/fetch/pull/1817

LibWeb: Replace request's "window" with "traversable for user prompts" 
- https://github.com/whatwg/fetch/pull/1823

LibWeb: Implement AO populate request from client
LibWeb: Align Fetching chapter's "To fetch" with latest spec changes
- https://github.com/whatwg/fetch/pull/1793