### PR TITLE
LibIPC: Shutdown IPC event handler when transport is lost (ALTERNATE)

### DIFF
--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -56,6 +56,8 @@ protected:
     Vector<NonnullOwnPtr<Message>> m_unprocessed_messages;
 
     u32 m_local_endpoint_magic { 0 };
+
+    bool volatile m_shutdown_in_progress { false };
 };
 
 template<typename LocalEndpoint, typename PeerEndpoint>
@@ -107,6 +109,9 @@ protected:
         auto peer_message = PeerEndpoint::decode_message(bytes, fds);
         if (!peer_message.is_error())
             return peer_message.release_value();
+
+        dbgln("nullptr LocalEndpoint error: {}", local_message.error());
+        dbgln("nullptr PeerEndpoint  error: {}", peer_message.error());
 
         return nullptr;
     }

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -501,8 +501,8 @@ String PageClient::page_did_request_cookie(URL::URL const& url, Web::Cookie::Sou
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestCookie>(url, source);
     if (!response) {
-        dbgln("WebContent client disconnected during DidRequestCookie. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidRequestCookie. Exiting soon!!!");
+        return String {}; // we have to return something... but what!!!
     }
     return response->take_cookie();
 }
@@ -511,8 +511,7 @@ void PageClient::page_did_set_cookie(URL::URL const& url, Web::Cookie::ParsedCoo
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidSetCookie>(url, cookie, source);
     if (!response) {
-        dbgln("WebContent client disconnected during DidSetCookie. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidSetCookie. Exiting soon!!!");
     }
 }
 
@@ -530,8 +529,8 @@ Optional<String> PageClient::page_did_request_storage_item(Web::StorageAPI::Stor
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestStorageItem>(storage_endpoint, storage_key, bottle_key);
     if (!response) {
-        dbgln("WebContent client disconnected during DidRequestStorageItem. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!");
+        return {}; // we have to return something... but what!!!
     }
     return response->take_value();
 }
@@ -540,8 +539,8 @@ WebView::StorageOperationError PageClient::page_did_set_storage_item(Web::Storag
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidSetStorageItem>(storage_endpoint, storage_key, bottle_key, value);
     if (!response) {
-        dbgln("WebContent client disconnected during DidSetStorageItem. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidSetStorageItem. Exiting soon!!!");
+        return {}; // we have to return something... but what!!!
     }
     return response->error();
 }
@@ -550,8 +549,7 @@ void PageClient::page_did_remove_storage_item(Web::StorageAPI::StorageEndpointTy
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRemoveStorageItem>(storage_endpoint, storage_key, bottle_key);
     if (!response) {
-        dbgln("WebContent client disconnected during DidRemoveStorageItem. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidRemoveStorageItem. Exiting soon!!!");
     }
 }
 
@@ -559,8 +557,8 @@ Vector<String> PageClient::page_did_request_storage_keys(Web::StorageAPI::Storag
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestStorageKeys>(storage_endpoint, storage_key);
     if (!response) {
-        dbgln("WebContent client disconnected during DidRequestStorageKeys. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidRequestStorageKeys. Exiting soon!!!");
+        return {}; // we have to return something... but what!!!
     }
     return response->take_keys();
 }
@@ -569,8 +567,7 @@ void PageClient::page_did_clear_storage(Web::StorageAPI::StorageEndpointType sto
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidClearStorage>(storage_endpoint, storage_key);
     if (!response) {
-        dbgln("WebContent client disconnected during DidClearStorage. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidClearStorage. Exiting soon!!!");
     }
 }
 
@@ -593,8 +590,8 @@ PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML
 
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestNewWebView>(m_id, activate_tab, hints, page_id);
     if (!response) {
-        dbgln("WebContent client disconnected during DidRequestNewWebView. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during DidRequestNewWebView. Exiting soon!!!");
+        return {}; // we have to return something... but what!!!
     }
 
     return { &new_client.page(), response->take_handle() };
