### PR TITLE
LibWeb: Avoid dereferencing a null pointer to document

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -754,7 +754,12 @@ GC::Ptr<CSSPropertyRule> Parser::convert_to_property_rule(AtRule const& rule)
         return {};
     }
 
-    auto parsing_params = CSS::Parser::ParsingParams { *document() };
+    CSS::Parser::ParsingParams parsing_params;
+    if (document())
+        parsing_params = CSS::Parser::ParsingParams { *document() };
+    else
+        parsing_params = CSS::Parser::ParsingParams { realm() };
+
     auto syntax_component_values = parse_component_values_list(parsing_params, syntax_maybe.value());
     auto maybe_syntax = parse_as_syntax(syntax_component_values);
 

--- a/Tests/LibWeb/Text/expected/DOM/replaceSync-Property.txt
+++ b/Tests/LibWeb/Text/expected/DOM/replaceSync-Property.txt
@@ -1,0 +1,1 @@
+PASS (Didn't crash)

--- a/Tests/LibWeb/Text/input/DOM/replaceSync-Property.html
+++ b/Tests/LibWeb/Text/input/DOM/replaceSync-Property.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+  test(() => {
+      const sheet = new CSSStyleSheet();
+      const css = `
+        @property --test {
+          syntax: '<color>';
+          inherits: false;
+          initial-value: black;
+        }
+      `;
+      sheet.replaceSync(css);
+      document.adoptedStyleSheets = [sheet];
+      println("PASS (Didn't crash)");
+  });
+</script>


### PR DESCRIPTION
This is the fix for [https://github.com/LadybirdBrowser/ladybird/issues/6063](https://github.com/LadybirdBrowser/ladybird/issues/6063)

This commit fixes a crash in the LibWeb when converting an at-rule to a property rule. It handles a case where a document might not be available by falling back to using the realm to get the ParsingParams.