### PR TITLE
Everywhere: Fix a few unreachable-return / unreachable-break warnings

### DIFF
--- a/Libraries/LibCore/Process.cpp
+++ b/Libraries/LibCore/Process.cpp
@@ -292,9 +292,10 @@ ErrorOr<bool> Process::is_being_debugged()
 #    elif defined(AK_OS_FREEBSD)
     return ((info.ki_flag & P_TRACED) != 0);
 #    endif
-#endif
+#else
     // FIXME: Implement this for more platforms.
     return Error::from_string_literal("Platform does not support checking for debugger");
+#endif
 }
 
 // Forces the process to sleep until a debugger is attached, then breaks.

--- a/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Libraries/LibWasm/WASI/Wasi.cpp
@@ -685,7 +685,6 @@ ErrorOr<Result<Timestamp>> Implementation::impl$clock_time_get(Configuration&, C
     case ClockID::ProcessCPUTimeID:
     case ClockID::ThreadCPUTimeID:
         return Errno::NoSys;
-        break;
     }
 
     struct timespec ts;

--- a/Libraries/LibWeb/CSS/Transformation.cpp
+++ b/Libraries/LibWeb/CSS/Transformation.cpp
@@ -84,13 +84,11 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
                 0, 1, 0, 0,
                 0, 0, 1, 0,
                 0, 0, -1 / (distance <= 0 ? 1 : distance), 1);
-        } else {
-            return Gfx::FloatMatrix4x4(1, 0, 0, 0,
-                0, 1, 0, 0,
-                0, 0, 1, 0,
-                0, 0, 0, 1);
         }
-        break;
+        return Gfx::FloatMatrix4x4(1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1);
     case CSS::TransformFunction::Matrix:
         if (count == 6)
             return Gfx::FloatMatrix4x4(TRY(value(0)), TRY(value(2)), 0, TRY(value(4)),
@@ -122,7 +120,6 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
             0, 1, 0, TRY(value(1, height)),
             0, 0, 1, TRY(value(2)),
             0, 0, 0, 1);
-        break;
     case CSS::TransformFunction::TranslateX:
         if (count == 1)
             return Gfx::FloatMatrix4x4(1, 0, 0, TRY(value(0, width)),


### PR DESCRIPTION
I was playing with clang's -Wunreachable-code-aggressive a bit. This fixes a handful uncontroversial things it flags.

No behavior change.