### PR TITLE
LibWebView+UI: A couple menu fixes and improvements, and generate the Inspect menu

### DIFF
--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -212,9 +212,12 @@ Optional<String> get_registrable_domain(StringView host);
 
 inline URL about_blank() { return URL::about("blank"_string); }
 inline URL about_srcdoc() { return URL::about("srcdoc"_string); }
+
 inline URL about_error() { return URL::about("error"_string); }
-inline URL about_version() { return URL::about("version"_string); }
 inline URL about_newtab() { return URL::about("newtab"_string); }
+inline URL about_processes() { return URL::about("processes"_string); }
+inline URL about_settings() { return URL::about("settings"_string); }
+inline URL about_version() { return URL::about("version"_string); }
 
 }
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -278,6 +278,12 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     return {};
 }
 
+void Application::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTab activate_tab) const
+{
+    if (auto view = open_blank_new_tab(activate_tab); view.has_value())
+        view->load(url);
+}
+
 static ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&> view)
 {
     auto request_server_socket = TRY(connect_new_request_server_client());

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -679,19 +679,8 @@ void Application::initialize_actions()
     m_open_about_page_action = Action::create("About Ladybird"sv, ActionID::OpenAboutPage, [this]() {
         open_url_in_new_tab(URL::about_version(), Web::HTML::ActivateTab::Yes);
     });
-    m_open_processes_page_action = Action::create("Open Task Manager"sv, ActionID::OpenProcessesPage, [this]() {
-        open_url_in_new_tab(URL::about_processes(), Web::HTML::ActivateTab::Yes);
-    });
     m_open_settings_page_action = Action::create("Settings"sv, ActionID::OpenSettingsPage, [this]() {
         open_url_in_new_tab(URL::about_settings(), Web::HTML::ActivateTab::Yes);
-    });
-    m_toggle_devtools_action = Action::create("Enable DevTools"sv, ActionID::ToggleDevTools, [this]() {
-        if (auto result = toggle_devtools_enabled(); result.is_error())
-            display_error_dialog(MUST(String::formatted("Unable to start DevTools: {}", result.error())));
-    });
-    m_view_source_action = Action::create("View Source"sv, ActionID::ViewSource, [this]() {
-        if (auto view = active_web_view(); view.has_value())
-            view->get_source();
     });
 
     m_zoom_menu = Menu::create_group("Zoom"sv);
@@ -762,8 +751,25 @@ void Application::initialize_actions()
     m_motion_menu->add_action(Action::create_checkable("No Preference"sv, ActionID::PreferredMotion, set_motion(Web::CSS::PreferredMotion::NoPreference)));
     m_motion_menu->items().first().get<NonnullRefPtr<Action>>()->set_checked(true);
 
-    m_debug_menu = Menu::create("Debug"sv);
+    m_inspect_menu = Menu::create("Inspect"sv);
 
+    m_view_source_action = Action::create("View Source"sv, ActionID::ViewSource, [this]() {
+        if (auto view = active_web_view(); view.has_value())
+            view->get_source();
+    });
+    m_inspect_menu->add_action(*m_view_source_action);
+
+    m_inspect_menu->add_action(Action::create("Open Task Manager"sv, ActionID::OpenProcessesPage, [this]() {
+        open_url_in_new_tab(URL::about_processes(), Web::HTML::ActivateTab::Yes);
+    }));
+
+    m_toggle_devtools_action = Action::create("Enable DevTools"sv, ActionID::ToggleDevTools, [this]() {
+        if (auto result = toggle_devtools_enabled(); result.is_error())
+            display_error_dialog(MUST(String::formatted("Unable to start DevTools: {}", result.error())));
+    });
+    m_inspect_menu->add_action(*m_toggle_devtools_action);
+
+    m_debug_menu = Menu::create("Debug"sv);
     m_debug_menu->add_action(Action::create("Dump Session History Tree"sv, ActionID::DumpSessionHistoryTree, debug_request("dump-session-history"sv)));
     m_debug_menu->add_action(Action::create("Dump DOM Tree"sv, ActionID::DumpDOMTree, debug_request("dump-dom-tree"sv)));
     m_debug_menu->add_action(Action::create("Dump Layout Tree"sv, ActionID::DumpLayoutTree, debug_request("dump-layout-tree"sv)));

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -674,6 +674,15 @@ void Application::initialize_actions()
             view->select_all();
     });
 
