### PR TITLE
AK: Use simdutf to validate UTF-16 strings as ASCII

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -151,9 +151,7 @@ bool Utf16View::is_ascii() const
 {
     if (has_ascii_storage())
         return true;
-
-    // FIXME: Petition simdutf to implement an ASCII validator for UTF-16.
-    return all_of(utf16_span(), AK::is_ascii);
+    return simdutf::validate_utf16_as_ascii(m_string.utf16, length_in_code_units());
 }
 
 bool Utf16View::validate() const

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "ee0973d8090e4e3e452244bb50d34c25fe907dc2",
+  "builtin-baseline": "120deac3062162151622ca4860575a33844ba10b",
   "dependencies": [
     {
       "name": "angle",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -211,7 +211,7 @@
     },
     {
       "name": "ffmpeg",
-      "version": "7.1.1#3"
+      "version": "7.1.1#4"
     },
     {
       "name": "fontconfig",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -251,7 +251,7 @@
     },
     {
       "name": "libwebp",
-      "version": "1.5.0#1"
+      "version": "1.6.0#0"
     },
     {
       "name": "mman",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -235,7 +235,7 @@
     },
     {
       "name": "libpng",
-      "version": "1.6.48#0"
+      "version": "1.6.50#0"
     },
     {
       "name": "libproxy",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -271,7 +271,7 @@
     },
     {
       "name": "simdutf",
-      "version": "7.3.3#0"
+      "version": "7.4.0#0"
     },
     {
       "name": "skia",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -279,7 +279,7 @@
     },
     {
       "name": "sqlite3",
-      "version": "3.50.2#0"
+      "version": "3.50.4#0"
     },
     {
       "name": "woff2",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -259,7 +259,7 @@
     },
     {
       "name": "openssl",
-      "version": "3.5.1#0"
+      "version": "3.5.2#0"
     },
     {
       "name": "qtbase",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -227,7 +227,7 @@
     },
     {
       "name": "libjpeg-turbo",
-      "version": "3.1.0#2"
+      "version": "3.1.1#0"
     },
     {
       "name": "libjxl",


### PR DESCRIPTION
Updated other packages while we're here since this busts the vcpkg cache. The ffmpeg update includes support for VAAPI, which seems of interest to us looking at discord history.