### PR TITLE
LibCore: Fix ThreadedPromise issues found with ThreadSanitizer

### DIFF
--- a/Libraries/LibCore/ThreadedPromise.h
+++ b/Libraries/LibCore/ThreadedPromise.h
@@ -61,7 +61,6 @@ public:
 
     bool has_completed()
     {
-        Threading::MutexLocker locker { m_mutex };
         return m_has_completed;
     }
 
@@ -183,7 +182,7 @@ private:
     Function<ErrorOr<void>(ResultType&&)> m_resolution_handler;
     Function<void(ErrorType&&)> m_rejection_handler;
     Threading::Mutex m_mutex;
-    bool m_has_completed;
+    Atomic<bool> m_has_completed;
 };
 
 }

--- a/Tests/LibCore/TestLibCorePromise.cpp
+++ b/Tests/LibCore/TestLibCorePromise.cpp
@@ -158,7 +158,7 @@ TEST_CASE(threaded_promise_resolved_later)
 {
     Core::EventLoop loop;
 
-    IGNORE_USE_IN_ESCAPING_LAMBDA bool unblock_thread = false;
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<bool> unblock_thread = false;
     bool resolved = false;
     bool rejected = true;
     Optional<pthread_t> thread_id;


### PR DESCRIPTION
Four data race warnings reported while running test TestLibCorePromise (from file `Tests/LibCore/TestLibCorePromise.cpp`)  under ThreadSanitizer in g++. (See pull request #6034)

Attaching complete log of TestLibCorePromise test run with ThreadSanitizer

[ThreadSanitizer_TestLibCorePromise.log](https://github.com/user-attachments/files/22100748/ThreadSanitizer_TestLibCorePromise.log)

Explanations:

1) Two warnings (one in test case `threaded_promise_instantly_resolved` and one in `threaded_promise_resolved_later`) about a data race in ThreadedPromise with `m_has_completed` flag variable access not controlled when accessed from multiple threads.  To resolve the data race the class variable m_has_completed changed to Atomic to make the access controlled.

```
WARNING: ThreadSanitizer: data race (pid=63130)
  Read of size 1 at 0x722800000138 by main thread (mutexes: write M0):
    #0 Core::ThreadedPromise<int, AK::Error>::has_completed() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:65 (TestLibCorePromise+0x38a35) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #1 Core::ThreadedPromise<int, AK::Error>::await() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:70 (TestLibCorePromise+0x38a35)
    #2 __test_threaded_promise_instantly_resolved /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:150 (TestLibCorePromise+0x38a35)
    #3 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #4 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #5 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #6 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #7 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

  Previous write of size 1 at 0x722800000138 by thread T1:
    #0 Core::ThreadedPromise<int, AK::Error>::resolve(int&&)::{lambda()#1}::operator()() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:39 (TestLibCorePromise+0x36919) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #1 void Core::ThreadedPromise<int, AK::Error>::when_error_handler_is_ready<Core::ThreadedPromise<int, AK::Error>::resolve(int&&)::{lambda()#1}>(Core::ThreadedPromise<int, AK::Error>::resolve(int&&)::{lambda()#1}) /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:177 (TestLibCorePromise+0x39f19) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #2 Core::ThreadedPromise<int, AK::Error>::resolve(int&&) /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:34 (TestLibCorePromise+0x274c4) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #3 operator() /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:133 (TestLibCorePromise+0x274c4)
    #4 call /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x274c4)
    #5 AK::Function<long ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-threading.so.0+0xff9f) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)
    #6 operator() /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:80 (liblagom-threading.so.0+0xff9f)
    #7 _FUN /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:98 (liblagom-threading.so.0+0x10320) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)

  Location is heap block of size 160 at 0x7228000000a0 allocated by main thread:
    #0 operator new(unsigned long) ../../../../src/libsanitizer/tsan/tsan_new_delete.cpp:64 (libtsan.so.2+0xa84c0) (BuildId: f20c41defecd9fb4a975b3090b18de14b9117ffc)
    #1 Core::ThreadedPromise<int, AK::Error>::create() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:26 (TestLibCorePromise+0x29d15) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #2 __test_threaded_promise_instantly_resolved /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:129 (TestLibCorePromise+0x38250) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #3 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #4 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #5 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #6 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #7 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

  Mutex M0 (0x722800000108) created at:
    #0 pthread_mutex_init ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1345 (libtsan.so.2+0x5a00a) (BuildId: f20c41defecd9fb4a975b3090b18de14b9117ffc)
    #1 Threading::Mutex::Mutex() /home/bobo/projects/myladybird/Libraries/LibThreading/Mutex.h:29 (TestLibCorePromise+0x29e97) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #2 Core::ThreadedPromise<int, AK::Error>::ThreadedPromise() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:181 (TestLibCorePromise+0x29e97)
    #3 Core::ThreadedPromise<int, AK::Error>::create() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:26 (TestLibCorePromise+0x29e97)
    #4 __test_threaded_promise_instantly_resolved /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:129 (TestLibCorePromise+0x38250) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #5 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #6 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #7 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #8 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #9 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

  Thread T1 (tid=63132, finished) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1041 (libtsan.so.2+0x5b3b7) (BuildId: f20c41defecd9fb4a975b3090b18de14b9117ffc)
    #1 Threading::Thread::start() /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:73 (liblagom-threading.so.0+0xfd39) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)
    #2 __test_threaded_promise_instantly_resolved /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:136 (TestLibCorePromise+0x384c1) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #3 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #4 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #5 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #6 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #7 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

SUMMARY: ThreadSanitizer: data race /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:65 in Core::ThreadedPromise<int, AK::Error>::has_completed()
```

2) One warning about a small issue with a bool flag (`unblock_thread`) in test case `threaded_promise_resolved_later`. This flag was being used in multiple threads to control the flow of the test and changing the variable to Atomic<bool> resolved the data race issue.

```
Running test 'threaded_promise_resolved_later'.
==================
WARNING: ThreadSanitizer: data race (pid=63130)
  Write of size 1 at 0x7fffffffd265 by main thread:
    #0 operator() /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:189 (TestLibCorePromise+0x1ec3d) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #1 call /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x1ec3d)
    #2 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-core.so.0+0xbb585) (BuildId: 37b8757494239f4cfa50cca02c173f6819ce8dcd)
    #3 Core::ThreadEventQueue::process() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadEventQueue.cpp:118 (liblagom-core.so.0+0xbb585)
    #4 Core::EventLoopImplementationUnix::pump(Core::EventLoopImplementation::PumpMode) /home/bobo/projects/myladybird/Libraries/LibCore/EventLoopImplementationUnix.cpp:309 (liblagom-core.so.0+0xdfcc8) (BuildId: 37b8757494239f4cfa50cca02c173f6819ce8dcd)
    #5 Core::EventLoop::pump(Core::EventLoop::WaitMode) /home/bobo/projects/myladybird/Libraries/LibCore/EventLoop.cpp:102 (liblagom-core.so.0+0x8f862) (BuildId: 37b8757494239f4cfa50cca02c173f6819ce8dcd)
    #6 Core::ThreadedPromise<int, AK::Error>::await() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:71 (TestLibCorePromise+0x377d6) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #7 __test_threaded_promise_resolved_later /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:191 (TestLibCorePromise+0x377d6)
    #8 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #9 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #10 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #11 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #12 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

  Previous read of size 1 at 0x7fffffffd265 by thread T2:
    #0 operator() /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:170 (TestLibCorePromise+0x26dfe) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #1 call /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x26dfe)
    #2 AK::Function<long ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-threading.so.0+0xff9f) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)
    #3 operator() /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:80 (liblagom-threading.so.0+0xff9f)
    #4 _FUN /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:98 (liblagom-threading.so.0+0x10320) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x20265)

  Thread T2 (tid=63133, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1041 (libtsan.so.2+0x5b3b7) (BuildId: f20c41defecd9fb4a975b3090b18de14b9117ffc)
    #1 Threading::Thread::start() /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:73 (liblagom-threading.so.0+0xfd39) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)
    #2 __test_threaded_promise_resolved_later /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:175 (TestLibCorePromise+0x37112) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #3 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #4 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #5 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #6 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #7 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

SUMMARY: ThreadSanitizer: data race /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:189 in operator()
```

3) One warning about a small issue with a bool flag (`resolved`) in test case `threaded_promise_instantly_resolved`. This issue required no specific change to resolve, it was automatically resolved when item 1 in this list was fixed.

