### PR TITLE
LibWeb: Fix algorithm that distributes space beyond limits [GFC]

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -828,14 +828,23 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_base_si
             }
 
             // if there are no such tracks, then all affected tracks.
-            if (tracks_to_grow_beyond_limits.size() == 0)
+            if (tracks_to_grow_beyond_limits.is_empty())
+                tracks_to_grow_beyond_limits = affected_tracks;
+        } else if (phase == SpaceDistributionPhase::AccommodateMaxContentContribution) {
+            // when accommodating max-content contributions into base sizes: any affected track that happens to also have
+            // a max-content max track sizing function;
+            for (auto& track : affected_tracks) {
+                if (track.max_track_sizing_function.is_max_content())
+                    tracks_to_grow_beyond_limits.append(track);
+            }
+
+            // if there are no such tracks, then all affected tracks.
+            if (tracks_to_grow_beyond_limits.is_empty())
                 tracks_to_grow_beyond_limits = affected_tracks;
         }
-        // FIXME: when accommodating max-content contributions: any affected track that happens to also have a
-        //        max-content max track sizing function; if there are no such tracks, then all affected tracks.
 
-        CSSPixels increase_per_track = extra_space / affected_tracks.size();
-        for (auto& track : affected_tracks) {
+        CSSPixels increase_per_track = extra_space / tracks_to_grow_beyond_limits.size();
+        for (auto& track : tracks_to_grow_beyond_limits) {
             auto increase = min(increase_per_track, extra_space);
             track.item_incurred_increase += increase;
             extra_space -= increase;

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-content-sized-columns-resolution.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-content-sized-columns-resolution.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 42 tests
 
-21 Pass
-21 Fail
+26 Pass
+16 Fail
 Pass	Element 'gridMinContentFixedAndAuto' grid-template-columns value computes to '15px 75px'
 Pass	Element 'gridAutoAndAuto' grid-template-columns value computes to '45px 45px'
 Fail	Element 'gridMinContentAndMinContentFixed' grid-template-columns value computes to '20px 30px'
@@ -40,9 +40,9 @@ Pass	Element 'gridAutoMinContentUnsorted' grid-template-columns value computes t
 Fail	Element 'gridAutoMaxContentUnsorted' grid-template-columns value computes to '0px 90px'
 Pass	Element 'gridMaxContentAndMinContentFixedUnsorted' grid-template-columns value computes to '50px 40px'
 Pass	Element 'gridMaxContentAndMaxContentFixedUnsorted' grid-template-columns value computes to '40px 70px'
-Fail	Element 'gridMinContentFixedAndAutoAboveLimits' grid-template-columns value computes to '15px 95px'
-Fail	Element 'gridMaxContentFixedAndAutoAboveLimits' grid-template-columns value computes to '15px 135px'
-Fail	Element 'gridMinContentFixedAndFixedFixedAndAuto' grid-template-columns value computes to '20px 20px 60px'
-Fail	Element 'gridAutoAndFixedFixedAndMaxContentFixed' grid-template-columns value computes to '110px 20px 20px'
+Pass	Element 'gridMinContentFixedAndAutoAboveLimits' grid-template-columns value computes to '15px 95px'
+Pass	Element 'gridMaxContentFixedAndAutoAboveLimits' grid-template-columns value computes to '15px 135px'
+Pass	Element 'gridMinContentFixedAndFixedFixedAndAuto' grid-template-columns value computes to '20px 20px 60px'
+Pass	Element 'gridAutoAndFixedFixedAndMaxContentFixed' grid-template-columns value computes to '110px 20px 20px'
 Pass	Element 'gridMaxContentAndMaxContentFixedAndMaxContent' grid-template-columns value computes to '70px 20px 50px'
-Fail	Element 'gridAutoAndMinContentFixedAndMinContent' grid-template-columns value computes to '55px 30px 65px'
+Pass	Element 'gridAutoAndMinContentFixedAndMinContent' grid-template-columns value computes to '55px 30px 65px'


### PR DESCRIPTION
Fixes bug when we didn't use `tracks_to_grow_beyond_limits` and instead distributed extra space to all affected tracks. Also implements missing "when accommodating max-content" part.