### PR TITLE
LibWeb: Allow blockification across display: contents boundary

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2337,6 +2337,10 @@ static BoxTypeTransformation required_box_type_transformation(ComputedProperties
     // NOTE: If we're computing style for a pseudo-element, the effective parent will be the originating element itself, not its parent.
     auto parent = element.element_to_inherit_style_from(pseudo_element);
 
+    // Climb out of `display: contents` context.
+    while (parent && parent->computed_properties() && parent->computed_properties()->display().is_contents())
+        parent = parent->element_to_inherit_style_from({});
+
     // A parent with a grid or flex display value blockifies the box’s display type. [CSS-GRID-1] [CSS-FLEXBOX-1]
     if (parent && parent->computed_properties()) {
         auto const& parent_display = parent->computed_properties()->display();

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
+#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 
 namespace Web::IntersectionObserver {
@@ -298,12 +299,13 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
         document = &intersection_root.get<GC::Root<DOM::Element>>().cell()->document();
     }
     if (m_document.has_value() && document->origin().is_same_origin(m_document->origin())) {
-        auto layout_node = intersection_root.visit([&](auto& elem) { return static_cast<GC::Root<DOM::Node>>(*elem)->layout_node(); });
-        rect.inflate(
-            m_root_margin[0].to_px(*layout_node, rect.height()),
-            m_root_margin[1].to_px(*layout_node, rect.width()),
-            m_root_margin[2].to_px(*layout_node, rect.height()),
-            m_root_margin[3].to_px(*layout_node, rect.width()));
+        if (auto layout_node = intersection_root.visit([&](auto& node) -> GC::Ptr<Layout::Node> { return node->layout_node(); })) {
+            rect.inflate(
+                m_root_margin[0].to_px(*layout_node, rect.height()),
+                m_root_margin[1].to_px(*layout_node, rect.width()),
+                m_root_margin[2].to_px(*layout_node, rect.height()),
+                m_root_margin[3].to_px(*layout_node, rect.width()));
+        }
     }
 
     return rect;

--- a/Tests/LibWeb/Layout/expected/display-contents-blockification-of-flex-items.txt
+++ b/Tests/LibWeb/Layout/expected/display-contents-blockification-of-flex-items.txt
@@ -1,0 +1,37 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x44 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x28 children: not-inline
+      Box <div.flex> at (8,8) content-size 784x28 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 24.171875x28 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 1, length: 3, rect: [8,8 24.171875x18] baseline: 13.796875
+              "163"
+          TextNode <#text>
+          TextNode <#text>
+        BlockContainer <foo-a> at (32.171875,8) content-size 58.15625x28 flex-item [BFC] children: not-inline
+          Box <foo-b> at (37.171875,13) content-size 48.15625x18 flex-container(row) [FFC] children: not-inline
+            BlockContainer <(anonymous)> at (37.171875,13) content-size 48.15625x18 flex-item [BFC] children: inline
+              frag 0 from TextNode start: 1, length: 5, rect: [37.171875,13 48.15625x18] baseline: 13.796875
+                  "Share"
+              TextNode <#text>
+              TextNode <#text>
+              TextNode <#text>
+              TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,36) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x44]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x28]
+      PaintableBox (Box<DIV>.flex) [8,8 784x28]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 24.171875x28]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<FOO-A>) [32.171875,8 58.15625x28]
+          PaintableBox (Box<FOO-B>) [32.171875,8 58.15625x28]
+            PaintableWithLines (BlockContainer(anonymous)) [37.171875,13 48.15625x18]
+              TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,36 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x44] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/display-contents-blockification-of-flex-items.html
+++ b/Tests/LibWeb/Layout/input/display-contents-blockification-of-flex-items.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<style type="text/css">
+  * {
+    outline: 1px solid black;
+  }
+  .flex {
+    display: flex;
+  }
+</style>
+<div class="flex">
+  163
+  <slot>
+    <foo-a
+      ><foo-b
+        ><template shadowrootmode="open">
+          <style>
+            :host {
+              display: flex;
+              border: 5px solid orange;
+            }
+          </style>
+          <slot></slot>
+        </template>
+        Share
+      </foo-b></foo-a
+    ></slot
+  >
+</div>


### PR DESCRIPTION
Flex/grid items are always blockified (have their CSS display forced
into "block") by style computation.

We were doing this by looking at the CSS display of the parent. However,
if the parent has `display: contents`, we must look at the *grandparent*
instead.

This corrects the layout of buttons underneath Reddit article cards.

Before:
<img width="868" height="601" alt="Screenshot 2025-08-17 at 17 43 47" src="https://github.com/user-attachments/assets/c4b0f6e6-5788-4dc4-8181-e778683f6e29" />

After:
<img width="868" height="601" alt="Screenshot 2025-08-17 at 17 43 04" src="https://github.com/user-attachments/assets/d8a585f8-e254-4557-b564-52e433c90322" />

(+bonus missing null check for IntersectionObserver that happened once while working on this and I don't know how to reproduce it.)
