### PR TITLE
Two IndexedDB crash fixes (missing GC visits)

### DIFF
--- a/Libraries/LibWeb/IndexedDB/IDBCursor.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBCursor.cpp
@@ -54,6 +54,9 @@ void IDBCursor::visit_edges(Visitor& visitor)
     visitor.visit(m_range);
     visitor.visit(m_request);
 
+    if (m_value.has_value())
+        visitor.visit(*m_value);
+
     m_source_handle.visit([&](auto& source) {
         visitor.visit(source);
     });

--- a/Libraries/LibWeb/IndexedDB/IDBRequest.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBRequest.cpp
@@ -9,6 +9,9 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/IndexedDB/IDBCursor.h>
+#include <LibWeb/IndexedDB/IDBIndex.h>
+#include <LibWeb/IndexedDB/IDBObjectStore.h>
 #include <LibWeb/IndexedDB/IDBRequest.h>
 #include <LibWeb/IndexedDB/IDBTransaction.h>
 
@@ -41,6 +44,10 @@ void IDBRequest::visit_edges(Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_result);
     visitor.visit(m_transaction);
+
+    m_source.visit(
+        [&](Empty) {},
+        [&](auto const& object) { visitor.visit(object); });
 
     if (m_error.has_value())
         visitor.visit(*m_error);


### PR DESCRIPTION
These were causing crashes in YouTube's embed scripts.

Filed two clang plugin issues to automate catching of these bugs:
- #5958 
- #5959 