### PR TITLE
LibWeb: A couple fetch/navigables spec changes

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -545,9 +545,8 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
             if (internal_response->url_list().is_empty())
                 internal_response->set_url_list(request->url_list());
 
-            // 17. If request has a redirect-tainted origin, then set internalResponse’s has-cross-origin-redirects to true.
-            if (request->has_redirect_tainted_origin())
-                internal_response->set_has_cross_origin_redirects(true);
+            // 17. Set internalResponse’s redirect taint to request’s redirect-taint.
+            internal_response->set_redirect_taint(request->redirect_taint());
 
             // 18. If request’s timing allow failed flag is unset, then set internalResponse’s timing allow passed flag.
             if (!request->timing_allow_failed())
@@ -706,8 +705,8 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
             // 6. Let responseStatus be 0.
             auto response_status = 0;
 
-            // 7. If fetchParams’s request’s mode is not "navigate" or response’s has-cross-origin-redirects is false:
-            if (fetch_params.request()->mode() != Infrastructure::Request::Mode::Navigate || !response.has_cross_origin_redirects()) {
+            // 7. If fetchParams’s request’s mode is not "navigate" or response’s redirect taint is "same-origin":
+            if (fetch_params.request()->mode() != Infrastructure::Request::Mode::Navigate || response.redirect_taint() == Infrastructure::RedirectTaint::SameOrigin) {
                 // 1. Set responseStatus to response’s status.
                 response_status = response.status();
 

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
@@ -47,6 +47,12 @@ enum class HttpQuotedStringExtractValue {
     Yes,
 };
 
+enum class RedirectTaint {
+    SameOrigin,
+    SameSite,
+    CrossSite,
+};
+
 [[nodiscard]] String collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStringExtractValue extract_value = HttpQuotedStringExtractValue::No);
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -19,6 +19,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/Origin.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Headers.h>
 #include <LibWeb/HTML/PolicyContainers.h>
@@ -310,7 +311,7 @@ public:
     [[nodiscard]] bool is_non_subresource_request() const;
     [[nodiscard]] bool is_navigation_request() const;
 
-    [[nodiscard]] bool has_redirect_tainted_origin() const;
+    [[nodiscard]] RedirectTaint redirect_taint() const;
 
     [[nodiscard]] String serialize_origin() const;
     [[nodiscard]] ByteBuffer byte_serialize_origin() const;

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.h
@@ -228,6 +228,9 @@ public:
     [[nodiscard]] OriginType const& origin() const { return m_origin; }
     void set_origin(OriginType origin) { m_origin = move(origin); }
 
+    [[nodiscard]] Optional<URL::Origin> const& top_level_navigation_initiator_origin() const { return m_top_level_navigation_initiator_origin; }
+    void set_top_level_navigation_initiator_origin(Optional<URL::Origin> top_level_navigation_initiator_origin) { m_top_level_navigation_initiator_origin = move(top_level_navigation_initiator_origin); }
+
     [[nodiscard]] PolicyContainerType const& policy_container() const { return m_policy_container; }
     void set_policy_container(PolicyContainerType policy_container) { m_policy_container = move(policy_container); }
 
@@ -416,6 +419,10 @@ private:
     // https://fetch.spec.whatwg.org/#concept-request-origin
     // A request has an associated origin, which is "client" or an origin. Unless stated otherwise it is "client".
     OriginType m_origin { Origin::Client };
+
+    // https://fetch.spec.whatwg.org/#request-top-level-navigation-initiator-origin
+    // A request has an associated top-level navigation initiator origin, which is an origin or null. Unless stated otherwise it is null.
+    Optional<URL::Origin> m_top_level_navigation_initiator_origin;
 
     // https://fetch.spec.whatwg.org/#concept-request-policy-container
     // A request has an associated policy container, which is "client" or a policy container. Unless stated otherwise

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -16,6 +16,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibURL/URL.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Headers.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Statuses.h>
@@ -103,8 +104,8 @@ public:
     [[nodiscard]] virtual BodyInfo const& body_info() const { return m_body_info; }
     virtual void set_body_info(BodyInfo body_info) { m_body_info = body_info; }
 
-    [[nodiscard]] bool has_cross_origin_redirects() const { return m_has_cross_origin_redirects; }
-    void set_has_cross_origin_redirects(bool has_cross_origin_redirects) { m_has_cross_origin_redirects = has_cross_origin_redirects; }
+    [[nodiscard]] RedirectTaint redirect_taint() const { return m_redirect_taint; }
+    void set_redirect_taint(RedirectTaint redirect_taint) { m_redirect_taint = move(redirect_taint); }
 
     [[nodiscard]] bool is_aborted_network_error() const;
     [[nodiscard]] bool is_network_error() const;
@@ -188,9 +189,9 @@ private:
     // https://fetch.spec.whatwg.org/#response-service-worker-timing-info
     // FIXME: A response has an associated service worker timing info (null or a service worker timing info), which is initially null.
 
-    // https://fetch.spec.whatwg.org/#response-has-cross-origin-redirects
-    // A response has an associated has-cross-origin-redirects (a boolean), which is initially false.
-    bool m_has_cross_origin_redirects { false };
+    // https://fetch.spec.whatwg.org/#response-redirect-taint
+    // A response has an associated redirect taint ("same-origin", "same-site", or "cross-site"), which is initially "same-origin".
+    RedirectTaint m_redirect_taint { RedirectTaint::SameOrigin };
 
     // FIXME is the type correct?
     u64 current_age() const;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -866,7 +866,10 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
     request->set_referrer(entry->document_state()->request_referrer());
     request->set_policy_container(source_snapshot_params.source_policy_container);
 
-    // FIXME: 4. If navigable is a top-level traversable, then set request's top-level navigation initiator origin to entry's document state's initiator origin.
+    // 4. If navigable is a top-level traversable, then set request's top-level navigation initiator origin to entry's
+    //    document state's initiator origin.
+    if (navigable->top_level_traversable()->parent() == nullptr)
+        request->set_top_level_navigation_initiator_origin(entry->document_state()->origin());
 
     // 5. If request's client is null:
     if (request->client() == nullptr) {


### PR DESCRIPTION
LibWeb: Pass top-level navigation initiator origin to Fetch's Request
- https://github.com/whatwg/html/pull/10991

LibWeb: Update Fetch's compute the redirect-taint concept
- https://github.com/whatwg/fetch/pull/1807