@@ -669,8 +666,8 @@ IPC::File PageClient::request_worker_agent(Web::Bindings::AgentType type)
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::RequestWorkerAgent>(m_id, type);
     if (!response) {
-        dbgln("WebContent client disconnected during RequestWorkerAgent. Exiting peacefully.");
-        exit(0);
+        dbgln("WebContent client disconnected during RequestWorkerAgent. Exiting soon!!!");
+        return {}; // we have to return something... but what!!!
     }
 
     return response->take_socket();


### PR DESCRIPTION
Alternate PR to #5018 to explore a few different points of investigation

Along with the changes in #5018, included a few special tweaks to see
what occurs if we don't come to a complete stop when a send_sync event
response fails to arrive before IPC shutdown. Mostly to see if the last
remaining queued events can be processed.

NOTE: I expect this pull request to be rejected as it is basically a demonstration piece, but providing here for discussion. Maybe some bits of it could be useful as a debugging aid.


List of changes:

1) In `Services/WebContent/PageClient.cpp` remove the `exit(0)` and return a dummy/empty response where needed, when a send_sync response is not received. This is to allow further processing and not do a complete hard stop when an expected response is not received.  Those dummy/empty responses might cause further unexpected behaviour so not a great solution, but just to see what could happen.
2) Show the queued messages being actually handled during the shutdown in progress.
3) If a post_message is called during the shutdown in progress, parse the message buffer and print the message name out to see what is being attempted to be posted, and return without failing.
4) If a message buffer can not be parsed (does happen for some specific messages), show the errors that were generated during the parsing and dump the raw buffer if can't parse.

Item 3+4 or a variation, could be useful to debug other cases when a post_message is coming during IPC shutdown.


First output is using my busysite.html reproduction (which is somewhat similar to site hltv.org).

```
5544.097 WebContent(100559): Failed to receive message_id: 49
5544.103 WebContent(100559): Transport shutdown with unprocessed messages left: 3
5544.103 WebContent(100559):  Message 000 is: 67-WebContentServer::SetHasFocus
5544.103 WebContent(100559):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
5544.103 WebContent(100559):  Message 002 is:  3-WebContentServer::CloseServer
5544.103 WebContent(100559): WebContent client disconnected during DidSetCookie. Exiting soon!!!
5544.103 WebContent(100559): Handling Message during shutdown in progress: WebContentServer::SetHasFocus
5544.103 WebContent(100559): Handling Message during shutdown in progress: WebContentServer::SetSystemVisibilityState
5544.104 WebContent(100559): Handling Message during shutdown in progress: WebContentServer::CloseServer
5544.106 WebContent(100559): Trying to post_message during IPC shutdown in progress
5544.110 WebContent(100559): Post_message: WebContentClient::DidPaint
5544.110 WebContent(100559): Trying to post_message during IPC shutdown in progress
5544.110 WebContent(100559): Post_message: WebContentClient::DidPaint
```

Above output seems reasonable and queued messages do get handled.  Some stray post_message are attempted.

and again using the same repro...

```
9250.120 WebContent(104617): Failed to receive message_id: 47
9250.120 WebContent(104617): Transport shutdown with unprocessed messages left: 1
9250.120 WebContent(104617):  Message 000 is:  3-WebContentServer::CloseServer
9250.120 WebContent(104617): WebContent client disconnected during DidRequestCookie. Exiting soon!!!
9250.120 WebContent(104617): Trying to post_message during IPC shutdown in progress
9250.120 WebContent(104617): Post_message: WebContentClient::DidSetCookie
9250.120 WebContent(104617): Failed to receive message_id: 49
9250.120 WebContent(104617): Transport shutdown with unprocessed messages left: 1
9250.120 WebContent(104617):  Message 000 is:  3-WebContentServer::CloseServer
9250.120 WebContent(104617): WebContent client disconnected during DidSetCookie. Exiting soon!!!
9250.120 WebContent(104617): Trying to post_message during IPC shutdown in progress
9250.120 WebContent(104617): Post_message: WebContentClient::DidPaint
9250.120 WebContent(104617): Handling Message during shutdown in progress: WebContentServer::CloseServer
```

