### PR TITLE
Add inline caching for adding new own properties to objects

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -185,18 +185,24 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassMethod::class_element_evaluatio
     if (property_key_or_private_name.has<PropertyKey>()) {
         auto& property_key = property_key_or_private_name.get<PropertyKey>();
         switch (kind()) {
-        case ClassMethod::Kind::Method:
+        case ClassMethod::Kind::Method: {
             set_function_name();
-            TRY(target.define_property_or_throw(property_key, { .value = method_value, .writable = true, .enumerable = false, .configurable = true }));
+            PropertyDescriptor descriptor { .value = method_value, .writable = true, .enumerable = false, .configurable = true };
+            TRY(target.define_property_or_throw(property_key, descriptor));
             break;
-        case ClassMethod::Kind::Getter:
+        }
+        case ClassMethod::Kind::Getter: {
             set_function_name("get"sv);
-            TRY(target.define_property_or_throw(property_key, { .get = &method_function, .enumerable = false, .configurable = true }));
+            PropertyDescriptor descriptor { .get = &method_function, .enumerable = false, .configurable = true };
+            TRY(target.define_property_or_throw(property_key, descriptor));
             break;
-        case ClassMethod::Kind::Setter:
+        }
+        case ClassMethod::Kind::Setter: {
             set_function_name("set"sv);
-            TRY(target.define_property_or_throw(property_key, { .set = &method_function, .enumerable = false, .configurable = true }));
+            PropertyDescriptor descriptor { .set = &method_function, .enumerable = false, .configurable = true };
+            TRY(target.define_property_or_throw(property_key, descriptor));
             break;
+        }
         default:
             VERIFY_NOT_REACHED();
         }

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -28,6 +28,16 @@ namespace JS::Bytecode {
 struct PropertyLookupCache {
     static constexpr size_t max_number_of_shapes_to_remember = 4;
     struct Entry {
+        enum class Type {
+            Empty,
+            AddOwnProperty,
+            ChangeOwnProperty,
+            GetOwnProperty,
+            ChangePropertyInPrototypeChain,
+            GetPropertyInPrototypeChain,
+        };
+        Type type { Type::Empty };
+        WeakPtr<Shape> from_shape;
         WeakPtr<Shape> shape;
         Optional<u32> property_offset;
         WeakPtr<Object> prototype;

--- a/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -40,8 +40,8 @@ ThrowCompletionOr<GC::RootVector<Value>> create_list_from_array_like(VM&, Value,
 ThrowCompletionOr<FunctionObject*> species_constructor(VM&, Object const&, FunctionObject& default_constructor);
 JS_API ThrowCompletionOr<Realm*> get_function_realm(VM&, FunctionObject const&);
 ThrowCompletionOr<void> initialize_bound_name(VM&, Utf16FlyString const&, Value, Environment*);
-bool is_compatible_property_descriptor(bool extensible, PropertyDescriptor const&, Optional<PropertyDescriptor> const& current);
-bool validate_and_apply_property_descriptor(Object*, PropertyKey const&, bool extensible, PropertyDescriptor const&, Optional<PropertyDescriptor> const& current);
+bool is_compatible_property_descriptor(bool extensible, PropertyDescriptor&, Optional<PropertyDescriptor> const& current);
+bool validate_and_apply_property_descriptor(Object*, PropertyKey const&, bool extensible, PropertyDescriptor&, Optional<PropertyDescriptor> const& current);
 JS_API ThrowCompletionOr<Object*> get_prototype_from_constructor(VM&, FunctionObject const& constructor, GC::Ref<Object> (Intrinsics::*intrinsic_default_prototype)());
 Object* create_unmapped_arguments_object(VM&, ReadonlySpan<Value> arguments);
 Object* create_mapped_arguments_object(VM&, FunctionObject&, NonnullRefPtr<FunctionParameters const> const&, ReadonlySpan<Value> arguments, Environment&);

--- a/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/AggregateErrorConstructor.cpp
@@ -68,7 +68,8 @@ ThrowCompletionOr<GC::Ref<Object>> AggregateErrorConstructor::construct(Function
     auto errors_list = TRY(iterator_to_list(vm, TRY(get_iterator(vm, errors, IteratorHint::Sync))));
 
     // 6. Perform ! DefinePropertyOrThrow(O, "errors", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: CreateArrayFromList(errorsList) }).
-    MUST(aggregate_error->define_property_or_throw(vm.names.errors, { .value = Array::create_from(realm, errors_list), .writable = true, .enumerable = false, .configurable = true }));
+    PropertyDescriptor descriptor { .value = Array::create_from(realm, errors_list), .writable = true, .enumerable = false, .configurable = true };
+    MUST(aggregate_error->define_property_or_throw(vm.names.errors, descriptor));
 
     // 7. Return O.
     return aggregate_error;

--- a/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -126,7 +126,7 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> ArgumentsObject::internal_get_ow
 }
 
 // 10.4.4.2 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-arguments-exotic-objects-defineownproperty-p-desc
-ThrowCompletionOr<bool> ArgumentsObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor const& descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
+ThrowCompletionOr<bool> ArgumentsObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor& descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
 {
     // 1. Let map be args.[[ParameterMap]].
     // 2. Let isMapped be ! HasOwnProperty(map, P).

--- a/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -38,7 +38,7 @@ bool ArgumentsObject::parameter_map_has(PropertyKey const& key) const
 }
 
 // 10.4.4.3 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-arguments-exotic-objects-get-p-receiver
-ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
+ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& property_key, Value receiver, CacheableGetPropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     // 1. Let map be args.[[ParameterMap]].
     // 2. Let isMapped be ! HasOwnProperty(map, P).
@@ -56,7 +56,7 @@ ThrowCompletionOr<Value> ArgumentsObject::internal_get(PropertyKey const& proper
 }
 
 // 10.4.4.4 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-arguments-exotic-objects-set-p-v-receiver
-ThrowCompletionOr<bool> ArgumentsObject::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase)
+ThrowCompletionOr<bool> ArgumentsObject::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheableSetPropertyMetadata*, PropertyLookupPhase)
 {
     bool is_mapped = false;
 

--- a/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -21,7 +21,7 @@ public:
     virtual ~ArgumentsObject() override = default;
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;

--- a/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -22,8 +22,8 @@ public:
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const override;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheableGetPropertyMetadata*, PropertyLookupPhase) const override;
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheableSetPropertyMetadata*, PropertyLookupPhase) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
 
     void set_mapped_names(Vector<Utf16FlyString> mapped_names) { m_mapped_names = move(mapped_names); }

--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -326,7 +326,7 @@ bool Array::default_prototype_chain_intact() const
     return true;
 }
 
-ThrowCompletionOr<bool> Array::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase)
+ThrowCompletionOr<bool> Array::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheableSetPropertyMetadata* cacheable_metadata, PropertyLookupPhase phase)
 {
     auto& vm = this->vm();
 

--- a/Libraries/LibJS/Runtime/Array.cpp
+++ b/Libraries/LibJS/Runtime/Array.cpp
@@ -38,7 +38,8 @@ ThrowCompletionOr<GC::Ref<Array>> Array::create(Realm& realm, u64 length, Object
     auto array = realm.create<Array>(realm, *prototype);
 
     // 6. Perform ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
-    MUST(array->internal_define_own_property(vm.names.length, { .value = Value(length), .writable = true, .enumerable = false, .configurable = false }));
+    PropertyDescriptor descriptor { .value = Value(length), .writable = true, .enumerable = false, .configurable = false };
+    MUST(array->internal_define_own_property(vm.names.length, descriptor));
 
     // 7. Return A.
     return array;
@@ -367,7 +368,7 @@ ThrowCompletionOr<bool> Array::internal_set(PropertyKey const& property_key, Val
 }
 
 // 10.4.2.1 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-array-exotic-objects-defineownproperty-p-desc
-ThrowCompletionOr<bool> Array::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor const& property_descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
+ThrowCompletionOr<bool> Array::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor& property_descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
 {
     auto& vm = this->vm();
 

--- a/Libraries/LibJS/Runtime/Array.h
+++ b/Libraries/LibJS/Runtime/Array.h
@@ -49,7 +49,7 @@ public:
     virtual ~Array() override = default;
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override final;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheableSetPropertyMetadata*, PropertyLookupPhase) override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override final;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override final;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;

--- a/Libraries/LibJS/Runtime/Array.h
+++ b/Libraries/LibJS/Runtime/Array.h
@@ -50,7 +50,7 @@ public:
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override final;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override final;
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override final;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override final;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const override final;

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -457,8 +457,10 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
         prototype->put_direct(realm.intrinsics().normal_function_prototype_constructor_offset(), this);
         put_direct(realm.intrinsics().normal_function_prototype_offset(), prototype);
     } else {
-        MUST(define_property_or_throw(vm.names.length, { .value = Value(function_length()), .writable = false, .enumerable = false, .configurable = true }));
-        MUST(define_property_or_throw(vm.names.name, { .value = m_name_string, .writable = false, .enumerable = false, .configurable = true }));
+        PropertyDescriptor length_descriptor { .value = Value(function_length()), .writable = false, .enumerable = false, .configurable = true };
+        MUST(define_property_or_throw(vm.names.length, length_descriptor));
+        PropertyDescriptor name_descriptor { .value = m_name_string, .writable = false, .enumerable = false, .configurable = true };
+        MUST(define_property_or_throw(vm.names.name, name_descriptor));
 
         if (!is_arrow_function()) {
             Object* prototype = nullptr;
@@ -915,7 +917,8 @@ void ECMAScriptFunctionObject::set_name(Utf16FlyString const& name)
     auto& vm = this->vm();
     const_cast<SharedFunctionInstanceData&>(shared_data()).m_name = name;
     m_name_string = PrimitiveString::create(vm, name);
-    MUST(define_property_or_throw(vm.names.name, { .value = m_name_string, .writable = false, .enumerable = false, .configurable = true }));
+    PropertyDescriptor descriptor { .value = m_name_string, .writable = false, .enumerable = false, .configurable = true };
+    MUST(define_property_or_throw(vm.names.name, descriptor));
 }
 
 ECMAScriptFunctionObject::ClassData& ECMAScriptFunctionObject::ensure_class_data() const

--- a/Libraries/LibJS/Runtime/FunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/FunctionObject.cpp
@@ -85,7 +85,8 @@ void FunctionObject::set_function_name(Variant<PropertyKey, PrivateName> const& 
     auto name = make_function_name(name_arg, prefix);
 
     // 6. Perform ! DefinePropertyOrThrow(F, "name", PropertyDescriptor { [[Value]]: name, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
-    MUST(define_property_or_throw(vm.names.name, PropertyDescriptor { .value = name, .writable = false, .enumerable = false, .configurable = true }));
+    PropertyDescriptor descriptor { .value = name, .writable = false, .enumerable = false, .configurable = true };
+    MUST(define_property_or_throw(vm.names.name, descriptor));
 
     // 7. Return unused.
 }
@@ -103,7 +104,8 @@ void FunctionObject::set_function_length(double length)
     VERIFY(!storage_has(vm.names.length));
 
     // 2. Perform ! DefinePropertyOrThrow(F, "length", PropertyDescriptor { [[Value]]: 𝔽(length), [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }).
-    MUST(define_property_or_throw(vm.names.length, PropertyDescriptor { .value = Value { length }, .writable = false, .enumerable = false, .configurable = true }));
+    PropertyDescriptor descriptor { .value = Value { length }, .writable = false, .enumerable = false, .configurable = true };
+    MUST(define_property_or_throw(vm.names.length, descriptor));
 
     // 3. Return unused.
 }

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -136,7 +136,7 @@ ThrowCompletionOr<bool> ModuleNamespaceObject::internal_has_property(PropertyKey
 }
 
 // 10.4.6.8 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-get-p-receiver
-ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
+ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& property_key, Value receiver, CacheableGetPropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     auto& vm = this->vm();
 
@@ -183,7 +183,7 @@ ThrowCompletionOr<Value> ModuleNamespaceObject::internal_get(PropertyKey const& 
 }
 
 // 10.4.6.9 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-set-p-v-receiver
-ThrowCompletionOr<bool> ModuleNamespaceObject::internal_set(PropertyKey const&, Value, Value, CacheablePropertyMetadata*, PropertyLookupPhase)
+ThrowCompletionOr<bool> ModuleNamespaceObject::internal_set(PropertyKey const&, Value, Value, CacheableSetPropertyMetadata*, PropertyLookupPhase)
 {
     // 1. Return false.
     return false;

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.cpp
@@ -81,7 +81,7 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> ModuleNamespaceObject::internal_
 }
 
 // 10.4.6.6 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-defineownproperty-p-desc
-ThrowCompletionOr<bool> ModuleNamespaceObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor const& descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
+ThrowCompletionOr<bool> ModuleNamespaceObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor& descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
 {
     // 1. If Type(P) is Symbol, return ! OrdinaryDefineOwnProperty(O, P, Desc).
     if (property_key.is_symbol())

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -24,7 +24,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_is_extensible() const override;
     virtual ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;

--- a/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
+++ b/Libraries/LibJS/Runtime/ModuleNamespaceObject.h
@@ -26,8 +26,8 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) const override;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheableGetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) const override;
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheableSetPropertyMetadata*, PropertyLookupPhase) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const override;
     virtual void initialize(Realm&) override;

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -114,7 +114,7 @@ public:
     void create_method_property(PropertyKey const&, Value);
     ThrowCompletionOr<bool> create_data_property_or_throw(PropertyKey const&, Value);
     void create_non_enumerable_data_property_or_throw(PropertyKey const&, Value);
