### PR TITLE
LibWeb: Throw parsing error if `::slotted()` argument is not simple

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -517,6 +517,15 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                         });
                         return ParseError::SyntaxError;
                     }
+                    function_tokens.discard_whitespace();
+                    if (function_tokens.has_next_token()) {
+                        ErrorReporter::the().report(InvalidPseudoClassOrElementError {
+                            .name = MUST(String::formatted("::{}", pseudo_name)),
+                            .value_string = name_token.to_string(),
+                            .description = "Trailing tokens after compound selector argument."_string,
+                        });
+                        return ParseError::SyntaxError;
+                    }
 
                     auto compound_selector = compound_selector_or_error.release_value().release_value();
                     compound_selector.combinator = Selector::Combinator::None;

--- a/Tests/LibWeb/Layout/expected/misc/invalid-slotted-selector.txt
+++ b/Tests/LibWeb/Layout/expected/misc/invalid-slotted-selector.txt
@@ -1,0 +1,34 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 18 0+0+16] children: not-inline
+      BlockContainer <div> at [8,16] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+        Box <ul> at [48,16] flex-container(row) [0+0+40 744 0+0+0] [16+0+0 18 0+0+16] [FFC] children: not-inline
+          ListItemBox <li> at [48,16] flex-item [0+0+0 57.296875 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            ListItemMarkerBox <(anonymous)> at [48,16] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+            InlineNode <a> at [48,16] [0+0+0 57.296875 0+0+0] [0+0+0 18 0+0+0]
+              frag 0 from TextNode start: 0, length: 5, rect: [48,16 57.296875x18] baseline: 13.796875
+                  "HELLO"
+              TextNode <#text> (not painted)
+          ListItemBox <li> at [105.296875,16] flex-item [0+0+0 16.828125 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            ListItemMarkerBox <(anonymous)> at [105.296875,16] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+            InlineNode <a> at [105.296875,16] [0+0+0 16.828125 0+0+0] [0+0+0 18 0+0+0]
+              frag 0 from TextNode start: 0, length: 2, rect: [105.296875,16 16.828125x18] baseline: 13.796875
+                  "HI"
+              TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x18]
+      PaintableWithLines (BlockContainer<DIV>) [8,16 784x18]
+        PaintableBox (Box<UL>) [8,16 784x18]
+          PaintableWithLines (ListItemBox<LI>) [48,16 57.296875x18]
+            MarkerPaintable (ListItemMarkerBox(anonymous)) [48,16 0x0]
+            PaintableWithLines (InlineNode<A>) [48,16 57.296875x18]
+              TextPaintable (TextNode<#text>)
+          PaintableWithLines (ListItemBox<LI>) [105.296875,16 16.828125x18]
+            MarkerPaintable (ListItemMarkerBox(anonymous)) [105.296875,16 0x0]
+            PaintableWithLines (InlineNode<A>) [105.296875,16 16.828125x18]
+              TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x50] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/misc/invalid-slotted-selector.html
+++ b/Tests/LibWeb/Layout/input/misc/invalid-slotted-selector.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html><div><template shadowrootmode="open"><style>
+slot[name='nav-links']::slotted(ul) {
+    display: flex;
+    flex-direction: row;
+    list-style: none;
+    background-color: red;
+}
+slot[name='nav-links']::slotted(ul > li) { /* This selector is invalid, because ::slotted argument is limited to 1 compound selector */
+    display: inline-block;
+}
+</style><slot name="nav-links"></slot></template><ul slot="nav-links"><li><a>HELLO</a></li><li><a>HI</a></li></ul></div>


### PR DESCRIPTION
...selector. Grammar per spec: `::slotted( <compound-selector> )`, so we should reject selector as invalid if first compound selector is followed by something else.

This change makes layout more correct on https://www.rottentomatoes.com/

Before:
<img width="2412" height="998" alt="CleanShot 2025-09-04 at 13 21 45@2x" src="https://github.com/user-attachments/assets/a3764651-8c62-40a1-a2d8-f288d966e75d" />

After:
<img width="2412" height="998" alt="CleanShot 2025-09-04 at 13 22 16@2x" src="https://github.com/user-attachments/assets/00f2e8ff-ff3e-4901-bfad-03e248d73654" />
