### PR TITLE
LibWeb: Fire change events on deletion in FormAssociated Text Elements

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -62,6 +62,7 @@ enum class ShouldComputeRole {
     X(DidLoseFocus)                                 \
     X(DidReceiveFocus)                              \
     X(EditingInsertion)                             \
+    X(EditingDeletion)                              \
     X(ElementAttributeChange)                       \
     X(ElementSetShadowRoot)                         \
     X(HTMLDialogElementSetIsModal)                  \

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -880,6 +880,9 @@ void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
     }
 
     MUST(set_range_text({}, selection_start, selection_end, Bindings::SelectionMode::End));
+
+    text_node->invalidate_style(DOM::StyleInvalidationReason::EditingDeletion);
+    did_edit_text_node();
 }
 
 EventResult FormAssociatedTextControlElement::handle_return_key(FlyString const&)


### PR DESCRIPTION
Previously we would only trigger change events on insertion, which resulted in javascript code missing changes due to deletion.

This makes the calculator on the [MDN simple web worker demo](https://mdn.github.io/dom-examples/web-workers/simple-web-worker/) update on deletion as well.