### PR TITLE
LibWeb: Render SVG images on GPU when it's available

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -141,19 +141,17 @@ Navigable::Navigable(GC::Ref<Page> page, bool is_svg_page)
 {
     all_navigables().set(*this);
 
-    if (!m_is_svg_page) {
-        auto display_list_player_type = page->client().display_list_player_type();
-        OwnPtr<Painting::DisplayListPlayerSkia> skia_player;
-        if (display_list_player_type == DisplayListPlayerType::SkiaGPUIfAvailable) {
-            m_skia_backend_context = get_skia_backend_context();
-            skia_player = make<Painting::DisplayListPlayerSkia>(m_skia_backend_context);
-        } else {
-            skia_player = make<Painting::DisplayListPlayerSkia>();
-        }
-
-        m_rendering_thread.set_skia_player(move(skia_player));
-        m_rendering_thread.start(display_list_player_type);
+    auto display_list_player_type = page->client().display_list_player_type();
+    OwnPtr<Painting::DisplayListPlayerSkia> skia_player;
+    if (display_list_player_type == DisplayListPlayerType::SkiaGPUIfAvailable) {
+        m_skia_backend_context = get_skia_backend_context();
+        skia_player = make<Painting::DisplayListPlayerSkia>(m_skia_backend_context);
+    } else {
+        skia_player = make<Painting::DisplayListPlayerSkia>();
     }
+
+    m_rendering_thread.set_skia_player(move(skia_player));
+    m_rendering_thread.start(display_list_player_type);
 }
 
 Navigable::~Navigable() = default;

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -221,6 +221,8 @@ public:
 
     void set_should_show_line_box_borders(bool value) { m_should_show_line_box_borders = value; }
 
+    RenderingThread& rendering_thread() { return m_rendering_thread; }
+
     bool is_svg_page() const { return m_is_svg_page; }
 
     template<typename T>

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -40,7 +40,7 @@ public:
 private:
     SVGDecodedImageData(GC::Ref<Page>, GC::Ref<SVGPageClient>, GC::Ref<DOM::Document>, GC::Ref<SVG::SVGSVGElement>);
 
-    RefPtr<Gfx::Bitmap> render(Gfx::IntSize) const;
+    RefPtr<Gfx::ImmutableBitmap> render(Gfx::IntSize) const;
 
     mutable HashMap<Gfx::IntSize, NonnullRefPtr<Gfx::ImmutableBitmap>> m_cached_rendered_bitmaps;
 


### PR DESCRIPTION
Instead of rasterizing SVG images on the main thread using the CPU, we now offload the work to the rasterization thread that owns the GPU context (or the CPU if the GPU is unavailable). Currently, the main thread waits synchronously for the rendering thread to finish. Making this process asynchronous is left as an exercise for our future selves.

Makes initial loading of https://www.unkey.com/ much faster.