### PR TITLE
Meta: Use `pathlib.Path(file).parent.parent` instead of...

### DIFF
--- a/Meta/check-html-doctype.py
+++ b/Meta/check-html-doctype.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -52,5 +53,5 @@ def run():
 
 
 if __name__ == "__main__":
-    os.chdir(os.path.dirname(__file__) + "/..")
+    os.chdir(pathlib.Path(__file__).parent.parent)
     run()

--- a/Meta/check-idl-files.py
+++ b/Meta/check-idl-files.py
@@ -86,5 +86,5 @@ def run():
 
 
 if __name__ == "__main__":
-    os.chdir(os.path.dirname(__file__) + "/..")
+    os.chdir(pathlib.Path(__file__).parent.parent)
     run()

--- a/Meta/check-newlines-at-eof.py
+++ b/Meta/check-newlines-at-eof.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -74,5 +75,5 @@ def run():
 
 
 if __name__ == "__main__":
-    os.chdir(os.path.dirname(__file__) + "/..")
+    os.chdir(pathlib.Path(__file__).parent.parent)
     run()

--- a/Meta/check-style.py
+++ b/Meta/check-style.py
@@ -190,5 +190,5 @@ def run():
 
 
 if __name__ == "__main__":
-    os.chdir(os.path.dirname(__file__) + "/..")
+    os.chdir(pathlib.Path(__file__).parent.parent)
     run()


### PR DESCRIPTION
... `os.path.dirname(file) + "/.."` in Python scripts

This makes them a little more system agnostic.

Since Python 3.6 `chdir` accepts [path-like object](https://docs.python.org/3/library/os.html#os.chdir).