### PR TITLE
LibWeb: Use document's global object in `is_base_allowed_for_document`

### DIFF
--- a/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/BlockingAlgorithms.cpp
@@ -625,8 +625,7 @@ JS::ThrowCompletionOr<void> ensure_csp_does_not_block_wasm_byte_compilation(JS::
 Directives::Directive::Result is_base_allowed_for_document(JS::Realm& realm, URL::URL const& base, GC::Ref<DOM::Document const> document)
 {
     // 1. For each policy of document’s global object’s csp list:
-    VERIFY(document->window());
-    auto csp_list = PolicyList::from_object(*document->window());
+    auto csp_list = PolicyList::from_object(document->realm().global_object());
     VERIFY(csp_list);
     for (auto const policy : csp_list->policies()) {
         // 1. Let source list be null.

--- a/Tests/LibWeb/Crash/DOM/base-element-insert-crash.html
+++ b/Tests/LibWeb/Crash/DOM/base-element-insert-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html id="html">
+    <head></head>
+    <script>
+        document.head.innerHTML = `<base href="https://example.com">`;
+    </script>
+</html>


### PR DESCRIPTION
Previously we were using the document's window - this was both contrary to spec and causing crashes when the document did not have a window (for instance the `temp_document` in `HTMLParser::parse_html_fragment`.

This means we no longer crash when navigating between pages on https://rocketlabcorp.com