### PR TITLE
LibWeb/Fetch: Enable callbacks in the abort signal algorithm callback

### DIFF
--- a/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -143,7 +143,7 @@ GC::Ref<WebIDL::Promise> fetch(JS::VM& vm, RequestInfo const& input, RequestInit
         controller_holder->controller()->abort(relevant_realm, request_object->signal()->reason());
 
         // AD-HOC: An execution context is required for Promise functions.
-        HTML::TemporaryExecutionContext execution_context { relevant_realm };
+        HTML::TemporaryExecutionContext execution_context { relevant_realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         // 4. Abort the fetch() call with p, request, responseObject, and requestObject’s signal’s abort reason.
         abort_fetch(relevant_realm, *promise_capability, request, response_object, request_object->signal()->reason());

--- a/Tests/LibWeb/Text/expected/Fetch/fetch-controller-abort-with-body-does-not-crash-with-timeout.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/fetch-controller-abort-with-body-does-not-crash-with-timeout.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/Fetch/fetch-controller-abort-with-body-does-not-crash-with-timeout.html
+++ b/Tests/LibWeb/Text/input/Fetch/fetch-controller-abort-with-body-does-not-crash-with-timeout.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        const timeoutSignal = AbortSignal.timeout(0);
+        fetch('data:text/plain,fetched from far', { signal: timeoutSignal, body: "message in a bottle", method: "POST" });
+        setTimeout(() => {
+            println("PASS! (Didn't crash)");
+            done();
+        }, 1);
+    });
+</script>


### PR DESCRIPTION
If the request has a body, the abort will interact with promises, which requires callbacks to be enabled.

Fixes crashing on Atlassian products.