### PR TITLE
LibWeb/FileAPI: Make sure to always run the constructor steps for Blob

### DIFF
--- a/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -212,12 +212,9 @@ GC::Ref<Blob> Blob::create(JS::Realm& realm, Optional<BlobPartsOrByteBuffer> con
         // FIXME: 2. Convert every character in t to ASCII lowercase.
 
         // NOTE: The spec is out of date, and we are supposed to call into the MimeType parser here.
-        if (!options->type.is_empty()) {
-            auto maybe_parsed_type = Web::MimeSniff::MimeType::parse(options->type);
-
-            if (maybe_parsed_type.has_value())
-                type = maybe_parsed_type->serialized();
-        }
+        auto maybe_parsed_type = MimeSniff::MimeType::parse(options->type);
+        if (maybe_parsed_type.has_value())
+            type = maybe_parsed_type->serialized();
     }
 
     // 4. Return a Blob object referring to bytes as its associated byte sequence, with its size set to the length of bytes, and its type set to the value of t from the substeps above.

--- a/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Libraries/LibWeb/FileAPI/Blob.h
@@ -18,6 +18,8 @@
 namespace Web::FileAPI {
 
 using BlobPart = Variant<GC::Root<WebIDL::BufferSource>, GC::Root<Blob>, String>;
+using BlobParts = Vector<BlobPart>;
+using BlobPartsOrByteBuffer = Variant<BlobParts, ByteBuffer>;
 
 struct BlobPropertyBag {
     String type = String {};
@@ -25,7 +27,7 @@ struct BlobPropertyBag {
 };
 
 [[nodiscard]] ErrorOr<String> convert_line_endings_to_native(StringView string);
-[[nodiscard]] ErrorOr<ByteBuffer> process_blob_parts(Vector<BlobPart> const& blob_parts, Optional<BlobPropertyBag> const& options = {});
+[[nodiscard]] ErrorOr<ByteBuffer> process_blob_parts(BlobParts const& blob_parts, Optional<BlobPropertyBag> const& options = {});
 [[nodiscard]] bool is_basic_latin(StringView view);
 
 class WEB_API Blob
@@ -38,8 +40,8 @@ public:
     virtual ~Blob() override;
 
     [[nodiscard]] static GC::Ref<Blob> create(JS::Realm&, ByteBuffer, String type);
-    [[nodiscard]] static GC::Ref<Blob> create(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
-    static WebIDL::ExceptionOr<GC::Ref<Blob>> construct_impl(JS::Realm&, Optional<Vector<BlobPart>> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
+    [[nodiscard]] static GC::Ref<Blob> create(JS::Realm&, Optional<BlobPartsOrByteBuffer> const& blob_parts_or_byte_buffer = {}, Optional<BlobPropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<GC::Ref<Blob>> construct_impl(JS::Realm&, Optional<BlobParts> const& blob_parts = {}, Optional<BlobPropertyBag> const& options = {});
 
     // https://w3c.github.io/FileAPI/#dfn-size
     u64 size() const { return m_byte_buffer.size(); }

--- a/Libraries/LibWeb/FileAPI/File.cpp
+++ b/Libraries/LibWeb/FileAPI/File.cpp
@@ -43,7 +43,7 @@ GC::Ref<File> File::create(JS::Realm& realm)
 }
 
 // https://w3c.github.io/FileAPI/#ref-for-dom-file-file
-WebIDL::ExceptionOr<GC::Ref<File>> File::create(JS::Realm& realm, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
+WebIDL::ExceptionOr<GC::Ref<File>> File::create(JS::Realm& realm, BlobParts const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
 {
     auto& vm = realm.vm();
 
@@ -83,7 +83,7 @@ WebIDL::ExceptionOr<GC::Ref<File>> File::create(JS::Realm& realm, Vector<BlobPar
     return realm.create<File>(realm, move(bytes), move(name), move(type), last_modified);
 }
 
-WebIDL::ExceptionOr<GC::Ref<File>> File::construct_impl(JS::Realm& realm, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
+WebIDL::ExceptionOr<GC::Ref<File>> File::construct_impl(JS::Realm& realm, BlobParts const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options)
 {
     return create(realm, file_bits, file_name, options);
 }

--- a/Libraries/LibWeb/FileAPI/File.h
+++ b/Libraries/LibWeb/FileAPI/File.h
@@ -20,8 +20,8 @@ class File : public Blob {
 
 public:
     static GC::Ref<File> create(JS::Realm& realm);
-    static WebIDL::ExceptionOr<GC::Ref<File>> create(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
-    static WebIDL::ExceptionOr<GC::Ref<File>> construct_impl(JS::Realm&, Vector<BlobPart> const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<GC::Ref<File>> create(JS::Realm&, BlobParts const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
+    static WebIDL::ExceptionOr<GC::Ref<File>> construct_impl(JS::Realm&, BlobParts const& file_bits, String const& file_name, Optional<FilePropertyBag> const& options = {});
 
     virtual ~File() override;
 


### PR DESCRIPTION
While reviewing #6039 I was made aware that we do not always run the
proper constructors steps depending on which of the two `Blob::create()`
methods were used.

Previously we did not execute the constructor steps if we constructed a
Blob from a ByteBuffer and a String. Though we only construct a Blob
from ByteBuffer and String internally we still need to run these steps.

By creating the new type 'BlobPartsOrByteBuffer' we can consolidate
those two approaches to creating a Blob into our already existing
constructor steps.