### PR TITLE
LibWeb: Always update computed properties for finished animations

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -16,7 +16,6 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/Performance.h>
-#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/Promise.h>
 

--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1182,7 +1182,6 @@ void Animation::update_finished_state(DidSeek did_seek, SynchronouslyNotify sync
     // 6. If current finished state is false and animation’s current finished promise is already resolved, set
     //    animation’s current finished promise to a new promise in the relevant Realm of animation.
     if (!current_finished_state && m_is_finished) {
-        HTML::TemporaryExecutionContext execution_context { realm };
         m_current_finished_promise = WebIDL::create_promise(realm);
         m_is_finished = false;
     }

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -54,7 +54,7 @@ struct BaseKeyframe {
 };
 
 // https://www.w3.org/TR/web-animations-1/#the-keyframeeffect-interface
-class KeyframeEffect : public AnimationEffect {
+class KeyframeEffect final : public AnimationEffect {
     WEB_PLATFORM_OBJECT(KeyframeEffect, AnimationEffect);
     GC_DECLARE_ALLOCATOR(KeyframeEffect);
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1574,11 +1574,10 @@ void Document::update_animated_style_if_needed()
 
     for (auto& timeline : m_associated_animation_timelines) {
         for (auto& animation : timeline->associated_animations()) {
-            if (animation->is_idle() || animation->is_finished())
+            if (animation->is_idle())
                 continue;
-            if (auto effect = animation->effect()) {
+            if (auto effect = animation->effect())
                 effect->update_computed_properties(context);
-            }
         }
     }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/transitioncancel-003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/transitioncancel-003.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	Mid-transition transition changes affect subsequent transitions
+1 Pass
+Pass	Mid-transition transition changes affect subsequent transitions


### PR DESCRIPTION
If an animation got to its finished state before its target's computed properties could be updated, we would end up with invalid styles. Do not skip finished animations, but prevent effect invalidation on timeline updates if the animation is already finished.

This fixes the CI flake on WPT test `css/css-transitions/inherit-height-transition.html`.