### PR TITLE
LibWeb: Don't indicate focus for all form associated elements

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4078,7 +4078,7 @@ bool Element::should_indicate_focus() const
 
     // * If the element which supports keyboard input (such as an input element, or any other element that would
     //   triggers a virtual keyboard to be shown on focus if a physical keyboard were not present), indicate focus.
-    if (is<HTML::FormAssociatedElement>(this))
+    if (is<HTML::FormAssociatedTextControlElement>(this))
         return true;
 
     // * If the user interacts with the page via keyboard or some other non-pointing device, indicate focus. (This means

--- a/Tests/LibWeb/Text/expected/focus-shouldIndicateFocus.txt
+++ b/Tests/LibWeb/Text/expected/focus-shouldIndicateFocus.txt
@@ -1,0 +1,2 @@
+INPUT: rgb(0, 0, 0) auto 3px
+BUTTON: rgb(0, 0, 0) 0px

--- a/Tests/LibWeb/Text/input/focus-shouldIndicateFocus.html
+++ b/Tests/LibWeb/Text/input/focus-shouldIndicateFocus.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<input value="foo"><br>
+<button>bar</button>
+<script src="include.js"></script>
+<script>
+test(() => {
+    const reportOutline = e => { println(`${e.target.tagName}: ${window.getComputedStyle(e.target).outline}`); }
+    const runOutlineTest = (selector) => {
+        const elm = document.querySelector(selector);
+        elm.addEventListener('focus', reportOutline);
+        internals.click(elm.offsetLeft + 5, elm.offsetTop + 5);
+    };
+
+    runOutlineTest('input');
+    runOutlineTest('button');
+});
+</script>


### PR DESCRIPTION
This was a misinterpretation of the spec; we should only indicate focus if the form associated element supports keyboard input, for which FormAssociatedTextControlElement is a much better match.