### PR TITLE
LibWeb: Prevent creation of new UsedValues for nested inline nodes

### DIFF
--- a/Tests/LibWeb/Crash/Layout/button-display-inline-with-nested-inlines.html
+++ b/Tests/LibWeb/Crash/Layout/button-display-inline-with-nested-inlines.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<button style="display: inline"><span><span>


### PR DESCRIPTION
Fixes #6015.

CC @awesomekling 