### PR TITLE
LibWeb: Use `shape-rendering` to control anti aliasing for SVG paths

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1911,6 +1911,12 @@ ScrollbarWidth ComputedProperties::scrollbar_width() const
     return keyword_to_scrollbar_width(value.to_keyword()).release_value();
 }
 
+ShapeRendering ComputedProperties::shape_rendering() const
+{
+    auto const& value = property(PropertyID::ShapeRendering);
+    return keyword_to_shape_rendering(value.to_keyword()).release_value();
+}
+
 WillChange ComputedProperties::will_change() const
 {
     auto const& value = property(PropertyID::WillChange);

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -195,6 +195,7 @@ public:
     FillRule fill_rule() const;
     ClipRule clip_rule() const;
     float flood_opacity() const;
+    CSS::ShapeRendering shape_rendering() const;
 
     WillChange will_change() const;
 

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -258,6 +258,7 @@ public:
         };
     }
     static CSS::ScrollbarWidth scrollbar_width() { return CSS::ScrollbarWidth::Auto; }
+    static CSS::ShapeRendering shape_rendering() { return CSS::ShapeRendering::Auto; }
     static WillChange will_change() { return WillChange::make_auto(); }
 };
 
@@ -539,6 +540,7 @@ public:
     CSS::MixBlendMode mix_blend_mode() const { return m_noninherited.mix_blend_mode; }
     Optional<FlyString> view_transition_name() const { return m_noninherited.view_transition_name; }
     TouchActionData touch_action() const { return m_noninherited.touch_action; }
+    CSS::ShapeRendering shape_rendering() const { return m_noninherited.shape_rendering; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -838,6 +840,8 @@ protected:
 
         Color flood_color { InitialValues::flood_color() };
         float flood_opacity { InitialValues::flood_opacity() };
+
+        CSS::ShapeRendering shape_rendering { InitialValues::shape_rendering() };
     } m_noninherited;
 };
 
@@ -1027,6 +1031,7 @@ public:
     void set_clip_rule(CSS::ClipRule value) { m_inherited.clip_rule = value; }
     void set_flood_color(Color value) { m_noninherited.flood_color = value; }
     void set_flood_opacity(float value) { m_noninherited.flood_opacity = value; }
+    void set_shape_rendering(CSS::ShapeRendering value) { m_noninherited.shape_rendering = value; }
 
     void set_cx(LengthPercentage cx) { m_noninherited.cx = move(cx); }
     void set_cy(LengthPercentage cy) { m_noninherited.cy = move(cy); }

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -632,6 +632,12 @@
     "thin",
     "none"
   ],
+  "shape-rendering": [
+    "auto",
+    "optimizespeed",
+    "crispedges",
+    "geometricprecision"
+  ],
   "stroke-linecap": [
     "butt",
     "square",

--- a/Libraries/LibWeb/CSS/Keywords.json
+++ b/Libraries/LibWeb/CSS/Keywords.json
@@ -151,6 +151,7 @@
   "copy",
   "cover",
   "crisp-edges",
+  "crispedges",
   "crop",
   "cross",
   "crosshair",

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -3060,6 +3060,15 @@
       "none"
     ]
   },
