### PR TITLE
LibWeb: Simplify `SourceSet::normalize_source_densities`

### DIFF
--- a/Tests/LibWeb/Ref/expected/img-srcset-font-relative-sizes-ref.html
+++ b/Tests/LibWeb/Ref/expected/img-srcset-font-relative-sizes-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<img
+    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgaGD4DwAChAGAZM0bBgAAAABJRU5ErkJggg=="
+    width="400"
+    height="400"
+/>

--- a/Tests/LibWeb/Ref/input/img-srcset-font-relative-sizes.html
+++ b/Tests/LibWeb/Ref/input/img-srcset-font-relative-sizes.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/img-srcset-font-relative-sizes-ref.html" />
+<div style="font-size: 10px">
+    <!-- Font relative units should be resolved relative to the initial font regardless of the img element's style -->
+    <img
+        sizes="10em"
+        srcset="
+            data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P4z8DwHwAFAAH/F1FwBgAAAABJRU5ErkJggg== 100w,
+            data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgaGD4DwAChAGAZM0bBgAAAABJRU5ErkJggg== 200w
+        "
+        width="400"
+        height="400"
+    />
+</div>


### PR DESCRIPTION
Relative lengths should be resolved against the initial font rather than the element's font so all the work around updating layout is unnecessary