-    ThrowCompletionOr<void> define_property_or_throw(PropertyKey const&, PropertyDescriptor const&);
+    ThrowCompletionOr<void> define_property_or_throw(PropertyKey const&, PropertyDescriptor&);
     ThrowCompletionOr<void> delete_property_or_throw(PropertyKey const&);
     ThrowCompletionOr<bool> has_property(PropertyKey const&) const;
     ThrowCompletionOr<bool> has_own_property(PropertyKey const&) const;
@@ -139,7 +139,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_is_extensible() const;
     virtual ThrowCompletionOr<bool> internal_prevent_extensions();
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const;
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr);
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr);
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const;
     enum class PropertyLookupPhase {
         OwnProperty,
@@ -174,14 +174,14 @@ public:
 
     Optional<ValueAndAttributes> storage_get(PropertyKey const&) const;
     bool storage_has(PropertyKey const&) const;
-    void storage_set(PropertyKey const&, ValueAndAttributes const&);
+    Optional<u32> storage_set(PropertyKey const&, ValueAndAttributes const&);
     void storage_delete(PropertyKey const&);
 
     // Non-standard methods
 
     Value get_without_side_effects(PropertyKey const&) const;
 
-    void define_direct_property(PropertyKey const& property_key, Value value, PropertyAttributes attributes) { storage_set(property_key, { value, attributes }); }
+    void define_direct_property(PropertyKey const& property_key, Value value, PropertyAttributes attributes) { (void)storage_set(property_key, { value, attributes }); }
     void define_direct_accessor(PropertyKey const&, FunctionObject* getter, FunctionObject* setter, PropertyAttributes attributes);
 
     using IntrinsicAccessor = Value (*)(Realm&);

--- a/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
+++ b/Libraries/LibJS/Runtime/ObjectEnvironment.cpp
@@ -66,7 +66,8 @@ ThrowCompletionOr<void> ObjectEnvironment::create_mutable_binding(VM&, Utf16FlyS
 {
     // 1. Let bindingObject be envRec.[[BindingObject]].
     // 2. Perform ? DefinePropertyOrThrow(bindingObject, N, PropertyDescriptor { [[Value]]: undefined, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: D }).
-    TRY(m_binding_object->define_property_or_throw(name, { .value = js_undefined(), .writable = true, .enumerable = true, .configurable = can_be_deleted }));
+    PropertyDescriptor descriptor { .value = js_undefined(), .writable = true, .enumerable = true, .configurable = can_be_deleted };
+    TRY(m_binding_object->define_property_or_throw(name, descriptor));
 
     // 3. Return unused.
     return {};

--- a/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -182,7 +182,8 @@ static ThrowCompletionOr<Value> perform_promise_any(VM& vm, IteratorRecord& iter
 
             // 2. Perform ! DefinePropertyOrThrow(error, "errors", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: CreateArrayFromList(errors) }).
             auto errors_array = Array::create_from(realm, errors.values());
-            MUST(error->define_property_or_throw(vm.names.errors, { .value = errors_array, .writable = true, .enumerable = false, .configurable = true }));
+            PropertyDescriptor descriptor { .value = errors_array, .writable = true, .enumerable = false, .configurable = true };
+            MUST(error->define_property_or_throw(vm.names.errors, descriptor));
 
             // 3. Return ThrowCompletion(error).
             return throw_completion(error);

--- a/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -200,7 +200,8 @@ ThrowCompletionOr<Value> PromiseAnyRejectElementFunction::resolve_element()
 
         // b. Perform ! DefinePropertyOrThrow(error, "errors", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: CreateArrayFromList(errors) }).
         auto errors_array = Array::create_from(realm, m_values->values());
-        MUST(error->define_property_or_throw(vm.names.errors, { .value = errors_array, .writable = true, .enumerable = false, .configurable = true }));
+        PropertyDescriptor descriptor { .value = errors_array, .writable = true, .enumerable = false, .configurable = true };
+        MUST(error->define_property_or_throw(vm.names.errors, descriptor));
 
         // c. Return ? Call(promiseCapability.[[Reject]], undefined, « error »).
         return JS::call(vm, *m_capability->reject(), js_undefined(), error);

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -470,7 +470,7 @@ ThrowCompletionOr<bool> ProxyObject::internal_has_property(PropertyKey const& pr
 }
 
 // 10.5.8 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
-ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const
+ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_key, Value receiver, CacheableGetPropertyMetadata*, PropertyLookupPhase) const
 {
     LIMIT_PROXY_RECURSION_DEPTH();
 
@@ -539,7 +539,7 @@ ThrowCompletionOr<Value> ProxyObject::internal_get(PropertyKey const& property_k
 }
 
 // 10.5.9 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver
-ThrowCompletionOr<bool> ProxyObject::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase)
+ThrowCompletionOr<bool> ProxyObject::internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheableSetPropertyMetadata*, PropertyLookupPhase)
 {
     LIMIT_PROXY_RECURSION_DEPTH();
 

--- a/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -327,7 +327,7 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> ProxyObject::internal_get_own_pr
 }
 
 // 10.5.6 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-ThrowCompletionOr<bool> ProxyObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor const& property_descriptor, Optional<PropertyDescriptor>*)
+ThrowCompletionOr<bool> ProxyObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor& property_descriptor, Optional<PropertyDescriptor>*)
 {
     LIMIT_PROXY_RECURSION_DEPTH();
 

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -38,8 +38,8 @@ public:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const override;
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheableGetPropertyMetadata*, PropertyLookupPhase) const override;
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheableSetPropertyMetadata*, PropertyLookupPhase) override;
     virtual ThrowCompletionOr<bool> internal_delete(PropertyKey const&) override;
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const override;
     virtual ThrowCompletionOr<Value> internal_call(ExecutionContext&, Value this_argument) override;