+  "shape-rendering": {
+    "affects-layout": true,
+    "animation-type": "discrete",
+    "inherited": true,
+    "initial": "auto",
+    "valid-types": [
+      "shape-rendering"
+    ]
+  },
   "stop-color": {
     "affects-layout": false,
     "animation-type": "by-computed-value",

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -896,6 +896,7 @@ class VideoPaintable;
 class ViewportPaintable;
 
 enum class PaintPhase;
+enum class ShouldAntiAlias : bool;
 
 struct BorderRadiiData;
 struct BorderRadiusData;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -913,6 +913,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_stroke_width(stroke_width.as_length().length());
     else if (stroke_width.is_percentage())
         computed_values.set_stroke_width(CSS::LengthPercentage { stroke_width.as_percentage().percentage() });
+    computed_values.set_shape_rendering(computed_style.shape_rendering());
 
     auto const& mask_image = computed_style.property(CSS::PropertyID::MaskImage);
     if (mask_image.is_url()) {
@@ -1035,6 +1036,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     computed_values.set_mix_blend_mode(computed_style.mix_blend_mode());
     computed_values.set_view_transition_name(computed_style.view_transition_name());
     computed_values.set_contain(computed_style.contain());
+    computed_values.set_shape_rendering(computed_values.shape_rendering());
     computed_values.set_will_change(computed_style.will_change());
 
     computed_values.set_caret_color(computed_style.caret_color(*this));

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -30,6 +30,7 @@
 #include <LibWeb/Painting/PaintBoxShadowParams.h>
 #include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/Painting/ScrollState.h>
+#include <LibWeb/Painting/ShouldAntiAlias.h>
 
 namespace Web::Painting {
 
@@ -217,6 +218,7 @@ struct FillPath {
     float opacity { 1.0f };
     PaintStyleOrColor paint_style_or_color;
     Gfx::WindingRule winding_rule;
+    ShouldAntiAlias should_anti_alias { ShouldAntiAlias::Yes };
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return path_bounding_rect; }
 
@@ -239,6 +241,7 @@ struct StrokePath {
     float opacity;
     PaintStyleOrColor paint_style_or_color;
     float thickness;
+    ShouldAntiAlias should_anti_alias { ShouldAntiAlias::Yes };
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return path_bounding_rect; }
 

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -654,7 +654,7 @@ void DisplayListPlayerSkia::fill_path(FillPath const& command)
         auto const& color = command.paint_style_or_color.get<Color>();
         paint.setColor(to_skia_color(color));
     }
-    paint.setAntiAlias(true);
+    paint.setAntiAlias(command.should_anti_alias == ShouldAntiAlias::Yes);
     surface().canvas().drawPath(path, paint);
 }
 
@@ -670,7 +670,7 @@ void DisplayListPlayerSkia::stroke_path(StrokePath const& command)
         auto const& color = command.paint_style_or_color.get<Color>();
         paint.setColor(to_skia_color(color));
     }
-    paint.setAntiAlias(true);
+    paint.setAntiAlias(command.should_anti_alias == ShouldAntiAlias::Yes);
     paint.setStyle(SkPaint::Style::kStroke_Style);
     paint.setStrokeWidth(command.thickness);
     paint.setStrokeCap(to_skia_cap(command.cap_style));

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -78,7 +78,7 @@ void DisplayListRecorder::fill_path(FillPathParams params)
         .opacity = params.opacity,
         .paint_style_or_color = params.paint_style_or_color,
         .winding_rule = params.winding_rule,
-    });
+        .should_anti_alias = params.should_anti_alias });
 }
 
 void DisplayListRecorder::stroke_path(StrokePathParams params)
@@ -105,7 +105,7 @@ void DisplayListRecorder::stroke_path(StrokePathParams params)
         .opacity = params.opacity,
         .paint_style_or_color = params.paint_style_or_color,
         .thickness = params.thickness,
-    });
+        .should_anti_alias = params.should_anti_alias });
 }
 
 void DisplayListRecorder::draw_ellipse(Gfx::IntRect const& a_rect, Color color, int thickness)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -25,6 +25,7 @@
 #include <LibWeb/Painting/GradientData.h>
 #include <LibWeb/Painting/PaintBoxShadowParams.h>
 #include <LibWeb/Painting/PaintStyle.h>
+#include <LibWeb/Painting/ShouldAntiAlias.h>
 
 namespace Web::Painting {
 
@@ -45,6 +46,7 @@ public:
         float opacity = 1.0f;
         PaintStyleOrColor paint_style_or_color;
         Gfx::WindingRule winding_rule = Gfx::WindingRule::EvenOdd;
+        ShouldAntiAlias should_anti_alias { ShouldAntiAlias::Yes };
     };
     void fill_path(FillPathParams params);
 
