### PR TITLE
LibWeb+LibWebView+Base: Add basic parental controls

### DIFF
--- a/Base/res/ladybird/about-pages/about.html
+++ b/Base/res/ladybird/about-pages/about.html
@@ -9,6 +9,7 @@
     <h1>List of About URLs</h1>
     <ul>
         <li><a href="about:about">about:about</a></li>
+        <li><a href="about:blocked">about:blocked</a></li>
         <li><a href="about:newtab">about:newtab</a></li>
         <li><a href="about:processes">about:processes</a></li>
         <li><a href="about:settings">about:settings</a></li>

--- a/Base/res/ladybird/about-pages/blocked.html
+++ b/Base/res/ladybird/about-pages/blocked.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="color-scheme" content="light dark">
+    <title>Blocked by Parental Controls</title>
+</head>
+<body>
+    <h1>Blocked by Parental Controls</h1>
+    <p>
+        The page you were trying to access has been blocked by parental controls.
+    </p>
+</body>
+</html>

--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -378,6 +378,19 @@
         </div>
 
         <div class="card">
+            <div class="card-header">Parental Controls</div>
+            <div class="card-body">
+                <div class="card-group inline-container">
+                    <div>
+                        <label for="adult-content-toggle">Block websites that contain adult content</label>
+                        <p class="description">This will block pages which identify themselves as containing adult content.</p>
+                    </div>
+                    <input id="adult-content-toggle" type="checkbox" switch />
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
             <div class="card-header">Network</div>
             <div class="card-body">
                 <div class="card-group">
@@ -515,6 +528,7 @@
         <script src="resource://ladybird/about-pages/settings/permissions.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/privacy.js" type="module"></script>
         <script src="resource://ladybird/about-pages/settings/search.js" type="module"></script>
+        <script src="resource://ladybird/about-pages/settings/parentalControls.js" type="module"></script>
 
         <script type="module">
             const restoreDefaults = document.querySelector("#restore-defaults");

--- a/Base/res/ladybird/about-pages/settings/parentalControls.js
+++ b/Base/res/ladybird/about-pages/settings/parentalControls.js
@@ -1,0 +1,15 @@
+const adultContentToggle = document.querySelector("#adult-content-toggle");
+
+function loadSettings(settings) {
+    adultContentToggle.checked = settings.blockAdultContent;
+}
+
+adultContentToggle.addEventListener("change", () => {
+    ladybird.sendMessage("setBlockAdultContent", adultContentToggle.checked);
+});
+
+document.addEventListener("WebUIMessage", event => {
+    if (event.detail.name === "loadSettings") {
+        loadSettings(event.detail.data);
+    }
+});

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -205,6 +205,7 @@ bool is_public_suffix(StringView host);
 Optional<String> get_registrable_domain(StringView host);
 
 inline URL about_blank() { return URL::about("blank"_string); }
+inline URL about_blocked() { return URL::about("blocked"_string); }
 inline URL about_srcdoc() { return URL::about("srcdoc"_string); }
 inline URL about_error() { return URL::about("error"_string); }
 inline URL about_version() { return URL::about("version"_string); }

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -66,6 +66,9 @@ public:
     bool enable_do_not_track() const { return m_enable_do_not_track; }
     void set_enable_do_not_track(bool enable) { m_enable_do_not_track = enable; }
 
+    bool enable_block_adult_content() const { return m_enable_block_adult_content; }
+    void set_enable_block_adult_content(bool enable) { m_enable_block_adult_content = enable; }
+
     void clear_cache();
     void evict_from_cache(LoadRequest const&);
 
@@ -89,6 +92,7 @@ private:
     Vector<String> m_preferred_languages = { "en"_string };
     NavigatorCompatibilityMode m_navigator_compatibility_mode;
     bool m_enable_do_not_track { false };
+    bool m_enable_block_adult_content { false };
 };
 
 }

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -25,6 +25,11 @@ struct SiteSetting {
     OrderedHashTable<String> site_filters;
 };
 
