### PR TITLE
RequestServer: Sanitizing curl GET headers

### DIFF
--- a/Libraries/LibHTTP/HeaderMap.h
+++ b/Libraries/LibHTTP/HeaderMap.h
@@ -49,6 +49,22 @@ public:
         return m_headers;
     }
 
+    void sanitize_request_headers_for_method(const ByteString& method)
+    {
+        auto method_allows_body = method.is_one_of("POST"sv, "PUT"sv, "PATCH"sv, "DELETE"sv);
+
+        if (!method_allows_body) {
+            m_map.remove_all_matching([](auto const& header_name, auto const&) {
+                auto& name = header_name;
+                return name.is_one_of("content-length"sv, "content-type"sv, "transfer-encoding"sv, "content-encoding"sv, "expect"sv);
+            });
+            m_headers.remove_all_matching([](auto const& header) {
+                auto& name = header.name;
+                return name.is_one_of("Content-Length"sv, "Content-Type"sv, "Transfer-Encoding"sv, "Content-Encoding"sv, "Expect"sv);
+            });
+        }
+    }
+
 private:
     HashMap<ByteString, ByteString, CaseInsensitiveStringTraits> m_map;
     Vector<Header> m_headers;

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -531,8 +531,10 @@ void ConnectionFromClient::start_request(i32 request_id, ByteString method, URL:
 
             struct curl_slist* curl_headers = nullptr;
 
+            request_headers.sanitize_request_headers_for_method(method);
             // NOTE: CURLOPT_POSTFIELDS automatically sets the Content-Type header.
             //       Tell curl to remove it by setting a blank value if the headers passed in don't contain a content type.
+
             if (did_set_body && !request_headers.contains("Content-Type"))
                 curl_headers = curl_slist_append(curl_headers, "Content-Type:");
 

--- a/Tests/LibWeb/Text/expected/wpt-import/cors/simple-requests.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/cors/simple-requests.txt
@@ -1,0 +1,29 @@
+Harness status: OK
+
+Found 24 tests
+
+24 Fail
+Fail	No preflight GET and {"Accept":"test"}
+Fail	No preflight HEAD and {"Accept":"test"}
+Fail	No preflight POST and {"Accept":"test"}
+Fail	No preflight GET and {"accept-language":"test"}
+Fail	No preflight HEAD and {"accept-language":"test"}
+Fail	No preflight POST and {"accept-language":"test"}
+Fail	No preflight GET and {"CONTENT-language":"test"}
+Fail	No preflight HEAD and {"CONTENT-language":"test"}
+Fail	No preflight POST and {"CONTENT-language":"test"}
+Fail	No preflight GET and {"Content-Type":"application/x-www-form-urlencoded"}
+Fail	No preflight HEAD and {"Content-Type":"application/x-www-form-urlencoded"}
+Fail	No preflight POST and {"Content-Type":"application/x-www-form-urlencoded"}
+Fail	No preflight GET and {"content-type":"multipart/form-data"}
+Fail	No preflight HEAD and {"content-type":"multipart/form-data"}
+Fail	No preflight POST and {"content-type":"multipart/form-data"}
+Fail	No preflight GET and {"content-type":"text/plain"}
+Fail	No preflight HEAD and {"content-type":"text/plain"}
+Fail	No preflight POST and {"content-type":"text/plain"}
+Fail	No preflight GET and {"accept":"test","accept-language":"test","content-language":"test","content-type":"text/plain; parameter=whatever"}
+Fail	No preflight HEAD and {"accept":"test","accept-language":"test","content-language":"test","content-type":"text/plain; parameter=whatever"}
+Fail	No preflight POST and {"accept":"test","accept-language":"test","content-language":"test","content-type":"text/plain; parameter=whatever"}
+Fail	No preflight Get and {"content-type":"text/plain; parameter=extra_bonus"}
+Fail	No preflight post and {"content-type":"text/plain"}
+Fail	Check simple headers (async)

--- a/Tests/LibWeb/Text/input/wpt-import/cors/simple-requests.htm
+++ b/Tests/LibWeb/Text/input/wpt-import/cors/simple-requests.htm
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>CORS - simple requests</title>
+<meta name=author title="Odin Hørthe Omdal" href="mailto:odiho@opera.com">
+
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<script src=support.js?pipe=sub></script>
+<script src=../common/utils.js></script>
+
+<h1>Simple requests</h1>
+<p>Simple requests shouldn't trigger preflight</p>
+
+<div id=log></div>
+<script>
+
+var test_c = 0;
+
+function check_simple(method, headers)
+{
+    test(function() {
+        var client = new XMLHttpRequest()
+        var uuid_token = token();
+        client.open(method, CROSSDOMAIN + 'resources/preflight.py?token='
+                            + uuid_token, false)
+        for (head in headers)
+            client.setRequestHeader(head, headers[head])
+        client.send("data")
+        assert_equals(client.getResponseHeader('content-type'), "text/plain")
+        if (method == 'HEAD')
+            assert_equals(client.response, '', 'response')
+        else
+            assert_equals(client.response, 'NO', 'response')
+
+        client.open('GET', 'resources/preflight.py?check&token='
+                          + uuid_token, false)
+        client.send("data")
+        assert_equals(client.response, "0", "Found preflight log")
+    },
+    'No preflight ' + method + ' and ' + JSON.stringify(headers))
+}
+
+function check_simple_headers(headers) {
+    check_simple('GET', headers)
+    check_simple('HEAD', headers)
+    check_simple('POST', headers)
+}
+
+check_simple_headers({'Accept': 'test'})
+check_simple_headers({'accept-language': 'test'})
+check_simple_headers({'CONTENT-language': 'test'})
+
+check_simple_headers({'Content-Type': 'application/x-www-form-urlencoded'})
+check_simple_headers({'content-type': 'multipart/form-data'})
+check_simple_headers({'content-type': 'text/plain'})
+
+check_simple_headers({
+                        'accept': 'test',
+                        'accept-language': 'test',
+                        'content-language': 'test',
+                        'content-type': 'text/plain; parameter=whatever'
+                     })
+
+check_simple('Get', {'content-type': 'text/plain; parameter=extra_bonus'})
+check_simple('post', {'content-type': 'text/plain'})
+
+/* Extra async test */
+
+var simple_async = async_test("Check simple headers (async)")
+simple_async.step(function (){
+    var time = new Date().getTime(),
+        client = new XMLHttpRequest()
+    var uuid_token = token();
+    client.open('POST', CROSSDOMAIN + 'resources/preflight.py?token='
+                        + uuid_token, true)
+
+    client.setRequestHeader('Accept', 'jewelry')
+    client.setRequestHeader('accept-language', 'nn-NO,nn,en')
+    client.setRequestHeader('content-type', 'text/plain; parameter=extra')
+    client.setRequestHeader('content-Language', 'nn-NO')
+
+    client.onload = simple_async.step_func(function() {
+        assert_equals(client.getResponseHeader('content-type'), "text/plain", 'content-type response header')
+        assert_equals(client.response, 'NO', 'response')
+        simple_async.done()
+    })
+    client.onerror = simple_async.step_func(function () { assert_unreached('onerror') })
+    client.send()
+})
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/cors/support.js?pipe=sub
+++ b/Tests/LibWeb/Text/input/wpt-import/cors/support.js?pipe=sub
@@ -1,0 +1,17 @@
+function dirname(path) {
+    return path.replace(/\/[^\/]*$/, '/')
+}
+
+/* This subdomain should point to this same location */
+var SUBDOMAIN = 'www1'
+var SUBDOMAIN2 = 'www2'
+var PORT = {{ports[http][1]}}
+//XXX HTTPS
+var PORTS = {{ports[https][0]}}
+
+/* Changes http://example.com/abc/def/cool.htm to http://www1.example.com/abc/def/ */
+var CROSSDOMAIN     = dirname(location.href)
+                        .replace('://', '://' + SUBDOMAIN + '.')
+var REMOTE_HOST     = SUBDOMAIN + '.' + location.host
+var REMOTE_PROTOCOL = location.protocol
+var REMOTE_ORIGIN   = REMOTE_PROTOCOL + '//' + REMOTE_HOST


### PR DESCRIPTION
cURL is re-using open connections and some GET requests was including  a Content-Length header, which broke subsequent GET/HEAD requests that reused the same connection.

This fixes one WPT test.

Before the changes in this PR the results of ./Meta/WPT.sh run cors was:

> Ran 27 tests finished in 6.3 seconds.
> 	. 18 ran as expected. 0 tests skipped.
> 	. 9 tests had unexpected subtest results

After the changes is:

> Ran 27 tests finished in 6.3 seconds.
> 	.19 ran as expected. 0 tests skipped.
> 	. 8 tests had unexpected subtest results.