### PR TITLE
LibWeb: Make HTMLScriptElement.src getter resolve to absolute URL

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -62,7 +62,7 @@ public:
     TrustedTypes::TrustedScriptOrString text() const { return child_text_content(); }
     WebIDL::ExceptionOr<void> set_text(TrustedTypes::TrustedScriptOrString);
 
-    TrustedTypes::TrustedScriptURLOrString src() const { return Utf16String::from_utf8(get_attribute_value(AttributeNames::src)); }
+    TrustedTypes::TrustedScriptURLOrString src() const;
     WebIDL::ExceptionOr<void> set_src(TrustedTypes::TrustedScriptURLOrString);
 
     Variant<GC::Root<TrustedTypes::TrustedScript>, Utf16String, Empty> text_content() const;

--- a/Tests/LibWeb/Text/expected/htmlscript-src-reflection.txt
+++ b/Tests/LibWeb/Text/expected/htmlscript-src-reflection.txt
@@ -1,0 +1,3 @@
+is_string = true
+has_protocol = true
+ends_with_dummy = true

--- a/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
+++ b/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
@@ -11,6 +11,7 @@ input.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 link.href final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 object.codeBase final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 object.data final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+script.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 source.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 track.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 video.poster final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD

--- a/Tests/LibWeb/Text/input/htmlscript-src-reflection.html
+++ b/Tests/LibWeb/Text/input/htmlscript-src-reflection.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const script = document.createElement("script");
+        script.src = "./dummy.js"; // not appended/loaded; we only check the getter resolution
+        const value = script.src;
+
+        // Print booleans so expected output is stable.
+        const is_string = typeof value === "string";
+        println(`is_string = ${is_string}`);
+
+        // Must be absolute per spec: has a scheme like "file:" or "http:"
+        let has_protocol = false;
+        try { has_protocol = !!new URL(value).protocol; } catch {}
+        println(`has_protocol = ${has_protocol}`);
+
+        // Should end with the filename we set.
+        const ends_with = value.endsWith("/dummy.js");
+        println(`ends_with_dummy = ${ends_with}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/usvstring-url-reflection.html
+++ b/Tests/LibWeb/Text/input/usvstring-url-reflection.html
@@ -16,6 +16,7 @@
             { "link": "href" },
             { "object": "codeBase" },
             { "object": "data" },
+            { "script": "src" },
             { "source": "src" },
             { "track": "src" },
             { "video": "poster" },


### PR DESCRIPTION
LibWeb: Make HTMLScriptElement.src getter resolve to absolute URL

The src IDL attribute was previously implemented as an inline getter that returned the raw attribute value. This broke spec semantics and sites like Telegram Web that rely on document.currentScript.src to compute Webpack’s publicPath.

According to the HTML Standard:
https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes

For URL-reflecting attributes:
  1. If contentAttributeValue is null, then return the empty string.
  2. Let urlString be the result of encoding-parsing-and-serializing a URL given contentAttributeValue, relative to element’s node document.
  3. If urlString is not failure, then return urlString.
  
  This PR implements these steps

  Fixes #6253