### PR TITLE
LibWeb: Create XML document object for SVG-as-image

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -56,7 +56,7 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& rea
         HTML::UserNavigationInvolvement::None);
 
     // FIXME: Use Navigable::navigate() instead of manually replacing the navigable's document.
-    auto document = MUST(DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params));
+    auto document = MUST(DOM::Document::create_and_initialize(DOM::Document::Type::XML, "image/svg+xml"_string, navigation_params));
     navigable->set_ongoing_navigation({});
     navigable->active_document()->destroy();
     navigable->active_session_history_entry()->document_state()->set_document(document);

--- a/Tests/LibWeb/Crash/SVG/image-as-svg-with-cdata.html
+++ b/Tests/LibWeb/Crash/SVG/image-as-svg-with-cdata.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<img src="svg-with-cdata.svg">

--- a/Tests/LibWeb/Crash/SVG/svg-with-cdata.svg
+++ b/Tests/LibWeb/Crash/SVG/svg-with-cdata.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"><style><![CDATA[.foo{}]]></style></svg>


### PR DESCRIPTION
It's not enough to just use the XML parser, we also have to make sure the DOM document we produce is an actual XML document.

Fixes #5966