### PR TITLE
LibWeb+WebContent+UI: Port text pasting to UTF-16

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2576,7 +2576,7 @@ void Navigable::select_all()
     }
 }
 
-void Navigable::paste(String const& text)
+void Navigable::paste(Utf16String const& text)
 {
     auto document = active_document();
     if (!document)

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -196,7 +196,7 @@ public:
 
     String selected_text() const;
     void select_all();
-    void paste(String const&);
+    void paste(Utf16String const&);
 
     Web::EventHandler& event_handler() { return m_event_handler; }
     Web::EventHandler const& event_handler() const { return m_event_handler; }

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -156,7 +156,7 @@ void Internals::send_key(HTML::HTMLElement& target, String const& key_name, WebI
     page().handle_keydown(key_code, modifiers, 0, false);
 }
 
-void Internals::paste(HTML::HTMLElement& target, String const& text)
+void Internals::paste(HTML::HTMLElement& target, Utf16String const& text)
 {
     auto& page = this->page();
     target.focus();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -32,7 +32,7 @@ public:
 
     void send_text(HTML::HTMLElement&, String const&, WebIDL::UnsignedShort modifiers);
     void send_key(HTML::HTMLElement&, String const&, WebIDL::UnsignedShort modifiers);
-    void paste(HTML::HTMLElement& target, String const& text);
+    void paste(HTML::HTMLElement& target, Utf16String const& text);
     void commit_text();
 
     void click(double x, double y);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -24,7 +24,7 @@ interface Internals {
 
     undefined sendText(HTMLElement target, DOMString text, optional unsigned short modifiers = 0);
     undefined sendKey(HTMLElement target, DOMString keyName, optional unsigned short modifiers = 0);
-    undefined paste(HTMLElement target, DOMString text);
+    undefined paste(HTMLElement target, Utf16DOMString text);
     undefined commitText();
 
     undefined click(double x, double y);

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1445,7 +1445,7 @@ EventResult EventHandler::handle_keyup(UIEvents::KeyCode key, u32 modifiers, u32
     return fire_keyboard_event(UIEvents::EventNames::keyup, m_navigable, key, modifiers, code_point, false);
 }
 
-EventResult EventHandler::handle_paste(String const& text)
+EventResult EventHandler::handle_paste(Utf16String const& text)
 {
     auto active_document = m_navigable->active_document();
     if (!active_document)
@@ -1457,10 +1457,9 @@ EventResult EventHandler::handle_paste(String const& text)
     if (!target)
         return EventResult::Dropped;
 
-    auto utf16_string = Utf16String::from_utf8(text);
+    FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::insertFromPaste, m_navigable, text));
+    target->handle_insert(text);
 
-    FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::insertFromPaste, m_navigable, utf16_string));
-    target->handle_insert(utf16_string);
     return EventResult::Handled;
 }
 

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -42,7 +42,7 @@ public:
 
     void set_mouse_event_tracking_paintable(GC::Ptr<Painting::Paintable>);
 
-    EventResult handle_paste(String const& text);
+    EventResult handle_paste(Utf16String const& text);
 
     void handle_sdl_input_events();
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -665,7 +665,7 @@ void Application::initialize_actions()
 
     m_copy_selection_action = Action::create("Copy"sv, ActionID::CopySelection, [this]() {
         if (auto view = active_web_view(); view.has_value())
-            view->insert_text_into_clipboard(view->selected_text());
+            insert_clipboard_entry({ view->selected_text(), "text/plain"_string });
     });
     m_paste_action = Action::create("Paste"sv, ActionID::Paste, [this]() {
         if (auto view = active_web_view(); view.has_value())

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -21,6 +21,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
+#include <LibWeb/Clipboard/SystemClipboard.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Options.h>
@@ -74,6 +75,10 @@ public:
 
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const;
     virtual void display_error_dialog(StringView error_message) const;
+
+    virtual String clipboard_text() const { return {}; }
+    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const { return {}; }
+    virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) { }
 
     Action& reload_action() { return *m_reload_action; }
     Action& copy_selection_action() { return *m_copy_selection_action; }

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -76,7 +76,7 @@ public:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const;
     virtual void display_error_dialog(StringView error_message) const;
 
-    virtual String clipboard_text() const { return {}; }
+    virtual Utf16String clipboard_text() const { return {}; }
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const { return {}; }
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) { }
 

--- a/Libraries/LibWebView/HeadlessWebView.cpp
+++ b/Libraries/LibWebView/HeadlessWebView.cpp
@@ -141,20 +141,6 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
         m_pending_prompt_text.clear();
     };
 