@@ -58,6 +60,7 @@ public:
         float opacity = 1.0f;
         PaintStyleOrColor paint_style_or_color;
         float thickness;
+        ShouldAntiAlias should_anti_alias { ShouldAntiAlias::Yes };
     };
     void stroke_path(StrokePathParams);
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -18,6 +18,7 @@
 #include <LibWeb/Painting/ClipFrame.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableFragment.h>
+#include <LibWeb/Painting/ShouldAntiAlias.h>
 
 namespace Web::Painting {
 

--- a/Libraries/LibWeb/Painting/SVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPaintable.cpp
@@ -33,4 +33,12 @@ CSSPixelRect SVGPaintable::compute_absolute_rect() const
     return PaintableBox::compute_absolute_rect();
 }
 
+ShouldAntiAlias SVGPaintable::should_anti_alias() const
+{
+    auto shape_rendering = computed_values().shape_rendering();
+    if (first_is_one_of(shape_rendering, CSS::ShapeRendering::Optimizespeed, CSS::ShapeRendering::Crispedges))
+        return ShouldAntiAlias::No;
+    return ShouldAntiAlias::Yes;
+}
+
 }

--- a/Libraries/LibWeb/Painting/SVGPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGPaintable.h
@@ -23,6 +23,8 @@ protected:
     SVGPaintable(Layout::SVGBox const&);
 
     virtual CSSPixelRect compute_absolute_rect() const override;
+
+    ShouldAntiAlias should_anti_alias() const;
 };
 
 template<>

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -98,6 +98,7 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
             .path = closed_path(),
             .paint_style_or_color = Gfx::Color(Color::Black),
             .winding_rule = to_gfx_winding_rule(graphics_element.clip_rule().value_or(SVG::ClipRule::Nonzero)),
+            .should_anti_alias = should_anti_alias(),
         });
         return;
     }
@@ -116,12 +117,14 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
             .opacity = fill_opacity,
             .paint_style_or_color = *paint_style,
             .winding_rule = winding_rule,
+            .should_anti_alias = should_anti_alias(),
         });
     } else if (auto fill_color = graphics_element.fill_color(); fill_color.has_value()) {
         context.display_list_recorder().fill_path({
             .path = closed_path(),
             .paint_style_or_color = fill_color->with_opacity(fill_opacity),
             .winding_rule = winding_rule,
+            .should_anti_alias = should_anti_alias(),
         });
     }
 
@@ -177,6 +180,7 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
             .opacity = stroke_opacity,
             .paint_style_or_color = *paint_style,
             .thickness = stroke_thickness,
+            .should_anti_alias = should_anti_alias(),
         });
     } else if (auto stroke_color = graphics_element.stroke_color(); stroke_color.has_value()) {
         context.display_list_recorder().stroke_path({
@@ -188,6 +192,7 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
             .path = path,
             .paint_style_or_color = stroke_color->with_opacity(stroke_opacity),
             .thickness = stroke_thickness,
+            .should_anti_alias = should_anti_alias(),
         });
     }
 }

--- a/Libraries/LibWeb/Painting/ShouldAntiAlias.h
+++ b/Libraries/LibWeb/Painting/ShouldAntiAlias.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::Painting {
+
+enum class ShouldAntiAlias : bool {
+    Yes,
+    No,
+};
+
+}

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -80,6 +80,7 @@ static ReadonlySpan<NamedPropertyID> attribute_style_properties()
         NamedPropertyID(CSS::PropertyID::R, { SVG::TagNames::circle }),
         NamedPropertyID(CSS::PropertyID::Rx, { SVG::TagNames::ellipse, SVG::TagNames::rect }),
         NamedPropertyID(CSS::PropertyID::Ry, { SVG::TagNames::ellipse, SVG::TagNames::rect }),
