### PR TITLE
LibWeb: Reset cursor blink cycle, even if there's no viewport paintable

### DIFF
--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -104,8 +104,8 @@ void Range::update_associated_selection()
         return;
 
     auto& document = m_start_container->document();
+    document.reset_cursor_blink_cycle();
     if (auto* viewport = document.paintable()) {
-        document.reset_cursor_blink_cycle();
         viewport->recompute_selection_states(*this);
         viewport->set_needs_display();
     }


### PR DESCRIPTION
If we programmatically set a selection in an editable element during document load, we failed to start the cursor blink cycle timer. The cursor blink logic already takes care of us not having the paintable yet, so start it unconditionally.