### PR TITLE
LibWeb: Treat <input disabled> and <textarea disabled> as non-mutable 

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -220,8 +220,8 @@ public:
     bool has_scheduled_selectionchange_event() const { return m_has_scheduled_selectionchange_event; }
     void set_scheduled_selectionchange_event(bool value) { m_has_scheduled_selectionchange_event = value; }
 
-    bool is_mutable() const { return m_is_mutable; }
-    void set_is_mutable(bool is_mutable) { m_is_mutable = is_mutable; }
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#mutability
+    virtual bool is_mutable() const = 0;
 
     virtual void did_edit_text_node() = 0;
 
@@ -260,9 +260,6 @@ private:
 
     // https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event
     bool m_has_scheduled_selectionchange_event { false };
-
-    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#mutability
-    bool m_is_mutable { true };
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -893,13 +893,6 @@ void HTMLInputElement::handle_maxlength_attribute()
     }
 }
 
-// https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
-void HTMLInputElement::handle_readonly_attribute()
-{
-    // The readonly attribute is a boolean attribute that controls whether or not the user can edit the form control. When specified, the element is not mutable.
-    set_is_mutable(!is_readonly());
-}
-
 // https://html.spec.whatwg.org/multipage/input.html#the-input-element:attr-input-placeholder-3
 static bool is_allowed_to_have_placeholder(HTML::HTMLInputElement::TypeAttributeState state)
 {
@@ -1066,7 +1059,6 @@ void HTMLInputElement::create_text_input_shadow_tree()
     MUST(element->append_child(*m_inner_text_element));
 
     m_text_node = realm().create<DOM::Text>(document(), move(initial_value));
-    handle_readonly_attribute();
     if (type_state() == TypeAttributeState::Password)
         m_text_node->set_is_password_input({}, true);
     handle_maxlength_attribute();
@@ -1414,8 +1406,6 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
             m_placeholder_text_node->set_data(Utf16String::from_utf8(placeholder()));
             update_placeholder_visibility();
         }