-    on_insert_clipboard_entry = [this](Web::Clipboard::SystemClipboardRepresentation entry, auto const&) {
-        Web::Clipboard::SystemClipboardItem item;
-        item.system_clipboard_representations.append(move(entry));
-
-        m_clipboard = move(item);
-    };
-
-    on_request_clipboard_entries = [this](auto request_id) {
-        if (m_clipboard.has_value())
-            retrieved_clipboard_entries(request_id, { { *m_clipboard } });
-        else
-            retrieved_clipboard_entries(request_id, {});
-    };
-
     m_system_visibility_state = Web::HTML::VisibilityState::Visible;
 }
 

--- a/Libraries/LibWebView/HeadlessWebView.h
+++ b/Libraries/LibWebView/HeadlessWebView.h
@@ -36,9 +36,6 @@ protected:
     Web::Page::PendingDialog m_pending_dialog { Web::Page::PendingDialog::None };
     Optional<String> m_pending_prompt_text;
 
-    // FIXME: We should implement UI-agnostic platform APIs to interact with the system clipboard.
-    Optional<Web::Clipboard::SystemClipboardItem> m_clipboard;
-
     Vector<NonnullOwnPtr<HeadlessWebView>> m_child_web_views;
 };
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -130,7 +130,6 @@ public:
     void file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files);
     void select_dropdown_closed(Optional<u32> const& selected_item_id);
 
-    void insert_text_into_clipboard(ByteString) const;
     void paste_text_from_clipboard();
     void retrieved_clipboard_entries(u64 request_id, ReadonlySpan<Web::Clipboard::SystemClipboardItem>);
 
@@ -217,9 +216,6 @@ public:
     Function<void(JsonValue)> on_reference_test_metadata;
     Function<void(size_t current_match_index, Optional<size_t> const& total_match_count)> on_find_in_page;
     Function<void(Gfx::Color)> on_theme_color_change;
-    Function<void(Web::Clipboard::SystemClipboardRepresentation, String const&)> on_insert_clipboard_entry;
-    Function<String()> on_request_clipboard_text;
-    Function<void(u64 request_id)> on_request_clipboard_entries;
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
     Function<void()> on_web_content_crashed;
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -663,19 +663,19 @@ void WebContentClient::did_change_theme_color(u64 page_id, Gfx::Color color)
     }
 }
 
-void WebContentClient::did_insert_clipboard_entry(u64 page_id, Web::Clipboard::SystemClipboardRepresentation entry, String presentation_style)
+void WebContentClient::did_insert_clipboard_entry(u64, Web::Clipboard::SystemClipboardRepresentation entry, String)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_insert_clipboard_entry)
-            view->on_insert_clipboard_entry(move(entry), presentation_style);
-    }
+    Application::the().insert_clipboard_entry(move(entry));
 }
 
 void WebContentClient::did_request_clipboard_entries(u64 page_id, u64 request_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_request_clipboard_entries)
-            view->on_request_clipboard_entries(request_id);
+        Vector<Web::Clipboard::SystemClipboardItem> items;
+        if (auto entries = Application::the().clipboard_entries(); !entries.is_empty())
+            items.empend(move(entries));
+
+        view->retrieved_clipboard_entries(request_id, items);
     }
 }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1076,7 +1076,7 @@ void ConnectionFromClient::find_in_page_previous_match(u64 page_id)
     async_did_find_in_page(page_id, result.current_match_index, result.total_match_count);
 }
 
-void ConnectionFromClient::paste(u64 page_id, String text)
+void ConnectionFromClient::paste(u64 page_id, Utf16String text)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().paste(text);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -155,7 +155,7 @@ private:
     virtual void find_in_page_next_match(u64 page_id) override;
     virtual void find_in_page_previous_match(u64 page_id) override;
 
-    virtual void paste(u64 page_id, String text) override;
+    virtual void paste(u64 page_id, Utf16String text) override;
 
     virtual void system_time_zone_changed() override;
     virtual void cookies_changed(Vector<Web::Cookie::Cookie>) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -82,7 +82,7 @@ endpoint WebContentServer
 
     get_selected_text(u64 page_id) => (ByteString selection)
     select_all(u64 page_id) =|
-    paste(u64 page_id, String text) =|
+    paste(u64 page_id, Utf16String text) =|
 
     find_in_page(u64 page_id, String query, AK::CaseSensitivity case_sensitivity) =|
     find_in_page_next_match(u64 page_id) =|

--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -93,4 +93,16 @@ ErrorOr<void> Application::launch_test_fixtures()
     return {};
 }
 
+Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const
+{
+    if (m_clipboard.has_value())
+        return { *m_clipboard };
+    return {};
+}
+
+void Application::insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation entry)
+{
+    m_clipboard = move(entry);
+}
+
 }

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -45,6 +45,13 @@ public:
     int per_test_timeout_in_seconds { 30 };
 
     u8 verbosity { 0 };
+
+private:
+    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
+    virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
+
+    // FIXME: We should implement UI-agnostic platform APIs to interact with the system clipboard.
+    Optional<Web::Clipboard::SystemClipboardRepresentation> m_clipboard;
 };
 
 }

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -27,7 +27,7 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
-    virtual String clipboard_text() const override;
+    virtual Utf16String clipboard_text() const override;
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -27,6 +27,10 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
+    virtual String clipboard_text() const override;
+    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
+    virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
+
     virtual void on_devtools_enabled() const override;
     virtual void on_devtools_disabled() const override;
 };

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -98,12 +98,12 @@ void Application::display_error_dialog(StringView error_message) const
                    completionHandler:nil];
 }
 
-String Application::clipboard_text() const
+Utf16String Application::clipboard_text() const
 {
     auto* paste_board = [NSPasteboard generalPasteboard];
 
     if (auto* contents = [paste_board stringForType:NSPasteboardTypeString])
-        return Ladybird::ns_string_to_string(contents);
+        return Ladybird::ns_string_to_utf16_string(contents);
     return {};
 }
 

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -136,10 +136,10 @@ void Application::display_error_dialog(StringView error_message) const
     QMessageBox::warning(active_tab(), "Ladybird", qstring_from_ak_string(error_message));
 }
 
-String Application::clipboard_text() const
+Utf16String Application::clipboard_text() const
 {
     auto const* clipboard = QGuiApplication::clipboard();
-    return ak_string_from_qstring(clipboard->text());
+    return utf16_string_from_qstring(clipboard->text());
 }
 
 Vector<Web::Clipboard::SystemClipboardRepresentation> Application::clipboard_entries() const

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -43,7 +43,7 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
-    virtual String clipboard_text() const override;
+    virtual Utf16String clipboard_text() const override;
     virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
     virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
 

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -43,6 +43,10 @@ private:
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;
 
+    virtual String clipboard_text() const override;
+    virtual Vector<Web::Clipboard::SystemClipboardRepresentation> clipboard_entries() const override;
+    virtual void insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation) override;
+
     virtual void on_devtools_enabled() const override;
     virtual void on_devtools_disabled() const override;
 

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -15,19 +15,16 @@
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
 
-#include <QClipboard>
 #include <QColorDialog>
 #include <QFileDialog>
 #include <QFont>
 #include <QFontMetrics>
-#include <QGuiApplication>
 #include <QImage>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
 #include <QMimeDatabase>
-#include <QMimeType>
 #include <QResizeEvent>
 
 namespace Ladybird {
@@ -354,44 +351,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     view().on_fullscreen_window = [this]() {
         m_window->showFullScreen();
         view().did_update_window_rect();
-    };
-
-    view().on_insert_clipboard_entry = [](Web::Clipboard::SystemClipboardRepresentation const& entry, auto const&) {
-        auto* mime_data = new QMimeData();
-        mime_data->setData(qstring_from_ak_string(entry.mime_type), qbytearray_from_ak_string(entry.data));
-
-        auto* clipboard = QGuiApplication::clipboard();
-        clipboard->setMimeData(mime_data);
-    };
-
-    view().on_request_clipboard_text = []() {
-        auto const* clipboard = QGuiApplication::clipboard();
-        return ak_string_from_qstring(clipboard->text());
-    };
-
-    view().on_request_clipboard_entries = [this](auto request_id) {
-        auto const* clipboard = QGuiApplication::clipboard();
-
-        auto const* mime_data = clipboard->mimeData();
-        if (!mime_data) {
-            view().retrieved_clipboard_entries(request_id, {});
-            return;
-        }
-
-        Vector<Web::Clipboard::SystemClipboardItem> items;
-        Vector<Web::Clipboard::SystemClipboardRepresentation> representations;
-
-        for (auto const& format : mime_data->formats()) {
-            auto data = ak_byte_string_from_qbytearray(mime_data->data(format));
-            auto mime_type = ak_string_from_qstring(format);
-
-            representations.empend(AK::move(data), AK::move(mime_type));
-        }
-
-        if (!representations.is_empty())
-            items.empend(AK::move(representations));
-
-        view().retrieved_clipboard_entries(request_id, items);
     };
 
     view().on_audio_play_state_changed = [this](auto play_state) {


### PR DESCRIPTION
This PR first does a bit of organization around clipboard handling, then ports the `paste` action to UTF-16.