### PR TITLE
LibWeb: Fix cyclic percentage resolution in calculate_min_content_width

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1442,6 +1442,20 @@ CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box
 
 CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box) const
 {
+    if (box.is_replaced_box()) {
+        // https://www.w3.org/TR/css-sizing-3/#replaced-percentage-min-contribution
+        // NOTE: If the box is replaced, a cyclic percentage in the value of any max size property or
+        //       preferred size property (width/max-width/height/max-height), is resolved against zero
+        //       when calculating the min-content contribution in the corresponding axis.
+        // FIXME: If the box also has a preferred aspect ratio, then this min-content contribution is
+        //        floored by any <length-percentage> minimum size from the opposite axis—resolving any
+        //        such percentage against zero—transferred through the preferred aspect ratio.
+        if (auto const& width = box.computed_values().width(); width.is_percentage())
+            return width.to_px(box, 0);
+        if (auto const& max_width = box.computed_values().max_width(); max_width.is_percentage())
+            return max_width.to_px(box, 0);
+    }
+
     if (box.has_natural_width())
         return *box.natural_width();
 

--- a/Tests/LibWeb/Layout/expected/grid/replaced-box-with-percentage-max-width-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/replaced-box-with-percentage-max-width-2.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 50x50 [BFC] children: not-inline
+    Box <body> at (0,0) content-size 50x50 [GFC] children: not-inline
+      Box <div> at (0,0) content-size 50x50 [GFC] children: not-inline
+        ImageBox <img> at (0,0) content-size 50x50 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 50x50]
+    PaintableBox (Box<BODY>) [0,0 50x50]
+      PaintableBox (Box<DIV>) [0,0 50x50]
+        ImagePaintable (ImageBox<IMG>) [0,0 50x50]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 50x50] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/replaced-box-with-percentage-max-width-2.html
+++ b/Tests/LibWeb/Layout/input/grid/replaced-box-with-percentage-max-width-2.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    html { width: 50px; margin: 0 }
+    body { display: grid; margin: 0 }
+    div { display: grid; }
+    img { max-width: 100%; }
+</style><body><div><img src="../../../Assets/120.png">


### PR DESCRIPTION
Brings back some code removed in 652a457, but this time with explanation from https://www.w3.org/TR/css-sizing-3 spec.