### PR TITLE
LibWeb: Make SVGGraphicsElement::getBBox() throw error for non-rendered elements

### DIFF
--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -17,6 +17,8 @@
 #include <LibWeb/SVG/SVGFitToViewBox.h>
 #include <LibWeb/SVG/SVGGradientElement.h>
 #include <LibWeb/SVG/TagNames.h>
+#include <LibWeb/WebIDL/DOMException.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::SVG {
 
@@ -69,7 +71,7 @@ public:
     GC::Ptr<SVG::SVGMaskElement const> mask() const;
     GC::Ptr<SVG::SVGClipPathElement const> clip_path() const;
 
-    GC::Ref<Geometry::DOMRect> get_b_box(Optional<SVGBoundingBoxOptions>);
+    WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> get_b_box(Optional<SVGBoundingBoxOptions>);
     GC::Ref<SVGAnimatedTransformList> transform() const;
 
     GC::Ptr<Geometry::DOMMatrix> get_ctm();

--- a/Tests/LibWeb/Text/expected/SVG/getBBox-marker-crash.txt
+++ b/Tests/LibWeb/Text/expected/SVG/getBBox-marker-crash.txt
@@ -1,0 +1,1 @@
+Threw InvalidStateError

--- a/Tests/LibWeb/Text/expected/SVG/getBBox-pattern-crash.txt
+++ b/Tests/LibWeb/Text/expected/SVG/getBBox-pattern-crash.txt
@@ -1,0 +1,1 @@
+Threw InvalidStateError

--- a/Tests/LibWeb/Text/input/SVG/getBBox-marker-crash.html
+++ b/Tests/LibWeb/Text/input/SVG/getBBox-marker-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg width="1" height="1">
+  <marker id="mk" markerWidth="1" markerHeight="1">
+    <circle id="t" cx="0" cy="0" r="0"></circle>
+  </marker>
+</svg>
+<script>
+  test(() => {
+    try {
+      document.getElementById("t").getBBox();
+      println("Did not throw");
+    } catch (e) {
+      println(`Threw ${e.name}`);
+    }
+  });
+</script>

--- a/Tests/LibWeb/Text/input/SVG/getBBox-pattern-crash.html
+++ b/Tests/LibWeb/Text/input/SVG/getBBox-pattern-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg width="1" height="1">
+  <pattern id="pat" width="1" height="1" patternUnits="userSpaceOnUse">
+    <rect id="tp" width="1" height="1"></rect>
+  </pattern>
+</svg>
+<script>
+  test(() => {
+    try {
+      document.getElementById("tp").getBBox();
+      println("Did not throw");
+    } catch (e) {
+      println(`Threw ${e.name}`);
+    }
+  });
+</script>


### PR DESCRIPTION
Per SVG2 spec (§ Geometry Properties: getBBox), getBBox() must throw InvalidStateError if the element is not rendered and its geometry cannot be computed. Previously we would crash on null paintables; now we throw with a clear error instead.

Fixes #5990