### PR TITLE
LibWeb: Use 0 as min-content size for items with `overflow:hidden` [GFC]

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2460,7 +2460,14 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
     }
 
     if (should_treat_preferred_size_as_auto) {
-        auto result = item.add_margin_box_sizes(calculate_min_content_size(item, dimension), dimension);
+        CSSPixels min_content_size;
+        // NOTE: This behavior is not defined in the spec, but seems required to match other browsers.
+        if (item.box->is_scroll_container()) {
+            min_content_size = 0;
+        } else {
+            min_content_size = calculate_min_content_size(item, dimension);
+        }
+        auto result = item.add_margin_box_sizes(min_content_size, dimension);
         return min(result, maximum_size);
     }
 

--- a/Tests/LibWeb/Layout/expected/grid/inline-item-with-overflow-hidden.txt
+++ b/Tests/LibWeb/Layout/expected/grid/inline-item-with-overflow-hidden.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
+      Box <div.a> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [GFC] children: not-inline
+        Box <div.b> at [8,8] [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [GFC] children: not-inline
+          BlockContainer <span> at [8,8] [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 115, rect: [8,8 970.5625x18] baseline: 13.796875
+                "Very very very long sentence lorem ipsum too long to fit what will happen with this sentence? Nobody knows for sure"
+            TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      PaintableBox (Box<DIV>.a) [8,8 784x18]
+        PaintableBox (Box<DIV>.b) [8,8 196x18]
+          PaintableWithLines (BlockContainer<SPAN>) [8,8 196x18] overflow: [8,8 970.5625x18]
+            TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/inline-item-with-overflow-hidden.html
+++ b/Tests/LibWeb/Layout/input/grid/inline-item-with-overflow-hidden.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+.a {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+}
+.b {
+    background-color: #5f5;
+    display: grid;
+}
+span {
+    overflow: hidden;
+    white-space: nowrap;
+}
+</style>
+<div class="a"><div class="b"><span>Very very very long sentence lorem ipsum too long to fit what will happen with this sentence? Nobody knows for sure


### PR DESCRIPTION
This behavior is not specified but required to match other browsers.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/5907