### PR TITLE
AK: Store hash with HashTable entry to avoid expensive equality checks

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -200,6 +200,7 @@ private:
 template<>
 struct Traits<FlyString> : public DefaultTraits<FlyString> {
     static unsigned hash(FlyString const&);
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 template<>

--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -26,6 +26,7 @@ private:
     };
 
     struct EntryTraits {
+        static constexpr bool may_have_slow_equality_check() { return KeyTraits::may_have_slow_equality_check(); }
         static unsigned hash(Entry const& entry) { return KeyTraits::hash(entry.key); }
         static bool equals(Entry const& a, Entry const& b) { return KeyTraits::equals(a.key, b.key); }
     };

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -169,6 +169,7 @@ struct Traits<NonnullOwnPtr<T>> : public DefaultTraits<NonnullOwnPtr<T>> {
     using ConstPeekType = T const*;
     static unsigned hash(NonnullOwnPtr<T> const& p) { return ptr_hash(p.ptr()); }
     static bool equals(NonnullOwnPtr<T> const& a, NonnullOwnPtr<T> const& b) { return a.ptr() == b.ptr(); }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 template<typename T, typename U>

--- a/AK/NonnullRawPtr.h
+++ b/AK/NonnullRawPtr.h
@@ -50,6 +50,7 @@ private:
 template<typename T>
 struct Traits<NonnullRawPtr<T>> : public DefaultTraits<NonnullRawPtr<T>> {
     static unsigned hash(NonnullRawPtr<T> const& handle) { return Traits<T>::hash(handle); }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 namespace Detail {

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -276,6 +276,7 @@ struct Traits<NonnullRefPtr<T>> : public DefaultTraits<NonnullRefPtr<T>> {
     using ConstPeekType = T const*;
     static unsigned hash(NonnullRefPtr<T> const& p) { return ptr_hash(p.ptr()); }
     static bool equals(NonnullRefPtr<T> const& a, NonnullRefPtr<T> const& b) { return a.ptr() == b.ptr(); }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 }

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -198,6 +198,7 @@ struct Traits<OwnPtr<T>> : public DefaultTraits<OwnPtr<T>> {
     using ConstPeekType = T const*;
     static unsigned hash(OwnPtr<T> const& p) { return ptr_hash(p.ptr()); }
     static bool equals(OwnPtr<T> const& a, OwnPtr<T> const& b) { return a.ptr() == b.ptr(); }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 template<typename T>

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -298,6 +298,7 @@ struct Traits<RefPtr<T>> : public DefaultTraits<RefPtr<T>> {
     using ConstPeekType = T const*;
     static unsigned hash(RefPtr<T> const& p) { return ptr_hash(p.ptr()); }
     static bool equals(RefPtr<T> const& a, RefPtr<T> const& b) { return a.ptr() == b.ptr(); }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 template<typename T, typename U>

--- a/AK/Utf16FlyString.h
+++ b/AK/Utf16FlyString.h
@@ -251,6 +251,7 @@ private:
 template<>
 struct Traits<Utf16FlyString> : public DefaultTraits<Utf16FlyString> {
     static unsigned hash(Utf16FlyString const& string) { return string.hash(); }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 template<>

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -212,6 +212,7 @@ struct Traits<WeakPtr<T>> : public DefaultTraits<WeakPtr<T>> {
     using ConstPeekType = T const*;
     static unsigned hash(WeakPtr<T> const& p) { return ptr_hash(p.ptr()); }
     static bool equals(WeakPtr<T> const& a, WeakPtr<T> const& b) { return a.ptr() == b.ptr(); }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 }

--- a/Libraries/LibGC/Ptr.h
+++ b/Libraries/LibGC/Ptr.h
@@ -235,6 +235,7 @@ struct Traits<GC::Ptr<T>> : public DefaultTraits<GC::Ptr<T>> {
     {
         return Traits<T*>::hash(value.ptr());
     }
+    static constexpr bool may_have_slow_equality_check() { return false; }
 };
 
 template<typename T>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateNamedCharacterReferences.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateNamedCharacterReferences.cpp
@@ -269,6 +269,7 @@ static u8 ascii_alphabetic_to_index(u8 c)
 class Node final : public RefCounted<Node> {
 private:
     struct NonnullRefPtrNodeTraits {
+        static constexpr bool may_have_slow_equality_check() { return true; }
         static unsigned hash(NonnullRefPtr<Node> const& node)
         {
             u32 hash = 0;


### PR DESCRIPTION
When T in HashTable<T> has a potentially slow equality check, it can be very profitable to check for a matching hash before full equality.

This patch adds may_have_slow_equality() check to AK::Traits and defaults it to true. For trivial types (pointers, integers, etc) we default it to false. This means we skip the hash check when the equality check would be a single-CPU-word compare anyway.

This synergizes really well with things like HashMap<String, V> where collisions previously meant we may have to churn through multiple O(n) equality checks.

Looks like benchmarks are neutral or slightly faster across the board. Many micro-benchmarks improve noticeably on my MBP.

```
Suite           Test                                      Speedup  Old (Mean ± Range)           New (Mean ± Range)
--------------  --------------------------------------  ---------  ---------------------------  ---------------------------
SunSpider       3d-cube.js                                  1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       3d-morph.js                                 1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider       3d-raytrace.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider       access-binary-trees.js                      1.333  0.020 ± 0.020 … 0.020        0.015 ± 0.010 … 0.020
SunSpider       access-fannkuch.js                          1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider       access-nbody.js                             1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider       access-nsieve.js                            1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       bitops-3bit-bits-in-byte.js                 1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       bitops-bits-in-byte.js                      1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       bitops-bitwise-and.js                       1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       bitops-nsieve-bits.js                       1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       controlflow-recursive.js                    1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
SunSpider       crypto-aes.js                               1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider       crypto-md5.js                               1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       crypto-sha1.js                              1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       date-format-tofte.js                        1      0.040 ± 0.040 … 0.040        0.040 ± 0.040 … 0.040
SunSpider       date-format-xparb.js                        1.167  0.035 ± 0.030 … 0.040        0.030 ± 0.030 … 0.030
SunSpider       math-cordic.js                              1      0.020 ± 0.020 … 0.020        0.020 ± 0.020 … 0.020
SunSpider       math-partial-sums.js                        1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       math-spectral-norm.js                       1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
SunSpider       regexp-dna.js                               1.019  0.265 ± 0.260 … 0.270        0.260 ± 0.260 … 0.260
SunSpider       string-base64.js                            2      0.020 ± 0.020 … 0.020        0.010 ± 0.010 … 0.010
SunSpider       string-fasta.js                             1      0.100 ± 0.100 … 0.100        0.100 ± 0.100 … 0.100
SunSpider       string-tagcloud.js                          1      0.080 ± 0.080 … 0.080        0.080 ± 0.080 … 0.080
SunSpider       string-unpack-code.js                       1      0.090 ± 0.090 … 0.090        0.090 ± 0.090 … 0.090
SunSpider       string-validate-input.js                    1      0.030 ± 0.030 … 0.030        0.030 ± 0.030 … 0.030
Kraken          ai-astar.js                                 0.875  1.190 ± 1.170 … 1.210        1.360 ± 1.340 … 1.380
Kraken          audio-beat-detection.js                     0.994  0.805 ± 0.800 … 0.810        0.810 ± 0.810 … 0.810
Kraken          audio-dft.js                                0.993  0.705 ± 0.700 … 0.710        0.710 ± 0.710 … 0.710
Kraken          audio-fft.js                                1      0.680 ± 0.680 … 0.680        0.680 ± 0.680 … 0.680
Kraken          audio-oscillator.js                         1      0.750 ± 0.750 … 0.750        0.750 ± 0.750 … 0.750
Kraken          imaging-darkroom.js                         1.009  1.080 ± 1.080 … 1.080        1.070 ± 1.070 … 1.070
Kraken          imaging-desaturate.js                       0.996  1.215 ± 1.210 … 1.220        1.220 ± 1.220 … 1.220
Kraken          imaging-gaussian-blur.js                    1.001  4.795 ± 4.790 … 4.800        4.790 ± 4.790 … 4.790
Kraken          json-parse-financial.js                     1      0.070 ± 0.070 … 0.070        0.070 ± 0.070 … 0.070
Kraken          json-stringify-tinderbox.js                 1.125  0.090 ± 0.090 … 0.090        0.080 ± 0.080 … 0.080
Kraken          stanford-crypto-aes.js                      1      0.310 ± 0.310 … 0.310        0.310 ± 0.310 … 0.310
Kraken          stanford-crypto-ccm.js                      1.033  0.310 ± 0.310 … 0.310        0.300 ± 0.300 … 0.300
Kraken          stanford-crypto-pbkdf2.js                   1      0.550 ± 0.550 … 0.550        0.550 ± 0.550 … 0.550
Kraken          stanford-crypto-sha256-iterative.js         1      0.210 ± 0.210 … 0.210        0.210 ± 0.210 … 0.210
Octane          box2d.js                                    1      1.130 ± 1.130 … 1.130        1.130 ± 1.130 … 1.130
Octane          code-load.js                                1.002  2.020 ± 2.020 … 2.020        2.015 ± 2.010 … 2.020
Octane          crypto.js                                   1.002  5.070 ± 5.070 … 5.070        5.060 ± 5.060 … 5.060
Octane          deltablue.js                                1      2.010 ± 2.010 … 2.010        2.010 ± 2.010 … 2.010
Octane          earley-boyer.js                             0.982  7.140 ± 7.130 … 7.150        7.270 ± 7.250 … 7.290
Octane          gbemu.js                                    1.004  1.190 ± 1.190 … 1.190        1.185 ± 1.180 … 1.190
Octane          mandreel.js                                 0.999  6.455 ± 6.450 … 6.460        6.460 ± 6.450 … 6.470
Octane          navier-stokes.js                            1.002  2.030 ± 2.030 … 2.030        2.025 ± 2.020 … 2.030
Octane          pdfjs.js                                    1.012  1.270 ± 1.260 … 1.280        1.255 ± 1.250 … 1.260
Octane          raytrace.js                                 1.007  3.095 ± 3.090 … 3.100        3.075 ± 3.060 … 3.090
Octane          regexp.js                                   1.014  13.750 ± 13.730 … 13.770     13.565 ± 13.520 … 13.610
Octane          richards.js                                 1.002  2.010 ± 2.010 … 2.010        2.005 ± 2.000 … 2.010
Octane          splay.js                                    1      2.260 ± 2.260 … 2.260        2.260 ± 2.260 … 2.260
Octane          typescript.js                               1      11.105 ± 11.100 … 11.110     11.100 ± 11.070 … 11.130
Octane          zlib.js                                     0.995  48.925 ± 48.910 … 48.940     49.170 ± 49.150 … 49.190
JetStream       bigfib.cpp.js                               0.983  8.845 ± 8.840 … 8.850        8.995 ± 8.980 … 9.010
JetStream       cdjs.js                                     0.986  4.350 ± 4.320 … 4.380        4.410 ± 4.390 … 4.430
JetStream       container.cpp.js                            0.984  36.300 ± 36.260 … 36.340     36.900 ± 36.730 … 37.070
JetStream       dry.c.js                                    0.997  20.900 ± 20.890 … 20.910     20.970 ± 20.960 … 20.980
JetStream       float-mm.c.js                               0.961  21.200 ± 21.160 … 21.240     22.050 ± 22.010 … 22.090
JetStream       gcc-loops.cpp.js                            0.997  126.850 ± 125.370 … 128.330  127.225 ± 126.550 … 127.900
JetStream       hash-map.js                                 1.013  1.535 ± 1.530 … 1.540        1.515 ± 1.510 … 1.520
JetStream       n-body.c.js                                 1.028  31.265 ± 31.200 … 31.330     30.425 ± 30.360 … 30.490
JetStream       quicksort.c.js                              1.061  5.750 ± 5.740 … 5.760        5.420 ± 5.070 … 5.770
JetStream       towers.c.js                                 1.018  6.320 ± 6.310 … 6.330        6.210 ± 6.200 … 6.220
JetStream3      js-tokens.js                                1.027  0.750 ± 0.750 … 0.750        0.730 ± 0.730 … 0.730
JetStream3      lazy-collections.js                         1.027  1.525 ± 1.520 … 1.530        1.485 ± 1.480 … 1.490
JetStream3      raytrace-private-class-fields.js            1.008  5.115 ± 5.110 … 5.120        5.075 ± 5.070 … 5.080
JetStream3      raytrace-public-class-fields.js             1.014  3.955 ± 3.950 … 3.960        3.900 ± 3.880 … 3.920
JetStream3      sync-file-system.js                         1.025  2.090 ± 2.060 … 2.120        2.040 ± 2.020 … 2.060
RegExp          speedometer-jquery-regexp-1.js              1.017  1.455 ± 1.450 … 1.460        1.430 ± 1.430 … 1.430
RegExp          speedometer-jquery-regexp-2.js              1      0.190 ± 0.190 … 0.190        0.190 ± 0.190 … 0.190
MicroBench      array-destructuring-assignment-rest.js      1.011  0.480 ± 0.480 … 0.480        0.475 ± 0.470 … 0.480
MicroBench      array-destructuring-assignment.js           1.015  3.360 ± 3.360 … 3.360        3.310 ± 3.260 … 3.360
MicroBench      array-prototype-map.js                      1.012  1.305 ± 1.290 … 1.320        1.290 ± 1.280 … 1.300
MicroBench      array-prototype-shift.js                    1      0.010 ± 0.010 … 0.010        0.010 ± 0.010 … 0.010
MicroBench      bound-call-00-args.js                       1.033  1.575 ± 1.570 … 1.580        1.525 ± 1.520 … 1.530
MicroBench      bound-call-04-args.js                       1.055  1.725 ± 1.630 … 1.820        1.635 ± 1.620 … 1.650
MicroBench      bound-call-16-args.js                       1.008  1.850 ± 1.840 … 1.860        1.835 ± 1.830 … 1.840
MicroBench      call-00-args.js                             1.049  1.605 ± 1.600 … 1.610        1.530 ± 1.530 … 1.530
MicroBench      call-01-args.js                             1.097  1.640 ± 1.610 … 1.670        1.495 ± 1.470 … 1.520
MicroBench      call-02-args.js                             1.019  1.595 ± 1.570 … 1.620        1.565 ± 1.550 … 1.580
MicroBench      call-03-args.js                             1.048  1.635 ± 1.630 … 1.640        1.560 ± 1.520 … 1.600
MicroBench      call-04-args.js                             1.053  1.680 ± 1.660 … 1.700        1.595 ± 1.560 … 1.630
MicroBench      call-16-args.js                             1.053  1.780 ± 1.780 … 1.780        1.690 ± 1.680 … 1.700
MicroBench      call-32-args.js                             1.056  2.070 ± 2.050 … 2.090        1.960 ± 1.910 … 2.010
MicroBench      for-in-indexed-properties.js                1.022  3.440 ± 3.430 … 3.450        3.365 ± 3.360 … 3.370
MicroBench      for-in-named-properties.js                  1.024  3.365 ± 3.360 … 3.370        3.285 ± 3.270 … 3.300
MicroBench      for-of.js                                   0.988  0.410 ± 0.410 … 0.410        0.415 ± 0.410 … 0.420
MicroBench      object-keys.js                              1.037  3.335 ± 3.320 … 3.350        3.215 ± 3.210 … 3.220
MicroBench      pic-add-own.js                              1.024  0.855 ± 0.850 … 0.860        0.835 ± 0.830 … 0.840
MicroBench      pic-get-own.js                              1.088  1.605 ± 1.530 … 1.680        1.475 ± 1.470 … 1.480
MicroBench      pic-get-pchain.js                           1.106  1.620 ± 1.550 … 1.690        1.465 ± 1.460 … 1.470
MicroBench      pic-put-own.js                              1.032  1.635 ± 1.610 … 1.660        1.585 ± 1.580 … 1.590
MicroBench      pic-put-pchain.js                           1.028  2.920 ± 2.830 … 3.010        2.840 ± 2.830 … 2.850
MicroBench      setter-in-prototype-chain.js                1.087  2.305 ± 2.270 … 2.340        2.120 ± 2.110 … 2.130
MicroBench      strictly-equals-object.js                   1.04   1.170 ± 1.150 … 1.190        1.125 ± 1.110 … 1.140
WasmMicroBench  call-00-args.wasm                           0.997  3.365 ± 3.350 … 3.380        3.375 ± 3.370 … 3.380
WasmMicroBench  call-01-args.wasm                           0.996  6.685 ± 6.660 … 6.710        6.710 ± 6.680 … 6.740
WasmMicroBench  call-02-args.wasm                           1.001  6.980 ± 6.970 … 6.990        6.970 ± 6.950 … 6.990
WasmMicroBench  call-03-args.wasm                           1.003  7.570 ± 7.520 … 7.620        7.545 ± 7.530 … 7.560
WasmMicroBench  call-04-args.wasm                           0.997  7.750 ± 7.710 … 7.790        7.770 ± 7.730 … 7.810
WasmMicroBench  call-16-args.wasm                           1.013  14.380 ± 14.340 … 14.420     14.190 ± 14.090 … 14.290
WasmMicroBench  call-32-args.wasm                           1.002  21.440 ± 21.400 … 21.480     21.395 ± 21.150 … 21.640
WasmCoremark    coremark-minimal.wasm                       0.996  473.504 ± 473.149 … 473.859  471.758 ± 470.367 … 473.149
SunSpider       Total                                       1.027  0.940                        0.915
Kraken          Total                                       0.988  12.760                       12.910
Octane          Total                                       0.999  109.460                      109.585
JetStream       Total                                       0.997  263.315                      264.120
JetStream3      Total                                       1.015  13.435                       13.230
RegExp          Total                                       1.015  1.645                        1.620
MicroBench      Total                                       1.041  44.970                       43.200
WasmMicroBench  Total                                       1.003  68.170                       67.955
WasmCoremark    Total                                       0.996  473.504                      471.758
All Suites      Total                                       1.002  529.750                      528.655
```