### PR TITLE
LibJS: Add PutByNumericId and change PutById to be string key only

### DIFF
--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -651,7 +651,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> AssignmentExpression::g
                     } else if (expression.property().is_identifier()) {
                         auto identifier_table_ref = generator.intern_identifier(as<Identifier>(expression.property()).string());
                         if (!lhs_is_super_expression)
-                            generator.emit<Bytecode::Op::PutById>(*base, identifier_table_ref, rval, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache(), move(base_identifier));
+                            generator.emit_put_by_id(*base, identifier_table_ref, rval, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache(), move(base_identifier));
                         else
                             generator.emit<Bytecode::Op::PutByIdWithThis>(*base, *this_value, identifier_table_ref, rval, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache());
                     } else if (expression.property().is_private_identifier()) {
@@ -1188,7 +1188,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> ObjectExpression::gener
                 value = TRY(generator.emit_named_evaluation_if_anonymous_function(property->value(), name));
             }
 
-            generator.emit<Bytecode::Op::PutById>(object, key_name, *value, property_kind, generator.next_property_lookup_cache());
+            generator.emit_put_by_id(object, key_name, *value, property_kind, generator.next_property_lookup_cache());
         } else {
             auto property_name = TRY(property->key().generate_bytecode(generator)).value();
             auto value = TRY(property->value().generate_bytecode(generator)).value();
@@ -2540,7 +2540,7 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> TaggedTemplateLiteral::
         generator.emit_with_extra_operand_slots<Bytecode::Op::NewArray>(raw_string_regs.size(), raw_strings_array, raw_string_regs);
     }
 
-    generator.emit<Bytecode::Op::PutById>(strings_array, generator.intern_identifier("raw"_utf16_fly_string), raw_strings_array, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache());
+    generator.emit_put_by_id(strings_array, generator.intern_identifier("raw"_utf16_fly_string), raw_strings_array, Bytecode::Op::PropertyKind::KeyValue, generator.next_property_lookup_cache());
 
     auto arguments = generator.allocate_register();
     if (!argument_regs.is_empty())

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -329,6 +329,8 @@ public:
     void emit_get_by_value(ScopedOperand dst, ScopedOperand base, ScopedOperand property, Optional<IdentifierTableIndex> base_identifier = {});
     void emit_get_by_value_with_this(ScopedOperand dst, ScopedOperand base, ScopedOperand property, ScopedOperand this_value);
 
+    void emit_put_by_id(Operand base, IdentifierTableIndex property, Operand src, Op::PropertyKind kind, u32 cache_index, Optional<IdentifierTableIndex> base_identifier = {});
+
     void emit_put_by_value(ScopedOperand base, ScopedOperand property, ScopedOperand src, Bytecode::Op::PropertyKind, Optional<IdentifierTableIndex> base_identifier);
     void emit_put_by_value_with_this(ScopedOperand base, ScopedOperand property, ScopedOperand this_value, ScopedOperand src, Bytecode::Op::PropertyKind);
 

--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -123,6 +123,7 @@
     O(PostfixDecrement)                \
     O(PostfixIncrement)                \
     O(PutById)                         \
+    O(PutByNumericId)                  \
     O(PutByIdWithThis)                 \
     O(PutBySpread)                     \
     O(PutByValue)                      \

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -2656,7 +2656,7 @@ ThrowCompletionOr<void> PutByIdWithThis::execute_impl(Bytecode::Interpreter& int
     auto& vm = interpreter.vm();
     auto value = interpreter.get(m_src);
     auto base = interpreter.get(m_base);
-    PropertyKey name = interpreter.current_executable().get_identifier(m_property);
+    PropertyKey name { interpreter.current_executable().get_identifier(m_property), PropertyKey::StringMayBeNumber::No };
     auto& cache = interpreter.current_executable().property_lookup_caches[m_cache_index];
     TRY(put_by_property_key(vm, base, interpreter.get(m_this_value), value, {}, name, m_kind, &cache));
     return {};

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -1249,6 +1249,36 @@ private:
     Optional<IdentifierTableIndex> m_base_identifier {};
 };
 
+class PutByNumericId final : public Instruction {
+public:
+    explicit PutByNumericId(Operand base, u64 property_index, Operand src, PropertyKind kind, u32 cache_index, Optional<IdentifierTableIndex> base_identifier = {})
+        : Instruction(Type::PutByNumericId)
+        , m_base(base)
+        , m_property_index(property_index)
+        , m_src(src)
+        , m_kind(kind)
+        , m_cache_index(cache_index)
+        , m_base_identifier(move(base_identifier))
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
+    void visit_operands_impl(Function<void(Operand&)> visitor)
+    {
+        visitor(m_base);
+        visitor(m_src);
+    }
+
+private:
+    Operand m_base;
+    u64 m_property_index;
+    Operand m_src;
+    PropertyKind m_kind;
+    u32 m_cache_index { 0 };
+    Optional<IdentifierTableIndex> m_base_identifier {};
+};
+
 class PutByIdWithThis final : public Instruction {
 public:
     PutByIdWithThis(Operand base, Operand this_value, IdentifierTableIndex property, Operand src, PropertyKind kind, u32 cache_index)

--- a/Libraries/LibJS/Tests/builtins/Object/Object.defineProperties.js
+++ b/Libraries/LibJS/Tests/builtins/Object/Object.defineProperties.js
@@ -54,4 +54,11 @@ describe("normal behavior", () => {
             configurable: false,
         });
     });
+
+    test("maps numeric string key 0 to array index 0", () => {
+        var arr = [0];
+        // prettier-ignore
+        Object.defineProperties(arr, { "0": { value: 12 } });
+        expect(arr[0]).toBe(12);
+    });
 });


### PR DESCRIPTION
Previously, PutById constructed a PropertyKey from the identifier,
which coerced numeric-like strings to numbers. This moves that decision
to bytecode generation: the bytecode generator now emits PutByNumericId
for numeric keys and PutById for string keys. This removes per-execution
parsing from the interpreter.

1.4x speedup on the following microbenchmark:
```js
const o = {};
for (let i = 0; i < 10_000_000; i++) {
    o.a = 1;
    o.b = 2;
    o.c = 3;
}
```