### PR TITLE
AK: Add Optional<T>::ensure() 

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
+ * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -121,6 +122,14 @@ public:
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
         return TRY(callback());
+    }
+
+    template<typename Callable>
+    [[nodiscard]] ALWAYS_INLINE constexpr T& ensure(Callable callable) &
+    {
+        if (!static_cast<Self&>(*this).has_value())
+            static_cast<Self&>(*this) = callable();
+        return static_cast<Self&>(*this).value();
     }
 
     [[nodiscard]] ALWAYS_INLINE constexpr T const& operator*() const { return static_cast<Self const&>(*this).value(); }
@@ -602,6 +611,14 @@ public:
         if (m_pointer != nullptr)
             return value();
         return TRY(callback());
+    }
+
+    template<typename Callback>
+    [[nodiscard]] ALWAYS_INLINE constexpr T ensure(Callback callback) &
+    {
+        if (m_pointer == nullptr)
+            m_pointer = &callback();
+        return *m_pointer;
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -360,13 +360,11 @@ FLATTEN SignedBigInteger SignedBigInteger::negated_value() const
 
 u32 SignedBigInteger::hash() const
 {
-    if (m_hash.has_value())
-        return *m_hash;
-
-    auto buffer = MUST(ByteBuffer::create_zeroed(byte_length()));
-    auto result = export_data(buffer);
-    m_hash = string_hash(reinterpret_cast<char const*>(result.data()), result.size());
-    return *m_hash;
+    return m_hash.ensure([&] {
+        auto buffer = MUST(ByteBuffer::create_zeroed(byte_length()));
+        auto result = export_data(buffer);
+        return string_hash(reinterpret_cast<char const*>(result.data()), result.size());
+    });
 }
 
 bool SignedBigInteger::operator==(SignedBigInteger const& other) const

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -359,13 +359,11 @@ FLATTEN UnsignedBigInteger UnsignedBigInteger::lcm(UnsignedBigInteger const& oth
 
 u32 UnsignedBigInteger::hash() const
 {
-    if (m_hash.has_value())
-        return *m_hash;
-
-    auto buffer = MUST(ByteBuffer::create_zeroed(byte_length()));
-    auto result = export_data(buffer);
-    m_hash = string_hash(reinterpret_cast<char const*>(result.data()), result.size());
-    return *m_hash;
+    return m_hash.ensure([&] {
+        auto buffer = MUST(ByteBuffer::create_zeroed(byte_length()));
+        auto result = export_data(buffer);
+        return string_hash(reinterpret_cast<char const*>(result.data()), result.size());
+    });
 }
 
 bool UnsignedBigInteger::operator==(UnsignedBigInteger const& other) const

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -114,12 +114,11 @@ void TypefaceSkia::populate_glyph_page(GlyphPage& glyph_page, size_t page_index)
 
 FlyString const& TypefaceSkia::family() const
 {
-    if (!m_family.has_value()) {
+    return m_family.ensure([&] {
         SkString family_name;
         impl().skia_typeface->getFamilyName(&family_name);
-        m_family = FlyString::from_utf8_without_validation(ReadonlyBytes { family_name.c_str(), family_name.size() });
-    }
-    return m_family.value();
+        return FlyString::from_utf8_without_validation(ReadonlyBytes { family_name.c_str(), family_name.size() });
+    });
 }
 
 u16 TypefaceSkia::weight() const

--- a/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -38,9 +38,7 @@ Locale::Locale(Object& prototype)
 
 Unicode::LocaleID const& Locale::locale_id() const
 {
-    if (!m_cached_locale_id.has_value())
-        m_cached_locale_id = Unicode::parse_unicode_locale_id(locale());
-    return *m_cached_locale_id;
+    return m_cached_locale_id.ensure([&] { return Unicode::parse_unicode_locale_id(locale()); });
 }
 
 // 15.5.5 GetLocaleVariants ( locale ), https://tc39.es/ecma402/#sec-getlocalevariants

--- a/Libraries/LibTest/TestRunner.h
+++ b/Libraries/LibTest/TestRunner.h
@@ -53,9 +53,7 @@ public:
 
     Vector<Test::Suite>& ensure_suites()
     {
-        if (!m_suites.has_value())
-            m_suites = Vector<Suite> {};
-        return *m_suites;
+        return m_suites.ensure([] { return Vector<Suite> {}; });
     }
 
 protected:

--- a/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Libraries/LibWasm/WASI/Wasi.cpp
@@ -315,41 +315,29 @@ static FDFlags fd_flags_of(struct stat const& buf);
 
 Vector<AK::String> const& Implementation::arguments() const
 {
-    if (!cache.cached_arguments.has_value()) {
-        cache.cached_arguments.lazy_emplace([&] {
-            if (provide_arguments)
-                return provide_arguments();
-            return Vector<AK::String> {};
-        });
-    }
-
-    return *cache.cached_arguments;
+    return cache.cached_arguments.ensure([&] {
+        if (provide_arguments)
+            return provide_arguments();
+        return Vector<AK::String> {};
+    });
 }
 
 Vector<AK::String> const& Implementation::environment() const
 {
-    if (!cache.cached_environment.has_value()) {
-        cache.cached_environment.lazy_emplace([&] {
-            if (provide_environment)
-                return provide_environment();
-            return Vector<AK::String> {};
-        });
-    }
-
-    return *cache.cached_environment;
+    return cache.cached_environment.ensure([&] {
+        if (provide_environment)
+            return provide_environment();
+        return Vector<AK::String> {};
+    });
 }
 
 Vector<Implementation::MappedPath> const& Implementation::preopened_directories() const
 {
-    if (!cache.cached_preopened_directories.has_value()) {
-        cache.cached_preopened_directories.lazy_emplace([&] {
-            if (provide_preopened_directories)
-                return provide_preopened_directories();
-            return Vector<MappedPath> {};
-        });
-    }
-
-    return *cache.cached_preopened_directories;
+    return cache.cached_preopened_directories.ensure([&] {
+        if (provide_preopened_directories)
+            return provide_preopened_directories();
+        return Vector<MappedPath> {};
+    });
 }
 
 Implementation::Descriptor Implementation::map_fd(FD fd)

--- a/Libraries/LibWeb/CSS/CSSRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSRule.cpp
@@ -72,7 +72,7 @@ void CSSRule::clear_caches()
     m_cached_layer_name.clear();
 }
 
-FlyString const& CSSRule::parent_layer_internal_qualified_name_slow_case() const
+FlyString CSSRule::parent_layer_internal_qualified_name_slow_case() const
 {
     Vector<FlyString> layer_names;
     for (auto* rule = parent_rule(); rule; rule = rule->parent_rule()) {
@@ -105,8 +105,7 @@ FlyString const& CSSRule::parent_layer_internal_qualified_name_slow_case() const
         }
     }
 
-    m_cached_layer_name = MUST(String::join("."sv, layer_names.in_reverse()));
-    return m_cached_layer_name.value();
+    return MUST(String::join('.', layer_names.in_reverse()));
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSRule.h
+++ b/Libraries/LibWeb/CSS/CSSRule.h
@@ -70,12 +70,10 @@ protected:
 
     [[nodiscard]] FlyString const& parent_layer_internal_qualified_name() const
     {
-        if (!m_cached_layer_name.has_value())
-            return parent_layer_internal_qualified_name_slow_case();
-        return m_cached_layer_name.value();
+        return m_cached_layer_name.ensure([&] { return parent_layer_internal_qualified_name_slow_case(); });
     }
 
-    [[nodiscard]] FlyString const& parent_layer_internal_qualified_name_slow_case() const;
+    [[nodiscard]] FlyString parent_layer_internal_qualified_name_slow_case() const;
 
     Type m_type;
     GC::Ptr<CSSRule> m_parent_rule;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4053,9 +4053,7 @@ GC::Ptr<NamedNodeMap const> Element::attributes() const
 
 FlyString const& Element::html_uppercased_qualified_name() const
 {
-    if (!m_html_uppercased_qualified_name.has_value())
-        m_html_uppercased_qualified_name = make_html_uppercased_qualified_name();
-    return m_html_uppercased_qualified_name.value();
+    return m_html_uppercased_qualified_name.ensure([&] { return make_html_uppercased_qualified_name(); });
 }
 
 void Element::play_or_cancel_animations_after_display_property_change()

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -213,9 +213,7 @@ void HTMLTextAreaElement::set_raw_value(Utf16String value)
 Utf16String HTMLTextAreaElement::api_value() const
 {
     // The algorithm for obtaining the element's API value is to return the element's raw value, with newlines normalized.
-    if (!m_api_value.has_value())
-        m_api_value = Infra::normalize_newlines(m_raw_value);
-    return *m_api_value;
+    return m_api_value.ensure([&] { return Infra::normalize_newlines(m_raw_value); });
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value

--- a/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
+++ b/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
@@ -21,15 +21,14 @@ bool ListOfAvailableImages::Key::operator==(Key const& other) const
 
 u32 ListOfAvailableImages::Key::hash() const
 {
-    if (!cached_hash.has_value()) {
+    return cached_hash.ensure([&] {
         u32 url_hash = url.hash();
         u32 mode_hash = static_cast<u32>(mode);
         u32 origin_hash = 0;
         if (origin.has_value())
             origin_hash = Traits<URL::Origin>::hash(origin.value());
-        cached_hash = pair_int_hash(url_hash, pair_int_hash(mode_hash, origin_hash));
-    }
-    return cached_hash.value();
+        return pair_int_hash(url_hash, pair_int_hash(mode_hash, origin_hash));
+    });
 }
 
 void ListOfAvailableImages::visit_edges(JS::Cell::Visitor& visitor)

--- a/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -45,11 +45,9 @@ void ImageBox::prepare_for_replaced_layout()
             set_natural_height(0);
         } else {
             auto font = Platform::FontPlugin::the().default_font(12);
-            CSSPixels alt_text_width = 0;
-            if (!m_cached_alt_text_width.has_value())
-                m_cached_alt_text_width = CSSPixels::nearest_value_for(font->width(alt));
-            alt_text_width = m_cached_alt_text_width.value();
-
+            CSSPixels alt_text_width = m_cached_alt_text_width.ensure([&] {
+                return CSSPixels::nearest_value_for(font->width(alt));
+            });
             set_natural_width(alt_text_width + 16);
             set_natural_height(CSSPixels::nearest_value_for(font->pixel_size()) + 16);
         }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -68,14 +68,12 @@ CSS::Display Paintable::display() const
 
 PaintableBox* Paintable::containing_block() const
 {
-    if (!m_containing_block.has_value()) {
+    return m_containing_block.ensure([&] -> GC::Ptr<PaintableBox> {
         auto containing_layout_box = m_layout_node->containing_block();
-        if (containing_layout_box)
-            m_containing_block = const_cast<PaintableBox*>(containing_layout_box->paintable_box());
-        else
-            m_containing_block = nullptr;
-    }
-    return *m_containing_block;
+        if (!containing_layout_box)
+            return nullptr;
+        return const_cast<PaintableBox*>(containing_layout_box->paintable_box());
+    });
 }
 
 CSS::ImmutableComputedValues const& Paintable::computed_values() const

--- a/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -24,13 +24,12 @@ public:
 
     CSSPixelPoint cumulative_offset() const
     {
-        if (!m_cached_cumulative_offset.has_value()) {
-            m_cached_cumulative_offset = m_own_offset;
-            if (m_parent) {
-                m_cached_cumulative_offset.value() += m_parent->cumulative_offset();
-            }
-        }
-        return m_cached_cumulative_offset.value();
+        return m_cached_cumulative_offset.ensure([&] {
+            auto offset = m_own_offset;
+            if (m_parent)
+                offset += m_parent->cumulative_offset();
+            return offset;
+        });
     }
 
     CSSPixelPoint own_offset() const { return m_own_offset; }


### PR DESCRIPTION
We often use Optional<T> in a cache pattern such as:

```cpp
  if (!m_cache.has_value())
      m_cache = slow_thing();
  return m_cache.value();
```

The new ::ensure() makes it a bit simpler:

```cpp
  return m_cache.ensure([&] { return slow_thing(); });
```