### PR TITLE
wasm: Don't use a new AbstractMachine to instantiate modules

### DIFF
--- a/Utilities/wasm.cpp
+++ b/Utilities/wasm.cpp
@@ -579,7 +579,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     }
 
     if (attempt_instantiate || print_compiled) {
-        Wasm::AbstractMachine machine;
 #if !defined(AK_OS_WINDOWS)
         Optional<Wasm::Wasi::Implementation> wasi_impl;
 


### PR DESCRIPTION
Bad rebase conflict resolution broke code, grug sad.