### PR TITLE
LibWeb: Assume CSP list is empty if document has no associated window

### DIFF
--- a/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.cpp
@@ -561,7 +561,8 @@ JS::ThrowCompletionOr<void> ensure_csp_does_not_block_wasm_byte_compilation(JS::
 Directives::Directive::Result is_base_allowed_for_document(JS::Realm& realm, URL::URL const& base, GC::Ref<DOM::Document const> document)
 {
     // 1. For each policy of document’s global object’s csp list:
-    VERIFY(document->window());
+    if (!document->window())
+        return Directives::Directive::Result::Allowed;
     auto csp_list = PolicyList::from_object(*document->window());
     VERIFY(csp_list);
     for (auto const policy : csp_list->policies()) {

--- a/Tests/LibWeb/Assets/minimal.xml
+++ b/Tests/LibWeb/Assets/minimal.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<empty />

--- a/Tests/LibWeb/Crash/XHR/XMLHttpRequest-responsexml-base-element.html
+++ b/Tests/LibWeb/Crash/XHR/XMLHttpRequest-responsexml-base-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script>
+    const client = new XMLHttpRequest();
+    client.open("GET", "../../Assets/minimal.xml");
+    client.send();
+    client.onload = () => {
+        client.responseXML.documentElement.remove();
+        const newBase = document.createElement("base");
+        newBase.href = "http://example.com";
+        client.responseXML.appendChild(newBase);
+    };
+</script>


### PR DESCRIPTION
Previously, a crash would occur when checking whether a `<base>` element was allowed by CSP, if the relevant document didn't have an associated window.

I first encountered this in the wild on a BBC website but wasn't easily able to reproduce the problem. I found that this WPT test has the same issue: https://wpt.live/xhr/responsexml-document-properties.htm. 

This test is fixed by this PR, but isn't importable because it relies on a Python file provided by the WPT runner.