--- a/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Libraries/LibJS/Runtime/ProxyObject.h
@@ -36,7 +36,7 @@ public:
     virtual ThrowCompletionOr<bool> internal_is_extensible() const override;
     virtual ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual ThrowCompletionOr<bool> internal_has_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<Value> internal_get(PropertyKey const&, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual ThrowCompletionOr<bool> internal_set(PropertyKey const&, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override;

--- a/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -357,7 +357,8 @@ ThrowCompletionOr<GC::Ref<RegExpObject>> regexp_alloc(VM& vm, FunctionObject& ne
     }
 
     // 6. Perform ! DefinePropertyOrThrow(obj, "lastIndex", PropertyDescriptor { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
-    MUST(regexp_object->define_property_or_throw(vm.names.lastIndex, PropertyDescriptor { .writable = true, .enumerable = false, .configurable = false }));
+    PropertyDescriptor descriptor { .writable = true, .enumerable = false, .configurable = false };
+    MUST(regexp_object->define_property_or_throw(vm.names.lastIndex, descriptor));
 
     // 7. Return obj.
     return regexp_object;

--- a/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Libraries/LibJS/Runtime/StringObject.cpp
@@ -109,7 +109,7 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> StringObject::internal_get_own_p
 }
 
 // 10.4.3.2 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc
-ThrowCompletionOr<bool> StringObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor const& property_descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
+ThrowCompletionOr<bool> StringObject::internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor& property_descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property)
 {
     // 1. Let stringDesc be StringGetOwnProperty(S, P).
     auto string_descriptor = TRY(string_get_own_property(*this, property_key));

--- a/Libraries/LibJS/Runtime/StringObject.h
+++ b/Libraries/LibJS/Runtime/StringObject.h
@@ -29,7 +29,7 @@ protected:
 
 private:
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor&, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual ThrowCompletionOr<GC::RootVector<Value>> internal_own_property_keys() const override;
 
     virtual bool is_string_object() const final { return true; }

--- a/Libraries/LibJS/Runtime/SuppressedErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/SuppressedErrorConstructor.cpp
@@ -64,10 +64,12 @@ ThrowCompletionOr<GC::Ref<Object>> SuppressedErrorConstructor::construct(Functio
     TRY(suppressed_error->install_error_cause(options));
 
     // 5. Perform ! DefinePropertyOrThrow(O, "error", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: error }).
-    MUST(suppressed_error->define_property_or_throw(vm.names.error, { .value = error, .writable = true, .enumerable = false, .configurable = true }));
+    PropertyDescriptor error_descriptor { .value = error, .writable = true, .enumerable = false, .configurable = true };
+    MUST(suppressed_error->define_property_or_throw(vm.names.error, error_descriptor));
 
     // 6. Perform ! DefinePropertyOrThrow(O, "suppressed", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: suppressed }).
-    MUST(suppressed_error->define_property_or_throw(vm.names.suppressed, { .value = suppressed, .writable = true, .enumerable = false, .configurable = true }));
+    PropertyDescriptor names_descriptor { .value = suppressed, .writable = true, .enumerable = false, .configurable = true };
+    MUST(suppressed_error->define_property_or_throw(vm.names.suppressed, names_descriptor));
 
     // 7. Return O.
     return suppressed_error;

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -325,7 +325,7 @@ public:
     }
 
     // 10.4.5.5 [[Get]] ( P, Receiver ), https://tc39.es/ecma262/#sec-typedarray-get
-    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const& property_key, Value receiver, CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const override
+    virtual ThrowCompletionOr<Value> internal_get(PropertyKey const& property_key, Value receiver, CacheableGetPropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const override
     {
         VERIFY(!receiver.is_special_empty_value());
 
@@ -350,7 +350,7 @@ public:
     }
 
     // 10.4.5.6 [[Set]] ( P, V, Receiver ), https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-set-p-v-receiver
-    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheablePropertyMetadata*, PropertyLookupPhase) override
+    virtual ThrowCompletionOr<bool> internal_set(PropertyKey const& property_key, Value value, Value receiver, CacheableSetPropertyMetadata*, PropertyLookupPhase) override
     {
         VERIFY(!value.is_special_empty_value());
         VERIFY(!receiver.is_special_empty_value());

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -278,7 +278,7 @@ public:
     }
 
     // 10.4.5.4 [[DefineOwnProperty]] ( P, Desc ), https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-defineownproperty-p-desc
-    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor const& property_descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override
+    virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const& property_key, PropertyDescriptor& property_descriptor, Optional<PropertyDescriptor>* precomputed_get_own_property = nullptr) override
     {
         // NOTE: If the property name is a number type (An implementation-defined optimized
         // property key type), it can be treated as a string property that will transparently be

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -253,7 +253,7 @@ JS::ThrowCompletionOr<bool> PlatformObject::internal_set(JS::PropertyKey const& 
 }
 
 // https://webidl.spec.whatwg.org/#legacy-platform-object-defineownproperty
-JS::ThrowCompletionOr<bool> PlatformObject::internal_define_own_property(JS::PropertyKey const& property_name, JS::PropertyDescriptor const& property_descriptor, Optional<JS::PropertyDescriptor>* precomputed_get_own_property)
+JS::ThrowCompletionOr<bool> PlatformObject::internal_define_own_property(JS::PropertyKey const& property_name, JS::PropertyDescriptor& property_descriptor, Optional<JS::PropertyDescriptor>* precomputed_get_own_property)
 {
     Optional<JS::PropertyDescriptor> get_own_property_result = {};
 

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -215,7 +215,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> PlatformObject::internal
 }
 
 // https://webidl.spec.whatwg.org/#legacy-platform-object-set
-JS::ThrowCompletionOr<bool> PlatformObject::internal_set(JS::PropertyKey const& property_name, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata* metadata, PropertyLookupPhase phase)
+JS::ThrowCompletionOr<bool> PlatformObject::internal_set(JS::PropertyKey const& property_name, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata* metadata, PropertyLookupPhase phase)
 {
     if (!m_legacy_platform_object_flags.has_value() || m_legacy_platform_object_flags->has_global_interface_extended_attribute)
         return Base::internal_set(property_name, value, receiver, metadata, phase);

--- a/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -38,7 +38,7 @@ public:
     // ^JS::Object
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value, JS::CacheablePropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) override;
-    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<GC::RootVector<JS::Value>> internal_own_property_keys() const override;

--- a/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -37,7 +37,7 @@ public:
 
     // ^JS::Object
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value, JS::CacheablePropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value, JS::Value, JS::CacheableSetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -659,7 +659,7 @@ JS::ThrowCompletionOr<bool> Location::internal_define_own_property(JS::PropertyK
 }
 
 // 7.10.5.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/history.html#location-get
-JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
+JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheableGetPropertyMetadata* cacheable_metadata, PropertyLookupPhase phase) const
 {
     auto& vm = this->vm();
 
@@ -672,7 +672,7 @@ JS::ThrowCompletionOr<JS::Value> Location::internal_get(JS::PropertyKey const& p
 }
 
 // 7.10.5.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/history.html#location-set
-JS::ThrowCompletionOr<bool> Location::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata* cacheable_metadata, PropertyLookupPhase phase)
+JS::ThrowCompletionOr<bool> Location::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata* cacheable_metadata, PropertyLookupPhase phase)
 {
     auto& vm = this->vm();
 

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -645,7 +645,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> Location::internal_get_o
 }
 
 // 7.10.5.6 [[DefineOwnProperty]] ( P, Desc ), https://html.spec.whatwg.org/multipage/history.html#location-defineownproperty
