### PR TITLE
LibJS+LibWeb: Inline fast path for `Value::to_object()`

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -19,6 +19,7 @@
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/PromiseConstructor.h>
 #include <LibJS/Runtime/Shape.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -28,6 +28,7 @@
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/PromiseConstructor.h>
 #include <LibJS/Runtime/Value.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -14,6 +14,7 @@
 #include <LibJS/Runtime/ObjectConstructor.h>
 #include <LibJS/Runtime/ProxyObject.h>
 #include <LibJS/Runtime/Shape.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -18,6 +18,7 @@
 #include <LibJS/Runtime/RegExpObject.h>
 #include <LibJS/Runtime/StringObject.h>
 #include <LibJS/Runtime/Value.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -16,6 +16,7 @@
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/PromiseConstructor.h>
 #include <LibJS/Runtime/PromiseResolvingElementFunctions.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/PrototypeObject.h
+++ b/Libraries/LibJS/Runtime/PrototypeObject.h
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/Reference.cpp
+++ b/Libraries/LibJS/Runtime/Reference.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/Error.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Reference.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/Iterator.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/TypedArrayConstructor.h>
+#include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -585,7 +585,7 @@ ThrowCompletionOr<Value> Value::to_primitive_slow_case(VM& vm, PreferredType pre
 }
 
 // 7.1.18 ToObject ( argument ), https://tc39.es/ecma262/#sec-toobject
-ThrowCompletionOr<GC::Ref<Object>> Value::to_object(VM& vm) const
+ThrowCompletionOr<GC::Ref<Object>> Value::to_object_slow(VM& vm) const
 {
     auto& realm = *vm.current_realm();
     VERIFY(!is_special_empty_value());

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -355,6 +355,7 @@ public:
     ThrowCompletionOr<GC::Ref<PrimitiveString>> to_primitive_string(VM&);
     ThrowCompletionOr<Value> to_primitive(VM&, PreferredType preferred_type = PreferredType::Default) const;
     ThrowCompletionOr<GC::Ref<Object>> to_object(VM&) const;
+    ThrowCompletionOr<GC::Ref<Object>> to_object_slow(VM&) const;
     ThrowCompletionOr<Value> to_numeric(VM&) const;
     ThrowCompletionOr<Value> to_number(VM&) const;
     ThrowCompletionOr<GC::Ref<BigInt>> to_bigint(VM&) const;

--- a/Libraries/LibJS/Runtime/ValueInlines.h
+++ b/Libraries/LibJS/Runtime/ValueInlines.h
@@ -48,4 +48,11 @@ inline ThrowCompletionOr<Value> Value::to_primitive(VM& vm, PreferredType prefer
     return to_primitive_slow_case(vm, preferred_type);
 }
 
+inline ThrowCompletionOr<GC::Ref<Object>> Value::to_object(VM& vm) const
+{
+    if (is_object())
+        return const_cast<Object&>(as_object());
+    return to_object_slow(vm);
+}
+
 }

--- a/Libraries/LibWeb/Crypto/CryptoKey.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoKey.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Memory.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/CryptoKeyPrototype.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Crypto/CryptoKey.h>

--- a/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/KeyAlgorithms.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/PrimitiveString.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Crypto/KeyAlgorithms.h>
 

--- a/Libraries/LibWeb/WebIDL/AsyncIterator.h
+++ b/Libraries/LibWeb/WebIDL/AsyncIterator.h
@@ -11,6 +11,7 @@
 #include <LibJS/Runtime/PromiseCapability.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibJS/Runtime/VM.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/WebIDL/Promise.h>
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -5600,6 +5600,7 @@ void generate_iterator_prototype_implementation(IDL::Interface const& interface,
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibWeb/Bindings/@prototype_class@.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/ValueInlines.h>
 #include <LibTest/JavaScriptTestRunner.h>
 #include <LibUnicode/TimeZone.h>
 


### PR DESCRIPTION
Adds inline implementation for the most common case when `Value` is already an object.

1.47x improvement on the following benchmark:
```js
const o = {};
for (let i = 0; i < 10_000_000; i++) {
    o.a = 1;
    o.b = 2;
    o.c = 3;
}
```