### PR TITLE
Tests/LibWeb: Ensure SIGINT causes test-web to exit with a non-zero code

### DIFF
--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -785,7 +785,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         }
     }
 
-    return fail_count + timeout_count + crashed_count;
+    return fail_count + timeout_count + crashed_count + tests_remaining;
 }
 
 static void handle_signal(int signal)


### PR DESCRIPTION
Sending a ctrl+c to a program should generally cause it to exit with a non-zero status code.