### PR TITLE
LibWeb: Handle `text-overflow: ellipsis` with trailing whitespace

### DIFF
--- a/Tests/LibWeb/Ref/expected/text-overflow-ellipsis-with-trailing-whitespace-ref.html
+++ b/Tests/LibWeb/Ref/expected/text-overflow-ellipsis-with-trailing-whitespace-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<span>abc</span>

--- a/Tests/LibWeb/Ref/input/text-overflow-ellipsis-with-trailing-whitespace.html
+++ b/Tests/LibWeb/Ref/input/text-overflow-ellipsis-with-trailing-whitespace.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/text-overflow-ellipsis-with-trailing-whitespace-ref.html" />
+<style>
+    #foo {
+        display: inline-block;
+        width: min-content;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        text-wrap: nowrap;
+    }
+</style>
+<span id="foo">abc </span>


### PR DESCRIPTION
We should calculate whether we need to truncate text with an ellipsis exclusive of any trailing collapsible whitespace.

This was causing issues where an inline element was automatically sized (e.g. min-content) as we would calculate available width exclusive of trailing collapsible whitespace and then our text chunk would be wider, always inserting an ellipsis.

Fixes the visual element of #4048 but we still are incorrect in how we collapse whitespace more generally