### PR TITLE
LibJS: Revert common error types to only hold a single string

### DIFF
--- a/Libraries/LibJS/Runtime/ErrorTypes.cpp
+++ b/Libraries/LibJS/Runtime/ErrorTypes.cpp
@@ -9,15 +9,8 @@
 namespace JS {
 
 #define __ENUMERATE_JS_ERROR(name, message) \
-    const ErrorType ErrorType::name = ErrorType(message##sv);
+    const ErrorType ErrorType::name = ErrorType(message##_utf16);
 JS_ENUMERATE_ERROR_TYPES(__ENUMERATE_JS_ERROR)
 #undef __ENUMERATE_JS_ERROR
-
-Utf16String const& ErrorType::message() const
-{
-    if (m_message.is_empty())
-        m_message = Utf16String::from_utf8_without_validation(m_format);
-    return m_message;
-}
 
 }

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -314,17 +314,16 @@ public:
     JS_ENUMERATE_ERROR_TYPES(__ENUMERATE_JS_ERROR)
 #undef __ENUMERATE_JS_ERROR
 
-    StringView format() const { return m_format; }
-    Utf16String const& message() const;
+    StringView format() const { return m_message.ascii_view(); }
+    Utf16String const& message() const { return m_message; }
 
 private:
-    explicit ErrorType(StringView format)
-        : m_format(format)
+    explicit ErrorType(Utf16String message)
+        : m_message(move(message))
     {
     }
 
-    StringView m_format;
-    mutable Utf16String m_message;
+    Utf16String m_message;
 };
 
 }

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -90,7 +90,7 @@ def main():
         parents=[preset_parser, compiler_parser, target_parser],
     )
     profile_parser.add_argument(
-        "args", nargs=argparse.REMAINDER, help="Additional arguments passed through to the build system"
+        "args", nargs=argparse.REMAINDER, help="Additional arguments passed through to the application"
     )
 
     install_parser = subparsers.add_parser(
@@ -168,8 +168,8 @@ def main():
         debug_main(platform.host_system, build_dir, args.target, args.debugger, args.cmd)
     elif args.command == "profile":
         build_dir = configure_main(platform, args.preset, args.cc, args.cxx)
-        build_main(build_dir, args.jobs, args.target, args.args)
-        profile_main(platform.host_system, build_dir, args.target)
+        build_main(build_dir, args.jobs, args.target)
+        profile_main(platform.host_system, build_dir, args.target, args.args)
     elif args.command == "install":
         build_dir = configure_main(platform, args.preset, args.cc, args.cxx)
         build_main(build_dir, args.jobs, args.target, args.args)
@@ -400,7 +400,7 @@ def debug_main(host_system: HostSystem, build_dir: Path, target: str, debugger: 
     run_command(gdb_args, exit_on_failure=True)
 
 
-def profile_main(host_system: HostSystem, build_dir: Path, target: str):
+def profile_main(host_system: HostSystem, build_dir: Path, target: str, args: list[str]):
     if not shutil.which("valgrind"):
         print("Please install valgrind", file=sys.stderr)
         sys.exit(1)
@@ -411,6 +411,8 @@ def profile_main(host_system: HostSystem, build_dir: Path, target: str):
         valgrind_args.append(str(build_dir.joinpath("bin", "Ladybird.app")))
     else:
         valgrind_args.append(str(build_dir.joinpath("bin", target)))
+
+    valgrind_args.extend(args)
 
     run_command(valgrind_args, exit_on_failure=True)
 


### PR DESCRIPTION
This brings Octane back down to previous numbers on my machine.