### PR TITLE
LibWeb/Gamepad: Forward declare SDL components to fix Windows build

### DIFF
--- a/Libraries/LibWeb/Gamepad/Gamepad.cpp
+++ b/Libraries/LibWeb/Gamepad/Gamepad.cpp
@@ -16,6 +16,8 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 
+#include <SDL3/SDL_gamepad.h>
+
 namespace Web::Gamepad {
 
 GC_DEFINE_ALLOCATOR(Gamepad);

--- a/Libraries/LibWeb/Gamepad/Gamepad.h
+++ b/Libraries/LibWeb/Gamepad/Gamepad.h
@@ -9,8 +9,8 @@
 
 #include <LibWeb/Bindings/GamepadPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/Gamepad/SDLGamepadForward.h>
 #include <LibWeb/HighResolutionTime/DOMHighResTimeStamp.h>
-#include <SDL3/SDL_gamepad.h>
 
 namespace Web::Gamepad {
 

--- a/Libraries/LibWeb/Gamepad/GamepadButton.cpp
+++ b/Libraries/LibWeb/Gamepad/GamepadButton.cpp
@@ -8,6 +8,8 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Gamepad/GamepadButton.h>
 
+#include <SDL3/SDL_gamepad.h>
+
 namespace Web::Gamepad {
 
 GC_DEFINE_ALLOCATOR(GamepadButton);

--- a/Libraries/LibWeb/Gamepad/GamepadButton.h
+++ b/Libraries/LibWeb/Gamepad/GamepadButton.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <LibWeb/Bindings/PlatformObject.h>
-#include <SDL3/SDL_gamepad.h>
 
 namespace Web::Gamepad {
 

--- a/Libraries/LibWeb/Gamepad/NavigatorGamepad.cpp
+++ b/Libraries/LibWeb/Gamepad/NavigatorGamepad.cpp
@@ -14,6 +14,8 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 
+#include <SDL3/SDL_gamepad.h>
+
 namespace Web::Gamepad {
 
 // https://w3c.github.io/gamepad/#dom-navigator-getgamepads

--- a/Libraries/LibWeb/Gamepad/NavigatorGamepad.h
+++ b/Libraries/LibWeb/Gamepad/NavigatorGamepad.h
@@ -9,9 +9,8 @@
 #include <LibGC/Ptr.h>
 #include <LibGC/RootVector.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Gamepad/SDLGamepadForward.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
-
-#include <SDL3/SDL_gamepad.h>
 
 namespace Web::Gamepad {
 

--- a/Libraries/LibWeb/Gamepad/SDLGamepadForward.h
+++ b/Libraries/LibWeb/Gamepad/SDLGamepadForward.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025, ayeteadoe <ayeteadoe@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+typedef uint32_t Uint32;
+typedef Uint32 SDL_JoystickID;
+
+typedef struct SDL_Joystick SDL_Joystick;
+
+typedef struct SDL_Gamepad SDL_Gamepad;

--- a/Libraries/LibWeb/Internals/InternalGamepad.cpp
+++ b/Libraries/LibWeb/Internals/InternalGamepad.cpp
@@ -8,11 +8,14 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Internals/InternalGamepad.h>
 
+#include <SDL3/SDL_gamepad.h>
+#include <SDL3/SDL_joystick.h>
+
 namespace Web::Internals {
 
 GC_DEFINE_ALLOCATOR(InternalGamepad);
 
-static constexpr Array<SDL_GamepadButton, 15> BUTTONS = {
+static constexpr Array<i32, 15> BUTTONS = {
     SDL_GAMEPAD_BUTTON_SOUTH,
     SDL_GAMEPAD_BUTTON_EAST,
     SDL_GAMEPAD_BUTTON_WEST,
@@ -30,14 +33,14 @@ static constexpr Array<SDL_GamepadButton, 15> BUTTONS = {
     SDL_GAMEPAD_BUTTON_GUIDE,
 };
 
-static constexpr Array<SDL_GamepadAxis, 4> AXES {
+static constexpr Array<i32, 4> AXES {
     SDL_GAMEPAD_AXIS_LEFTX,
     SDL_GAMEPAD_AXIS_LEFTY,
     SDL_GAMEPAD_AXIS_RIGHTX,
     SDL_GAMEPAD_AXIS_RIGHTY,
 };
 
-static constexpr Array<SDL_GamepadAxis, 2> TRIGGERS {
+static constexpr Array<i32, 2> TRIGGERS {
     SDL_GAMEPAD_AXIS_LEFT_TRIGGER,
     SDL_GAMEPAD_AXIS_RIGHT_TRIGGER,
 };
@@ -112,17 +115,17 @@ void InternalGamepad::finalize()
     disconnect();
 }
 
-Array<SDL_GamepadButton, 15> const& InternalGamepad::buttons()
+Array<i32, 15> const& InternalGamepad::buttons()
 {
     return BUTTONS;
 }
 
-Array<SDL_GamepadAxis, 4> const& InternalGamepad::axes()
+Array<i32, 4> const& InternalGamepad::axes()
 {
     return AXES;
 }
 
-Array<SDL_GamepadAxis, 2> const& InternalGamepad::triggers()
+Array<i32, 2> const& InternalGamepad::triggers()
 {
     return TRIGGERS;
 }

--- a/Libraries/LibWeb/Internals/InternalGamepad.h
+++ b/Libraries/LibWeb/Internals/InternalGamepad.h
@@ -7,8 +7,7 @@
 #pragma once
 
 #include <LibWeb/Bindings/PlatformObject.h>
-#include <SDL3/SDL_gamepad.h>
-#include <SDL3/SDL_joystick.h>
+#include <LibWeb/Gamepad/SDLGamepadForward.h>
 
 namespace Web::Internals {
 
@@ -21,9 +20,9 @@ public:
 
     virtual ~InternalGamepad() override;
 
-    Array<SDL_GamepadButton, 15> const& buttons();
-    Array<SDL_GamepadAxis, 4> const& axes();
-    Array<SDL_GamepadAxis, 2> const& triggers();
+    Array<i32, 15> const& buttons();
+    Array<i32, 4> const& axes();
+    Array<i32, 2> const& triggers();
 
     void set_button(int button, bool down);
     void set_axis(int axis, short value);

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -39,6 +39,7 @@
 #include <LibWeb/UIEvents/WheelEvent.h>
 
 #include <SDL3/SDL_events.h>
+#include <SDL3/SDL_joystick.h>
 
 namespace Web {
 

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -15,12 +15,11 @@
 #include <LibUnicode/Forward.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Gamepad/SDLGamepadForward.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/UIEvents/KeyCode.h>
-
-#include <SDL3/SDL_joystick.h>
 
 namespace Web {
 


### PR DESCRIPTION
The recent Gamepad PR added the SDL3 dependency, which caused the following build error on Windows:
```
In file included from C:\Users\ayeteadoe\Development\ladybird\Libraries\LibWeb\Gamepad\Gamepad.cpp:14:
In file included from C:\Users\ayeteadoe\Development\ladybird\Libraries\LibWeb\HTML\Navigator.h:14:
In file included from C:\Users\ayeteadoe\Development\ladybird\Libraries\LibWeb\HTML\NavigatorConcurrentHardware.h:10:
In file included from C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\System.h:35:
C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\SocketAddressWindows.h(21,9): error: 'WINAPI_FAMILY_PARTITION' macro redefined [-Werror,-Wmacro-redefined]
   21 | #define WINAPI_FAMILY_PARTITION(x) 1
      |         ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\shared\winapifamily.h(226,9): note: previous definition is here
  226 | #define WINAPI_FAMILY_PARTITION(Partitions)     (Partitions)
      |         ^
1 error generated.
```

We have to prevent from including any SDL headers in LibWeb headers. Otherwise on there will be transitive Windows.h includes that will re-declare some of our existing forward decls/defines in LibCore/SocketAddressWindows.h