### PR TITLE
LibWebView+Base: Remove unnecessary scrollbar from error pages

### DIFF
--- a/Base/res/ladybird/templates/error.html
+++ b/Base/res/ladybird/templates/error.html
@@ -14,6 +14,7 @@
             align-items: center;
             justify-content: center;
             min-height: 100vh;
+            box-sizing: border-box;
             margin: 0;
             padding: 1rem;
             text-align: center;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -634,7 +634,7 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
         builder.append("<!DOCTYPE html>"sv);
         builder.append("<html lang=\"en\"><head><meta charset=\"UTF-8\"><title>Error!</title><style>"
                        ":root { color-scheme: light dark; font-family: system-ui, sans-serif; }"
-                       "body { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; margin: 0; padding: 1rem; text-align: center; }"
+                       "body { display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; box-sizing: border-box; margin: 0; padding: 1rem; text-align: center; }"
                        "header { display: flex; flex-direction: column; align-items: center; gap: 2rem; margin-bottom: 1rem; }"
                        "svg { height: 64px; width: auto; stroke: currentColor; fill: none; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; }"
                        "h1 { margin: 0; font-size: 1.5rem; }"


### PR DESCRIPTION
I've been looking at the crash-page too much recently and the slight scrollbar caused by the padding has been annoying me.