### PR TITLE
LibWeb: Propagate border-box dimensions when getting max content width

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1496,9 +1496,17 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
 
     LayoutState throwaway_state;
 
+    auto const& actual_box_state = m_state.get(box);
+
     auto& box_state = throwaway_state.get_mutable(box);
     box_state.width_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_width();
+
+    box_state.border_left = actual_box_state.border_left;
+    box_state.padding_left = actual_box_state.padding_left;
+
+    box_state.border_right = actual_box_state.border_right;
+    box_state.padding_right = actual_box_state.padding_right;
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
     if (!context) {

--- a/Tests/LibWeb/Layout/expected/min-width-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/min-width-border-box.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x50 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [18,18 30x30] baseline: 23.796875
+      BlockContainer <div.min-width> at (18,18) content-size 30x30 inline-block [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [18,18 6.34375x18] baseline: 13.796875
+            "1"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableWithLines (BlockContainer<DIV>.min-width) [8,8 50x50]
+        TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x66] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/min-width-border-box.html
+++ b/Tests/LibWeb/Layout/input/min-width-border-box.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            .min-width {
+                background-color: red;
+                box-sizing: border-box;
+                display: inline-block;
+                height: 50px;
+                min-width: 50px;
+                padding: 10px;
+            }
+        </style>
+    </head><body><div class="min-width">1</div></body></html>


### PR DESCRIPTION
This means that we now calculate the inner width correctly for `display: inline-block` nodes when we have `box-sizing: border-box` and `min-width`, as we would previously assume these dimensions were all `0`