### PR TITLE
LibWeb: Add `::slotted()` pseudo-element support

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -137,6 +137,13 @@ Selector::Selector(Vector<CompoundSelector>&& compound_selectors)
 
 void Selector::collect_ancestor_hashes()
 {
+    if (is_slotted()) {
+        // Ancestor filtering is not supported for slotted selectors, because those
+        // are supposed to be collected for element inside a slot, while being
+        // matched against slot element.
+        return;
+    }
+
     size_t next_hash_index = 0;
     auto append_unique_hash = [&](u32 hash) -> bool {
         if (next_hash_index >= m_ancestor_hashes.size())

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -228,6 +228,8 @@ public:
 
     size_t sibling_invalidation_distance() const;
 
+    bool is_slotted() const { return m_pseudo_element.has_value() && m_pseudo_element->type() == PseudoElement::Slotted; }
+
 private:
     explicit Selector(Vector<CompoundSelector>&&);
 

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -1136,6 +1136,10 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, DOM::
     case CSS::Selector::SimpleSelector::Type::PseudoClass:
         return matches_pseudo_class(component.pseudo_class(), element, shadow_host, context, scope, selector_kind);
     case CSS::Selector::SimpleSelector::Type::PseudoElement:
+        if (component.pseudo_element().type() == CSS::PseudoElement::Slotted) {
+            VERIFY(context.slotted_element);
+            return matches(component.pseudo_element().compound_selector(), *context.slotted_element, shadow_host, context);
+        }
         // Pseudo-element matching/not-matching is handled in the top level matches().
         return true;
     case CSS::Selector::SimpleSelector::Type::Nesting:

--- a/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -19,6 +19,7 @@ enum class SelectorKind {
 struct MatchContext {
     GC::Ptr<CSS::CSSStyleSheet const> style_sheet_for_rule {};
     GC::Ptr<DOM::Element const> subject {};
+    GC::Ptr<DOM::Element const> slotted_element {}; // Only set when matching a ::slotted() pseudo-element
     bool collect_per_element_selector_involvement_metadata { false };
     CSS::PseudoClassBitmap attempted_pseudo_class_matches {};
 };

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -87,6 +87,7 @@ struct MatchingRule {
     u32 specificity { 0 };
     CascadeOrigin cascade_origin;
     bool contains_pseudo_element { false };
+    bool slotted { false };
 
     // Helpers to deal with the fact that `rule` might be a CSSStyleRule or a CSSNestedDeclarations
     CSSStyleProperties const& declaration() const;
@@ -117,6 +118,7 @@ struct RuleCache {
     HashMap<FlyString, Vector<MatchingRule>, AK::ASCIICaseInsensitiveFlyStringTraits> rules_by_attribute_name;
     Array<Vector<MatchingRule>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)> rules_by_pseudo_element;
     Vector<MatchingRule> root_rules;
+    Vector<MatchingRule> slotted_rules;
     Vector<MatchingRule> other_rules;
 
     HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-scoping/reference/green-box.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-scoping/reference/green-box.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - A green box reference</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+</head>
+<body>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <div style="width: 100px; height: 100px; background: green;"></div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-scoping/css-scoping-shadow-slotted-rule.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-scoping/css-scoping-shadow-slotted-rule.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Scoping Module Level 1 - :slotted pseudo element must allow selecting elements assigned to a slot element</title>
+    <link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org"/>
+    <link rel="help" href="http://www.w3.org/TR/css-scoping-1/#slotted-pseudo">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-scoping/reference/green-box.html"/>
+</head>
+<body>
+    <style>
+        my-host {
+            display: block;
+            width: 100px;
+            height: 100px;
+            color: red;
+            background: green;
+        }
+        my-host > div, nested-host {
+            display: block;
+            width: 100px;
+            height: 25px;
+        }
+    </style>
+    <p>Test passes if you see a single 100px by 100px green box below.</p>
+    <my-host>
+        <div class="green">FAIL1</div>
+        <myelem><span>FAIL2</span></myelem>
+        <nested-host>
+            <span>FAIL3</span>
+        </nested-host>
+        <another-host>
+            <b>FAIL4</b>
+        </another-host>
+    </my-host>
+    <script>
+
+        try {
+            var shadowHost = document.querySelector('my-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<slot></slot><style> ::slotted(.green), ::slotted(myelem) { color:green; } </style>';
+
+            shadowHost = document.querySelector('nested-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> .mydiv ::slotted(*) { color:green; } </style><div class=mydiv><slot></slot></div>';
+
+            shadowHost = document.querySelector('another-host');
+            shadowRoot = shadowHost.attachShadow({mode: 'open'});
+            shadowRoot.innerHTML = '<style> ::slotted(*) { color:green; } </style><slot></slot>';
+        } catch (exception) {
+            document.body.appendChild(document.createTextNode(exception));
+        }
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Implements `::slotted()` to enough extent we could pass the imported WPT test and make substantial layout correctness improvement on https://www.rottentomatoes.com/

Before:
<img width="2274" height="1546" alt="CleanShot 2025-09-03 at 17 05 14@2x" src="https://github.com/user-attachments/assets/e829ab2b-640f-4eb9-8a6f-04f6d1599033" />

After:
<img width="2274" height="1546" alt="CleanShot 2025-09-03 at 17 05 45@2x" src="https://github.com/user-attachments/assets/cc808259-f804-4bd4-bbf8-0c3acef135a7" />
