### PR TITLE
LibCore: Don't send SIGTRAP when debugger attaches

### DIFF
--- a/Libraries/LibCore/Process.cpp
+++ b/Libraries/LibCore/Process.cpp
@@ -307,10 +307,8 @@ void Process::wait_for_debugger_and_break()
             dbgln("Cannot wait for debugger: {}. Continuing.", check.release_error());
             return;
         }
-        if (check.value()) {
-            kill(getpid(), SIGTRAP);
+        if (check.value())
             return;
-        }
         if (should_print_process_info) {
             dbgln("Process {} with pid {} is sleeping, waiting for debugger.", Process::get_name(), getpid());
             should_print_process_info = false;


### PR DESCRIPTION
Both gdb and lldb interrupt execution after attaching to the process, so no need to send a SIGTRAP immediately after which would require typing `continue` in the debugger twice.