### PR TITLE
LibWeb/XHR: Minor cleanup in XMLHttpRequest

### DIFF
--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -808,8 +808,6 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
             if (!length.has<u64>())
                 length = 0;
 
-            // FIXME: We can't implement these steps yet, as we don't fully implement the Streams standard.
-
             // 10. Let processBodyChunk given bytes be these steps:
             auto process_body_chunks = GC::create_function(heap(), [this, length](ByteBuffer byte_buffer) {
                 // 1. Append bytes to this’s received bytes.


### PR DESCRIPTION
Mostly removing outdated FIXME comments, and adding one missing spec comment.

Also, MUSTing `handle_{errors,response_end_of_body}` since these are not supposed to throw in an async context, and we no longer want to handle minor OOMs.

