### PR TITLE
LibWeb: Couple small GFC optimizations

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -307,6 +307,14 @@ private:
     size_t m_explicit_rows_line_count { 0 };
     size_t m_explicit_columns_line_count { 0 };
 
+    bool m_has_flexible_row_tracks { false };
+    bool m_has_flexible_column_tracks { false };
+
+    bool has_flexible_tracks(GridDimension dimension) const
+    {
+        return dimension == GridDimension::Column ? m_has_flexible_column_tracks : m_has_flexible_row_tracks;
+    }
+
     OccupationGrid m_occupation_grid;
     Vector<GridItem> m_grid_items;
 


### PR DESCRIPTION
- We could skip doing item's intrinsic min-content layout if we know for sure that there's no tracks with intrinsic sizing function to distribute the min-content size to.
- We could skip calculating fr unit size if we know there's no flexible tracks.