-JS::ThrowCompletionOr<bool> Location::internal_define_own_property(JS::PropertyKey const& property_key, JS::PropertyDescriptor const& descriptor, Optional<JS::PropertyDescriptor>* precomputed_get_own_property)
+JS::ThrowCompletionOr<bool> Location::internal_define_own_property(JS::PropertyKey const& property_key, JS::PropertyDescriptor& descriptor, Optional<JS::PropertyDescriptor>* precomputed_get_own_property)
 {
     // 1. If IsPlatformObjectSameOrigin(this) is true, then:
     if (HTML::is_platform_object_same_origin(*this)) {

--- a/Libraries/LibWeb/HTML/Location.h
+++ b/Libraries/LibWeb/HTML/Location.h
@@ -59,7 +59,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_is_extensible() const override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;

--- a/Libraries/LibWeb/HTML/Location.h
+++ b/Libraries/LibWeb/HTML/Location.h
@@ -60,8 +60,8 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheableGetPropertyMetadata*, PropertyLookupPhase) const override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata*, PropertyLookupPhase) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<GC::RootVector<JS::Value>> internal_own_property_keys() const override;
 

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1045,7 +1045,8 @@ WebIDL::ExceptionOr<void> Window::set_opener(JS::Value value)
 
     // 2. If the given value is non-null, then perform ? DefinePropertyOrThrow(this, "opener", { [[Value]]: the given value, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
     if (!value.is_null()) {
-        TRY(define_property_or_throw(vm().names.opener, { .value = value, .writable = true, .enumerable = true, .configurable = true }));
+        JS::PropertyDescriptor descriptor { .value = value, .writable = true, .enumerable = true, .configurable = true };
+        TRY(define_property_or_throw(vm().names.opener, descriptor));
     }
 
     return {};

