### PR TITLE
LibGC: Make GC::Root bool operator explicit

### DIFF
--- a/Libraries/LibGC/Root.h
+++ b/Libraries/LibGC/Root.h
@@ -105,7 +105,7 @@ public:
     {
         return !cell();
     }
-    operator bool() const
+    explicit operator bool() const
     {
         return cell();
     }


### PR DESCRIPTION
Not having this led to a sneaky bug where, given a Variant like so:

```c++
Variant<double, GC::Root<T>>
```

An incorrectly-written visit() branch for the Root would just cause it to be cast to a double and call that branch instead.

With the cast made explicit, we get a compiler error, which is far more useful.