### PR TITLE
LibWeb: Make DOM::Position's node mandatory

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -477,14 +477,11 @@ Document::Document(JS::Realm& realm, const URL::URL& url, TemporaryDocumentForFr
         if (!cursor_position)
             return;
 
-        auto node = cursor_position->node();
-        if (!node)
-            return;
-
         auto navigable = this->navigable();
         if (!navigable || !navigable->is_focused())
             return;
 
+        auto node = cursor_position->node();
         node->document().update_layout(UpdateLayoutReason::CursorBlinkTimer);
 
         if (node->paintable()) {

--- a/Libraries/LibWeb/DOM/Position.cpp
+++ b/Libraries/LibWeb/DOM/Position.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,7 +14,7 @@ namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(Position);
 
-Position::Position(GC::Ptr<Node> node, unsigned offset)
+Position::Position(GC::Ref<Node> node, unsigned offset)
     : m_node(node)
     , m_offset(offset)
 {
@@ -27,8 +28,6 @@ void Position::visit_edges(Visitor& visitor)
 
 ErrorOr<String> Position::to_string() const
 {
-    if (!node())
-        return String::formatted("DOM::Position(nullptr, {})", offset());
     return String::formatted("DOM::Position({} ({})), {})", node()->node_name(), node().ptr(), offset());
 }
 

--- a/Libraries/LibWeb/DOM/Position.h
+++ b/Libraries/LibWeb/DOM/Position.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,7 +9,6 @@
 #pragma once
 
 #include <AK/Error.h>
-#include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <LibGC/Heap.h>
 #include <LibWeb/DOM/Node.h>
@@ -26,24 +26,24 @@ public:
         return realm.create<Position>(node, offset);
     }
 
-    GC::Ptr<Node> node() { return m_node; }
-    GC::Ptr<Node const> node() const { return m_node; }
+    GC::Ref<Node> node() { return m_node; }
+    GC::Ref<Node const> node() const { return m_node; }
 
     unsigned offset() const { return m_offset; }
 
     bool equals(GC::Ref<Position> other) const
     {
-        return m_node.ptr() == other->m_node.ptr() && m_offset == other->m_offset;
+        return m_node == other->m_node && m_offset == other->m_offset;
     }
 
     ErrorOr<String> to_string() const;
 
 private:
-    Position(GC::Ptr<Node>, unsigned offset);
+    Position(GC::Ref<Node>, unsigned offset);
 
     virtual void visit_edges(Visitor&) override;
 
-    GC::Ptr<Node> m_node;
+    GC::Ref<Node> m_node;
     unsigned m_offset { 0 };
 };
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -695,7 +695,7 @@ void paint_cursor_if_needed(DisplayListRecordingContext& context, TextPaintable 
         return;
 
     auto cursor_position = document.cursor_position();
-    if (!cursor_position || !cursor_position->node())
+    if (!cursor_position)
         return;
 
     if (cursor_position->node() != paintable.dom_node())


### PR DESCRIPTION
We can only construct positions if there's a node involved, which was already enforced by Position::create() only accepting a GC::Ref.