### PR TITLE
LibWeb: Handle correctly case when abspos and relpos GFC is interleaved

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2120,7 +2120,7 @@ void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
         //       `Node::containing_block()` is not aware of that. Therefore, we need to
         //       find the closest grid item ancestor in order to identify grid area it belongs to.
         NodeWithStyle const* containing_grid_item = &box;
-        while (containing_grid_item->parent() && !containing_grid_item->parent()->display().is_grid_inside())
+        while (containing_grid_item->parent() && containing_grid_item->parent() != &grid_container())
             containing_grid_item = containing_grid_item->parent();
 
         auto const& computed_values = containing_grid_item->computed_values();

--- a/Tests/LibWeb/Layout/expected/grid/gfc-between-relpos-gfc-and-abspos-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid/gfc-between-relpos-gfc-and-abspos-item.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      Box <div.outer> at (8,8) content-size 784x0 positioned [GFC] children: not-inline
+        Box <div.middle> at (8,8) content-size 784x0 [GFC] children: not-inline
+          BlockContainer <div> at (8,8) content-size 784x0 [BFC] children: not-inline
+            BlockContainer <div.abs> at (8,8) content-size 0x0 positioned [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>.outer) [8,8 784x0]
+        PaintableBox (Box<DIV>.middle) [8,8 784x0]
+          PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
+            PaintableWithLines (BlockContainer<DIV>.abs) [8,8 0x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/gfc-between-relpos-gfc-and-abspos-item.html
+++ b/Tests/LibWeb/Layout/input/grid/gfc-between-relpos-gfc-and-abspos-item.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html><style>
+.outer { display: grid; position: relative; }
+.middle { display: grid; }
+.abs { position: absolute; }
+</style><div class="outer"><div class="middle"><div><div class="abs"></div>


### PR DESCRIPTION
...by another GFC. When searching for grid item that contains an abspos box positioned relative to GFC, it's incorrect to assume that the closest ancestor box whose parent establishes GFC is always the one we are looking for, because there may be non-positioned GFC in between.

Fixes regression introduced in 80c8e78.