### PR TITLE
Add missing X_API macros to classes needing them for DEBUG macro builds

### DIFF
--- a/Libraries/LibDNS/Message.h
+++ b/Libraries/LibDNS/Message.h
@@ -537,7 +537,7 @@ struct CDS : public DS {
     static constexpr ResourceType type = ResourceType::CDS;
     static ErrorOr<CDS> from_raw(ParseContext& raw) { return DS::from_raw(raw); }
 };
-struct SIG {
+struct DNS_API SIG {
     ResourceType type_covered;
     DNSSEC::Algorithm algorithm;
     u8 label_count;

--- a/Libraries/LibRegex/RegexByteCode.h
+++ b/Libraries/LibRegex/RegexByteCode.h
@@ -640,7 +640,7 @@ StringView boundary_check_type_name(BoundaryCheckType);
 StringView character_compare_type_name(CharacterCompareType result);
 StringView character_class_name(CharClass ch_class);
 
-class OpCode {
+class REGEX_API OpCode {
 public:
     OpCode() = default;
     virtual ~OpCode() = default;
@@ -846,7 +846,7 @@ public:
     }
 };
 
-class OpCode_Compare final : public OpCode {
+class REGEX_API OpCode_Compare final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Compare; }


### PR DESCRIPTION
When building with ENABLE_ALL_THE_DEBUG_MACROS there are a number of issues encountered.  See #6173 for the details.

This PR fixes the remaining linking issues (undefined references) by adding X_API macros (DNS_API and REGEX_API) to the specific classes that encountered the issue.

1- DNS_DEBUG issue with `Libraries/LibDNS/Resolver.h:1003` with undefined reference `DNS::Messages::Records::SIG::to_string() const`

which impacts

 - bin/dns
 - bin/TestDNSResolver
 - libexec/RequestServer

2- REGEX_DEBUG issue with `Libraries/LibRegex/RegexDebug.h:76` with undefined reference `regex::OpCode_Compare::variable_arguments_to_byte_string(AK::Optional<regex::MatchInput const&>) const`

which impacts:

 - bin/TestRegex

3- REGEX_DEBUG issue with `Libraries/LibRegex/RegexByteCode.h:672` with undefined reference `regex::OpCode::name(regex::OpCodeId)`

which impacts:

 - bin/TestRegex


fixes: #6173