### PR TITLE
LibIDL: Allow `iterable<T>` to be defined before property getter 

### DIFF
--- a/Libraries/LibIDL/Types.h
+++ b/Libraries/LibIDL/Types.h
@@ -287,7 +287,9 @@ public:
     bool has_unscopable_member { false };
 
     Optional<NonnullRefPtr<Type const>> value_iterator_type;
+    Optional<size_t> value_iterator_offset;
     Optional<Tuple<NonnullRefPtr<Type const>, NonnullRefPtr<Type const>>> pair_iterator_types;
+    Optional<size_t> pair_iterator_offset;
 
     Optional<NonnullRefPtr<Type const>> async_value_iterator_type;
     Vector<Parameter> async_value_iterator_parameters;

--- a/Libraries/LibWeb/CSS/CSSNumericArray.idl
+++ b/Libraries/LibWeb/CSS/CSSNumericArray.idl
@@ -3,9 +3,7 @@
 // https://drafts.css-houdini.org/css-typed-om-1/#cssnumericarray
 [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 interface CSSNumericArray {
+    iterable<CSSNumericValue>;
     readonly attribute unsigned long length;
     getter CSSNumericValue (unsigned long index);
-    
-    // FIXME: Different order than the spec, because IDLParser requires that this comes after the indexed property getter.
-    iterable<CSSNumericValue>;
 };

--- a/Libraries/LibWeb/CSS/CSSUnparsedValue.idl
+++ b/Libraries/LibWeb/CSS/CSSUnparsedValue.idl
@@ -5,11 +5,10 @@
 [Exposed=(Window, Worker, PaintWorklet, LayoutWorklet)]
 interface CSSUnparsedValue : CSSStyleValue {
     constructor(sequence<CSSUnparsedSegment> members);
+    iterable<CSSUnparsedSegment>;
     readonly attribute unsigned long length;
     getter CSSUnparsedSegment (unsigned long index);
     setter undefined (unsigned long index, CSSUnparsedSegment val);
-    // FIXME: Different order from the spec, because our IDL parser needs the indexed getter to be defined already.
-    iterable<CSSUnparsedSegment>;
 };
 
 // https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-cssunparsedsegment


### PR DESCRIPTION
Previously, an error would occur if an `iterable<T>` was defined before the required value iterator. An is now also reported if an`iterable<T>` is defined before a pair iterator, previously this error would only be reported if the iterable was defined after the pair iterator.

Fixes #5940