+enum class BlockAdultContent {
+    No,
+    Yes,
+};
+
 enum class DoNotTrack {
     No,
     Yes,
@@ -40,6 +45,7 @@ public:
     virtual void search_engine_changed() { }
     virtual void autocomplete_engine_changed() { }
     virtual void autoplay_settings_changed() { }
+    virtual void block_adult_content_changed() { }
     virtual void do_not_track_changed() { }
     virtual void dns_settings_changed() { }
 };
@@ -75,6 +81,9 @@ public:
     void remove_autoplay_site_filter(String const&);
     void remove_all_autoplay_site_filters();
 
+    BlockAdultContent block_adult_content() const { return m_block_adult_content; }
+    void set_block_adult_content(BlockAdultContent);
+
     DoNotTrack do_not_track() const { return m_do_not_track; }
     void set_do_not_track(DoNotTrack);
 
@@ -100,6 +109,7 @@ private:
     Vector<SearchEngine> m_custom_search_engines;
     Optional<AutocompleteEngine> m_autocomplete_engine;
     SiteSetting m_autoplay;
+    BlockAdultContent m_block_adult_content { BlockAdultContent::No };
     DoNotTrack m_do_not_track { DoNotTrack::No };
     DNSSettings m_dns_settings { SystemDNS() };
     bool m_dns_override_by_command_line { false };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -602,6 +602,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
 
     languages_changed();
     autoplay_settings_changed();
+    block_adult_content_changed();
     do_not_track_changed();
 }
 
@@ -665,6 +666,12 @@ void ViewImplementation::autoplay_settings_changed()
         client().async_set_autoplay_allowed_on_all_websites(page_id());
     else
         client().async_set_autoplay_allowlist(page_id(), autoplay_settings.site_filters.values());
+}
+
+void ViewImplementation::block_adult_content_changed()
+{
+    auto block_adult_content = Application::settings().block_adult_content();
+    client().async_set_enable_block_adult_content(page_id(), block_adult_content == BlockAdultContent::Yes);
 }
 
 void ViewImplementation::do_not_track_changed()

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -266,6 +266,7 @@ protected:
 
     virtual void languages_changed() override;
     virtual void autoplay_settings_changed() override;
+    virtual void block_adult_content_changed() override;
     virtual void do_not_track_changed() override;
 
     struct SharedBitmap {

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -60,6 +60,9 @@ void SettingsUI::register_interfaces()
         remove_all_site_setting_filters(data);
     });
 
+    register_interface("setBlockAdultContent"sv, [this](auto const& data) {
+        set_block_adult_content(data);
+    });
     register_interface("setDoNotTrack"sv, [this](auto const& data) {
         set_do_not_track(data);
     });
@@ -261,6 +264,14 @@ void SettingsUI::remove_all_site_setting_filters(JsonValue const& site_setting)
     }
 
     load_current_settings();
+}
+
+void SettingsUI::set_block_adult_content(JsonValue const& block_adult_content)
+{
+    if (!block_adult_content.is_bool())
+        return;
+
+    WebView::Application::settings().set_block_adult_content(block_adult_content.as_bool() ? BlockAdultContent::Yes : BlockAdultContent::No);
 }
 
 void SettingsUI::set_do_not_track(JsonValue const& do_not_track)

--- a/Libraries/LibWebView/WebUI/SettingsUI.h
+++ b/Libraries/LibWebView/WebUI/SettingsUI.h
@@ -34,6 +34,8 @@ private:
     void remove_site_setting_filter(JsonValue const&);
     void remove_all_site_setting_filters(JsonValue const&);
 
+    void set_block_adult_content(JsonValue const&);
+
     void set_do_not_track(JsonValue const&);
 
     void set_dns_settings(JsonValue const&);

