### PR TITLE
LibWeb: Implement optional function IDL arguments

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6679,7 +6679,6 @@ void Document::set_onvisibilitychange(WebIDL::CallbackType* value)
 }
 
 // https://drafts.csswg.org/css-view-transitions-1/#dom-document-startviewtransition
-// FIXME: Calling document.startViewTransition() without arguments throws TypeError instead of calling this.
 GC::Ptr<ViewTransition::ViewTransition> Document::start_view_transition(ViewTransition::ViewTransitionUpdateCallback update_callback)
 {
     // The method steps for startViewTransition(updateCallback) are as follows:

--- a/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-display-none-during-transition-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-view-transitions/root-element-display-none-during-transition-crash.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class=test-wait>
+<title>View transitions: entry animation from root display none</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:vmpstr@chromium.org">
+
+<style>
+.hidden {
+  display: none;
+}
+::view-transition-group(*) {
+  animation-duration: 500s
+}
+</style>
+
+<script>
+async function runTest() {
+  transition = document.startViewTransition();
+  transition.ready.then(() => {
+    requestAnimationFrame(() => {
+      document.documentElement.classList.toggle("hidden");
+    });
+  });
+  transition.finished.then(() => document.documentElement.classList.remove("test-wait"));
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>


### PR DESCRIPTION
This allows us to run some more view transitions WPT tests, one of which has been imported.
I'm sure there is some others that this makes us pass as well that could be imported, but I don't want to go down the entire list to find them.