### PR TITLE
LibJS: A couple Temporal normative and editorial updates

### DIFF
--- a/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -1693,33 +1693,33 @@ ThrowCompletionOr<DifferenceSettings> get_difference_settings(VM& vm, DurationOp
     // 2. Let largestUnit be ? GetTemporalUnitValuedOption(options, "largestUnit", UNSET).
     auto largest_unit = TRY(get_temporal_unit_valued_option(vm, options, vm.names.largestUnit, Unset {}));
 
-    // 3. Perform ? ValidateTemporalUnitValue(largestUnit, unitGroup, « AUTO »).
+    // 3. Let roundingIncrement be ? GetRoundingIncrementOption(options).
+    auto rounding_increment = TRY(get_rounding_increment_option(vm, options));
+
+    // 4. Let roundingMode be ? GetRoundingModeOption(options, TRUNC).
+    auto rounding_mode = TRY(get_rounding_mode_option(vm, options, RoundingMode::Trunc));
+
+    // 5. Let smallestUnit be ? GetTemporalUnitValuedOption(options, "smallestUnit", UNSET).
+    auto smallest_unit = TRY(get_temporal_unit_valued_option(vm, options, vm.names.smallestUnit, Unset {}));
+
+    // 6. Perform ? ValidateTemporalUnitValue(largestUnit, unitGroup, « AUTO »).
     TRY(validate_temporal_unit_value(vm, vm.names.largestUnit, largest_unit, unit_group, { { Auto {} } }));
 
-    // 4. If largestUnit is UNSET, then
+    // 7. If largestUnit is UNSET, then
     if (largest_unit.has<Unset>()) {
         // a. Set largestUnit to AUTO.
         largest_unit = Auto {};
     }
 
-    // 5. If disallowedUnits contains largestUnit, throw a RangeError exception.
+    // 8. If disallowedUnits contains largestUnit, throw a RangeError exception.
     if (auto* unit = largest_unit.get_pointer<Unit>(); unit && disallowed_units.contains_slow(*unit))
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, temporal_unit_to_string(*unit), vm.names.largestUnit);
 
-    // 6. Let roundingIncrement be ? GetRoundingIncrementOption(options).
-    auto rounding_increment = TRY(get_rounding_increment_option(vm, options));
-
-    // 7. Let roundingMode be ? GetRoundingModeOption(options, TRUNC).
-    auto rounding_mode = TRY(get_rounding_mode_option(vm, options, RoundingMode::Trunc));
-
-    // 8. If operation is SINCE, then
+    // 9. If operation is SINCE, then
     if (operation == DurationOperation::Since) {
         // a. Set roundingMode to NegateRoundingMode(roundingMode).
         rounding_mode = negate_rounding_mode(rounding_mode);
     }
-
-    // 9. Let smallestUnit be ? GetTemporalUnitValuedOption(options, "smallestUnit", UNSET).
-    auto smallest_unit = TRY(get_temporal_unit_valued_option(vm, options, vm.names.smallestUnit, Unset {}));
 
     // 10. Perform ? ValidateTemporalUnitValue(smallestUnit, unitGroup).
     TRY(validate_temporal_unit_value(vm, vm.names.smallestUnit, smallest_unit, unit_group));

