### PR TITLE
Tests: Report view's test path instead of URL in test-web

### DIFF
--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -803,14 +803,14 @@ static void handle_signal(int signal)
 
     auto now = UnixDateTime::now();
     WebView::ViewImplementation::for_each_view([&](WebView::ViewImplementation const& view) {
-        dbg("- View {}: {} ", view.view_id(), view.url());
+        dbg("- View {}: ", view.view_id());
 
         auto maybe_test = s_test_by_view.get(&view);
         if (maybe_test.has_value()) {
             auto const& test = *maybe_test.release_value();
-            dbgln("(duration: {})", human_readable_time(now - test.start_time));
+            dbgln("{} (duration: {})", test.relative_path, human_readable_time(now - test.start_time));
         } else {
-            dbgln("(no active test)");
+            dbgln("{} (no active test)", view.url());
         }
 
         return IterationDecision::Continue;


### PR DESCRIPTION
When a test is active in a test-web view, show the relative path to the test instead of the view's URL. This gives a better starting point for debugging than whatever the last loaded URL happened to be.

If no test is active, we still show the view's URL.

<img width="690" height="287" alt="image" src="https://github.com/user-attachments/assets/3bb57bdf-d910-4ea3-9fb6-7ff539b57df3" />
