### PR TITLE
LibWasm: Fix Negate::name() to return "neg"

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -545,7 +545,7 @@ struct Negate {
         return -lhs;
     }
 
-    static StringView name() { return "== 0"sv; }
+    static StringView name() { return "neg"sv; }
 };
 
 struct Ceil {


### PR DESCRIPTION
Negate was incorrectly returning "== 0", a copy/paste from EqualsZero. This patch corrects it to return "neg", matching the operator's actual semantics and WebAssembly mnemonics (f32.neg, f64.neg).