### PR TITLE
LibWeb: Fix input/textarea width inconsistencies in flex containers

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -279,6 +279,9 @@ private:
     // https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image):dimension-attributes
     virtual bool supports_dimension_attributes() const override { return type_state() == TypeAttributeState::ImageButton; }
 
+    bool is_text_input_type() const;
+    void set_natural_width_from_size(Layout::Box& layout_node) const;
+
     // ^Layout::ImageProvider
     virtual bool is_image_available() const override;
     virtual Optional<CSSPixels> intrinsic_width() const override;

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -32,6 +32,7 @@ public:
     virtual ~HTMLTextAreaElement() override;
 
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
+    virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
 
     String const& type() const
     {

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1929,6 +1929,14 @@ CSSPixels FlexFormattingContext::calculate_main_min_content_contribution(FlexIte
         auto inner_min_content_size = calculate_min_content_main_size(item);
         if (computed_main_size(item.box).is_auto())
             return inner_min_content_size;
+
+        // During intrinsic sizing, percentages in the main axis cannot be resolved
+        // and should be treated as auto
+        if (m_available_space_for_items->main.is_intrinsic_sizing_constraint()
+            && computed_main_size(item.box).is_percentage()) {
+            return inner_min_content_size;
+        }
+
         auto inner_preferred_size = is_row_layout() ? get_pixel_width(item.box, computed_main_size(item.box)) : get_pixel_height(item.box, computed_main_size(item.box));
         return max(inner_min_content_size, inner_preferred_size);
     }();
@@ -1950,6 +1958,14 @@ CSSPixels FlexFormattingContext::calculate_main_max_content_contribution(FlexIte
         auto inner_max_content_size = calculate_max_content_main_size(item);
         if (computed_main_size(item.box).is_auto())
             return inner_max_content_size;
+
+        // During intrinsic sizing, percentages in the main axis cannot be resolved
+        // and should be treated as auto
+        if (m_available_space_for_items->main.is_intrinsic_sizing_constraint()
+            && computed_main_size(item.box).is_percentage()) {
+            return inner_max_content_size;
+        }
+
         auto inner_preferred_size = is_row_layout() ? get_pixel_width(item.box, computed_main_size(item.box)) : get_pixel_height(item.box, computed_main_size(item.box));
         return max(inner_max_content_size, inner_preferred_size);
     }();

--- a/Tests/LibWeb/Ref/expected/input-css-width-in-flex-container-ref.html
+++ b/Tests/LibWeb/Ref/expected/input-css-width-in-flex-container-ref.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<style>
+.flex {
+    display: flex;
+    justify-content: space-between;
+    width: 500px;
+    background: #eee;
+    margin-bottom: 30px;
+}
+
+.left {
+    display: flex;
+}
+
+input {
+    width: 100%;
+    border-radius: 9999px;
+    background: red;
+    border: 2px solid darkred;
+    height: 40px;
+    box-sizing: border-box;
+}
+
+textarea {
+    width: 100%;
+    background: blue;
+    border: 2px solid darkblue;
+    height: 60px;
+    border-radius: 4px;
+    box-sizing: border-box;
+    resize: none;
+}
+
+.spacer {
+    width: 50px;
+    background: #333;
+}
+</style>
+
+<div class="flex">
+    <div class="left">
+        <div class="spacer"></div>
+        <input type="text">
+    </div>
+    <div class="spacer"></div>
+</div>
+
+<div class="flex">
+    <div class="left">
+        <div class="spacer"></div>
+        <textarea></textarea>
+    </div>
+    <div class="spacer"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/input-css-width-in-flex-container.html
+++ b/Tests/LibWeb/Ref/input/input-css-width-in-flex-container.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/input-css-width-in-flex-container-ref.html" />
+<style>
+.flex {
+    display: flex;
+    justify-content: space-between;
+    width: 500px;
+    background: #eee;
+    margin-bottom: 30px;
+}
+
+.left {
+    display: flex;
+}
+
+input {
+    width: 100%;
+    border-radius: 9999px;
+    background: red;
+    border: 2px solid darkred;
+    height: 40px;
+    box-sizing: border-box;
+}
+
+textarea {
+    width: 100%;
+    background: blue;
+    border: 2px solid darkblue;
+    height: 60px;
+    border-radius: 4px;
+    box-sizing: border-box;
+    resize: none;
+}
+
+.spacer {
+    width: 50px;
+    background: #333;
+}
+</style>
+
+<div class="flex">
+    <div class="left">
+        <div class="spacer"></div>
+        <input type="text">
+    </div>
+    <div class="spacer"></div>
+</div>
+
+<div class="flex">
+    <div class="left">
+        <div class="spacer"></div>
+        <textarea></textarea>
+    </div>
+    <div class="spacer"></div>
+</div>


### PR DESCRIPTION
Input and textarea elements were overriding explicit CSS width values with their default size/cols attribute widths. This prevented them from properly expanding when given width: 100% in flex containers.

The fix uses natural_width in create_layout_node() for intrinsic sizing instead of forcing widths via adjust_computed_style(), allowing CSS width properties to take precedence while still providing appropriate default sizing.

> before
<img width="706" height="66" alt="Screenshot 2025-08-23 at 10 04 39 PM" src="https://github.com/user-attachments/assets/8fbf8443-ed97-4b67-ae07-ff242bbfd5a2" />
<img width="526" height="157" alt="Screenshot 2025-08-23 at 10 02 46 PM" src="https://github.com/user-attachments/assets/89fe8e16-c6f8-46d3-b278-7a05a084f49c" />

> after
<img width="705" height="65" alt="Screenshot 2025-08-23 at 10 04 04 PM" src="https://github.com/user-attachments/assets/12868de8-a063-4a07-a83e-10cf5a963a5e" />
<img width="524" height="150" alt="Screenshot 2025-08-23 at 10 03 29 PM" src="https://github.com/user-attachments/assets/2b902724-8df2-4efd-991b-d6883ca202a3" />

## Note
There's a lot of variance for how this renders across different browsers - the current approach renders closest to safari:
> chrome
<img width="523" height="150" alt="Screenshot 2025-08-23 at 10 11 09 PM" src="https://github.com/user-attachments/assets/463ffcbc-051d-4080-a904-98fc30c2f6d5" />

> firefox
<img width="522" height="160" alt="Screenshot 2025-08-23 at 10 11 21 PM" src="https://github.com/user-attachments/assets/4646ae2b-2e89-4309-bc93-48bc75093aa7" />

> safari
<img width="519" height="152" alt="Screenshot 2025-08-23 at 10 11 35 PM" src="https://github.com/user-attachments/assets/64154674-fa80-4567-ab8e-a7158ad365e3" />
