### PR TITLE
LibWeb/IndexedDB: Throw an InvalidStateException when handling a removed index / object store

### DIFF
--- a/Libraries/LibWeb/IndexedDB/IDBDatabase.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBDatabase.cpp
@@ -186,6 +186,8 @@ WebIDL::ExceptionOr<void> IDBDatabase::delete_object_store(String const& name)
     // 7. Destroy store.
     database->remove_object_store(*store);
 
+    store->mark_deleted();
+
     return {};
 }
 

--- a/Libraries/LibWeb/IndexedDB/IDBIndex.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBIndex.cpp
@@ -66,7 +66,9 @@ WebIDL::ExceptionOr<void> IDBIndex::set_name(String const& value)
     if (!transaction->is_active())
         return WebIDL::TransactionInactiveError::create(realm, "Transaction is not active while updating index name"_utf16);
 
-    // FIXME: 6. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 6. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or index’s object store has been deleted"_utf16);
 
     // 7. If index’s name is equal to name, terminate these steps.
     if (index->name() == name)
@@ -112,9 +114,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_cursor(JS::Value query, 
     auto transaction = this->transaction();
 
     // 2. Let index be this’s index.
-    [[maybe_unused]] auto index = this->index();
+    auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or index’s object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -152,7 +156,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::get(JS::Value query)
     // 2. Let index be this’s index.
     auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or index’s object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -183,7 +189,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::get_key(JS::Value query)
     // 2. Let index be this’s index.
     auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or index’s object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -230,7 +238,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::count(JS::Value query)
     // 2. Let index be this’s index.
     auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or index’s object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -259,9 +269,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_key_cursor(JS::Value que
     auto transaction = this->transaction();
 
     // 2. Let index be this’s index.
-    [[maybe_unused]] auto index = this->index();
+    auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or index’s object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())

--- a/Libraries/LibWeb/IndexedDB/Internal/Index.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Index.h
@@ -45,6 +45,9 @@ public:
 
     HTML::SerializationRecord referenced_value(IndexRecord const& index_record) const;
 
+    [[nodiscard]] bool is_deleted() const { return m_deleted; }
+    void mark_deleted() { m_deleted = true; }
+
 protected:
     virtual void visit_edges(Visitor&) override;
 
@@ -68,6 +71,8 @@ private:
 
     // The keys are derived from the referenced object store’s values using a key path.
     KeyPath m_key_path;
+
+    bool m_deleted { false };
 };
 
 }

--- a/Libraries/LibWeb/IndexedDB/Internal/ObjectStore.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/ObjectStore.h
@@ -54,6 +54,9 @@ public:
     GC::ConservativeVector<ObjectStoreRecord> first_n_in_range(GC::Ref<IDBKeyRange> range, Optional<WebIDL::UnsignedLong> count);
     GC::ConservativeVector<ObjectStoreRecord> last_n_in_range(GC::Ref<IDBKeyRange> range, Optional<WebIDL::UnsignedLong> count);
 
+    [[nodiscard]] bool is_deleted() const { return m_deleted; }
+    void mark_deleted() { m_deleted = true; }
+
 protected:
     virtual void visit_edges(Visitor&) override;
 
@@ -77,6 +80,8 @@ private:
 
     // An object store has a list of records
     Vector<ObjectStoreRecord> m_records;
+
+    bool m_deleted { false };
 };
 
 }


### PR DESCRIPTION
This fixes a bunch of FIXME's and passes a previously crashing subtest on WPT https://wpt.fyi/results/IndexedDB/idbindex-rename-errors.any.html.