+        NamedPropertyID(CSS::PropertyID::ShapeRendering),
         NamedPropertyID(CSS::PropertyID::StopColor),
         NamedPropertyID(CSS::PropertyID::StopOpacity),
         NamedPropertyID(CSS::PropertyID::Stroke),

--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
@@ -43,6 +43,7 @@ All properties associated with getComputedStyle(document.body):
     "math-style",
     "pointer-events",
     "quotes",
+    "shape-rendering",
     "stroke",
     "stroke-dasharray",
     "stroke-dashoffset",

--- a/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
@@ -634,6 +634,8 @@ All supported properties and their default values exposed from CSSStylePropertie
 'scrollbar-gutter': 'auto'
 'scrollbarWidth': 'auto'
 'scrollbar-width': 'auto'
+'shapeRendering': 'auto'
+'shape-rendering': 'auto'
 'stopColor': 'rgb(0, 0, 0)'
 'stop-color': 'rgb(0, 0, 0)'
 'stopOpacity': '1'

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -41,6 +41,7 @@ math-shift: normal
 math-style: normal
 pointer-events: auto
 quotes: auto
+shape-rendering: auto
 stroke: none
 stroke-dasharray: none
 stroke-dashoffset: 0
@@ -90,7 +91,7 @@ background-position-x: 0%
 background-position-y: 0%
 background-repeat: repeat
 background-size: auto
-block-size: 1380px
+block-size: 1395px
 border-block-end-color: rgb(0, 0, 0)
 border-block-end-style: none
 border-block-end-width: 0px
@@ -166,7 +167,7 @@ grid-row-start: auto
 grid-template-areas: none
 grid-template-columns: none
 grid-template-rows: none
-height: 2520px
+height: 2535px
 inline-size: 784px
 inset-block-end: auto
 inset-block-start: auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 256 tests
+Found 257 tests
 
-249 Pass
+250 Pass
 7 Fail
 Pass	accent-color
 Pass	border-collapse
@@ -45,6 +45,7 @@ Pass	math-shift
 Pass	math-style
 Pass	pointer-events
 Pass	quotes
+Pass	shape-rendering
 Pass	stroke
 Pass	stroke-dasharray
 Pass	stroke-dashoffset

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/shorthand-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/shorthand-values.txt
@@ -2,15 +2,15 @@ Harness status: OK
 
 Found 20 tests
 
-14 Pass
-6 Fail
+15 Pass
+5 Fail
 Pass	The serialization of border: 1px; border-top: 1px; should be canonical.
 Pass	The serialization of border: 1px solid red; should be canonical.
 Pass	The serialization of border: 1px red; should be canonical.
 Pass	The serialization of border: red; should be canonical.
 Fail	The serialization of border-top: 1px; border-right: 1px; border-bottom: 1px; border-left: 1px; border-image: none; should be canonical.
 Fail	The serialization of border-top: 1px; border-right: 1px; border-bottom: 1px; border-left: 1px; should be canonical.
-Fail	The serialization of border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px; should be canonical.
+Pass	The serialization of border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px; should be canonical.
 Fail	The serialization of border: 1px; border-top: 2px; should be canonical.
 Fail	The serialization of border: 1px; border-top: 1px !important; should be canonical.
 Fail	The serialization of border: 1px; border-top-color: red; should be canonical.

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/shape-rendering-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/shape-rendering-invalid.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	e.style['shape-rendering'] = "optimizelegibility" should not set the property value
+Pass	e.style['shape-rendering'] = "auto optimizespeed" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/shape-rendering-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/painting/parsing/shape-rendering-valid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	e.style['shape-rendering'] = "auto" should set the property value
+Pass	e.style['shape-rendering'] = "optimizespeed" should set the property value
+Pass	e.style['shape-rendering'] = "crispedges" should set the property value
+Pass	e.style['shape-rendering'] = "geometricprecision" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-irrelevant.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-irrelevant.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 46 tests
+Found 47 tests
 
