### PR TITLE
LibJS: Track current shape dictionary generation in PropertyLookupCache

### DIFF
--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -43,6 +43,7 @@ struct PropertyLookupCache {
         Optional<u32> property_offset;
         GC::Weak<Object> prototype;
         GC::Weak<PrototypeChainValidity> prototype_chain_validity;
+        Optional<u32> shape_dictionary_generation;
     };
     AK::Array<Entry, max_number_of_shapes_to_remember> entries;
 };

--- a/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Libraries/LibJS/Runtime/Shape.cpp
@@ -291,6 +291,7 @@ void Shape::add_property_without_transition(PropertyKey const& property_key, Pro
     if (m_property_table->set(property_key, { m_property_count, attributes }) == AK::HashSetResult::InsertedNewEntry) {
         VERIFY(m_property_count < NumericLimits<u32>::max());
         ++m_property_count;
+        ++m_dictionary_generation;
     }
 }
 
@@ -303,6 +304,7 @@ void Shape::set_property_attributes_without_transition(PropertyKey const& proper
     VERIFY(it != m_property_table->end());
     it->value.attributes = attributes;
     m_property_table->set(property_key, it->value);
+    ++m_dictionary_generation;
 }
 
 void Shape::remove_property_without_transition(PropertyKey const& property_key, u32 offset)
@@ -317,6 +319,7 @@ void Shape::remove_property_without_transition(PropertyKey const& property_key, 
         if (it.value.offset > offset)
             --it.value.offset;
     }
+    ++m_dictionary_generation;
 }
 
 GC::Ref<Shape> Shape::clone_for_prototype()

--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -84,6 +84,8 @@ public:
     [[nodiscard]] bool is_cacheable_dictionary() const { return m_dictionary && m_cacheable; }
     [[nodiscard]] bool is_uncacheable_dictionary() const { return m_dictionary && !m_cacheable; }
 
+    [[nodiscard]] u32 dictionary_generation() const { return m_dictionary_generation; }
+
     [[nodiscard]] bool is_prototype_shape() const { return m_is_prototype_shape; }
     void set_prototype_shape();
 
@@ -137,6 +139,7 @@ private:
     GC::Ptr<PrototypeChainValidity> m_prototype_chain_validity;
 
     u32 m_property_count { 0 };
+    u32 m_dictionary_generation { 0 };
 
     PropertyAttributes m_attributes { 0 };
     TransitionType m_transition_type { TransitionType::Invalid };


### PR DESCRIPTION
When an object becomes too big (currently 64 properties or more), we
change its shape to a dictionary and don't do any further transitions.

However, this means the Shape of the object no longer changes, so the
cache invalidation check of `current_shape != cache.shape` is no longer
a valid check.

This fixes that by keeping track of a generation number for the Shape
both on the Shape object and in the cache, allowing that to be checked
instead of the Shape identity. The generation is incremented whenever
the dictionary is mutated.

Fixes stale cache lookups on Gmail preventing emails from being
displayed.

I was not able to produce a reproduction for this, plus the generation
count was over the 20k mark on Gmail.
