### PR TITLE
LibWeb: Keep view transition pseudo styles in sync with new element

### DIFF
--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1308,6 +1308,13 @@ GC::Ref<CSS::CSSStyleProperties> Window::get_computed_style(DOM::Element& elemen
             // TODO: Keep the function arguments of the pseudo-element if there are any.
             object = { element, type.value().type() };
         }
+
+        // https://drafts.csswg.org/css-view-transitions-1/#update-pseudo-element-styles
+        // This algorithm must be executed to update styles in user-agent origin if its effects can be observed by a web API.
+        // NB: View transition pseudo-elements only ever originate from the document element and only ::view-transition-group() and its descendants can be affected by update_pseudo_element_styles().
+        if (element.is_document_element() && first_is_one_of(type.value().type(), CSS::PseudoElement::ViewTransitionGroup, CSS::PseudoElement::ViewTransitionImagePair, CSS::PseudoElement::ViewTransitionOld, CSS::PseudoElement::ViewTransitionNew)) {
+            (void)element.document().active_view_transition()->update_pseudo_element_styles();
+        }
     }
 
     // FIXME: Implement steps 4 and 5 when we can.

--- a/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
+++ b/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
@@ -991,10 +991,6 @@ ErrorOr<void> ViewTransition::update_pseudo_element_styles()
             new_->m_content = captured_element->new_element->capture_the_image();
         }
     }
-
-    // This algorithm must be executed to update styles in user-agent origin if its effects can be observed by a web API.
-    // FIXME: Find all the places where this is relevant.
-
     return {};
 }
 


### PR DESCRIPTION
This makes it so that view-transition pseudo-element styles are updated before returning them from window.getComputedStyle(). This is necessary because they could be outdated, in case JS has modified the styles of the elements they are trying to stay in sync with since last frame.

The corresponding WPT test has not been imported, since it still fails for unrelated reasons.