### PR TITLE
LibWeb: Fix crashing in `LengthOrAutoOrCalculated::without_auto()`

### DIFF
--- a/Libraries/LibWeb/CSS/CalculatedOr.cpp
+++ b/Libraries/LibWeb/CSS/CalculatedOr.cpp
@@ -89,6 +89,8 @@ bool LengthOrAutoOrCalculated::is_auto() const
 LengthOrCalculated LengthOrAutoOrCalculated::without_auto() const
 {
     VERIFY(!is_auto());
+    if (is_calculated())
+        return calculated();
     return value().length();
 }
 

--- a/Tests/LibWeb/Layout/expected/crash-tests/img-with-calc-inside-sizes-attr.txt
+++ b/Tests/LibWeb/Layout/expected/crash-tests/img-with-calc-inside-sizes-attr.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: inline
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,21 0x0] baseline: 0
+      ImageBox <img> at [8,21] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      ImagePaintable (ImageBox<IMG>) [8,21 0x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/crash-tests/img-with-calc-inside-sizes-attr.html
+++ b/Tests/LibWeb/Layout/input/crash-tests/img-with-calc-inside-sizes-attr.html
@@ -1,0 +1,1 @@
+<!doctype html><img sizes="calc(90vw - 32px), 33vw">


### PR DESCRIPTION
...when `LengthOrAutoOrCalculated` holds calculated value. We were incorrectly assuming that if contained value is not auto, then it must be a length.

Fixes crashing on https://hollowknightsilksong.com/