Above output seems similar to the previous one, except here both the request cookie and set cookie are attempted.


Output using #4988 issue site hltv.org

As of 2025/08/14, rendering of the site is very slow, but eventually "appears".

```
9174.725 WebContent(104270): Failed to receive message_id: 47
9174.725 WebContent(104270): Transport shutdown with unprocessed messages left: 1
9174.725 WebContent(104270):  Message 000 is:  3-WebContentServer::CloseServer
9174.725 WebContent(104270): WebContent client disconnected during DidRequestCookie. Exiting soon!!!
9174.725 WebContent(104270): Handling Message during shutdown in progress: WebContentServer::CloseServer
```

Above output is basic and boring. Site does not seem as responsive as when the issue was initially opened.


Output using #1734 issue site t-online.de

```
7194.511 WebContent(102479): Failed to receive message_id: 53
7194.511 WebContent(102479): Transport shutdown with unprocessed messages left: 1
7194.511 WebContent(102479):  Message 000 is:  3-WebContentServer::CloseServer
7194.511 WebContent(102479): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
7194.511 WebContent(102479): Trying to post_message during IPC shutdown in progress
7194.511 WebContent(102479): Post_message: WebContentClient::DidRequestStorageItem
7194.511 WebContent(102479): Failed to receive message_id: 53
7194.511 WebContent(102479): Transport shutdown with unprocessed messages left: 1
7194.511 WebContent(102479):  Message 000 is:  3-WebContentServer::CloseServer
7194.511 WebContent(102479): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
7194.512 WebContent(102479): Handling Message during shutdown in progress: WebContentServer::CloseServer
7194.520 WebContent(102479): Trying to post_message during IPC shutdown in progress
A7194.520 WebContent(102479): Post_message: WebContentClient::DidRequestCookie
7194.520 WebContent(102479): Failed to receive message_id: 47
7194.520 WebContent(102479): WebContent client disconnected during DidRequestCookie. Exiting soon!!!

```

Above output is interesting as it is not only cookie related.


again more output from t-online.de

