### PR TITLE
LibWeb: Replace `is<T>()` with `as_if<T>()` where possible

### DIFF
--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -477,9 +477,8 @@ GC::Ref<WebIDL::Promise> FontFace::load()
 
         // FIXME: We should probably put the 'font cache' on the WindowOrWorkerGlobalScope instead of tying it to the document's style computer
         auto& global = HTML::relevant_global_object(*font);
-        if (is<HTML::Window>(global)) {
-            auto& window = static_cast<HTML::Window&>(global);
-            auto& style_computer = const_cast<StyleComputer&>(window.document()->style_computer());
+        if (auto* window = as_if<HTML::Window>(global)) {
+            auto& style_computer = const_cast<StyleComputer&>(window->document()->style_computer());
 
             // FIXME: The ParsedFontFace is kind of expensive to create. We should be using a shared sub-object for the data
             ParsedFontFace parsed_font_face {

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -638,8 +638,8 @@ RefPtr<StyleValue const> interpolate_transform(DOM::Element& element, StyleValue
             return {};
         Optional<Painting::PaintableBox const&> paintable_box;
         if (auto layout_node = element.layout_node()) {
-            if (auto paintable = layout_node->first_paintable(); paintable && is<Painting::PaintableBox>(paintable))
-                paintable_box = *static_cast<Painting::PaintableBox*>(paintable);
+            if (auto* paintable = as_if<Painting::PaintableBox>(layout_node->first_paintable()))
+                paintable_box = *paintable;
         }
         if (auto matrix = transformation->to_matrix(paintable_box); !matrix.is_error())
             return matrix.value();

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -508,7 +508,7 @@ bool StyleComputer::invalidation_property_used_in_has_selector(InvalidationSet::
 Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::Element const& element, CascadeOrigin cascade_origin, Optional<CSS::PseudoElement> pseudo_element, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name) const
 {
     auto const& root_node = element.root();
-    auto shadow_root = is<DOM::ShadowRoot>(root_node) ? static_cast<DOM::ShadowRoot const*>(&root_node) : nullptr;
+    auto shadow_root = as_if<DOM::ShadowRoot>(root_node);
     auto element_shadow_root = element.shadow_root();
     auto const& element_namespace_uri = element.namespace_uri();
 

--- a/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
+++ b/Libraries/LibWeb/ContentSecurityPolicy/Directives/DirectiveOperations.cpp
@@ -897,9 +897,8 @@ MatchResult does_element_match_source_list_for_type_and_source(GC::Ptr<DOM::Elem
                 VERIFY(is<HTML::HTMLElement>(element.ptr()) || is<SVG::SVGElement>(element.ptr()));
 
                 String element_nonce;
-                if (is<HTML::HTMLElement>(element.ptr())) {
-                    auto const& html_element = static_cast<HTML::HTMLElement const&>(*element);
-                    element_nonce = html_element.nonce();
+                if (auto* html_element = as_if<HTML::HTMLElement>(element.ptr())) {
+                    element_nonce = html_element->nonce();
                 } else {
                     auto const& svg_element = as<SVG::SVGElement>(*element);
                     element_nonce = svg_element.nonce();

--- a/Libraries/LibWeb/Crypto/CryptoKey.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoKey.cpp
@@ -117,9 +117,10 @@ static JS::ThrowCompletionOr<CryptoKeyPair*> impl_from(JS::VM& vm)
     else
         this_object = TRY(this_value.to_object(vm));
 
-    if (!is<CryptoKeyPair>(this_object))
+    auto* crypto_key_pair = as_if<CryptoKeyPair>(this_object);
+    if (!crypto_key_pair)
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "CryptoKeyPair");
-    return static_cast<CryptoKeyPair*>(this_object);
+    return crypto_key_pair;
 }
 
 JS_DEFINE_NATIVE_FUNCTION(CryptoKeyPair::public_key_getter)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -904,9 +904,7 @@ HTML::HTMLHtmlElement* Document::html_element()
 {
     // The html element of a document is its document element, if it's an html element, and null otherwise.
     auto* html = document_element();
-    if (is<HTML::HTMLHtmlElement>(html))
-        return as<HTML::HTMLHtmlElement>(html);
-    return nullptr;
+    return as_if<HTML::HTMLHtmlElement>(html);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#the-head-element-2

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1049,14 +1049,15 @@ WebIDL::ExceptionOr<void> Element::set_inner_html(StringView value)
     auto fragment = TRY(as<Element>(*context).parse_fragment(value));
 
     // 4. If context is a template element, then set context to the template element's template contents (a DocumentFragment).
-    if (is<HTML::HTMLTemplateElement>(*context))
-        context = as<HTML::HTMLTemplateElement>(*context).content();
+    auto* template_element = as_if<HTML::HTMLTemplateElement>(*context);
+    if (template_element)
+        context = template_element->content();
 
     // 5. Replace all with fragment within context.
     context->replace_all(fragment);
 
     // NOTE: We don't invalidate style & layout for <template> elements since they don't affect rendering.
-    if (!is<HTML::HTMLTemplateElement>(*context)) {
+    if (!template_element) {
         context->set_needs_style_update(true);
 
         if (context->is_connected()) {

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -491,10 +491,11 @@ public:
     void for_each_numbered_item_owned_by_list_owner(Callback callback)
     {
         for (auto* node = this->first_child(); node != nullptr; node = node->next_in_pre_order(this)) {
-            if (!is<Element>(*node))
+            auto* element = as_if<Element>(node);
+            if (!element)
                 continue;
 
-            static_cast<Element*>(node)->m_is_contained_in_list_subtree = true;
+            element->m_is_contained_in_list_subtree = true;
 
             if (node->is_html_ol_ul_menu_element()) {
                 // Skip list nodes and their descendents. They have their own, unrelated ordinals.
@@ -506,8 +507,6 @@ public:
 
             if (!node->layout_node())
                 continue; // Skip nodes that do not participate in the layout.
-
-            auto* element = static_cast<Element*>(node);
 
             if (!element->computed_properties()->display().is_list_item())
                 continue; // Skip nodes that are not list items.

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -164,8 +164,7 @@ static bool default_passive_value(FlyString const& type, EventTarget* event_targ
         if (is<HTML::Window>(event_target))
             return true;
 
-        if (is<Node>(event_target)) {
-            auto* node = as<Node>(event_target);
+        if (auto* node = as_if<Node>(event_target)) {
             if (&node->document() == event_target || node->document().document_element() == event_target || node->document().body() == event_target)
                 return true;
         }
@@ -400,8 +399,7 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
         GC::Ptr<Element> element;
         GC::Ptr<Document> document;
 
-        if (is<Element>(this)) {
-            auto* element_event_target = as<Element>(this);
+        if (auto* element_event_target = as_if<Element>(this)) {
             element = element_event_target;
             document = &element_event_target->document();
         } else {

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -526,10 +526,8 @@ TaskID queue_global_task(HTML::Task::Source source, JS::Object& global_object, G
 
     // 2. Let document be global's associated Document, if global is a Window object; otherwise null.
     DOM::Document* document { nullptr };
-    if (is<HTML::Window>(global_object)) {
-        auto& window_object = as<HTML::Window>(global_object);
-        document = &window_object.associated_document();
-    }
+    if (auto* window_object = as_if<HTML::Window>(global_object))
+        document = &window_object->associated_document();
 
     // 3. Queue a task given source, event loop, document, and steps.
     return queue_a_task(source, *event_loop, document, steps);

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -1087,8 +1087,8 @@ static void update_the_source_set(DOM::Element& element)
     VERIFY(is<HTMLImageElement>(element) || is<HTMLLinkElement>(element));
 
     // 1. Set el's source set to an empty source set.
-    if (is<HTMLImageElement>(element))
-        static_cast<HTMLImageElement&>(element).set_source_set(SourceSet {});
+    if (auto* image_element = as_if<HTMLImageElement>(element))
+        image_element->set_source_set(SourceSet {});
     else if (is<HTMLLinkElement>(element))
         TODO();
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -494,11 +494,9 @@ WebIDL::ExceptionOr<void> HTMLInputElement::run_input_activation_behavior(DOM::E
 
         // 3. If the user activated the control while explicitly selecting a coordinate, then set the element's selected
         //    coordinate to that coordinate.
-        if (event.is_trusted() && is<UIEvents::MouseEvent>(event)) {
-            auto const& mouse_event = static_cast<UIEvents::MouseEvent const&>(event);
-
-            CSSPixels x { mouse_event.offset_x() };
-            CSSPixels y { mouse_event.offset_y() };
+        if (auto* mouse_event = as_if<UIEvents::MouseEvent>(event); mouse_event && event.is_trusted()) {
+            CSSPixels x { mouse_event->offset_x() };
+            CSSPixels y { mouse_event->offset_y() };
 
             m_selected_coordinate = { x.to_int(), y.to_int() };
         }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -715,8 +715,8 @@ private:
         }
 
         // 14. ⌛ If the node after pointer is a source element, let candidate be that element.
-        if (is<HTMLSourceElement>(next_sibling))
-            candidate = static_cast<HTMLSourceElement*>(next_sibling);
+        if (auto* source_element = as_if<HTMLSourceElement>(next_sibling))
+            candidate = source_element;
 
         // 15. ⌛ Advance pointer so that the node before pointer is now the node that was after pointer, and the node
         //     after pointer is the node after the node that used to be after pointer, if any.

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -213,8 +213,7 @@ GC::Ptr<HTMLTableSectionElement> HTMLTableElement::t_head()
     // The tHead IDL attribute must return, on getting, the first thead element child of the table element,
     // if any, or null otherwise.
     for (auto* child = first_child(); child; child = child->next_sibling()) {
-        if (is<HTMLTableSectionElement>(*child)) {
-            auto table_section_element = &as<HTMLTableSectionElement>(*child);
+        if (auto* table_section_element = as_if<HTMLTableSectionElement>(*child)) {
             if (table_section_element->local_name() == TagNames::thead)
                 return table_section_element;
         }
@@ -248,8 +247,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::set_t_head(HTMLTableSectionElement* 
             continue;
         if (is<HTMLTableCaptionElement>(*child))
             continue;
-        if (is<HTMLTableColElement>(*child)) {
-            auto table_col_element = &as<HTMLTableColElement>(*child);
+        if (auto* table_col_element = as_if<HTMLTableColElement>(*child)) {
             if (table_col_element->local_name() == TagNames::colgroup)
                 continue;
         }
@@ -280,8 +278,7 @@ GC::Ref<HTMLTableSectionElement> HTMLTableElement::create_t_head()
             continue;
         if (is<HTMLTableCaptionElement>(*child))
             continue;
-        if (is<HTMLTableColElement>(*child)) {
-            auto table_col_element = &as<HTMLTableColElement>(*child);
+        if (auto* table_col_element = as_if<HTMLTableColElement>(*child)) {
             if (table_col_element->local_name() == TagNames::colgroup)
                 continue;
         }
@@ -311,8 +308,7 @@ GC::Ptr<HTMLTableSectionElement> HTMLTableElement::t_foot()
     // The tFoot IDL attribute must return, on getting, the first tfoot element child of the table element,
     // if any, or null otherwise.
     for (auto* child = first_child(); child; child = child->next_sibling()) {
-        if (is<HTMLTableSectionElement>(*child)) {
-            auto table_section_element = &as<HTMLTableSectionElement>(*child);
+        if (auto* table_section_element = as_if<HTMLTableSectionElement>(*child)) {
             if (table_section_element->local_name() == TagNames::tfoot)
                 return table_section_element;
         }
@@ -384,8 +380,7 @@ GC::Ref<HTMLTableSectionElement> HTMLTableElement::create_t_body()
     for (auto* child = last_child(); child; child = child->previous_sibling()) {
         if (!is<HTMLElement>(*child))
             continue;
-        if (is<HTMLTableSectionElement>(*child)) {
-            auto table_section_element = &as<HTMLTableSectionElement>(*child);
+        if (auto* table_section_element = as_if<HTMLTableSectionElement>(*child)) {
             if (table_section_element->local_name() == TagNames::tbody) {
                 // We have found an element which is a <tbody> we'll insert after this
                 child_to_insert_before = child->next_sibling();

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1228,8 +1228,10 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
 
     // 26. If navigable's container is an iframe, and response's timing allow passed flag is set,
     //     then set navigable's container's pending resource-timing start time to null.
-    if (navigable->container() && is<HTML::HTMLIFrameElement>(*navigable->container()) && response_holder->response()->timing_allow_passed())
-        static_cast<HTML::HTMLIFrameElement&>(*navigable->container()).set_pending_resource_start_time({});
+    if (navigable->container() && response_holder->response()->timing_allow_passed()) {
+        if (auto* iframe_element = as_if<HTML::HTMLIFrameElement>(*navigable->container()))
+            iframe_element->set_pending_resource_start_time({});
+    }
 
     // 27. Return a new navigation params, with
     //     id: navigationId

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -766,8 +766,8 @@ HTMLParser::AdjustedInsertionLocation HTMLParser::find_appropriate_place_for_ins
 
     // 3. If the adjusted insertion location is inside a template element,
     //    let it instead be inside the template element's template contents, after its last child (if any).
-    if (is<HTMLTemplateElement>(*adjusted_insertion_location.parent))
-        adjusted_insertion_location = { static_cast<HTMLTemplateElement const&>(*adjusted_insertion_location.parent).content().ptr(), nullptr };
+    if (auto* template_element = as_if<HTMLTemplateElement>(*adjusted_insertion_location.parent))
+        adjusted_insertion_location = { template_element->content().ptr(), nullptr };
 
     // 4. Return the adjusted insertion location.
     return adjusted_insertion_location;

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1238,8 +1238,8 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
         // FIXME: Use a FrozenArray
         Vector<GC::Root<MessagePort>> new_ports;
         for (auto const& object : deserialize_record.transferred_values) {
-            if (is<HTML::MessagePort>(*object)) {
-                new_ports.append(as<MessagePort>(*object));
+            if (auto* message_port = as_if<HTML::MessagePort>(*object)) {
+                new_ports.append(*message_port);
             }
         }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -871,9 +871,9 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     // but the rest of section 10.3.7 is replaced by the following rules:
 
     // 1. The used value of 'width' is determined as for inline replaced elements.
-    if (is<ReplacedBox>(box)) {
+    if (auto const* replaced = as_if<ReplacedBox>(box)) {
         // FIXME: This const_cast is gross.
-        static_cast<ReplacedBox&>(const_cast<Box&>(box)).prepare_for_replaced_layout();
+        const_cast<ReplacedBox&>(*replaced).prepare_for_replaced_layout();
     }
 
     auto width = compute_width_for_replaced_element(box, available_space);

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -308,19 +308,18 @@ void InlineFormattingContext::generate_line_boxes()
             break;
         }
         case InlineLevelIterator::Item::Type::AbsolutelyPositionedElement:
-            if (is<Box>(*item.node)) {
-                auto const& box = static_cast<Layout::Box const&>(*item.node);
+            if (auto const* box = as_if<Box>(*item.node)) {
                 // Calculation of static position for absolute boxes is delayed until trailing whitespaces are removed.
-                absolute_boxes.append(&box);
+                absolute_boxes.append(box);
             }
             break;
 
         case InlineLevelIterator::Item::Type::FloatingElement:
-            if (is<Box>(*item.node)) {
+            if (auto* box = as_if<Box>(*item.node)) {
                 (void)parent().clear_floating_boxes(*item.node, *this);
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
-                parent().layout_floating_box(static_cast<Layout::Box const&>(*item.node), containing_block(), *m_available_space, 0, &line_builder);
+                parent().layout_floating_box(*box, containing_block(), *m_available_space, 0, &line_builder);
             }
             break;
 

--- a/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -61,9 +61,9 @@ bool LineBoxFragment::is_justifiable_whitespace() const
 
 Utf16View LineBoxFragment::text() const
 {
-    if (!is<TextNode>(layout_node()))
-        return {};
-    return as<TextNode>(layout_node()).text_for_rendering().substring_view(m_start, m_length);
+    if (auto* text_node = as_if<TextNode>(layout_node()))
+        return text_node->text_for_rendering().substring_view(m_start, m_length);
+    return {};
 }
 
 bool LineBoxFragment::is_atomic_inline() const

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1056,10 +1056,9 @@ void NodeWithStyle::propagate_style_to_anonymous_wrappers()
 
     // If this is a `display:table` box with an anonymous wrapper parent,
     // the parent inherits style from *this* node, not the other way around.
-    if (display().is_table_inside() && is<TableWrapper>(parent())) {
-        auto& table_wrapper = *static_cast<TableWrapper*>(parent());
-        static_cast<CSS::MutableComputedValues&>(static_cast<CSS::ComputedValues&>(const_cast<CSS::ImmutableComputedValues&>(table_wrapper.computed_values()))).inherit_from(computed_values());
-        transfer_table_box_computed_values_to_wrapper_computed_values(table_wrapper.mutable_computed_values());
+    if (auto* table_wrapper = as_if<TableWrapper>(parent()); table_wrapper && display().is_table_inside()) {
+        static_cast<CSS::MutableComputedValues&>(static_cast<CSS::ComputedValues&>(const_cast<CSS::ImmutableComputedValues&>(table_wrapper->computed_values()))).inherit_from(computed_values());
+        transfer_table_box_computed_values_to_wrapper_computed_values(table_wrapper->mutable_computed_values());
     }
 
     // Propagate style to all anonymous children (except table wrappers!)

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -41,9 +41,8 @@ static RefPtr<DisplayList> compute_text_clip_paths(DisplayListRecordingContext& 
     };
 
     paintable.for_each_in_inclusive_subtree([&](auto& paintable) {
-        if (is<PaintableWithLines>(paintable)) {
-            auto const& paintable_lines = static_cast<PaintableWithLines const&>(paintable);
-            for (auto const& fragment : paintable_lines.fragments()) {
+        if (auto* paintable_lines = as_if<PaintableWithLines>(paintable)) {
+            for (auto const& fragment : paintable_lines->fragments()) {
                 if (is<Layout::TextNode>(fragment.layout_node()))
                     add_text_clip_path(fragment);
             }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -132,8 +132,8 @@ void PaintableBox::set_scroll_offset(CSSPixelPoint offset)
     auto& node = layout_node();
     if (auto pseudo_element = node.generated_for_pseudo_element(); pseudo_element.has_value()) {
         node.pseudo_element_generator()->set_scroll_offset(*pseudo_element, offset);
-    } else if (is<DOM::Element>(*dom_node())) {
-        static_cast<DOM::Element*>(dom_node())->set_scroll_offset({}, offset);
+    } else if (auto* element = as_if<DOM::Element>(dom_node())) {
+        element->set_scroll_offset({}, offset);
     } else {
         return;
     }


### PR DESCRIPTION
This is a non-functional change that replaces `is<T>()` with `as_if<T>()` in places where `is<T>()` was previously followed by some kind of cast to `T`.