### PR TITLE
LibWeb: Don't process mouseleave events while primary button is pressed

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -70,6 +70,7 @@ private:
     GC::Ref<HTML::Navigable> m_navigable;
 
     bool m_in_mouse_selection { false };
+    bool m_primary_button_held { false };
     InputEventsTarget* m_mouse_selection_target { nullptr };
 
     GC::Ptr<Painting::Paintable> m_mouse_event_tracking_paintable;


### PR DESCRIPTION
Prevents scrolling from being attempted if the thumb size exceeds the gutter size. This should never happen, however, if you drag the thumb while moving the mouse outside the window the gutter is no longer rendered. As such, the gutter has a size of 0 while the, still rendered, thumb has a positive size. 

Fixes #5844