### PR TITLE
LibWeb/CSS: Use response to get stylesheet encoding in at-rule import

### DIFF
--- a/Tests/LibWeb/Text/expected/css/import-rule-shift-jis.txt
+++ b/Tests/LibWeb/Text/expected/css/import-rule-shift-jis.txt
@@ -1,1 +1,2 @@
-PASS (didn't crash)
+rgb(0, 128, 0)
+rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/css/import-rule-shift-jis.html
+++ b/Tests/LibWeb/Text/input/css/import-rule-shift-jis.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <style>
-    @import "data:text/css;charset=shift_jis;base64,77u/I2RpdjIKewogICAgY29sb3I6IGdyZWVuOwp9Cgoulb2YYQp7CiAgICBjb2xvcjogcmVkOwp9Cg==";
+    @import "data:text/css;charset=shift_jis;base64,QGNoYXJzZXQgIndpbmRvd3MtMTI1MiI7Ci6VvZhhLCAjZGl2Mgp7CiAgICBjb2xvcjogZ3JlZW47Cn0=";
 </style>
 <script src="../include.js"></script>
+<div class="平和" id="平和">Filler Text</div>
+<div id="div2"></div>
 <script>
     test(() => {
-        println("PASS (didn't crash)");
+        println(getComputedStyle(平和).color);
+        println(getComputedStyle(div2).color);
     });
 </script>


### PR DESCRIPTION
A change to fix [this WPT test](https://wpt.live/css/CSS2/syntax/at-charset-002.xht) (EDIT: Also:  [4º](https://wpt.live/css/CSS2/syntax/at-charset-004.xht), [5º](https://wpt.live/css/CSS2/syntax/at-charset-005.xht) and [6º](https://wpt.live/css/CSS2/syntax/at-charset-006.xht)).

According to the [CSS Syntax spec](https://drafts.csswg.org/css-syntax/#input-byte-stream):

> If HTTP or equivalent protocol provides an encoding label (e.g. via the charset parameter of the Content-Type header) for the stylesheet, [get an encoding](https://encoding.spec.whatwg.org/#concept-encoding-get) from encoding label. If that does not return failure, return it.