### PR TITLE
LibWebView: Add validation for span indices to prevent crashes

### DIFF
--- a/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Libraries/LibWebView/SourceHighlighter.cpp
@@ -388,6 +388,11 @@ String SourceHighlighterClient::to_html_string(Optional<URL::URL> const& url, UR
                 span_consumed = true;
             }
 
+            if (span_start > line.length() || span_end > line.length() || span_start > span_end) {
+                ++span_index;
+                continue;
+            }
+
             if (span_start != next_column) {
                 // Draw unspanned text between spans
                 draw_text_helper(next_column, span_start, {});


### PR DESCRIPTION
Ensures span start/end positions are valid within a line, preventing crashes from invalid spans due to malformed input like self-closing tags or newlines.

Closes #6211 