### PR TITLE
LibWeb: Remove unnecessary as_if<SVGGradientPaintStyle>() on paint_style

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -633,7 +633,7 @@ static SkPaint paint_style_to_skia_paint(Painting::SVGGradientPaintStyle const& 
         shader = SkGradientShader::MakeTwoPointConical(start_center, start_radius, end_center, end_radius, colors.data(), positions.data(), color_stops.size(), tile_mode, 0, &matrix);
     }
     paint.setShader(shader);
-    if (auto* gradient_paint_style = as_if<SVGGradientPaintStyle>(paint_style); gradient_paint_style->color_space() == Gfx::InterpolationColorSpace::LinearRGB) {
+    if (paint_style.color_space() == Gfx::InterpolationColorSpace::LinearRGB) {
         paint.setColorFilter(SkColorFilters::LinearToSRGBGamma());
     }
 


### PR DESCRIPTION
This causes a compiler error on GCC 15.0.1 and should be unnecessary since paint_style already is of type SVGGradientPaintStyle.