### PR TITLE
LibWasm: Use 0x40 flag for SIMD memory memidx like scalar ops

### DIFF
--- a/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Libraries/LibWasm/Parser/Parser.cpp
@@ -588,8 +588,8 @@ ParseResult<Instruction> Instruction::parse(ConstrainedStream& stream)
 
             // Proposal "multi-memory", if bit 6 of alignment is set, then a memory index follows the alignment.
             auto memory_index = 0;
-            if ((align & 0x20) != 0) {
-                align &= ~0x20;
+            if ((align & 0x40) != 0) {
+                align &= ~0x40;
                 memory_index = TRY_READ(stream, LEB128<u32>, ParseError::InvalidInput);
             }
 
@@ -610,8 +610,8 @@ ParseResult<Instruction> Instruction::parse(ConstrainedStream& stream)
 
             // Proposal "multi-memory", if bit 6 of alignment is set, then a memory index follows the alignment.
             auto memory_index = 0;
-            if ((align & 0x20) != 0) {
-                align &= ~0x20;
+            if ((align & 0x40) != 0) {
+                align &= ~0x40;
                 memory_index = TRY_READ(stream, LEB128<u32>, ParseError::InvalidInput);
             }
 


### PR DESCRIPTION
SIMD loads/stores checked bit 0x20 of the align immediate to detect a following memory index, unlike scalar mem ops which use 0x40 per the multi-memory encoding. This caused the memidx byte to be misparsed as the next immediate (e.g. offset).

Update both SIMD sites (v128 load/store and lane variants) to check and clear 0x40, then read LEB128<u32> memidx.

Repro:
```
  (module (memory $m0 1) (memory $m1 1)
    (func (export "go")
      i32.const 0
      v128.load (memory 1)
      drop))
```
Before: printed memidx 0 with offset 1.
After:  prints memidx 1 with offset 0.