### PR TITLE
LibWeb: Process <iframe> attributes synchronously after insertion

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLFrameElement.h>
+#include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 
 namespace Web::HTML {
@@ -50,10 +51,15 @@ void HTMLFrameElement::inserted()
 
     // 3. Create a new child navigable for insertedNode.
     MUST(create_new_child_navigable(GC::create_function(realm().heap(), [this] {
-        // 4. Process the frame attributes for insertedNode, with initialInsertion set to true.
-        process_the_frame_attributes(InitialInsertion::Yes);
         set_content_navigable_has_session_history_entry_and_ready_for_navigation();
     })));
+
+    // 4. Process the frame attributes for insertedNode, with initialInsertion set to true.
+    process_the_frame_attributes(InitialInsertion::Yes);
+
+    // FIXME: See related FIXME in HTMLIFrameElement.cpp
+    if (auto navigable = content_navigable())
+        navigable->traversable_navigable()->synchronously_spin_session_history_traversal_queue_fixme();
 }
 
 // https://html.spec.whatwg.org/multipage/obsolete.html#frames:html-element-removing-steps

--- a/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
+++ b/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
@@ -50,12 +50,14 @@ public:
 
     void append(GC::Ref<GC::Function<void()>> steps);
     void append_sync(GC::Ref<GC::Function<void()>> steps, GC::Ptr<Navigable> target_navigable);
+    void synchronously_spin_fixme() { spin(); }
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#sync-navigations-jump-queue
     GC::Ptr<SessionHistoryTraversalQueueEntry> first_synchronous_navigation_steps_with_target_navigable_not_contained_in(HashTable<GC::Ref<Navigable>> const&);
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;
+    void spin();
 
     Vector<GC::Ref<SessionHistoryTraversalQueueEntry>> m_queue;
     RefPtr<Core::Timer> m_timer;

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -96,6 +96,11 @@ public:
         m_session_history_traversal_queue->append_sync(steps, target_navigable);
     }
 
+    void synchronously_spin_session_history_traversal_queue_fixme()
+    {
+        m_session_history_traversal_queue->synchronously_spin_fixme();
+    }
+
     String window_handle() const { return m_window_handle; }
     void set_window_handle(String window_handle) { m_window_handle = move(window_handle); }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	load event fires synchronously on <iframe> element created with no src
