### PR TITLE
LibWeb/CSS: Fix basic absolute positioning inside grid containers

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1937,11 +1937,14 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         // is that of the corresponding padding edge of the grid container (the padding edge of the scrollable area, if the grid container
         // overflows). These lines become the first and last lines (0th and -0th) of the augmented grid used for positioning absolutely-positioned items.
         CSSPixels height = 0;
-        for (auto const& row_track : m_grid_rows_and_gaps) {
-            height += row_track.base_size;
+        if (m_available_space->height.is_definite()) {
+            height = m_available_space->height.to_px_or_zero();
+        } else {
+            for (auto const& row_track : m_grid_rows_and_gaps)
+                height += row_track.base_size;
         }
-        height += m_grid_container_used_values.padding_top;
-        height += m_grid_container_used_values.padding_bottom;
+        height += m_grid_container_used_values.padding_top + m_grid_container_used_values.padding_bottom;
+
         area_rect.set_height(height);
         area_rect.set_y(-m_grid_container_used_values.padding_top);
     }
@@ -1954,11 +1957,14 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         }
     } else {
         CSSPixels width = 0;
-        for (auto const& col_track : m_grid_columns_and_gaps) {
-            width += col_track.base_size;
+        if (m_available_space->width.is_definite()) {
+            width = m_available_space->width.to_px_or_zero();
+        } else {
+            for (auto const& col_track : m_grid_columns_and_gaps)
+                width += col_track.base_size;
         }
-        width += m_grid_container_used_values.padding_left;
-        width += m_grid_container_used_values.padding_right;
+        width += m_grid_container_used_values.padding_left + m_grid_container_used_values.padding_right;
+
         area_rect.set_width(width);
         area_rect.set_x(-m_grid_container_used_values.padding_left);
     }

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-grid/abspos/absolute-positioning-changing-containing-block-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-grid/abspos/absolute-positioning-changing-containing-block-001-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Absolute positioning changing containing block reference file</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<style>
+.wrapper {
+  width: 100px;
+  height: 100px;
+  margin-bottom: 25px;
+  background: purple;
+}
+
+.grid {
+  width: 50px;
+  height: 50px;
+  background: lightblue;
+}
+
+.item {
+  width: 75%;
+  height: 75%;
+  background: orange;
+}
+</style>
+
+<p>The test PASS if you see an orange box inside a purple box on top and a small orange box inside a light blue box inside a purple box on bottom.</p>
+
+<div class="wrapper">
+  <div class="item"></div>
+</div>
+<div class="wrapper">
+  <div class="grid">
+    <div class="item"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-grid/abspos/absolute-positioning-changing-containing-block-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-grid/abspos/absolute-positioning-changing-containing-block-001.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang=en class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Absolute positioning changing containing block</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos" title="9. Absolute Positioning">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-grid/abspos/absolute-positioning-changing-containing-block-001-ref.html">
+<meta name="assert" content="This test checks that absolutelly positioned children of a grid are properly sized when the containing block switches between the grid container and a grid ancestor.">
+<style>
+.wrapper {
+  width: 100px;
+  height: 100px;
+  margin-bottom: 25px;
+  background: purple;
+  position: relative;
+}
+
+.grid {
+  display: grid;
+  grid-template: 10px / 10px;
+  width: 50px;
+  height: 50px;
+  background: lightblue;
+}
+
+.item {
+  width: 75%;
+  height: 75%;
+  background: orange;
+  position: absolute;
+}
+</style>
+
+<p>The test PASS if you see an orange box inside a purple box on top and a small orange box inside a light blue box inside a purple box on bottom.</p>
+
+<div class="wrapper">
+  <div id="grid-as-cb" class="grid" style="position: relative;">
+    <div class="item"></div>
+  </div>
+</div>
+<div class="wrapper">
+  <div id="grid-as-parent" class="grid">
+    <div class="item"></div>
+  </div>
+</div>
+
+<script>
+  window.requestAnimationFrame(() => {
+    document.getElementById("grid-as-cb").style.position = "initial";
+    document.getElementById("grid-as-parent").style.position = "relative";
+    document.body.offsetLeft;
+    document.documentElement.classList.remove('reftest-wait');
+  });
+</script>
+
+</html>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.txt
@@ -1,0 +1,18 @@
+Harness status: OK
+
+Found 12 tests
+
+3 Pass
+9 Fail
+Pass	.container 1
+Pass	.container 2
+Pass	.container 3
+Fail	.container 4
+Fail	.container 5
+Fail	.container 6
+Fail	.container 7
+Fail	.container 8
+Fail	.container 9
+Fail	.container 10
+Fail	.container 11
+Fail	.container 12

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.txt
@@ -2,17 +2,17 @@ Harness status: OK
 
 Found 12 tests
 
-3 Pass
-9 Fail
+5 Pass
+7 Fail
 Pass	.container 1
 Pass	.container 2
 Pass	.container 3
-Fail	.container 4
+Pass	.container 4
 Fail	.container 5
 Fail	.container 6
 Fail	.container 7
 Fail	.container 8
 Fail	.container 9
-Fail	.container 10
+Pass	.container 10
 Fail	.container 11
 Fail	.container 12

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-grid/abspos/absolute-positioning-grid-container-parent-001.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Absolute positioning grid container parent</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#abspos" title="9. Absolute Positioning">
+<meta name="assert" content="This test checks the behavior of the absolutely positioned elements with a grid container as parent.">
+<link rel="stylesheet" href="../../../fonts/ahem.css">
+<link rel="stylesheet" href="../../../css/support/grid.css">
+<style>
+
+.grid {
+  grid-template-columns: 50px 100px 150px;
+  grid-template-rows: 25px 50px 100px;
+  width: 300px;
+  height: 200px;
+  border: 5px solid black;
+  margin: 20px 30px;
+  padding: 5px 15px;
+}
+
+.container {
+  width: 500px;
+  height: 400px;
+}
+
+.relative {
+  /* Ensures that the element is the containing block of the absolutely positioned elements. */
+  position: relative;
+}
+
+.absolute {
+  position: absolute;
+}
+
+</style>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../resources/check-layout-th.js"></script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { checkLayout('.container'); })">
+
+<div id="log"></div>
+
+<div class="container relative">
+  <div class="grid">
+    <div class="sizedToGridArea absolute autoRowAutoColumn" data-offset-x="50" data-offset-y="10" data-expected-width="500" data-expected-height="400"></div>
+  </div>
+</div>
+
+<div class="container relative">
+  <div class="grid">
+    <div class="sizedToGridArea absolute firstRowFirstColumn" data-offset-x="50" data-offset-y="10" data-expected-width="500" data-expected-height="400"></div>
+  </div>
+</div>
+
+<div class="container relative">
+  <div class="grid">
+    <div class="sizedToGridArea absolute secondRowSecondColumn" data-offset-x="50" data-offset-y="10" data-expected-width="500" data-expected-height="400"></div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="grid relative">
+    <div class="sizedToGridArea absolute autoRowAutoColumn" data-offset-x="0" data-offset-y="0" data-expected-width="330" data-expected-height="210"></div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="grid relative">
+    <div class="sizedToGridArea absolute firstRowFirstColumn" data-offset-x="15" data-offset-y="5" data-expected-width="315" data-expected-height="205"></div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="grid relative">
+    <div class="sizedToGridArea absolute secondRowSecondColumn" data-offset-x="65" data-offset-y="30" data-expected-width="265" data-expected-height="180"></div>
+  </div>
+</div>
+
+<div class="container relative">
+  <div class="grid directionRTL">
+    <div class="sizedToGridArea absolute autoRowAutoColumn" data-offset-x="-150" data-offset-y="10" data-expected-width="500" data-expected-height="400"></div>
+  </div>
+</div>
+
+<div class="container relative">
+  <div class="grid directionRTL">
+    <div class="sizedToGridArea absolute firstRowFirstColumn" data-offset-x="-150" data-offset-y="10" data-expected-width="500" data-expected-height="400"></div>
+  </div>
+</div>
+
+<div class="container relative">
+  <div class="grid directionRTL">
+    <div class="sizedToGridArea absolute secondRowSecondColumn" data-offset-x="-150" data-offset-y="10" data-expected-width="500" data-expected-height="400"></div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="grid relative directionRTL">
+    <div class="sizedToGridArea absolute autoRowAutoColumn" data-offset-x="0" data-offset-y="0" data-expected-width="330" data-expected-height="210"></div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="grid relative directionRTL">
+    <div class="sizedToGridArea absolute firstRowFirstColumn" data-offset-x="0" data-offset-y="5" data-expected-width="315" data-expected-height="205"></div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="grid relative directionRTL">
+    <div class="sizedToGridArea absolute secondRowSecondColumn" data-offset-x="0" data-offset-y="30" data-expected-width="265" data-expected-height="180"></div>
+  </div>
+</div>
+
+</body>


### PR DESCRIPTION
Now elements with position `absolute` properly resolve their position inside parent elements with `grid`. I also imported some WPT tests related to that topic.

Part 2 of resolving issues on https://hack4krak.pl

Before:
<img width="1281" height="539" alt="Screenshot From 2025-08-17 08-32-36" src="https://github.com/user-attachments/assets/33132a61-e43c-442b-bd55-774529bffa3b" />


After:
<img width="1288" height="531" alt="image" src="https://github.com/user-attachments/assets/a2ffa6c0-acbb-4bff-9266-2dad234784a9" />

