### PR TITLE
Revert "LibJS: Revert common error types to only hold a single string"

### DIFF
--- a/Libraries/LibJS/Runtime/ErrorTypes.cpp
+++ b/Libraries/LibJS/Runtime/ErrorTypes.cpp
@@ -9,8 +9,15 @@
 namespace JS {
 
 #define __ENUMERATE_JS_ERROR(name, message) \
-    const ErrorType ErrorType::name = ErrorType(message##_utf16);
+    const ErrorType ErrorType::name = ErrorType(message##sv);
 JS_ENUMERATE_ERROR_TYPES(__ENUMERATE_JS_ERROR)
 #undef __ENUMERATE_JS_ERROR
+
+Utf16String const& ErrorType::message() const
+{
+    if (m_message.is_empty())
+        m_message = Utf16String::from_utf8_without_validation(m_format);
+    return m_message;
+}
 
 }

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -314,16 +314,17 @@ public:
     JS_ENUMERATE_ERROR_TYPES(__ENUMERATE_JS_ERROR)
 #undef __ENUMERATE_JS_ERROR
 
-    StringView format() const { return m_message.ascii_view(); }
-    Utf16String const& message() const { return m_message; }
+    StringView format() const { return m_format; }
+    Utf16String const& message() const;
 
 private:
-    explicit ErrorType(Utf16String message)
-        : m_message(move(message))
+    explicit ErrorType(StringView format)
+        : m_format(format)
     {
     }
 
-    Utf16String m_message;
+    StringView m_format;
+    mutable Utf16String m_message;
 };
 
 }


### PR DESCRIPTION
This reverts commit 695bbcb991828344a3fa11d84fc258b69b9d929f.

Despite improving performance on my Linux machine, this managed to tank performance on the Linux benchmark machine.