### PR TITLE
LibWeb: Use rendered text to find word boundaries when double-clicking

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -981,8 +981,11 @@ EventResult EventHandler::handle_doubleclick(CSSPixelPoint viewport_position, CS
             if (hit_dom_node.is_password_input()) {
                 next_boundary = hit_dom_node.length_in_utf16_code_units();
             } else {
-                previous_boundary = hit_dom_node.word_segmenter().previous_boundary(result->index_in_node, Unicode::Segmenter::Inclusive::Yes).value_or(0);
-                next_boundary = hit_dom_node.word_segmenter().next_boundary(result->index_in_node).value_or(hit_dom_node.length());
+                auto& segmenter = word_segmenter();
+                segmenter.set_segmented_text(hit_paintable.text_for_rendering());
+
+                previous_boundary = segmenter.previous_boundary(result->index_in_node, Unicode::Segmenter::Inclusive::Yes).value_or(0);
+                next_boundary = segmenter.next_boundary(result->index_in_node).value_or(hit_dom_node.length());
             }
 
             if (auto* target = document.active_input_events_target()) {

--- a/Tests/LibWeb/Text/expected/selection-on-rendered-text.txt
+++ b/Tests/LibWeb/Text/expected/selection-on-rendered-text.txt
@@ -1,0 +1,1 @@
+Selected range: 6 - 11

--- a/Tests/LibWeb/Text/input/selection-on-rendered-text.html
+++ b/Tests/LibWeb/Text/input/selection-on-rendered-text.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<p id="text">Lorem     ipsum dolor sit amet</p>
+<script>
+    test(() => {
+        internals.doubleclick(85, 20);
+
+        const selection = document.getSelection().getRangeAt(0);
+        println(`Selected range: ${selection.startOffset} - ${selection.endOffset}`);
+    });
+</script>


### PR DESCRIPTION
This effectively reverts da26941b505ea3a2aab1dae99c3a6d648f4222a9.

When the user double-clicks a word on screen, they are interacting with the rendered text, which has e.g. whitespace collapsing applied. If we acquire word boundaries from the raw text, the resulting selection is not right.

With the following page:
```html
<p id="text">Lorem     ipsum dolor sit amet</p>
```

Double-clicking the word "ipsum" would previously render as:
<img width="232" height="51" alt="before" src="https://github.com/user-attachments/assets/c60b34dd-f9db-4607-ae56-3dd56066154b" />

It now renders as:
<img width="228" height="57" alt="after" src="https://github.com/user-attachments/assets/b24e0895-858f-4e13-8828-d93146d0ab9f" />

We still have issues with acquiring the right selection via APIs such as `document.getSelection`. The offsets computed here are effectively then applied to the raw text. But this issue is present all over EventHandler and this patch at least makes the selection visually accurate.