--- a/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -1378,8 +1378,8 @@ ThrowCompletionOr<Crypto::BigFraction> total_relative_duration(VM& vm, InternalD
 {
     // 1. If IsCalendarUnit(unit) is true, or timeZone is not UNSET and unit is DAY, then
     if (is_calendar_unit(unit) || (time_zone.has_value() && unit == Unit::Day)) {
-        // a. Let sign be InternalDurationSign(duration).
-        auto sign = internal_duration_sign(duration);
+        // a. If InternalDurationSign(duration) < 0, let sign be -1; else let sign be 1.
+        auto sign = internal_duration_sign(duration) < 0 ? -1 : 1;
 
         // b. Let record be ? NudgeToCalendarUnit(sign, duration, destEpochNs, isoDateTime, timeZone, calendar, 1, unit, TRUNC).
         auto record = TRY(nudge_to_calendar_unit(vm, sign, duration, dest_epoch_ns, iso_date_time, time_zone, calendar, 1, unit, RoundingMode::Trunc));

--- a/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/InstantPrototype.cpp
@@ -268,15 +268,15 @@ JS_DEFINE_NATIVE_FUNCTION(InstantPrototype::to_string)
     // 7. Let smallestUnit be ? GetTemporalUnitValuedOption(resolvedOptions, "smallestUnit", UNSET).
     auto smallest_unit = TRY(get_temporal_unit_valued_option(vm, resolved_options, vm.names.smallestUnit, Unset {}));
 
-    // 8. Perform ? ValidateTemporalUnitValue(smallestUnit, TIME).
+    // 8. Let timeZone be ? Get(resolvedOptions, "timeZone").
+    auto time_zone_value = TRY(resolved_options->get(vm.names.timeZone));
+
+    // 9. Perform ? ValidateTemporalUnitValue(smallestUnit, TIME).
     TRY(validate_temporal_unit_value(vm, vm.names.smallestUnit, smallest_unit, UnitGroup::Time));
 
-    // 9. If smallestUnit is HOUR, throw a RangeError exception.
+    // 10. If smallestUnit is HOUR, throw a RangeError exception.
     if (auto const* unit = smallest_unit.get_pointer<Unit>(); unit && *unit == Unit::Hour)
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, temporal_unit_to_string(*unit), vm.names.smallestUnit);
-
-    // 10. Let timeZone be ? Get(resolvedOptions, "timeZone").
-    auto time_zone_value = TRY(resolved_options->get(vm.names.timeZone));
 
     String time_zone_buffer;
     Optional<StringView> time_zone;

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -776,15 +776,15 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_string)
     // 9. Let smallestUnit be ? GetTemporalUnitValuedOption(resolvedOptions, "smallestUnit", UNSET).
     auto smallest_unit = TRY(get_temporal_unit_valued_option(vm, resolved_options, vm.names.smallestUnit, Unset {}));
 
-    // 10. Perform ? ValidateTemporalUnitValue(smallestUnit, TIME).
+    // 10. Let showTimeZone be ? GetTemporalShowTimeZoneNameOption(resolvedOptions).
+    auto show_time_zone = TRY(get_temporal_show_time_zone_name_option(vm, resolved_options));
+
+    // 11. Perform ? ValidateTemporalUnitValue(smallestUnit, TIME).
     TRY(validate_temporal_unit_value(vm, vm.names.smallestUnit, smallest_unit, UnitGroup::Time));
 
-    // 11. If smallestUnit is HOUR, throw a RangeError exception.
+    // 12. If smallestUnit is HOUR, throw a RangeError exception.
     if (auto const* unit = smallest_unit.get_pointer<Unit>(); unit && *unit == Unit::Hour)
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, temporal_unit_to_string(*unit), vm.names.smallestUnit);
-
-    // 12. Let showTimeZone be ? GetTemporalShowTimeZoneNameOption(resolvedOptions).
-    auto show_time_zone = TRY(get_temporal_show_time_zone_name_option(vm, resolved_options));
 
     // 13. Let precision be ToSecondsStringPrecisionRecord(smallestUnit, digits).
     auto precision = to_seconds_string_precision_record(smallest_unit, digits);

--- a/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
@@ -17,6 +17,14 @@ describe("correct behavior", () => {
         }
     });
 
+    test("blank duration", () => {
+        const duration = new Temporal.Duration();
+        const relativeTo = new Temporal.ZonedDateTime(1n, "UTC");
+
+        const result = duration.total({ unit: "years", relativeTo: relativeTo });
+        expect(result).toBe(0);
+    });
+
     test("relative to plain date", () => {
         const duration = new Temporal.Duration(0, 0, 0, 31);
 


### PR DESCRIPTION
The first commits are normative just because they change order of fallible operations for consistency, thus are observable. The third commit is a bugfix to the spec that fixes an assertion.

test262 diff:
```
test/built-ins/Temporal/Duration/prototype/total/blank-duration.js                                     💥️ -> ✅
test/built-ins/Temporal/Instant/prototype/since/options-read-before-algorithmic-validation.js          ❌ -> ✅
test/built-ins/Temporal/Instant/prototype/toString/options-read-before-algorithmic-validation.js       ❌ -> ✅
test/built-ins/Temporal/Instant/prototype/until/options-read-before-algorithmic-validation.js          ❌ -> ✅
test/built-ins/Temporal/PlainDate/prototype/since/options-read-before-algorithmic-validation.js        ❌ -> ✅
test/built-ins/Temporal/PlainDate/prototype/until/options-read-before-algorithmic-validation.js        ❌ -> ✅
test/built-ins/Temporal/PlainTime/prototype/since/options-read-before-algorithmic-validation.js        ❌ -> ✅
test/built-ins/Temporal/PlainTime/prototype/until/options-read-before-algorithmic-validation.js        ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/prototype/since/options-read-before-algorithmic-validation.js   ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/prototype/until/options-read-before-algorithmic-validation.js   ❌ -> ✅
test/built-ins/Temporal/ZonedDateTime/prototype/toString/options-read-before-algorithmic-validation.js ❌ -> ✅
```

Brings us back up to 100% passing for built-ins/Temporal.