### PR TITLE
LibMedia: Note that PlaybackStream callbacks cannot run simultaneously

### DIFF
--- a/Libraries/LibMedia/Audio/PlaybackStream.h
+++ b/Libraries/LibMedia/Audio/PlaybackStream.h
@@ -34,8 +34,9 @@ public:
     //
     // The initial_output_state parameter determines whether it will begin playback immediately.
     //
-    // The AudioDataRequestCallback will be called when the Output needs more audio data to fill
-    // its buffers and continue playback.
+    // The AudioDataRequestCallback will be called when the Output needs more audio data to fill its buffers and
+    // continue playback. This callback will only be allowed to run on one thread at a time, to prevent any data
+    // race on the resource used by the callback.
     static ErrorOr<NonnullRefPtr<PlaybackStream>> create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&&);
 
     virtual ~PlaybackStream() = default;


### PR DESCRIPTION
This is a requirement of implementations of PlaybackStream, so we should have a little comment about it. Otherwise, we may encounter data races later.