### PR TITLE
LibWeb: Implement cookie fetching for Workers

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1944,11 +1944,8 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 // 1. Let cookies be the result of running the "cookie-string" algorithm (see section 5.4 of [COOKIES])
                 //    with the user agent’s cookie store and httpRequest’s current URL.
                 auto cookies = ([&] {
-                    // FIXME: Getting to the page client reliably is way too complicated, and going via the document won't work in workers.
-                    auto document = Bindings::principal_host_defined_environment_settings_object(HTML::principal_realm(realm)).responsible_document();
-                    if (!document)
-                        return String {};
-                    return document->page().client().page_did_request_cookie(http_request->current_url(), Cookie::Source::Http);
+                    auto& page = Bindings::principal_host_defined_page(HTML::principal_realm(realm));
+                    return page.client().page_did_request_cookie(http_request->current_url(), Cookie::Source::Http);
                 })();
 
                 // 2. If cookies is not the empty string, then append (`Cookie`, cookies) to httpRequest’s header list.

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -31,6 +31,8 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
+    void setup_worker_ipc_callbacks(JS::Realm&);
+
     WorkerOptions m_worker_options;
     Bindings::AgentType m_agent_type { Bindings::AgentType::DedicatedWorker };
     URL::URL m_url;

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -200,13 +200,8 @@ ErrorOr<void> WebSocket::establish_web_socket_connection(URL::URL const& url_rec
     HTTP::HeaderMap additional_headers;
 
     auto cookies = ([&] {
-        // FIXME: Getting to the page client reliably is way too complicated, and going via the document won't work in workers.
-        auto document = client.responsible_document();
-        if (!document)
-            return String {};
-
-        // NOTE: The WebSocket handshake is sent as an HTTP request, so the source should be Http.
-        return document->page().client().page_did_request_cookie(url_record, Cookie::Source::Http);
+        auto& page = Bindings::principal_host_defined_page(HTML::principal_realm(realm()));
+        return page.client().page_did_request_cookie(url_record, Cookie::Source::Http);
     })();
 
     if (!cookies.is_empty()) {

--- a/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -20,6 +20,13 @@ void WebWorkerClient::did_close_worker()
         on_worker_close();
 }
 
+Messages::WebWorkerClient::DidRequestCookieResponse WebWorkerClient::did_request_cookie(URL::URL url, Cookie::Source source)
+{
+    if (on_request_cookie)
+        return on_request_cookie(url, source);
+    return String {};
+}
+
 WebWorkerClient::WebWorkerClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport))
 {

--- a/Libraries/LibWeb/Worker/WebWorkerClient.h
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibIPC/ConnectionToServer.h>
+#include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Worker/WebWorkerClientEndpoint.h>
 #include <LibWeb/Worker/WebWorkerServerEndpoint.h>
@@ -22,8 +23,10 @@ public:
     explicit WebWorkerClient(NonnullOwnPtr<IPC::Transport>);
 
     virtual void did_close_worker() override;
+    virtual Messages::WebWorkerClient::DidRequestCookieResponse did_request_cookie(URL::URL, Cookie::Source) override;
 
     Function<void()> on_worker_close;
+    Function<String(URL::URL const&, Cookie::Source)> on_request_cookie;
 
     IPC::File clone_transport();
 

--- a/Libraries/LibWeb/Worker/WebWorkerClient.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.ipc
@@ -1,3 +1,7 @@
+#include <LibURL/URL.h>
+#include <LibWeb/Cookie/Cookie.h>
+
 endpoint WebWorkerClient {
     did_close_worker() =|
+    did_request_cookie(URL::URL url, Web::Cookie::Source source) => (String cookie)
 }

--- a/Services/WebWorker/PageHost.cpp
+++ b/Services/WebWorker/PageHost.cpp
@@ -77,6 +77,11 @@ Web::CSS::PreferredMotion PageHost::preferred_motion() const
     return Web::CSS::PreferredMotion::Auto;
 }
 
+String PageHost::page_did_request_cookie(URL::URL const& url, Web::Cookie::Source source)
+{
+    return m_client.did_request_cookie(url, source);
+}
+
 void PageHost::request_file(Web::FileRequest request)
 {
     m_client.request_file(move(request));

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -32,6 +32,7 @@ public:
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override;
     virtual Web::CSS::PreferredContrast preferred_contrast() const override;
     virtual Web::CSS::PreferredMotion preferred_motion() const override;
+    virtual String page_did_request_cookie(URL::URL const&, Web::Cookie::Source) override;
     virtual void request_file(Web::FileRequest) override;
     virtual Web::DisplayListPlayerType display_list_player_type() const override { VERIFY_NOT_REACHED(); }
     virtual bool is_headless() const override { VERIFY_NOT_REACHED(); }


### PR DESCRIPTION
Allows formulas to update on Google Sheets, which uses a Worker to
update them and makes cookie authenticated requests, which was failing
before this PR.

This has the limitation that it has to proxy through the WebContent
process, but that's how the current infrastructure is, which is outside
the scope of this PR.

https://github.com/user-attachments/assets/004cf98b-30a2-4669-ba4a-835d281eb150

