### PR TITLE
LibWeb: Dont allocate space for shorthands in ComputedProperties

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -634,13 +634,13 @@ void AnimationEffect::visit_edges(JS::Cell::Visitor& visitor)
 static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation_for_animated_properties(HashMap<CSS::PropertyID, NonnullRefPtr<CSS::StyleValue const>> const& old_properties, HashMap<CSS::PropertyID, NonnullRefPtr<CSS::StyleValue const>> const& new_properties)
 {
     CSS::RequiredInvalidationAfterStyleChange invalidation;
-    auto old_and_new_properties = MUST(Bitmap::create(to_underlying(CSS::last_property_id) + 1, 0));
+    auto old_and_new_properties = MUST(Bitmap::create(CSS::number_of_longhand_properties, 0));
     for (auto const& [property_id, _] : old_properties)
-        old_and_new_properties.set(to_underlying(property_id), 1);
+        old_and_new_properties.set(to_underlying(property_id) - to_underlying(CSS::first_longhand_property_id), 1);
     for (auto const& [property_id, _] : new_properties)
-        old_and_new_properties.set(to_underlying(property_id), 1);
-    for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {
-        if (!old_and_new_properties.get(i))
+        old_and_new_properties.set(to_underlying(property_id) - to_underlying(CSS::first_longhand_property_id), 1);
+    for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
+        if (!old_and_new_properties.get(i - to_underlying(CSS::first_longhand_property_id)))
             continue;
         auto property_id = static_cast<CSS::PropertyID>(i);
         auto const* old_value = old_properties.get(property_id).value_or({});

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -187,15 +187,9 @@ Optional<StyleProperty> CSSStyleProperties::property(PropertyID property_id) con
         if (!layout_node) {
             auto style = element.document().style_computer().compute_style(element, pseudo_element);
 
-            // FIXME: This is a stopgap until we implement shorthand -> longhand conversion.
-            auto const* value = style->maybe_null_property(property_id);
-            if (!value) {
-                dbgln("FIXME: CSSStyleProperties::property(property_id={:#x}) No value for property ID in newly computed style case.", to_underlying(property_id));
-                return {};
-            }
             return StyleProperty {
                 .property_id = property_id,
-                .value = *value,
+                .value = style->property(property_id),
             };
         }
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -128,7 +128,7 @@ size_t CSSStyleProperties::length() const
     if (is_computed()) {
         if (!owner_node().has_value())
             return 0;
-        return to_underlying(last_longhand_property_id) - to_underlying(first_longhand_property_id) + 1;
+        return number_of_longhand_properties;
     }
 
     return m_properties.size();

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -159,16 +159,6 @@ StyleValue const& ComputedProperties::property(PropertyID property_id, WithAnima
     return *m_property_values[to_underlying(property_id) - to_underlying(first_longhand_property_id)];
 }
 
-StyleValue const* ComputedProperties::maybe_null_property(PropertyID property_id) const
-{
-    VERIFY(property_id >= first_longhand_property_id && property_id <= last_longhand_property_id);
-
-    if (auto animated_value = m_animated_property_values.get(property_id); animated_value.has_value())
-        return animated_value.value();
-
-    return m_property_values[to_underlying(property_id) - to_underlying(first_longhand_property_id)];
-}
-
 Variant<LengthPercentage, NormalGap> ComputedProperties::gap_value(PropertyID id) const
 {
     auto const& value = property(id);

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -787,9 +787,6 @@ Positioning ComputedProperties::position() const
 
 bool ComputedProperties::operator==(ComputedProperties const& other) const
 {
-    if (m_property_values.size() != other.m_property_values.size())
-        return false;
-
     for (size_t i = 0; i < m_property_values.size(); ++i) {
         auto const& my_style = m_property_values[i];
         auto const& other_style = other.m_property_values[i];

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1977,4 +1977,9 @@ WillChange ComputedProperties::will_change() const
     return WillChange::make_auto();
 }
 
+CSSPixels ComputedProperties::font_size() const
+{
+    return property(PropertyID::FontSize).as_length().length().absolute_length_to_px();
+}
+
 }

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -258,8 +258,6 @@ public:
     }
 
 private:
-    friend class StyleComputer;
-
     ComputedProperties();
 
     virtual void visit_edges(Visitor&) override;

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -227,8 +227,7 @@ public:
 
     [[nodiscard]] CSSPixels line_height() const { return *m_line_height; }
     void set_line_height(Badge<StyleComputer> const&, CSSPixels line_height) { m_line_height = line_height; }
-    [[nodiscard]] CSSPixels font_size() const { return *m_font_size; }
-    void set_font_size(Badge<StyleComputer> const&, CSSPixels font_size) { m_font_size = font_size; }
+    [[nodiscard]] CSSPixels font_size() const;
 
     bool operator==(ComputedProperties const&) const;
 
@@ -283,7 +282,6 @@ private:
     RefPtr<Gfx::Font const> m_first_available_computed_font;
 
     Optional<CSSPixels> m_line_height;
-    Optional<CSSPixels> m_font_size;
 
     PseudoClassBitmap m_attempted_pseudo_class_matches;
 };

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -66,7 +66,6 @@ public:
         Yes,
     };
     StyleValue const& property(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
-    StyleValue const* maybe_null_property(PropertyID) const;
     void revert_property(PropertyID, ComputedProperties const& style_for_revert);
 
     GC::Ptr<CSSStyleDeclaration const> animation_name_source() const { return m_animation_name_source; }

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -31,7 +31,6 @@ class WEB_API ComputedProperties final : public JS::Cell {
 
 public:
     static constexpr double normal_line_height_scale = 1.15;
-    static constexpr size_t number_of_properties = to_underlying(last_property_id) + 1;
 
     virtual ~ComputedProperties() override;
 
@@ -40,7 +39,7 @@ public:
     {
         for (size_t i = 0; i < m_property_values.size(); ++i) {
             if (m_property_values[i])
-                callback((PropertyID)i, *m_property_values[i]);
+                callback(static_cast<PropertyID>(i + to_underlying(first_longhand_property_id)), *m_property_values[i]);
         }
     }
 
@@ -268,10 +267,10 @@ private:
     GC::Ptr<CSSStyleDeclaration const> m_animation_name_source;
     GC::Ptr<CSSStyleDeclaration const> m_transition_property_source;
 
-    Array<RefPtr<StyleValue const>, number_of_properties> m_property_values;
-    Array<u8, ceil_div(number_of_properties, 8uz)> m_property_important {};
-    Array<u8, ceil_div(number_of_properties, 8uz)> m_property_inherited {};
-    Array<u8, ceil_div(number_of_properties, 8uz)> m_animated_property_inherited {};
+    Array<RefPtr<StyleValue const>, number_of_longhand_properties> m_property_values;
+    Array<u8, ceil_div(number_of_longhand_properties, 8uz)> m_property_important {};
+    Array<u8, ceil_div(number_of_longhand_properties, 8uz)> m_property_inherited {};
+    Array<u8, ceil_div(number_of_longhand_properties, 8uz)> m_animated_property_inherited {};
 
     HashMap<PropertyID, NonnullRefPtr<StyleValue const>> m_animated_property_values;
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1058,7 +1058,7 @@ void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::
     auto compute_keyframe_values = [refresh, &computed_properties, &element, &pseudo_element, this](auto const& keyframe_values) {
         HashMap<PropertyID, RefPtr<StyleValue const>> result;
         HashMap<PropertyID, PropertyID> longhands_set_by_property_id;
-        auto property_is_set_by_use_initial = MUST(Bitmap::create(to_underlying(last_longhand_property_id) - to_underlying(first_longhand_property_id) + 1, false));
+        auto property_is_set_by_use_initial = MUST(Bitmap::create(number_of_longhand_properties, false));
 
         auto property_is_logical_alias_including_shorthands = [&](PropertyID property_id) {
             if (property_is_shorthand(property_id))

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1348,23 +1348,23 @@ static void compute_transitioned_properties(ComputedProperties const& style, DOM
     }
 
     auto normalize_transition_length_list = [&properties, &style](PropertyID property, auto make_default_value) {
-        auto const* style_value = style.maybe_null_property(property);
+        auto const& style_value = style.property(property);
         StyleValueVector list;
 
-        if (style_value && !style_value->is_value_list()) {
+        if (!style_value.is_value_list()) {
             for (size_t i = 0; i < properties.size(); i++)
-                list.append(*style_value);
+                list.append(style_value);
             return list;
         }
 
-        if (!style_value || !style_value->is_value_list() || style_value->as_value_list().size() == 0) {
+        if (style_value.as_value_list().size() == 0) {
             auto default_value = make_default_value();
             for (size_t i = 0; i < properties.size(); i++)
                 list.append(default_value);
             return list;
         }
 
-        auto const& value_list = style_value->as_value_list();
+        auto const& value_list = style_value.as_value_list();
         for (size_t i = 0; i < properties.size(); i++)
             list.append(value_list.value_at(i, true));
 
@@ -2617,14 +2617,12 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
 
     // Animation declarations [css-animations-2]
     auto animation_name = [&]() -> Optional<String> {
-        auto const animation_name = computed_style->maybe_null_property(PropertyID::AnimationName);
-        if (!animation_name)
+        auto const& animation_name = computed_style->property(PropertyID::AnimationName);
+        if (animation_name.is_keyword() && animation_name.to_keyword() == Keyword::None)
             return OptionalNone {};
-        if (animation_name->is_keyword() && animation_name->to_keyword() == Keyword::None)
-            return OptionalNone {};
-        if (animation_name->is_string())
-            return animation_name->as_string().string_value().to_string();
-        return animation_name->to_string(SerializationMode::Normal);
+        if (animation_name.is_string())
+            return animation_name.as_string().string_value().to_string();
+        return animation_name.to_string(SerializationMode::Normal);
     }();
 
     if (animation_name.has_value()) {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2143,21 +2143,13 @@ void StyleComputer::absolutize_values(ComputedProperties& style) const
         style.first_available_computed_font().pixel_metrics()
     };
 
-    // NOTE: Percentage line-height values are relative to the font-size of the element.
-    //       We have to resolve them right away, so that the *computed* line-height is ready for inheritance.
-    //       We can't simply absolutize *all* percentage values against the font size,
-    //       because most percentages are relative to containing block metrics.
     auto& line_height_value_slot = style.m_property_values[to_underlying(CSS::PropertyID::LineHeight)];
-    if (line_height_value_slot && line_height_value_slot->is_percentage()) {
-        line_height_value_slot = LengthStyleValue::create(
-            Length::make_px(CSSPixels::nearest_value_for(style.font_size() * static_cast<double>(line_height_value_slot->as_percentage().percentage().as_fraction()))));
-    }
 
     auto line_height = style.compute_line_height(viewport_rect(), font_metrics, m_root_element_font_metrics);
     font_metrics.line_height = line_height;
 
     // NOTE: line-height might be using lh which should be resolved against the parent line height (like we did here already)
-    if (line_height_value_slot && line_height_value_slot->is_length())
+    if (line_height_value_slot && (line_height_value_slot->is_length() || line_height_value_slot->is_percentage()))
         line_height_value_slot = LengthStyleValue::create(Length::make_px(line_height));
 
     for (size_t i = 0; i < style.m_property_values.size(); ++i) {

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -193,7 +193,7 @@ public:
 
     [[nodiscard]] GC::Ref<ComputedProperties> compute_properties(DOM::Element&, Optional<PseudoElement>, CascadedProperties&) const;
 
-    void absolutize_values(ComputedProperties&, GC::Ptr<DOM::Element const>) const;
+    void absolutize_values(ComputedProperties&) const;
     void compute_font(ComputedProperties&, DOM::Element const*, Optional<CSS::PseudoElement>) const;
 
     [[nodiscard]] inline bool should_reject_with_ancestor_filter(Selector const&) const;

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
@@ -184,10 +184,13 @@ RefPtr<StyleValue const> StylePropertyMapReadOnly::get_style_value(Source& sourc
                     return registered_custom_property.value()->initial_style_value();
                 return nullptr;
             }
-            // FIXME: This will only ever be null for pseudo-elements. What should we do in that case?
-            //        The property's value is also sometimes null. Is that correct?
-            if (auto computed_properties = element.computed_properties())
-                return computed_properties->maybe_null_property(property_id.value());
+
+            if (*property_id >= first_longhand_property_id && *property_id <= last_longhand_property_id) {
+                // FIXME: This will only ever be null for pseudo-elements. What should we do in that case?
+                if (auto computed_properties = element.computed_properties())
+                    return computed_properties->property(property_id.value());
+            }
+
             return nullptr;
         },
         [&property](GC::Ref<CSSStyleDeclaration>& declaration) {

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
@@ -150,7 +150,6 @@ WebIDL::UnsignedLong StylePropertyMapReadOnly::size() const
             // value on this"
             // Ensure style is computed on the element before we try to read it.
             element.document().update_style();
-            auto longhands_count = to_underlying(last_longhand_property_id) - to_underlying(first_longhand_property_id) + 1;
 
             // Some custom properties set on the element might also be in the registered custom properties set, so we
             // want the size of the union of the two sets.
@@ -160,7 +159,7 @@ WebIDL::UnsignedLong StylePropertyMapReadOnly::size() const
             for (auto const& [key, _] : element.document().registered_custom_properties())
                 custom_properties.set(key);
 
-            return longhands_count + custom_properties.size();
+            return number_of_longhand_properties + custom_properties.size();
         },
         [](GC::Ref<CSSStyleDeclaration> const& declaration) { return declaration->length(); });
 }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -805,8 +805,10 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
     CSS::RequiredInvalidationAfterStyleChange invalidation;
 
     HashMap<size_t, RefPtr<CSS::StyleValue const>> old_values_with_relative_units;
-    for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {
+    for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         auto property_id = static_cast<CSS::PropertyID>(i);
+        // FIXME: We should use the specified value rather than the cascaded value as the cascaded value may include
+        //        unresolved CSS-wide keywords (e.g. 'initial' or 'inherit') rather than the resolved value.
         auto const& preabsolutized_value = m_cascaded_properties->property(property_id);
         RefPtr old_value = computed_properties->maybe_null_property(property_id);
         // Update property if it uses relative units as it might have been affected by a change in ancestor element style.

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -839,7 +839,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
         return invalidation;
 
     document().style_computer().compute_font(*computed_properties, this, {});
-    document().style_computer().absolutize_values(*computed_properties, this);
+    document().style_computer().absolutize_values(*computed_properties);
 
     for (auto [property_id, old_value] : old_values_with_relative_units) {
         auto new_value = computed_properties->maybe_null_property(static_cast<CSS::PropertyID>(property_id));

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -674,7 +674,7 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(C
     if (!old_style.computed_font_list().equals(new_style.computed_font_list()))
         invalidation.relayout = true;
 
-    for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {
+    for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         auto property_id = static_cast<CSS::PropertyID>(i);
         auto old_value = old_style.maybe_null_property(property_id);
         auto new_value = new_style.maybe_null_property(property_id);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -676,12 +676,8 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(C
 
     for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         auto property_id = static_cast<CSS::PropertyID>(i);
-        auto old_value = old_style.maybe_null_property(property_id);
-        auto new_value = new_style.maybe_null_property(property_id);
-        if (!old_value && !new_value)
-            continue;
 
-        invalidation |= CSS::compute_property_invalidation(property_id, old_value, new_value);
+        invalidation |= CSS::compute_property_invalidation(property_id, old_style.property(property_id), new_style.property(property_id));
     }
     return invalidation;
 }
@@ -810,7 +806,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
         // FIXME: We should use the specified value rather than the cascaded value as the cascaded value may include
         //        unresolved CSS-wide keywords (e.g. 'initial' or 'inherit') rather than the resolved value.
         auto const& preabsolutized_value = m_cascaded_properties->property(property_id);
-        RefPtr old_value = computed_properties->maybe_null_property(property_id);
+        RefPtr old_value = computed_properties->property(property_id);
         // Update property if it uses relative units as it might have been affected by a change in ancestor element style.
         if (preabsolutized_value && preabsolutized_value->is_length() && preabsolutized_value->as_length().length().is_font_relative()) {
             auto is_inherited = computed_properties->is_property_inherited(property_id);
@@ -842,7 +838,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
     document().style_computer().absolutize_values(*computed_properties);
 
     for (auto [property_id, old_value] : old_values_with_relative_units) {
-        auto new_value = computed_properties->maybe_null_property(static_cast<CSS::PropertyID>(property_id));
+        auto const& new_value = computed_properties->property(static_cast<CSS::PropertyID>(property_id));
         invalidation |= CSS::compute_property_invalidation(static_cast<CSS::PropertyID>(property_id), old_value, new_value);
     }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -851,22 +851,6 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style()
     return invalidation;
 }
 
-GC::Ref<CSS::ComputedProperties> Element::resolved_css_values(Optional<CSS::PseudoElement> type)
-{
-    auto element_computed_style = CSS::CSSStyleProperties::create_resolved_style(realm(), AbstractElement { *this, type });
-    auto properties = heap().allocate<CSS::ComputedProperties>();
-
-    for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {
-        auto property_id = (CSS::PropertyID)i;
-        auto maybe_value = element_computed_style->property(property_id);
-        if (!maybe_value.has_value())
-            continue;
-        properties->set_property(property_id, maybe_value.release_value().value);
-    }
-
-    return properties;
-}
-
 DOMTokenList* Element::class_list()
 {
     if (!m_class_list)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -215,7 +215,6 @@ public:
     GC::Ptr<CSS::ComputedProperties> computed_properties(Optional<CSS::PseudoElement> = {});
     GC::Ptr<CSS::ComputedProperties const> computed_properties(Optional<CSS::PseudoElement> = {}) const;
     void set_computed_properties(Optional<CSS::PseudoElement>, GC::Ptr<CSS::ComputedProperties>);
-    GC::Ref<CSS::ComputedProperties> resolved_css_values(Optional<CSS::PseudoElement> = {});
 
     [[nodiscard]] GC::Ptr<CSS::CascadedProperties> cascaded_properties(Optional<CSS::PseudoElement>) const;
     void set_cascaded_properties(Optional<CSS::PseudoElement>, GC::Ptr<CSS::CascadedProperties>);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -300,6 +300,7 @@ constexpr PropertyID first_inherited_longhand_property_id = PropertyID::@first_i
 constexpr PropertyID last_inherited_longhand_property_id = PropertyID::@last_inherited_longhand_property_id@;
 constexpr PropertyID first_longhand_property_id = PropertyID::@first_longhand_property_id@;
 constexpr PropertyID last_longhand_property_id = PropertyID::@last_longhand_property_id@;
+constexpr size_t number_of_longhand_properties = to_underlying(last_longhand_property_id) - to_underlying(first_longhand_property_id) + 1;
 
 enum class Quirk {
     // https://quirks.spec.whatwg.org/#the-hashless-hex-color-quirk

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -328,8 +328,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
         auto dump_style = [](String const& title, Web::CSS::ComputedProperties const& style, HashMap<FlyString, Web::CSS::StyleProperty> const& custom_properties) {
             dbgln("+ {}", title);
             for (size_t i = to_underlying(Web::CSS::first_longhand_property_id); i < to_underlying(Web::CSS::last_longhand_property_id); ++i) {
-                auto property = style.maybe_null_property(static_cast<Web::CSS::PropertyID>(i));
-                dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), property ? property->to_string(Web::CSS::SerializationMode::Normal) : ""_string);
+                dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), style.property(static_cast<Web::CSS::PropertyID>(i)).to_string(Web::CSS::SerializationMode::Normal));
             }
             for (auto const& [name, property] : custom_properties) {
                 dbgln("|  {} = {}", name, property.value->to_string(Web::CSS::SerializationMode::Normal));

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -327,7 +327,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString request, ByteSt
     if (request == "dump-all-resolved-styles") {
         auto dump_style = [](String const& title, Web::CSS::ComputedProperties const& style, HashMap<FlyString, Web::CSS::StyleProperty> const& custom_properties) {
             dbgln("+ {}", title);
-            for (size_t i = 0; i < Web::CSS::ComputedProperties::number_of_properties; ++i) {
+            for (size_t i = to_underlying(Web::CSS::first_longhand_property_id); i < to_underlying(Web::CSS::last_longhand_property_id); ++i) {
                 auto property = style.maybe_null_property(static_cast<Web::CSS::PropertyID>(i));
                 dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), property ? property->to_string(Web::CSS::SerializationMode::Normal) : ""_string);
             }


### PR DESCRIPTION
We only ever compute values for longhands so having space allocated for shorthands is just wasted memory.

Most of the commits are around making sure we don't ever try to get shorthands from ComputedProperties but there are a couple miscellaneous cleanups that don't warrant their own PR as well - see individual commits for details.