+    m_open_about_page_action = Action::create("About Ladybird"sv, ActionID::OpenAboutPage, [this]() {
+        open_url_in_new_tab(URL::about_version(), Web::HTML::ActivateTab::Yes);
+    });
+    m_open_processes_page_action = Action::create("Open Task Manager"sv, ActionID::OpenProcessesPage, [this]() {
+        open_url_in_new_tab(URL::about_processes(), Web::HTML::ActivateTab::Yes);
+    });
+    m_open_settings_page_action = Action::create("Settings"sv, ActionID::OpenSettingsPage, [this]() {
+        open_url_in_new_tab(URL::about_settings(), Web::HTML::ActivateTab::Yes);
+    });
     m_view_source_action = Action::create("View Source"sv, ActionID::ViewSource, [this]() {
         if (auto view = active_web_view(); view.has_value())
             view->get_source();

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -79,6 +79,10 @@ public:
     Action& copy_selection_action() { return *m_copy_selection_action; }
     Action& paste_action() { return *m_paste_action; }
     Action& select_all_action() { return *m_select_all_action; }
+
+    Action& open_about_page_action() { return *m_open_about_page_action; }
+    Action& open_processes_page_action() { return *m_open_processes_page_action; }
+    Action& open_settings_page_action() { return *m_open_settings_page_action; }
     Action& view_source_action() { return *m_view_source_action; }
 
     Menu& zoom_menu() { return *m_zoom_menu; }
@@ -181,6 +185,10 @@ private:
     RefPtr<Action> m_copy_selection_action;
     RefPtr<Action> m_paste_action;
     RefPtr<Action> m_select_all_action;
+
+    RefPtr<Action> m_open_about_page_action;
+    RefPtr<Action> m_open_processes_page_action;
+    RefPtr<Action> m_open_settings_page_action;
     RefPtr<Action> m_view_source_action;
 
     RefPtr<Menu> m_zoom_menu;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -81,10 +81,7 @@ public:
     Action& select_all_action() { return *m_select_all_action; }
 
     Action& open_about_page_action() { return *m_open_about_page_action; }
-    Action& open_processes_page_action() { return *m_open_processes_page_action; }
     Action& open_settings_page_action() { return *m_open_settings_page_action; }
-    Action& toggle_devtools_action() { return *m_toggle_devtools_action; }
-    Action& view_source_action() { return *m_view_source_action; }
 
     Menu& zoom_menu() { return *m_zoom_menu; }
     Action& reset_zoom_action() { return *m_reset_zoom_action; }
@@ -92,6 +89,10 @@ public:
     Menu& color_scheme_menu() { return *m_color_scheme_menu; }
     Menu& contrast_menu() { return *m_contrast_menu; }
     Menu& motion_menu() { return *m_motion_menu; }
+
+    Menu& inspect_menu() { return *m_inspect_menu; }
+    Action& view_source_action() { return *m_view_source_action; }
+
     Menu& debug_menu() { return *m_debug_menu; }
 
     void apply_view_options(Badge<ViewImplementation>, ViewImplementation&);
@@ -187,10 +188,7 @@ private:
     RefPtr<Action> m_select_all_action;
 
     RefPtr<Action> m_open_about_page_action;
-    RefPtr<Action> m_open_processes_page_action;
     RefPtr<Action> m_open_settings_page_action;
-    RefPtr<Action> m_toggle_devtools_action;
-    RefPtr<Action> m_view_source_action;
 
     RefPtr<Menu> m_zoom_menu;
     RefPtr<Action> m_reset_zoom_action;
@@ -203,6 +201,10 @@ private:
 
     RefPtr<Menu> m_motion_menu;
     Web::CSS::PreferredMotion m_motion { Web::CSS::PreferredMotion::Auto };
+
+    RefPtr<Menu> m_inspect_menu;
+    RefPtr<Action> m_view_source_action;
+    RefPtr<Action> m_toggle_devtools_action;
 
     RefPtr<Menu> m_debug_menu;
     RefPtr<Action> m_show_line_box_borders_action;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -83,6 +83,7 @@ public:
     Action& open_about_page_action() { return *m_open_about_page_action; }
     Action& open_processes_page_action() { return *m_open_processes_page_action; }
     Action& open_settings_page_action() { return *m_open_settings_page_action; }
+    Action& toggle_devtools_action() { return *m_toggle_devtools_action; }
     Action& view_source_action() { return *m_view_source_action; }
 
     Menu& zoom_menu() { return *m_zoom_menu; }
@@ -95,11 +96,7 @@ public:
 
     void apply_view_options(Badge<ViewImplementation>, ViewImplementation&);
 
-    enum class DevtoolsState {
-        Disabled,
-        Enabled,
-    };
-    ErrorOr<DevtoolsState> toggle_devtools_enabled();
+    ErrorOr<void> toggle_devtools_enabled();
     void refresh_tab_list();
 
 protected:
@@ -114,6 +111,9 @@ protected:
     virtual NonnullOwnPtr<Core::EventLoop> create_platform_event_loop();
 
     virtual Optional<ByteString> ask_user_for_download_folder() const { return {}; }
+
+    virtual void on_devtools_enabled() const;
+    virtual void on_devtools_disabled() const;
 
     Main::Arguments& arguments() { return m_arguments; }
 
@@ -189,6 +189,7 @@ private:
     RefPtr<Action> m_open_about_page_action;
     RefPtr<Action> m_open_processes_page_action;
     RefPtr<Action> m_open_settings_page_action;
+    RefPtr<Action> m_toggle_devtools_action;
     RefPtr<Action> m_view_source_action;
 
     RefPtr<Menu> m_zoom_menu;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -21,6 +21,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
+#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Options.h>
 #include <LibWebView/Process.h>
@@ -56,7 +57,10 @@ public:
     static ProcessManager& process_manager() { return *the().m_process_manager; }
 
     ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
+
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
+    virtual Optional<ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const { return {}; }
+    void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
 
     void add_child_process(Process&&);
 

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -39,6 +39,7 @@ enum class ActionID {
     OpenAboutPage,
     OpenProcessesPage,
     OpenSettingsPage,
+    ToggleDevTools,
     ViewSource,
 
     OpenInNewTab,

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -36,6 +36,9 @@ enum class ActionID {
     TakeVisibleScreenshot,
     TakeFullScreenshot,
 
+    OpenAboutPage,
+    OpenProcessesPage,
+    OpenSettingsPage,
     ViewSource,
 
     OpenInNewTab,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -158,11 +158,6 @@ void ViewImplementation::load_html(StringView html)
     client().async_load_html(page_id(), html);
 }
 
-void ViewImplementation::load_empty_document()
-{
-    load_html(""sv);
-}
-
 void ViewImplementation::reload()
 {
     client().async_reload(page_id());
@@ -834,8 +829,7 @@ void ViewImplementation::initialize_context_menus()
         auto url = URL::Parser::basic_parse(url_string);
         VERIFY(url.has_value());
 
-        if (on_link_click)
-            on_link_click(*url, "_blank"sv, 0);
+        Application::the().open_url_in_new_tab(*url, Web::HTML::ActivateTab::Yes);
     });
     m_search_selected_text_action->set_visible(false);
 
@@ -861,16 +855,14 @@ void ViewImplementation::initialize_context_menus()
     });
 
     m_open_in_new_tab_action = Action::create("Open in New Tab"sv, ActionID::OpenInNewTab, [this]() {
-        if (on_link_click)
-            on_link_click(m_context_menu_url, {}, Web::UIEvents::Mod_PlatformCtrl);
+        Application::the().open_url_in_new_tab(m_context_menu_url, Web::HTML::ActivateTab::No);
     });
     m_copy_url_action = Action::create("Copy URL"sv, ActionID::CopyURL, [this]() {
         insert_text_into_clipboard(url_text_to_copy(m_context_menu_url));
     });
 
     m_open_image_action = Action::create("Open Image"sv, ActionID::OpenImage, [this]() {
-        if (on_link_click)
-            on_link_click(m_context_menu_url, {}, {});
+        load(m_context_menu_url);
     });
     m_copy_image_action = Action::create("Copy Image"sv, ActionID::CopyImage, [this]() {
         if (!m_image_context_menu_bitmap.has_value())
@@ -889,12 +881,10 @@ void ViewImplementation::initialize_context_menus()
     });
 
     m_open_audio_action = Action::create("Open Audio"sv, ActionID::OpenAudio, [this]() {
-        if (on_link_click)
-            on_link_click(m_context_menu_url, {}, {});
+        load(m_context_menu_url);
     });
     m_open_video_action = Action::create("Open Video"sv, ActionID::OpenVideo, [this]() {
-        if (on_link_click)
-            on_link_click(m_context_menu_url, {}, {});
+        load(m_context_menu_url);
     });
     m_media_play_action = Action::create("Play"sv, ActionID::PlayMedia, [this]() {
         client().async_toggle_media_play_state(page_id());

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -63,7 +63,6 @@ public:
 
     void load(URL::URL const&);
     void load_html(StringView);
-    void load_empty_document();
     void reload();
     void traverse_the_history_by_delta(int delta);
 
@@ -172,8 +171,6 @@ public:
     Function<void()> on_close;
     Function<void(URL::URL const&)> on_link_hover;
     Function<void()> on_link_unhover;
-    Function<void(URL::URL const&, ByteString const& target, unsigned modifiers)> on_link_click;
-    Function<void(URL::URL const&, ByteString const& target, unsigned modifiers)> on_link_middle_click;
     Function<void(Utf16String const&)> on_title_change;
     Function<void(URL::URL const&)> on_url_change;
     Function<void(URL::URL const&, bool)> on_load_start;
@@ -191,7 +188,6 @@ public:
     Function<void(String const& message)> on_request_set_prompt_text;
     Function<void()> on_request_accept_dialog;
     Function<void()> on_request_dismiss_dialog;
-    Function<void(URL::URL const&, URL::URL const&, String const&)> on_received_source;
     Function<void(JsonObject)> on_received_dom_tree;
     Function<void(DOMNodeProperties)> on_received_dom_node_properties;
     Function<void(JsonObject)> on_received_accessibility_tree;

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -21,6 +21,7 @@ private:
     virtual NonnullOwnPtr<Core::EventLoop> create_platform_event_loop() override;
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
+    virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
 
     virtual Optional<ByteString> ask_user_for_download_folder() const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -26,6 +26,9 @@ private:
     virtual Optional<ByteString> ask_user_for_download_folder() const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
+
+    virtual void on_devtools_enabled() const override;
+    virtual void on_devtools_disabled() const override;
 };
 
 }

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -13,6 +13,7 @@
 #import <Application/ApplicationDelegate.h>
 #import <Interface/LadybirdWebView.h>
 #import <Interface/Tab.h>
