### PR TITLE
LibWeb: Cache results of harfbuzz text shaping

### DIFF
--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -61,8 +61,6 @@ ScaledFontMetrics Font::metrics() const
     return metrics;
 }
 
-float Font::width(StringView view) const { return measure_text_width(Utf8View(view), *this, {}); }
-float Font::width(Utf8View const& view) const { return measure_text_width(view, *this, {}); }
 float Font::width(Utf16View const& view) const { return measure_text_width(view, *this, {}); }
 
 float Font::glyph_width(u32 code_point) const

--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
  * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -123,6 +124,25 @@ SkFont Font::skia_font(float scale) const
     auto sk_font = SkFont { sk_ref_sp(sk_typeface), pixel_size() * scale };
     sk_font.setSubpixel(true);
     return sk_font;
+}
+
+Font::ShapingCache::~ShapingCache()
+{
+    clear();
+}
+
+void Font::ShapingCache::clear()
+{
+    for (auto& it : map) {
+        hb_buffer_destroy(it.value);
+    }
+    map.clear();
+    for (auto& buffer : single_ascii_character_map) {
+        if (buffer) {
+            hb_buffer_destroy(buffer);
+            buffer = nullptr;
+        }
+    }
 }
 
 }

--- a/Libraries/LibGfx/Font/Font.cpp
+++ b/Libraries/LibGfx/Font/Font.cpp
@@ -6,7 +6,7 @@
  */
 
 #include <AK/TypeCasts.h>
-#include <AK/Utf8View.h>
+#include <AK/Utf16String.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/TypefaceSkia.h>
@@ -65,8 +65,8 @@ float Font::width(Utf16View const& view) const { return measure_text_width(view,
 
 float Font::glyph_width(u32 code_point) const
 {
-    auto string = String::from_code_point(code_point);
-    return measure_text_width(Utf8View(string), *this, {});
+    auto string = Utf16String::from_code_point(code_point);
+    return measure_text_width(string.utf16_view(), *this, {});
 }
 
 NonnullRefPtr<Font> Font::scaled_with_size(float point_size) const

--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@serenityos.org>
  * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
- * Copyright (c) 2023, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2023-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -10,11 +10,14 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/Utf16String.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/Typeface.h>
+#include <LibGfx/ShapeFeature.h>
 
 class SkFont;
 struct hb_font_t;
+struct hb_buffer_t;
 
 namespace Gfx {
 
@@ -80,9 +83,23 @@ public:
     Font const& bold_variant() const;
     hb_font_t* harfbuzz_font() const;
 
+    struct ShapingCache {
+        // Before using the cache, make sure the features match! If they don't, clear the cache.
+        ShapeFeatures features;
+
+        HashMap<Utf16String, hb_buffer_t*> map;
+        hb_buffer_t* single_ascii_character_map[128] { nullptr };
+
+        ~ShapingCache();
+        void clear();
+    };
+    ShapingCache& shaping_cache() const { return m_shaping_cache; }
+
 private:
     mutable RefPtr<Font const> m_bold_variant;
     mutable hb_font_t* m_harfbuzz_font { nullptr };
+
+    mutable ShapingCache m_shaping_cache;
 
     NonnullRefPtr<Typeface const> m_typeface;
     float m_x_scale { 0.0f };

--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -67,8 +67,6 @@ public:
     float preferred_line_height() const { return metrics().height() + metrics().line_gap; }
     int x_height() const { return m_point_height; } // FIXME: Read from font
     u8 baseline() const { return m_point_height; }  // FIXME: Read from font
-    float width(StringView) const;
-    float width(Utf8View const&) const;
     float width(Utf16View const&) const;
     FlyString const& family() const { return m_typeface->family(); }
 

--- a/Libraries/LibGfx/ShapeFeature.h
+++ b/Libraries/LibGfx/ShapeFeature.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Gfx {
+
+struct ShapeFeature {
+    char tag[4];
+    u32 value;
+
+    bool operator==(ShapeFeature const&) const = default;
+    bool operator!=(ShapeFeature const&) const = default;
+};
+
+using ShapeFeatures = Vector<ShapeFeature, 4>;
+
+}

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -64,13 +64,8 @@ private:
     float m_width { 0 };
 };
 
-template<typename UnicodeView>
-NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, UnicodeView const& string, Gfx::Font const& font, GlyphRun::TextType, ShapeFeatures const& features);
-
-template<typename UnicodeView>
-Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, UnicodeView const& string, FontCascadeList const&);
-
-template<typename UnicodeView>
-float measure_text_width(UnicodeView const& string, Gfx::Font const& font, ShapeFeatures const& features);
+NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, Utf16View const&, Gfx::Font const& font, GlyphRun::TextType, ShapeFeatures const& features);
+Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View const&, FontCascadeList const&);
+float measure_text_width(Utf16View const&, Gfx::Font const& font, ShapeFeatures const& features);
 
 }

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -15,6 +15,7 @@
 #include <LibGfx/FontCascadeList.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
