### PR TITLE
LibWeb: Apply nested inline margin box sizes to inline layout nodes

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -31,7 +31,7 @@ LayoutState::UsedValues& LayoutState::get_mutable(NodeWithStyle const& node)
 
     auto new_used_values = adopt_own(*new UsedValues);
     auto* new_used_values_ptr = new_used_values.ptr();
-    new_used_values->set_node(const_cast<NodeWithStyle&>(node), containing_block_used_values);
+    new_used_values->set_node(node, containing_block_used_values);
     used_values_per_layout_node.set(node, move(new_used_values));
     return *new_used_values_ptr;
 }
@@ -45,7 +45,7 @@ LayoutState::UsedValues const& LayoutState::get(NodeWithStyle const& node) const
 
     auto new_used_values = adopt_own(*new UsedValues);
     auto* new_used_values_ptr = new_used_values.ptr();
-    new_used_values->set_node(const_cast<NodeWithStyle&>(node), containing_block_used_values);
+    new_used_values->set_node(node, containing_block_used_values);
     const_cast<LayoutState*>(this)->used_values_per_layout_node.set(node, move(new_used_values));
     return *new_used_values_ptr;
 }
@@ -489,7 +489,7 @@ void LayoutState::commit(Box& root)
     }
 }
 
-void LayoutState::UsedValues::set_node(NodeWithStyle& node, UsedValues const* containing_block_used_values)
+void LayoutState::UsedValues::set_node(NodeWithStyle const& node, UsedValues const* containing_block_used_values)
 {
     m_node = &node;
     m_containing_block_used_values = containing_block_used_values;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -58,7 +58,7 @@ struct LayoutState {
     struct UsedValues {
         NodeWithStyle const& node() const { return *m_node; }
         NodeWithStyle& node() { return const_cast<NodeWithStyle&>(*m_node); }
-        void set_node(NodeWithStyle&, UsedValues const* containing_block_used_values);
+        void set_node(NodeWithStyle const&, UsedValues const* containing_block_used_values);
 
         UsedValues const* containing_block_used_values() const { return m_containing_block_used_values; }
 

--- a/Tests/LibWeb/Layout/expected/inline-nested-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/inline-nested-with-padding.txt
@@ -1,0 +1,59 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 106 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 90 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+        InlineNode <span.a> at [10,8] [0+2+0 86.953125 0+2+0] [0+2+0 18 0+2+0]
+          InlineNode <span.b> at [40,8] [0+0+30 26.953125 30+0+0] [0+0+0 18 0+0+0]
+            frag 0 from TextNode start: 0, length: 3, rect: [40,8 26.953125x18] baseline: 13.796875
+                "whf"
+            TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <hr> at [9,35] [0+1+0 782 0+1+0] [8+1+0 0 0+1+8] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span.a> at [10,44] [0+2+0 190.109375 0+2+0] [0+2+0 18 0+2+0]
+          InlineNode <span.b> at [40,44] [0+0+30 130.109375 30+0+0] [0+0+0 18 0+0+0]
+            frag 0 from TextNode start: 0, length: 2, rect: [40,44 20.515625x18] baseline: 13.796875
+                "wh"
+            frag 1 from TextNode start: 0, length: 1, rect: [163.671875,44 6.4375x18] baseline: 13.796875
+                "f"
+            TextNode <#text> (not painted)
+            InlineNode <span.b> at [90.515625,44] [0+0+30 43.15625 30+0+0] [0+0+0 18 0+0+0]
+              frag 0 from TextNode start: 0, length: 5, rect: [90.515625,44 43.15625x18] baseline: 13.796875
+                  " foo "
+              TextNode <#text> (not painted)
+            TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <hr> at [9,71] [0+1+0 782 0+1+0] [8+1+0 0 0+1+8] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,80] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span.a> at [10,80] [0+2+0 26.953125 0+2+0] [0+2+0 18 0+2+0]
+          InlineNode <span.c> at [10,80] [0+0+0 26.953125 0+0+0] [0+0+30 18 30+0+0]
+            frag 0 from TextNode start: 0, length: 3, rect: [10,80 26.953125x18] baseline: 13.796875
+                "whf"
+            TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x106]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x90]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
+        PaintableWithLines (InlineNode<SPAN>.a) [8,6 90.953125x22]
+          PaintableWithLines (InlineNode<SPAN>.b) [10,8 86.953125x18]
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<HR>) [8,34 784x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,44 784x18]
+        PaintableWithLines (InlineNode<SPAN>.a) [8,42 194.109375x22]
+          PaintableWithLines (InlineNode<SPAN>.b) [10,44 190.109375x18]
+            TextPaintable (TextNode<#text>)
+            PaintableWithLines (InlineNode<SPAN>.b) [60.515625,44 103.15625x18]
+              TextPaintable (TextNode<#text>)
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<HR>) [8,70 784x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,80 784x18]
+        PaintableWithLines (InlineNode<SPAN>.a) [8,78 30.953125x22]
+          PaintableWithLines (InlineNode<SPAN>.c) [10,50 26.953125x78]
+            TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x106] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/inline-nested-with-padding.html
+++ b/Tests/LibWeb/Layout/input/inline-nested-with-padding.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+.a {
+    border: 2px solid red;
+}
+.b {
+    background: blue;
+    color: white;
+    padding: 0 30px;
+}
+.c {
+    background: green;
+    color: white;
+    padding: 30px 0;
+}
+</style>
+<span class="a"><span class="b">whf</span></span>
+<hr>
+<span class="a"><span class="b">wh<span class="b"> foo </span>f</span></span>
+<hr>
+<span class="a"><span class="c">whf</span></span>


### PR DESCRIPTION
Improves layout of [Wikipedia's monobook skin](https://en.wikipedia.org/wiki/Main_Page?useskin=monobook):

| Before | After |
|--|--|
| <img width="544" height="155" alt="image" src="https://github.com/user-attachments/assets/dd569f8c-457e-4d3d-be23-945777ba1cc3" /> | <img width="545" height="155" alt="image" src="https://github.com/user-attachments/assets/06501c9e-c6a4-44cd-bdad-28f76799d7f5" /> |

Also fixes #3491:

| Before | After |
|--|--|
| <img width="92" height="51" alt="image" src="https://github.com/user-attachments/assets/0a3f2eb3-3830-4745-9b35-28894122112f" /> | <img width="111" height="52" alt="image" src="https://github.com/user-attachments/assets/e7a8d623-f3ae-4936-a885-b3f39df4cdc0" /> |