+#import <Interface/TabController.h>
 
 #if !__has_feature(objc_arc)
 #    error "This project requires ARC"
@@ -39,6 +40,16 @@ Optional<WebView::ViewImplementation&> Application::active_web_view() const
     if (auto* tab = [delegate activeTab])
         return [[tab web_view] view];
     return {};
+}
+
+Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML::ActivateTab activate_tab) const
+{
+    ApplicationDelegate* delegate = [NSApp delegate];
+
+    auto* controller = [delegate createNewTab:activate_tab fromTab:[delegate activeTab]];
+    auto* tab = (Tab*)[controller window];
+
+    return [[tab web_view] view];
 }
 
 Optional<ByteString> Application::ask_user_for_download_folder() const

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -98,6 +98,22 @@ void Application::display_error_dialog(StringView error_message) const
                    completionHandler:nil];
 }
 
+void Application::on_devtools_enabled() const
+{
+    WebView::Application::on_devtools_enabled();
+
+    ApplicationDelegate* delegate = [NSApp delegate];
+    [delegate onDevtoolsEnabled];
+}
+
+void Application::on_devtools_disabled() const
+{
+    WebView::Application::on_devtools_disabled();
+
+    ApplicationDelegate* delegate = [NSApp delegate];
+    [delegate onDevtoolsDisabled];
+}
+
 }
 
 @interface Application ()

