### PR TITLE
LibWeb: Select the entire input when double clicking password fields

### DIFF
--- a/Tests/LibWeb/Text/expected/double-click-password.txt
+++ b/Tests/LibWeb/Text/expected/double-click-password.txt
@@ -1,0 +1,1 @@
+well hello friends

--- a/Tests/LibWeb/Text/input/double-click-password.html
+++ b/Tests/LibWeb/Text/input/double-click-password.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<script src="include.js"></script>
+<input type="password" value="well hello friends" />
+<script>
+    test(() => {
+        internals.doubleclick(20, 20);
+        println(window.getSelection().toString());
+    });
+</script>


### PR DESCRIPTION
This matches the behavior of other browsers, and hides any indication of word boundaries in the password.

Fixes #5795