### PR TITLE
LibMedia: Initialize Track's primitive fields to zero

### DIFF
--- a/Libraries/LibMedia/Track.h
+++ b/Libraries/LibMedia/Track.h
@@ -68,8 +68,8 @@ public:
     }
 
 private:
-    TrackType m_type;
-    size_t m_identifier;
+    TrackType m_type { 0 };
+    size_t m_identifier { 0 };
 
     Variant<Empty, VideoData> m_track_data;
 };


### PR DESCRIPTION
A little thing I noticed while looking into A/V sync.