--- a/UI/AppKit/Application/ApplicationDelegate.h
+++ b/UI/AppKit/Application/ApplicationDelegate.h
@@ -20,12 +20,10 @@
 
 - (nullable instancetype)init;
 
-- (nonnull TabController*)createNewTab:(Optional<URL::URL> const&)url
-                               fromTab:(nullable Tab*)tab
-                           activateTab:(Web::HTML::ActivateTab)activate_tab;
+- (nonnull TabController*)createNewTab:(Web::HTML::ActivateTab)activate_tab
+                               fromTab:(nullable Tab*)tab;
 
-- (nonnull TabController*)createNewTab:(StringView)html
-                                   url:(URL::URL const&)url
+- (nonnull TabController*)createNewTab:(Optional<URL::URL> const&)url
                                fromTab:(nullable Tab*)tab
                            activateTab:(Web::HTML::ActivateTab)activate_tab;
 

--- a/UI/AppKit/Application/ApplicationDelegate.h
+++ b/UI/AppKit/Application/ApplicationDelegate.h
@@ -37,4 +37,7 @@
 
 - (void)removeTab:(nonnull TabController*)controller;
 
+- (void)onDevtoolsEnabled;
+- (void)onDevtoolsDisabled;
+
 @end

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -67,6 +67,17 @@
 
 #pragma mark - Public methods
 
+- (nonnull TabController*)createNewTab:(Web::HTML::ActivateTab)activate_tab
+                               fromTab:(nullable Tab*)tab
+{
+    auto* controller = [[TabController alloc] init];
+    [self initializeTabController:controller
+                      activateTab:activate_tab
+                          fromTab:tab];
+
+    return controller;
+}
+
 - (TabController*)createNewTab:(Optional<URL::URL> const&)url
                        fromTab:(Tab*)tab
                    activateTab:(Web::HTML::ActivateTab)activate_tab
@@ -76,17 +87,6 @@
     if (url.has_value()) {
         [controller loadURL:*url];
     }
-
-    return controller;
-}
-
-- (nonnull TabController*)createNewTab:(StringView)html
-                                   url:(URL::URL const&)url
-                               fromTab:(nullable Tab*)tab
-                           activateTab:(Web::HTML::ActivateTab)activate_tab
-{
-    auto* controller = [self createNewTab:activate_tab fromTab:tab];
-    [controller loadHTML:html url:url];
 
     return controller;
 }
@@ -162,17 +162,6 @@
 
     auto* controller = (TabController*)[current_tab windowController];
     [controller focusLocationToolbarItem];
-}
-
-- (nonnull TabController*)createNewTab:(Web::HTML::ActivateTab)activate_tab
-                               fromTab:(nullable Tab*)tab
-{
-    auto* controller = [[TabController alloc] init];
-    [self initializeTabController:controller
-                      activateTab:activate_tab
-                          fromTab:tab];
-
-    return controller;
 }
 
 - (nonnull TabController*)createChildTab:(Web::HTML::ActivateTab)activate_tab

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -126,32 +126,6 @@
 
 #pragma mark - Private methods
 
