### PR TITLE
IDLGenerators: Support `null` as a default value for dictionary types

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -616,7 +616,9 @@ static void generate_to_integral(SourceGenerator& scoped_generator, ParameterTyp
 )~~~");
     }
 
-    if (optional_default_value.has_value()) {
+    // FIXME: The Optional<foo> defaults to empty, and can't be explicitly set to `null`.
+    //        So, just skip the assignment.
+    if (optional_default_value.has_value() && optional_default_value != "null"sv) {
         scoped_generator.append(R"~~~(
     else
         @cpp_name@ = static_cast<@cpp_type@>(@parameter.optional_default_value@);


### PR DESCRIPTION
Specifically, NotificationOptions has this:

```webidl
dictionary NotificationOptions {
    // ...
    boolean? silent = null;
    // ...
};
```
https://notifications.spec.whatwg.org/#dictdef-notificationoptions

Without this patch, we generate this code, which isn't valid:

```c++
silent_value_11 = static_cast<bool>(null);
```

Treating `null` the same as no default value seems like the best option, as they're equivalent in our C++ types.