### PR TITLE
LibWeb: Allow style inheritance through slots

### DIFF
--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -40,6 +40,11 @@ GC::Ptr<Element const> AbstractElement::parent_element() const
     return m_element->parent_element();
 }
 
+GC::Ptr<Element const> AbstractElement::element_to_inherit_style_from() const
+{
+    return m_element->element_to_inherit_style_from(m_pseudo_element);
+}
+
 Optional<AbstractElement> AbstractElement::walk_layout_tree(WalkMethod walk_method)
 {
     GC::Ptr<Layout::Node> node = layout_node();

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -27,6 +27,7 @@ public:
     GC::Ptr<Layout::NodeWithStyle const> layout_node() const { return const_cast<AbstractElement*>(this)->layout_node(); }
 
     GC::Ptr<Element const> parent_element() const;
+    GC::Ptr<Element const> element_to_inherit_style_from() const;
     Optional<AbstractElement> previous_in_tree_order() { return walk_layout_tree(WalkMethod::Previous); }
     Optional<AbstractElement> previous_sibling_in_tree_order() { return walk_layout_tree(WalkMethod::PreviousSibling); }
     bool is_before(AbstractElement const&) const;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4131,4 +4131,17 @@ GC::Ref<CSS::StylePropertyMapReadOnly> Element::computed_style_map()
     return *m_computed_style_map_cache;
 }
 
+// The element to inherit style from.
+// If a pseudo-element is specified, this will return the element itself.
+// Otherwise, if this element is slotted somewhere, it will return the slot's element to inherit style from.
+// Otherwise, it will return the parent or shadow host element of this element.
+GC::Ptr<Element const> Element::element_to_inherit_style_from(Optional<CSS::PseudoElement> pseudo_element) const
+{
+    if (pseudo_element.has_value())
+        return this;
+    while (auto const slot = assigned_slot_internal())
+        return slot->element_to_inherit_style_from({});
+    return parent_or_shadow_host_element();
+}
+
 }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -233,6 +233,8 @@ public:
 
     WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> parse_fragment(StringView markup);
 
+    [[nodiscard]] GC::Ptr<Element const> element_to_inherit_style_from(Optional<CSS::PseudoElement>) const;
+
     WebIDL::ExceptionOr<String> inner_html() const;
     WebIDL::ExceptionOr<void> set_inner_html(StringView);
 

--- a/Tests/LibWeb/Layout/expected/slot-style-inheritance.txt
+++ b/Tests/LibWeb/Layout/expected/slot-style-inheritance.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x54 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x38 children: not-inline
+      Box <main> at (13,13) content-size 774x28 flex-container(row) [FFC] children: not-inline
+        BlockContainer <foobar> at (13,13) content-size 52.5625x28 flex-item [BFC] children: not-inline
+          BlockContainer <div> at (18,18) content-size 42.5625x18 children: inline
+            frag 0 from TextNode start: 0, length: 5, rect: [18,18 42.5625x18] baseline: 13.796875
+                "story"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x54]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x38]
+      PaintableBox (Box<MAIN>) [8,8 784x38]
+        PaintableWithLines (BlockContainer<FOOBAR>) [13,13 52.5625x28]
+          PaintableWithLines (BlockContainer<DIV>) [13,13 52.5625x28]
+            TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x54] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/slot-style-inheritance.html
+++ b/Tests/LibWeb/Layout/input/slot-style-inheritance.html
@@ -1,0 +1,9 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    div { border: 5px solid lime; }
+</style><body><template shadowrootmode="open"><style>
+    main {
+        display: flex;
+        border: 5px solid orange;
+    }
+</style><main><slot></slot></main></template><foobar><div>story


### PR DESCRIPTION
When a subtree is projected through a slot, its root now inherits style from the slot's parent, rather than the parent of the unprojected root.

This fixes a ton of subtle issues, and is very noticeable on Reddit.

Before:
<img width="1442" height="857" alt="Screenshot 2025-08-16 at 14 10 51" src="https://github.com/user-attachments/assets/62a0adbb-232e-4e2e-bdac-c8e46a543326" />

After:
<img width="1442" height="857" alt="Screenshot 2025-08-16 at 14 10 22" src="https://github.com/user-attachments/assets/754a08a7-8526-48bc-bccf-3799068fc6f1" />