-- (void)openAboutVersionPage:(id)sender
-{
-    auto* current_tab = [NSApp keyWindow];
-    if (![current_tab isKindOfClass:[Tab class]]) {
-        return;
-    }
-
-    [self createNewTab:URL::URL(URL::about_version())
-               fromTab:(Tab*)current_tab
-           activateTab:Web::HTML::ActivateTab::Yes];
-}
-
-- (void)openSettings:(id)sender
-{
-    [self createNewTab:URL::URL::about("settings"_string)
-               fromTab:self.active_tab
-           activateTab:Web::HTML::ActivateTab::Yes];
-}
-
-- (void)openTaskManager:(id)sender
-{
-    [self createNewTab:URL::URL::about("processes"_string)
-               fromTab:self.active_tab
-           activateTab:Web::HTML::ActivateTab::Yes];
-}
-
 - (void)openLocation:(id)sender
 {
     auto* current_tab = [NSApp keyWindow];
@@ -269,14 +243,10 @@
     auto* process_name = [[NSProcessInfo processInfo] processName];
     auto* submenu = [[NSMenu alloc] initWithTitle:process_name];
 
-    [submenu addItem:[[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:@"About %@", process_name]
-                                                action:@selector(openAboutVersionPage:)
-                                         keyEquivalent:@""]];
+    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().open_about_page_action())];
     [submenu addItem:[NSMenuItem separatorItem]];
 
-    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Settings"
-                                                action:@selector(openSettings:)
-                                         keyEquivalent:@","]];
+    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().open_settings_page_action())];
     [submenu addItem:[NSMenuItem separatorItem]];
 
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:@"Hide %@", process_name]
@@ -424,9 +394,7 @@
                                                          keyEquivalent:@"I"];
     [submenu addItem:self.toggle_devtools_menu_item];
 
-    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Open Task Manager"
-                                                action:@selector(openTaskManager:)
-                                         keyEquivalent:@"M"]];
+    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().open_processes_page_action())];
 
     [menu setSubmenu:submenu];
     return menu;

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -356,13 +356,10 @@
 - (NSMenuItem*)createInspectMenu
 {
     auto* menu = [[NSMenuItem alloc] init];
-    auto* submenu = [[NSMenu alloc] initWithTitle:@"Inspect"];
 
-    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().view_source_action())];
-    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().toggle_devtools_action())];
-    [submenu addItem:Ladybird::create_application_menu_item(WebView::Application::the().open_processes_page_action())];
-
+    auto* submenu = Ladybird::create_application_menu(WebView::Application::the().inspect_menu());
     [menu setSubmenu:submenu];
+
     return menu;
 }
 

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -21,15 +21,10 @@
 - (String const&)onCreateNewTab:(Optional<URL::URL> const&)url
                     activateTab:(Web::HTML::ActivateTab)activate_tab;
 
-- (String const&)onCreateNewTab:(StringView)html
-                            url:(URL::URL const&)url
-                    activateTab:(Web::HTML::ActivateTab)activate_tab;
-
 - (String const&)onCreateChildTab:(Optional<URL::URL> const&)url
                       activateTab:(Web::HTML::ActivateTab)activate_tab
                         pageIndex:(u64)page_index;
 
-- (void)loadURL:(URL::URL const&)url;
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)is_redirect;
 - (void)onLoadFinish:(URL::URL const&)url;
 
@@ -51,7 +46,6 @@
                   pageIndex:(u64)page_index;
 
 - (void)loadURL:(URL::URL const&)url;
-- (void)loadHTML:(StringView)html;
 
 - (WebView::ViewImplementation&)view;
 - (String const&)handle;

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -144,6 +144,17 @@ static void initialize_native_control(WebView::Action& action, id control)
         set_control_image(control, @"magnifyingglass");
         break;
 
+    case WebView::ActionID::OpenAboutPage:
+        set_control_image(control, @"info.circle");
+        break;
+    case WebView::ActionID::OpenProcessesPage:
+        set_control_image(control, @"gearshape.2");
+        [control setKeyEquivalent:@"M"];
+        break;
+    case WebView::ActionID::OpenSettingsPage:
+        set_control_image(control, @"gearshape");
+        [control setKeyEquivalent:@","];
+        break;
     case WebView::ActionID::ViewSource:
         set_control_image(control, @"text.document");
         [control setKeyEquivalent:@"u"];

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -155,6 +155,10 @@ static void initialize_native_control(WebView::Action& action, id control)
         set_control_image(control, @"gearshape");
         [control setKeyEquivalent:@","];
         break;
+    case WebView::ActionID::ToggleDevTools:
+        set_control_image(control, @"chevron.left.chevron.right");
+        [control setKeyEquivalent:@"I"];
+        break;
     case WebView::ActionID::ViewSource:
         set_control_image(control, @"text.document");
         [control setKeyEquivalent:@"u"];

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -197,12 +197,15 @@ static void initialize_native_control(WebView::Action& action, id control)
         break;
 
     case WebView::ActionID::ZoomIn:
