### PR TITLE
LibWeb: Do nothing when calling `CanvasPath.closePath()` with empty path

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasPath.cpp
@@ -23,8 +23,14 @@ void CanvasPath::ensure_subpath(float x, float y)
         m_path.move_to(Gfx::FloatPoint { x, y });
 }
 
+// https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-closepath
 void CanvasPath::close_path()
 {
+    // The closePath() method, when invoked, must do nothing if the object's path has no subpaths. Otherwise, it must
+    // mark the last subpath as closed, create a new subpath whose first point is the same as the previous subpath's
+    // first point, and finally add this new subpath to the path.
+    if (m_path.is_empty())
+        return;
     m_path.close();
 }
 

--- a/Tests/LibWeb/Ref/expected/HTML/canvas-close-empty-path-ref.html
+++ b/Tests/LibWeb/Ref/expected/HTML/canvas-close-empty-path-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div>There should be no diagonal line drawn to the canvas</div>
+<canvas width="100" height="100" style="border:1px solid black"></canvas>

--- a/Tests/LibWeb/Ref/input/HTML/canvas-close-empty-path.html
+++ b/Tests/LibWeb/Ref/input/HTML/canvas-close-empty-path.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/HTML/canvas-close-empty-path-ref.html" />
+<div>There should be no diagonal line drawn to the canvas</div>
+<canvas width="100" height="100" style="border:1px solid black"></canvas>
+<script>
+    const canvas = document.querySelector("canvas");
+    const ctx = canvas.getContext("2d");
+
+    // Start a fresh path but DO NOT moveTo() first.
+    ctx.beginPath();
+    // Should be a no-op per spec if there's no current subpath.
+    ctx.closePath();
+
+    // Because there's no current point, lineTo(50,50) should start a new subpath at (50,50)
+    // and draw nothing until a subsequent lineTo/moveTo.
+    // If an unintended moveTo(0,0) happened, this will draw from (0,0)->(50,50).
+    ctx.lineTo(50, 50);
+
+    ctx.strokeStyle = 'black';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+</script>


### PR DESCRIPTION
Fixes #6085