### PR TITLE
LibWeb: Make text cursor same height as text

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -723,11 +723,15 @@ void paint_cursor_if_needed(DisplayListRecordingContext& context, TextPaintable 
     auto const& font = fragment.glyph_run() ? fragment.glyph_run()->font() : fragment.layout_node().first_available_font();
     auto cursor_offset = font.width(text.substring_view(0, cursor_position->offset() - fragment.start_offset()));
 
+    auto font_metrics = font.pixel_metrics();
+
+    auto cursor_height = font_metrics.ascent + font_metrics.descent;
+
     CSSPixelRect cursor_rect {
         fragment_rect.x() + CSSPixels::nearest_value_for(cursor_offset),
-        fragment_rect.top(),
+        fragment_rect.top() + fragment.baseline() - CSSPixels::nearest_value_for(font_metrics.ascent),
         1,
-        fragment_rect.height()
+        CSSPixels::nearest_value_for(cursor_height)
     };
     auto cursor_device_rect = context.rounded_device_rect(cursor_rect).to_type<int>();
 


### PR DESCRIPTION
Previously we would paint the cursor the entire height of the text fragment - this didn't look great with large line-heights. Now we only paint it the height of the actual text, with the top of the cursor aligning with the font "ascent" and the bottom the "descent".

Before:
<img width="1920" height="1080" alt="cursor-before" src="https://github.com/user-attachments/assets/d0be4003-5a63-4ba9-b783-63c4e194fb73" />


After:
<img width="1920" height="1080" alt="cursor-after" src="https://github.com/user-attachments/assets/4f7ce33e-2ef7-43fe-b578-61eee166466e" />