--- a/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -154,7 +154,7 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::Proper
 
 // 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-get
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-get
-JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const
+JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheableGetPropertyMetadata*, PropertyLookupPhase) const
 {
     auto& vm = this->vm();
 
@@ -175,7 +175,7 @@ JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const
 
 // 7.4.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-set
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-set
-JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase)
+JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata*, PropertyLookupPhase)
 {
     auto& vm = this->vm();
 

--- a/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -133,7 +133,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> WindowProxy::internal_ge
 }
 
 // 7.4.6 [[DefineOwnProperty]] ( P, Desc ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-defineownproperty
-JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::PropertyKey const& property_key, JS::PropertyDescriptor const& descriptor, Optional<JS::PropertyDescriptor>*)
+JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::PropertyKey const& property_key, JS::PropertyDescriptor& descriptor, Optional<JS::PropertyDescriptor>*)
 {
     // 1. Let W be the value of the [[Window]] internal slot of this.
 

--- a/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Libraries/LibWeb/HTML/WindowProxy.h
@@ -27,7 +27,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_is_extensible() const override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
     virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;

--- a/Libraries/LibWeb/HTML/WindowProxy.h
+++ b/Libraries/LibWeb/HTML/WindowProxy.h
@@ -28,8 +28,8 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
     virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
-    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver, JS::CacheableGetPropertyMetadata*, PropertyLookupPhase) const override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata*, PropertyLookupPhase) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<GC::RootVector<JS::Value>> internal_own_property_keys() const override;
 