--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -270,6 +270,7 @@ web_resources = [
 
 about_pages = [
   "//Base/res/ladybird/about-pages/about.html",
+  "//Base/res/ladybird/about-pages/blocked.html",
   "//Base/res/ladybird/about-pages/newtab.html",
 ]
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1135,6 +1135,11 @@ void ConnectionFromClient::set_preferred_languages(u64, Vector<String> preferred
     Web::ResourceLoader::the().set_preferred_languages(move(preferred_languages));
 }
 
+void ConnectionFromClient::set_enable_block_adult_content(u64, bool enable)
+{
+    Web::ResourceLoader::the().set_enable_block_adult_content(enable);
+}
+
 void ConnectionFromClient::set_enable_do_not_track(u64, bool enable)
 {
     Web::ResourceLoader::the().set_enable_do_not_track(enable);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -108,6 +108,7 @@ private:
     virtual void set_preferred_contrast(u64 page_id, Web::CSS::PreferredContrast) override;
     virtual void set_preferred_motion(u64 page_id, Web::CSS::PreferredMotion) override;
     virtual void set_preferred_languages(u64 page_id, Vector<String>) override;
+    virtual void set_enable_block_adult_content(u64 page_id, bool) override;
     virtual void set_enable_do_not_track(u64 page_id, bool) override;
     virtual void set_has_focus(u64 page_id, bool) override;
     virtual void set_is_scripting_enabled(u64 page_id, bool) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -95,6 +95,7 @@ endpoint WebContentServer
     set_preferred_contrast(u64 page_id, Web::CSS::PreferredContrast contrast) =|
     set_preferred_motion(u64 page_id, Web::CSS::PreferredMotion motion) =|
     set_preferred_languages(u64 page_id, Vector<String> preferred_languages) =|
+    set_enable_block_adult_content(u64 page_id, bool enable) =|
     set_enable_do_not_track(u64 page_id, bool enable) =|
     set_has_focus(u64 page_id, bool has_focus) =|
     set_is_scripting_enabled(u64 page_id, bool is_scripting_enabled) =|

--- a/UI/Qt/Settings.h
+++ b/UI/Qt/Settings.h
@@ -46,6 +46,7 @@ public:
 
 signals:
     void show_menubar_changed(bool show_menubar);
+    void enable_block_adult_content_changed(bool enable);
     void enable_do_not_track_changed(bool enable);
 
 protected:

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -68,6 +68,7 @@ list(TRANSFORM INTERNAL_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladyb
 
 set(ABOUT_PAGES
     about.html
+    blocked.html
     newtab.html
     processes.html
     settings.html
@@ -78,6 +79,7 @@ set(ABOUT_SETTINGS_RESOURCES
     languages.js
     network.js
     new-tab-page.js
+    parentalControls.js
     permissions.js
     privacy.js
     search.js


### PR DESCRIPTION
Adds very basic parental controls to the settings to block websites with adult content on them. If you need an adult website to test this with, pornhub.com includes the relevant meta tags on their site. (I've also tested quite a few other adult sites to see how well the coverage is, it seems like most adult websites use at least one of these)

About the checked tags:
`"adult"` - commonly used on porn sites, seems to be given as a recommendation online
`"RTA-5042-1996-1400-1577-RTA"` - The [Restricted to Adults label](https://www.rtalabel.org/), probably the closest thing to a standard that exists here.* Also commonly used.
`"mature"` - used on some NSFW image boards, such as rule34.xxx

I did consider just checking for the presence of a rating meta tag, but some image boards (like safebooru.org) set it to "general" to indicate that the content is NOT adult content.

Note: Of course this setting is awful as actual parental controls, since any kid could just disable it. For that, we might want to consider password-locking this somehow or tying into the OS's parental control options in the future.

\* Except for the two actual standards that exist for this:
1. [age.xml](https://www.jugendschutzprogramm.de/en/provider/age-xml/), which is a lot more complex and therefore used a lot less on actual pages out in the wild. (example: pornhub does not have an age.xml)
2. The `prefer: safe` HTTP header. [Firefox sends this](https://blog.mozilla.org/netpolicy/2014/07/22/prefersafe-making-online-safety-simpler-in-firefox/) when the OS has parental controls enabled, though I'm not sure if websites actually respect that. It also comes with similar problems as the Do Not Track header, giving the server an extra bit of a user's tracking footprint + potentially informing bad actors of the fact that a user has parental controls enabled. (= is probably underage)