### PR TITLE
AK: Specialize Optional for Utf16String and Utf16FlyString

### DIFF
--- a/AK/Utf16StringBase.h
+++ b/AK/Utf16StringBase.h
@@ -330,9 +330,17 @@ public:
         (*this_data)->ref();
     }
 
-    [[nodiscard]] constexpr FlatPtr raw(Badge<Utf16FlyString>) const { return bit_cast<FlatPtr>(m_value); }
+    template<OneOf<Utf16String, Utf16FlyString> T>
+    constexpr Utf16StringBase(Badge<T>, nullptr_t)
+        : m_value { .data = nullptr }
+    {
+    }
+
+    [[nodiscard]] constexpr FlatPtr raw(Badge<Utf16FlyString>) const { return raw(); }
 
 protected:
+    [[nodiscard]] constexpr FlatPtr raw() const { return bit_cast<FlatPtr>(m_value); }
+
     ALWAYS_INLINE void destroy_string() const
     {
         if (has_long_storage()) {

--- a/Tests/AK/TestUtf16FlyString.cpp
+++ b/Tests/AK/TestUtf16FlyString.cpp
@@ -146,3 +146,27 @@ TEST_CASE(is_one_of)
     EXPECT(bar.is_one_of("bar"sv, "foo"sv));
     EXPECT(bar.is_one_of("bar"sv));
 }
+
+TEST_CASE(optional)
+{
+    static_assert(AssertSize<Optional<Utf16FlyString>, sizeof(Utf16FlyString)>());
+
+    Optional<Utf16FlyString> string;
+    EXPECT(!string.has_value());
+
+    string = "ascii"_utf16_fly_string;
+    EXPECT(string.has_value());
+    EXPECT_EQ(string.value(), "ascii"sv);
+
+    auto released = string.release_value();
+    EXPECT(!string.has_value());
+    EXPECT_EQ(released, "ascii"sv);
+
+    string = u"well 😀 hello"_utf16_fly_string;
+    EXPECT(string.has_value());
+    EXPECT_EQ(string.value(), u"well 😀 hello"sv);
+
+    released = string.release_value();
+    EXPECT(!string.has_value());
+    EXPECT_EQ(released, u"well 😀 hello"sv);
+}

--- a/Tests/AK/TestUtf16String.cpp
+++ b/Tests/AK/TestUtf16String.cpp
@@ -1271,3 +1271,27 @@ TEST_CASE(code_point_at)
     test(u"😀"sv, 1);
     test(u"hello 😀 there!"sv, 14);
 }
+
+TEST_CASE(optional)
+{
+    static_assert(AssertSize<Optional<Utf16String>, sizeof(Utf16String)>());
+
+    Optional<Utf16String> string;
+    EXPECT(!string.has_value());
+
+    string = "ascii"_utf16;
+    EXPECT(string.has_value());
+    EXPECT_EQ(string.value(), "ascii"sv);
+
+    auto released = string.release_value();
+    EXPECT(!string.has_value());
+    EXPECT_EQ(released, "ascii"sv);
+
+    string = u"well 😀 hello"_utf16;
+    EXPECT(string.has_value());
+    EXPECT_EQ(string.value(), u"well 😀 hello"sv);
+
+    released = string.release_value();
+    EXPECT(!string.has_value());
+    EXPECT_EQ(released, u"well 😀 hello"sv);
+}


### PR DESCRIPTION
We added this for String some time ago, so let's give Utf16String the same optimization. Note that Utf16String was already handling its data member potentially being null as of 5af99f4dd0f0288eb7b9d4edaa3fdbace.