### PR TITLE
LibWasm: Don't clobber registers on (most) calls

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -356,6 +356,14 @@ public:
     }
 
     template<typename T>
+    T& unsafe_get()
+    requires(can_contain<T>())
+    {
+        ASSERT(has<T>());
+        return *bit_cast<T*>(&m_data);
+    }
+
+    template<typename T>
     T& get()
     requires(can_contain<T>())
     {
@@ -377,6 +385,14 @@ public:
     requires(can_contain<T>())
     {
         VERIFY(has<T>());
+        return *bit_cast<T const*>(&m_data);
+    }
+
+    template<typename T>
+    T const& unsafe_get() const
+    requires(can_contain<T>())
+    {
+        ASSERT(has<T>());
         return *bit_cast<T const*>(&m_data);
     }
 

--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -270,7 +270,7 @@ InstantiationResult AbstractMachine::instantiate(Module const& module, Vector<Ex
                 auxiliary_instance,
                 Vector<Value> {},
                 entry,
-                entry.instructions().size(),
+                entry.instructions().size() - 1,
             });
             auto result = config.execute(interpreter);
             if (result.is_trap())

--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -572,6 +572,8 @@ public:
     DataInstance* get(DataAddress);
     ElementInstance* get(ElementAddress);
 
+    MemoryInstance* unsafe_get(MemoryAddress address) { return &m_memories.data()[address.value()]; }
+
 private:
     Vector<FunctionInstance> m_functions;
     Vector<TableInstance> m_tables;

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -79,15 +79,13 @@ template<bool HasCompiledList, bool HasDynamicInsnLimit>
 void BytecodeInterpreter::interpret_impl(Configuration& configuration, Expression const& expression)
 {
     auto& instructions = expression.instructions();
-    u64 max_ip_value = HasCompiledList ? expression.compiled_instructions.dispatches.size() : instructions.size();
-    auto& current_ip_value = configuration.ip();
+    u64 max_ip_value = (HasCompiledList ? expression.compiled_instructions.dispatches.size() : instructions.size()) - 1;
+    auto current_ip_value = configuration.ip();
     u64 executed_instructions = 0;
-    configuration.sources[0] = Dispatch::RegisterOrStack::Stack;
-    configuration.sources[1] = Dispatch::RegisterOrStack::Stack;
-    configuration.sources[2] = Dispatch::RegisterOrStack::Stack;
-    configuration.destination = Dispatch::RegisterOrStack::Stack;
 
     constexpr static u32 default_sources_and_destination = (to_underlying(Dispatch::RegisterOrStack::Stack) | (to_underlying(Dispatch::RegisterOrStack::Stack) << 2) | (to_underlying(Dispatch::RegisterOrStack::Stack) << 4));
+    SourcesAndDestination addresses { .sources_and_destination = default_sources_and_destination };
+
     enum class CouldHaveChangedIP {
         No,
         Yes
@@ -95,7 +93,7 @@ void BytecodeInterpreter::interpret_impl(Configuration& configuration, Expressio
 
     auto const cc = expression.compiled_instructions.dispatches.data();
 
-    while (current_ip_value < max_ip_value) {
+    while (true) {
         if constexpr (HasDynamicInsnLimit) {
             if (executed_instructions++ >= Constants::max_allowed_executed_instructions_per_call) [[unlikely]] {
                 m_trap = Trap::from_string("Exceeded maximum allowed number of instructions");
@@ -103,136 +101,96 @@ void BytecodeInterpreter::interpret_impl(Configuration& configuration, Expressio
             }
         }
         // bounds checked by loop condition.
-        auto old_ip = current_ip_value;
-        {
-            configuration.sources_and_destination = HasCompiledList
-                ? cc[current_ip_value].sources_and_destination
-                : default_sources_and_destination;
+        addresses.sources_and_destination = HasCompiledList
+            ? cc[current_ip_value].sources_and_destination
+            : default_sources_and_destination;
+        auto const instruction = HasCompiledList
+            ? cc[current_ip_value].instruction
+            : &instructions.data()[current_ip_value];
+        auto const opcode = (HasCompiledList
+                ? cc[current_ip_value].instruction_opcode
+                : instruction->opcode())
+                                .value();
 
-            auto const instruction = HasCompiledList
-                ? cc[current_ip_value].instruction
-                : &instructions.data()[current_ip_value];
-
-            auto const opcode = instruction->opcode().value();
-
-#define RUN_NEXT_INSTRUCTION(ip_changed)                      \
-    {                                                         \
-        if constexpr (ip_changed == CouldHaveChangedIP::No) { \
-            ++current_ip_value;                               \
-        } else {                                              \
-            if (current_ip_value == old_ip)                   \
-                ++current_ip_value;                           \
-        }                                                     \
-        break;                                                \
+#define RUN_NEXT_INSTRUCTION() \
+    {                          \
+        ++current_ip_value;    \
+        break;                 \
     }
 
-            dbgln_if(WASM_TRACE_DEBUG, "Executing instruction {} at current_ip_value {}", instruction_name(instruction->opcode()), current_ip_value);
-            if ((opcode & Instructions::SyntheticInstructionBase.value()) != Instructions::SyntheticInstructionBase.value())
-                __builtin_prefetch(&instruction->arguments(), /* read */ 0, /* low temporal locality */ 1);
+        dbgln_if(WASM_TRACE_DEBUG, "Executing instruction {} at current_ip_value {}", instruction_name(instruction->opcode()), current_ip_value);
+        if ((opcode & Instructions::SyntheticInstructionBase.value()) != Instructions::SyntheticInstructionBase.value())
+            __builtin_prefetch(&instruction->arguments(), /* read */ 0, /* low temporal locality */ 1);
 
-            switch (opcode) {
-            case Instructions::local_get.value():
-                configuration.push_to_destination(configuration.local(instruction->local_index()));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_const.value():
-                configuration.push_to_destination(Value(instruction->arguments().get<i32>()));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::synthetic_i32_add2local.value():
-                configuration.push_to_destination(Value(static_cast<i32>(Operators::Add {}(configuration.local(instruction->local_index()).to<u32>(), configuration.local(instruction->arguments().get<LocalIndex>()).to<u32>()))));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::synthetic_i32_addconstlocal.value():
-                configuration.push_to_destination(Value(static_cast<i32>(Operators::Add {}(configuration.local(instruction->local_index()).to<u32>(), instruction->arguments().get<i32>()))));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::synthetic_i32_andconstlocal.value():
-                configuration.push_to_destination(Value(Operators::BitAnd {}(configuration.local(instruction->local_index()).to<i32>(), instruction->arguments().get<i32>())));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::synthetic_i32_storelocal.value():
-                if (store_value(configuration, *instruction, ConvertToRaw<i32> {}(configuration.local(instruction->local_index()).to<i32>()), 0))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::synthetic_i64_storelocal.value():
-                if (store_value(configuration, *instruction, ConvertToRaw<i64> {}(configuration.local(instruction->local_index()).to<i64>()), 0))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::synthetic_local_seti32_const.value():
-                configuration.local(instruction->local_index()) = Value(instruction->arguments().get<i32>());
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::synthetic_call_00.value():
-            case Instructions::synthetic_call_01.value():
-            case Instructions::synthetic_call_10.value():
-            case Instructions::synthetic_call_11.value():
-            case Instructions::synthetic_call_20.value():
-            case Instructions::synthetic_call_21.value():
-            case Instructions::synthetic_call_30.value():
-            case Instructions::synthetic_call_31.value(): {
-                auto regs_copy = configuration.regs;
-                auto index = instruction->arguments().get<FunctionIndex>();
-                auto address = configuration.frame().module().functions()[index.value()];
-                dbgln_if(WASM_TRACE_DEBUG, "[{}] call(#{} -> {})", current_ip_value, index.value(), address.value());
-                if (call_address(configuration, address))
-                    return;
-                configuration.regs = regs_copy;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::unreachable.value():
-                m_trap = Trap::from_string("Unreachable");
+        switch (opcode) {
+        case Instructions::local_get.value():
+            configuration.push_to_destination(configuration.local(instruction->local_index()), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_const.value():
+            configuration.push_to_destination(Value(instruction->arguments().unsafe_get<i32>()), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_i32_add2local.value():
+            configuration.push_to_destination(Value(static_cast<i32>(Operators::Add {}(configuration.local(instruction->local_index()).to<u32>(), configuration.local(instruction->arguments().get<LocalIndex>()).to<u32>()))), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_i32_addconstlocal.value():
+            configuration.push_to_destination(Value(static_cast<i32>(Operators::Add {}(configuration.local(instruction->local_index()).to<u32>(), instruction->arguments().unsafe_get<i32>()))), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_i32_andconstlocal.value():
+            configuration.push_to_destination(Value(Operators::BitAnd {}(configuration.local(instruction->local_index()).to<i32>(), instruction->arguments().unsafe_get<i32>())), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_i32_storelocal.value():
+            if (store_value(configuration, *instruction, ConvertToRaw<i32> {}(configuration.local(instruction->local_index()).to<i32>()), 0, addresses))
                 return;
-            case Instructions::nop.value():
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::local_set.value(): {
-                // bounds checked by verifier.
-                configuration.local(instruction->local_index()) = configuration.take_source(0);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::i64_const.value():
-                configuration.push_to_destination(Value(instruction->arguments().get<i64>()));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_const.value():
-                configuration.push_to_destination(Value(instruction->arguments().get<float>()));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_const.value():
-                configuration.push_to_destination(Value(instruction->arguments().get<double>()));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::block.value(): {
-                size_t arity = 0;
-                size_t param_arity = 0;
-                auto& args = instruction->arguments().get<Instruction::StructuredInstructionArgs>();
-                if (args.block_type.kind() != BlockType::Empty) [[unlikely]] {
-                    switch (args.block_type.kind()) {
-                    case BlockType::Type:
-                        arity = 1;
-                        break;
-                    case BlockType::Index: {
-                        auto& type = configuration.frame().module().types()[args.block_type.type_index().value()];
-                        arity = type.results().size();
-                        param_arity = type.parameters().size();
-                        break;
-                    }
-                    case BlockType::Empty:
-                        VERIFY_NOT_REACHED();
-                    }
-                }
-
-                configuration.label_stack().append(Label(arity, args.end_ip, configuration.value_stack().size() - param_arity));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::loop.value(): {
-                auto& args = instruction->arguments().get<Instruction::StructuredInstructionArgs>();
-                size_t arity = 0;
-                if (args.block_type.kind() == BlockType::Index) {
-                    auto& type = configuration.frame().module().types()[args.block_type.type_index().value()];
-                    arity = type.parameters().size();
-                }
-                configuration.label_stack().append(Label(arity, current_ip_value + 1, configuration.value_stack().size() - arity));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::if_.value(): {
-                size_t arity = 0;
-                size_t param_arity = 0;
-                auto& args = instruction->arguments().get<Instruction::StructuredInstructionArgs>();
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_i64_storelocal.value():
+            if (store_value(configuration, *instruction, ConvertToRaw<i64> {}(configuration.local(instruction->local_index()).to<i64>()), 0, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_local_seti32_const.value():
+            configuration.local(instruction->local_index()) = Value(instruction->arguments().unsafe_get<i32>());
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_call_00.value():
+        case Instructions::synthetic_call_01.value():
+        case Instructions::synthetic_call_10.value():
+        case Instructions::synthetic_call_11.value():
+        case Instructions::synthetic_call_20.value():
+        case Instructions::synthetic_call_21.value():
+        case Instructions::synthetic_call_30.value():
+        case Instructions::synthetic_call_31.value(): {
+            auto regs_copy = configuration.regs;
+            auto index = instruction->arguments().get<FunctionIndex>();
+            auto address = configuration.frame().module().functions()[index.value()];
+            dbgln_if(WASM_TRACE_DEBUG, "[{}] call(#{} -> {})", current_ip_value, index.value(), address.value());
+            if (call_address(configuration, address))
+                return;
+            configuration.regs = regs_copy;
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::unreachable.value():
+            m_trap = Trap::from_string("Unreachable");
+            return;
+        case Instructions::nop.value():
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::local_set.value(): {
+            // bounds checked by verifier.
+            configuration.local(instruction->local_index()) = configuration.take_source(0, addresses.sources);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::i64_const.value():
+            configuration.push_to_destination(Value(instruction->arguments().unsafe_get<i64>()), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_const.value():
+            configuration.push_to_destination(Value(instruction->arguments().unsafe_get<float>()), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_const.value():
+            configuration.push_to_destination(Value(instruction->arguments().unsafe_get<double>()), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::block.value(): {
+            size_t arity = 0;
+            size_t param_arity = 0;
+            auto& args = instruction->arguments().unsafe_get<Instruction::StructuredInstructionArgs>();
+            if (args.block_type.kind() != BlockType::Empty) [[unlikely]] {
                 switch (args.block_type.kind()) {
-                case BlockType::Empty:
-                    break;
                 case BlockType::Type:
                     arity = 1;
                     break;
@@ -240,1996 +198,2031 @@ void BytecodeInterpreter::interpret_impl(Configuration& configuration, Expressio
                     auto& type = configuration.frame().module().types()[args.block_type.type_index().value()];
                     arity = type.results().size();
                     param_arity = type.parameters().size();
+                    break;
                 }
+                case BlockType::Empty:
+                    VERIFY_NOT_REACHED();
                 }
+            }
 
-                auto value = configuration.take_source(0).to<i32>();
-                auto end_label = Label(arity, args.end_ip.value(), configuration.value_stack().size() - param_arity);
-                if (value == 0) {
-                    if (args.else_ip.has_value()) {
-                        configuration.ip() = args.else_ip->value();
-                        configuration.label_stack().append(end_label);
-                    } else {
-                        configuration.ip() = args.end_ip.value() + 1;
-                    }
-                } else {
+            configuration.label_stack().append(Label(arity, args.end_ip, configuration.value_stack().size() - param_arity));
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::loop.value(): {
+            auto& args = instruction->arguments().get<Instruction::StructuredInstructionArgs>();
+            size_t arity = 0;
+            if (args.block_type.kind() == BlockType::Index) {
+                auto& type = configuration.frame().module().types()[args.block_type.type_index().value()];
+                arity = type.parameters().size();
+            }
+            configuration.label_stack().append(Label(arity, current_ip_value + 1, configuration.value_stack().size() - arity));
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::if_.value(): {
+            size_t arity = 0;
+            size_t param_arity = 0;
+            auto& args = instruction->arguments().unsafe_get<Instruction::StructuredInstructionArgs>();
+            switch (args.block_type.kind()) {
+            case BlockType::Empty:
+                break;
+            case BlockType::Type:
+                arity = 1;
+                break;
+            case BlockType::Index: {
+                auto& type = configuration.frame().module().types()[args.block_type.type_index().value()];
+                arity = type.results().size();
+                param_arity = type.parameters().size();
+            }
+            }
+
+            auto value = configuration.take_source(0, addresses.sources).to<i32>();
+            auto end_label = Label(arity, args.end_ip.value(), configuration.value_stack().size() - param_arity);
+            if (value == 0) {
+                if (args.else_ip.has_value()) {
+                    current_ip_value = args.else_ip->value() - 1;
                     configuration.label_stack().append(end_label);
-                }
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::structured_end.value():
-                configuration.label_stack().take_last();
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::structured_else.value(): {
-                auto label = configuration.label_stack().take_last();
-                // Jump to the end label
-                configuration.ip() = label.continuation().value();
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::return_.value(): {
-                configuration.label_stack().shrink(configuration.frame().label_index() + 1, true);
-                configuration.ip() = max_ip_value;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::br.value():
-                branch_to_label(configuration, instruction->arguments().get<LabelIndex>());
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            case Instructions::br_if.value(): {
-                // bounds checked by verifier.
-                auto cond = configuration.take_source(0).to<i32>();
-                if (cond == 0)
-                    RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-                branch_to_label(configuration, instruction->arguments().get<LabelIndex>());
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::br_table.value(): {
-                auto& arguments = instruction->arguments().get<Instruction::TableBranchArgs>();
-                auto i = configuration.take_source(0).to<u32>();
-
-                if (i >= arguments.labels.size()) {
-                    branch_to_label(configuration, arguments.default_);
-                    RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-                }
-                branch_to_label(configuration, arguments.labels[i]);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::call.value(): {
-                auto index = instruction->arguments().get<FunctionIndex>();
-                auto address = configuration.frame().module().functions()[index.value()];
-                dbgln_if(WASM_TRACE_DEBUG, "call({})", address.value());
-                if (call_address(configuration, address))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::call_indirect.value(): {
-                auto& args = instruction->arguments().get<Instruction::IndirectCallArgs>();
-                auto table_address = configuration.frame().module().tables()[args.table.value()];
-                auto table_instance = configuration.store().get(table_address);
-                // bounds checked by verifier.
-                auto index = configuration.take_source(0).to<i32>();
-                TRAP_IN_LOOP_IF_NOT(index >= 0);
-                TRAP_IN_LOOP_IF_NOT(static_cast<size_t>(index) < table_instance->elements().size());
-                auto& element = table_instance->elements()[index];
-                TRAP_IN_LOOP_IF_NOT(element.ref().has<Reference::Func>());
-                auto address = element.ref().get<Reference::Func>().address;
-                auto const& type_actual = configuration.store().get(address)->visit([](auto& f) -> decltype(auto) { return f.type(); });
-                auto const& type_expected = configuration.frame().module().types()[args.type.value()];
-                TRAP_IN_LOOP_IF_NOT(type_actual.parameters().size() == type_expected.parameters().size());
-                TRAP_IN_LOOP_IF_NOT(type_actual.results().size() == type_expected.results().size());
-                TRAP_IN_LOOP_IF_NOT(type_actual.parameters() == type_expected.parameters());
-                TRAP_IN_LOOP_IF_NOT(type_actual.results() == type_expected.results());
-
-                dbgln_if(WASM_TRACE_DEBUG, "call_indirect({} -> {})", index, address.value());
-                if (call_address(configuration, address, CallAddressSource::IndirectCall))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
-            }
-            case Instructions::i32_load.value():
-                if (load_and_push<i32, i32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_load.value():
-                if (load_and_push<i64, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_load.value():
-                if (load_and_push<float, float>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_load.value():
-                if (load_and_push<double, double>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_load8_s.value():
-                if (load_and_push<i8, i32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_load8_u.value():
-                if (load_and_push<u8, i32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_load16_s.value():
-                if (load_and_push<i16, i32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_load16_u.value():
-                if (load_and_push<u16, i32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_load8_s.value():
-                if (load_and_push<i8, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_load8_u.value():
-                if (load_and_push<u8, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_load16_s.value():
-                if (load_and_push<i16, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_load16_u.value():
-                if (load_and_push<u16, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_load32_s.value():
-                if (load_and_push<i32, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_load32_u.value():
-                if (load_and_push<u32, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_store.value():
-                if (pop_and_store<i32, i32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_store.value():
-                if (pop_and_store<i64, i64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_store.value():
-                if (pop_and_store<float, float>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_store.value():
-                if (pop_and_store<double, double>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_store8.value():
-                if (pop_and_store<i32, i8>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_store16.value():
-                if (pop_and_store<i32, i16>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_store8.value():
-                if (pop_and_store<i64, i8>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_store16.value():
-                if (pop_and_store<i64, i16>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_store32.value():
-                if (pop_and_store<i64, i32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::local_tee.value(): {
-                auto value = configuration.source_value(0); // bounds checked by verifier.
-                auto local_index = instruction->local_index();
-                dbgln_if(WASM_TRACE_DEBUG, "stack:peek -> locals({})", local_index.value());
-                configuration.frame().locals()[local_index.value()] = value;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::global_get.value(): {
-                auto global_index = instruction->arguments().get<GlobalIndex>();
-                // This check here is for const expressions. In non-const expressions,
-                // a validation error would have been thrown.
-                TRAP_IN_LOOP_IF_NOT(global_index < configuration.frame().module().globals().size());
-                auto address = configuration.frame().module().globals()[global_index.value()];
-                dbgln_if(WASM_TRACE_DEBUG, "global({}) -> stack", address.value());
-                auto global = configuration.store().get(address);
-                configuration.push_to_destination(global->value());
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::global_set.value(): {
-                auto global_index = instruction->arguments().get<GlobalIndex>();
-                auto address = configuration.frame().module().globals()[global_index.value()];
-                // bounds checked by verifier.
-                auto value = configuration.take_source(0);
-                dbgln_if(WASM_TRACE_DEBUG, "stack -> global({})", address.value());
-                auto global = configuration.store().get(address);
-                global->set_value(value);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::memory_size.value(): {
-                auto& args = instruction->arguments().get<Instruction::MemoryIndexArgument>();
-                auto address = configuration.frame().module().memories()[args.memory_index.value()];
-                auto instance = configuration.store().get(address);
-                auto pages = instance->size() / Constants::page_size;
-                dbgln_if(WASM_TRACE_DEBUG, "memory.size -> stack({})", pages);
-                configuration.push_to_destination(Value(static_cast<i32>(pages)));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::memory_grow.value(): {
-                auto& args = instruction->arguments().get<Instruction::MemoryIndexArgument>();
-                auto address = configuration.frame().module().memories()[args.memory_index.value()];
-                auto instance = configuration.store().get(address);
-                i32 old_pages = instance->size() / Constants::page_size;
-                auto& entry = configuration.source_value(0); // bounds checked by verifier.
-                auto new_pages = entry.to<i32>();
-                dbgln_if(WASM_TRACE_DEBUG, "memory.grow({}), previously {} pages...", new_pages, old_pages);
-                if (instance->grow(new_pages * Constants::page_size))
-                    entry = Value(old_pages);
-                else
-                    entry = Value(-1);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            // https://webassembly.github.io/spec/core/bikeshed/#exec-memory-fill
-            case Instructions::memory_fill.value(): {
-                auto& args = instruction->arguments().get<Instruction::MemoryIndexArgument>();
-                auto address = configuration.frame().module().memories()[args.memory_index.value()];
-                auto instance = configuration.store().get(address);
-                // bounds checked by verifier.
-                auto count = configuration.take_source(0).to<u32>();
-                u8 value = static_cast<u8>(configuration.take_source(1).to<u32>());
-                auto destination_offset = configuration.take_source(2).to<u32>();
-
-                TRAP_IN_LOOP_IF_NOT(static_cast<size_t>(destination_offset + count) <= instance->data().size());
-
-                if (count == 0)
-                    RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-
-                for (u32 i = 0; i < count; ++i) {
-                    if (store_to_memory(configuration, Instruction::MemoryArgument { 0, 0 }, { &value, sizeof(value) }, destination_offset + i))
-                        return;
-                }
-
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            // https://webassembly.github.io/spec/core/bikeshed/#exec-memory-copy
-            case Instructions::memory_copy.value(): {
-                auto& args = instruction->arguments().get<Instruction::MemoryCopyArgs>();
-                auto source_address = configuration.frame().module().memories()[args.src_index.value()];
-                auto destination_address = configuration.frame().module().memories()[args.dst_index.value()];
-                auto source_instance = configuration.store().get(source_address);
-                auto destination_instance = configuration.store().get(destination_address);
-
-                // bounds checked by verifier.
-                auto count = configuration.take_source(0).to<i32>();
-                auto source_offset = configuration.take_source(1).to<i32>();
-                auto destination_offset = configuration.take_source(2).to<i32>();
-
-                Checked<size_t> source_position = source_offset;
-                source_position.saturating_add(count);
-                Checked<size_t> destination_position = destination_offset;
-                destination_position.saturating_add(count);
-                TRAP_IN_LOOP_IF_NOT(source_position <= source_instance->data().size());
-                TRAP_IN_LOOP_IF_NOT(destination_position <= destination_instance->data().size());
-
-                if (count == 0)
-                    RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-
-                Instruction::MemoryArgument memarg { 0, 0, args.dst_index };
-                if (destination_offset <= source_offset) {
-                    for (auto i = 0; i < count; ++i) {
-                        auto value = source_instance->data()[source_offset + i];
-                        if (store_to_memory(configuration, memarg, { &value, sizeof(value) }, destination_offset + i))
-                            return;
-                    }
                 } else {
-                    for (auto i = count - 1; i >= 0; --i) {
-                        auto value = source_instance->data()[source_offset + i];
-                        if (store_to_memory(configuration, memarg, { &value, sizeof(value) }, destination_offset + i))
-                            return;
-                    }
+                    current_ip_value = args.end_ip.value();
                 }
-
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
+            } else {
+                configuration.label_stack().append(end_label);
             }
-            // https://webassembly.github.io/spec/core/bikeshed/#exec-memory-init
-            case Instructions::memory_init.value(): {
-                auto& args = instruction->arguments().get<Instruction::MemoryInitArgs>();
-                auto& data_address = configuration.frame().module().datas()[args.data_index.value()];
-                auto& data = *configuration.store().get(data_address);
-                auto memory_address = configuration.frame().module().memories()[args.memory_index.value()];
-                auto memory = configuration.store().get(memory_address);
-                // bounds checked by verifier.
-                auto count = configuration.take_source(0).to<u32>();
-                auto source_offset = configuration.take_source(1).to<u32>();
-                auto destination_offset = configuration.take_source(2).to<u32>();
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::structured_end.value():
+            configuration.label_stack().take_last();
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::structured_else.value(): {
+            auto label = configuration.label_stack().take_last();
+            // Jump to the end label
+            current_ip_value = label.continuation().value() - 1;
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::return_.value(): {
+            configuration.label_stack().shrink(configuration.frame().label_index() + 1, true);
+            current_ip_value = max_ip_value - 1;
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::br.value():
+            current_ip_value = branch_to_label(configuration, instruction->arguments().get<LabelIndex>()).value();
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::br_if.value(): {
+            // bounds checked by verifier.
+            auto cond = configuration.take_source(0, addresses.sources).to<i32>();
+            if (cond == 0)
+                RUN_NEXT_INSTRUCTION();
+            current_ip_value = branch_to_label(configuration, instruction->arguments().get<LabelIndex>()).value();
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::br_table.value(): {
+            auto& arguments = instruction->arguments().get<Instruction::TableBranchArgs>();
+            auto i = configuration.take_source(0, addresses.sources).to<u32>();
 
-                Checked<size_t> source_position = source_offset;
-                source_position.saturating_add(count);
-                Checked<size_t> destination_position = destination_offset;
-                destination_position.saturating_add(count);
-                TRAP_IN_LOOP_IF_NOT(source_position <= data.data().size());
-                TRAP_IN_LOOP_IF_NOT(destination_position <= memory->data().size());
+            if (i >= arguments.labels.size()) {
+                current_ip_value = branch_to_label(configuration, arguments.default_).value();
+                RUN_NEXT_INSTRUCTION();
+            }
+            current_ip_value = branch_to_label(configuration, arguments.labels[i]).value();
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::call.value(): {
+            auto index = instruction->arguments().get<FunctionIndex>();
+            auto address = configuration.frame().module().functions()[index.value()];
+            dbgln_if(WASM_TRACE_DEBUG, "call({})", address.value());
+            if (call_address(configuration, address))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::call_indirect.value(): {
+            auto& args = instruction->arguments().get<Instruction::IndirectCallArgs>();
+            auto table_address = configuration.frame().module().tables()[args.table.value()];
+            auto table_instance = configuration.store().get(table_address);
+            // bounds checked by verifier.
+            auto index = configuration.take_source(0, addresses.sources).to<i32>();
+            TRAP_IN_LOOP_IF_NOT(index >= 0);
+            TRAP_IN_LOOP_IF_NOT(static_cast<size_t>(index) < table_instance->elements().size());
+            auto& element = table_instance->elements()[index];
+            TRAP_IN_LOOP_IF_NOT(element.ref().has<Reference::Func>());
+            auto address = element.ref().get<Reference::Func>().address;
+            auto const& type_actual = configuration.store().get(address)->visit([](auto& f) -> decltype(auto) { return f.type(); });
+            auto const& type_expected = configuration.frame().module().types()[args.type.value()];
+            TRAP_IN_LOOP_IF_NOT(type_actual.parameters().size() == type_expected.parameters().size());
+            TRAP_IN_LOOP_IF_NOT(type_actual.results().size() == type_expected.results().size());
+            TRAP_IN_LOOP_IF_NOT(type_actual.parameters() == type_expected.parameters());
+            TRAP_IN_LOOP_IF_NOT(type_actual.results() == type_expected.results());
 
-                if (count == 0)
-                    RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
+            dbgln_if(WASM_TRACE_DEBUG, "call_indirect({} -> {})", index, address.value());
+            if (call_address(configuration, address, CallAddressSource::IndirectCall))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::i32_load.value():
+            if (load_and_push<i32, i32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_load.value():
+            if (load_and_push<i64, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_load.value():
+            if (load_and_push<float, float>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_load.value():
+            if (load_and_push<double, double>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_load8_s.value():
+            if (load_and_push<i8, i32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_load8_u.value():
+            if (load_and_push<u8, i32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_load16_s.value():
+            if (load_and_push<i16, i32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_load16_u.value():
+            if (load_and_push<u16, i32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_load8_s.value():
+            if (load_and_push<i8, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_load8_u.value():
+            if (load_and_push<u8, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_load16_s.value():
+            if (load_and_push<i16, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_load16_u.value():
+            if (load_and_push<u16, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_load32_s.value():
+            if (load_and_push<i32, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_load32_u.value():
+            if (load_and_push<u32, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_store.value():
+            if (pop_and_store<i32, i32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_store.value():
+            if (pop_and_store<i64, i64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_store.value():
+            if (pop_and_store<float, float>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_store.value():
+            if (pop_and_store<double, double>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_store8.value():
+            if (pop_and_store<i32, i8>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_store16.value():
+            if (pop_and_store<i32, i16>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_store8.value():
+            if (pop_and_store<i64, i8>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_store16.value():
+            if (pop_and_store<i64, i16>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_store32.value():
+            if (pop_and_store<i64, i32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::local_tee.value(): {
+            auto value = configuration.source_value(0, addresses.sources); // bounds checked by verifier.
+            auto local_index = instruction->local_index();
+            dbgln_if(WASM_TRACE_DEBUG, "stack:peek -> locals({})", local_index.value());
+            configuration.frame().locals()[local_index.value()] = value;
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::global_get.value(): {
+            auto global_index = instruction->arguments().get<GlobalIndex>();
+            // This check here is for const expressions. In non-const expressions,
+            // a validation error would have been thrown.
+            TRAP_IN_LOOP_IF_NOT(global_index < configuration.frame().module().globals().size());
+            auto address = configuration.frame().module().globals()[global_index.value()];
+            dbgln_if(WASM_TRACE_DEBUG, "global({}) -> stack", address.value());
+            auto global = configuration.store().get(address);
+            configuration.push_to_destination(global->value(), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::global_set.value(): {
+            auto global_index = instruction->arguments().get<GlobalIndex>();
+            auto address = configuration.frame().module().globals()[global_index.value()];
+            // bounds checked by verifier.
+            auto value = configuration.take_source(0, addresses.sources);
+            dbgln_if(WASM_TRACE_DEBUG, "stack -> global({})", address.value());
+            auto global = configuration.store().get(address);
+            global->set_value(value);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::memory_size.value(): {
+            auto& args = instruction->arguments().get<Instruction::MemoryIndexArgument>();
+            auto address = configuration.frame().module().memories().data()[args.memory_index.value()];
+            auto instance = configuration.store().get(address);
+            auto pages = instance->size() / Constants::page_size;
+            dbgln_if(WASM_TRACE_DEBUG, "memory.size -> stack({})", pages);
+            configuration.push_to_destination(Value(static_cast<i32>(pages)), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::memory_grow.value(): {
+            auto& args = instruction->arguments().get<Instruction::MemoryIndexArgument>();
+            auto address = configuration.frame().module().memories().data()[args.memory_index.value()];
+            auto instance = configuration.store().get(address);
+            i32 old_pages = instance->size() / Constants::page_size;
+            auto& entry = configuration.source_value(0, addresses.sources); // bounds checked by verifier.
+            auto new_pages = entry.to<i32>();
+            dbgln_if(WASM_TRACE_DEBUG, "memory.grow({}), previously {} pages...", new_pages, old_pages);
+            if (instance->grow(new_pages * Constants::page_size))
+                entry = Value(old_pages);
+            else
+                entry = Value(-1);
+            RUN_NEXT_INSTRUCTION();
+        }
+        // https://webassembly.github.io/spec/core/bikeshed/#exec-memory-fill
+        case Instructions::memory_fill.value(): {
+            auto& args = instruction->arguments().get<Instruction::MemoryIndexArgument>();
+            auto address = configuration.frame().module().memories().data()[args.memory_index.value()];
+            auto instance = configuration.store().get(address);
+            // bounds checked by verifier.
+            auto count = configuration.take_source(0, addresses.sources).to<u32>();
+            u8 value = static_cast<u8>(configuration.take_source(1, addresses.sources).to<u32>());
+            auto destination_offset = configuration.take_source(2, addresses.sources).to<u32>();
 
-                Instruction::MemoryArgument memarg { 0, 0, args.memory_index };
-                for (size_t i = 0; i < (size_t)count; ++i) {
-                    auto value = data.data()[source_offset + i];
+            TRAP_IN_LOOP_IF_NOT(static_cast<size_t>(destination_offset + count) <= instance->data().size());
+
+            if (count == 0)
+                RUN_NEXT_INSTRUCTION();
+
+            for (u32 i = 0; i < count; ++i) {
+                if (store_to_memory(configuration, Instruction::MemoryArgument { 0, 0 }, { &value, sizeof(value) }, destination_offset + i))
+                    return;
+            }
+
+            RUN_NEXT_INSTRUCTION();
+        }
+        // https://webassembly.github.io/spec/core/bikeshed/#exec-memory-copy
+        case Instructions::memory_copy.value(): {
+            auto& args = instruction->arguments().get<Instruction::MemoryCopyArgs>();
+            auto source_address = configuration.frame().module().memories().data()[args.src_index.value()];
+            auto destination_address = configuration.frame().module().memories().data()[args.dst_index.value()];
+            auto source_instance = configuration.store().get(source_address);
+            auto destination_instance = configuration.store().get(destination_address);
+
+            // bounds checked by verifier.
+            auto count = configuration.take_source(0, addresses.sources).to<i32>();
+            auto source_offset = configuration.take_source(1, addresses.sources).to<i32>();
+            auto destination_offset = configuration.take_source(2, addresses.sources).to<i32>();
+
+            Checked<size_t> source_position = source_offset;
+            source_position.saturating_add(count);
+            Checked<size_t> destination_position = destination_offset;
+            destination_position.saturating_add(count);
+            TRAP_IN_LOOP_IF_NOT(source_position <= source_instance->data().size());
+            TRAP_IN_LOOP_IF_NOT(destination_position <= destination_instance->data().size());
+
+            if (count == 0)
+                RUN_NEXT_INSTRUCTION();
+
+            Instruction::MemoryArgument memarg { 0, 0, args.dst_index };
+            if (destination_offset <= source_offset) {
+                for (auto i = 0; i < count; ++i) {
+                    auto value = source_instance->data()[source_offset + i];
                     if (store_to_memory(configuration, memarg, { &value, sizeof(value) }, destination_offset + i))
                         return;
                 }
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            // https://webassembly.github.io/spec/core/bikeshed/#exec-data-drop
-            case Instructions::data_drop.value(): {
-                auto data_index = instruction->arguments().get<DataIndex>();
-                auto data_address = configuration.frame().module().datas()[data_index.value()];
-                *configuration.store().get(data_address) = DataInstance({});
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::elem_drop.value(): {
-                auto elem_index = instruction->arguments().get<ElementIndex>();
-                auto address = configuration.frame().module().elements()[elem_index.value()];
-                auto elem = configuration.store().get(address);
-                *configuration.store().get(address) = ElementInstance(elem->type(), {});
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::table_init.value(): {
-                auto& args = instruction->arguments().get<Instruction::TableElementArgs>();
-                auto table_address = configuration.frame().module().tables()[args.table_index.value()];
-                auto table = configuration.store().get(table_address);
-                auto element_address = configuration.frame().module().elements()[args.element_index.value()];
-                auto element = configuration.store().get(element_address);
-                // bounds checked by verifier.
-                auto count = configuration.take_source(0).to<u32>();
-                auto source_offset = configuration.take_source(1).to<u32>();
-                auto destination_offset = configuration.take_source(2).to<u32>();
-
-                Checked<u32> checked_source_offset = source_offset;
-                Checked<u32> checked_destination_offset = destination_offset;
-                checked_source_offset += count;
-                checked_destination_offset += count;
-                TRAP_IN_LOOP_IF_NOT(!checked_source_offset.has_overflow() && checked_source_offset <= (u32)element->references().size());
-                TRAP_IN_LOOP_IF_NOT(!checked_destination_offset.has_overflow() && checked_destination_offset <= (u32)table->elements().size());
-
-                for (u32 i = 0; i < count; ++i)
-                    table->elements()[destination_offset + i] = element->references()[source_offset + i];
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::table_copy.value(): {
-                auto& args = instruction->arguments().get<Instruction::TableTableArgs>();
-                auto source_address = configuration.frame().module().tables()[args.rhs.value()];
-                auto destination_address = configuration.frame().module().tables()[args.lhs.value()];
-                auto source_instance = configuration.store().get(source_address);
-                auto destination_instance = configuration.store().get(destination_address);
-
-                // bounds checked by verifier.
-                auto count = configuration.take_source(0).to<u32>();
-                auto source_offset = configuration.take_source(1).to<u32>();
-                auto destination_offset = configuration.take_source(2).to<u32>();
-
-                Checked<size_t> source_position = source_offset;
-                source_position.saturating_add(count);
-                Checked<size_t> destination_position = destination_offset;
-                destination_position.saturating_add(count);
-                TRAP_IN_LOOP_IF_NOT(source_position <= source_instance->elements().size());
-                TRAP_IN_LOOP_IF_NOT(destination_position <= destination_instance->elements().size());
-
-                if (count == 0)
-                    RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-
-                if (destination_offset <= source_offset) {
-                    for (u32 i = 0; i < count; ++i) {
-                        auto value = source_instance->elements()[source_offset + i];
-                        destination_instance->elements()[destination_offset + i] = value;
-                    }
-                } else {
-                    for (u32 i = count - 1; i != NumericLimits<u32>::max(); --i) {
-                        auto value = source_instance->elements()[source_offset + i];
-                        destination_instance->elements()[destination_offset + i] = value;
-                    }
+            } else {
+                for (auto i = count - 1; i >= 0; --i) {
+                    auto value = source_instance->data()[source_offset + i];
+                    if (store_to_memory(configuration, memarg, { &value, sizeof(value) }, destination_offset + i))
+                        return;
                 }
+            }
 
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::table_fill.value(): {
-                auto table_index = instruction->arguments().get<TableIndex>();
-                auto address = configuration.frame().module().tables()[table_index.value()];
-                auto table = configuration.store().get(address);
-                // bounds checked by verifier.
-                auto count = configuration.take_source(0).to<u32>();
-                auto value = configuration.take_source(1);
-                auto start = configuration.take_source(2).to<u32>();
+            RUN_NEXT_INSTRUCTION();
+        }
+        // https://webassembly.github.io/spec/core/bikeshed/#exec-memory-init
+        case Instructions::memory_init.value(): {
+            auto& args = instruction->arguments().get<Instruction::MemoryInitArgs>();
+            auto& data_address = configuration.frame().module().datas()[args.data_index.value()];
+            auto& data = *configuration.store().get(data_address);
+            auto memory_address = configuration.frame().module().memories().data()[args.memory_index.value()];
+            auto memory = configuration.store().unsafe_get(memory_address);
+            // bounds checked by verifier.
+            auto count = configuration.take_source(0, addresses.sources).to<u32>();
+            auto source_offset = configuration.take_source(1, addresses.sources).to<u32>();
+            auto destination_offset = configuration.take_source(2, addresses.sources).to<u32>();
 
-                Checked<u32> checked_offset = start;
-                checked_offset += count;
-                TRAP_IN_LOOP_IF_NOT(!checked_offset.has_overflow() && checked_offset <= (u32)table->elements().size());
+            Checked<size_t> source_position = source_offset;
+            source_position.saturating_add(count);
+            Checked<size_t> destination_position = destination_offset;
+            destination_position.saturating_add(count);
+            TRAP_IN_LOOP_IF_NOT(source_position <= data.data().size());
+            TRAP_IN_LOOP_IF_NOT(destination_position <= memory->data().size());
 
-                for (u32 i = 0; i < count; ++i)
-                    table->elements()[start + i] = value.to<Reference>();
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
+            if (count == 0)
+                RUN_NEXT_INSTRUCTION();
+
+            Instruction::MemoryArgument memarg { 0, 0, args.memory_index };
+            for (size_t i = 0; i < (size_t)count; ++i) {
+                auto value = data.data()[source_offset + i];
+                if (store_to_memory(configuration, memarg, { &value, sizeof(value) }, destination_offset + i))
+                    return;
             }
-            case Instructions::table_set.value(): {
-                // bounds checked by verifier.
-                auto ref = configuration.take_source(0);
-                auto index = (size_t)(configuration.take_source(1).to<i32>());
-                auto table_index = instruction->arguments().get<TableIndex>();
-                auto address = configuration.frame().module().tables()[table_index.value()];
-                auto table = configuration.store().get(address);
-                TRAP_IN_LOOP_IF_NOT(index < table->elements().size());
-                table->elements()[index] = ref.to<Reference>();
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::table_get.value(): {
-                // bounds checked by verifier.
-                auto& index_value = configuration.source_value(0);
-                auto index = static_cast<size_t>(index_value.to<i32>());
-                auto table_index = instruction->arguments().get<TableIndex>();
-                auto address = configuration.frame().module().tables()[table_index.value()];
-                auto table = configuration.store().get(address);
-                TRAP_IN_LOOP_IF_NOT(index < table->elements().size());
-                index_value = Value(table->elements()[index]);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::table_grow.value(): {
-                // bounds checked by verifier.
-                auto size = configuration.take_source(0).to<u32>();
-                auto fill_value = configuration.take_source(1);
-                auto table_index = instruction->arguments().get<TableIndex>();
-                auto address = configuration.frame().module().tables()[table_index.value()];
-                auto table = configuration.store().get(address);
-                auto previous_size = table->elements().size();
-                auto did_grow = table->grow(size, fill_value.to<Reference>());
-                if (!did_grow) {
-                    configuration.push_to_destination(Value(-1));
-                } else {
-                    configuration.push_to_destination(Value(static_cast<i32>(previous_size)));
+            RUN_NEXT_INSTRUCTION();
+        }
+        // https://webassembly.github.io/spec/core/bikeshed/#exec-data-drop
+        case Instructions::data_drop.value(): {
+            auto data_index = instruction->arguments().get<DataIndex>();
+            auto data_address = configuration.frame().module().datas()[data_index.value()];
+            *configuration.store().get(data_address) = DataInstance({});
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::elem_drop.value(): {
+            auto elem_index = instruction->arguments().get<ElementIndex>();
+            auto address = configuration.frame().module().elements()[elem_index.value()];
+            auto elem = configuration.store().get(address);
+            *configuration.store().get(address) = ElementInstance(elem->type(), {});
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::table_init.value(): {
+            auto& args = instruction->arguments().get<Instruction::TableElementArgs>();
+            auto table_address = configuration.frame().module().tables()[args.table_index.value()];
+            auto table = configuration.store().get(table_address);
+            auto element_address = configuration.frame().module().elements()[args.element_index.value()];
+            auto element = configuration.store().get(element_address);
+            // bounds checked by verifier.
+            auto count = configuration.take_source(0, addresses.sources).to<u32>();
+            auto source_offset = configuration.take_source(1, addresses.sources).to<u32>();
+            auto destination_offset = configuration.take_source(2, addresses.sources).to<u32>();
+
+            Checked<u32> checked_source_offset = source_offset;
+            Checked<u32> checked_destination_offset = destination_offset;
+            checked_source_offset += count;
+            checked_destination_offset += count;
+            TRAP_IN_LOOP_IF_NOT(!checked_source_offset.has_overflow() && checked_source_offset <= (u32)element->references().size());
+            TRAP_IN_LOOP_IF_NOT(!checked_destination_offset.has_overflow() && checked_destination_offset <= (u32)table->elements().size());
+
+            for (u32 i = 0; i < count; ++i)
+                table->elements()[destination_offset + i] = element->references()[source_offset + i];
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::table_copy.value(): {
+            auto& args = instruction->arguments().get<Instruction::TableTableArgs>();
+            auto source_address = configuration.frame().module().tables()[args.rhs.value()];
+            auto destination_address = configuration.frame().module().tables()[args.lhs.value()];
+            auto source_instance = configuration.store().get(source_address);
+            auto destination_instance = configuration.store().get(destination_address);
+
+            // bounds checked by verifier.
+            auto count = configuration.take_source(0, addresses.sources).to<u32>();
+            auto source_offset = configuration.take_source(1, addresses.sources).to<u32>();
+            auto destination_offset = configuration.take_source(2, addresses.sources).to<u32>();
+
+            Checked<size_t> source_position = source_offset;
+            source_position.saturating_add(count);
+            Checked<size_t> destination_position = destination_offset;
+            destination_position.saturating_add(count);
+            TRAP_IN_LOOP_IF_NOT(source_position <= source_instance->elements().size());
+            TRAP_IN_LOOP_IF_NOT(destination_position <= destination_instance->elements().size());
+
+            if (count == 0)
+                RUN_NEXT_INSTRUCTION();
+
+            if (destination_offset <= source_offset) {
+                for (u32 i = 0; i < count; ++i) {
+                    auto value = source_instance->elements()[source_offset + i];
+                    destination_instance->elements()[destination_offset + i] = value;
                 }
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
+            } else {
+                for (u32 i = count - 1; i != NumericLimits<u32>::max(); --i) {
+                    auto value = source_instance->elements()[source_offset + i];
+                    destination_instance->elements()[destination_offset + i] = value;
+                }
             }
-            case Instructions::table_size.value(): {
-                auto table_index = instruction->arguments().get<TableIndex>();
-                auto address = configuration.frame().module().tables()[table_index.value()];
-                auto table = configuration.store().get(address);
-                configuration.push_to_destination(Value(static_cast<i32>(table->elements().size())));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
+
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::table_fill.value(): {
+            auto table_index = instruction->arguments().get<TableIndex>();
+            auto address = configuration.frame().module().tables()[table_index.value()];
+            auto table = configuration.store().get(address);
+            // bounds checked by verifier.
+            auto count = configuration.take_source(0, addresses.sources).to<u32>();
+            auto value = configuration.take_source(1, addresses.sources);
+            auto start = configuration.take_source(2, addresses.sources).to<u32>();
+
+            Checked<u32> checked_offset = start;
+            checked_offset += count;
+            TRAP_IN_LOOP_IF_NOT(!checked_offset.has_overflow() && checked_offset <= (u32)table->elements().size());
+
+            for (u32 i = 0; i < count; ++i)
+                table->elements()[start + i] = value.to<Reference>();
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::table_set.value(): {
+            // bounds checked by verifier.
+            auto ref = configuration.take_source(0, addresses.sources);
+            auto index = (size_t)(configuration.take_source(1, addresses.sources).to<i32>());
+            auto table_index = instruction->arguments().get<TableIndex>();
+            auto address = configuration.frame().module().tables()[table_index.value()];
+            auto table = configuration.store().get(address);
+            TRAP_IN_LOOP_IF_NOT(index < table->elements().size());
+            table->elements()[index] = ref.to<Reference>();
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::table_get.value(): {
+            // bounds checked by verifier.
+            auto& index_value = configuration.source_value(0, addresses.sources);
+            auto index = static_cast<size_t>(index_value.to<i32>());
+            auto table_index = instruction->arguments().get<TableIndex>();
+            auto address = configuration.frame().module().tables()[table_index.value()];
+            auto table = configuration.store().get(address);
+            TRAP_IN_LOOP_IF_NOT(index < table->elements().size());
+            index_value = Value(table->elements()[index]);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::table_grow.value(): {
+            // bounds checked by verifier.
+            auto size = configuration.take_source(0, addresses.sources).to<u32>();
+            auto fill_value = configuration.take_source(1, addresses.sources);
+            auto table_index = instruction->arguments().get<TableIndex>();
+            auto address = configuration.frame().module().tables()[table_index.value()];
+            auto table = configuration.store().get(address);
+            auto previous_size = table->elements().size();
+            auto did_grow = table->grow(size, fill_value.to<Reference>());
+            if (!did_grow) {
+                configuration.push_to_destination(Value(-1), addresses.destination);
+            } else {
+                configuration.push_to_destination(Value(static_cast<i32>(previous_size)), addresses.destination);
             }
-            case Instructions::ref_null.value(): {
-                auto type = instruction->arguments().get<ValueType>();
-                configuration.push_to_destination(Value(Reference(Reference::Null { type })));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            };
-            case Instructions::ref_func.value(): {
-                auto index = instruction->arguments().get<FunctionIndex>().value();
-                auto& functions = configuration.frame().module().functions();
-                auto address = functions[index];
-                configuration.push_to_destination(Value(Reference { Reference::Func { address, configuration.store().get_module_for(address) } }));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::ref_is_null.value(): {
-                // bounds checked by verifier.
-                auto ref = configuration.take_source(0);
-                configuration.push_to_destination(Value(static_cast<i32>(ref.to<Reference>().ref().has<Reference::Null>() ? 1 : 0)));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::drop.value():
-                // bounds checked by verifier.
-                configuration.take_source(0);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::select.value():
-            case Instructions::select_typed.value(): {
-                // Note: The type seems to only be used for validation.
-                auto value = configuration.take_source(0).to<i32>(); // bounds checked by verifier.
-                dbgln_if(WASM_TRACE_DEBUG, "select({})", value);
-                auto rhs = configuration.take_source(1);
-                auto& lhs = configuration.source_value(2); // bounds checked by verifier.
-                lhs = value != 0 ? lhs : rhs;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::i32_eqz.value():
-                if (unary_operation<i32, i32, Operators::EqualsZero>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_eq.value():
-                if (binary_numeric_operation<i32, i32, Operators::Equals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_ne.value():
-                if (binary_numeric_operation<i32, i32, Operators::NotEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_lts.value():
-                if (binary_numeric_operation<i32, i32, Operators::LessThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_ltu.value():
-                if (binary_numeric_operation<u32, i32, Operators::LessThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_gts.value():
-                if (binary_numeric_operation<i32, i32, Operators::GreaterThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_gtu.value():
-                if (binary_numeric_operation<u32, i32, Operators::GreaterThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_les.value():
-                if (binary_numeric_operation<i32, i32, Operators::LessThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_leu.value():
-                if (binary_numeric_operation<u32, i32, Operators::LessThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_ges.value():
-                if (binary_numeric_operation<i32, i32, Operators::GreaterThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_geu.value():
-                if (binary_numeric_operation<u32, i32, Operators::GreaterThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_eqz.value():
-                if (unary_operation<i64, i32, Operators::EqualsZero>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_eq.value():
-                if (binary_numeric_operation<i64, i32, Operators::Equals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_ne.value():
-                if (binary_numeric_operation<i64, i32, Operators::NotEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_lts.value():
-                if (binary_numeric_operation<i64, i32, Operators::LessThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_ltu.value():
-                if (binary_numeric_operation<u64, i32, Operators::LessThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_gts.value():
-                if (binary_numeric_operation<i64, i32, Operators::GreaterThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_gtu.value():
-                if (binary_numeric_operation<u64, i32, Operators::GreaterThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_les.value():
-                if (binary_numeric_operation<i64, i32, Operators::LessThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_leu.value():
-                if (binary_numeric_operation<u64, i32, Operators::LessThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_ges.value():
-                if (binary_numeric_operation<i64, i32, Operators::GreaterThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_geu.value():
-                if (binary_numeric_operation<u64, i32, Operators::GreaterThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_eq.value():
-                if (binary_numeric_operation<float, i32, Operators::Equals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_ne.value():
-                if (binary_numeric_operation<float, i32, Operators::NotEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_lt.value():
-                if (binary_numeric_operation<float, i32, Operators::LessThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_gt.value():
-                if (binary_numeric_operation<float, i32, Operators::GreaterThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_le.value():
-                if (binary_numeric_operation<float, i32, Operators::LessThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_ge.value():
-                if (binary_numeric_operation<float, i32, Operators::GreaterThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_eq.value():
-                if (binary_numeric_operation<double, i32, Operators::Equals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_ne.value():
-                if (binary_numeric_operation<double, i32, Operators::NotEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_lt.value():
-                if (binary_numeric_operation<double, i32, Operators::LessThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_gt.value():
-                if (binary_numeric_operation<double, i32, Operators::GreaterThan>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_le.value():
-                if (binary_numeric_operation<double, i32, Operators::LessThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_ge.value():
-                if (binary_numeric_operation<double, i32, Operators::GreaterThanOrEquals>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_clz.value():
-                if (unary_operation<i32, i32, Operators::CountLeadingZeros>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_ctz.value():
-                if (unary_operation<i32, i32, Operators::CountTrailingZeros>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_popcnt.value():
-                if (unary_operation<i32, i32, Operators::PopCount>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_add.value():
-                if (binary_numeric_operation<u32, i32, Operators::Add>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_sub.value():
-                if (binary_numeric_operation<u32, i32, Operators::Subtract>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_mul.value():
-                if (binary_numeric_operation<u32, i32, Operators::Multiply>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_divs.value():
-                if (binary_numeric_operation<i32, i32, Operators::Divide>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_divu.value():
-                if (binary_numeric_operation<u32, i32, Operators::Divide>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_rems.value():
-                if (binary_numeric_operation<i32, i32, Operators::Modulo>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_remu.value():
-                if (binary_numeric_operation<u32, i32, Operators::Modulo>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_and.value():
-                if (binary_numeric_operation<i32, i32, Operators::BitAnd>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_or.value():
-                if (binary_numeric_operation<i32, i32, Operators::BitOr>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_xor.value():
-                if (binary_numeric_operation<i32, i32, Operators::BitXor>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_shl.value():
-                if (binary_numeric_operation<u32, i32, Operators::BitShiftLeft>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_shrs.value():
-                if (binary_numeric_operation<i32, i32, Operators::BitShiftRight>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_shru.value():
-                if (binary_numeric_operation<u32, i32, Operators::BitShiftRight>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_rotl.value():
-                if (binary_numeric_operation<u32, i32, Operators::BitRotateLeft>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_rotr.value():
-                if (binary_numeric_operation<u32, i32, Operators::BitRotateRight>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_clz.value():
-                if (unary_operation<i64, i64, Operators::CountLeadingZeros>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_ctz.value():
-                if (unary_operation<i64, i64, Operators::CountTrailingZeros>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_popcnt.value():
-                if (unary_operation<i64, i64, Operators::PopCount>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_add.value():
-                if (binary_numeric_operation<u64, i64, Operators::Add>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_sub.value():
-                if (binary_numeric_operation<u64, i64, Operators::Subtract>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_mul.value():
-                if (binary_numeric_operation<u64, i64, Operators::Multiply>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_divs.value():
-                if (binary_numeric_operation<i64, i64, Operators::Divide>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_divu.value():
-                if (binary_numeric_operation<u64, i64, Operators::Divide>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_rems.value():
-                if (binary_numeric_operation<i64, i64, Operators::Modulo>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_remu.value():
-                if (binary_numeric_operation<u64, i64, Operators::Modulo>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_and.value():
-                if (binary_numeric_operation<i64, i64, Operators::BitAnd>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_or.value():
-                if (binary_numeric_operation<i64, i64, Operators::BitOr>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_xor.value():
-                if (binary_numeric_operation<i64, i64, Operators::BitXor>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_shl.value():
-                if (binary_numeric_operation<u64, i64, Operators::BitShiftLeft>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_shrs.value():
-                if (binary_numeric_operation<i64, i64, Operators::BitShiftRight>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_shru.value():
-                if (binary_numeric_operation<u64, i64, Operators::BitShiftRight>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_rotl.value():
-                if (binary_numeric_operation<u64, i64, Operators::BitRotateLeft>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_rotr.value():
-                if (binary_numeric_operation<u64, i64, Operators::BitRotateRight>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_abs.value():
-                if (unary_operation<float, float, Operators::Absolute>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_neg.value():
-                if (unary_operation<float, float, Operators::Negate>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_ceil.value():
-                if (unary_operation<float, float, Operators::Ceil>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_floor.value():
-                if (unary_operation<float, float, Operators::Floor>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_trunc.value():
-                if (unary_operation<float, float, Operators::Truncate>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_nearest.value():
-                if (unary_operation<float, float, Operators::NearbyIntegral>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_sqrt.value():
-                if (unary_operation<float, float, Operators::SquareRoot>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_add.value():
-                if (binary_numeric_operation<float, float, Operators::Add>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_sub.value():
-                if (binary_numeric_operation<float, float, Operators::Subtract>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_mul.value():
-                if (binary_numeric_operation<float, float, Operators::Multiply>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_div.value():
-                if (binary_numeric_operation<float, float, Operators::Divide>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_min.value():
-                if (binary_numeric_operation<float, float, Operators::Minimum>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_max.value():
-                if (binary_numeric_operation<float, float, Operators::Maximum>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_copysign.value():
-                if (binary_numeric_operation<float, float, Operators::CopySign>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_abs.value():
-                if (unary_operation<double, double, Operators::Absolute>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_neg.value():
-                if (unary_operation<double, double, Operators::Negate>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_ceil.value():
-                if (unary_operation<double, double, Operators::Ceil>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_floor.value():
-                if (unary_operation<double, double, Operators::Floor>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_trunc.value():
-                if (unary_operation<double, double, Operators::Truncate>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_nearest.value():
-                if (unary_operation<double, double, Operators::NearbyIntegral>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_sqrt.value():
-                if (unary_operation<double, double, Operators::SquareRoot>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_add.value():
-                if (binary_numeric_operation<double, double, Operators::Add>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_sub.value():
-                if (binary_numeric_operation<double, double, Operators::Subtract>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_mul.value():
-                if (binary_numeric_operation<double, double, Operators::Multiply>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_div.value():
-                if (binary_numeric_operation<double, double, Operators::Divide>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_min.value():
-                if (binary_numeric_operation<double, double, Operators::Minimum>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_max.value():
-                if (binary_numeric_operation<double, double, Operators::Maximum>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_copysign.value():
-                if (binary_numeric_operation<double, double, Operators::CopySign>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_wrap_i64.value():
-                if (unary_operation<i64, i32, Operators::Wrap<i32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_sf32.value():
-                if (unary_operation<float, i32, Operators::CheckedTruncate<i32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_uf32.value():
-                if (unary_operation<float, i32, Operators::CheckedTruncate<u32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_sf64.value():
-                if (unary_operation<double, i32, Operators::CheckedTruncate<i32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_uf64.value():
-                if (unary_operation<double, i32, Operators::CheckedTruncate<u32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_sf32.value():
-                if (unary_operation<float, i64, Operators::CheckedTruncate<i64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_uf32.value():
-                if (unary_operation<float, i64, Operators::CheckedTruncate<u64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_sf64.value():
-                if (unary_operation<double, i64, Operators::CheckedTruncate<i64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_uf64.value():
-                if (unary_operation<double, i64, Operators::CheckedTruncate<u64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_extend_si32.value():
-                if (unary_operation<i32, i64, Operators::Extend<i64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_extend_ui32.value():
-                if (unary_operation<u32, i64, Operators::Extend<i64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_convert_si32.value():
-                if (unary_operation<i32, float, Operators::Convert<float>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_convert_ui32.value():
-                if (unary_operation<u32, float, Operators::Convert<float>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_convert_si64.value():
-                if (unary_operation<i64, float, Operators::Convert<float>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_convert_ui64.value():
-                if (unary_operation<u64, float, Operators::Convert<float>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_demote_f64.value():
-                if (unary_operation<double, float, Operators::Demote>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_convert_si32.value():
-                if (unary_operation<i32, double, Operators::Convert<double>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_convert_ui32.value():
-                if (unary_operation<u32, double, Operators::Convert<double>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_convert_si64.value():
-                if (unary_operation<i64, double, Operators::Convert<double>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_convert_ui64.value():
-                if (unary_operation<u64, double, Operators::Convert<double>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_promote_f32.value():
-                if (unary_operation<float, double, Operators::Promote>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_reinterpret_f32.value():
-                if (unary_operation<float, i32, Operators::Reinterpret<i32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_reinterpret_f64.value():
-                if (unary_operation<double, i64, Operators::Reinterpret<i64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32_reinterpret_i32.value():
-                if (unary_operation<i32, float, Operators::Reinterpret<float>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64_reinterpret_i64.value():
-                if (unary_operation<i64, double, Operators::Reinterpret<double>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_extend8_s.value():
-                if (unary_operation<i32, i32, Operators::SignExtend<i8>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_extend16_s.value():
-                if (unary_operation<i32, i32, Operators::SignExtend<i16>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_extend8_s.value():
-                if (unary_operation<i64, i64, Operators::SignExtend<i8>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_extend16_s.value():
-                if (unary_operation<i64, i64, Operators::SignExtend<i16>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_extend32_s.value():
-                if (unary_operation<i64, i64, Operators::SignExtend<i32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_sat_f32_s.value():
-                if (unary_operation<float, i32, Operators::SaturatingTruncate<i32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_sat_f32_u.value():
-                if (unary_operation<float, i32, Operators::SaturatingTruncate<u32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_sat_f64_s.value():
-                if (unary_operation<double, i32, Operators::SaturatingTruncate<i32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32_trunc_sat_f64_u.value():
-                if (unary_operation<double, i32, Operators::SaturatingTruncate<u32>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_sat_f32_s.value():
-                if (unary_operation<float, i64, Operators::SaturatingTruncate<i64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_sat_f32_u.value():
-                if (unary_operation<float, i64, Operators::SaturatingTruncate<u64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_sat_f64_s.value():
-                if (unary_operation<double, i64, Operators::SaturatingTruncate<i64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64_trunc_sat_f64_u.value():
-                if (unary_operation<double, i64, Operators::SaturatingTruncate<u64>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_const.value():
-                configuration.push_to_destination(Value(instruction->arguments().get<u128>()));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load.value():
-                if (load_and_push<u128, u128>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load8x8_s.value():
-                if (load_and_push_mxn<8, 8, MakeSigned>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load8x8_u.value():
-                if (load_and_push_mxn<8, 8, MakeUnsigned>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load16x4_s.value():
-                if (load_and_push_mxn<16, 4, MakeSigned>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load16x4_u.value():
-                if (load_and_push_mxn<16, 4, MakeUnsigned>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load32x2_s.value():
-                if (load_and_push_mxn<32, 2, MakeSigned>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load32x2_u.value():
-                if (load_and_push_mxn<32, 2, MakeUnsigned>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load8_splat.value():
-                if (load_and_push_m_splat<8>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load16_splat.value():
-                if (load_and_push_m_splat<16>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load32_splat.value():
-                if (load_and_push_m_splat<32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load64_splat.value():
-                if (load_and_push_m_splat<64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_splat.value():
-                pop_and_push_m_splat<8, NativeIntegralType>(configuration, *instruction);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_splat.value():
-                pop_and_push_m_splat<16, NativeIntegralType>(configuration, *instruction);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_splat.value():
-                pop_and_push_m_splat<32, NativeIntegralType>(configuration, *instruction);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_splat.value():
-                pop_and_push_m_splat<64, NativeIntegralType>(configuration, *instruction);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_splat.value():
-                pop_and_push_m_splat<32, NativeFloatingType>(configuration, *instruction);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_splat.value():
-                pop_and_push_m_splat<64, NativeFloatingType>(configuration, *instruction);
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_shuffle.value(): {
-                auto& arg = instruction->arguments().get<Instruction::ShuffleArgument>();
-                auto b = pop_vector<u8, MakeUnsigned>(configuration, 0);
-                auto a = pop_vector<u8, MakeUnsigned>(configuration, 1);
-                using VectorType = Native128ByteVectorOf<u8, MakeUnsigned>;
-                VectorType result;
-                for (size_t i = 0; i < 16; ++i)
-                    if (arg.lanes[i] < 16)
-                        result[i] = a[arg.lanes[i]];
-                    else
-                        result[i] = b[arg.lanes[i] - 16];
-                configuration.push_to_destination(Value(bit_cast<u128>(result)));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::v128_store.value():
-                if (pop_and_store<u128, u128>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_shl.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<16>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_shr_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<16, MakeUnsigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_shr_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<16, MakeSigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_shl.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<8>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_shr_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<8, MakeUnsigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_shr_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<8, MakeSigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_shl.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<4>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_shr_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<4, MakeUnsigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_shr_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<4, MakeSigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_shl.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<2>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_shr_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<2, MakeUnsigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_shr_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<2, MakeSigned>, i32>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_swizzle.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorSwizzle>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_extract_lane_s.value():
-                if (unary_operation<u128, i8, Operators::VectorExtractLane<16, MakeSigned>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_extract_lane_u.value():
-                if (unary_operation<u128, u8, Operators::VectorExtractLane<16, MakeUnsigned>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extract_lane_s.value():
-                if (unary_operation<u128, i16, Operators::VectorExtractLane<8, MakeSigned>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extract_lane_u.value():
-                if (unary_operation<u128, u16, Operators::VectorExtractLane<8, MakeUnsigned>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extract_lane.value():
-                if (unary_operation<u128, i32, Operators::VectorExtractLane<4, MakeSigned>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extract_lane.value():
-                if (unary_operation<u128, i64, Operators::VectorExtractLane<2, MakeSigned>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_extract_lane.value():
-                if (unary_operation<u128, float, Operators::VectorExtractLaneFloat<4>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_extract_lane.value():
-                if (unary_operation<u128, double, Operators::VectorExtractLaneFloat<2>>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_replace_lane.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<16, i32>, i32>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_replace_lane.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<8, i32>, i32>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_replace_lane.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<4>, i32>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_replace_lane.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<2>, i64>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_replace_lane.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<4, float>, float>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_replace_lane.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<2, double>, double>(configuration, instruction->arguments().get<Instruction::LaneIndex>().lane))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_eq.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::Equals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_ne.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::NotEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_lt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_lt_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThan, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_gt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_gt_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThan, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_le_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_le_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThanOrEquals, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_ge_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_ge_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThanOrEquals, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_abs.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<16, Operators::Absolute>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_neg.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<16, Operators::Negate>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_all_true.value():
-                if (unary_operation<u128, i32, Operators::VectorAllTrue<16>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_popcnt.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<16, Operators::PopCount>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_add.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Add>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_sub.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Subtract>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_avgr_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Average, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_add_sat_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<i8, Operators::Add>, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_add_sat_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<u8, Operators::Add>, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_sub_sat_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<i8, Operators::Subtract>, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_sub_sat_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<u8, Operators::Subtract>, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_min_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Minimum, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_min_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Minimum, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_max_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Maximum, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_max_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Maximum, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_eq.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::Equals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_ne.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::NotEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_lt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_lt_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThan, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_gt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_gt_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThan, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_le_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_le_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThanOrEquals, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_ge_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_ge_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThanOrEquals, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_abs.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<8, Operators::Absolute>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_neg.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<8, Operators::Negate>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_all_true.value():
-                if (unary_operation<u128, i32, Operators::VectorAllTrue<8>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_add.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Add>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_sub.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Subtract>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_mul.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Multiply>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_avgr_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Average, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_add_sat_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<i16, Operators::Add>, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_add_sat_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<u16, Operators::Add>, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_sub_sat_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<i16, Operators::Subtract>, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_sub_sat_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<u16, Operators::Subtract>, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_min_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Minimum, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_min_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Minimum, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_max_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Maximum, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_max_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Maximum, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extend_low_i8x16_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::Low, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extend_high_i8x16_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::High, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extend_low_i8x16_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::Low, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extend_high_i8x16_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::High, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extadd_pairwise_i8x16_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<8, Operators::Add, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extadd_pairwise_i8x16_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<8, Operators::Add, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extmul_low_i8x16_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::Low, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extmul_high_i8x16_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::High, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extmul_low_i8x16_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::Low, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_extmul_high_i8x16_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::High, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_eq.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::Equals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_ne.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::NotEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_lt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_lt_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThan, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_gt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_gt_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThan, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_le_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_le_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThanOrEquals, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_ge_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_ge_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThanOrEquals, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_abs.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<4, Operators::Absolute>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_neg.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<4, Operators::Negate, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_all_true.value():
-                if (unary_operation<u128, i32, Operators::VectorAllTrue<4>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_add.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Add, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_sub.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Subtract, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_mul.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Multiply, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_min_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Minimum, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_min_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Minimum, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_max_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Maximum, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_max_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Maximum, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extend_low_i16x8_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::Low, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extend_high_i16x8_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::High, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extend_low_i16x8_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::Low, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extend_high_i16x8_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::High, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extadd_pairwise_i16x8_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<4, Operators::Add, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extadd_pairwise_i16x8_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<4, Operators::Add, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extmul_low_i16x8_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::Low, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extmul_high_i16x8_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::High, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extmul_low_i16x8_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::Low, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_extmul_high_i16x8_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::High, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_eq.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::Equals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_ne.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::NotEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_lt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::LessThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_gt_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::GreaterThan, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_le_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::LessThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_ge_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::GreaterThanOrEquals, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_abs.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<2, Operators::Absolute>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_neg.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<2, Operators::Negate, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_all_true.value():
-                if (unary_operation<u128, i32, Operators::VectorAllTrue<2>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_add.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<2, Operators::Add, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_sub.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<2, Operators::Subtract, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_mul.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<2, Operators::Multiply, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extend_low_i32x4_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::Low, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extend_high_i32x4_s.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::High, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extend_low_i32x4_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::Low, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extend_high_i32x4_u.value():
-                if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::High, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extmul_low_i32x4_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::Low, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extmul_high_i32x4_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::High, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extmul_low_i32x4_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::Low, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_extmul_high_i32x4_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::High, MakeUnsigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_eq.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::Equals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_ne.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::NotEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_lt.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::LessThan>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_gt.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::GreaterThan>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_le.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::LessThanOrEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_ge.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::GreaterThanOrEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_min.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Minimum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_max.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Maximum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_eq.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::Equals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_ne.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::NotEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_lt.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::LessThan>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_gt.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::GreaterThan>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_le.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::LessThanOrEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_ge.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::GreaterThanOrEquals>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_min.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Minimum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_max.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Maximum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_div.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Divide>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_mul.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Multiply>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_sub.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Subtract>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_add.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Add>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_pmin.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::PseudoMinimum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_pmax.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::PseudoMaximum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_div.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Divide>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_mul.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Multiply>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_sub.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Subtract>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_add.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Add>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_pmin.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::PseudoMinimum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_pmax.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::PseudoMaximum>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_ceil.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Ceil>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_floor.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Floor>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_trunc.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Truncate>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_nearest.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::NearbyIntegral>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_sqrt.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::SquareRoot>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_neg.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Negate>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_abs.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Absolute>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_ceil.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Ceil>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_floor.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Floor>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_trunc.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Truncate>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_nearest.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::NearbyIntegral>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_sqrt.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::SquareRoot>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_neg.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Negate>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_abs.value():
-                if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Absolute>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_and.value():
-                if (binary_numeric_operation<u128, u128, Operators::BitAnd>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_or.value():
-                if (binary_numeric_operation<u128, u128, Operators::BitOr>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_xor.value():
-                if (binary_numeric_operation<u128, u128, Operators::BitXor>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_not.value():
-                if (unary_operation<u128, u128, Operators::BitNot>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_andnot.value():
-                if (binary_numeric_operation<u128, u128, Operators::BitAndNot>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_bitselect.value(): {
-                // bounds checked by verifier.
-                auto mask = configuration.take_source(0).to<u128>();
-                auto false_vector = configuration.take_source(1).to<u128>();
-                auto true_vector = configuration.take_source(2).to<u128>();
-                u128 result = (true_vector & mask) | (false_vector & ~mask);
-                configuration.push_to_destination(Value(result));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::v128_any_true.value(): {
-                auto vector = configuration.take_source(0).to<u128>(); // bounds checked by verifier.
-                configuration.push_to_destination(Value(static_cast<i32>(vector != 0)));
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            }
-            case Instructions::v128_load8_lane.value():
-                if (load_and_push_lane_n<8>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load16_lane.value():
-                if (load_and_push_lane_n<16>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load32_lane.value():
-                if (load_and_push_lane_n<32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load64_lane.value():
-                if (load_and_push_lane_n<64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load32_zero.value():
-                if (load_and_push_zero_n<32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_load64_zero.value():
-                if (load_and_push_zero_n<64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_store8_lane.value():
-                if (pop_and_store_lane_n<8>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_store16_lane.value():
-                if (pop_and_store_lane_n<16>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_store32_lane.value():
-                if (pop_and_store_lane_n<32>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::v128_store64_lane.value():
-                if (pop_and_store_lane_n<64>(configuration, *instruction))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_trunc_sat_f32x4_s.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, f32, Operators::SaturatingTruncate<i32>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_trunc_sat_f32x4_u.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, f32, Operators::SaturatingTruncate<u32>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_bitmask.value():
-                if (unary_operation<u128, i32, Operators::VectorBitmask<16>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_bitmask.value():
-                if (unary_operation<u128, i32, Operators::VectorBitmask<8>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_bitmask.value():
-                if (unary_operation<u128, i32, Operators::VectorBitmask<4>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i64x2_bitmask.value():
-                if (unary_operation<u128, i32, Operators::VectorBitmask<2>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_dot_i16x8_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorDotProduct<4>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_narrow_i16x8_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<16, i8>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i8x16_narrow_i16x8_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<16, u8>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_narrow_i32x4_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<8, i16>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_narrow_i32x4_u.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<8, u16>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i16x8_q15mulr_sat_s.value():
-                if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<i16, Operators::Q15Mul>, MakeSigned>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_convert_i32x4_s.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, i32, Operators::Convert<f32>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_convert_i32x4_u.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, u32, Operators::Convert<f32>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_convert_low_i32x4_s.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<2, 4, u64, i32, Operators::Convert<f64>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_convert_low_i32x4_u.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<2, 4, u64, u32, Operators::Convert<f64>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f32x4_demote_f64x2_zero.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 2, u32, f64, Operators::Convert<f32>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::f64x2_promote_low_f32x4.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<2, 4, u64, f32, Operators::Convert<f64>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_trunc_sat_f64x2_s_zero.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 2, u32, f64, Operators::SaturatingTruncate<i32>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            case Instructions::i32x4_trunc_sat_f64x2_u_zero.value():
-                if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 2, u32, f64, Operators::SaturatingTruncate<u32>>>(configuration))
-                    return;
-                RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::No);
-            default:
-                VERIFY_NOT_REACHED();
-            }
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::table_size.value(): {
+            auto table_index = instruction->arguments().get<TableIndex>();
+            auto address = configuration.frame().module().tables()[table_index.value()];
+            auto table = configuration.store().get(address);
+            configuration.push_to_destination(Value(static_cast<i32>(table->elements().size())), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::ref_null.value(): {
+            auto type = instruction->arguments().get<ValueType>();
+            configuration.push_to_destination(Value(Reference(Reference::Null { type })), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        };
+        case Instructions::ref_func.value(): {
+            auto index = instruction->arguments().get<FunctionIndex>().value();
+            auto& functions = configuration.frame().module().functions();
+            auto address = functions[index];
+            configuration.push_to_destination(Value(Reference { Reference::Func { address, configuration.store().get_module_for(address) } }), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::ref_is_null.value(): {
+            // bounds checked by verifier.
+            auto ref = configuration.take_source(0, addresses.sources);
+            configuration.push_to_destination(Value(static_cast<i32>(ref.to<Reference>().ref().has<Reference::Null>() ? 1 : 0)), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::drop.value():
+            // bounds checked by verifier.
+            configuration.take_source(0, addresses.sources);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::select.value():
+        case Instructions::select_typed.value(): {
+            // Note: The type seems to only be used for validation.
+            auto value = configuration.take_source(0, addresses.sources).to<i32>(); // bounds checked by verifier.
+            dbgln_if(WASM_TRACE_DEBUG, "select({})", value);
+            auto rhs = configuration.take_source(1, addresses.sources);
+            auto& lhs = configuration.source_value(2, addresses.sources); // bounds checked by verifier.
+            lhs = value != 0 ? lhs : rhs;
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::i32_eqz.value():
+            if (unary_operation<i32, i32, Operators::EqualsZero>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_eq.value():
+            if (binary_numeric_operation<i32, i32, Operators::Equals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_ne.value():
+            if (binary_numeric_operation<i32, i32, Operators::NotEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_lts.value():
+            if (binary_numeric_operation<i32, i32, Operators::LessThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_ltu.value():
+            if (binary_numeric_operation<u32, i32, Operators::LessThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_gts.value():
+            if (binary_numeric_operation<i32, i32, Operators::GreaterThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_gtu.value():
+            if (binary_numeric_operation<u32, i32, Operators::GreaterThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_les.value():
+            if (binary_numeric_operation<i32, i32, Operators::LessThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_leu.value():
+            if (binary_numeric_operation<u32, i32, Operators::LessThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_ges.value():
+            if (binary_numeric_operation<i32, i32, Operators::GreaterThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_geu.value():
+            if (binary_numeric_operation<u32, i32, Operators::GreaterThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_eqz.value():
+            if (unary_operation<i64, i32, Operators::EqualsZero>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_eq.value():
+            if (binary_numeric_operation<i64, i32, Operators::Equals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_ne.value():
+            if (binary_numeric_operation<i64, i32, Operators::NotEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_lts.value():
+            if (binary_numeric_operation<i64, i32, Operators::LessThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_ltu.value():
+            if (binary_numeric_operation<u64, i32, Operators::LessThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_gts.value():
+            if (binary_numeric_operation<i64, i32, Operators::GreaterThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_gtu.value():
+            if (binary_numeric_operation<u64, i32, Operators::GreaterThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_les.value():
+            if (binary_numeric_operation<i64, i32, Operators::LessThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_leu.value():
+            if (binary_numeric_operation<u64, i32, Operators::LessThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_ges.value():
+            if (binary_numeric_operation<i64, i32, Operators::GreaterThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_geu.value():
+            if (binary_numeric_operation<u64, i32, Operators::GreaterThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_eq.value():
+            if (binary_numeric_operation<float, i32, Operators::Equals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_ne.value():
+            if (binary_numeric_operation<float, i32, Operators::NotEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_lt.value():
+            if (binary_numeric_operation<float, i32, Operators::LessThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_gt.value():
+            if (binary_numeric_operation<float, i32, Operators::GreaterThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_le.value():
+            if (binary_numeric_operation<float, i32, Operators::LessThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_ge.value():
+            if (binary_numeric_operation<float, i32, Operators::GreaterThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_eq.value():
+            if (binary_numeric_operation<double, i32, Operators::Equals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_ne.value():
+            if (binary_numeric_operation<double, i32, Operators::NotEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_lt.value():
+            if (binary_numeric_operation<double, i32, Operators::LessThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_gt.value():
+            if (binary_numeric_operation<double, i32, Operators::GreaterThan>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_le.value():
+            if (binary_numeric_operation<double, i32, Operators::LessThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_ge.value():
+            if (binary_numeric_operation<double, i32, Operators::GreaterThanOrEquals>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_clz.value():
+            if (unary_operation<i32, i32, Operators::CountLeadingZeros>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_ctz.value():
+            if (unary_operation<i32, i32, Operators::CountTrailingZeros>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_popcnt.value():
+            if (unary_operation<i32, i32, Operators::PopCount>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_add.value():
+            if (binary_numeric_operation<u32, i32, Operators::Add>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_sub.value():
+            if (binary_numeric_operation<u32, i32, Operators::Subtract>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_mul.value():
+            if (binary_numeric_operation<u32, i32, Operators::Multiply>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_divs.value():
+            if (binary_numeric_operation<i32, i32, Operators::Divide>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_divu.value():
+            if (binary_numeric_operation<u32, i32, Operators::Divide>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_rems.value():
+            if (binary_numeric_operation<i32, i32, Operators::Modulo>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_remu.value():
+            if (binary_numeric_operation<u32, i32, Operators::Modulo>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_and.value():
+            if (binary_numeric_operation<i32, i32, Operators::BitAnd>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_or.value():
+            if (binary_numeric_operation<i32, i32, Operators::BitOr>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_xor.value():
+            if (binary_numeric_operation<i32, i32, Operators::BitXor>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_shl.value():
+            if (binary_numeric_operation<u32, i32, Operators::BitShiftLeft>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_shrs.value():
+            if (binary_numeric_operation<i32, i32, Operators::BitShiftRight>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_shru.value():
+            if (binary_numeric_operation<u32, i32, Operators::BitShiftRight>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_rotl.value():
+            if (binary_numeric_operation<u32, i32, Operators::BitRotateLeft>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_rotr.value():
+            if (binary_numeric_operation<u32, i32, Operators::BitRotateRight>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_clz.value():
+            if (unary_operation<i64, i64, Operators::CountLeadingZeros>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_ctz.value():
+            if (unary_operation<i64, i64, Operators::CountTrailingZeros>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_popcnt.value():
+            if (unary_operation<i64, i64, Operators::PopCount>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_add.value():
+            if (binary_numeric_operation<u64, i64, Operators::Add>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_sub.value():
+            if (binary_numeric_operation<u64, i64, Operators::Subtract>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_mul.value():
+            if (binary_numeric_operation<u64, i64, Operators::Multiply>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_divs.value():
+            if (binary_numeric_operation<i64, i64, Operators::Divide>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_divu.value():
+            if (binary_numeric_operation<u64, i64, Operators::Divide>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_rems.value():
+            if (binary_numeric_operation<i64, i64, Operators::Modulo>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_remu.value():
+            if (binary_numeric_operation<u64, i64, Operators::Modulo>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_and.value():
+            if (binary_numeric_operation<i64, i64, Operators::BitAnd>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_or.value():
+            if (binary_numeric_operation<i64, i64, Operators::BitOr>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_xor.value():
+            if (binary_numeric_operation<i64, i64, Operators::BitXor>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_shl.value():
+            if (binary_numeric_operation<u64, i64, Operators::BitShiftLeft>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_shrs.value():
+            if (binary_numeric_operation<i64, i64, Operators::BitShiftRight>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_shru.value():
+            if (binary_numeric_operation<u64, i64, Operators::BitShiftRight>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_rotl.value():
+            if (binary_numeric_operation<u64, i64, Operators::BitRotateLeft>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_rotr.value():
+            if (binary_numeric_operation<u64, i64, Operators::BitRotateRight>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_abs.value():
+            if (unary_operation<float, float, Operators::Absolute>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_neg.value():
+            if (unary_operation<float, float, Operators::Negate>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_ceil.value():
+            if (unary_operation<float, float, Operators::Ceil>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_floor.value():
+            if (unary_operation<float, float, Operators::Floor>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_trunc.value():
+            if (unary_operation<float, float, Operators::Truncate>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_nearest.value():
+            if (unary_operation<float, float, Operators::NearbyIntegral>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_sqrt.value():
+            if (unary_operation<float, float, Operators::SquareRoot>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_add.value():
+            if (binary_numeric_operation<float, float, Operators::Add>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_sub.value():
+            if (binary_numeric_operation<float, float, Operators::Subtract>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_mul.value():
+            if (binary_numeric_operation<float, float, Operators::Multiply>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_div.value():
+            if (binary_numeric_operation<float, float, Operators::Divide>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_min.value():
+            if (binary_numeric_operation<float, float, Operators::Minimum>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_max.value():
+            if (binary_numeric_operation<float, float, Operators::Maximum>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_copysign.value():
+            if (binary_numeric_operation<float, float, Operators::CopySign>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_abs.value():
+            if (unary_operation<double, double, Operators::Absolute>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_neg.value():
+            if (unary_operation<double, double, Operators::Negate>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_ceil.value():
+            if (unary_operation<double, double, Operators::Ceil>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_floor.value():
+            if (unary_operation<double, double, Operators::Floor>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_trunc.value():
+            if (unary_operation<double, double, Operators::Truncate>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_nearest.value():
+            if (unary_operation<double, double, Operators::NearbyIntegral>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_sqrt.value():
+            if (unary_operation<double, double, Operators::SquareRoot>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_add.value():
+            if (binary_numeric_operation<double, double, Operators::Add>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_sub.value():
+            if (binary_numeric_operation<double, double, Operators::Subtract>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_mul.value():
+            if (binary_numeric_operation<double, double, Operators::Multiply>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_div.value():
+            if (binary_numeric_operation<double, double, Operators::Divide>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_min.value():
+            if (binary_numeric_operation<double, double, Operators::Minimum>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_max.value():
+            if (binary_numeric_operation<double, double, Operators::Maximum>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_copysign.value():
+            if (binary_numeric_operation<double, double, Operators::CopySign>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_wrap_i64.value():
+            if (unary_operation<i64, i32, Operators::Wrap<i32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_sf32.value():
+            if (unary_operation<float, i32, Operators::CheckedTruncate<i32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_uf32.value():
+            if (unary_operation<float, i32, Operators::CheckedTruncate<u32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_sf64.value():
+            if (unary_operation<double, i32, Operators::CheckedTruncate<i32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_uf64.value():
+            if (unary_operation<double, i32, Operators::CheckedTruncate<u32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_sf32.value():
+            if (unary_operation<float, i64, Operators::CheckedTruncate<i64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_uf32.value():
+            if (unary_operation<float, i64, Operators::CheckedTruncate<u64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_sf64.value():
+            if (unary_operation<double, i64, Operators::CheckedTruncate<i64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_uf64.value():
+            if (unary_operation<double, i64, Operators::CheckedTruncate<u64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_extend_si32.value():
+            if (unary_operation<i32, i64, Operators::Extend<i64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_extend_ui32.value():
+            if (unary_operation<u32, i64, Operators::Extend<i64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_convert_si32.value():
+            if (unary_operation<i32, float, Operators::Convert<float>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_convert_ui32.value():
+            if (unary_operation<u32, float, Operators::Convert<float>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_convert_si64.value():
+            if (unary_operation<i64, float, Operators::Convert<float>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_convert_ui64.value():
+            if (unary_operation<u64, float, Operators::Convert<float>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_demote_f64.value():
+            if (unary_operation<double, float, Operators::Demote>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_convert_si32.value():
+            if (unary_operation<i32, double, Operators::Convert<double>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_convert_ui32.value():
+            if (unary_operation<u32, double, Operators::Convert<double>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_convert_si64.value():
+            if (unary_operation<i64, double, Operators::Convert<double>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_convert_ui64.value():
+            if (unary_operation<u64, double, Operators::Convert<double>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_promote_f32.value():
+            if (unary_operation<float, double, Operators::Promote>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_reinterpret_f32.value():
+            if (unary_operation<float, i32, Operators::Reinterpret<i32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_reinterpret_f64.value():
+            if (unary_operation<double, i64, Operators::Reinterpret<i64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32_reinterpret_i32.value():
+            if (unary_operation<i32, float, Operators::Reinterpret<float>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64_reinterpret_i64.value():
+            if (unary_operation<i64, double, Operators::Reinterpret<double>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_extend8_s.value():
+            if (unary_operation<i32, i32, Operators::SignExtend<i8>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_extend16_s.value():
+            if (unary_operation<i32, i32, Operators::SignExtend<i16>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_extend8_s.value():
+            if (unary_operation<i64, i64, Operators::SignExtend<i8>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_extend16_s.value():
+            if (unary_operation<i64, i64, Operators::SignExtend<i16>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_extend32_s.value():
+            if (unary_operation<i64, i64, Operators::SignExtend<i32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_sat_f32_s.value():
+            if (unary_operation<float, i32, Operators::SaturatingTruncate<i32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_sat_f32_u.value():
+            if (unary_operation<float, i32, Operators::SaturatingTruncate<u32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_sat_f64_s.value():
+            if (unary_operation<double, i32, Operators::SaturatingTruncate<i32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32_trunc_sat_f64_u.value():
+            if (unary_operation<double, i32, Operators::SaturatingTruncate<u32>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_sat_f32_s.value():
+            if (unary_operation<float, i64, Operators::SaturatingTruncate<i64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_sat_f32_u.value():
+            if (unary_operation<float, i64, Operators::SaturatingTruncate<u64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_sat_f64_s.value():
+            if (unary_operation<double, i64, Operators::SaturatingTruncate<i64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64_trunc_sat_f64_u.value():
+            if (unary_operation<double, i64, Operators::SaturatingTruncate<u64>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_const.value():
+            configuration.push_to_destination(Value(instruction->arguments().get<u128>()), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load.value():
+            if (load_and_push<u128, u128>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load8x8_s.value():
+            if (load_and_push_mxn<8, 8, MakeSigned>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load8x8_u.value():
+            if (load_and_push_mxn<8, 8, MakeUnsigned>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load16x4_s.value():
+            if (load_and_push_mxn<16, 4, MakeSigned>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load16x4_u.value():
+            if (load_and_push_mxn<16, 4, MakeUnsigned>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load32x2_s.value():
+            if (load_and_push_mxn<32, 2, MakeSigned>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load32x2_u.value():
+            if (load_and_push_mxn<32, 2, MakeUnsigned>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load8_splat.value():
+            if (load_and_push_m_splat<8>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load16_splat.value():
+            if (load_and_push_m_splat<16>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load32_splat.value():
+            if (load_and_push_m_splat<32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load64_splat.value():
+            if (load_and_push_m_splat<64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_splat.value():
+            pop_and_push_m_splat<8, NativeIntegralType>(configuration, *instruction, addresses);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_splat.value():
+            pop_and_push_m_splat<16, NativeIntegralType>(configuration, *instruction, addresses);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_splat.value():
+            pop_and_push_m_splat<32, NativeIntegralType>(configuration, *instruction, addresses);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_splat.value():
+            pop_and_push_m_splat<64, NativeIntegralType>(configuration, *instruction, addresses);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_splat.value():
+            pop_and_push_m_splat<32, NativeFloatingType>(configuration, *instruction, addresses);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_splat.value():
+            pop_and_push_m_splat<64, NativeFloatingType>(configuration, *instruction, addresses);
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_shuffle.value(): {
+            auto& arg = instruction->arguments().get<Instruction::ShuffleArgument>();
+            auto b = pop_vector<u8, MakeUnsigned>(configuration, 0, addresses);
+            auto a = pop_vector<u8, MakeUnsigned>(configuration, 1, addresses);
+            using VectorType = Native128ByteVectorOf<u8, MakeUnsigned>;
+            VectorType result;
+            for (size_t i = 0; i < 16; ++i)
+                if (arg.lanes[i] < 16)
+                    result[i] = a[arg.lanes[i]];
+                else
+                    result[i] = b[arg.lanes[i] - 16];
+            configuration.push_to_destination(Value(bit_cast<u128>(result)), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::v128_store.value():
+            if (pop_and_store<u128, u128>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_shl.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<16>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_shr_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<16, MakeUnsigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_shr_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<16, MakeSigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_shl.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<8>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_shr_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<8, MakeUnsigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_shr_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<8, MakeSigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_shl.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<4>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_shr_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<4, MakeUnsigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_shr_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<4, MakeSigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_shl.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftLeft<2>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_shr_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<2, MakeUnsigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_shr_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorShiftRight<2, MakeSigned>, i32>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_swizzle.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorSwizzle>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_extract_lane_s.value():
+            if (unary_operation<u128, i8, Operators::VectorExtractLane<16, MakeSigned>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_extract_lane_u.value():
+            if (unary_operation<u128, u8, Operators::VectorExtractLane<16, MakeUnsigned>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extract_lane_s.value():
+            if (unary_operation<u128, i16, Operators::VectorExtractLane<8, MakeSigned>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extract_lane_u.value():
+            if (unary_operation<u128, u16, Operators::VectorExtractLane<8, MakeUnsigned>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extract_lane.value():
+            if (unary_operation<u128, i32, Operators::VectorExtractLane<4, MakeSigned>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extract_lane.value():
+            if (unary_operation<u128, i64, Operators::VectorExtractLane<2, MakeSigned>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_extract_lane.value():
+            if (unary_operation<u128, float, Operators::VectorExtractLaneFloat<4>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_extract_lane.value():
+            if (unary_operation<u128, double, Operators::VectorExtractLaneFloat<2>>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_replace_lane.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<16, i32>, i32>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_replace_lane.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<8, i32>, i32>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_replace_lane.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<4>, i32>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_replace_lane.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<2>, i64>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_replace_lane.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<4, float>, float>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_replace_lane.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorReplaceLane<2, double>, double>(configuration, addresses, instruction->arguments().get<Instruction::LaneIndex>().lane))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_eq.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::Equals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_ne.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::NotEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_lt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_lt_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThan, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_gt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_gt_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThan, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_le_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_le_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::LessThanOrEquals, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_ge_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_ge_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<16, Operators::GreaterThanOrEquals, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_abs.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<16, Operators::Absolute>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_neg.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<16, Operators::Negate>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_all_true.value():
+            if (unary_operation<u128, i32, Operators::VectorAllTrue<16>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_popcnt.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<16, Operators::PopCount>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_add.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Add>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_sub.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Subtract>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_avgr_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Average, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_add_sat_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<i8, Operators::Add>, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_add_sat_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<u8, Operators::Add>, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_sub_sat_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<i8, Operators::Subtract>, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_sub_sat_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::SaturatingOp<u8, Operators::Subtract>, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_min_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Minimum, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_min_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Minimum, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_max_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Maximum, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_max_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<16, Operators::Maximum, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_eq.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::Equals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_ne.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::NotEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_lt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_lt_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThan, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_gt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_gt_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThan, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_le_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_le_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::LessThanOrEquals, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_ge_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_ge_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<8, Operators::GreaterThanOrEquals, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_abs.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<8, Operators::Absolute>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_neg.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<8, Operators::Negate>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_all_true.value():
+            if (unary_operation<u128, i32, Operators::VectorAllTrue<8>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_add.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Add>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_sub.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Subtract>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_mul.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Multiply>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_avgr_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Average, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_add_sat_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<i16, Operators::Add>, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_add_sat_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<u16, Operators::Add>, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_sub_sat_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<i16, Operators::Subtract>, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_sub_sat_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<u16, Operators::Subtract>, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_min_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Minimum, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_min_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Minimum, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_max_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Maximum, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_max_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::Maximum, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extend_low_i8x16_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::Low, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extend_high_i8x16_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::High, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extend_low_i8x16_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::Low, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extend_high_i8x16_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<8, Operators::VectorExt::High, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extadd_pairwise_i8x16_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<8, Operators::Add, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extadd_pairwise_i8x16_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<8, Operators::Add, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extmul_low_i8x16_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::Low, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extmul_high_i8x16_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::High, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extmul_low_i8x16_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::Low, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_extmul_high_i8x16_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<8, Operators::Multiply, Operators::VectorExt::High, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_eq.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::Equals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_ne.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::NotEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_lt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_lt_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThan, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_gt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_gt_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThan, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_le_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_le_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::LessThanOrEquals, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_ge_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_ge_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<4, Operators::GreaterThanOrEquals, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_abs.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<4, Operators::Absolute>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_neg.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<4, Operators::Negate, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_all_true.value():
+            if (unary_operation<u128, i32, Operators::VectorAllTrue<4>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_add.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Add, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_sub.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Subtract, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_mul.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Multiply, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_min_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Minimum, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_min_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Minimum, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_max_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Maximum, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_max_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<4, Operators::Maximum, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extend_low_i16x8_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::Low, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extend_high_i16x8_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::High, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extend_low_i16x8_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::Low, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extend_high_i16x8_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<4, Operators::VectorExt::High, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extadd_pairwise_i16x8_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<4, Operators::Add, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extadd_pairwise_i16x8_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExtOpPairwise<4, Operators::Add, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extmul_low_i16x8_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::Low, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extmul_high_i16x8_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::High, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extmul_low_i16x8_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::Low, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_extmul_high_i16x8_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<4, Operators::Multiply, Operators::VectorExt::High, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_eq.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::Equals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_ne.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::NotEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_lt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::LessThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_gt_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::GreaterThan, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_le_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::LessThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_ge_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorCmpOp<2, Operators::GreaterThanOrEquals, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_abs.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<2, Operators::Absolute>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_neg.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerUnaryOp<2, Operators::Negate, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_all_true.value():
+            if (unary_operation<u128, i32, Operators::VectorAllTrue<2>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_add.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<2, Operators::Add, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_sub.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<2, Operators::Subtract, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_mul.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<2, Operators::Multiply, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extend_low_i32x4_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::Low, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extend_high_i32x4_s.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::High, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extend_low_i32x4_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::Low, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extend_high_i32x4_u.value():
+            if (unary_operation<u128, u128, Operators::VectorIntegerExt<2, Operators::VectorExt::High, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extmul_low_i32x4_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::Low, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extmul_high_i32x4_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::High, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extmul_low_i32x4_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::Low, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_extmul_high_i32x4_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerExtOp<2, Operators::Multiply, Operators::VectorExt::High, MakeUnsigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_eq.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::Equals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_ne.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::NotEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_lt.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::LessThan>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_gt.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::GreaterThan>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_le.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::LessThanOrEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_ge.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<4, Operators::GreaterThanOrEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_min.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Minimum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_max.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Maximum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_eq.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::Equals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_ne.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::NotEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_lt.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::LessThan>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_gt.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::GreaterThan>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_le.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::LessThanOrEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_ge.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatCmpOp<2, Operators::GreaterThanOrEquals>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_min.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Minimum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_max.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Maximum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_div.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Divide>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_mul.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Multiply>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_sub.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Subtract>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_add.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::Add>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_pmin.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::PseudoMinimum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_pmax.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<4, Operators::PseudoMaximum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_div.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Divide>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_mul.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Multiply>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_sub.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Subtract>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_add.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::Add>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_pmin.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::PseudoMinimum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_pmax.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorFloatBinaryOp<2, Operators::PseudoMaximum>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_ceil.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Ceil>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_floor.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Floor>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_trunc.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Truncate>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_nearest.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::NearbyIntegral>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_sqrt.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::SquareRoot>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_neg.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Negate>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_abs.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<4, Operators::Absolute>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_ceil.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Ceil>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_floor.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Floor>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_trunc.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Truncate>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_nearest.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::NearbyIntegral>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_sqrt.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::SquareRoot>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_neg.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Negate>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_abs.value():
+            if (unary_operation<u128, u128, Operators::VectorFloatUnaryOp<2, Operators::Absolute>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_and.value():
+            if (binary_numeric_operation<u128, u128, Operators::BitAnd>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_or.value():
+            if (binary_numeric_operation<u128, u128, Operators::BitOr>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_xor.value():
+            if (binary_numeric_operation<u128, u128, Operators::BitXor>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_not.value():
+            if (unary_operation<u128, u128, Operators::BitNot>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_andnot.value():
+            if (binary_numeric_operation<u128, u128, Operators::BitAndNot>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_bitselect.value(): {
+            // bounds checked by verifier.
+            auto mask = configuration.take_source(0, addresses.sources).to<u128>();
+            auto false_vector = configuration.take_source(1, addresses.sources).to<u128>();
+            auto true_vector = configuration.take_source(2, addresses.sources).to<u128>();
+            u128 result = (true_vector & mask) | (false_vector & ~mask);
+            configuration.push_to_destination(Value(result), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::v128_any_true.value(): {
+            auto vector = configuration.take_source(0, addresses.sources).to<u128>(); // bounds checked by verifier.
+            configuration.push_to_destination(Value(static_cast<i32>(vector != 0)), addresses.destination);
+            RUN_NEXT_INSTRUCTION();
+        }
+        case Instructions::v128_load8_lane.value():
+            if (load_and_push_lane_n<8>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load16_lane.value():
+            if (load_and_push_lane_n<16>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load32_lane.value():
+            if (load_and_push_lane_n<32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load64_lane.value():
+            if (load_and_push_lane_n<64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load32_zero.value():
+            if (load_and_push_zero_n<32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_load64_zero.value():
+            if (load_and_push_zero_n<64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_store8_lane.value():
+            if (pop_and_store_lane_n<8>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_store16_lane.value():
+            if (pop_and_store_lane_n<16>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_store32_lane.value():
+            if (pop_and_store_lane_n<32>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::v128_store64_lane.value():
+            if (pop_and_store_lane_n<64>(configuration, *instruction, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_trunc_sat_f32x4_s.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, f32, Operators::SaturatingTruncate<i32>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_trunc_sat_f32x4_u.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, f32, Operators::SaturatingTruncate<u32>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_bitmask.value():
+            if (unary_operation<u128, i32, Operators::VectorBitmask<16>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_bitmask.value():
+            if (unary_operation<u128, i32, Operators::VectorBitmask<8>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_bitmask.value():
+            if (unary_operation<u128, i32, Operators::VectorBitmask<4>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i64x2_bitmask.value():
+            if (unary_operation<u128, i32, Operators::VectorBitmask<2>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_dot_i16x8_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorDotProduct<4>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_narrow_i16x8_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<16, i8>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i8x16_narrow_i16x8_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<16, u8>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_narrow_i32x4_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<8, i16>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_narrow_i32x4_u.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorNarrow<8, u16>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i16x8_q15mulr_sat_s.value():
+            if (binary_numeric_operation<u128, u128, Operators::VectorIntegerBinaryOp<8, Operators::SaturatingOp<i16, Operators::Q15Mul>, MakeSigned>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_convert_i32x4_s.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, i32, Operators::Convert<f32>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_convert_i32x4_u.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 4, u32, u32, Operators::Convert<f32>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_convert_low_i32x4_s.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<2, 4, u64, i32, Operators::Convert<f64>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_convert_low_i32x4_u.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<2, 4, u64, u32, Operators::Convert<f64>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f32x4_demote_f64x2_zero.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 2, u32, f64, Operators::Convert<f32>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::f64x2_promote_low_f32x4.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<2, 4, u64, f32, Operators::Convert<f64>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_trunc_sat_f64x2_s_zero.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 2, u32, f64, Operators::SaturatingTruncate<i32>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::i32x4_trunc_sat_f64x2_u_zero.value():
+            if (unary_operation<u128, u128, Operators::VectorConvertOp<4, 2, u32, f64, Operators::SaturatingTruncate<u32>>>(configuration, addresses))
+                return;
+            RUN_NEXT_INSTRUCTION();
+        case Instructions::synthetic_end_expression.value():
+            return;
+        default:
+            VERIFY_NOT_REACHED();
         }
     }
 }
 
-void BytecodeInterpreter::branch_to_label(Configuration& configuration, LabelIndex index)
+InstructionPointer BytecodeInterpreter::branch_to_label(Configuration& configuration, LabelIndex index)
 {
     dbgln_if(WASM_TRACE_DEBUG, "Branch to label with index {}...", index.value());
     auto& label_stack = configuration.label_stack();
@@ -2238,16 +2231,16 @@ void BytecodeInterpreter::branch_to_label(Configuration& configuration, LabelInd
     dbgln_if(WASM_TRACE_DEBUG, "...which is actually IP {}, and has {} result(s)", label.continuation().value(), label.arity());
 
     configuration.value_stack().remove(label.stack_height(), configuration.value_stack().size() - label.stack_height() - label.arity());
-    configuration.ip() = label.continuation().value();
+    return label.continuation().value() - 1;
 }
 
 template<typename ReadType, typename PushType>
-bool BytecodeInterpreter::load_and_push(Configuration& configuration, Instruction const& instruction)
+bool BytecodeInterpreter::load_and_push(Configuration& configuration, Instruction const& instruction, SourcesAndDestination const& addresses)
 {
     auto& arg = instruction.arguments().get<Instruction::MemoryArgument>();
     auto& address = configuration.frame().module().memories()[arg.memory_index.value()];
     auto memory = configuration.store().get(address);
-    auto& entry = configuration.source_value(0); // bounds checked by verifier.
+    auto& entry = configuration.source_value(0, addresses.sources); // bounds checked by verifier.
     auto base = entry.to<i32>();
     u64 instance_address = static_cast<u64>(bit_cast<u32>(base)) + arg.offset;
     if (instance_address + sizeof(ReadType) > memory->size()) {
@@ -2268,12 +2261,12 @@ ALWAYS_INLINE static TDst convert_vector(TSrc v)
 }
 
 template<size_t M, size_t N, template<typename> typename SetSign>
-bool BytecodeInterpreter::load_and_push_mxn(Configuration& configuration, Instruction const& instruction)
+bool BytecodeInterpreter::load_and_push_mxn(Configuration& configuration, Instruction const& instruction, SourcesAndDestination const& addresses)
 {
     auto& arg = instruction.arguments().get<Instruction::MemoryArgument>();
     auto& address = configuration.frame().module().memories()[arg.memory_index.value()];
     auto memory = configuration.store().get(address);
-    auto& entry = configuration.source_value(0); // bounds checked by verifier.
+    auto& entry = configuration.source_value(0, addresses.sources); // bounds checked by verifier.
     auto base = entry.to<i32>();
     u64 instance_address = static_cast<u64>(bit_cast<u32>(base)) + arg.offset;
     if (instance_address + M * N / 8 > memory->size()) {
@@ -2297,14 +2290,14 @@ bool BytecodeInterpreter::load_and_push_mxn(Configuration& configuration, Instru
 }
 
 template<size_t N>
-bool BytecodeInterpreter::load_and_push_lane_n(Configuration& configuration, Instruction const& instruction)
+bool BytecodeInterpreter::load_and_push_lane_n(Configuration& configuration, Instruction const& instruction, SourcesAndDestination const& addresses)
 {
     auto memarg_and_lane = instruction.arguments().get<Instruction::MemoryAndLaneArgument>();
     auto& address = configuration.frame().module().memories()[memarg_and_lane.memory.memory_index.value()];
     auto memory = configuration.store().get(address);
     // bounds checked by verifier.
-    auto vector = configuration.take_source(0).to<u128>();
-    auto base = configuration.take_source(1).to<u32>();
+    auto vector = configuration.take_source(0, addresses.sources).to<u128>();
+    auto base = configuration.take_source(1, addresses.sources).to<u32>();
     u64 instance_address = static_cast<u64>(bit_cast<u32>(base)) + memarg_and_lane.memory.offset;
     if (instance_address + N / 8 > memory->size()) {
         m_trap = Trap::from_string("Memory access out of bounds");
@@ -2313,18 +2306,18 @@ bool BytecodeInterpreter::load_and_push_lane_n(Configuration& configuration, Ins
     auto slice = memory->data().bytes().slice(instance_address, N / 8);
     auto dst = bit_cast<u8*>(&vector) + memarg_and_lane.lane * N / 8;
     memcpy(dst, slice.data(), N / 8);
-    configuration.push_to_destination(Value(vector));
+    configuration.push_to_destination(Value(vector), addresses.destination);
     return false;
 }
 
 template<size_t N>
-bool BytecodeInterpreter::load_and_push_zero_n(Configuration& configuration, Instruction const& instruction)
+bool BytecodeInterpreter::load_and_push_zero_n(Configuration& configuration, Instruction const& instruction, SourcesAndDestination const& addresses)
 {
     auto memarg_and_lane = instruction.arguments().get<Instruction::MemoryArgument>();
     auto& address = configuration.frame().module().memories()[memarg_and_lane.memory_index.value()];
     auto memory = configuration.store().get(address);
     // bounds checked by verifier.
-    auto base = configuration.take_source(0).to<u32>();
+    auto base = configuration.take_source(0, addresses.sources).to<u32>();
     u64 instance_address = static_cast<u64>(bit_cast<u32>(base)) + memarg_and_lane.offset;
     if (instance_address + N / 8 > memory->size()) {
         m_trap = Trap::from_string("Memory access out of bounds");
@@ -2333,17 +2326,17 @@ bool BytecodeInterpreter::load_and_push_zero_n(Configuration& configuration, Ins
     auto slice = memory->data().bytes().slice(instance_address, N / 8);
     u128 vector = 0;
     memcpy(&vector, slice.data(), N / 8);
-    configuration.push_to_destination(Value(vector));
+    configuration.push_to_destination(Value(vector), addresses.destination);
     return false;
 }
 
 template<size_t M>
-bool BytecodeInterpreter::load_and_push_m_splat(Configuration& configuration, Instruction const& instruction)
+bool BytecodeInterpreter::load_and_push_m_splat(Configuration& configuration, Instruction const& instruction, SourcesAndDestination const& addresses)
 {
     auto& arg = instruction.arguments().get<Instruction::MemoryArgument>();
     auto& address = configuration.frame().module().memories()[arg.memory_index.value()];
     auto memory = configuration.store().get(address);
-    auto& entry = configuration.source_value(0); // bounds checked by verifier.
+    auto& entry = configuration.source_value(0, addresses.sources); // bounds checked by verifier.
     auto base = entry.to<i32>();
     u64 instance_address = static_cast<u64>(bit_cast<u32>(base)) + arg.offset;
     if (instance_address + M / 8 > memory->size()) {
@@ -2354,15 +2347,15 @@ bool BytecodeInterpreter::load_and_push_m_splat(Configuration& configuration, In
     dbgln_if(WASM_TRACE_DEBUG, "vec-splat({} : {}) -> stack", instance_address, M / 8);
     auto slice = memory->data().bytes().slice(instance_address, M / 8);
     auto value = read_value<NativeIntegralType<M>>(slice);
-    set_top_m_splat<M, NativeIntegralType>(configuration, value);
+    set_top_m_splat<M, NativeIntegralType>(configuration, value, addresses);
     return false;
 }
 
 template<size_t M, template<size_t> typename NativeType>
-void BytecodeInterpreter::set_top_m_splat(Wasm::Configuration& configuration, NativeType<M> value)
+void BytecodeInterpreter::set_top_m_splat(Wasm::Configuration& configuration, NativeType<M> value, SourcesAndDestination const& addresses)
 {
     auto push = [&](auto result) {
-        configuration.source_value(0) = Value(bit_cast<u128>(result));
+        configuration.source_value(0, addresses.sources) = Value(bit_cast<u128>(result));
     };
 
     if constexpr (IsFloatingPoint<NativeType<32>>) {
@@ -2387,21 +2380,21 @@ void BytecodeInterpreter::set_top_m_splat(Wasm::Configuration& configuration, Na
 }
 
 template<size_t M, template<size_t> typename NativeType>
-void BytecodeInterpreter::pop_and_push_m_splat(Wasm::Configuration& configuration, Instruction const&)
+void BytecodeInterpreter::pop_and_push_m_splat(Wasm::Configuration& configuration, Instruction const&, SourcesAndDestination const& addresses)
 {
     using PopT = Conditional<M <= 32, NativeType<32>, NativeType<64>>;
     using ReadT = NativeType<M>;
-    auto entry = configuration.source_value(0);
+    auto entry = configuration.source_value(0, addresses.sources);
     auto value = static_cast<ReadT>(entry.to<PopT>());
     dbgln_if(WASM_TRACE_DEBUG, "stack({}) -> splat({})", value, M);
-    set_top_m_splat<M, NativeType>(configuration, value);
+    set_top_m_splat<M, NativeType>(configuration, value, addresses);
 }
 
 template<typename M, template<typename> typename SetSign, typename VectorType>
-VectorType BytecodeInterpreter::pop_vector(Configuration& configuration, size_t source)
+VectorType BytecodeInterpreter::pop_vector(Configuration& configuration, size_t source, SourcesAndDestination const& addresses)
 {
     // bounds checked by verifier.
-    return bit_cast<VectorType>(configuration.take_source(source).to<u128>());
+    return bit_cast<VectorType>(configuration.take_source(source, addresses.sources).to<u128>());
 }
 
 bool BytecodeInterpreter::call_address(Configuration& configuration, FunctionAddress address, CallAddressSource source)
@@ -2447,11 +2440,11 @@ bool BytecodeInterpreter::call_address(Configuration& configuration, FunctionAdd
 }
 
 template<typename PopTypeLHS, typename PushType, typename Operator, typename PopTypeRHS, typename... Args>
-bool BytecodeInterpreter::binary_numeric_operation(Configuration& configuration, Args&&... args)
+bool BytecodeInterpreter::binary_numeric_operation(Configuration& configuration, SourcesAndDestination const& addresses, Args&&... args)
 {
     // bounds checked by Nor.
-    auto rhs = configuration.take_source(0).to<PopTypeRHS>();
-    auto lhs = configuration.take_source(1).to<PopTypeLHS>(); // bounds checked by verifier.
+    auto rhs = configuration.take_source(0, addresses.sources).to<PopTypeRHS>();
+    auto lhs = configuration.take_source(1, addresses.sources).to<PopTypeLHS>(); // bounds checked by verifier.
     PushType result;
     auto call_result = Operator { forward<Args>(args)... }(lhs, rhs);
     if constexpr (IsSpecializationOf<decltype(call_result), AK::ErrorOr>) {
@@ -2462,14 +2455,14 @@ bool BytecodeInterpreter::binary_numeric_operation(Configuration& configuration,
         result = call_result;
     }
     dbgln_if(WASM_TRACE_DEBUG, "{} {} {} = {}", lhs, Operator::name(), rhs, result);
-    configuration.push_to_destination(Value(result));
+    configuration.push_to_destination(Value(result), addresses.destination);
     return false;
 }
 
 template<typename PopType, typename PushType, typename Operator, typename... Args>
-bool BytecodeInterpreter::unary_operation(Configuration& configuration, Args&&... args)
+bool BytecodeInterpreter::unary_operation(Configuration& configuration, SourcesAndDestination const& addresses, Args&&... args)
 {
-    auto& entry = configuration.source_value(0); // bounds checked by veriNor.
+    auto& entry = configuration.source_value(0, addresses.sources); // bounds checked by verifier.
     auto value = entry.to<PopType>();
     auto call_result = Operator { forward<Args>(args)... }(value);
     PushType result;
@@ -2486,48 +2479,48 @@ bool BytecodeInterpreter::unary_operation(Configuration& configuration, Args&&..
 }
 
 template<typename PopT, typename StoreT>
-bool BytecodeInterpreter::pop_and_store(Configuration& configuration, Instruction const& instruction)
+bool BytecodeInterpreter::pop_and_store(Configuration& configuration, Instruction const& instruction, SourcesAndDestination const& addresses)
 {
     // bounds checked by verifier.
-    auto entry = configuration.take_source(0);
+    auto entry = configuration.take_source(0, addresses.sources);
     auto value = ConvertToRaw<StoreT> {}(entry.to<PopT>());
-    return store_value(configuration, instruction, value, 1);
+    return store_value(configuration, instruction, value, 1, addresses);
 }
 
 template<typename StoreT>
-bool BytecodeInterpreter::store_value(Configuration& configuration, Instruction const& instruction, StoreT value, size_t address_source)
+bool BytecodeInterpreter::store_value(Configuration& configuration, Instruction const& instruction, StoreT value, size_t address_source, SourcesAndDestination const& addresses)
 {
-    auto& memarg = instruction.arguments().get<Instruction::MemoryArgument>();
+    auto& memarg = instruction.arguments().unsafe_get<Instruction::MemoryArgument>();
     dbgln_if(WASM_TRACE_DEBUG, "stack({}) -> temporary({}b)", value, sizeof(StoreT));
-    auto base = configuration.take_source(address_source).to<i32>();
+    auto base = configuration.take_source(address_source, addresses.sources).to<i32>();
     return store_to_memory(configuration, memarg, { &value, sizeof(StoreT) }, base);
 }
 
 template<size_t N>
-bool BytecodeInterpreter::pop_and_store_lane_n(Configuration& configuration, Instruction const& instruction)
+bool BytecodeInterpreter::pop_and_store_lane_n(Configuration& configuration, Instruction const& instruction, SourcesAndDestination const& addresses)
 {
     auto& memarg_and_lane = instruction.arguments().get<Instruction::MemoryAndLaneArgument>();
     // bounds checked by verifier.
-    auto vector = configuration.take_source(0).to<u128>();
+    auto vector = configuration.take_source(0, addresses.sources).to<u128>();
     auto src = bit_cast<u8*>(&vector) + memarg_and_lane.lane * N / 8;
-    auto base = configuration.take_source(1).to<u32>();
+    auto base = configuration.take_source(1, addresses.sources).to<u32>();
     return store_to_memory(configuration, memarg_and_lane.memory, { src, N / 8 }, base);
 }
 
 bool BytecodeInterpreter::store_to_memory(Configuration& configuration, Instruction::MemoryArgument const& arg, ReadonlyBytes data, u32 base)
 {
-    auto& address = configuration.frame().module().memories()[arg.memory_index.value()];
+    auto& address = configuration.frame().module().memories().data()[arg.memory_index.value()];
     auto memory = configuration.store().get(address);
     u64 instance_address = static_cast<u64>(base) + arg.offset;
     Checked addition { instance_address };
     addition += data.size();
-    if (addition.has_overflow() || addition.value() > memory->size()) {
+    if (addition.has_overflow() || addition.value() > memory->size()) [[unlikely]] {
         m_trap = Trap::from_string("Memory access out of bounds");
         dbgln_if(WASM_TRACE_DEBUG, "LibWasm: Memory access out of bounds (expected 0 <= {} and {} <= {})", instance_address, instance_address + data.size(), memory->size());
         return true;
     }
     dbgln_if(WASM_TRACE_DEBUG, "temporary({}b) -> store({})", data.size(), instance_address);
-    data.copy_to(memory->data().bytes().slice(instance_address, data.size()));
+    (void)data.copy_to(memory->data().bytes().slice(instance_address, data.size()));
     return false;
 }
 
@@ -2574,6 +2567,7 @@ CompiledInstructions try_compile_instructions(Expression const& expression, Span
     static Instruction nop { Instructions::nop };
     constexpr auto default_dispatch = [](Instruction const& instruction) {
         return Dispatch {
+            instruction.opcode(),
             &instruction,
             { .sources = { Dispatch::Stack, Dispatch::Stack, Dispatch::Stack }, .destination = Dispatch::Stack }
         };
@@ -2808,6 +2802,7 @@ CompiledInstructions try_compile_instructions(Expression const& expression, Span
             };
             result.extra_instruction_storage.append(move(instruction));
             result.dispatches[i].instruction = &result.extra_instruction_storage.unsafe_last();
+            result.dispatches[i].instruction_opcode = result.dispatches[i].instruction->opcode();
         }
     }
     for (auto index : nops_to_remove.in_reverse())

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -267,8 +267,7 @@ void BytecodeInterpreter::interpret_impl(Configuration& configuration, Expressio
                 RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
             }
             case Instructions::return_.value(): {
-                while (configuration.label_stack().size() - 1 != configuration.frame().label_index())
-                    configuration.label_stack().take_last();
+                configuration.label_stack().shrink(configuration.frame().label_index() + 1, true);
                 configuration.ip() = max_ip_value;
                 RUN_NEXT_INSTRUCTION(CouldHaveChangedIP::Yes);
             }
@@ -2233,8 +2232,8 @@ void BytecodeInterpreter::interpret_impl(Configuration& configuration, Expressio
 void BytecodeInterpreter::branch_to_label(Configuration& configuration, LabelIndex index)
 {
     dbgln_if(WASM_TRACE_DEBUG, "Branch to label with index {}...", index.value());
-    for (size_t i = 0; i < index.value(); ++i)
-        configuration.label_stack().take_last();
+    auto& label_stack = configuration.label_stack();
+    label_stack.shrink(label_stack.size() - index.value(), true);
     auto label = configuration.label_stack().last();
     dbgln_if(WASM_TRACE_DEBUG, "...which is actually IP {}, and has {} result(s)", label.continuation().value(), label.arity());
 

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -13,6 +13,14 @@
 
 namespace Wasm {
 
+union SourcesAndDestination {
+    struct {
+        Dispatch::RegisterOrStack sources[3];
+        Dispatch::RegisterOrStack destination;
+    };
+    u32 sources_and_destination;
+};
+
 struct WASM_API BytecodeInterpreter final : public Interpreter {
     explicit BytecodeInterpreter(StackInfo const& stack_info)
         : m_stack_info(stack_info)
@@ -57,37 +65,37 @@ struct WASM_API BytecodeInterpreter final : public Interpreter {
     void interpret_impl(Configuration&, Expression const&);
 
 protected:
-    void branch_to_label(Configuration&, LabelIndex);
+    InstructionPointer branch_to_label(Configuration&, LabelIndex);
     template<typename ReadT, typename PushT>
-    bool load_and_push(Configuration&, Instruction const&);
+    bool load_and_push(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<typename PopT, typename StoreT>
-    bool pop_and_store(Configuration&, Instruction const&);
+    bool pop_and_store(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<typename StoreT>
-    bool store_value(Configuration&, Instruction const&, StoreT, size_t address_source);
+    bool store_value(Configuration&, Instruction const&, StoreT, size_t address_source, SourcesAndDestination const&);
     template<size_t N>
-    bool pop_and_store_lane_n(Configuration&, Instruction const&);
+    bool pop_and_store_lane_n(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<size_t M, size_t N, template<typename> typename SetSign>
-    bool load_and_push_mxn(Configuration&, Instruction const&);
+    bool load_and_push_mxn(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<size_t N>
-    bool load_and_push_lane_n(Configuration&, Instruction const&);
+    bool load_and_push_lane_n(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<size_t N>
-    bool load_and_push_zero_n(Configuration&, Instruction const&);
+    bool load_and_push_zero_n(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<size_t M>
-    bool load_and_push_m_splat(Configuration&, Instruction const&);
+    bool load_and_push_m_splat(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<size_t M, template<size_t> typename NativeType>
-    void set_top_m_splat(Configuration&, NativeType<M>);
+    void set_top_m_splat(Configuration&, NativeType<M>, SourcesAndDestination const&);
     template<size_t M, template<size_t> typename NativeType>
-    void pop_and_push_m_splat(Configuration&, Instruction const&);
+    void pop_and_push_m_splat(Configuration&, Instruction const&, SourcesAndDestination const&);
     template<typename M, template<typename> typename SetSign, typename VectorType = Native128ByteVectorOf<M, SetSign>>
-    VectorType pop_vector(Configuration&, size_t source);
+    VectorType pop_vector(Configuration&, size_t source, SourcesAndDestination const&);
     bool store_to_memory(Configuration&, Instruction::MemoryArgument const&, ReadonlyBytes data, u32 base);
     bool call_address(Configuration&, FunctionAddress, CallAddressSource = CallAddressSource::DirectCall);
 
     template<typename PopTypeLHS, typename PushType, typename Operator, typename PopTypeRHS = PopTypeLHS, typename... Args>
-    bool binary_numeric_operation(Configuration&, Args&&...);
+    bool binary_numeric_operation(Configuration&, SourcesAndDestination const&, Args&&...);
 
     template<typename PopType, typename PushType, typename Operator, typename... Args>
-    bool unary_operation(Configuration&, Args&&...);
+    bool unary_operation(Configuration&, SourcesAndDestination const&, Args&&...);
 
     template<typename T>
     T read_value(ReadonlyBytes data);

--- a/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -11,11 +11,10 @@
 
 namespace Wasm {
 
-void Configuration::unwind(Badge<CallFrameHandle>, CallFrameHandle const& frame_handle)
+void Configuration::unwind(Badge<CallFrameHandle>, CallFrameHandle const&)
 {
     m_frame_stack.take_last();
     m_depth--;
-    m_ip = frame_handle.ip.value();
     m_locals_base = m_frame_stack.is_empty() ? nullptr : m_frame_stack.unchecked_last().locals().data();
 }
 

--- a/Libraries/LibWasm/AbstractMachine/Configuration.h
+++ b/Libraries/LibWasm/AbstractMachine/Configuration.h
@@ -106,7 +106,7 @@ public:
         u32 sources_and_destination;
     };
 
-    Value regs[Dispatch::RegisterOrStack::CountRegisters] = {
+    Array<Value, Dispatch::RegisterOrStack::CountRegisters> regs = {
         Value(0),
         Value(0),
         Value(0),

--- a/Libraries/LibWasm/AbstractMachine/Configuration.h
+++ b/Libraries/LibWasm/AbstractMachine/Configuration.h
@@ -25,6 +25,8 @@ public:
         frame.label_index() = m_label_stack.size();
         if (auto hint = frame.expression().stack_usage_hint(); hint.has_value())
             m_value_stack.ensure_capacity(*hint + m_value_stack.size());
+        if (auto hint = frame.expression().frame_usage_hint(); hint.has_value())
+            m_label_stack.ensure_capacity(*hint + m_label_stack.size());
         m_frame_stack.append(move(frame));
         m_label_stack.append(label);
         m_locals_base = m_frame_stack.unchecked_last().locals().data();
@@ -120,7 +122,7 @@ public:
 private:
     Store& m_store;
     Vector<Value, 64, FastLastAccess::Yes> m_value_stack;
-    DoublyLinkedList<Label, 128> m_label_stack;
+    Vector<Label, 64> m_label_stack;
     DoublyLinkedList<Frame, 128> m_frame_stack;
     size_t m_depth { 0 };
     u64 m_ip { 0 };

--- a/Libraries/LibWasm/AbstractMachine/Configuration.h
+++ b/Libraries/LibWasm/AbstractMachine/Configuration.h
@@ -80,7 +80,7 @@ public:
             value_stack().unchecked_append(value);
             return;
         }
-        regs[to_underlying(destination)] = value;
+        regs.data()[to_underlying(destination)] = value;
     }
 
     ALWAYS_INLINE FLATTEN Value& source_value(u8 index)
@@ -89,7 +89,7 @@ public:
         auto const source = sources[index];
         if (source == Dispatch::RegisterOrStack::Stack)
             return value_stack().unsafe_last();
-        return regs[to_underlying(source)];
+        return regs.data()[to_underlying(source)];
     }
 
     ALWAYS_INLINE FLATTEN Value take_source(u8 index)
@@ -97,7 +97,7 @@ public:
         auto const source = sources[index];
         if (source == Dispatch::RegisterOrStack::Stack)
             return value_stack().unsafe_take_last();
-        return regs[to_underlying(source)];
+        return regs.data()[to_underlying(source)];
     }
 
     union {

--- a/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -271,6 +271,7 @@ ErrorOr<void, ValidationError> Validator::validate(CodeSection const& section)
         }
 
         function_validator.m_frames.empend(function_type, FrameKind::Function, (size_t)0);
+        function_validator.m_max_frame_size = max(function_validator.m_max_frame_size, function_validator.m_frames.size());
 
         auto results = TRY(function_validator.validate(function.body(), function_type.results()));
         if (results.result_types.size() != function_type.results().size())
@@ -1971,6 +1972,7 @@ VALIDATE_INSTRUCTION(block)
         TRY(stack.take(parameters[parameters.size() - i]));
 
     m_frames.empend(block_type, FrameKind::Block, stack.size());
+    m_max_frame_size = max(m_max_frame_size, m_frames.size());
     for (auto& parameter : parameters)
         stack.append(parameter);
 
@@ -1987,6 +1989,7 @@ VALIDATE_INSTRUCTION(loop)
         TRY(stack.take(parameters[parameters.size() - i]));
 
     m_frames.empend(block_type, FrameKind::Loop, stack.size());
+    m_max_frame_size = max(m_max_frame_size, m_frames.size());
     for (auto& parameter : parameters)
         stack.append(parameter);
 
@@ -2007,6 +2010,7 @@ VALIDATE_INSTRUCTION(if_)
         TRY(stack.take(parameters[parameters.size() - i]));
 
     m_frames.empend(block_type, FrameKind::If, stack.size());
+    m_max_frame_size = max(m_max_frame_size, m_frames.size());
     for (auto& parameter : parameters)
         stack.append(parameter);
 
@@ -3734,9 +3738,12 @@ ErrorOr<Validator::ExpressionTypeResult, ValidationError> Validator::validate(Ex
     for (auto& type : result_types)
         stack.append(type);
     m_frames.take_last();
-    VERIFY(m_frames.is_empty());
 
     expression.set_stack_usage_hint(stack.max_known_size());
+    expression.set_frame_usage_hint(m_max_frame_size);
+
+    VERIFY(m_frames.is_empty());
+    m_max_frame_size = 0;
 
     // Now that we're in happy land, try to compile the expression down to a list of labels to help dispatch.
     expression.compiled_instructions = try_compile_instructions(expression, m_context.functions.span());

--- a/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -3700,6 +3700,12 @@ VALIDATE_INSTRUCTION(f64x2_convert_low_i32x4_u)
     return stack.take_and_put<ValueType::V128>(ValueType::V128);
 }
 
+VALIDATE_INSTRUCTION(synthetic_end_expression)
+{
+    is_constant = true;
+    return {}; // Always valid.
+}
+
 ErrorOr<void, ValidationError> Validator::validate(Instruction const& instruction, Stack& stack, bool& is_constant)
 {
     switch (instruction.opcode().value()) {

--- a/Libraries/LibWasm/AbstractMachine/Validator.h
+++ b/Libraries/LibWasm/AbstractMachine/Validator.h
@@ -361,6 +361,7 @@ private:
 
     Context m_context;
     Vector<Frame> m_frames;
+    size_t m_max_frame_size { 0 };
     COWVector<GlobalType> m_globals_without_internal_globals;
 };
 

--- a/Libraries/LibWasm/Opcode.h
+++ b/Libraries/LibWasm/Opcode.h
@@ -473,7 +473,8 @@ namespace Instructions {
     M(synthetic_call_20, 0xfe0000000000000aull, 2, 0)            \
     M(synthetic_call_21, 0xfe0000000000000bull, 2, 1)            \
     M(synthetic_call_30, 0xfe0000000000000cull, 3, 0)            \
-    M(synthetic_call_31, 0xfe0000000000000dull, 3, 1)
+    M(synthetic_call_31, 0xfe0000000000000dull, 3, 1)            \
+    M(synthetic_end_expression, 0xfe0000000000000eull, 0, 0)
 
 #define ENUMERATE_WASM_OPCODES(M)         \
     ENUMERATE_SINGLE_BYTE_WASM_OPCODES(M) \
@@ -484,7 +485,7 @@ ENUMERATE_WASM_OPCODES(M)
 #undef M
 
 static constexpr inline OpCode SyntheticInstructionBase = 0xfe00000000000000ull;
-static constexpr inline size_t SyntheticInstructionCount = 14;
+static constexpr inline size_t SyntheticInstructionCount = 15;
 
 }
 

--- a/Libraries/LibWasm/Opcode.h
+++ b/Libraries/LibWasm/Opcode.h
@@ -459,13 +459,21 @@ namespace Instructions {
     /* Synthetic fused insns */                                   \
     ENUMERATE_SYNTHETIC_INSTRUCTION_OPCODES(M)
 
-#define ENUMERATE_SYNTHETIC_INSTRUCTION_OPCODES(M)              \
-    M(synthetic_i32_add2local, 0xfe00000000000000ull, 0, 1)     \
-    M(synthetic_i32_addconstlocal, 0xfe00000000000001ull, 0, 1) \
-    M(synthetic_i32_andconstlocal, 0xfe00000000000002ull, 0, 1) \
-    M(synthetic_i32_storelocal, 0xfe00000000000003ull, 1, 0)    \
-    M(synthetic_i64_storelocal, 0xfe00000000000004ull, 1, 0)    \
-    M(synthetic_local_seti32_const, 0xfe00000000000005ull, 0, 0)
+#define ENUMERATE_SYNTHETIC_INSTRUCTION_OPCODES(M)               \
+    M(synthetic_i32_add2local, 0xfe00000000000000ull, 0, 1)      \
+    M(synthetic_i32_addconstlocal, 0xfe00000000000001ull, 0, 1)  \
+    M(synthetic_i32_andconstlocal, 0xfe00000000000002ull, 0, 1)  \
+    M(synthetic_i32_storelocal, 0xfe00000000000003ull, 1, 0)     \
+    M(synthetic_i64_storelocal, 0xfe00000000000004ull, 1, 0)     \
+    M(synthetic_local_seti32_const, 0xfe00000000000005ull, 0, 0) \
+    M(synthetic_call_00, 0xfe00000000000006ull, 0, 0)            \
+    M(synthetic_call_01, 0xfe00000000000007ull, 0, 1)            \
+    M(synthetic_call_10, 0xfe00000000000008ull, 1, 0)            \
+    M(synthetic_call_11, 0xfe00000000000009ull, 1, 1)            \
+    M(synthetic_call_20, 0xfe0000000000000aull, 2, 0)            \
+    M(synthetic_call_21, 0xfe0000000000000bull, 2, 1)            \
+    M(synthetic_call_30, 0xfe0000000000000cull, 3, 0)            \
+    M(synthetic_call_31, 0xfe0000000000000dull, 3, 1)
 
 #define ENUMERATE_WASM_OPCODES(M)         \
     ENUMERATE_SINGLE_BYTE_WASM_OPCODES(M) \
@@ -476,7 +484,7 @@ ENUMERATE_WASM_OPCODES(M)
 #undef M
 
 static constexpr inline OpCode SyntheticInstructionBase = 0xfe00000000000000ull;
-static constexpr inline size_t SyntheticInstructionCount = 6;
+static constexpr inline size_t SyntheticInstructionCount = 14;
 
 }
 

--- a/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Libraries/LibWasm/Printer/Printer.cpp
@@ -1160,5 +1160,6 @@ HashMap<Wasm::OpCode, ByteString> Wasm::Names::instruction_names {
     { Instructions::synthetic_call_21, "synthetic:call.21" },
     { Instructions::synthetic_call_30, "synthetic:call.30" },
     { Instructions::synthetic_call_31, "synthetic:call.31" },
+    { Instructions::synthetic_end_expression, "synthetic:expression.end" },
 };
 HashMap<ByteString, Wasm::OpCode> Wasm::Names::instructions_by_name;

--- a/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Libraries/LibWasm/Printer/Printer.cpp
@@ -1151,6 +1151,14 @@ HashMap<Wasm::OpCode, ByteString> Wasm::Names::instruction_names {
     { Instructions::synthetic_i32_andconstlocal, "synthetic:i32.and_const_local" },
     { Instructions::synthetic_i32_storelocal, "synthetic:i32.store_local" },
     { Instructions::synthetic_i64_storelocal, "synthetic:i64.store_local" },
-    { Instructions::synthetic_local_seti32_const, "synthetic:local.set_i32_const" }
+    { Instructions::synthetic_local_seti32_const, "synthetic:local.set_i32_const" },
+    { Instructions::synthetic_call_00, "synthetic:call.00" },
+    { Instructions::synthetic_call_01, "synthetic:call.01" },
+    { Instructions::synthetic_call_10, "synthetic:call.10" },
+    { Instructions::synthetic_call_11, "synthetic:call.11" },
+    { Instructions::synthetic_call_20, "synthetic:call.20" },
+    { Instructions::synthetic_call_21, "synthetic:call.21" },
+    { Instructions::synthetic_call_30, "synthetic:call.30" },
+    { Instructions::synthetic_call_31, "synthetic:call.31" },
 };
 HashMap<ByteString, Wasm::OpCode> Wasm::Names::instructions_by_name;

--- a/Libraries/LibWasm/Types.h
+++ b/Libraries/LibWasm/Types.h
@@ -535,6 +535,7 @@ struct Dispatch {
         Stack = CountRegisters,
     };
 
+    OpCode instruction_opcode;
     Instruction const* instruction { nullptr };
     union {
         struct {

--- a/Libraries/LibWasm/Types.h
+++ b/Libraries/LibWasm/Types.h
@@ -758,11 +758,15 @@ public:
 
     void set_stack_usage_hint(size_t value) const { m_stack_usage_hint = value; }
     auto stack_usage_hint() const { return m_stack_usage_hint; }
+    void set_frame_usage_hint(size_t value) const { m_frame_usage_hint = value; }
+    auto frame_usage_hint() const { return m_frame_usage_hint; }
+
     mutable CompiledInstructions compiled_instructions;
 
 private:
     Vector<Instruction> m_instructions;
     mutable Optional<size_t> m_stack_usage_hint;
+    mutable Optional<size_t> m_frame_usage_hint;
 };
 
 class GlobalSection {

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -1,10 +1,10 @@
 if(WIN32)
     # FIXME: Add support for LibLine on Windows
     lagom_utility(js SOURCES js.cpp LIBS LibCrypto LibJS LibUnicode LibMain LibTextCodec LibGC Threads::Threads)
-    lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibMain)
+    lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibMain LibJS LibCrypto LibGC)
 else()
     lagom_utility(js SOURCES js.cpp LIBS LibCrypto LibJS LibLine LibUnicode LibMain LibTextCodec LibGC Threads::Threads)
-    lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibLine LibMain)
+    lagom_utility(wasm SOURCES wasm.cpp LIBS LibFileSystem LibWasm LibLine LibMain LibJS LibCrypto LibGC)
 endif()
 
 lagom_utility(xml SOURCES xml.cpp LIBS LibFileSystem LibMain LibXML LibURL)


### PR DESCRIPTION
This still passes the values on the stack, but registers are now allowed to cross a call boundary.
This is a very significant (>50%) improvement on the small call microbenchmarks on my machine.