### PR TITLE
Unify functions in form associated element

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -244,6 +244,13 @@ bool FormAssociatedElement::report_validity()
     return report_validity_steps();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
+bool FormAssociatedElement::check_validity()
+{
+    // The checkValidity() method, when invoked, must run the check validity steps on this element.
+    return check_validity_steps();
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#check-validity-steps
 bool FormAssociatedElement::check_validity_steps()
 {

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -259,6 +259,24 @@ bool FormAssociatedElement::will_validate() const
     return is_candidate_for_constraint_validation();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+Utf16String FormAssociatedElement::validation_message() const
+{
+    // 1. If this element is not a candidate for constraint validation or if this element satisfies its constraints,
+    //    then return the empty string.
+    if (!is_candidate_for_constraint_validation() || satisfies_its_constraints())
+        return {};
+
+    // FIXME
+    // 2. Return a suitably localized message that the user agent would show the user if this were the only form
+    //    control with a validity constraint problem. If the user agent would not actually show a textual message in
+    //    such a situation (e.g., it would show a graphical cue instead), then return a suitably localized message that
+    //    expresses (one or more of) the validity constraint(s) that the control does not satisfy. If the element is a
+    //    candidate for constraint validation and is suffering from a custom error, then the custom validity error
+    //    message should be present in the return value.
+    return "Invalid form"_utf16;
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#check-validity-steps
 bool FormAssociatedElement::check_validity_steps()
 {

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -237,6 +237,13 @@ WebIDL::ExceptionOr<void> FormAssociatedElement::set_form_action(String const& v
     return html_element.set_attribute(HTML::AttributeNames::formaction, value);
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
+bool FormAssociatedElement::report_validity()
+{
+    // The reportValidity() method, when invoked, must run the report validity steps on this element.
+    return report_validity_steps();
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#check-validity-steps
 bool FormAssociatedElement::check_validity_steps()
 {

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -251,6 +251,14 @@ bool FormAssociatedElement::check_validity()
     return check_validity_steps();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
+bool FormAssociatedElement::will_validate() const
+{
+    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation,
+    // and false otherwise (i.e., false if any conditions are barring it from constraint validation).
+    return is_candidate_for_constraint_validation();
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#check-validity-steps
 bool FormAssociatedElement::check_validity_steps()
 {

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -149,6 +149,9 @@ public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
     bool will_validate() const;
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+    Utf16String validation_message() const;
+
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
     GC::Ref<ValidityState const> validity() const;
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -143,6 +143,9 @@ public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
     bool report_validity();
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
+    bool check_validity();
+
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
     GC::Ref<ValidityState const> validity() const;
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -140,6 +140,9 @@ public:
     String form_action() const;
     WebIDL::ExceptionOr<void> set_form_action(String const&);
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
+    bool report_validity();
+
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
     GC::Ref<ValidityState const> validity() const;
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -146,6 +146,9 @@ public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
     bool check_validity();
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
+    bool will_validate() const;
+
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
     GC::Ref<ValidityState const> validity() const;
 

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -273,13 +273,6 @@ void HTMLButtonElement::activation_behavior(DOM::Event const& event)
         PopoverInvokerElement::popover_target_activation_behaviour(*this, as<DOM::Node>(*event.target()));
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
-bool HTMLButtonElement::will_validate()
-{
-    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation
-    return is_candidate_for_constraint_validation();
-}
-
 bool HTMLButtonElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -44,8 +44,6 @@ public:
 
     virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
-    bool will_validate();
-
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-button-element
     // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -31,7 +31,7 @@ interface HTMLButtonElement : HTMLElement {
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
-    [FIXME] boolean checkValidity();
+    boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -32,7 +32,7 @@ interface HTMLButtonElement : HTMLElement {
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
-    [FIXME] boolean reportValidity();
+    boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
     readonly attribute NodeList labels;

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -30,7 +30,7 @@ interface HTMLButtonElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -88,15 +88,4 @@ GC::Ptr<Layout::Node> HTMLFieldSetElement::create_layout_node(GC::Ref<CSS::Compu
     return heap().allocate<Layout::FieldSetBox>(document(), *this, style);
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
-bool HTMLFieldSetElement::will_validate()
-{
-    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation,
-    // and false otherwise (i.e., false if any conditions are barring it from constraint validation).
-    // A submittable element is a candidate for constraint validation
-    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
-    // Submittable elements: button, input, select, textarea, form-associated custom elements [but not fieldset]
-    return false;
-}
-
 }

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -42,8 +42,6 @@ public:
 
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::group; }
 
-    static bool will_validate();
-
     virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
     Layout::FieldSetBox* layout_node();
     Layout::FieldSetBox const* layout_node() const;

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
@@ -15,7 +15,7 @@ interface HTMLFieldSetElement : HTMLElement {
     [SameObject] readonly attribute HTMLCollection elements;
 
     readonly attribute boolean willValidate;
-    [FIXME, SameObject] readonly attribute ValidityState validity;
+    [SameObject] readonly attribute ValidityState validity;
     readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
@@ -17,7 +17,7 @@ interface HTMLFieldSetElement : HTMLElement {
     readonly attribute boolean willValidate;
     [FIXME, SameObject] readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
-    [FIXME] boolean checkValidity();
+    boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 };

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
@@ -16,7 +16,7 @@ interface HTMLFieldSetElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     [FIXME, SameObject] readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLFieldSetElement.idl
@@ -18,6 +18,6 @@ interface HTMLFieldSetElement : HTMLElement {
     [FIXME, SameObject] readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
-    [FIXME] boolean reportValidity();
+    boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 };

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2913,13 +2913,6 @@ WebIDL::ExceptionOr<void> HTMLInputElement::step_up_or_down(bool is_down, WebIDL
     return {};
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
-bool HTMLInputElement::will_validate()
-{
-    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation
-    return is_candidate_for_constraint_validation();
-}
-
 Optional<ARIA::Role> HTMLInputElement::default_role() const
 {
     // http://wpt.live/html-aam/roles-dynamic-switch.tentative.window.html "Disconnected <input type=checkbox switch>"

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2920,12 +2920,6 @@ bool HTMLInputElement::will_validate()
     return is_candidate_for_constraint_validation();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
-WebIDL::ExceptionOr<bool> HTMLInputElement::check_validity()
-{
-    return check_validity_steps();
-}
-
 Optional<ARIA::Role> HTMLInputElement::default_role() const
 {
     // http://wpt.live/html-aam/roles-dynamic-switch.tentative.window.html "Disconnected <input type=checkbox switch>"

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2926,12 +2926,6 @@ WebIDL::ExceptionOr<bool> HTMLInputElement::check_validity()
     return check_validity_steps();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
-WebIDL::ExceptionOr<bool> HTMLInputElement::report_validity()
-{
-    return report_validity_steps();
-}
-
 Optional<ARIA::Role> HTMLInputElement::default_role() const
 {
     // http://wpt.live/html-aam/roles-dynamic-switch.tentative.window.html "Disconnected <input type=checkbox switch>"

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -160,7 +160,6 @@ public:
     WebIDL::ExceptionOr<void> step_down(WebIDL::Long n = 1);
 
     bool will_validate();
-    WebIDL::ExceptionOr<bool> check_validity();
 
     WebIDL::ExceptionOr<void> show_picker();
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -161,7 +161,6 @@ public:
 
     bool will_validate();
     WebIDL::ExceptionOr<bool> check_validity();
-    WebIDL::ExceptionOr<bool> report_validity();
 
     WebIDL::ExceptionOr<void> show_picker();
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -159,8 +159,6 @@ public:
     WebIDL::ExceptionOr<void> step_up(WebIDL::Long n = 1);
     WebIDL::ExceptionOr<void> step_down(WebIDL::Long n = 1);
 
-    bool will_validate();
-
     WebIDL::ExceptionOr<void> show_picker();
 
     // ^EventTarget

--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -54,7 +54,7 @@ interface HTMLInputElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.idl
@@ -25,7 +25,7 @@ enum PotentialDestination {
     "style",
     "track",
     "video",
-    "webidentity", 
+    "webidentity",
     "worker",
     "xslt",
     "fetch"

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -81,17 +81,6 @@ void HTMLObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observer);
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
-bool HTMLObjectElement::will_validate()
-{
-    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation,
-    // and false otherwise (i.e., false if any conditions are barring it from constraint validation).
-    // A submittable element is a candidate for constraint validation
-    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
-    // Submittable elements: button, input, select, textarea, form-associated custom elements [but not object]
-    return false;
-}
-
 void HTMLObjectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&)
 {
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -47,8 +47,6 @@ public:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    static bool will_validate();
-
 private:
     HTMLObjectElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -20,7 +20,7 @@ interface HTMLObjectElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -22,7 +22,7 @@ interface HTMLObjectElement : HTMLElement {
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
-    [FIXME] boolean reportValidity();
+    boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
     // Obsolete

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -21,7 +21,7 @@ interface HTMLObjectElement : HTMLElement {
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
-    [FIXME] boolean checkValidity();
+    boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -110,15 +110,4 @@ void HTMLOutputElement::clear_algorithm()
     string_replace_all({});
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
-bool HTMLOutputElement::will_validate()
-{
-    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation,
-    // and false otherwise (i.e., false if any conditions are barring it from constraint validation).
-    // A submittable element is a candidate for constraint validation
-    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
-    // Submittable elements: button, input, select, textarea, form-associated custom elements [but not output]
-    return false;
-}
-
 }

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -57,8 +57,6 @@ public:
     // https://www.w3.org/TR/html-aria/#el-output
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::status; }
 
-    static bool will_validate();
-
 private:
     HTMLOutputElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.idl
@@ -17,7 +17,7 @@ interface HTMLOutputElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.idl
@@ -19,7 +19,7 @@ interface HTMLOutputElement : HTMLElement {
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
-    [FIXME] boolean reportValidity();
+    boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 
     readonly attribute NodeList labels;

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.idl
@@ -18,7 +18,7 @@ interface HTMLOutputElement : HTMLElement {
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
-    [FIXME] boolean checkValidity();
+    boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -704,12 +704,6 @@ bool HTMLSelectElement::check_validity()
     return check_validity_steps();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
-bool HTMLSelectElement::report_validity()
-{
-    return report_validity_steps();
-}
-
 bool HTMLSelectElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -698,12 +698,6 @@ bool HTMLSelectElement::will_validate()
     return is_candidate_for_constraint_validation();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
-bool HTMLSelectElement::check_validity()
-{
-    return check_validity_steps();
-}
-
 bool HTMLSelectElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -691,13 +691,6 @@ void HTMLSelectElement::update_selectedness()
     update_inner_text_element();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
-bool HTMLSelectElement::will_validate()
-{
-    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation
-    return is_candidate_for_constraint_validation();
-}
-
 bool HTMLSelectElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -63,7 +63,6 @@ public:
     Vector<GC::Root<HTMLOptionElement>> list_of_options() const;
 
     bool will_validate();
-    bool check_validity();
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-select-element

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -62,8 +62,6 @@ public:
 
     Vector<GC::Root<HTMLOptionElement>> list_of_options() const;
 
-    bool will_validate();
-
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-select-element
     // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -64,7 +64,6 @@ public:
 
     bool will_validate();
     bool check_validity();
-    bool report_validity();
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-select-element

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -33,7 +33,7 @@ interface HTMLSelectElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -239,12 +239,6 @@ bool HTMLTextAreaElement::will_validate()
     return is_candidate_for_constraint_validation();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
-bool HTMLTextAreaElement::check_validity()
-{
-    return check_validity_steps();
-}
-
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength
 WebIDL::Long HTMLTextAreaElement::max_length() const
 {

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -232,13 +232,6 @@ u32 HTMLTextAreaElement::text_length() const
     return api_value().length_in_code_units();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
-bool HTMLTextAreaElement::will_validate()
-{
-    // The willValidate attribute's getter must return true, if this element is a candidate for constraint validation
-    return is_candidate_for_constraint_validation();
-}
-
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength
 WebIDL::Long HTMLTextAreaElement::max_length() const
 {

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -245,12 +245,6 @@ bool HTMLTextAreaElement::check_validity()
     return check_validity_steps();
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
-bool HTMLTextAreaElement::report_validity()
-{
-    return report_validity_steps();
-}
-
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength
 WebIDL::Long HTMLTextAreaElement::max_length() const
 {

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -100,7 +100,6 @@ public:
 
     bool will_validate();
     bool check_validity();
-    bool report_validity();
 
     WebIDL::Long max_length() const;
     WebIDL::ExceptionOr<void> set_max_length(WebIDL::Long);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -99,7 +99,6 @@ public:
     u32 text_length() const;
 
     bool will_validate();
-    bool check_validity();
 
     WebIDL::Long max_length() const;
     WebIDL::ExceptionOr<void> set_max_length(WebIDL::Long);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -98,8 +98,6 @@ public:
 
     u32 text_length() const;
 
-    bool will_validate();
-
     WebIDL::Long max_length() const;
     WebIDL::ExceptionOr<void> set_max_length(WebIDL::Long);
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
@@ -28,7 +28,7 @@ interface HTMLTextAreaElement : HTMLElement {
 
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
-    [FIXME] readonly attribute DOMString validationMessage;
+    readonly attribute Utf16DOMString validationMessage;
     boolean checkValidity();
     boolean reportValidity();
     undefined setCustomValidity(DOMString error);

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-valueMissing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-valueMissing.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 78 tests
 
-77 Pass
-1 Fail
+78 Pass
 Pass	[INPUT in TEXT status] The required attribute is not set
 Pass	[INPUT in TEXT status] The value is not empty and required is true
 Pass	[INPUT in TEXT status] The value is empty and required is true
@@ -81,4 +80,4 @@ Pass	[select]  Selected the option with value equals to empty
 Pass	[textarea]  The required attribute is not set
 Pass	[textarea]  The value is not empty
 Pass	[textarea]  The value is empty
-Fail	validationMessage should return empty string when willValidate is false and valueMissing is true
+Pass	validationMessage should return empty string when willValidate is false and valueMissing is true


### PR DESCRIPTION
I noticed 3 functions:
 * `report_validity`
 * `check_validity`
 * `will_validate`

Where repeated in many classes. Considering we have a FormAssociatedElement class to unify this kind of behavior I decided to refactor the code out.

I also went ahead and implemented a barebones `validation_message` that gives us one more WPT test.

This removes 15 FIXME's in IDL files for very little effort :)