### PR TITLE
LibWeb: Early return if document doesn't have navigable in container

### DIFF
--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -197,6 +197,9 @@ HTML::WindowProxy* NavigableContainer::content_window()
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#shared-attribute-processing-steps-for-iframe-and-frame-elements
 Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_iframe_and_frame(InitialInsertion initial_insertion)
 {
+    if (!navigable())
+        return OptionalNone {};
+
     // AD-HOC: If the element was added and immediately removed, the content navigable will be null. Don't process the
     //         src attribute any further.
     if (!m_content_navigable)


### PR DESCRIPTION
...navigable shared attribute processing steps.

After e095bf3a5f6
https://wpt.live/html/rendering/pixel-length-attributes.html ends up in this function with null navigable, which leads to crash while executing steps. Adding early return in case iframe's document doesn't have a navigable is enough to make the test pass again.

This commit doesn't import the WPT test, because it's already imported and we have it disabled since it takes too much time on CI.