### PR TITLE
Documentation: Rectify incorrect preset name

### DIFF
--- a/Documentation/EditorConfiguration/CLionConfiguration.md
+++ b/Documentation/EditorConfiguration/CLionConfiguration.md
@@ -4,7 +4,7 @@ CLion can integrate with CMake to provide code comprehension features.
 
 After opening the `ladybird` repository in CLion as a new project, the "`Open Project Wizard`" window will open.
 
-Select the `default` Preset in the `Settings -> Build, Execution and Deployment -> CMake` window and check the `Enable profile` checkbox.
+Select the `Release` Preset in the `Settings -> Build, Execution and Deployment -> CMake` window and check the `Enable profile` checkbox.
 Then select the `Debug` profile and uncheck the `Enable profile` checkbox.
 
 If the build complains that there is no `Default` Toolchain, go to the `Settings -> Build, Execution and Deployment -> Toolchains`


### PR DESCRIPTION
This piece of documentation currently refers to a "default" preset.
Sam Atkins informed me it is supposed to say "Release".
This PR addresses this.

<img width="866" height="162" alt="image" src="https://github.com/user-attachments/assets/43c19b21-ab79-4657-a427-2f7d84a02910" />
