### PR TITLE
LibWeb: Use correct style rule index in view transitions and import crash tests

### DIFF
--- a/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
+++ b/Libraries/LibWeb/ViewTransition/ViewTransition.cpp
@@ -526,7 +526,7 @@ void ViewTransition::setup_transition_pseudo_elements()
                                                               transition_name, "transform", width, height, "backdrop_filter")),
                 stylesheet->rules().length()));
             // FIXME: all the strings above should be the identically named variables, serialized somehow.
-            captured_element->group_keyframes = as<CSS::CSSKeyframesRule>(stylesheet->css_rules()->item(0));
+            captured_element->group_keyframes = as<CSS::CSSKeyframesRule>(stylesheet->css_rules()->item(index));
 
             // 6. Set capturedElement’s group animation name rule to a new CSSStyleRule representing the
             //    following CSS, and append it to document’s dynamic view transition style sheet:

--- a/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/first-line-reparent-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/first-line-reparent-crash.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html class="test-wait">
+<script>
+window.addEventListener("load", () => {
+  const a = document.createElement("style")
+  document.documentElement.appendChild(a)
+  a.textContent = ":first-line{}"
+  document.adoptNode(document.body)
+  document.startViewTransition().ready.then(() => {
+    document.documentElement.className = "";
+  });
+})
+</script>

--- a/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/list-style-position-style-change-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/list-style-position-style-change-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<title>View transitions: list-style-position crash</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:bokan@chromium.org">
+
+<script>
+onload = async () => {
+  let vt = document.startViewTransition();
+  await vt.ready;
+  await new Promise(resolve => requestAnimationFrame(resolve));
+
+  document.documentElement.style.listStylePosition = 'inside';
+  // Force style update.
+  window.scrollX;
+
+  document.documentElement.classList.remove('test-wait');
+}
+</script>
+</html>

--- a/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-cv-hidden-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-cv-hidden-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>View transitions: content-visibility:hidden on root element crash</title>
+<link rel="help" href="https://crbug.com/1429947">
+<style>
+  html {
+    content-visibility: hidden;
+  }
+</style>
+<script>
+  document.startViewTransition();
+</script>

--- a/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-display-none-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-display-none-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class=test-wait>
+<title>View transitions: html display none</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:vmpstr@chromium.org">
+
+<style>
+html {
+  display: none;
+}
+</style>
+
+<script>
+function finish() {
+  document.documentElement.removeAttribute("class");
+}
+
+async function runTest() {
+  if (!document.startViewTransition) {
+    document.body.textContent = "Precondition Failed: Missing document.startViewTransition";
+    finish();
+    return;
+  }
+
+  document.startViewTransition().finished.then(finish, finish);
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+

--- a/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-display-none-during-transition-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-display-none-during-transition-crash.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class=test-wait>
+<title>View transitions: entry animation from root display none</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:vmpstr@chromium.org">
+
+<style>
+.hidden {
+  display: none;
+}
+::view-transition-group(*) {
+  animation-duration: 500s
+}
+</style>
+
+<script>
+async function runTest() {
+  transition = document.startViewTransition();
+  transition.ready.then(() => {
+    requestAnimationFrame(() => {
+      document.documentElement.classList.toggle("hidden");
+    });
+  });
+  transition.finished.then(() => document.documentElement.classList.remove("test-wait"));
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>


### PR DESCRIPTION
This used to crash a lot of attempted view transitions, now it doesn't anymore.