```
7383.768 WebContent(103023): Failed to receive message_id: 59
7383.768 WebContent(103023): Transport shutdown with unprocessed messages left: 2
7383.768 WebContent(103023):  Message 000 is: 75-WebContentServer::SetSystemVisibilityState
7383.768 WebContent(103023):  Message 001 is:  3-WebContentServer::CloseServer
7383.768 WebContent(103023): WebContent client disconnected during DidRequestStorageKeys. Exiting soon!!!
7383.768 WebContent(103023): Trying to post_message during IPC shutdown in progress
7383.768 WebContent(103023): Post_message: WebContentClient::DidSetStorageItem
7383.768 WebContent(103023): Failed to receive message_id: 55
7383.768 WebContent(103023): Transport shutdown with unprocessed messages left: 2
7383.768 WebContent(103023):  Message 000 is: 75-WebContentServer::SetSystemVisibilityState
7383.768 WebContent(103023):  Message 001 is:  3-WebContentServer::CloseServer
7383.768 WebContent(103023): WebContent client disconnected during DidSetStorageItem. Exiting soon!!!
7383.770 WebContent(103023): Trying to post_message during IPC shutdown in progress
7383.770 WebContent(103023): Post_message: WebContentClient::DidRequestStorageKeys
7383.770 WebContent(103023): Failed to receive message_id: 59
7383.770 WebContent(103023): Transport shutdown with unprocessed messages left: 2
7383.770 WebContent(103023):  Message 000 is: 75-WebContentServer::SetSystemVisibilityState
7383.770 WebContent(103023):  Message 001 is:  3-WebContentServer::CloseServer
7383.770 WebContent(103023): WebContent client disconnected during DidRequestStorageKeys. Exiting soon!!!
7383.770 WebContent(103023): Trying to post_message during IPC shutdown in progress
7383.770 WebContent(103023): Post_message: WebContentClient::DidRequestStorageItem
7383.770 WebContent(103023): Failed to receive message_id: 53
7383.770 WebContent(103023): Transport shutdown with unprocessed messages left: 2
7383.770 WebContent(103023):  Message 000 is: 75-WebContentServer::SetSystemVisibilityState
7383.770 WebContent(103023):  Message 001 is:  3-WebContentServer::CloseServer
7383.770 WebContent(103023): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
7383.770 WebContent(103023): Trying to post_message during IPC shutdown in progress
7383.770 WebContent(103023): Post_message: WebContentClient::DidRequestStorageKeys
7383.770 WebContent(103023): Failed to receive message_id: 59
7383.770 WebContent(103023): Transport shutdown with unprocessed messages left: 2
7383.770 WebContent(103023):  Message 000 is: 75-WebContentServer::SetSystemVisibilityState
7383.770 WebContent(103023):  Message 001 is:  3-WebContentServer::CloseServer
7383.770 WebContent(103023): WebContent client disconnected during DidRequestStorageKeys. Exiting soon!!!
7383.770 WebContent(103023): Trying to post_message during IPC shutdown in progress
7383.770 WebContent(103023): Post_message: WebContentClient::DidRequestStorageItem
7383.770 WebContent(103023): Failed to receive message_id: 53
7383.770 WebContent(103023): Transport shutdown with unprocessed messages left: 2
7383.770 WebContent(103023):  Message 000 is: 75-WebContentServer::SetSystemVisibilityState
7383.770 WebContent(103023):  Message 001 is:  3-WebContentServer::CloseServer
7383.770 WebContent(103023): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
7383.772 WebContent(103023): Handling Message during shutdown in progress: WebContentServer::SetSystemVisibilityState
7383.772 WebContent(103023): Handling Message during shutdown in progress: WebContentServer::CloseServer
7383.772 WebContent(103023): Trying to post_message during IPC shutdown in progress
7383.772 WebContent(103023): Post_message: WebContentClient::DidPaint
7383.941 RequestServer(103015): Warning: Request destroyed with buffered data (it's likely that the client disappeared or the request was cancelled)
```

Above output is interesting as it is not cookie related at all, but we see that the system is trying repeatedly to request StorageKeys and set/request StorageItem.  There are also a few stray post_messages. Some of the issues with this one could be due to the dummy/empty responses from previous events.


Output using #5300 issue site youtube.com

I tried to view the Ladybird Browser July 2025 Update video on Youtube. I could see WebContent was having issues with memory usage at >2GB and a busy CPU, so I pressed the X to terminate the Ladybird process.

