### PR TITLE
LibJS: LEXER_DEBUG code_unit_at() goes beyond end of line

### DIFF
--- a/Libraries/LibJS/Lexer.cpp
+++ b/Libraries/LibJS/Lexer.cpp
@@ -327,10 +327,12 @@ void Lexer::consume()
                 type = "LINE FEED"sv;
             else if (m_current_code_unit == '\r')
                 type = "CARRIAGE RETURN"sv;
-            else if (m_source.code_unit_at(m_position + 1) == LINE_SEPARATOR)
+            else if (m_current_code_unit == LINE_SEPARATOR)
                 type = "LINE SEPARATOR"sv;
-            else
+            else if (m_current_code_unit == PARAGRAPH_SEPARATOR)
                 type = "PARAGRAPH SEPARATOR"sv;
+            else
+                VERIFY_NOT_REACHED();
             dbgln("Found a line terminator: {}", type);
         }
 


### PR DESCRIPTION
When compiled with LEXER_DEBUG or ENABLE_ALL_THE_DEBUG_MACROS=ON and the test-js is run, the following backtrace will be seen:

(see #6173 where this all started)

Note: there is another issue in LibJS (and test-js) that will strike first when using ENABLE_ALL_THE_DEBUG_MACROS=ON.  See #6263


```
VERIFICATION FAILED: index < length_in_code_units() at /home/bobo/projects/myladybird/AK/Utf16View.h:366
/home/bobo/projects/myladybird/Build/release/lib/liblagom-ak.so.0(dump_backtrace+0x4a) [0x7fe1cbeb34fa]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-ak.so.0(ak_trap+0xf) [0x7fe1cbeb375f]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-ak.so.0(ak_verification_failed+0x49) [0x7fe1cbeb3499]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Lexer::consume() 0x23c) [0x7fe1cb98b41c]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Lexer::next() 0x1478) [0x7fe1cb98ed28]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Parser::ParserState::ParserState(JS::Lexer, JS::Program::Type) 0x296) [0x7fe1cb998cf6]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Parser::Parser(JS::Lexer, JS::Program::Type, AK::Optional<JS::Parser::EvalInitialState>) 0x274) [0x7fe1cb999134]
/home/bobo/projects/myladybird/Build/release/bin/test-js(+0xb009) [0x6431f7891009]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::NativeFunction::call() 0x62) [0x7fe1cbb5b452]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::NativeFunction::internal_call(JS::ExecutionContext&, JS::Value) 0xab) [0x7fe1cbb5b61b]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x153b9a) [0x7fe1cb953b9a]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x154419) [0x7fe1cb954419]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_bytecode(unsigned long) 0xee9) [0x7fe1cb958e59]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) 0x24b) [0x7fe1cb95c11b]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::ECMAScriptFunctionObject::internal_call(JS::ExecutionContext&, JS::Value) 0x214) [0x7fe1cba86494]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x153b9a) [0x7fe1cb953b9a]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x154419) [0x7fe1cb954419]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_bytecode(unsigned long) 0xee9) [0x7fe1cb958e59]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) 0x24b) [0x7fe1cb95c11b]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::ECMAScriptFunctionObject::internal_call(JS::ExecutionContext&, JS::Value) 0x214) [0x7fe1cba86494]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x153b9a) [0x7fe1cb953b9a]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x154419) [0x7fe1cb954419]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_bytecode(unsigned long) 0xee9) [0x7fe1cb958e59]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) 0x24b) [0x7fe1cb95c11b]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::ECMAScriptFunctionObject::internal_call(JS::ExecutionContext&, JS::Value) 0x214) [0x7fe1cba86494]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x153b9a) [0x7fe1cb953b9a]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0(+0x154419) [0x7fe1cb954419]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_bytecode(unsigned long) 0xee9) [0x7fe1cb958e59]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run_executable(JS::Bytecode::Executable&, AK::Optional<unsigned long>, JS::Value) 0x24b) [0x7fe1cb95c11b]
/home/bobo/projects/myladybird/Build/release/lib/liblagom-js.so.0 JS::Bytecode::Interpreter::run(JS::Script&, GC::Ptr<JS::Environment>) 0x1fe) [0x7fe1cb95cc0e]
/home/bobo/projects/myladybird/Build/release/bin/test-js(+0x160f2) [0x6431f789c0f2]
/home/bobo/projects/myladybird/Build/release/bin/test-js(+0x14e51) [0x6431f789ae51]
/home/bobo/projects/myladybird/Build/release/bin/test-js(+0x870a) [0x6431f788e70a]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a578) [0x7fe1cb02a578]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b) [0x7fe1cb02a63b]
/home/bobo/projects/myladybird/Build/release/bin/test-js(+0x9025) [0x6431f788f025]
```

After debugging the issue is in `JS::Lexer:consume()` on `Libraries/LibJS/Lexer.cpp:330`,

`else if (m_source.code_unit_at(m_position + 1) == LINE_SEPARATOR)`

the m_position + 1 is causing the retrieval of the code_point to go beyond the end of the line by one character.

Code was changed to use current_code_point() to check for the LINE_SEPARATOR and also the PARAGRAPH_SEPARATOR, and that appears to resolve the issue.


Both of these variations below appear to work identically, which one is the better choice I would really appreciate some feedback.

```
            else if (current_code_point() == LINE_SEPARATOR)
                type = "LINE SEPARATOR"sv;
            else if (current_code_point() == PARAGRAPH_SEPARATOR)
                type = "PARAGRAPH SEPARATOR"sv;
            else
                VERIFY_NOT_REACHED();
```

```
            else if (m_source.code_unit_at(m_position - 1) == LINE_SEPARATOR)
                type = "LINE SEPARATOR"sv;
            else if (m_source.code_unit_at(m_position - 1) == PARAGRAPH_SEPARATOR)
                type = "PARAGRAPH SEPARATOR"sv;
            else
                VERIFY_NOT_REACHED();
```


Both versions gave the same result when I searched for "Found a line terminator" in the output

```
     15 Found a line terminator: CARRIAGE RETURN
 805619 Found a line terminator: LINE FEED
     14 Found a line terminator: LINE SEPARATOR
     14 Found a line terminator: PARAGRAPH SEPARATOR
```
