### PR TITLE
CI: Fixate js-benchmarks to current master

### DIFF
--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           repository: LadybirdBrowser/js-benchmarks
           path: js-benchmarks
+          ref: d151be80c96e4f8acb364d3f199c25481b56f287
 
       - name: 'Install dependencies'
         if: ${{ matrix.os_name == 'Linux' }}


### PR DESCRIPTION
The output format for js-benchmarks is going to change, and while the webhook parsing the results has not yet been updated fixate the js-benchmark checkout to a specific commit.