### PR TITLE
LibThreading: Forward-declare Thread and remove its Weakable functionality

### DIFF
--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -9,6 +9,7 @@
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
 #include <LibIPC/TransportSocket.h>
+#include <LibThreading/Thread.h>
 
 namespace IPC {
 

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -13,9 +13,9 @@
 #include <LibIPC/AutoCloseFileDescriptor.h>
 #include <LibIPC/File.h>
 #include <LibThreading/ConditionVariable.h>
+#include <LibThreading/Forward.h>
 #include <LibThreading/MutexProtected.h>
 #include <LibThreading/RWLock.h>
-#include <LibThreading/Thread.h>
 
 namespace IPC {
 

--- a/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "PlaybackStreamPulseAudio.h"
-
 #include <LibCore/ThreadedPromise.h>
+#include <LibThreading/Thread.h>
+
+#include "PlaybackStreamPulseAudio.h"
 
 namespace Audio {
 

--- a/Libraries/LibMedia/Audio/PulseAudioWrappers.h
+++ b/Libraries/LibMedia/Audio/PulseAudioWrappers.h
@@ -13,7 +13,6 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Time.h>
 #include <LibMedia/Export.h>
-#include <LibThreading/Thread.h>
 #include <pulse/pulseaudio.h>
 
 namespace Audio {

--- a/Libraries/LibThreading/BackgroundAction.h
+++ b/Libraries/LibThreading/BackgroundAction.h
@@ -16,7 +16,7 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/EventReceiver.h>
 #include <LibCore/Promise.h>
-#include <LibThreading/Thread.h>
+#include <LibThreading/Forward.h>
 
 namespace Threading {
 

--- a/Libraries/LibThreading/Forward.h
+++ b/Libraries/LibThreading/Forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Gregory Bertilson <gregory@ladybird.org>
+ * Copyright (c) 2023-2025, Gregory Bertilson <gregory@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +7,8 @@
 #pragma once
 
 namespace Threading {
+
+class Thread;
 
 template<typename ErrorType>
 class WorkerThread;

--- a/Libraries/LibThreading/Forward.h
+++ b/Libraries/LibThreading/Forward.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
- * Copyright (c) 2021, Spencer Dixon <spencercdixon@gmail.com>
+ * Copyright (c) 2023, Gregory Bertilson <gregory@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Libraries/LibThreading/Thread.h
+++ b/Libraries/LibThreading/Thread.h
@@ -43,8 +43,7 @@ enum class ThreadState : u8 {
 };
 
 class Thread final
-    : public AtomicRefCounted<Thread>
-    , public Weakable<Thread> {
+    : public AtomicRefCounted<Thread> {
 public:
     static NonnullRefPtr<Thread> construct(ESCAPING Function<intptr_t()> action, StringView thread_name = {})
     {

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/EventLoop.h>
+#include <LibThreading/Thread.h>
 #include <LibWeb/HTML/RenderingThread.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -10,8 +10,8 @@
 #include <AK/Queue.h>
 #include <LibCore/Promise.h>
 #include <LibThreading/ConditionVariable.h>
+#include <LibThreading/Forward.h>
 #include <LibThreading/Mutex.h>
-#include <LibThreading/Thread.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/Page.h>
 

--- a/Libraries/LibWebView/MachPortServer.cpp
+++ b/Libraries/LibWebView/MachPortServer.cpp
@@ -7,6 +7,7 @@
 #include <AK/Debug.h>
 #include <LibCore/Platform/MachMessageTypes.h>
 #include <LibCore/Platform/ProcessStatisticsMach.h>
+#include <LibThreading/Thread.h>
 #include <LibWebView/MachPortServer.h>
 
 namespace WebView {

--- a/Libraries/LibWebView/MachPortServer.h
+++ b/Libraries/LibWebView/MachPortServer.h
@@ -10,7 +10,7 @@
 #include <AK/Platform.h>
 #include <AK/String.h>
 #include <LibCore/MachPort.h>
-#include <LibThreading/Thread.h>
+#include <LibThreading/Forward.h>
 #include <LibWebView/Forward.h>
 
 #if !defined(AK_OS_MACH)


### PR DESCRIPTION
`Threading::Thread` is ref-counted, so using forward declarations in a lot of headers currently including Thread.h is an easy change.

Also, `Weakable` is not thread-safe, so taking a strong reference from a `WeakPtr<Thread>` may result in a use-after-free. We don't use this functionality anywhere anyway, so remove it.

No functional changes, hopefully.