### PR TITLE
LibWeb: Correctly position absolute inline boxes in last line

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -447,6 +447,8 @@ void InlineFormattingContext::generate_line_boxes()
         auto& box_state = m_state.get_mutable(*box);
         box_state.set_static_position_rect(calculate_static_position_rect(*box));
     }
+
+    line_builder.update_last_line();
 }
 
 bool InlineFormattingContext::any_floats_intrude_at_block_offset(CSSPixels block_offset) const

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -157,12 +157,9 @@ struct LayoutState {
         void set_static_position_rect(StaticPositionRect const& static_position_rect) { m_static_position_rect = static_position_rect; }
         CSSPixelPoint static_position() const
         {
-            CSSPixelSize size;
-            size.set_width(content_width() + padding_left + padding_right + border_left + border_right + margin_left + margin_right);
-            size.set_height(content_height() + padding_top + padding_bottom + border_top + border_bottom + margin_top + margin_bottom);
             if (!m_static_position_rect.has_value())
                 return {};
-            return m_static_position_rect->aligned_position_for_box_with_size(size);
+            return m_static_position_rect->aligned_position_for_box_with_size({ margin_box_width(), margin_box_height() });
         }
 
     private:

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -21,12 +21,6 @@ LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_s
     begin_new_line(false);
 }
 
-LineBuilder::~LineBuilder()
-{
-    if (m_last_line_needs_update)
-        update_last_line();
-}
-
 void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_item_width)
 {
     // FIXME: Respect inline direction.
@@ -35,7 +29,9 @@ void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_
     last_line_box.m_has_break = true;
     last_line_box.m_has_forced_break = forced_break == ForcedBreak::Yes;
 
+    m_last_line_needs_update = true;
     update_last_line();
+
     size_t break_count = 0;
     bool floats_intrude_at_current_y = false;
     do {
@@ -192,9 +188,11 @@ bool LineBuilder::should_break(CSSPixels next_item_width)
 
 void LineBuilder::update_last_line()
 {
+    if (!m_last_line_needs_update)
+        return;
     m_last_line_needs_update = false;
-    auto& line_boxes = m_containing_block_used_values.line_boxes;
 
+    auto& line_boxes = m_containing_block_used_values.line_boxes;
     if (line_boxes.is_empty())
         return;
 

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -16,7 +16,6 @@ class LineBuilder {
 
 public:
     LineBuilder(InlineFormattingContext&, LayoutState&, LayoutState::UsedValues& containing_block_used_values, CSS::Direction, CSS::WritingMode);
-    ~LineBuilder();
 
     enum class ForcedBreak {
         No,

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-inline.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-inline.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: inline
+      frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x18] baseline: 13.796875
+          "foo"
+      TextNode <#text> (not painted)
+      BlockContainer <span> at [35.15625,8] positioned [0+0+0 27.640625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [35.15625,8 27.640625x18] baseline: 13.796875
+            "bar"
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<SPAN>) [35.15625,8 27.640625x18]
+        TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-inline.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-inline.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+foo <span style="position:absolute">bar</span>


### PR DESCRIPTION
If we were calculating the static position for an absolutely positioned inline box that resides in the last line of its containing block, we would not have yet provided the fragments in that line with their final positions. Additionally, we would always move the box beneath the fragment, which was incorrect.

Fixes #5867.

| Before | After |
|--|--|
| <img width="55" height="46" alt="image" src="https://github.com/user-attachments/assets/a62e0f1e-e9db-4c91-bee0-2fcc8218c37f" /> | <img width="60" height="30" alt="image" src="https://github.com/user-attachments/assets/48af8187-14bf-40a1-8408-661f2d850d6e" /> |
