### PR TITLE
LibWeb: Fix grid layout for replaced items with percentage max-width

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1442,10 +1442,6 @@ CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box
 
 CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box) const
 {
-    if (box.is_replaced_box() && box.computed_values().width().is_percentage()) {
-        return 0;
-    }
-
     if (box.has_natural_width())
         return *box.natural_width();
 

--- a/Tests/LibWeb/Layout/expected/grid/replaced-box-with-percentage-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/replaced-box-with-percentage-max-width.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 100x50 children: not-inline
+      Box <div> at (8,8) content-size 100x50 [GFC] children: not-inline
+        ImageBox <img> at (8,8) content-size 50x50 children: not-inline
+        ImageBox <img> at (58,8) content-size 50x50 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 100x50]
+      PaintableBox (Box<DIV>) [8,8 100x50]
+        ImagePaintable (ImageBox<IMG>) [8,8 50x50]
+        ImagePaintable (ImageBox<IMG>) [58,8 50x50]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x66] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/replaced-box-with-percentage-max-width.html
+++ b/Tests/LibWeb/Layout/input/grid/replaced-box-with-percentage-max-width.html
@@ -1,0 +1,11 @@
+<!doctype html><style>
+* { outline: 1px solid black; }
+body { width: 100px; }
+div {
+    grid-template-columns: auto auto;
+    display: grid;
+}
+img {
+    max-width: 100%;
+}
+</style><body><div><img src="../../../Assets/120.png"><img src="../../../Assets/120.png">


### PR DESCRIPTION
CSS grid specification states that for grid items with a replaced element and a percentage preferred size or maximum size, the percentage should be resolved against 0 during content-based minimum size calculation. This makes sense, as it prevents replaced items from overshooting their grid track while intrinsic track sizes are calculated, and allows later track size resolution steps to scale replaced items to fit their grid track.