### PR TITLE
LibWeb: Handle redundant default namespace with prefixed attributes

### DIFF
--- a/Libraries/LibWeb/HTML/XMLSerializer.cpp
+++ b/Libraries/LibWeb/HTML/XMLSerializer.cpp
@@ -533,7 +533,8 @@ static WebIDL::ExceptionOr<String> serialize_element(DOM::Element const& element
     // 11. If inherited ns is equal to ns, then:
     if (inherited_ns == ns) {
         // 1. If local default namespace is not null, then set ignore namespace definition attribute to true.
-        if (local_default_namespace.has_value())
+        // AD HOC: only ignore default namespace if there are no prefixed namespace attributes on this element
+        if (local_default_namespace.has_value() && local_prefixes_map.is_empty())
             ignore_namespace_definition_attribute = true;
 
         // 2. If ns is the XML namespace, then append to qualified name the concatenation of the string "xml:" and the value of node's localName.

--- a/Tests/LibWeb/Text/expected/wpt-import/domparsing/XMLSerializer-serializeToString.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domparsing/XMLSerializer-serializeToString.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 27 tests
 
-10 Pass
-17 Fail
+11 Pass
+16 Fail
 Pass	check XMLSerializer.serializeToString method could parsing xmldoc to string
 Pass	check XMLSerializer.serializeToString method could parsing document to string
 Pass	Check if the default namespace is correctly reset.
@@ -29,5 +29,5 @@ Fail	Check if "ns1" is generated even if the element already has xmlns:ns1.
 Fail	Check if no special handling for XLink namespace unlike HTML serializer.
 Pass	Check if document fragment serializes.
 Pass	Check children were included for void elements
-Fail	Check if a prefix bound to an empty namespace URI ("no namespace") serialize
+Pass	Check if a prefix bound to an empty namespace URI ("no namespace") serialize
 Pass	Attribute nodes are serialized as the empty string


### PR DESCRIPTION
Only ignore the default namespace (xmlns="") if there are no prefixed namespace attributes (xmlns:foo).

This is an ad hoc solution to reconcile WPT XMLSerializer-serializeToString:
- line 11: "Check if redundant xmlns='...' is dropped"
- line 32: "Check if a prefix bound to an empty namespace URI ('no namespace') serialize"