### PR TITLE
Meta: Update simdutf to v7.4.0 in Flatpak manifest

### DIFF
--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -35,7 +35,7 @@
         {
           "type": "git",
           "url": "https://github.com/simdutf/simdutf.git",
-          "tag": "v7.3.2"
+          "tag": "v7.4.0"
         }
       ],
       "config-opts": [


### PR DESCRIPTION
As a result of https://github.com/LadybirdBrowser/ladybird/commit/086877a280dd614a62d247dd2b3b58071c9afdda, also the Flatpak manifest needs the simdutf update.