+        set_control_image(control, @"plus.magnifyingglass");
         [control setKeyEquivalent:@"+"];
         break;
     case WebView::ActionID::ZoomOut:
+        set_control_image(control, @"minus.magnifyingglass");
         [control setKeyEquivalent:@"-"];
         break;
     case WebView::ActionID::ResetZoom:
+        set_control_image(control, @"1.magnifyingglass");
         [control setKeyEquivalent:@"0"];
         break;
 

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -231,21 +231,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     return [[tab web_view] handle];
 }
 
-- (String const&)onCreateNewTab:(StringView)html
-                            url:(URL::URL const&)url
-                    activateTab:(Web::HTML::ActivateTab)activate_tab
-{
-    auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-
-    auto* controller = [delegate createNewTab:html
-                                          url:url
-                                      fromTab:self
-                                  activateTab:activate_tab];
-
-    auto* tab = (Tab*)[controller window];
-    return [[tab web_view] handle];
-}
-
 - (String const&)onCreateChildTab:(Optional<URL::URL> const&)url
                       activateTab:(Web::HTML::ActivateTab)activate_tab
                         pageIndex:(u64)page_index
@@ -259,11 +244,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
     auto* tab = (Tab*)[controller window];
     return [[tab web_view] handle];
-}
-
-- (void)loadURL:(URL::URL const&)url
-{
-    [[self tabController] loadURL:url];
 }
 
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)is_redirect

--- a/UI/AppKit/Interface/TabController.h
+++ b/UI/AppKit/Interface/TabController.h
@@ -20,7 +20,6 @@
                   pageIndex:(u64)page_index;
 
 - (void)loadURL:(URL::URL const&)url;
-- (void)loadHTML:(StringView)html url:(URL::URL const&)url;
 
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect;
 

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -135,11 +135,6 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     [[self tab].web_view loadURL:url];
 }
 
-- (void)loadHTML:(StringView)html url:(URL::URL const&)url
-{
-    [[self tab].web_view loadHTML:html];
-}
-
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect
 {
     [self setLocationFieldText:url.serialize()];

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -134,4 +134,20 @@ void Application::display_error_dialog(StringView error_message) const
     QMessageBox::warning(active_tab(), "Ladybird", qstring_from_ak_string(error_message));
 }
 
+void Application::on_devtools_enabled() const
+{
+    WebView::Application::on_devtools_enabled();
+
+    if (m_active_window)
+        m_active_window->on_devtools_enabled();
+}
+
+void Application::on_devtools_disabled() const
+{
+    WebView::Application::on_devtools_disabled();
+
+    if (m_active_window)
+        m_active_window->on_devtools_disabled();
+}
+
 }

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -97,6 +97,12 @@ Optional<WebView::ViewImplementation&> Application::active_web_view() const
     return {};
 }
 
+Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML::ActivateTab activate_tab) const
+{
+    auto& tab = active_window().create_new_tab(activate_tab);
+    return tab.view();
+}
+
 Optional<ByteString> Application::ask_user_for_download_folder() const
 {
     auto path = QFileDialog::getExistingDirectory(nullptr, "Select download directory", QDir::homePath());

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -37,6 +37,7 @@ private:
     virtual NonnullOwnPtr<Core::EventLoop> create_platform_event_loop() override;
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
+    virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
 
     virtual Optional<ByteString> ask_user_for_download_folder() const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -43,6 +43,9 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
+    virtual void on_devtools_enabled() const override;
+    virtual void on_devtools_disabled() const override;
+
     OwnPtr<QApplication> m_application;
     BrowserWindow* m_active_window { nullptr };
 };

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -209,7 +209,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     auto* inspect_menu = m_hamburger_menu->addMenu("&Inspect");
     menuBar()->addMenu(inspect_menu);
 
-    edit_menu->addAction(create_application_action(*this, Application::the().view_source_action()));
+    inspect_menu->addAction(create_application_action(*this, Application::the().view_source_action()));
 
     m_enable_devtools_action = new QAction("Enable &DevTools", this);
     m_enable_devtools_action->setIcon(load_icon_from_uri("resource://icons/browser/dom-tree.png"sv));

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -199,10 +199,8 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         Settings::the()->set_show_menubar(checked);
     });
 
-    auto* inspect_menu = m_hamburger_menu->addMenu("&Inspect");
-    inspect_menu->addAction(create_application_action(*inspect_menu, Application::the().view_source_action()));
-    inspect_menu->addAction(create_application_action(*inspect_menu, Application::the().toggle_devtools_action()));
-    inspect_menu->addAction(create_application_action(*inspect_menu, Application::the().open_processes_page_action()));
+    auto* inspect_menu = create_application_menu(*m_hamburger_menu, Application::the().inspect_menu());
+    m_hamburger_menu->addMenu(inspect_menu);
     menuBar()->addMenu(inspect_menu);
 
     auto* debug_menu = create_application_menu(*m_hamburger_menu, Application::the().debug_menu());

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -350,13 +350,6 @@ Tab& BrowserWindow::new_tab_from_url(URL::URL const& url, Web::HTML::ActivateTab
     return tab;
 }
 
