### PR TITLE
LibWeb: Avoid premature layout of absolutely positioned children of `td`

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -889,10 +889,8 @@ void TableFormattingContext::compute_table_height()
         // - the horizontal/vertical border-spacing times the amount of spanned visible columns/rows minus one
         // FIXME: Account for visibility.
         cell_state.set_content_width(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
-        if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, cell_state.available_inner_space_or_constraints_from(*m_available_space))) {
+        if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, cell_state.available_inner_space_or_constraints_from(*m_available_space)))
             cell_state.set_content_height(independent_formatting_context->automatic_content_height());
-            independent_formatting_context->parent_context_did_dimension_child_root_box();
-        }
 
         cell.baseline = box_baseline(cell.box);
 
@@ -1174,6 +1172,9 @@ void TableFormattingContext::position_cell_boxes()
         cell_state.offset = row_state.offset.translated(
             cell_state.border_box_left() + m_columns[cell.column_index].left_offset + cell.column_index * border_spacing_horizontal(),
             cell_state.border_box_top());
+
+        if (auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, cell.box))
+            independent_formatting_context->parent_context_did_dimension_child_root_box();
     }
 }
 

--- a/Tests/LibWeb/Layout/expected/abspos-td-child.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-td-child.txt
@@ -1,0 +1,46 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x120 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x104 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 6x104 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 6x104 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (10,10) content-size 2x100 table-row-group children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (10,10) content-size 2x100 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,60) content-size 0x0 positioned table-cell [BFC] children: inline
+                TextNode <#text>
+                BlockContainer <div> at (11,92) content-size 27.15625x18 positioned [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [11,92 27.15625x18] baseline: 13.796875
+                      "foo"
+                  TextNode <#text>
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+      BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x120] overflow: [0,0 800x160]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104] overflow: [8,8 784x152]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x104] overflow: [8,8 30.15625x152]
+        PaintableBox (Box<TABLE>) [8,8 6x104]
+          PaintableBox (Box<TBODY>) [10,10 2x100]
+            PaintableBox (Box<TR>) [10,10 2x100]
+              PaintableWithLines (BlockContainer<TD>) [10,10 2x100] overflow: [10,10 28.15625x150]
+                PaintableWithLines (BlockContainer<DIV>) [11,92 27.15625x18]
+                  TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x120] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/abspos-td-child.html
+++ b/Tests/LibWeb/Layout/input/abspos-td-child.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <table style="height: 100px">
+            <tbody>
+                <tr>
+                    <td style="position: relative">
+                        <div style="position: absolute; bottom: 0">foo</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
Absolute positions are relative to the padding edge of the containing block, this means that we should only layout absolutely positioned children of a containing block once that block has had it's padding finalized.

Previously we would layout absolutely positioned children of table cells before we added padding related to vertical alignment which meant that children positioned relative to `top` or `bottom` could appear in the wrong position.