--- a/Libraries/LibWeb/WebIDL/ObservableArray.cpp
+++ b/Libraries/LibWeb/WebIDL/ObservableArray.cpp
@@ -39,7 +39,7 @@ void ObservableArray::set_on_delete_an_indexed_value_callback(DeleteAnIndexedVal
     m_on_delete_an_indexed_value = GC::create_function(heap(), move(callback));
 }
 
-JS::ThrowCompletionOr<bool> ObservableArray::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata* metadata, PropertyLookupPhase phase)
+JS::ThrowCompletionOr<bool> ObservableArray::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata* metadata, PropertyLookupPhase phase)
 {
     if (property_key.is_number() && m_on_set_an_indexed_value)
         TRY(Bindings::throw_dom_exception_if_needed(vm(), [&] { return m_on_set_an_indexed_value->function()(value); }));

--- a/Libraries/LibWeb/WebIDL/ObservableArray.h
+++ b/Libraries/LibWeb/WebIDL/ObservableArray.h
@@ -20,7 +20,7 @@ class WEB_API ObservableArray final : public JS::Array {
 public:
     static GC::Ref<ObservableArray> create(JS::Realm& realm);
 
-    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata* metadata = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheableSetPropertyMetadata* metadata = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const& property_key) override;
 
     using SetAnIndexedValueCallbackFunction = Function<ExceptionOr<void>(JS::Value&)>;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3376,7 +3376,7 @@ public:
     JS::Realm& realm() const { return m_realm; }
 private:
     virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
-    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
+    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property = nullptr) override;
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
@@ -3494,7 +3494,7 @@ JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> @named_properties_class@
 }
 
 // https://webidl.spec.whatwg.org/#named-properties-object-defineownproperty
-JS::ThrowCompletionOr<bool> @named_properties_class@::internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&, Optional<JS::PropertyDescriptor>*)
+JS::ThrowCompletionOr<bool> @named_properties_class@::internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>*)
 {
     // 1. Return false.
     return false;
@@ -4524,7 +4524,8 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::BadArgCountOne, "@namespaced_name@ setter");
 
     auto* impl = TRY(impl_from(vm));
-    TRY(impl->internal_define_own_property("@attribute.name@"_utf16_fly_string, JS::PropertyDescriptor { .value = vm.argument(0), .writable = true }));
+    JS::PropertyDescriptor descriptor { .value = vm.argument(0), .writable = true };
+    TRY(impl->internal_define_own_property("@attribute.name@"_utf16_fly_string, descriptor));
     return JS::js_undefined();
 }
 )~~~");


### PR DESCRIPTION
We already had IC support in PutById for the following cases:
- Changing an existing own property
- Calling a setter located in the prototype chain

This was enough to speed up code where structurally identical objects
(same shape) are processed in a loop:
```js
const arr = [{ a: 1 }, { a: 2 }, { a: 3 }];
for (let obj of arr) {
    obj.a += 1;
}
```

However, creating structurally identical objects in a loop was still
slow:
```js
for (let i = 0; i < 10_000_000; i++) {
    const o = {};
    o.a = 1;
    o.b = 2;
    o.c = 3;
}
```

This change addresses that by adding a new IC type that caches both the
source and target shapes, allowing property additions to be fast-pathed
by directly jumping to the shape that already includes the new property.