-    } else if (name == HTML::AttributeNames::readonly) {
-        handle_readonly_attribute();
     } else if (name == HTML::AttributeNames::src) {
         handle_src_attribute(value.value_or({})).release_value_but_fixme_should_propagate_errors();
     } else if (name == HTML::AttributeNames::alt) {
@@ -2941,6 +2931,16 @@ bool HTMLInputElement::is_submit_button() const
     // https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image):concept-submit-button
     return type_state() == TypeAttributeState::SubmitButton
         || type_state() == TypeAttributeState::ImageButton;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#mutability
+bool HTMLInputElement::is_mutable() const
+{
+    // https://html.spec.whatwg.org/multipage/input.html#the-input-element:concept-fe-mutable-3
+    // When an input element is disabled, it is not mutable.
+    // https://html.spec.whatwg.org/multipage/input.html#the-readonly-attribute:concept-fe-mutable
+    // The readonly attribute is a boolean attribute that controls whether or not the user can edit the form control. When specified, the element is not mutable.
+    return enabled() && !is_readonly();
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -894,10 +894,10 @@ void HTMLInputElement::handle_maxlength_attribute()
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
-void HTMLInputElement::handle_readonly_attribute(Optional<String> const& maybe_value)
+void HTMLInputElement::handle_readonly_attribute()
 {
     // The readonly attribute is a boolean attribute that controls whether or not the user can edit the form control. When specified, the element is not mutable.
-    set_is_mutable(!maybe_value.has_value() || !is_allowed_to_be_readonly(m_type));
+    set_is_mutable(!is_readonly());
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#the-input-element:attr-input-placeholder-3
@@ -1066,7 +1066,7 @@ void HTMLInputElement::create_text_input_shadow_tree()
     MUST(element->append_child(*m_inner_text_element));
 
     m_text_node = realm().create<DOM::Text>(document(), move(initial_value));
-    handle_readonly_attribute(attribute(HTML::AttributeNames::readonly));
+    handle_readonly_attribute();
     if (type_state() == TypeAttributeState::Password)
         m_text_node->set_is_password_input({}, true);
     handle_maxlength_attribute();
@@ -1415,7 +1415,7 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
             update_placeholder_visibility();
         }
     } else if (name == HTML::AttributeNames::readonly) {
-        handle_readonly_attribute(value);
+        handle_readonly_attribute();
     } else if (name == HTML::AttributeNames::src) {
         handle_src_attribute(value.value_or({})).release_value_but_fixme_should_propagate_errors();
     } else if (name == HTML::AttributeNames::alt) {
@@ -2941,6 +2941,12 @@ bool HTMLInputElement::is_submit_button() const
     // https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image):concept-submit-button
     return type_state() == TypeAttributeState::SubmitButton
         || type_state() == TypeAttributeState::ImageButton;
+}
+
+// https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
+bool HTMLInputElement::is_readonly() const
+{
+    return attribute(HTML::AttributeNames::readonly).has_value() && is_allowed_to_be_readonly(m_type);
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -189,6 +189,9 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#concept-submit-button
     virtual bool is_submit_button() const override;
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#mutability
+    virtual bool is_mutable() const override;
+
     bool is_readonly() const;
 
     bool is_single_line() const;
@@ -322,7 +325,6 @@ private:
     void set_checked_within_group();
 
     void handle_maxlength_attribute();
-    void handle_readonly_attribute();
     WebIDL::ExceptionOr<void> handle_src_attribute(String const& value);
 
     void user_interaction_did_change_input_value();

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -189,6 +189,8 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#concept-submit-button
     virtual bool is_submit_button() const override;
 
+    bool is_readonly() const;
+
     bool is_single_line() const;
 
     virtual void reset_algorithm() override;
@@ -320,7 +322,7 @@ private:
     void set_checked_within_group();
 
     void handle_maxlength_attribute();
-    void handle_readonly_attribute(Optional<String> const& value);
+    void handle_readonly_attribute();
     WebIDL::ExceptionOr<void> handle_src_attribute(String const& value);
 
     void user_interaction_did_change_input_value();

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -376,7 +376,6 @@ void HTMLTextAreaElement::create_shadow_tree_if_needed()
     MUST(element->append_child(*m_inner_text_element));
 
     m_text_node = realm().create<DOM::Text>(document(), Utf16String {});
-    handle_readonly_attribute(attribute(HTML::AttributeNames::readonly));
     // NOTE: If `children_changed()` was called before now, `m_raw_value` will hold the text content.
     //       Otherwise, it will get filled in whenever that does get called.
     m_text_node->set_text_content(m_raw_value);
@@ -384,13 +383,6 @@ void HTMLTextAreaElement::create_shadow_tree_if_needed()
     MUST(m_inner_text_element->append_child(*m_text_node));
 
     update_placeholder_visibility();
-}
-
-// https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly
-void HTMLTextAreaElement::handle_readonly_attribute(Optional<String> const& maybe_value)
-{
-    // The readonly attribute is a boolean attribute that controls whether or not the user can edit the form control. When specified, the element is not mutable.
-    set_is_mutable(!maybe_value.has_value());
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength
@@ -442,8 +434,6 @@ void HTMLTextAreaElement::form_associated_element_attribute_changed(FlyString co
     if (name == HTML::AttributeNames::placeholder) {
         if (m_placeholder_text_node)
             m_placeholder_text_node->set_data(Utf16String::from_utf8(value.value_or(String {})));
-    } else if (name == HTML::AttributeNames::readonly) {
-        handle_readonly_attribute(value);
     } else if (name == HTML::AttributeNames::maxlength) {
         handle_maxlength_attribute();
     }
@@ -479,6 +469,13 @@ void HTMLTextAreaElement::queue_firing_input_event()
 bool HTMLTextAreaElement::is_focusable() const
 {
     return enabled();
+}
+
+bool HTMLTextAreaElement::is_mutable() const
+{
+    // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:concept-fe-mutable
+    // A textarea element is mutable if it is neither disabled nor has a readonly attribute specified.
+    return enabled() && !attribute(HTML::AttributeNames::readonly).has_value();
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element%3Asuffering-from-being-missing

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -64,6 +64,9 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#mutability
+    virtual bool is_mutable() const override;
+
     virtual void reset_algorithm() override;
     virtual void clear_algorithm() override;
 
@@ -147,7 +150,6 @@ private:
 
     void create_shadow_tree_if_needed();
 
-    void handle_readonly_attribute(Optional<String> const& value);
     void handle_maxlength_attribute();
 
     void queue_firing_input_event();

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-valueMissing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-valueMissing.txt
@@ -2,70 +2,70 @@ Harness status: OK
 
 Found 78 tests
 
-46 Pass
-32 Fail
+77 Pass
+1 Fail
 Pass	[INPUT in TEXT status] The required attribute is not set
 Pass	[INPUT in TEXT status] The value is not empty and required is true
-Fail	[INPUT in TEXT status] The value is empty and required is true
+Pass	[INPUT in TEXT status] The value is empty and required is true
 Pass	[INPUT in SEARCH status] The required attribute is not set
 Pass	[INPUT in SEARCH status] The value is not empty and required is true
-Fail	[INPUT in SEARCH status] The value is empty and required is true
+Pass	[INPUT in SEARCH status] The value is empty and required is true
 Pass	[INPUT in TEL status] The required attribute is not set
 Pass	[INPUT in TEL status] The value is not empty and required is true
-Fail	[INPUT in TEL status] The value is empty and required is true
+Pass	[INPUT in TEL status] The value is empty and required is true
 Pass	[INPUT in URL status] The required attribute is not set
 Pass	[INPUT in URL status] The value is not empty and required is true
-Fail	[INPUT in URL status] The value is empty and required is true
+Pass	[INPUT in URL status] The value is empty and required is true
 Pass	[INPUT in EMAIL status] The required attribute is not set
 Pass	[INPUT in EMAIL status] The value is not empty and required is true
-Fail	[INPUT in EMAIL status] The value is empty and required is true
+Pass	[INPUT in EMAIL status] The value is empty and required is true
 Pass	[INPUT in PASSWORD status] The required attribute is not set
 Pass	[INPUT in PASSWORD status] The value is not empty and required is true
-Fail	[INPUT in PASSWORD status] The value is empty and required is true
+Pass	[INPUT in PASSWORD status] The value is empty and required is true
 Pass	[INPUT in DATETIME-LOCAL status] The required attribute is not set
 Pass	[INPUT in DATETIME-LOCAL status] Valid local date and time string(2000-12-10T12:00:00)
 Pass	[INPUT in DATETIME-LOCAL status] Valid local date and time string(2000-12-10 12:00)
 Pass	[INPUT in DATETIME-LOCAL status] Valid local date and time string(1979-10-14T12:00:00.001)
-Fail	[INPUT in DATETIME-LOCAL status] The value attribute is a number(1234567)
-Fail	[INPUT in DATETIME-LOCAL status] The value attribute is a Date object
-Fail	[INPUT in DATETIME-LOCAL status] Invalid local date and time string(1979-10-99 99:99)
+Pass	[INPUT in DATETIME-LOCAL status] The value attribute is a number(1234567)
+Pass	[INPUT in DATETIME-LOCAL status] The value attribute is a Date object
+Pass	[INPUT in DATETIME-LOCAL status] Invalid local date and time string(1979-10-99 99:99)
 Pass	[INPUT in DATETIME-LOCAL status] Valid local date and time string(1979-10-14 12:00:00)
-Fail	[INPUT in DATETIME-LOCAL status] Invalid local date and time string(2001-12-21  12:00)-two white space
-Fail	[INPUT in DATETIME-LOCAL status] the value attribute is a string(abc)
-Fail	[INPUT in DATETIME-LOCAL status] The value attribute is empty string
+Pass	[INPUT in DATETIME-LOCAL status] Invalid local date and time string(2001-12-21  12:00)-two white space
+Pass	[INPUT in DATETIME-LOCAL status] the value attribute is a string(abc)
+Pass	[INPUT in DATETIME-LOCAL status] The value attribute is empty string
 Pass	[INPUT in DATE status] The required attribute is not set
 Pass	[INPUT in DATE status] Valid date string(2000-12-10)
 Pass	[INPUT in DATE status] Valid date string(9999-01-01)
-Fail	[INPUT in DATE status] The value attribute is a number(1234567)
-Fail	[INPUT in DATE status] The value attribute is a Date object
-Fail	[INPUT in DATE status] Invalid date string(9999-99-99)
-Fail	[INPUT in DATE status] Invalid date string(37-01-01)
-Fail	[INPUT in DATE status] Invalid date string(2000/01/01)
-Fail	[INPUT in DATE status] The value attribute is empty string
+Pass	[INPUT in DATE status] The value attribute is a number(1234567)
+Pass	[INPUT in DATE status] The value attribute is a Date object
+Pass	[INPUT in DATE status] Invalid date string(9999-99-99)
+Pass	[INPUT in DATE status] Invalid date string(37-01-01)
+Pass	[INPUT in DATE status] Invalid date string(2000/01/01)
+Pass	[INPUT in DATE status] The value attribute is empty string
 Pass	[INPUT in TIME status] The required attribute is not set
 Pass	[INPUT in TIME status] Validtime string(12:00:00)
 Pass	[INPUT in TIME status] Validtime string(12:00)
 Pass	[INPUT in TIME status] Valid time string(12:00:60.001)
 Pass	[INPUT in TIME status] Valid time string(12:00:60.01)
 Pass	[INPUT in TIME status] Valid time string(12:00:60.1)
-Fail	[INPUT in TIME status] The value attribute is a number(1234567)
-Fail	[INPUT in TIME status] The value attribute is a time object
-Fail	[INPUT in TIME status] Invalid time string(25:00:00)
-Fail	[INPUT in TIME status] Invalid time string(12:60:00)
-Fail	[INPUT in TIME status] Invalid time string(12:00:60)
-Fail	[INPUT in TIME status] Invalid time string(12:00:00:001)
-Fail	[INPUT in TIME status] The value attribute is empty string
+Pass	[INPUT in TIME status] The value attribute is a number(1234567)
+Pass	[INPUT in TIME status] The value attribute is a time object
+Pass	[INPUT in TIME status] Invalid time string(25:00:00)
+Pass	[INPUT in TIME status] Invalid time string(12:60:00)
+Pass	[INPUT in TIME status] Invalid time string(12:00:60)
+Pass	[INPUT in TIME status] Invalid time string(12:00:00:001)
+Pass	[INPUT in TIME status] The value attribute is empty string
 Pass	[INPUT in NUMBER status] The required attribute is not set
 Pass	[INPUT in NUMBER status] Value is an integer with a leading symbol '+'
 Pass	[INPUT in NUMBER status] Value is a number with a '-' symbol
 Pass	[INPUT in NUMBER status] Value is a number in scientific notation form(e is in lowercase)
 Pass	[INPUT in NUMBER status] Value is a number in scientific notation form(E is in uppercase)
 Pass	[INPUT in NUMBER status] Value is -0
-Fail	[INPUT in NUMBER status] Value is a number with some white spaces
-Fail	[INPUT in NUMBER status] Value is Math.pow(2, 1024)
-Fail	[INPUT in NUMBER status] Value is Math.pow(-2, 1024)
-Fail	[INPUT in NUMBER status] Value is a string that cannot be converted to a number
-Fail	[INPUT in NUMBER status] The value attribute is empty string
+Pass	[INPUT in NUMBER status] Value is a number with some white spaces
+Pass	[INPUT in NUMBER status] Value is Math.pow(2, 1024)
+Pass	[INPUT in NUMBER status] Value is Math.pow(-2, 1024)
+Pass	[INPUT in NUMBER status] Value is a string that cannot be converted to a number
+Pass	[INPUT in NUMBER status] The value attribute is empty string
 Pass	[INPUT in CHECKBOX status] The required attribute is not set
 Pass	[INPUT in CHECKBOX status] The checked attribute is true
 Pass	[INPUT in CHECKBOX status] The checked attribute is false
@@ -80,5 +80,5 @@ Pass	[select]  Selected the option with value equals to 1
 Pass	[select]  Selected the option with value equals to empty
 Pass	[textarea]  The required attribute is not set
 Pass	[textarea]  The value is not empty
-Fail	[textarea]  The value is empty
+Pass	[textarea]  The value is empty
 Fail	validationMessage should return empty string when willValidate is false and valueMissing is true


### PR DESCRIPTION
This lets Ladybird pass all but one of the [form-validation-validity-valueMissing](https://wpt.fyi/results/html/semantics/forms/constraints/form-validation-validity-valueMissing.html?label=master&product=chrome%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&aligned) subtests. (Specifically, we still fail the subtest pertaining to `validationMessage`.)

This change also seems to pass a total of 78 subtests when including other test files in `html/semantics/forms`:
* `constraints/form-validation-validity-valid-weekmonth.html`
* `constraints/form-validation-validity-valid.html`
* `constraints/form-validation-validity-valueMissing-weekmonth.html`
* `the-input-element/show-picker-disabled-readonly.html`