```
6374.454 WebContent(101749): Failed to receive message_id: 53
6374.454 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.454 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.454 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.454 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.454 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.456 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.459 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.462 WebContent(101749): Failed to receive message_id: 53
6374.462 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.462 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.462 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.463 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.463 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.464 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.464 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.464 WebContent(101749): Failed to receive message_id: 53
6374.464 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.464 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.464 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.464 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.464 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.465 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.465 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.465 WebContent(101749): Failed to receive message_id: 53
6374.465 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.465 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.465 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.465 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.465 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.465 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.465 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.465 WebContent(101749): Failed to receive message_id: 53
6374.465 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.465 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.465 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.465 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.465 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.465 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.465 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.465 WebContent(101749): Failed to receive message_id: 53
6374.465 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.465 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.465 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.465 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.465 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.465 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.465 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.465 WebContent(101749): Failed to receive message_id: 53
6374.465 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.465 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.465 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.465 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.465 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.465 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.465 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.465 WebContent(101749): Failed to receive message_id: 53
6374.465 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.465 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.465 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.465 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.465 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.465 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.465 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.465 WebContent(101749): Failed to receive message_id: 53
6374.465 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.465 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.465 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.465 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.465 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.470 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.470 WebContent(101749): Post_message: WebContentClient::DidUpdateResourceCount
6374.470 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.470 WebContent(101749): Post_message: WebContentClient::DidUpdateResourceCount
6374.470 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.471 WebContent(101749): Post_message: WebContentClient::DidUpdateResourceCount
6374.471 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.471 WebContent(101749): Post_message: WebContentClient::DidUpdateResourceCount
6374.471 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.472 WebContent(101749): Post_message: WebContentClient::DidUpdateResourceCount
UNEXPECTED ERROR: Trying to post_message during IPC shutdown at /home/bobo/projects/myladybird/Build/release/Lagom/Services/WebContent/WebContentServerEndpoint.h:5291
/home/bobo/projects/myladybird/Build/release/lib/liblagom-ak.so.0(dump_backtrace+0x4d) [0x79f4f9a8f4bd]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-ak.so.0(ak_trap+0xf) [0x79f4f9a8f71f]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-webview.so.0(+0x85ed4) [0x79f4fa6e6ed4]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-webview.so.0(+0x7c9fa) [0x79f4fa6dd9fa]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-webview.so.0 WebView::CookieJar::TransientStorage::purge_expired_cookies(AK::Optional<AK::Duration>) 0x4e4) [0x79f4fa6ddf04]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-webview.so.0(+0x80222) [0x79f4fa6e1222]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-webview.so.0 WebView::CookieJar::~CookieJar() 0x19d) [0x79f4fa6dc42d]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-webview.so.0 WebView::Application::~Application() 0x16b) [0x79f4fa6b9d7b]
./Build/release/bin/Ladybird(+0x2d9fb) [0x5794c8c5a9fb]
./Build/release/bin/Ladybird(+0x2c4eb) [0x5794c8c594eb]
./Build/release/bin/Ladybird(main+0x103) [0x5794c8c53c03]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a578) [0x79f4f642a578]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b) [0x79f4f642a63b]
./Build/release/bin/Ladybird(+0x26d35) [0x5794c8c53d35]
6374.553 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.553 WebContent(101749): Post_message: WebContentClient::DidUpdateResourceCount
6374.557 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.557 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.557 WebContent(101749): Failed to receive message_id: 53
6374.557 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.557 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.557 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.557 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.557 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.557 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.557 WebContent(101749): Post_message: WebContentClient::DidRequestStorageKeys
6374.557 WebContent(101749): Failed to receive message_id: 59
6374.557 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.557 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.557 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.557 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.557 WebContent(101749): WebContent client disconnected during DidRequestStorageKeys. Exiting soon!!!
6374.557 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.557 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.557 WebContent(101749): Failed to receive message_id: 53
6374.557 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.557 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.557 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.557 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.557 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.557 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.557 WebContent(101749): Post_message: WebContentClient::DidRequestStorageItem
6374.557 WebContent(101749): Failed to receive message_id: 53
6374.557 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.557 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.557 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.557 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.557 WebContent(101749): WebContent client disconnected during DidRequestStorageItem. Exiting soon!!!
6374.557 WebContent(101749): Trying to post_message during IPC shutdown in progress
6374.557 WebContent(101749): Post_message: WebContentClient::DidRequestStorageKeys
6374.557 WebContent(101749): Failed to receive message_id: 59
6374.557 WebContent(101749): Transport shutdown with unprocessed messages left: 3
6374.557 WebContent(101749):  Message 000 is: 67-WebContentServer::SetHasFocus
6374.557 WebContent(101749):  Message 001 is: 75-WebContentServer::SetSystemVisibilityState
6374.557 WebContent(101749):  Message 002 is:  3-WebContentServer::CloseServer
6374.557 WebContent(101749): WebContent client disconnected during DidRequestStorageKeys. Exiting soon!!!
```

Above output goes on and on without a break, only partial output is included as it was repeating over and over... didn't seem to ever stop.