-Tab& BrowserWindow::new_tab_from_content(StringView html, Web::HTML::ActivateTab activate_tab)
-{
-    auto& tab = create_new_tab(activate_tab);
-    tab.load_html(html);
-    return tab;
-}
-
 Tab& BrowserWindow::new_child_tab(Web::HTML::ActivateTab activate_tab, Tab& parent, Optional<u64> page_index)
 {
     return create_new_tab(activate_tab, parent, page_index);
@@ -421,27 +414,6 @@ void BrowserWindow::initialize_tab(Tab* tab)
         }
         auto& new_tab = new_child_tab(activate_tab, *tab, page_index);
         return new_tab.view().handle();
-    };
-
-    tab->view().on_tab_open_request = [this](auto url, auto activate_tab) {
-        auto& tab = new_tab_from_url(url, activate_tab);
-        return tab.view().handle();
-    };
-
-    tab->view().on_link_click = [this](auto url, auto target, unsigned modifiers) {
-        // TODO: maybe activate tabs according to some configuration, this is just normal current browser behavior
-        if (modifiers == Web::UIEvents::Mod_Ctrl) {
-            m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::No);
-        } else if (target == "_blank") {
-            m_current_tab->view().on_tab_open_request(url, Web::HTML::ActivateTab::Yes);
-        } else {
-            m_current_tab->view().load(url);
-        }
-    };
-
-    tab->view().on_link_middle_click = [this](auto url, auto target, unsigned modifiers) {
-        m_current_tab->view().on_link_click(url, target, Web::UIEvents::Mod_Ctrl);
-        (void)modifiers;
     };
 
     m_tabs_container->setTabIcon(m_tabs_container->indexOf(tab), tab->favicon());

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -166,14 +166,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     QObject::connect(m_find_in_page_action, &QAction::triggered, this, &BrowserWindow::show_find_in_page);
 
     edit_menu->addSeparator();
-
-    auto* settings_action = new QAction("&Settings", this);
-    settings_action->setIcon(load_icon_from_uri("resource://icons/16x16/settings.png"sv));
-    settings_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Preferences));
-    edit_menu->addAction(settings_action);
-    QObject::connect(settings_action, &QAction::triggered, this, [this] {
-        new_tab_from_url(URL::URL::about("settings"_string), Web::HTML::ActivateTab::Yes);
-    });
+    edit_menu->addAction(create_application_action(*edit_menu, Application::the().open_settings_page_action()));
 
     auto* view_menu = m_hamburger_menu->addMenu("&View");
     menuBar()->addMenu(view_menu);
@@ -235,13 +228,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         }
     });
 
-    auto* task_manager_action = new QAction("Open Task &Manager", this);
-    task_manager_action->setIcon(load_icon_from_uri("resource://icons/16x16/app-system-monitor.png"sv));
-    task_manager_action->setShortcuts({ QKeySequence("Ctrl+Shift+M") });
-    inspect_menu->addAction(task_manager_action);
-    QObject::connect(task_manager_action, &QAction::triggered, this, [this]() {
-        new_tab_from_url(URL::URL::about("processes"_string), Web::HTML::ActivateTab::Yes);
-    });
+    inspect_menu->addAction(create_application_action(*inspect_menu, Application::the().open_processes_page_action()));
 
     auto* debug_menu = create_application_menu(*m_hamburger_menu, Application::the().debug_menu());
     m_hamburger_menu->addMenu(debug_menu);
@@ -250,11 +237,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     auto* help_menu = m_hamburger_menu->addMenu("&Help");
     menuBar()->addMenu(help_menu);
 
-    auto* about_action = new QAction("&About Ladybird", this);
-    help_menu->addAction(about_action);
-    QObject::connect(about_action, &QAction::triggered, this, [this] {
-        new_tab_from_url(URL::about_version(), Web::HTML::ActivateTab::Yes);
-    });
+    help_menu->addAction(create_application_action(*help_menu, Application::the().open_about_page_action()));
 
     m_hamburger_menu->addSeparator();
     file_menu->addSeparator();

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -58,7 +58,6 @@ public slots:
     void tab_favicon_changed(int index, QIcon const& icon);
     void tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState);
     Tab& new_tab_from_url(URL::URL const&, Web::HTML::ActivateTab);
-    Tab& new_tab_from_content(StringView html, Web::HTML::ActivateTab);
     Tab& new_child_tab(Web::HTML::ActivateTab, Tab& parent, Optional<u64> page_index);
     void activate_tab(int index);
     void close_tab(int index);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -51,6 +51,9 @@ public:
 
     double refresh_rate() const { return m_refresh_rate; }
 
