### PR TITLE
LibWeb: Implement CSS-Multicol's 'Pseudo-Algorithm'

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -71,6 +71,13 @@ static bool margins_collapse_through(Box const& box, LayoutState& state)
 
 void BlockFormattingContext::run(AvailableSpace const& available_space)
 {
+    // https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
+    auto root_state = m_state.get(root());
+    auto column_count = determine_used_value_for_column_count(root_state.content_width());
+    if (column_count.has_value()) {
+        // FIXME: Do multi-column layout.
+    }
+
     if (is<Viewport>(root())) {
         layout_viewport(available_space);
         return;
@@ -1413,6 +1420,40 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
         });
     }
     return max_width;
+}
+
+// https://drafts.csswg.org/css-multicol/#pseudo-algorithm
+// The pseudo-algorithm below determines the used values for column-count (N) and column-width (W). There is
+// one other variable in the pseudo-algorithm: U is the used width of the multi-column container.
+Optional<int> BlockFormattingContext::determine_used_value_for_column_count(CSSPixels const& U) const
+{
+    auto const& computed_values = root().computed_values();
+    if (computed_values.column_width().is_auto() && computed_values.column_count().is_auto()) {
+        return {};
+    }
+    if (computed_values.column_width().is_auto()) {
+        return computed_values.column_count().value();
+    }
+    auto column_gap = get_column_gap_used_value_for_multicol(U);
+    auto column_width = computed_values.column_width().to_px(root(), U);
+    if (computed_values.column_count().is_auto()) {
+        return max(1, ((U + column_gap) / (column_width + column_gap)).to_int());
+    }
+    return min(computed_values.column_count().value(), max(1, ((U + column_gap) / (column_width + column_gap)).to_int()));
+}
+CSSPixels BlockFormattingContext::determine_used_value_for_column_width(CSSPixels const& U, int N) const
+{
+    auto column_gap = get_column_gap_used_value_for_multicol(U);
+    return max(CSSPixels(0), (U + column_gap) / N - column_gap);
+}
+
+// https://www.w3.org/TR/css-align-3/#column-row-gap
+CSSPixels BlockFormattingContext::get_column_gap_used_value_for_multicol(CSSPixels const& U) const
+{
+    // The 'normal' represents a used value of '1em' on multi-column containers
+    return root().computed_values().column_gap().visit(
+        [&](CSS::NormalGap) { return CSS::Length(1, CSS::Length::Type::Em).to_px(root()); },
+        [&](auto const& gap) { return gap.to_px(root(), U); });
 }
 
 }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -114,6 +114,12 @@ private:
 
     void measure_scrollable_overflow(Box const&, CSSPixels& bottom_edge, CSSPixels& right_edge) const;
 
+    // https://drafts.csswg.org/css-multicol/#pseudo-algorithm
+    Optional<int> determine_used_value_for_column_count(CSSPixels const& U) const;
+    CSSPixels determine_used_value_for_column_width(CSSPixels const& U, int N) const;
+
+    CSSPixels get_column_gap_used_value_for_multicol(CSSPixels const& U) const;
+
     enum class FloatSide {
         Left,
         Right,

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -115,7 +115,12 @@ bool FormattingContext::creates_block_formatting_context(Box const& box)
             return true;
     }
 
-    // FIXME: Multicol containers (elements where column-count or column-width isn't auto, including elements with column-count: 1).
+    // https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
+    // An element whose 'column-width', 'column-count', or 'column-height' property is not 'auto' establishes a multi-
+    // column container (or multicol container for short), and therefore acts as a container for multi-column layout.
+    // FIXME: Maybe add column-height, depending on the resolution for https://github.com/w3c/csswg-drafts/issues/12688
+    if (!box.computed_values().column_width().is_auto() || !box.computed_values().column_count().is_auto())
+        return true;
 
     // FIXME: column-span: all should always create a new formatting context, even when the column-span: all element isn't contained by a multicol container (Spec change, Chrome bug).
 


### PR DESCRIPTION
This implements [the pseudo-algorithm](https://drafts.csswg.org/css-multicol-2/#pseudo-algorithm) from the CSS Multicol spec.
I know, `determine_used_value_for_column_width` gets added but currently goes unused, it'd get used right where the FIXME got added. I hope that's fine. It's kinda part of the same algorithm.

I'm not sure if any of this is properly testable, since it only causes a BFC to be established on multicol elements for now. Any tests for that would likely have to be rewritten once actual column behavior gets implemented.