### PR TITLE
LibWeb: Implement Blob constructor type normalization

### DIFF
--- a/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Libraries/LibWeb/FileAPI/Blob.h
@@ -21,9 +21,15 @@ using BlobPart = Variant<GC::Root<WebIDL::BufferSource>, GC::Root<Blob>, String>
 using BlobParts = Vector<BlobPart>;
 using BlobPartsOrByteBuffer = Variant<BlobParts, ByteBuffer>;
 
+enum class TypeNormalization {
+    Standard,
+    None
+};
+
 struct BlobPropertyBag {
     String type = String {};
     Bindings::EndingType endings;
+    TypeNormalization typeNormalization = TypeNormalization::Standard;
 };
 
 [[nodiscard]] ErrorOr<String> convert_line_endings_to_native(StringView string);
@@ -40,6 +46,7 @@ public:
     virtual ~Blob() override;
 
     [[nodiscard]] static GC::Ref<Blob> create(JS::Realm&, ByteBuffer, String type);
+    [[nodiscard]] static GC::Ref<Blob> create(JS::Realm&, ByteBuffer, String type, TypeNormalization typeNormalization);
     [[nodiscard]] static GC::Ref<Blob> create(JS::Realm&, Optional<BlobPartsOrByteBuffer> const& blob_parts_or_byte_buffer = {}, Optional<BlobPropertyBag> const& options = {});
     static WebIDL::ExceptionOr<GC::Ref<Blob>> construct_impl(JS::Realm&, Optional<BlobParts> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
 

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -217,8 +217,13 @@ WebIDL::ExceptionOr<JS::Value> XMLHttpRequest::response()
     // 6. Otherwise, if this’s response type is "blob", set this’s response object to a new Blob object representing this’s received bytes with type set to the result of get a final MIME type for this.
     else if (m_response_type == Bindings::XMLHttpRequestResponseType::Blob) {
         auto mime_type_as_string = get_final_mime_type().serialized();
-        auto blob = FileAPI::Blob::create(realm(), m_received_bytes, move(mime_type_as_string));
-        m_response_object = GC::Ref<JS::Object> { blob };
+        if (!m_override_mime_type.has_value()) {
+            auto blob = FileAPI::Blob::create(realm(), m_received_bytes, move(mime_type_as_string));
+            m_response_object = GC::Ref<JS::Object> { blob };
+        } else {
+            auto blob = FileAPI::Blob::create(realm(), m_received_bytes, move(mime_type_as_string), FileAPI::TypeNormalization::None);
+            m_response_object = GC::Ref<JS::Object> { blob };
+        }
     }
     // 7. Otherwise, if this’s response type is "document", set a document response for this.
     else if (m_response_type == Bindings::XMLHttpRequestResponseType::Document) {

--- a/Tests/LibWeb/Text/expected/wpt-import/fetch/api/response/response-consume.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/fetch/api/response/response-consume.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 40 tests
 
-33 Pass
-7 Fail
+34 Pass
+6 Fail
 Pass	Consume response's body: from text to text
 Pass	Consume response's body: from text to blob
 Pass	Consume response's body: from text to arrayBuffer
@@ -28,7 +28,7 @@ Pass	Consume response's body: from FormData to text
 Pass	Consume response's body: from FormData to arrayBuffer
 Pass	Consume response's body: from URLSearchParams to formData
 Pass	Consume response's body: from URLSearchParams without correct type to formData (error case)
-Fail	Consume response's body: from URLSearchParams to blob
+Pass	Consume response's body: from URLSearchParams to blob
 Pass	Consume response's body: from URLSearchParams to text
 Pass	Consume response's body: from URLSearchParams to arrayBuffer
 Pass	Consume response's body: from stream to blob


### PR DESCRIPTION
Normalize the type option in the Blob constructor according to the File API specification:

This makes Blob.type spec-compliant and fixes the WPT: xhr/setrequestheader-content-type.htm