### PR TITLE
LibWasm: Close byte list for active data segments in WAT output

### DIFF
--- a/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Libraries/LibWasm/Printer/Printer.cpp
@@ -144,7 +144,7 @@ void Printer::print(Wasm::DataSection::Data const& data)
                 print_indent();
                 print("(active init {}xu8 (", value.init.size());
                 print("{}", ByteString::join(' ', value.init, "{:x}"sv));
-                print("\n");
+                print(")\n");
                 {
                     TemporaryChange change { m_indent, m_indent + 1 };
                     print_indent();
@@ -161,6 +161,8 @@ void Printer::print(Wasm::DataSection::Data const& data)
                     print_indent();
                     print("(index {})\n", value.index.value());
                 }
+                print_indent();
+                print(")\n");
             });
     }
     print_indent();


### PR DESCRIPTION
LibWasm/Printer no longer leaves the byte list in active data segments unclosed, nor does it leave active data section unclosed
Repro:
```
(module
  (memory 1)
  ;; Active data: write two bytes at offset 0
  (data (i32.const 0) "\01\02")
)
```
```
wat2wasm active-data.wat -o active-data.wasm
Build/release/bin/wasm --print active-data.wasm
```
Before:
```
(module
  (section memory
    (memory
      (type memory
        (limits min=1 unbounded)
      )
    )
  )
  (section data
    (data with value
      (active init 2xu8 (1 2
        (offset
            (i32.const (const 0))
            (synthetic:expression.end)
        )
        (index 0)
    )
  )
)
```
After:
```
(module
  (section memory
    (memory
      (type memory
        (limits min=1 unbounded)
      )
    )
  )
  (section data
    (data with value
      (active init 2xu8 (1 2)
        (offset
            (i32.const (const 0))
            (synthetic:expression.end)
        )
        (index 0)
      )
    )
  )
)
```