### PR TITLE
LibWeb: Use correct root element when resolving paint properties

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1537,7 +1537,8 @@ void PaintableBox::resolve_paint_properties()
 
         // Section 2.11.2: If the computed value of background-image on the root element is none and its background-color is transparent,
         // user agents must instead propagate the computed values of the background properties from that element’s first HTML BODY child element.
-        if (document().html_element()->should_use_body_background_properties()) {
+        auto& html_element = as<HTML::HTMLHtmlElement>(*layout_node_with_style_and_box_metrics().dom_node());
+        if (html_element.should_use_body_background_properties()) {
             background_layers = document().background_layers();
             background_color = document().background_color();
         }

--- a/Tests/LibWeb/Crash/SVG/foreignObject-with-html-root-element.svg
+++ b/Tests/LibWeb/Crash/SVG/foreignObject-with-html-root-element.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" >
+    <foreignObject>
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        </html>
+    </foreignObject>
+</svg>


### PR DESCRIPTION
Previously, the first `HTMLHtmlELement` in the given document would always be  used when determining whether to propagate background properties to the body element. This meant the wrong root element was used for SVG `foreignObject` elements, which could lead to a crash.

This fixes a crash seen in https://wpt.live/css/css-images/svg-images-are-ignored.html, but that test still doesn't pass after this change.