### PR TITLE
LibJS: Always allocate callee contexts up front

### DIFF
--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -27,7 +27,9 @@
     O(Call)                            \
     O(CallBuiltin)                     \
     O(CallConstruct)                   \
+    O(CallConstructWithArgumentArray)  \
     O(CallDirectEval)                  \
+    O(CallDirectEvalWithArgumentArray) \
     O(CallWithArgumentArray)           \
     O(Catch)                           \
     O(ConcatString)                    \

--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -77,11 +77,6 @@ public:
 
     Executable& current_executable() { return *m_current_executable; }
     Executable const& current_executable() const { return *m_current_executable; }
-    Span<Value> allocate_argument_values(size_t argument_count)
-    {
-        m_argument_values_buffer.resize_and_keep_capacity(argument_count);
-        return m_argument_values_buffer.span();
-    }
 
     ExecutionContext& running_execution_context() { return *m_running_execution_context; }
 
@@ -101,7 +96,6 @@ private:
     GC::Ptr<Object> m_global_object { nullptr };
     GC::Ptr<DeclarativeEnvironment> m_global_declarative_environment { nullptr };
     Span<Value> m_registers_and_constants_and_locals_arguments;
-    Vector<Value> m_argument_values_buffer;
     ExecutionContext* m_running_execution_context { nullptr };
 };
 

--- a/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Libraries/LibJS/Runtime/BoundFunction.h
@@ -21,7 +21,7 @@ public:
     virtual ~BoundFunction() override = default;
 
     virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
-    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ExecutionContext& arguments_list, FunctionObject& new_target) override;
 
     virtual bool is_strict_mode() const override { return m_bound_target_function->is_strict_mode(); }
     virtual bool has_constructor() const override { return m_bound_target_function->has_constructor(); }

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -119,7 +119,7 @@ public:
 
     virtual ThrowCompletionOr<void> get_stack_frame_size(size_t& registers_and_constants_and_locals_slots, size_t& argument_count) override;
     virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
-    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ExecutionContext&, FunctionObject& new_target) override;
 
     void make_method(Object& home_object);
 

--- a/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Libraries/LibJS/Runtime/FunctionObject.h
@@ -26,7 +26,7 @@ public:
 
     virtual ThrowCompletionOr<void> get_stack_frame_size([[maybe_unused]] size_t& registers_and_constants_and_locals_count, [[maybe_unused]] size_t& argument_count) { return {}; }
     virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) = 0;
-    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct([[maybe_unused]] ReadonlySpan<Value> arguments_list, [[maybe_unused]] FunctionObject& new_target) { VERIFY_NOT_REACHED(); }
+    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ExecutionContext&, [[maybe_unused]] FunctionObject& new_target) { VERIFY_NOT_REACHED(); }
 
     void set_function_name(Variant<PropertyKey, PrivateName> const& name_arg, Optional<StringView> const& prefix = {});
     void set_function_length(double length);

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -29,7 +29,7 @@ public:
     virtual ~NativeFunction() override = default;
 
     virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
-    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ExecutionContext&, FunctionObject& new_target) override;
 
     // Used for [[Call]] / [[Construct]]'s "...result of evaluating F in a manner that conforms to the specification of F".
     // Needs to be overridden by all NativeFunctions without an m_native_function.

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -43,7 +43,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const override;
     virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;
-    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
+    virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct(ExecutionContext&, FunctionObject& new_target) override;
     ThrowCompletionOr<void> validate_non_revoked_proxy() const;
 
 private:
@@ -53,6 +53,8 @@ private:
 
     virtual bool is_function() const override { return m_target->is_function(); }
     virtual bool is_proxy_object() const final { return true; }
+
+    virtual ThrowCompletionOr<void> get_stack_frame_size(size_t& registers_and_constants_and_locals_count, size_t& argument_count) override;
 
     GC::Ref<Object> m_target;
     GC::Ref<Object> m_handler;


### PR DESCRIPTION
We already do this for normal Call contexts, so this is just continuing
to propagate the same pattern to other instructions.

Fixes #6026