### PR TITLE
LibWeb: Indicate focus on contenteditable elements

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4078,7 +4078,7 @@ bool Element::should_indicate_focus() const
 
     // * If the element which supports keyboard input (such as an input element, or any other element that would
     //   triggers a virtual keyboard to be shown on focus if a physical keyboard were not present), indicate focus.
-    if (is<HTML::FormAssociatedTextControlElement>(this))
+    if (is<HTML::FormAssociatedTextControlElement>(this) || is_editable_or_editing_host())
         return true;
 
     // * If the user interacts with the page via keyboard or some other non-pointing device, indicate focus. (This means

--- a/Tests/LibWeb/Text/expected/focus-shouldIndicateFocus.txt
+++ b/Tests/LibWeb/Text/expected/focus-shouldIndicateFocus.txt
@@ -1,2 +1,3 @@
 INPUT: rgb(0, 0, 0) auto 3px
 BUTTON: rgb(0, 0, 0) 0px
+DIV: rgb(0, 0, 0) auto 3px

--- a/Tests/LibWeb/Text/input/focus-shouldIndicateFocus.html
+++ b/Tests/LibWeb/Text/input/focus-shouldIndicateFocus.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <input value="foo"><br>
 <button>bar</button>
+<div contenteditable>baz</div>
 <script src="include.js"></script>
 <script>
 test(() => {
@@ -13,5 +14,6 @@ test(() => {
 
     runOutlineTest('input');
     runOutlineTest('button');
+    runOutlineTest('div[contenteditable]');
 });
 </script>


### PR DESCRIPTION
This mirrors what Chrome and Firefox do.