### PR TITLE
LibWeb: Emit XMLHttpRequest timeout event when the request times out

### DIFF
--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -885,6 +885,8 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
                 if (!request->done()) {
                     m_timed_out = true;
                     m_fetch_controller->terminate();
+
+                    handle_errors().release_value_but_fixme_should_propagate_errors();
                 }
             });
 

--- a/Tests/LibWeb/Text/expected/wpt-import/xhr/abort-after-stop.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/xhr/abort-after-stop.window.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	XMLHttpRequest: abort event should fire when stop() method is used

--- a/Tests/LibWeb/Text/expected/wpt-import/xhr/abort-after-timeout.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/xhr/abort-after-timeout.any.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	XMLHttpRequest: abort() after a timeout should not fire "abort" event

--- a/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-stop.window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-stop.window.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>XMLHttpRequest: abort event should fire when stop() method is used</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../xhr/abort-after-stop.window.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-stop.window.js
+++ b/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-stop.window.js
@@ -1,0 +1,22 @@
+// META: title=XMLHttpRequest: abort event should fire when stop() method is used
+
+      var test = async_test();
+      window.onload = test.step_func(function() {
+        var client = new XMLHttpRequest();
+        var abortFired = false;
+        var sync = true;
+        client.onabort = test.step_func(function (e) {
+          assert_false(sync);
+          assert_equals(e.type, 'abort');
+          assert_equals(client.status, 0);
+          abortFired = true;
+        });
+        client.open("GET", "resources/delay.py?ms=3000", true);
+        client.send(null);
+        test.step_timeout(() => {
+          assert_equals(abortFired, true);
+          test.done();
+        }, 200);
+        window.stop();
+        sync = false;
+      });

--- a/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-timeout.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-timeout.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>XMLHttpRequest: abort() after a timeout should not fire "abort" event</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../xhr/abort-after-timeout.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-timeout.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/xhr/abort-after-timeout.any.js
@@ -1,0 +1,43 @@
+// META: title=XMLHttpRequest: abort() after a timeout should not fire "abort" event
+
+    var test = async_test();
+
+    test.step(function() {
+        // timeout is 100ms
+        // the download would otherwise take 1000ms
+        // we check after 300ms to make sure abort does not fire an "abort" event
+
+        var timeoutFired = false;
+
+        var client = new XMLHttpRequest();
+
+        assert_true('timeout' in client, 'xhr.timeout is not supported in this user agent');
+
+        client.timeout = 100;
+
+        test.step_timeout(() => {
+            assert_true(timeoutFired);
+
+            // abort should not cause the "abort" event to fire
+            client.abort();
+
+            test.step_timeout(() => { // use a timeout to catch any implementation that might queue an abort event for later - just in case
+              test.done()
+            }, 200);
+
+            assert_equals(client.readyState, 0);
+        }, 300);
+
+        client.ontimeout = function () {
+            timeoutFired = true;
+        };
+
+        client.onabort = test.step_func(function () {
+            // this should not fire!
+
+            assert_unreached("abort() should not cause the abort event to fire");
+        });
+
+        client.open("GET", "/common/blank.html?pipe=trickle(d1)", true);
+        client.send(null);
+    });


### PR DESCRIPTION
When an XMLHttpRequest times out, we now call handle_errors() to fire the timeout event. This is to prevent abort from firing if it gets called after the request has timed out. This change fixes 2 WPT tests that are also now imported into the tests folder.