### PR TITLE
Meta: Fix variable name `switfc` to `swiftc`

### DIFF
--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -196,7 +196,7 @@ def configure_main(platform: Platform, preset: str, cc: str, cxx: str) -> Path:
     if build_preset_dir.joinpath("build.ninja").exists() or build_preset_dir.joinpath("ladybird.sln").exists():
         return build_preset_dir
 
-    switfc: Optional[str] = None
+    swiftc: Optional[str] = None
     validate_cmake_version()
 
     if "Swift" in preset:
@@ -217,7 +217,7 @@ def configure_main(platform: Platform, preset: str, cc: str, cxx: str) -> Path:
         f"-DCMAKE_CXX_COMPILER={cxx}",
     ]
 
-    if switfc:
+    if swiftc:
         config_args.append(f"-DCMAKE_Swift_COMPILER={swiftc}")
 
     if platform.host_system == HostSystem.Linux and platform.host_architecture == HostArchitecture.AArch64:


### PR DESCRIPTION
**File:** `Meta/ladybird.py`

- In `configure_main()`, `switfc: Optional[str] = None` is initialized. For Swift
  presets, `(cc, cxx, swiftc)` is assigned via `pick_swift_compilers()`.
- The conditional checks `switfc` instead of `swiftc`, so `-DCMAKE_Swift_COMPILER`
  is never appended to the CMake arguments even when a Swift preset is used.
- Rename `switfc` to `swiftc` and update the conditional to correctly pass the
  Swift compiler to CMake.

This change affects only Swift presets; no behavior change otherwise.