### PR TITLE
LibCore: Add AVIF to registered types in MimeData

### DIFF
--- a/Libraries/LibCore/MimeData.cpp
+++ b/Libraries/LibCore/MimeData.cpp
@@ -114,6 +114,7 @@ static Array const s_registered_mime_type = {
     MimeType { .name = "font/woff"sv, .common_extensions = { "woff"sv }, .description = "WOFF font"sv, .magic_bytes = Vector<u8> { 'W', 'O', 'F', 'F' } },
     MimeType { .name = "font/woff2"sv, .common_extensions = { "woff2"sv }, .description = "WOFF2 font"sv, .magic_bytes = Vector<u8> { 'W', 'O', 'F', '2' } },
 
+    MimeType { .name = "image/avif"sv, .common_extensions = { ".avif"sv }, .description = "AVIF image data"sv },
     MimeType { .name = "image/bmp"sv, .common_extensions = { ".bmp"sv }, .description = "BMP image data"sv, .magic_bytes = Vector<u8> { 'B', 'M' } },
     MimeType { .name = "image/gif"sv, .common_extensions = { ".gif"sv }, .description = "GIF image data"sv, .magic_bytes = Vector<u8> { 'G', 'I', 'F', '8', '7', 'a' } },
     MimeType { .name = "image/gif"sv, .common_extensions = { ".gif"sv }, .description = "GIF image data"sv, .magic_bytes = Vector<u8> { 'G', 'I', 'F', '8', '9', 'a' } },

--- a/Tests/LibCore/TestLibCoreMimeType.cpp
+++ b/Tests/LibCore/TestLibCoreMimeType.cpp
@@ -54,4 +54,10 @@ TEST_CASE(various_types_guessed)
     check_filename_mimetype(gzip_filenames, "application/gzip"sv);
     check_filename_mimetype(markdown_filenames, "text/markdown"sv);
     check_filename_mimetype(shell_filenames, "text/x-shellscript"sv);
+
+    // Images
+    check_filename_mimetype(Vector { "image.png"sv }, "image/png"sv);
+    check_filename_mimetype(Vector { "smiley.jpg"sv, "apple.jpeg"sv }, "image/jpeg"sv);
+    check_filename_mimetype(Vector { "cats.webp"sv }, "image/webp"sv);
+    check_filename_mimetype(Vector { "dogs.avif"sv }, "image/avif"sv);
 }


### PR DESCRIPTION
This allows you to open local avif files using the `file://` schema.