### PR TITLE
LibWeb: Fix pathological border-radius normalization artifacts

### DIFF
--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -264,6 +264,16 @@ Painting::BorderRadiiData normalize_border_radii_data(Layout::Node const& node, 
         }
     }
 
+    // Sanity check: If normalization resulted in pathological asymmetric values,
+    // zero out the border radius to force square corners
+    for (auto* corner : { &radii_px.top_left, &radii_px.top_right, &radii_px.bottom_right, &radii_px.bottom_left }) {
+        bool has_extreme_asymmetry = (corner->horizontal_radius > rect.width() / 4 && corner->vertical_radius < 1) || (corner->vertical_radius > rect.height() / 4 && corner->horizontal_radius < 1);
+        if (has_extreme_asymmetry) {
+            corner->horizontal_radius = 0;
+            corner->vertical_radius = 0;
+        }
+    }
+
     return radii_px;
 }
 

--- a/Tests/LibWeb/Ref/expected/border-radius-asymmetric-normalization-ref.html
+++ b/Tests/LibWeb/Ref/expected/border-radius-asymmetric-normalization-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body {
+      margin: 0;
+      padding: 20px;
+      background-color: #f0f0f0;
+    }
+
+    .test-box {
+      width: 100px;
+      height: 60px;
+      background-color: #4CAF50;
+      border: 32px solid #333;
+      /* No border-radius - should be square corners */
+    }
+  </style>
+</head>
+<body>
+  <div class="test-box"></div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/border-radius-asymmetric-normalization.html
+++ b/Tests/LibWeb/Ref/input/border-radius-asymmetric-normalization.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="match" href="../expected/border-radius-asymmetric-normalization-ref.html" />
+  <style>
+    body {
+      margin: 0;
+      padding: 20px;
+      background-color: #f0f0f0;
+    }
+
+    .test-box {
+      width: 100px;
+      height: 60px;
+      background-color: #4CAF50;
+      border: 32px solid #333;
+      border-radius: 4327897432px / 342423px;
+    }
+  </style>
+</head>
+<body>
+  <div class="test-box"></div>
+</body>
+</html>


### PR DESCRIPTION
When extreme border-radius values are normalized, they can result in asymmetric values causing rendering artifacts where triangular slices appear instead of the expected border.

Fix by detecting these cases and forcing square corners as a fallback.

> before (current master)
<img width="205" height="196" alt="Screenshot 2025-08-21 at 10 30 25 PM" src="https://github.com/user-attachments/assets/12256755-82f1-430e-9372-8a20f6bcb578" />

> before with fix from #5936 
<img width="205" height="164" alt="Screenshot 2025-08-21 at 10 32 24 PM" src="https://github.com/user-attachments/assets/a3befe7e-d6c4-438c-9d72-37c5beb0c7dc" />

> after
<img width="209" height="168" alt="Screenshot 2025-08-21 at 10 29 20 PM" src="https://github.com/user-attachments/assets/a7a3f604-d7c9-4d48-a310-0dd8edd5b50f" />