```
WARNING: ThreadSanitizer: data race (pid=63130)
  Read of size 1 at 0x7fffffffd29e by main thread:
    #0 void Test::expect<bool>(bool const&, AK::StringView, AK::SourceLocation) /home/bobo/projects/myladybird/Libraries/LibTest/Macros.h:36 (TestLibCorePromise+0x30904) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #1 __test_threaded_promise_instantly_resolved /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:152 (TestLibCorePromise+0x38ba4) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #2 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #3 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #4 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #5 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #6 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

  Previous write of size 1 at 0x7fffffffd29e by thread T1:
    #0 operator() /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:142 (TestLibCorePromise+0x25d07) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #1 operator() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:89 (TestLibCorePromise+0x25d07)
    #2 call /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x25d07)
    #3 AK::Function<AK::ErrorOr<void, AK::Error> (int&&)>::operator()(int&&) const /home/bobo/projects/myladybird/AK/Function.h:148 (TestLibCorePromise+0x36893) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #4 Core::ThreadedPromise<int, AK::Error>::resolve(int&&)::{lambda()#1}::operator()() /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:36 (TestLibCorePromise+0x36893)
    #5 void Core::ThreadedPromise<int, AK::Error>::when_error_handler_is_ready<Core::ThreadedPromise<int, AK::Error>::resolve(int&&)::{lambda()#1}>(Core::ThreadedPromise<int, AK::Error>::resolve(int&&)::{lambda()#1}) /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:177 (TestLibCorePromise+0x39f19) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #6 Core::ThreadedPromise<int, AK::Error>::resolve(int&&) /home/bobo/projects/myladybird/Libraries/LibCore/ThreadedPromise.h:34 (TestLibCorePromise+0x274c4) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #7 operator() /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:133 (TestLibCorePromise+0x274c4)
    #8 call /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x274c4)
    #9 AK::Function<long ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-threading.so.0+0xff9f) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)
    #10 operator() /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:80 (liblagom-threading.so.0+0xff9f)
    #11 _FUN /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:98 (liblagom-threading.so.0+0x10320) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x2029e)

  Thread T1 (tid=63132, finished) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1041 (libtsan.so.2+0x5b3b7) (BuildId: f20c41defecd9fb4a975b3090b18de14b9117ffc)
    #1 Threading::Thread::start() /home/bobo/projects/myladybird/Libraries/LibThreading/Thread.cpp:73 (liblagom-threading.so.0+0xfd39) (BuildId: a2f7c41a8dce5e480ab74ec02ffa37d09e7375b5)
    #2 __test_threaded_promise_instantly_resolved /home/bobo/projects/myladybird/Tests/LibCore/TestLibCorePromise.cpp:136 (TestLibCorePromise+0x384c1) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #3 AK::Function<void ()>::CallableWrapper<void (*)()>::call() /home/bobo/projects/myladybird/AK/Function.h:225 (TestLibCorePromise+0x2792c) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)
    #4 AK::Function<void ()>::operator()() const /home/bobo/projects/myladybird/AK/Function.h:148 (liblagom-test.so+0x212c4) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #5 Test::TestSuite::run(AK::Vector<AK::NonnullRefPtr<Test::TestCase>, 0ul, (AK::FastLastAccess)0> const&) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:195 (liblagom-test.so+0xf5cd) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #6 Test::TestSuite::main(AK::ByteString const&, AK::Span<AK::StringView>) /home/bobo/projects/myladybird/Libraries/LibTest/TestSuite.cpp:147 (liblagom-test.so+0xd318) (BuildId: ccb4d3c7dfe19d4c7eb8411a1293c2b3e68b77b4)
    #7 main /home/bobo/projects/myladybird/Libraries/LibTest/TestMain.cpp:26 (TestLibCorePromise+0x1df05) (BuildId: 134766ece94da3edc73e31fff39909b6d727b969)

SUMMARY: ThreadSanitizer: data race /home/bobo/projects/myladybird/Libraries/LibTest/Macros.h:36 in void Test::expect<bool>(bool const&, AK::StringView, AK::SourceLocation)
==================
Completed test 'threaded_promise_instantly_resolved' in 92ms

```