### PR TITLE
LibWeb: Allow loading style sheets without a MIME type

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -426,7 +426,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
             mime_type_string = extracted_mime_type->essence();
     }
 
-    if (mime_type_string != "text/css"sv) {
+    if (mime_type_string.has_value() && mime_type_string != "text/css"sv) {
         success = false;
     }
 


### PR DESCRIPTION
Some websites do not specify the MIME type of style sheets, instead using as= or just leaving it empty.

Both Chromium and Firefox do load them regardless, so let's do it too.

Note: This is just #3757 with a slightly edited commit message since the original got stalebotted and I can't update it directly.