Existing benchmarks difference:
```
Suite       Test                                      Speedup  Old (Mean ± Range)           New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------------  ---------------------------
JetStream   bigfib.cpp.js                               1.019  8.440 ± 8.420 … 8.460        8.285 ± 8.270 … 8.300
JetStream   cdjs.js                                     1.197  4.730 ± 4.720 … 4.740        3.950 ± 3.940 … 3.960
JetStream   container.cpp.js                            0.99   32.305 ± 32.020 … 32.590     32.625 ± 32.570 … 32.680
JetStream   dry.c.js                                    0.966  20.575 ± 20.500 … 20.650     21.305 ± 21.110 … 21.500
JetStream   float-mm.c.js                               0.999  19.215 ± 19.200 … 19.230     19.230 ± 19.180 … 19.280
JetStream   gcc-loops.cpp.js                            1.012  121.920 ± 121.870 … 121.970  120.505 ± 120.320 … 120.690
JetStream   hash-map.js                                 1.108  1.635 ± 1.630 … 1.640        1.475 ± 1.470 … 1.480
JetStream   n-body.c.js                                 1.01   31.250 ± 31.190 … 31.310     30.935 ± 30.850 … 31.020
JetStream   quicksort.c.js                              0.944  4.665 ± 4.650 … 4.680        4.940 ± 4.560 … 5.320
JetStream   towers.c.js                                 0.952  6.345 ± 6.290 … 6.400        6.665 ± 6.650 … 6.680
JetStream3  js-tokens.js                                0.959  0.700 ± 0.700 … 0.700        0.730 ± 0.730 … 0.730
JetStream3  lazy-collections.js                         0.983  1.445 ± 1.440 … 1.450        1.470 ± 1.460 … 1.480
JetStream3  raytrace-private-class-fields.js            0.968  4.880 ± 4.820 … 4.940        5.040 ± 4.990 … 5.090
JetStream3  raytrace-public-class-fields.js             0.974  3.565 ± 3.540 … 3.590        3.660 ± 3.650 … 3.670
JetStream3  sync-file-system.js                         0.985  1.980 ± 1.980 … 1.980        2.010 ± 2.000 … 2.020
Kraken      ai-astar.js                                 1.047  1.115 ± 1.110 … 1.120        1.065 ± 1.050 … 1.080
Kraken      audio-beat-detection.js                     0.975  0.790 ± 0.790 … 0.790        0.810 ± 0.810 … 0.810
Kraken      audio-dft.js                                0.981  0.520 ± 0.520 … 0.520        0.530 ± 0.530 … 0.530
Kraken      audio-fft.js                                0.986  0.680 ± 0.680 … 0.680        0.690 ± 0.690 … 0.690
Kraken      audio-oscillator.js                         0.971  0.670 ± 0.670 … 0.670        0.690 ± 0.690 … 0.690
Kraken      imaging-darkroom.js                         0.995  0.980 ± 0.980 … 0.980        0.985 ± 0.960 … 1.010
Kraken      imaging-desaturate.js                       0.984  1.240 ± 1.240 … 1.240        1.260 ± 1.240 … 1.280
Kraken      imaging-gaussian-blur.js                    0.978  4.825 ± 4.820 … 4.830        4.935 ± 4.900 … 4.970
Kraken      json-parse-financial.js                     1      0.070 ± 0.070 … 0.070        0.070 ± 0.070 … 0.070
Kraken      json-stringify-tinderbox.js                 1      0.090 ± 0.090 … 0.090        0.090 ± 0.090 … 0.090
Kraken      stanford-crypto-aes.js                      1      0.320 ± 0.320 … 0.320        0.320 ± 0.320 … 0.320
Kraken      stanford-crypto-ccm.js                      0.984  0.305 ± 0.300 … 0.310        0.310 ± 0.310 … 0.310
Kraken      stanford-crypto-pbkdf2.js                   0.982  0.550 ± 0.550 … 0.550        0.560 ± 0.560 … 0.560
Kraken      stanford-crypto-sha256-iterative.js         0.952  0.200 ± 0.200 … 0.200        0.210 ± 0.210 … 0.210
LongSpider  3d-cube.js                                  0.987  4.440 ± 4.430 … 4.450        4.500 ± 4.480 … 4.520
LongSpider  3d-morph.js                                 0.963  2.750 ± 2.740 … 2.760        2.855 ± 2.850 … 2.860
LongSpider  3d-raytrace.js                              0.984  4.180 ± 4.180 … 4.180        4.250 ± 4.250 … 4.250
LongSpider  access-binary-trees.js                      1.601  30.090 ± 29.880 … 30.300     18.795 ± 18.500 … 19.090
LongSpider  access-fannkuch.js                          1      3.465 ± 3.430 … 3.500        3.465 ± 3.450 … 3.480
LongSpider  access-nbody.js                             0.955  7.390 ± 7.390 … 7.390        7.735 ± 7.690 … 7.780
LongSpider  access-nsieve.js                            0.941  7.790 ± 7.780 … 7.800        8.280 ± 8.190 … 8.370
LongSpider  bitops-3bit-bits-in-byte.js                 0.993  0.735 ± 0.730 … 0.740        0.740 ± 0.730 … 0.750
LongSpider  bitops-bits-in-byte.js                      1.009  1.075 ± 1.060 … 1.090        1.065 ± 1.050 … 1.080
LongSpider  bitops-nsieve-bits.js                       0.983  2.890 ± 2.890 … 2.890        2.940 ± 2.930 … 2.950
LongSpider  controlflow-recursive.js                    0.985  14.985 ± 14.940 … 15.030     15.215 ± 15.080 … 15.350
LongSpider  crypto-aes.js                               1.004  8.445 ± 8.360 … 8.530        8.410 ± 8.360 … 8.460
LongSpider  crypto-md5.js                               1.006  9.680 ± 9.670 … 9.690        9.620 ± 9.590 … 9.650
LongSpider  crypto-sha1.js                              0.996  20.145 ± 19.960 … 20.330     20.225 ± 20.160 … 20.290
LongSpider  date-format-tofte.js                        0.972  3.945 ± 3.940 … 3.950        4.060 ± 4.060 … 4.060
LongSpider  date-format-xparb.js                        0.991  6.675 ± 6.650 … 6.700        6.735 ± 6.700 … 6.770
LongSpider  hash-map.js                                 1.05   1.590 ± 1.590 … 1.590        1.515 ± 1.510 … 1.520
LongSpider  math-cordic.js                              0.997  7.625 ± 7.610 … 7.640        7.645 ± 7.630 … 7.660
LongSpider  math-partial-sums.js                        1.015  1.015 ± 1.010 … 1.020        1.000 ± 1.000 … 1.000
LongSpider  math-spectral-norm.js                       1.001  9.025 ± 8.990 … 9.060        9.020 ± 9.010 … 9.030
LongSpider  string-base64.js                            0.99   1.950 ± 1.940 … 1.960        1.970 ± 1.950 … 1.990
LongSpider  string-fasta.js                             1.002  10.225 ± 10.180 … 10.270     10.200 ± 10.090 … 10.310
LongSpider  string-tagcloud.js                          1.005  2.030 ± 2.030 … 2.030        2.020 ± 2.020 … 2.020
MicroBench  array-destructuring-assignment-rest.js      0.967  0.445 ± 0.440 … 0.450        0.460 ± 0.460 … 0.460
MicroBench  array-destructuring-assignment.js           0.971  3.180 ± 3.110 … 3.250        3.275 ± 3.180 … 3.370
MicroBench  array-prototype-map.js                      1      1.330 ± 1.330 … 1.330        1.330 ± 1.330 … 1.330
MicroBench  array-prototype-shift.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
MicroBench  bound-call-00-args.js                       1.082  1.590 ± 1.560 … 1.620        1.470 ± 1.470 … 1.470
MicroBench  bound-call-04-args.js                       1.026  1.560 ± 1.540 … 1.580        1.520 ± 1.500 … 1.540
MicroBench  bound-call-16-args.js                       1.022  1.900 ± 1.890 … 1.910        1.860 ± 1.830 … 1.890
MicroBench  call-00-args.js                             1.114  1.520 ± 1.510 … 1.530        1.365 ± 1.360 … 1.370
MicroBench  call-01-args.js                             1.039  1.465 ± 1.460 … 1.470        1.410 ± 1.410 … 1.410
MicroBench  call-02-args.js                             1.099  1.550 ± 1.540 … 1.560        1.410 ± 1.410 … 1.410
MicroBench  call-03-args.js                             1.103  1.550 ± 1.550 … 1.550        1.405 ± 1.400 … 1.410
MicroBench  call-04-args.js                             1.091  1.560 ± 1.560 … 1.560        1.430 ± 1.430 … 1.430
MicroBench  call-16-args.js                             1.063  1.680 ± 1.670 … 1.690        1.580 ± 1.580 … 1.580
MicroBench  call-32-args.js                             1.063  1.930 ± 1.890 … 1.970        1.815 ± 1.810 … 1.820
MicroBench  for-in-indexed-properties.js                0.975  1.935 ± 1.930 … 1.940        1.985 ± 1.930 … 2.040
MicroBench  for-in-named-properties.js                  1.005  3.175 ± 3.140 … 3.210        3.160 ± 3.150 … 3.170
MicroBench  for-of.js                                   1      0.370 ± 0.370 … 0.370        0.370 ± 0.370 … 0.370
MicroBench  object-assign.js                            0.984  6.310 ± 6.290 … 6.330        6.415 ± 6.360 … 6.470
MicroBench  object-keys.js                              0.993  3.040 ± 3.030 … 3.050        3.060 ± 3.050 … 3.070
MicroBench  pic-get-own.js                              1.142  1.565 ± 1.540 … 1.590        1.370 ± 1.370 … 1.370
MicroBench  pic-get-pchain.js                           1.129  1.620 ± 1.620 … 1.620        1.435 ± 1.410 … 1.460
MicroBench  pic-put-own.js                              0.977  1.460 ± 1.440 … 1.480        1.495 ± 1.450 … 1.540
MicroBench  pic-put-pchain.js                           0.963  2.900 ± 2.870 … 2.930        3.010 ± 2.970 … 3.050
MicroBench  setter-in-prototype-chain.js                0.995  2.075 ± 2.070 … 2.080        2.085 ± 2.070 … 2.100
MicroBench  strictly-equals-object.js                   0.978  1.095 ± 1.080 … 1.110        1.120 ± 1.120 … 1.120
Octane      box2d.js                                    0.991  1.095 ± 1.090 … 1.100        1.105 ± 1.100 … 1.110
Octane      code-load.js                                1.002  2.025 ± 2.020 … 2.030        2.020 ± 2.020 … 2.020
Octane      crypto.js                                   1.01   5.135 ± 5.130 … 5.140        5.085 ± 5.050 … 5.120
Octane      deltablue.js                                1.002  2.015 ± 2.010 … 2.020        2.010 ± 2.010 … 2.010
Octane      earley-boyer.js                             1.179  8.730 ± 8.670 … 8.790        7.405 ± 7.400 … 7.410
Octane      gbemu.js                                    0.969  1.105 ± 1.100 … 1.110        1.140 ± 1.140 … 1.140
Octane      mandreel.js                                 0.998  7.035 ± 6.980 … 7.090        7.050 ± 7.030 … 7.070
Octane      navier-stokes.js                            0.99   2.025 ± 2.020 … 2.030        2.045 ± 2.040 … 2.050
Octane      pdfjs.js                                    0.956  1.185 ± 1.170 … 1.200        1.240 ± 1.220 … 1.260
Octane      raytrace.js                                 1.011  3.130 ± 3.120 … 3.140        3.095 ± 3.070 … 3.120
Octane      regexp.js                                   0.988  12.850 ± 12.840 … 12.860     13.010 ± 13.000 … 13.020
Octane      richards.js                                 1      2.010 ± 2.010 … 2.010        2.010 ± 2.010 … 2.010
Octane      splay.js                                    1      2.240 ± 2.240 … 2.240        2.240 ± 2.230 … 2.250
Octane      typescript.js                               1.123  10.985 ± 10.970 … 11.000     9.785 ± 9.780 … 9.790
Octane      zlib.js                                     1.015  49.100 ± 48.860 … 49.340     48.390 ± 47.970 … 48.810
SunSpider   3d-cube.js                                  1.333  0.020 ± 0.020 … 0.020        0.015 ± 0.010 … 0.020
SunSpider   3d-morph.js                                 1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   3d-raytrace.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-binary-trees.js                      1.5    0.030 ± 0.030 … 0.030        0.020 ± 0.020 … 0.020
SunSpider   access-fannkuch.js                          1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   access-nbody.js                             1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   access-nsieve.js                            1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-3bit-bits-in-byte.js                 1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bits-in-byte.js                      1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   bitops-bitwise-and.js                       1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   bitops-nsieve-bits.js                       1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   controlflow-recursive.js                    1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider   crypto-aes.js                               1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   crypto-md5.js                               1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                              1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                        1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider   date-format-xparb.js                        1.143  0.040 ± 0.040 … 0.040        0.035 ± 0.030 … 0.040
SunSpider   math-cordic.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   math-partial-sums.js                        1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   math-spectral-norm.js                       1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider   regexp-dna.js                               1.019  0.265 ± 0.260 … 0.270        0.260 ± 0.260 … 0.260
SunSpider   string-base64.js                            1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider   string-fasta.js                             1.1    0.110 ± 0.110 … 0.110        0.100 ± 0.100 … 0.100
SunSpider   string-tagcloud.js                          1.143  0.080 ± 0.080 … 0.080        0.070 ± 0.070 … 0.070
SunSpider   string-unpack-code.js                       1      0.090 ± 0.090 … 0.090        0.090 ± 0.090 … 0.090
SunSpider   string-validate-input.js                    1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
JetStream   Total                                       1.005  251.080                      249.915
JetStream3  Total                                       0.974  12.570                       12.910
Kraken      Total                                       0.986  12.355                       12.525
LongSpider  Total                                       1.065  162.140                      152.260
MicroBench  Total                                       1.021  46.815                       45.845
Octane      Total                                       1.028  110.665                      107.630
SunSpider   Total                                       1.048  0.985                        0.940
All Suites  Total                                       1.025  596.610                      582.025
```