+    void on_devtools_enabled();
+    void on_devtools_disabled();
+
 public slots:
     void device_pixel_ratio_changed(qreal dpi);
     void refresh_rate_changed(qreal refresh_rate);
@@ -104,9 +107,6 @@ private:
     double m_device_pixel_ratio { 0 };
     double m_refresh_rate { 60.0 };
 
-    void devtools_disabled();
-    void devtools_enabled();
-
     QTabWidget* m_tabs_container { nullptr };
     Tab* m_current_tab { nullptr };
 
@@ -117,7 +117,6 @@ private:
     QAction* m_new_tab_action { nullptr };
     QAction* m_new_window_action { nullptr };
     QAction* m_find_in_page_action { nullptr };
-    QAction* m_enable_devtools_action { nullptr };
 
     IsPopupWindow m_is_popup_window { IsPopupWindow::No };
 };

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -114,6 +114,14 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/settings.png"sv));
         qaction.setShortcut(QKeySequence::StandardKey::Preferences);
         break;
+    case WebView::ActionID::ToggleDevTools:
+        qaction.setIcon(load_icon_from_uri("resource://icons/browser/dom-tree.png"sv));
+        qaction.setShortcuts({
+            QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_I),
+            QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_C),
+            QKeySequence(Qt::Key_F12),
+        });
+        break;
     case WebView::ActionID::ViewSource:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/filetype-html.png"sv));
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_U));

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -78,11 +78,11 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
     switch (action.id()) {
     case WebView::ActionID::NavigateBack:
         qaction.setIcon(create_tvg_icon_with_theme_colors("back", palette));
-        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Back));
+        qaction.setShortcut(QKeySequence::StandardKey::Back);
         break;
     case WebView::ActionID::NavigateForward:
         qaction.setIcon(create_tvg_icon_with_theme_colors("forward", palette));
-        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Forward));
+        qaction.setShortcut(QKeySequence::StandardKey::Forward);
         break;
     case WebView::ActionID::Reload:
         qaction.setIcon(create_tvg_icon_with_theme_colors("reload", palette));
@@ -91,15 +91,15 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
 
     case WebView::ActionID::CopySelection:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/edit-copy.png"sv));
-        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Copy));
+        qaction.setShortcut(QKeySequence::StandardKey::Copy);
         break;
     case WebView::ActionID::Paste:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/paste.png"sv));
-        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Paste));
+        qaction.setShortcut(QKeySequence::StandardKey::Paste);
         break;
     case WebView::ActionID::SelectAll:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/select-all.png"sv));
-        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::SelectAll));
+        qaction.setShortcut(QKeySequence::StandardKey::SelectAll);
         break;
 
     case WebView::ActionID::SearchSelectedText:
@@ -163,7 +163,7 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
     }
     case WebView::ActionID::ZoomOut:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/zoom-out.png"sv));
-        qaction.setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::ZoomOut));
+        qaction.setShortcut(QKeySequence::StandardKey::ZoomOut);
         break;
     case WebView::ActionID::ResetZoom:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/zoom-reset.png"sv));

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -106,6 +106,14 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/find.png"sv));
         break;
 
+    case WebView::ActionID::OpenProcessesPage:
+        qaction.setIcon(load_icon_from_uri("resource://icons/16x16/app-system-monitor.png"sv));
+        qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_M));
+        break;
+    case WebView::ActionID::OpenSettingsPage:
+        qaction.setIcon(load_icon_from_uri("resource://icons/16x16/settings.png"sv));
+        qaction.setShortcut(QKeySequence::StandardKey::Preferences);
+        break;
     case WebView::ActionID::ViewSource:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/filetype-html.png"sv));
         qaction.setShortcut(QKeySequence(Qt::CTRL | Qt::Key_U));

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -9,7 +9,6 @@
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/SourceHighlighter.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/Icon.h>
 #include <UI/Qt/Menu.h>
@@ -328,11 +327,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     };
 
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);
-
-    view().on_received_source = [this](auto const& url, auto const& base_url, auto const& source) {
-        auto html = WebView::highlight_source(url, base_url, source, Syntax::Language::HTML, WebView::HighlightOutputMode::FullDocument);
-        m_window->new_tab_from_content(html, Web::HTML::ActivateTab::Yes);
-    };
 
     view().on_restore_window = [this]() {
         m_window->showNormal();

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -15,7 +15,6 @@
 #include <LibGfx/Rect.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/ViewImplementation.h>
 
 #include <QMenu>
@@ -39,8 +38,6 @@ class WebContentView final
 public:
     WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0, WebContentViewInitialState initial_state = {});
     virtual ~WebContentView() override;
-
-    Function<String(URL::URL const&, Web::HTML::ActivateTab)> on_tab_open_request;
 
     virtual void paintEvent(QPaintEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;


### PR DESCRIPTION
* A couple minor fixes and simplifications after #6062
* Add a couple more menu icons for macOS Tahoe
* Generate the actions to open `about:` pages
* Generate the remaining actions for the Inspect menu and then the menu itself