### PR TITLE
LibWeb: Delete entire graphemes when the delete/backspace key is pressed

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -829,13 +829,12 @@ void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
 
     if (selection_start == selection_end) {
         if (direction == DeleteDirection::Backward) {
-            if (selection_start > 0)
-                MUST(set_range_text({}, selection_start - 1, selection_end, Bindings::SelectionMode::End));
+            if (auto offset = text_node->grapheme_segmenter().previous_boundary(m_selection_end); offset.has_value())
+                selection_start = *offset;
         } else {
-            if (selection_start < text_node->length_in_utf16_code_units())
-                MUST(set_range_text({}, selection_start, selection_end + 1, Bindings::SelectionMode::End));
+            if (auto offset = text_node->grapheme_segmenter().next_boundary(m_selection_end); offset.has_value())
+                selection_end = *offset;
         }
-        return;
     }
 
     MUST(set_range_text({}, selection_start, selection_end, Bindings::SelectionMode::End));

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-forwardDelete.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-forwardDelete.txt
@@ -19,3 +19,6 @@ After: a&nbsp; &nbsp; b
 --- g ---
 Before: &nbsp;&nbsp;b
 After: &nbsp;b
+--- h ---
+Before: foo👩🏼‍❤️‍👨🏻bar
+After: foobar

--- a/Tests/LibWeb/Text/expected/input-delete.txt
+++ b/Tests/LibWeb/Text/expected/input-delete.txt
@@ -1,6 +1,6 @@
 --- a ---
-Before: foobar
-After: fobar
+Before: foo👩🏼‍❤️‍👨🏻bar
+After: foobar
 --- b ---
 Before: foo👩🏼‍❤️‍👨🏻bar
 After: foobar

--- a/Tests/LibWeb/Text/input/Editing/execCommand-delete.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-delete.html
@@ -1,19 +1,25 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
-<div contenteditable="true">foobar</div>
+<div id="a" contenteditable="true">foobar</div>
+<div id="b" contenteditable="true">foo👩🏼‍❤️‍👨🏻bar</div>
 <script>
     test(() => {
-        var divElm = document.querySelector('div');
-        println(`Before: ${divElm.textContent}`);
+        const testDelete = function (divId, position) {
+            println(`--- ${divId} ---`);
+            const divElm = document.querySelector(`div#${divId}`);
+            println(`Before: ${divElm.textContent}`);
 
-        // Put cursor after 'foo'
-        var range = document.createRange();
-        range.setStart(divElm.childNodes[0], 3);
-        getSelection().addRange(range);
+            // Place cursor
+            const node = divElm.childNodes[0];
+            getSelection().setBaseAndExtent(node, position, node, position);
 
-        // Press backspace
-        document.execCommand('delete');
+            // Press backspace
+            document.execCommand("delete");
 
-        println(`After: ${divElm.textContent}`);
+            println(`After: ${divElm.textContent}`);
+        };
+
+        testDelete("a", 3);
+        testDelete("b", 15);
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/execCommand-forwardDelete.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-forwardDelete.html
@@ -7,6 +7,7 @@
 <div id="e" contenteditable="true">a&nbsp;&nbsp;&nbsp;&nbsp;b</div>
 <div id="f" contenteditable="true">a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;b</div>
 <div id="g" contenteditable="true">&nbsp;&nbsp;b</div>
+<div id="h" contenteditable="true">foo👩🏼‍❤️‍👨🏻bar</div>
 <script>
     test(() => {
         const testForwardDelete = function(divId, position) {
@@ -31,5 +32,6 @@
         testForwardDelete('e', 1);
         testForwardDelete('f', 1);
         testForwardDelete('g', 0);
+        testForwardDelete('h', 3);
     });
 </script>

--- a/Tests/LibWeb/Text/input/input-delete.html
+++ b/Tests/LibWeb/Text/input/input-delete.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<input id="a" value="foo👩🏼‍❤️‍👨🏻bar" />
+<input id="b" value="foo👩🏼‍❤️‍👨🏻bar" />
+<script>
+    test(() => {
+        const testDelete = function (id, position, key) {
+            println(`--- ${id} ---`);
+            const input = document.querySelector(`input#${id}`);
+            println(`Before: ${input.value}`);
+
+            // Place cursor
+            input.setSelectionRange(position, position);
+
+            // Press backspace
+            internals.sendKey(input, key);
+
+            println(`After: ${input.value}`);
+        };
+
+        testDelete("a", 15, "Backspace");
+        testDelete("b", 3, "Delete");
+    });
+</script>


### PR DESCRIPTION
We currently delete a single code unit. If the user presses backspace on a multi code point emoji, they are going to expect the entire emoji to be removed. This now matches the behavior of Chrome and Firefox.

Before:

https://github.com/user-attachments/assets/1ed48740-bb48-4e50-8f67-67838995826a

After:

https://github.com/user-attachments/assets/815d9a80-6f05-42b8-b290-5ce502bbda73

