### PR TITLE
LibWeb: Don't stop drawing scrollbar on mouseleave

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1049,6 +1049,11 @@ Paintable::DispatchEventOfSameName PaintableBox::handle_mousemove(Badge<EventHan
 
 void PaintableBox::handle_mouseleave(Badge<EventHandler>)
 {
+    // FIXME: early return needed as MacOSX calls this even when user is pressing mouse button
+    // https://github.com/LadybirdBrowser/ladybird/issues/5844
+    if (m_scroll_thumb_dragging_direction.has_value())
+        return;
+
     auto previous_draw_enlarged_horizontal_scrollbar = m_draw_enlarged_horizontal_scrollbar;
     m_draw_enlarged_horizontal_scrollbar = false;
     if (previous_draw_enlarged_horizontal_scrollbar != m_draw_enlarged_horizontal_scrollbar)


### PR DESCRIPTION
PaintableBox::handle_mouseleave is turning off scrollbar updating, but the user might still have the primary button down. Don't turn it off here.

Resolves crashing on MacOSX AppKit and Qt where gutter_size is 0 when mouse is moved outside window.

fixes: #5844