### PR TITLE
LibWeb: Fix abspos layout when box is contained by grid area

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/abspos-item-contained-by-grid-area.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-item-contained-by-grid-area.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      Box <div.gfc> at (8,8) content-size 800x600 positioned [GFC] children: not-inline
+        BlockContainer <div.grid-item> at (408,8) content-size 400x600 [BFC] children: not-inline
+          BlockContainer <div.abspos> at (408,8) content-size 100x18 positioned [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 5, rect: [408,8 39.78125x18] baseline: 13.796875
+                "Hello"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 808x608]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>.gfc) [8,8 800x600]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [408,8 400x600]
+          PaintableWithLines (BlockContainer<DIV>.abspos) [408,8 100x18]
+            TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/abspos-item-contained-by-grid-area.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-item-contained-by-grid-area.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><style>
+    .gfc {
+        display: grid;
+        grid-template-columns: 1fr [right-start] 1fr [grid-end];
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background-color: lightpink;
+    }
+    .grid-item {
+        grid-column: right-start/grid-end;
+        background-color: magenta;
+    }
+    .abspos {
+        position: absolute;
+        width: 100px;
+        background-color: orange;
+    }
+</style><div class="gfc"><div class="grid-item"><div class="abspos">Hello</div></div></div>


### PR DESCRIPTION
Before this change, `layout_absolutely_positioned_element()` in GFC had an assumption that all contained by grid container abspos boxes were also direct children of the grid container. This change adds handling for the cases when it's not true and, in order to identify grid area abspos box belongs to, we have to find ancestor grid item.

Before:
<img width="2098" height="1554" alt="CleanShot 2025-08-17 at 17 06 11@2x" src="https://github.com/user-attachments/assets/1c18b60e-c80b-4347-8e5a-70b7d3ad9095" />

After:
<img width="2098" height="1554" alt="CleanShot 2025-08-17 at 17 06 57@2x" src="https://github.com/user-attachments/assets/731f33c9-4925-4690-abd3-d058e1467121" />

