### PR TITLE
Devcontainer+Documentation: Add Devcontainer documentation and simplify use

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,11 @@
             "label": "Web VNC"
         }
     },
+    "remoteEnv": {
+        "CC": "clang-20",
+        "CXX": "clang++-20",
+        "XDG_RUNTIME_DIR": "/tmp"
+    },
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "pre-commit install; pre-commit install --hook-type commit-msg",
     // Configure tool-specific properties.
@@ -41,7 +46,8 @@
             "extensions": [
                 "ms-vscode.cmake-tools",
                 "llvm-vs-code-extensions.vscode-clangd",
-                "eamodio.gitlens"
+                "eamodio.gitlens",
+                "vadimcn.vscode-lldb"
             ],
             "settings": {
                 // Excluding the generated directories keeps your file view clean and speeds up search.
@@ -70,7 +76,7 @@
                 "git.inputValidationSubjectLength": 72,
                 // If clangd was obtained from a package manager, its path can be set here.
                 // Note: This has to be adjusted manually, to the "llvm_version" from above
-                "clangd.path": "clangd-19",
+                "clangd.path": "clangd-20",
                 "clangd.arguments": [
                     "--header-insertion=never" // See https://github.com/clangd/clangd/issues/1247
                 ]

--- a/.devcontainer/features/ladybird/install-fedora.sh
+++ b/.devcontainer/features/ladybird/install-fedora.sh
@@ -5,6 +5,6 @@ set -e
 dnf install -y git gh
 
 # Ladybird dev dependencies
-dnf install -y autoconf-archive automake ccache cmake curl google-noto-sans-mono-fonts liberation-sans-fonts libglvnd-devel \
-    nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel \
-    qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
+dnf install -y autoconf-archive automake ccache cmake curl gn google-noto-sans-mono-fonts libdrm-devel liberation-sans-fonts libglvnd-devel \
+    nasm ninja-build patchelf perl-FindBin perl-IPC-Cmd perl-lib pulseaudio-libs-devel qt6-qtbase-devel qt6-qtmultimedia-devel \
+    qt6-qttools-devel qt6-qtwayland-devel ShellCheck tar unzip zip zlib-ng-compat-static

--- a/.devcontainer/features/ladybird/install-ubuntu.sh
+++ b/.devcontainer/features/ladybird/install-ubuntu.sh
@@ -24,7 +24,9 @@ install_llvm_key() {
 ### Install packages
 
 apt update -y
-apt install -y lsb-release git python3 autoconf autoconf-archive automake build-essential cmake libdrm-dev libgl1-mesa-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev qt6-wayland ccache fonts-liberation2 zip unzip curl tar
+apt install -y autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git \
+    gn libdrm-dev libgl1-mesa-dev libpulse-dev lsb-release nasm ninja-build pkg-config python3 qt6-base-dev \
+    qt6-multimedia-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
 ### Ensure new enough host compiler is available
 
 VERSION="0.0.0"

--- a/.devcontainer/features/ladybird/install.sh
+++ b/.devcontainer/features/ladybird/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Feature options
-export LLVM_VERSION=${LLVM_VERSION:-19}
+export LLVM_VERSION=${LLVM_VERSION:-20}
 DISTRO=${DISTRO:-ubuntu}
 
 # call distro-specific script that lives in this directory

--- a/Documentation/EditorConfiguration/VSCodeConfiguration.md
+++ b/Documentation/EditorConfiguration/VSCodeConfiguration.md
@@ -294,9 +294,9 @@ If you want to run the debugger, first place the content below in `.vscode/launc
             "name": "Attach to WebContent",
             "type": "lldb",
             "request": "attach",
-            "program": "${workspaceFolder}/Build/debug/bin/Ladybird.app/Contents/MacOS/WebContent",
+            "program": "${workspaceFolder}/Build/debug/bin/Ladybird.app/Contents/MacOS/WebContent"
         }
-    ],
+    ]
 }
 ```
 
@@ -309,20 +309,36 @@ CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ BUILD_P
 Running Ladybird in this way will pause execution until a debugger is attached. You can then run the debugger by going to the **Run and Debug** menu and selecting the **Attach to WebContent** configuration.
 
 #### Linux
-For Linux, the `launch.json` will instead be the file below.
+For Linux, the `.vscode/launch.json` will instead be the file below.
 
 ```json
 {
-  "version": "2.0.0",
-  "configurations": [
-    {
-      "name": "Attach and debug",
-      "type": "cppdbg",
-      "request": "attach",
-      "program": "${workspaceRoot}/Build/debug/libexec/WebContent",
-      "MIMode": "gdb",
-    },
-  ]
+    "version": "2.0.0",
+    "configurations": [
+        {
+            "name": "Attach to WebContent",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceRoot}/Build/debug/libexec/WebContent",
+            "MIMode": "gdb"
+        }
+    ]
+}
+```
+
+Or for LLDB debugging:
+
+```json
+{
+    "version": "2.0.0",
+    "configurations": [
+        {
+            "name": "Attach to WebContent",
+            "type": "lldb",
+            "request": "attach",
+            "program": "${workspaceRoot}/Build/debug/libexec/WebContent"
+        }
+    ]
 }
 ```
 
@@ -332,7 +348,7 @@ Running Ladybird as follows:
 BUILD_PRESET=Debug Meta/ladybird.py run ladybird --debug-process WebContent
 ```
 
-Then follow the same steps found in the Mac section. Notice also that you need to have `gdb` (the GNU Debugger) installed.
+Then follow the same steps found in the Mac section. Notice also that you need to have `gdb` (the GNU Debugger) or `lldb` (the LLVM debugger) installed.
 
 ### License snippet
 

--- a/Documentation/EditorConfiguration/VSCodeDevContainer.md
+++ b/Documentation/EditorConfiguration/VSCodeDevContainer.md
@@ -1,0 +1,17 @@
+# Visual Studio Code Dev Container
+
+Visual Studio Code has support for containerized development environments, the Ladybird code base has such a Dev Container included to provided a consistent and easily reproducible development environment.
+
+Using the Dev Container requires the installation of the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+
+After installation the extension will detect the Ladybird Dev Container and provide the option to build it. Start the container build and wait for it to complete, the building process takes quite some time, view the log to monitor progress.
+
+The Dev Container already includes the recommended extensions and settings, as laid out in the [Visual Studio Code Project Configuration](VSCodeConfiguration.md), but it is still a good read for further details.
+
+## Usage
+Run `./Meta/ladybird.py run ladybird` at least once to kick off downloading and building vcpkg dependencies.
+
+On execution, the Ladybird processes run in the container without a browser window. It can be interacted with by connecting to the container using VNC. This can be done from a browser by accessing http://localhost:6080, or from a VNC application by accessing `localhost:5901`. Apps to use are [noVNC](https://novnc.com) in the former case, and [TigerVNC](https://tigervnc.org) in the latter case, or any alternative already available on the system.
+
+## Debugging with LLDB
+The Dev Container includes the [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension for debugging. Refer to the generic [VSCode Debugging](VSCodeConfiguration.md#debugging) section for setting up the LLDB lauch configuration.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -20,6 +20,7 @@ you are welcome to ask on [Discord](../README.md#get-in-touch-and-participate).
 * [Qt Creator](EditorConfiguration/QtCreatorConfiguration.md)
 * [Vim](EditorConfiguration/VimConfiguration.md)
 * [VS Code](EditorConfiguration/VSCodeConfiguration.md)
+* [VS Code Dev Container](EditorConfiguration/VSCodeDevContainer.md)
 
 ## Development
 * [How to Contribute](../CONTRIBUTING.md)


### PR DESCRIPTION
After building Ladybird using the Devcontainer I had to head over to Discord history to figure out how to do the actual running and debugging.

This pull request adds Devcontainer documentation and makes some container modifications to reduce manual setup, e.g. by setting up environment variables.