-43 Pass
+44 Pass
 3 Fail
 Pass	clip-path presentation attribute supported on an irrelevant element
 Pass	clip-rule presentation attribute supported on an irrelevant element
@@ -30,6 +30,7 @@ Pass	mask presentation attribute supported on an irrelevant element
 Pass	opacity presentation attribute supported on an irrelevant element
 Pass	overflow presentation attribute supported on an irrelevant element
 Pass	pointer-events presentation attribute supported on an irrelevant element
+Pass	shape-rendering presentation attribute supported on an irrelevant element
 Pass	stop-color presentation attribute supported on an irrelevant element
 Pass	stop-opacity presentation attribute supported on an irrelevant element
 Pass	stroke presentation attribute supported on an irrelevant element

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 56 tests
+Found 57 tests
 
-52 Pass
+53 Pass
 4 Fail
 Pass	clip-path presentation attribute supported on a relevant element
 Pass	clip-rule presentation attribute supported on a relevant element
@@ -36,6 +36,7 @@ Pass	pointer-events presentation attribute supported on a relevant element
 Pass	r presentation attribute supported on a relevant element
 Pass	rx presentation attribute supported on a relevant element
 Pass	ry presentation attribute supported on a relevant element
+Pass	shape-rendering presentation attribute supported on a relevant element
 Pass	stop-color presentation attribute supported on a relevant element
 Pass	stop-opacity presentation attribute supported on a relevant element
 Pass	stroke presentation attribute supported on a relevant element

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-unknown.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-unknown.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 46 tests
+Found 47 tests
 
-43 Pass
+44 Pass
 3 Fail
 Pass	clip-path presentation attribute supported on an unknown SVG element
 Pass	clip-rule presentation attribute supported on an unknown SVG element
@@ -30,6 +30,7 @@ Pass	mask presentation attribute supported on an unknown SVG element
 Pass	opacity presentation attribute supported on an unknown SVG element
 Pass	overflow presentation attribute supported on an unknown SVG element
 Pass	pointer-events presentation attribute supported on an unknown SVG element
+Pass	shape-rendering presentation attribute supported on an unknown SVG element
 Pass	stop-color presentation attribute supported on an unknown SVG element
 Pass	stop-opacity presentation attribute supported on an unknown SVG element
 Pass	stroke presentation attribute supported on an unknown SVG element

--- a/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/shape-rendering-invalid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/shape-rendering-invalid.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing shape-rendering with invalid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:meta name="assert" content="shape-rendering supports only the grammar 'auto | optimizeSpeed | crispEdges | geometricPrecision'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_invalid_value("shape-rendering", "optimizelegibility");
+test_invalid_value("shape-rendering", "auto optimizespeed");
+
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/shape-rendering-valid.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/painting/parsing/shape-rendering-valid.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="800px">
+  <title>SVG Painting: parsing shape-rendering with valid values</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty"/>
+    <h:meta name="assert" content="shape-rendering supports the full grammar 'auto | optimizeSpeed | crispEdges | geometricPrecision'."/>
+  </metadata>
+  <g id="target"></g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="../../../css/support/parsing-testcommon.js"/>
+  <script><![CDATA[
+
+test_valid_value("shape-rendering", "auto");
+test_valid_value("shape-rendering", "optimizespeed");
+test_valid_value("shape-rendering", "crispedges");
+test_valid_value("shape-rendering", "geometricprecision");
+
+  ]]></script>
+</svg>


### PR DESCRIPTION
Anti-aliasing is disabled if `shape-rendering` is set to `optimizeSpeed` or `crispEdges`.

Here's an example from https://developer.mozilla.org/en-US/docs/Web/CSS/shape-rendering - previously all of these ellipses looked the same:
<img width="1362" height="803" alt="image" src="https://github.com/user-attachments/assets/8bd10b3f-69d3-4ba9-8002-a62cd56535c9" />