+Pass	load event fires synchronously on <iframe> element created with src=''
+Pass	load event fires synchronously on <iframe> element created with src='about:blank'
+Pass	load event fires synchronously on <iframe> element created with src='about:blank#foo'
+Pass	load event fires synchronously on <iframe> element created with src='about:blank?foo'

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>"load" event fires on the iframe element when loading the initial empty document</title>
+<script src="../../../../../resources/testharness.js"></script>
+<script src="../../../../../resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+<body></body>
+<script>
+"use strict";
+
+promise_test(async t => {
+  const iframe = document.createElement("iframe");
+  let loadCount = 0;
+  iframe.addEventListener("load", () => {
+    loadCount++;
+  });
+  document.body.appendChild(iframe);
+  assert_equals(loadCount, 1);
+}, "load event fires synchronously on <iframe> element created with no src");
+
+promise_test(async t => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "";
+  let loadCount = 0;
+  iframe.addEventListener("load", () => {
+    loadCount++;
+  });
+  document.body.appendChild(iframe);
+  assert_equals(loadCount, 1);
+}, "load event fires synchronously on <iframe> element created with src=''");
+
+promise_test(async t => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "about:blank";
+  let loadCount = 0;
+  iframe.addEventListener("load", () => {
+    loadCount++;
+  });
+  document.body.appendChild(iframe);
+  assert_equals(loadCount, 1);
+}, "load event fires synchronously on <iframe> element created with src='about:blank'");
+
+promise_test(async t => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "about:blank#foo";
+  let loadCount = 0;
+  iframe.addEventListener("load", () => {
+    loadCount++;
+  });
+  document.body.appendChild(iframe);
+  assert_equals(loadCount, 1);
+}, "load event fires synchronously on <iframe> element created with src='about:blank#foo'");
+
+promise_test(async t => {
+  const iframe = document.createElement("iframe");
+  iframe.src = "about:blank?foo";
+  let loadCount = 0;
+  iframe.addEventListener("load", () => {
+    loadCount++;
+  });
+  document.body.appendChild(iframe);
+  assert_equals(loadCount, 1);
+}, "load event fires synchronously on <iframe> element created with src='about:blank?foo'");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/resources/helpers.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/resources/helpers.js
@@ -1,0 +1,121 @@
+// Returns a promise that asserts the "load" and "pageshow" events are not
+// fired on |target|.
+function assertNoLoadAndPageshowEvent(t, target) {
+  target.addEventListener("load", t.unreached_func("load should not be fired"));
+  target.addEventListener("pageshow", t.unreached_func("pageshow should not be fired"));
+  return new Promise(resolve => {
+    // Wait 50ms to ensure events fired after asynchronous navigations are
+    // also captured.
+    setTimeout(resolve, 50);
+  });
+}
+
+const url204 = "/common/blank.html?pipe=status(204)";
+const postMessageToOpenerOnLoad = `
+    window.onload = () => {
+      window.opener.postMessage("loaded", "*")
+    }
+  `;
+
+// -- Start of helpers for iframe initial empty document tests.
+
+// Creates an iframe with an unset src and appends it to the document.
+window.insertIframe = (t) => {
+  const iframe = document.createElement("iframe");
+  t.add_cleanup(() => iframe.remove());
+  document.body.append(iframe);
+  return iframe;
+};
+
+// Creates an iframe with src set to a URL that doesn't commit a new document
+// (results in a HTTP 204 response) and appends it to the document.
+window.insertIframeWith204Src = (t) => {
+  const iframe = document.createElement("iframe");
+  iframe.src = url204;
+  t.add_cleanup(() => iframe.remove());
+  document.body.append(iframe);
+  return iframe;
+};
+
+// Creates an iframe with src="about:blank" and appends it to the document.
+window.insertIframeWithAboutBlankSrc = (t) => {
+  const iframe = document.createElement("iframe");
+  t.add_cleanup(() => iframe.remove());
+  iframe.src = "about:blank";
+  document.body.append(iframe);
+  return iframe;
+};
+
+// Creates an iframe with src="about:blank", appends it to the document, and
+// waits for the non-initial about:blank document finished loading.
+window.insertIframeWithAboutBlankSrcWaitForLoad = async (t) => {
+  const iframe = insertIframeWithAboutBlankSrc(t);
+  const aboutBlankLoad = new Promise(resolve => {
+    // In some browsers, the non-initial about:blank navigation commits
+    // asynchronously, while in other browsers, it would commit synchronously.
+    // This means we can't wait for the "load" event as it might have already
+    // ran. Instead, just wait for 100ms before resolving, as the non-initial
+    // about:blank navigation will most likely take less than 100 ms to commit.
+    t.step_timeout(resolve, 100);
+  });
+  await aboutBlankLoad;
+  return iframe;
+};
+
+// Waits for the "load" event for |urlRelativeToThisDocument| to run on
+// |iframe|.
+window.waitForLoad = (t, iframe, urlRelativeToThisDocument) => {
+  return new Promise(resolve => {
+    iframe.addEventListener("load", t.step_func(() => {
+      assert_equals(iframe.contentWindow.location.href, (new URL(urlRelativeToThisDocument, location.href)).href);
+
+      // Wait a bit longer to ensure all history stuff has settled, e.g. the document is "completely loaded"
+      // (which happens from a queued task).
+      setTimeout(resolve, 0);
+    }), { once: true });
+  });
+};
+
+// -- End of helpers for iframe initial empty document tests.
+
+// -- Start of helpers for opened windows' initial empty document tests.
+
+// window.open() to a URL that doesn't load a new document (results in a HTTP
+// 204 response). This should create a new window that stays on the initial
+// empty document.
+window.windowOpen204 = (t) => {
+  const openedWindow = window.open(url204);
+  t.add_cleanup(() => openedWindow.close());
+  return openedWindow;
+};
+
+// window.open() (no URL set). This should create a new window that stays on
+// the initial empty document as it won't trigger a non-initial about:blank
+// navigation.
+window.windowOpenNoURL = (t) => {
+  const openedWindow = window.open();
+  t.add_cleanup(() => openedWindow.close());
+  return openedWindow;
+};
+
+// window.open("about:blank"). This should create a new window that stays on
+// the initial empty document as it won't trigger a non-initial about:blank
+// navigation.
+window.windowOpenAboutBlank = (t) => {
+  const openedWindow = window.open("about:blank");
+  t.add_cleanup(() => openedWindow.close());
+  return openedWindow;
+};
+
+// Waits for a postMessage with data set to |message| is received on the current
+// window.
+window.waitForMessage = (t, message) => {
+  return new Promise(resolve => {
+    window.addEventListener("message", t.step_func((event) => {
+      if (event.data == message)
+        resolve();
+    }));
+  });
+};
+
+// -- End of helpers for opened windows' initial empty document tests.


### PR DESCRIPTION
This should pass a lot of the [`results/html/semantics/forms/form-submission-0/text-plain.window.html`](https://wpt.fyi/results/html/semantics/forms/form-submission-0/text-plain.window.html?label=master&product=chrome%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=ladybird&aligned) subtests, which wait for the `load` event for the `<iframe>`s to be emitted after the form action URL loads (but instead it receives the event emitted for the initial `about:blank` load, which should have been emitted immediately upon the `<iframe>`'s insertion).

Unfortunately, to do so, we need to add a hack to spin the SHTQ synchronously. <s>I hope that's not a bad idea.</s> It's a bad idea. I can't get it to work at the moment.