### PR TITLE
LibWeb/HTML: Check all radio buttons in group for required attribute

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -7,6 +7,7 @@
  * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
  * Copyright (c) 2024, Fernando Kiotheka <fer@k6a.dev>
  * Copyright (c) 2025, Felipe Muñoz Mazur <felipe.munoz.mazur@protonmail.com>
+ * Copyright (c) 2025, Glenn Skrzypczak <glenn.skrzypczak@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -3323,7 +3324,7 @@ bool HTMLInputElement::suffering_from_being_missing() const
             if (is_in_same_radio_button_group(*this, element)) {
                 if (element.checked())
                     has_checkedness_false_for_all_elements_in_group = false;
-                if (has_attribute(HTML::AttributeNames::required))
+                if (element.has_attribute(HTML::AttributeNames::required))
                     has_required_element_in_group = true;
             }
             return TraversalDecision::Continue;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/radio-valueMissing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/radio-valueMissing.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-4 Pass
-2 Fail
+6 Pass
 Pass	The required attribute is not set
-Fail	One of the radios is required, but none checked
+Pass	One of the radios is required, but none checked
 Pass	One of the radios is required and checked
 Pass	One of the radios is required and another one is checked
-Fail	One of the radios is required and disabled, but none checked
+Pass	One of the radios is required and disabled, but none checked
 Pass	One of the radios is required, checked and disabled


### PR DESCRIPTION
This fixes a bug in the algorithm for determining if radio buttons are missing their value. Previously it was only checked if the button itself is required. Now the algorithm checks if the radio button group contains a required radio button in order to determine if the value is required.