### PR TITLE
test-web: Wait for crash tests with a `test-wait` attribute

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -338,3 +338,7 @@ Ref/input/wpt-import/css/css-transforms/individual-transform/stacking-context-00
 ; Frequently times out on CI
 ; https://github.com/LadybirdBrowser/ladybird/issues/6069
 Text/input/input-file.html
+
+; Times out due to `document.adoptNode` invocation
+; https://github.com/LadybirdBrowser/ladybird/issues/6150
+Crash/wpt-import/css/css-view-transitions/first-line-reparent-crash.html


### PR DESCRIPTION
Similar to ref tests, we don't want to incorrectly pass a test that did not remove this attribute.
