### PR TITLE
LibWeb: Don't assume grid-related properties don't have var() in them

### DIFF
--- a/Tests/LibWeb/Text/expected/css/style-attribute-serialization-with-var-in-grid-properties.txt
+++ b/Tests/LibWeb/Text/expected/css/style-attribute-serialization-with-var-in-grid-properties.txt
@@ -1,0 +1,1 @@
+grid: var(--foo) var(--baz) var(--bar);

--- a/Tests/LibWeb/Text/input/css/style-attribute-serialization-with-var-in-grid-properties.html
+++ b/Tests/LibWeb/Text/input/css/style-attribute-serialization-with-var-in-grid-properties.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let e = document.createElement("div");
+        e.style.gridTemplateAreas = "var(--foo)";
+        e.style.gridTemplateColumns = "var(--bar)";
+        e.style.gridTemplateRows = "var(--baz)";
+        println(e.getAttribute("style"));
+    });
+</script>


### PR DESCRIPTION
When serializing the "style" attribute, we were incorrectly assuming that some of the grid-related CSS properties would never contain var() substitution functions.

With this fixed, we can now book appointments on https://cal.com/ :^)