+#include <LibGfx/ShapeFeature.h>
 
 namespace Gfx {
 
@@ -24,13 +25,6 @@ struct DrawGlyph {
     float glyph_width { 0.0 };
     u32 glyph_id { 0 };
 };
-
-typedef struct ShapeFeature {
-    char tag[4];
-    u32 value;
-} ShapeFeature;
-
-using ShapeFeatures = Vector<ShapeFeature, 4>;
 
 class GlyphRun : public AtomicRefCounted<GlyphRun> {
 public:

--- a/Libraries/LibWeb/HTML/Canvas/CanvasText.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasText.h
@@ -17,9 +17,9 @@ class CanvasText {
 public:
     virtual ~CanvasText() = default;
 
-    virtual void fill_text(StringView, float x, float y, Optional<double> max_width) = 0;
-    virtual void stroke_text(StringView, float x, float y, Optional<double> max_width) = 0;
-    virtual GC::Ref<TextMetrics> measure_text(StringView text) = 0;
+    virtual void fill_text(Utf16String const&, float x, float y, Optional<double> max_width) = 0;
+    virtual void stroke_text(Utf16String const&, float x, float y, Optional<double> max_width) = 0;
+    virtual GC::Ref<TextMetrics> measure_text(Utf16String const&) = 0;
 
 protected:
     CanvasText() = default;

--- a/Libraries/LibWeb/HTML/Canvas/CanvasText.idl
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasText.idl
@@ -2,7 +2,7 @@
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvastext
 interface mixin CanvasText {
-    undefined fillText(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
-    undefined strokeText(DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
-    TextMetrics measureText(DOMString text);
+    undefined fillText(Utf16DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
+    undefined strokeText(Utf16DOMString text, unrestricted double x, unrestricted double y, optional unrestricted double maxWidth);
+    TextMetrics measureText(Utf16DOMString text);
 };

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -70,8 +70,8 @@ public:
     virtual void stroke() override;
     virtual void stroke(Path2D const& path) override;
 
-    virtual void fill_text(StringView, float x, float y, Optional<double> max_width) override;
-    virtual void stroke_text(StringView, float x, float y, Optional<double> max_width) override;
+    virtual void fill_text(Utf16String const&, float x, float y, Optional<double> max_width) override;
+    virtual void stroke_text(Utf16String const&, float x, float y, Optional<double> max_width) override;
 
     virtual void fill(StringView fill_rule) override;
     virtual void fill(Path2D& path, StringView fill_rule) override;
@@ -87,7 +87,7 @@ public:
 
     virtual CanvasRenderingContext2DSettings get_context_attributes() const override { return m_context_attributes; }
 
-    virtual GC::Ref<TextMetrics> measure_text(StringView text) override;
+    virtual GC::Ref<TextMetrics> measure_text(Utf16String const&) override;
 
     virtual void clip(StringView fill_rule) override;
     virtual void clip(Path2D& path, StringView fill_rule) override;
@@ -147,10 +147,10 @@ private:
 
     RefPtr<Gfx::FontCascadeList const> font_cascade_list();
 
-    PreparedText prepare_text(ByteString const& text, float max_width = INFINITY);
+    PreparedText prepare_text(Utf16String const&, float max_width = INFINITY);
 
     [[nodiscard]] Gfx::Path rect_path(float x, float y, float width, float height);
-    [[nodiscard]] Gfx::Path text_path(StringView text, float x, float y, Optional<double> max_width);
+    [[nodiscard]] Gfx::Path text_path(Utf16String const&, float x, float y, Optional<double> max_width);
 
     Gfx::Color clear_color() const;
 

--- a/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.cpp
@@ -119,12 +119,12 @@ void OffscreenCanvasRenderingContext2D::stroke(Path2D const&)
     dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::stroke(Path2D)");
 }
 
-void OffscreenCanvasRenderingContext2D::fill_text(StringView, float, float, Optional<double>)
+void OffscreenCanvasRenderingContext2D::fill_text(Utf16String const&, float, float, Optional<double>)
 {
     dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::fill_text()");
 }
 
-void OffscreenCanvasRenderingContext2D::stroke_text(StringView, float, float, Optional<double>)
+void OffscreenCanvasRenderingContext2D::stroke_text(Utf16String const&, float, float, Optional<double>)
 {
     dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::stroke_text()");
 }
@@ -166,7 +166,7 @@ void OffscreenCanvasRenderingContext2D::reset_to_default_state()
     dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::reset_to_default_state()");
 }
 
-GC::Ref<TextMetrics> OffscreenCanvasRenderingContext2D::measure_text(StringView)
+GC::Ref<TextMetrics> OffscreenCanvasRenderingContext2D::measure_text(Utf16String const&)
 {
     dbgln("(STUBBED) OffscreenCanvasRenderingContext2D::measure_text()");
 

--- a/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/OffscreenCanvasRenderingContext2D.h
@@ -75,8 +75,8 @@ public:
     virtual void stroke() override;
     virtual void stroke(Path2D const& path) override;
 
-    virtual void fill_text(StringView, float x, float y, Optional<double> max_width) override;
-    virtual void stroke_text(StringView, float x, float y, Optional<double> max_width) override;
+    virtual void fill_text(Utf16String const&, float x, float y, Optional<double> max_width) override;
+    virtual void stroke_text(Utf16String const&, float x, float y, Optional<double> max_width) override;
 
     virtual void fill(StringView fill_rule) override;
     virtual void fill(Path2D& path, StringView fill_rule) override;
@@ -90,7 +90,7 @@ public:
 
     virtual CanvasRenderingContext2DSettings get_context_attributes() const override { return m_context_attributes; }
 
-    virtual GC::Ref<TextMetrics> measure_text(StringView text) override;
+    virtual GC::Ref<TextMetrics> measure_text(Utf16String const&) override;
 
     virtual void clip(StringView fill_rule) override;
     virtual void clip(Path2D& path, StringView fill_rule) override;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1243,7 +1243,7 @@ void BlockFormattingContext::ensure_sizes_correct_for_left_offset_calculation(Li
     auto marker_text = marker.text();
     if (marker_text.has_value()) {
         // FIXME: Use per-code-point fonts to measure text.
-        auto text_width = marker_font.width(marker_text.value().code_points());
+        auto text_width = marker_font.width(Utf16String::from_utf8(marker_text.value()));
         marker_state.set_content_width(CSSPixels::nearest_value_for(text_width));
     } else {
         marker_state.set_content_width(marker_size);

--- a/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -46,7 +46,7 @@ void ImageBox::prepare_for_replaced_layout()
         } else {
             auto font = Platform::FontPlugin::the().default_font(12);
             CSSPixels alt_text_width = m_cached_alt_text_width.ensure([&] {
-                return CSSPixels::nearest_value_for(font->width(alt));
+                return CSSPixels::nearest_value_for(font->width(Utf16String::from_utf8(alt)));
             });
             set_natural_width(alt_text_width + 16);
             set_natural_height(CSSPixels::nearest_value_for(font->pixel_size()) + 16);

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -222,12 +222,12 @@ void DisplayListRecorder::draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color 
     });
 }
 
-void DisplayListRecorder::draw_text(Gfx::IntRect const& rect, String raw_text, Gfx::Font const& font, Gfx::TextAlignment alignment, Color color)
+void DisplayListRecorder::draw_text(Gfx::IntRect const& rect, Utf16String const& raw_text, Gfx::Font const& font, Gfx::TextAlignment alignment, Color color)
 {
     if (rect.is_empty() || color.alpha() == 0)
         return;
 
-    auto glyph_run = Gfx::shape_text({}, 0, raw_text.code_points(), font, Gfx::GlyphRun::TextType::Ltr, {});
+    auto glyph_run = Gfx::shape_text({}, 0, raw_text.utf16_view(), font, Gfx::GlyphRun::TextType::Ltr, {});
     float baseline_x = 0;
     if (alignment == Gfx::TextAlignment::CenterLeft) {
         baseline_x = rect.x();

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -84,7 +84,7 @@ public:
 
     void draw_line(Gfx::IntPoint from, Gfx::IntPoint to, Color color, int thickness = 1, Gfx::LineStyle style = Gfx::LineStyle::Solid, Color alternate_color = Color::Transparent);
 
-    void draw_text(Gfx::IntRect const&, String, Gfx::Font const&, Gfx::TextAlignment, Color);
+    void draw_text(Gfx::IntRect const&, Utf16String const&, Gfx::Font const&, Gfx::TextAlignment, Color);
 
     // Streamlined text drawing routine that does no wrapping/elision/alignment.
     void draw_glyph_run(Gfx::FloatPoint baseline_start, Gfx::GlyphRun const& glyph_run, Color color, Gfx::IntRect const& rect, double scale, Gfx::Orientation);

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -71,7 +71,7 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
             if (!m_alt_text.is_empty()) {
                 auto enclosing_rect = context.enclosing_device_rect(image_rect).to_type<int>();
                 context.display_list_recorder().draw_rect(enclosing_rect, Gfx::Color::Black);
-                context.display_list_recorder().draw_text(enclosing_rect, m_alt_text, *Platform::FontPlugin::the().default_font(12), Gfx::TextAlignment::Center, computed_values().color());
+                context.display_list_recorder().draw_text(enclosing_rect, Utf16String::from_utf8(m_alt_text), *Platform::FontPlugin::the().default_font(12), Gfx::TextAlignment::Center, computed_values().color());
             }
         } else if (auto bitmap = m_image_provider.current_image_bitmap_sized(image_rect_device_pixels.size().to_type<int>())) {
             ScopedCornerRadiusClip corner_clip { context, image_rect_device_pixels, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };

--- a/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -59,7 +59,7 @@ void MarkerPaintable::paint(DisplayListRecordingContext& context, PaintPhase pha
     if (auto text = layout_box().text(); text.has_value()) {
         // FIXME: This should use proper text layout logic!
         // This does not line up with the text in the <li> element which looks very sad :(
-        context.display_list_recorder().draw_text(device_rect.to_type<int>(), *text, layout_box().font(context), Gfx::TextAlignment::Center, color);
+        context.display_list_recorder().draw_text(device_rect.to_type<int>(), Utf16String::from_utf8(*text), layout_box().font(context), Gfx::TextAlignment::Center, color);
     } else if (auto const* counter_style = layout_box().list_style_type().get_pointer<CSS::CounterStyleNameKeyword>()) {
         switch (*counter_style) {
         case CSS::CounterStyleNameKeyword::Square:

--- a/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -119,7 +119,7 @@ MediaPaintable::Components MediaPaintable::compute_control_bar_components(Displa
 
     auto display_time = human_readable_digital_time(round(media_element.layout_display_time({})));
     auto duration = human_readable_digital_time(isnan(media_element.duration()) ? 0 : round(media_element.duration()));
-    components.timestamp = String::formatted("{} / {}", display_time, duration).release_value_but_fixme_should_propagate_errors();
+    components.timestamp = Utf16String::formatted("{} / {}", display_time, duration);
     components.timestamp_font = layout_node().font(context);
 
     auto timestamp_size = DevicePixels { static_cast<DevicePixels::Type>(ceilf(components.timestamp_font->width(components.timestamp))) };
@@ -196,7 +196,7 @@ void MediaPaintable::paint_control_bar_timestamp(DisplayListRecordingContext& co
     if (components.timestamp_rect.is_empty())
         return;
 
-    context.display_list_recorder().draw_text(components.timestamp_rect.to_type<int>(), components.timestamp, *components.timestamp_font, Gfx::TextAlignment::CenterLeft, Color::White);
+    context.display_list_recorder().draw_text(components.timestamp_rect.to_type<int>(), components.timestamp.to_well_formed_utf8(), *components.timestamp_font, Gfx::TextAlignment::CenterLeft, Color::White);
 }
 
 void MediaPaintable::paint_control_bar_speaker(DisplayListRecordingContext& context, HTML::HTMLMediaElement const& media_element, Components const& components, Optional<DevicePixelPoint> const& mouse_position)

--- a/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -196,7 +196,7 @@ void MediaPaintable::paint_control_bar_timestamp(DisplayListRecordingContext& co
     if (components.timestamp_rect.is_empty())
         return;
 
-    context.display_list_recorder().draw_text(components.timestamp_rect.to_type<int>(), components.timestamp.to_well_formed_utf8(), *components.timestamp_font, Gfx::TextAlignment::CenterLeft, Color::White);
+    context.display_list_recorder().draw_text(components.timestamp_rect.to_type<int>(), components.timestamp, *components.timestamp_font, Gfx::TextAlignment::CenterLeft, Color::White);
 }
 
 void MediaPaintable::paint_control_bar_speaker(DisplayListRecordingContext& context, HTML::HTMLMediaElement const& media_element, Components const& components, Optional<DevicePixelPoint> const& mouse_position)

--- a/Libraries/LibWeb/Painting/MediaPaintable.h
+++ b/Libraries/LibWeb/Painting/MediaPaintable.h
@@ -30,7 +30,7 @@ private:
         DevicePixelRect playback_button_rect;
         DevicePixelRect timeline_rect;
 
-        String timestamp;
+        Utf16String timestamp;
         RefPtr<Gfx::Font const> timestamp_font;
         DevicePixelRect timestamp_rect;
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -532,13 +532,13 @@ void PaintableBox::paint_inspector_overlay_internal(DisplayListRecordingContext&
 
     auto font = Platform::FontPlugin::the().default_font(12);
 
-    StringBuilder builder;
+    StringBuilder builder(StringBuilder::Mode::UTF16);
     if (layout_node_with_style_and_box_metrics().dom_node())
         builder.append(layout_node_with_style_and_box_metrics().dom_node()->debug_description());
     else
         builder.append(layout_node_with_style_and_box_metrics().debug_description());
     builder.appendff(" {}x{} @ {},{}", border_rect.width(), border_rect.height(), border_rect.x(), border_rect.y());
-    auto size_text = MUST(builder.to_string());
+    auto size_text = builder.to_utf16_string();
     auto size_text_rect = border_rect;
     size_text_rect.set_y(border_rect.y() + border_rect.height());
     size_text_rect.set_top(size_text_rect.top());
@@ -547,7 +547,7 @@ void PaintableBox::paint_inspector_overlay_internal(DisplayListRecordingContext&
     auto size_text_device_rect = context.enclosing_device_rect(size_text_rect).to_type<int>();
     context.display_list_recorder().fill_rect(size_text_device_rect, context.palette().color(Gfx::ColorRole::Tooltip));
     context.display_list_recorder().draw_rect(size_text_device_rect, context.palette().threed_shadow1());
-    context.display_list_recorder().draw_text(size_text_device_rect, size_text, font->with_size(font->point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
+    context.display_list_recorder().draw_text(size_text_device_rect, size_text.to_well_formed_utf8(), font->with_size(font->point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
 }
 
 void PaintableBox::set_stacking_context(NonnullOwnPtr<StackingContext> stacking_context)

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -547,7 +547,7 @@ void PaintableBox::paint_inspector_overlay_internal(DisplayListRecordingContext&
     auto size_text_device_rect = context.enclosing_device_rect(size_text_rect).to_type<int>();
     context.display_list_recorder().fill_rect(size_text_device_rect, context.palette().color(Gfx::ColorRole::Tooltip));
     context.display_list_recorder().draw_rect(size_text_device_rect, context.palette().threed_shadow1());
-    context.display_list_recorder().draw_text(size_text_device_rect, size_text.to_well_formed_utf8(), font->with_size(font->point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
+    context.display_list_recorder().draw_text(size_text_device_rect, size_text, font->with_size(font->point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
 }
 
 void PaintableBox::set_stacking_context(NonnullOwnPtr<StackingContext> stacking_context)


### PR DESCRIPTION
This patch introduces a per-`Gfx::Font` cache for harfbuzz text shaping
results. As long as the same OpenType features are used, we now cache
the results of harfbuzz shaping, saving massive amounts of time during
text layout.
    
As an example, it saves multiple seconds when loading the ECMAScript
specification at <https://tc39.es/ecma262>. Before this change, harfbuzz
shaping was taking up roughly 11% of a profile of loading that page.
The cache brings it down to 1.8%.
    
Note that the cache currently grows unbounded. I've left a FIXME about
adding some limits.
