### PR TITLE
LibMedia: Convert presentation time to AK::Duration with integer math

### DIFF
--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
@@ -38,7 +38,7 @@ public:
     virtual DecoderErrorOr<Sample> get_next_sample_for_track(Track track) override;
 
 private:
-    DecoderErrorOr<AK::Duration> duration_of_track_in_milliseconds(Track const& track);
+    DecoderErrorOr<AK::Duration> duration_of_track(Track const& track);
 
     NonnullOwnPtr<SeekableStream> m_stream;
     AVCodecContext* m_codec_context { nullptr };


### PR DESCRIPTION
The existing conversion was rounding to the nearest millisecond, which is much less precision than most videos will want. Instead, use only integer math to directly convert the presentation time to seconds and nanoseconds for our AK::Duration to represent accurately.