### PR TITLE
WebDriver: Make WebDriver unix socket fixed length

### DIFF
--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -254,7 +254,7 @@ ErrorOr<void> Session::start(LaunchBrowserCallback const& launch_browser_callbac
 {
     auto promise = ServerPromise::construct();
 
-    m_web_content_socket_path = ByteString::formatted("{}/webdriver/session_{}_{}", TRY(Core::StandardPaths::runtime_directory()), getpid(), m_session_id);
+    m_web_content_socket_path = ByteString::formatted("{}/webdriver/session_{}_{}", Core::StandardPaths::tempfile_directory(), getpid(), m_session_id);
     m_web_content_server = TRY(create_server(promise));
 
     m_browser_process = TRY(launch_browser_callback(*m_web_content_socket_path, m_options.headless));

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -100,7 +100,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     Web::WebDriver::set_default_interface_mode(headless ? Web::WebDriver::InterfaceMode::Headless : Web::WebDriver::InterfaceMode::Graphical);
 
-    auto webdriver_socket_path = ByteString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
+    auto webdriver_socket_path = ByteString::formatted("{}/webdriver", Core::StandardPaths::tempfile_directory());
     TRY(Core::Directory::create(webdriver_socket_path, Core::Directory::CreateDirectories::Yes));
 
     Core::EventLoop loop;


### PR DESCRIPTION
Unix socket max length of 104 characters on mac and 109 on Linux makes runing WPT locally unable to connect to the WebDriver for users with long usernames.
This places the socket in `/tmp/...` excluding the username from the socket path.

See [discusstion in test channel](https://discord.com/channels/1247070541085671459/1247090166909374474/1402663665722720286)