### PR TITLE
LibJS: Remove incorrect VERIFY

### DIFF
--- a/Libraries/LibJS/CyclicModule.cpp
+++ b/Libraries/LibJS/CyclicModule.cpp
@@ -344,7 +344,6 @@ ThrowCompletionOr<GC::Ref<Promise>> CyclicModule::evaluate(VM& vm)
     if ((m_status == ModuleStatus::EvaluatingAsync || m_status == ModuleStatus::Evaluated) && m_cycle_root != this) {
         // Note: This will continue this function with module.[[CycleRoot]]
         VERIFY(m_cycle_root);
-        VERIFY(m_cycle_root->m_status == ModuleStatus::Linked);
         dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root.ptr());
         return m_cycle_root->evaluate(vm);
     }

--- a/Tests/LibWeb/Crash/JS/cyclic-async-module-a.mjs
+++ b/Tests/LibWeb/Crash/JS/cyclic-async-module-a.mjs
@@ -1,0 +1,3 @@
+import { foo } from "./cyclic-async-module-b.mjs";
+
+await new Promise(resolve => setTimeout(resolve, 200));

--- a/Tests/LibWeb/Crash/JS/cyclic-async-module-b.mjs
+++ b/Tests/LibWeb/Crash/JS/cyclic-async-module-b.mjs
@@ -1,0 +1,3 @@
+import "./cyclic-async-module-a.mjs";
+
+export const foo = "value from B";

--- a/Tests/LibWeb/Crash/JS/cyclic-async-module.html
+++ b/Tests/LibWeb/Crash/JS/cyclic-async-module.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="./cyclic-async-module.mjs"></script>

--- a/Tests/LibWeb/Crash/JS/cyclic-async-module.mjs
+++ b/Tests/LibWeb/Crash/JS/cyclic-async-module.mjs
@@ -1,0 +1,7 @@
+(async function () {
+    const first = import("./cyclic-async-module-a.mjs");
+    const second = import("./cyclic-async-module-b.mjs");
+
+    await first;
+    await second;
+})();


### PR DESCRIPTION
This VERIFY is both incorrect and redundant. The VERIFY at step 2 verifies the status when evaluate is called on m_cycle_root.