### PR TITLE
LibWeb: Position absolute block-level boxes below previous siblings in inline formatting contexts

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -132,6 +132,16 @@ void ComputedProperties::revert_property(PropertyID id, ComputedProperties const
     set_property_inherited(id, style_for_revert.is_property_inherited(id) ? Inherited::Yes : Inherited::No);
 }
 
+Display ComputedProperties::display_before_box_type_transformation() const
+{
+    return m_display_before_box_type_transformation;
+}
+
+void ComputedProperties::set_display_before_box_type_transformation(Display value)
+{
+    m_display_before_box_type_transformation = value;
+}
+
 void ComputedProperties::set_animated_property(PropertyID id, NonnullRefPtr<StyleValue const> value, Inherited inherited)
 {
     m_animated_property_values.set(id, move(value));

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -186,6 +186,9 @@ public:
     MixBlendMode mix_blend_mode() const;
     Optional<FlyString> view_transition_name() const;
 
+    Display display_before_box_type_transformation() const;
+    void set_display_before_box_type_transformation(Display value);
+
     static Vector<Transformation> transformations_for_style_value(StyleValue const& value);
     Vector<Transformation> transformations() const;
     TransformBox transform_box() const;
@@ -278,6 +281,8 @@ private:
     Array<u8, ceil_div(number_of_longhand_properties, 8uz)> m_animated_property_inherited {};
 
     HashMap<PropertyID, NonnullRefPtr<StyleValue const>> m_animated_property_values;
+
+    Display m_display_before_box_type_transformation { InitialValues::display() };
 
     int m_math_depth { InitialValues::math_depth() };
     RefPtr<Gfx::FontCascadeList const> m_font_list;

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -487,6 +487,7 @@ public:
     CSS::ContentData content() const { return m_noninherited.content; }
     CSS::PointerEvents pointer_events() const { return m_inherited.pointer_events; }
     CSS::Display display() const { return m_noninherited.display; }
+    CSS::Display display_before_box_type_transformation() const { return m_noninherited.display_before_box_type_transformation; }
     Optional<int> const& z_index() const { return m_noninherited.z_index; }
     Variant<LengthOrCalculated, NumberOrCalculated> tab_size() const { return m_inherited.tab_size; }
     CSS::TextAlign text_align() const { return m_inherited.text_align; }
@@ -756,6 +757,7 @@ protected:
         CSS::Clear clear { InitialValues::clear() };
         CSS::Clip clip { InitialValues::clip() };
         CSS::Display display { InitialValues::display() };
+        CSS::Display display_before_box_type_transformation { InitialValues::display() };
         Optional<int> z_index;
         // FIXME: Store this as flags in a u8.
         Vector<CSS::TextDecorationLine> text_decoration_line { InitialValues::text_decoration_line() };
@@ -955,6 +957,7 @@ public:
     void set_list_style_type(CSS::ListStyleType value) { m_inherited.list_style_type = move(value); }
     void set_list_style_position(CSS::ListStylePosition value) { m_inherited.list_style_position = move(value); }
     void set_display(CSS::Display value) { m_noninherited.display = value; }
+    void set_display_before_box_type_transformation(CSS::Display value) { m_noninherited.display_before_box_type_transformation = value; }
     void set_backdrop_filter(CSS::Filter const& backdrop_filter) { m_noninherited.backdrop_filter = backdrop_filter; }
     void set_filter(CSS::Filter const& filter) { m_noninherited.filter = filter; }
     void set_border_bottom_left_radius(CSS::BorderRadiusData value)

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2154,6 +2154,8 @@ void StyleComputer::compute_property_values(ComputedProperties& style) const
 
         style.set_property(property_id, absolutized_value, is_inherited);
     });
+
+    style.set_display_before_box_type_transformation(style.display());
 }
 
 void StyleComputer::resolve_effective_overflow_values(ComputedProperties& style) const

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -571,6 +571,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
                 border_top_right_radius.as_border_radius().vertical_radius() });
     }
     computed_values.set_display(computed_style.display());
+    computed_values.set_display_before_box_type_transformation(computed_style.display_before_box_type_transformation());
 
     computed_values.set_flex_direction(computed_style.flex_direction());
     computed_values.set_flex_wrap(computed_style.flex_wrap());
@@ -966,6 +967,15 @@ CSS::Display Node::display() const
     }
 
     return computed_values().display();
+}
+
+CSS::Display Node::display_before_box_type_transformation() const
+{
+    if (!has_style()) {
+        return CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow);
+    }
+
+    return computed_values().display_before_box_type_transformation();
 }
 
 bool Node::is_inline() const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -90,6 +90,7 @@ public:
     virtual bool can_have_children() const { return true; }
 
     CSS::Display display() const;
+    CSS::Display display_before_box_type_transformation() const;
 
     bool is_inline() const;
     bool is_inline_block() const;

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-block.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: inline
+      frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x18] baseline: 13.796875
+          "foo"
+      TextNode <#text> (not painted)
+      BlockContainer <div> at [8,26] positioned [0+0+0 27.640625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [8,26 27.640625x18] baseline: 13.796875
+            "bar"
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,26 27.640625x18]
+        TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/abspos-block.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/abspos-block.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+foo <div style="position:absolute">bar</div>


### PR DESCRIPTION
Fixes #5798

Whether an absbox is positioned below or to the right of its previous sibling in an `InlineFormattingContext` is determined by the display-outside value before blockification, so we store the pre-blockification `display` value in `ComputedValues` to access it in `InlineFormattingContext` and position the box accordingly.

Before:
<img width="1049" height="136" alt="image" src="https://github.com/user-attachments/assets/fc150caa-9bce-4df8-bf3e-adc1b8d5a2e9" />

After:
<img width="1057" height="138" alt="image" src="https://github.com/user-attachments/assets/ea8f49e8-a229-4b3d-8650-41d4c4e531e3" />