### PR TITLE
LibTLS+Tests/LibDNS: Load Windows default certificate store and enable TLS-dependent tests in Windows CI

### DIFF
--- a/Libraries/LibCore/SocketWindows.cpp
+++ b/Libraries/LibCore/SocketWindows.cpp
@@ -116,7 +116,7 @@ ErrorOr<size_t> PosixSocketHelper::pending_bytes() const
         return Error::from_windows_error(WSAENOTCONN);
     }
 
-    u_long value;
+    u_long value = 0;
     TRY(System::ioctl(m_fd, FIONREAD, &value));
     return value;
 }

--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -222,7 +222,13 @@ ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect_internal(NonnullOwnPtr<Core::TCPS
         SSL_CTX_load_verify_file(ssl_ctx, path.characters());
     } else {
         // Use the default trusted certificate store
+#if defined(AK_OS_WINDOWS)
+        // https://stackoverflow.com/questions/9507184/can-openssl-on-windows-use-the-system-certificate-store
+        // https://docs.openssl.org/master/man7/OSSL_STORE-winstore/
+        OPENSSL_TRY(SSL_CTX_load_verify_store(ssl_ctx, "org.openssl.winstore://"));
+#else
         OPENSSL_TRY(SSL_CTX_set_default_verify_paths(ssl_ctx));
+#endif
     }
 
     // Require a minimum TLS version of TLSv1.2.

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(LibCompress)
 add_subdirectory(LibCore)
 add_subdirectory(LibCrypto)
 add_subdirectory(LibDiff)
+add_subdirectory(LibDNS)
 add_subdirectory(LibGC)
 add_subdirectory(LibJS)
 add_subdirectory(LibRegex)
@@ -21,13 +22,6 @@ if (ENABLE_GUI_TARGETS)
     add_subdirectory(LibWeb)
     add_subdirectory(LibWebView)
 endif()
-
-# FIXME: Increase support for building targets on Windows
-if (WIN32 AND ENABLE_WINDOWS_CI)
-    return()
-endif()
-
-add_subdirectory(LibDNS)
 
 if (ENABLE_CLANG_PLUGINS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     add_subdirectory(ClangPlugins)

--- a/Tests/LibTLS/CMakeLists.txt
+++ b/Tests/LibTLS/CMakeLists.txt
@@ -1,14 +1,7 @@
 set(TEST_SOURCES
     TestTLSCertificateParser.cpp
+    TestTLSHandshake.cpp
 )
-
-if (NOT WIN32 OR NOT ENABLE_WINDOWS_CI)
-    # FIXME: This test cannot find the default OpenSSL CA certificates on Windows CI
-    # https://github.com/LadybirdBrowser/ladybird/issues/5355
-    list(APPEND TEST_SOURCES
-       TestTLSHandshake.cpp
-    )
-endif()
 
 foreach(source IN LISTS TEST_SOURCES)
     lagom_test("${source}" LibTLS LIBS LibTLS LibCrypto WORKING_DIRECTORY ${Lagom_BINARY_DIR})


### PR DESCRIPTION
Initially was done just so `Tests/LibDNS` could be enabled (working towards loading web pages from `https` requests on Windows Ladybird), but I later found this also addresses #5355 too. This needs the `windows` label