### PR TITLE
LibWeb: Propagate use element width and height to the referenced element

### DIFF
--- a/Tests/LibWeb/Ref/expected/svg/use-element-geometry-properties-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/use-element-geometry-properties-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="100" height="100">
+    <rect width="100" height="100" fill="green"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/use-element-geometry-properties.html
+++ b/Tests/LibWeb/Ref/input/svg/use-element-geometry-properties.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/use-element-geometry-properties-ref.html" />
+<svg width="100" height="100">
+    <defs>
+        <svg id="rect" width="0" height="0">
+            <rect width="50" height="50" />
+        </svg>
+    </defs>
+    <use width="100" height="100" href="#rect" fill="green"></use>
+    <use x="0" y="50" width="100" height="100" href="#rect" fill="green"></use>
+    <use x="50" y="0" width="100" height="100" href="#rect" fill="green"></use>
+    <use x="50" y="50" width="100" height="100" href="#rect" fill="green"></use>
+</svg>


### PR DESCRIPTION
The `width` and `height` properties of a `use` element should override the corresponding `width` and/or `height` of a referenced `svg` or `symbol` element.

This improves the reddit logo at: https://redditinc.com/hubfs/Reddit%20Inc/Brand/Reddit_Lockup_Logo.svg

Before:
<img width="922" height="761" alt="image" src="https://github.com/user-attachments/assets/ef9c333e-f630-451e-9ca1-36e79f35846b" />


After:
<img width="922" height="761" alt="image" src="https://github.com/user-attachments/assets/ecabf816-7f11-46c8-9ec2-a40c2dfa9c74" />

