### PR TITLE
LibWeb: Improved parsing of animation properties

### DIFF
--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
@@ -83,6 +84,10 @@ GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, Font
             font_face->reject_status_promise(WebIDL::SyntaxError::create(realm, Utf16String::formatted("FontFace constructor: Invalid {}", to_string(descriptor_id))));
             return {};
         }
+
+        if (result->is_custom_ident())
+            return result->as_custom_ident().custom_ident().to_string();
+
         return result->to_string(SerializationMode::Normal);
     };
     font_face->m_family = try_parse_descriptor(DescriptorID::FontFamily, family);
@@ -225,7 +230,7 @@ WebIDL::ExceptionOr<void> FontFace::set_family(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-family property
     }
 
-    m_family = property->to_string(SerializationMode::Normal);
+    m_family = property->as_custom_ident().custom_ident().to_string();
 
     return {};
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -422,6 +422,7 @@ private:
     RefPtr<StyleValue const> parse_all_as_single_keyword_value(TokenStream<ComponentValue>&, Keyword);
 
     RefPtr<StyleValue const> parse_aspect_ratio_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue const> parse_animation_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue const> parse_background_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue const> parse_single_background_position_x_or_y_value(TokenStream<ComponentValue>&, PropertyID);
     RefPtr<StyleValue const> parse_single_background_size_value(PropertyID, TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -450,6 +450,18 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_css_value(Pr
         if (auto parsed_value = parse_aspect_ratio_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
+    case PropertyID::AnimationComposition:
+    case PropertyID::AnimationDelay:
+    case PropertyID::AnimationDirection:
+    case PropertyID::AnimationDuration:
+    case PropertyID::AnimationFillMode:
+    case PropertyID::AnimationIterationCount:
+    case PropertyID::AnimationName:
+    case PropertyID::AnimationPlayState:
+    case PropertyID::AnimationTimingFunction:
+        if (auto parsed_value = parse_simple_comma_separated_value_list(property_id, tokens); parsed_value && !tokens.has_next_token())
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
     case PropertyID::BackdropFilter:
     case PropertyID::Filter:
         if (auto parsed_value = parse_filter_value_list_value(tokens); parsed_value && !tokens.has_next_token())

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -199,14 +199,14 @@
     "inherited": false,
     "initial": "none 0s ease 1 normal running 0s none",
     "longhands": [
-      "animation-name",
       "animation-duration",
       "animation-timing-function",
+      "animation-delay",
       "animation-iteration-count",
       "animation-direction",
+      "animation-fill-mode",
       "animation-play-state",
-      "animation-delay",
-      "animation-fill-mode"
+      "animation-name"
     ]
   },
   "animation-composition": {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2595,6 +2595,7 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
     // 4. Convert properties into their computed forms
     compute_property_values(computed_style);
 
+    // FIXME: Support multiple entries for `animation` properties
     // Animation declarations [css-animations-2]
     auto animation_name = [&]() -> Optional<String> {
         auto const& animation_name = computed_style->property(PropertyID::AnimationName);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -973,8 +973,6 @@ void StyleComputer::collect_animation_into(DOM::AbstractElement abstract_element
             return camel_case_string_from_property_id(a) < camel_case_string_from_property_id(b);
         };
 
-        compute_font(computed_properties, abstract_element);
-        compute_property_values(computed_properties);
         Length::FontMetrics font_metrics {
             computed_properties.font_size(),
             computed_properties.first_available_computed_font().pixel_metrics()
@@ -2585,6 +2583,18 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
         }
     }
 
+    // Compute the value of custom properties
+    compute_custom_properties(computed_style, abstract_element);
+
+    // 2. Compute the math-depth property, since that might affect the font-size
+    compute_math_depth(computed_style, abstract_element);
+
+    // 3. Compute the font, since that may be needed for font-relative CSS units
+    compute_font(computed_style, abstract_element);
+
+    // 4. Convert properties into their computed forms
+    compute_property_values(computed_style);
+
     // Animation declarations [css-animations-2]
     auto animation_name = [&]() -> Optional<String> {
         auto const& animation_name = computed_style->property(PropertyID::AnimationName);
@@ -2653,18 +2663,6 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
             }
         }
     }
-
-    // Compute the value of custom properties
-    compute_custom_properties(computed_style, abstract_element);
-
-    // 2. Compute the math-depth property, since that might affect the font-size
-    compute_math_depth(computed_style, abstract_element);
-
-    // 3. Compute the font, since that may be needed for font-relative CSS units
-    compute_font(computed_style, abstract_element);
-
-    // 4. Convert properties into their computed forms
-    compute_property_values(computed_style);
 
     // 5. Run automatic box type transformations
     transform_box_type_if_needed(computed_style, abstract_element);

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -203,6 +203,7 @@ public:
         double device_pixels_per_css_pixel;
     };
     static NonnullRefPtr<StyleValue const> compute_value_of_property(PropertyID, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, PropertyValueComputationContext const&);
+    static NonnullRefPtr<StyleValue const> compute_animation_name(NonnullRefPtr<StyleValue const> const& specified_value, PropertyValueComputationContext const&);
     static NonnullRefPtr<StyleValue const> compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& specified_value, NonnullRefPtr<StyleValue const> const& style_specified_value, PropertyValueComputationContext const&);
     static NonnullRefPtr<StyleValue const> compute_font_size(NonnullRefPtr<StyleValue const> const& specified_value, int computed_math_depth, CSSPixels inherited_font_size, int inherited_math_depth, Length::ResolutionContext const& parent_length_resolution_context);
     static NonnullRefPtr<StyleValue const> compute_font_style(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& parent_length_resolution_context);

--- a/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 
 namespace Web::CSS {
@@ -22,7 +23,7 @@ public:
 
     FlyString const& custom_ident() const { return m_custom_ident; }
 
-    virtual String to_string(SerializationMode) const override { return m_custom_ident.to_string(); }
+    virtual String to_string(SerializationMode) const override { return serialize_an_identifier(m_custom_ident.to_string()); }
     virtual Vector<Parser::ComponentValue> tokenize() const override;
     virtual GC::Ref<CSSStyleValue> reify(JS::Realm& realm, String const&) const override;
 

--- a/Tests/LibWeb/Text/expected/css/animation-name-is-valid-other-property-value.txt
+++ b/Tests/LibWeb/Text/expected/css/animation-name-is-valid-other-property-value.txt
@@ -1,0 +1,4 @@
+#timing-function { animation: ease eAsE-In-OuT; }
+#direction { animation: normal rEvErSe; }
+#fill-mode { animation: none fOrWaRdS; }
+#running-state { animation: running pAuSeD; }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-composition-valid.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-composition-valid.tentative.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 4 tests
 
-3 Pass
-1 Fail
+4 Pass
 Pass	e.style['animation-composition'] = "replace" should set the property value
 Pass	e.style['animation-composition'] = "add" should set the property value
 Pass	e.style['animation-composition'] = "accumulate" should set the property value
-Fail	e.style['animation-composition'] = "replace, add, accumulate" should set the property value
+Pass	e.style['animation-composition'] = "replace, add, accumulate" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-computed.txt
@@ -1,0 +1,21 @@
+Harness status: OK
+
+Found 15 tests
+
+11 Pass
+4 Fail
+Pass	Default animation value
+Pass	Property animation value '1s'
+Pass	Property animation value 'cubic-bezier(0, -2, 1, 3)'
+Pass	Property animation value 'ease-in-out'
+Pass	Property animation value '1s -3s'
+Pass	Property animation value '4'
+Pass	Property animation value 'reverse'
+Pass	Property animation value 'both'
+Pass	Property animation value 'paused'
+Pass	Property animation value 'none'
+Pass	Property animation value 'anim'
+Fail	Property animation value 'anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)'
+Fail	Property animation value 'anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)'
+Fail	Property animation value 'none, none'
+Fail	Animation with a delay but no duration

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-computed.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 15 tests
 
-11 Pass
-4 Fail
+15 Pass
 Pass	Default animation value
 Pass	Property animation value '1s'
 Pass	Property animation value 'cubic-bezier(0, -2, 1, 3)'
@@ -15,7 +14,7 @@ Pass	Property animation value 'both'
 Pass	Property animation value 'paused'
 Pass	Property animation value 'none'
 Pass	Property animation value 'anim'
-Fail	Property animation value 'anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)'
-Fail	Property animation value 'anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)'
-Fail	Property animation value 'none, none'
-Fail	Animation with a delay but no duration
+Pass	Property animation value 'anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)'
+Pass	Property animation value 'anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)'
+Pass	Property animation value 'none, none'
+Pass	Animation with a delay but no duration

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-computed.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 4 tests
+
+2 Pass
+2 Fail
+Pass	Property animation-delay value '-500ms'
+Pass	Property animation-delay value 'calc(2 * 3s)'
+Fail	Property animation-delay value '20s, 10s'
+Fail	Property animation-delay value 'calc(10s + (sign(2cqw - 10px) * 5s))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-computed.txt
@@ -2,9 +2,9 @@ Harness status: OK
 
 Found 4 tests
 
-2 Pass
-2 Fail
+3 Pass
+1 Fail
 Pass	Property animation-delay value '-500ms'
 Pass	Property animation-delay value 'calc(2 * 3s)'
-Fail	Property animation-delay value '20s, 10s'
+Pass	Property animation-delay value '20s, 10s'
 Fail	Property animation-delay value 'calc(10s + (sign(2cqw - 10px) * 5s))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-invalid.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	e.style['animation-delay'] = "infinite" should not set the property value
+Pass	e.style['animation-delay'] = "0" should not set the property value
+Pass	e.style['animation-delay'] = "1s 2s 3s" should not set the property value
+Pass	e.style['animation-delay'] = "initial, -3s" should not set the property value
+Pass	e.style['animation-delay'] = "-3s, initial" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-valid.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 4 tests
+
+3 Pass
+1 Fail
+Pass	e.style['animation-delay'] = "-5ms" should set the property value
+Pass	e.style['animation-delay'] = "0s" should set the property value
+Pass	e.style['animation-delay'] = "10s" should set the property value
+Fail	e.style['animation-delay'] = "20s, 10s" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-delay-valid.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 4 tests
 
-3 Pass
-1 Fail
+4 Pass
 Pass	e.style['animation-delay'] = "-5ms" should set the property value
 Pass	e.style['animation-delay'] = "0s" should set the property value
 Pass	e.style['animation-delay'] = "10s" should set the property value
-Fail	e.style['animation-delay'] = "20s, 10s" should set the property value
+Pass	e.style['animation-delay'] = "20s, 10s" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-computed.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	Property animation-direction value 'normal, reverse, alternate, alternate-reverse'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-computed.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	Property animation-direction value 'normal, reverse, alternate, alternate-reverse'
+1 Pass
+Pass	Property animation-direction value 'normal, reverse, alternate, alternate-reverse'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-invalid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	e.style['animation-direction'] = "auto" should not set the property value
+Pass	e.style['animation-direction'] = "normal reverse" should not set the property value
+Pass	e.style['animation-direction'] = "reverse, initial" should not set the property value
+Pass	e.style['animation-direction'] = "initial, reverse" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-valid.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-4 Pass
-1 Fail
+5 Pass
 Pass	e.style['animation-direction'] = "normal" should set the property value
 Pass	e.style['animation-direction'] = "reverse" should set the property value
 Pass	e.style['animation-direction'] = "alternate" should set the property value
 Pass	e.style['animation-direction'] = "alternate-reverse" should set the property value
-Fail	e.style['animation-direction'] = "normal, reverse, alternate, alternate-reverse" should set the property value
+Pass	e.style['animation-direction'] = "normal, reverse, alternate, alternate-reverse" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-direction-valid.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+4 Pass
+1 Fail
+Pass	e.style['animation-direction'] = "normal" should set the property value
+Pass	e.style['animation-direction'] = "reverse" should set the property value
+Pass	e.style['animation-direction'] = "alternate" should set the property value
+Pass	e.style['animation-direction'] = "alternate-reverse" should set the property value
+Fail	e.style['animation-direction'] = "normal, reverse, alternate, alternate-reverse" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-computed.txt
@@ -2,12 +2,12 @@ Harness status: OK
 
 Found 15 tests
 
-10 Pass
-5 Fail
+11 Pass
+4 Fail
 Pass	Property animation-duration value '500ms'
 Pass	Property animation-duration value 'calc(2 * 3s)'
 Fail	Property animation-duration value 'calc(10s + (sign(2cqw - 10px) * 5s))'
-Fail	Property animation-duration value '20s, 10s'
+Pass	Property animation-duration value '20s, 10s'
 Fail	Property animation-duration value 'auto'
 Fail	Property animation-duration value 'auto, auto'
 Fail	Resolved value of animation-duration:auto with animation-timeline:auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-computed.txt
@@ -1,0 +1,21 @@
+Harness status: OK
+
+Found 15 tests
+
+10 Pass
+5 Fail
+Pass	Property animation-duration value '500ms'
+Pass	Property animation-duration value 'calc(2 * 3s)'
+Fail	Property animation-duration value 'calc(10s + (sign(2cqw - 10px) * 5s))'
+Fail	Property animation-duration value '20s, 10s'
+Fail	Property animation-duration value 'auto'
+Fail	Property animation-duration value 'auto, auto'
+Fail	Resolved value of animation-duration:auto with animation-timeline:auto
+Pass	Resolved value of animation-duration:auto with animation-timeline:auto, auto
+Pass	Resolved value of animation-duration:auto with animation-timeline:--t
+Pass	Resolved value of animation-duration:auto with animation-timeline:--t, --t2
+Pass	Resolved value of animation-duration:auto with animation-timeline:none
+Pass	Resolved value of animation-duration:auto with animation-timeline:scroll()
+Pass	Resolved value of animation-duration:auto with animation-timeline:view()
+Pass	Resolved value of animation-duration:0s with animation-timeline:auto
+Pass	Resolved value of animation-duration:0s with animation-timeline:auto, auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-invalid.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	e.style['animation-duration'] = "-3s" should not set the property value
+Pass	e.style['animation-duration'] = "0" should not set the property value
+Pass	e.style['animation-duration'] = "infinite" should not set the property value
+Pass	e.style['animation-duration'] = "1s 2s" should not set the property value
+Pass	e.style['animation-duration'] = "initial, 1s" should not set the property value
+Pass	e.style['animation-duration'] = "1s, initial" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-valid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	e.style['animation-duration'] = "3s" should set the property value
 Pass	e.style['animation-duration'] = "500ms" should set the property value
-Fail	e.style['animation-duration'] = "1s, 2s, 3s" should set the property value
+Pass	e.style['animation-duration'] = "1s, 2s, 3s" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-duration-valid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+2 Pass
+1 Fail
+Pass	e.style['animation-duration'] = "3s" should set the property value
+Pass	e.style['animation-duration'] = "500ms" should set the property value
+Fail	e.style['animation-duration'] = "1s, 2s, 3s" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-computed.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	Property animation-fill-mode value 'none, forwards, backwards, both'
+1 Pass
+Pass	Property animation-fill-mode value 'none, forwards, backwards, both'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-computed.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	Property animation-fill-mode value 'none, forwards, backwards, both'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-invalid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	e.style['animation-fill-mode'] = "auto" should not set the property value
+Pass	e.style['animation-fill-mode'] = "forwards backwards" should not set the property value
+Pass	e.style['animation-fill-mode'] = "both, initial" should not set the property value
+Pass	e.style['animation-fill-mode'] = "initial, both" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-valid.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-4 Pass
-1 Fail
+5 Pass
 Pass	e.style['animation-fill-mode'] = "none" should set the property value
 Pass	e.style['animation-fill-mode'] = "forwards" should set the property value
 Pass	e.style['animation-fill-mode'] = "backwards" should set the property value
 Pass	e.style['animation-fill-mode'] = "both" should set the property value
-Fail	e.style['animation-fill-mode'] = "none, forwards, backwards, both" should set the property value
+Pass	e.style['animation-fill-mode'] = "none, forwards, backwards, both" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-fill-mode-valid.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+4 Pass
+1 Fail
+Pass	e.style['animation-fill-mode'] = "none" should set the property value
+Pass	e.style['animation-fill-mode'] = "forwards" should set the property value
+Pass	e.style['animation-fill-mode'] = "backwards" should set the property value
+Pass	e.style['animation-fill-mode'] = "both" should set the property value
+Fail	e.style['animation-fill-mode'] = "none, forwards, backwards, both" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-invalid.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	e.style['animation'] = "1s 2s 3s" should not set the property value
+Pass	e.style['animation'] = "-1s -2s" should not set the property value
+Pass	e.style['animation'] = "steps(1) steps(2)" should not set the property value
+Pass	e.style['animation'] = "1 2" should not set the property value
+Pass	e.style['animation'] = "reverse alternate alternate-reverse anim" should not set the property value
+Pass	e.style['animation'] = "both backwards forwards anim" should not set the property value
+Pass	e.style['animation'] = "paused running paused anim" should not set the property value
+Pass	e.style['animation'] = "anim1 timeline1 anim2" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-computed.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	Property animation-iteration-count value '0, infinite, 3'
+1 Pass
+1 Fail
+Pass	Property animation-iteration-count value '0, infinite, 3'
 Fail	Property animation-iteration-count value 'calc(10 + (sign(2cqw - 10px) * 5))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-computed.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Fail
+Fail	Property animation-iteration-count value '0, infinite, 3'
+Fail	Property animation-iteration-count value 'calc(10 + (sign(2cqw - 10px) * 5))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-invalid.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	e.style['animation-iteration-count'] = "auto" should not set the property value
+Pass	e.style['animation-iteration-count'] = "-2" should not set the property value
+Pass	e.style['animation-iteration-count'] = "3 4" should not set the property value
+Pass	e.style['animation-iteration-count'] = "initial, 4" should not set the property value
+Pass	e.style['animation-iteration-count'] = "4, initial" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-valid.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+4 Pass
+1 Fail
+Pass	e.style['animation-iteration-count'] = "0" should set the property value
+Pass	e.style['animation-iteration-count'] = "3" should set the property value
+Pass	e.style['animation-iteration-count'] = "4.5" should set the property value
+Pass	e.style['animation-iteration-count'] = "infinite" should set the property value
+Fail	e.style['animation-iteration-count'] = "0, infinite, 3" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-iteration-count-valid.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-4 Pass
-1 Fail
+5 Pass
 Pass	e.style['animation-iteration-count'] = "0" should set the property value
 Pass	e.style['animation-iteration-count'] = "3" should set the property value
 Pass	e.style['animation-iteration-count'] = "4.5" should set the property value
 Pass	e.style['animation-iteration-count'] = "infinite" should set the property value
-Fail	e.style['animation-iteration-count'] = "0, infinite, 3" should set the property value
+Pass	e.style['animation-iteration-count'] = "0, infinite, 3" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 27 tests
 
-24 Pass
-3 Fail
+25 Pass
+2 Fail
 Pass	Property animation-name value 'none'
 Pass	Property animation-name value 'NONE'
 Pass	Property animation-name value 'foo'
@@ -12,7 +12,7 @@ Pass	Property animation-name value 'ease-in'
 Pass	Property animation-name value 'infinite'
 Pass	Property animation-name value 'paused'
 Pass	Property animation-name value 'first, second, third'
-Fail	Property animation-name value '"something"'
+Pass	Property animation-name value '"something"'
 Fail	Property animation-name value '"---\22---"'
 Fail	Property animation-name value '"multi word string"'
 Pass	Property animation-name value '"none"'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 27 tests
 
-21 Pass
-6 Fail
+24 Pass
+3 Fail
 Pass	Property animation-name value 'none'
 Pass	Property animation-name value 'NONE'
 Pass	Property animation-name value 'foo'
@@ -11,13 +11,13 @@ Pass	Property animation-name value 'Both'
 Pass	Property animation-name value 'ease-in'
 Pass	Property animation-name value 'infinite'
 Pass	Property animation-name value 'paused'
-Fail	Property animation-name value 'first, second, third'
+Pass	Property animation-name value 'first, second, third'
 Fail	Property animation-name value '"something"'
 Fail	Property animation-name value '"---\22---"'
 Fail	Property animation-name value '"multi word string"'
 Pass	Property animation-name value '"none"'
-Fail	Property animation-name value '"none", "INITIAL", "inherit"'
-Fail	Property animation-name value '"none", both, ease-in'
+Pass	Property animation-name value '"none", "INITIAL", "inherit"'
+Pass	Property animation-name value '"none", both, ease-in'
 Pass	Property animation-name value '"NoNe"'
 Pass	Property animation-name value '"initial"'
 Pass	Property animation-name value '"INITIAL"'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 27 tests
 
-25 Pass
-2 Fail
+27 Pass
 Pass	Property animation-name value 'none'
 Pass	Property animation-name value 'NONE'
 Pass	Property animation-name value 'foo'
@@ -13,8 +12,8 @@ Pass	Property animation-name value 'infinite'
 Pass	Property animation-name value 'paused'
 Pass	Property animation-name value 'first, second, third'
 Pass	Property animation-name value '"something"'
-Fail	Property animation-name value '"---\22---"'
-Fail	Property animation-name value '"multi word string"'
+Pass	Property animation-name value '"---\22---"'
+Pass	Property animation-name value '"multi word string"'
 Pass	Property animation-name value '"none"'
 Pass	Property animation-name value '"none", "INITIAL", "inherit"'
 Pass	Property animation-name value '"none", both, ease-in'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-computed.txt
@@ -1,0 +1,33 @@
+Harness status: OK
+
+Found 27 tests
+
+21 Pass
+6 Fail
+Pass	Property animation-name value 'none'
+Pass	Property animation-name value 'NONE'
+Pass	Property animation-name value 'foo'
+Pass	Property animation-name value 'Both'
+Pass	Property animation-name value 'ease-in'
+Pass	Property animation-name value 'infinite'
+Pass	Property animation-name value 'paused'
+Fail	Property animation-name value 'first, second, third'
+Fail	Property animation-name value '"something"'
+Fail	Property animation-name value '"---\22---"'
+Fail	Property animation-name value '"multi word string"'
+Pass	Property animation-name value '"none"'
+Fail	Property animation-name value '"none", "INITIAL", "inherit"'
+Fail	Property animation-name value '"none", both, ease-in'
+Pass	Property animation-name value '"NoNe"'
+Pass	Property animation-name value '"initial"'
+Pass	Property animation-name value '"INITIAL"'
+Pass	Property animation-name value '"inherit"'
+Pass	Property animation-name value '"INHERIT"'
+Pass	Property animation-name value '"revert"'
+Pass	Property animation-name value '"REVERT"'
+Pass	Property animation-name value '"revert-layer"'
+Pass	Property animation-name value '"REVERT-LAYER"'
+Pass	Property animation-name value '"unset"'
+Pass	Property animation-name value '"UNSET"'
+Pass	Property animation-name value '"default"'
+Pass	Property animation-name value '"DEFAULT"'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-invalid.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	e.style['animation-name'] = "12" should not set the property value
+Pass	e.style['animation-name'] = "one two" should not set the property value
+Pass	e.style['animation-name'] = "one, initial" should not set the property value
+Pass	e.style['animation-name'] = "one, inherit" should not set the property value
+Pass	e.style['animation-name'] = "one, unset" should not set the property value
+Pass	e.style['animation-name'] = "default, two" should not set the property value
+Pass	e.style['animation-name'] = "revert, three" should not set the property value
+Pass	e.style['animation-name'] = "revert-layer, four" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-valid.txt
@@ -1,0 +1,33 @@
+Harness status: OK
+
+Found 27 tests
+
+21 Pass
+6 Fail
+Pass	e.style['animation-name'] = "none" should set the property value
+Pass	e.style['animation-name'] = "NONE" should set the property value
+Pass	e.style['animation-name'] = "foo" should set the property value
+Pass	e.style['animation-name'] = "Both" should set the property value
+Pass	e.style['animation-name'] = "ease-in" should set the property value
+Pass	e.style['animation-name'] = "infinite" should set the property value
+Pass	e.style['animation-name'] = "paused" should set the property value
+Fail	e.style['animation-name'] = "first, second, third" should set the property value
+Fail	e.style['animation-name'] = "\"something\"" should set the property value
+Fail	e.style['animation-name'] = "\"---\\22---\"" should set the property value
+Fail	e.style['animation-name'] = "\"multi word string\"" should set the property value
+Pass	e.style['animation-name'] = "\"none\"" should set the property value
+Fail	e.style['animation-name'] = "\"none\", \"INITIAL\", \"inherit\"" should set the property value
+Fail	e.style['animation-name'] = "\"none\", both, ease-in" should set the property value
+Pass	e.style['animation-name'] = "\"NoNe\"" should set the property value
+Pass	e.style['animation-name'] = "\"initial\"" should set the property value
+Pass	e.style['animation-name'] = "\"INITIAL\"" should set the property value
+Pass	e.style['animation-name'] = "\"inherit\"" should set the property value
+Pass	e.style['animation-name'] = "\"INHERIT\"" should set the property value
+Pass	e.style['animation-name'] = "\"revert\"" should set the property value
+Pass	e.style['animation-name'] = "\"REVERT\"" should set the property value
+Pass	e.style['animation-name'] = "\"revert-layer\"" should set the property value
+Pass	e.style['animation-name'] = "\"REVERT-LAYER\"" should set the property value
+Pass	e.style['animation-name'] = "\"unset\"" should set the property value
+Pass	e.style['animation-name'] = "\"UNSET\"" should set the property value
+Pass	e.style['animation-name'] = "\"default\"" should set the property value
+Pass	e.style['animation-name'] = "\"DEFAULT\"" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-name-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 27 tests
 
-21 Pass
-6 Fail
+24 Pass
+3 Fail
 Pass	e.style['animation-name'] = "none" should set the property value
 Pass	e.style['animation-name'] = "NONE" should set the property value
 Pass	e.style['animation-name'] = "foo" should set the property value
@@ -11,13 +11,13 @@ Pass	e.style['animation-name'] = "Both" should set the property value
 Pass	e.style['animation-name'] = "ease-in" should set the property value
 Pass	e.style['animation-name'] = "infinite" should set the property value
 Pass	e.style['animation-name'] = "paused" should set the property value
-Fail	e.style['animation-name'] = "first, second, third" should set the property value
+Pass	e.style['animation-name'] = "first, second, third" should set the property value
 Fail	e.style['animation-name'] = "\"something\"" should set the property value
 Fail	e.style['animation-name'] = "\"---\\22---\"" should set the property value
 Fail	e.style['animation-name'] = "\"multi word string\"" should set the property value
 Pass	e.style['animation-name'] = "\"none\"" should set the property value
-Fail	e.style['animation-name'] = "\"none\", \"INITIAL\", \"inherit\"" should set the property value
-Fail	e.style['animation-name'] = "\"none\", both, ease-in" should set the property value
+Pass	e.style['animation-name'] = "\"none\", \"INITIAL\", \"inherit\"" should set the property value
+Pass	e.style['animation-name'] = "\"none\", both, ease-in" should set the property value
 Pass	e.style['animation-name'] = "\"NoNe\"" should set the property value
 Pass	e.style['animation-name'] = "\"initial\"" should set the property value
 Pass	e.style['animation-name'] = "\"INITIAL\"" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-computed.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	Property animation-play-state value 'running, paused'
+1 Pass
+Pass	Property animation-play-state value 'running, paused'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-computed.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	Property animation-play-state value 'running, paused'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-invalid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	e.style['animation-play-state'] = "auto" should not set the property value
+Pass	e.style['animation-play-state'] = "paused running" should not set the property value
+Pass	e.style['animation-play-state'] = "paused, initial" should not set the property value
+Pass	e.style['animation-play-state'] = "initial, paused" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-valid.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+2 Pass
+1 Fail
+Pass	e.style['animation-play-state'] = "running" should set the property value
+Pass	e.style['animation-play-state'] = "paused" should set the property value
+Fail	e.style['animation-play-state'] = "running, paused" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-play-state-valid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	e.style['animation-play-state'] = "running" should set the property value
 Pass	e.style['animation-play-state'] = "paused" should set the property value
-Fail	e.style['animation-play-state'] = "running, paused" should set the property value
+Pass	e.style['animation-play-state'] = "running, paused" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-shorthand.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 36 tests
 
-9 Pass
-27 Fail
+25 Pass
+11 Fail
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-delay
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-direction
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-duration
@@ -16,27 +16,27 @@ Fail	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -
 Fail	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timeline
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timing-function
 Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should not set unrelated longhands
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-delay
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-direction
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-delay
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-direction
 Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-duration
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-fill-mode
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-iteration-count
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-name
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-play-state
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-fill-mode
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-iteration-count
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-name
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-play-state
 Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-range-end
 Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-range-start
 Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timeline
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timing-function
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should not set unrelated longhands
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-delay
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-direction
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timing-function
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should not set unrelated longhands
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-delay
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-direction
 Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-duration
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-fill-mode
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-iteration-count
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-name
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-play-state
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-fill-mode
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-iteration-count
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-name
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-play-state
 Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-range-end
 Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-range-start
 Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-timeline
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-timing-function
-Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should not set unrelated longhands
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-timing-function
+Pass	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should not set unrelated longhands

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-shorthand.txt
@@ -1,0 +1,42 @@
+Harness status: OK
+
+Found 36 tests
+
+9 Pass
+27 Fail
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-delay
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-direction
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-duration
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-fill-mode
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-iteration-count
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-name
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-play-state
+Fail	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-range-end
+Fail	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-range-start
+Fail	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timeline
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timing-function
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should not set unrelated longhands
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-delay
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-direction
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-duration
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-fill-mode
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-iteration-count
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-name
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-play-state
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-range-end
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-range-start
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timeline
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set animation-timing-function
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should not set unrelated longhands
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-delay
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-direction
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-duration
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-fill-mode
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-iteration-count
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-name
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-play-state
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-range-end
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-range-start
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-timeline
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should set animation-timing-function
+Fail	e.style['animation'] = "4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse" should not set unrelated longhands

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-timing-function-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-timing-function-invalid.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 7 tests
+
+7 Pass
+Pass	e.style['animation-timing-function'] = "steps(2,()start)" should not set the property value
+Pass	e.style['animation-timing-function'] = "steps(2,() start)" should not set the property value
+Pass	e.style['animation-timing-function'] = "steps(2, ()start)" should not set the property value
+Pass	e.style['animation-timing-function'] = "steps(2())" should not set the property value
+Pass	e.style['animation-timing-function'] = "steps(2 ())" should not set the property value
+Pass	e.style['animation-timing-function'] = "steps(2,())" should not set the property value
+Pass	e.style['animation-timing-function'] = "steps(2, ())" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-valid.txt
@@ -1,0 +1,18 @@
+Harness status: OK
+
+Found 12 tests
+
+10 Pass
+2 Fail
+Pass	e.style['animation'] = "1s" should set the property value
+Pass	e.style['animation'] = "cubic-bezier(0, -2, 1, 3)" should set the property value
+Pass	e.style['animation'] = "cubic-bezier( 0, -2, 1, 3 )" should set the property value
+Pass	e.style['animation'] = "1s -3s" should set the property value
+Pass	e.style['animation'] = "4" should set the property value
+Pass	e.style['animation'] = "reverse" should set the property value
+Pass	e.style['animation'] = "both" should set the property value
+Pass	e.style['animation'] = "paused" should set the property value
+Pass	e.style['animation'] = "none" should set the property value
+Pass	e.style['animation'] = "anim" should set the property value
+Fail	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set the property value
+Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/parsing/animation-valid.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 12 tests
 
-10 Pass
-2 Fail
+12 Pass
 Pass	e.style['animation'] = "1s" should set the property value
 Pass	e.style['animation'] = "cubic-bezier(0, -2, 1, 3)" should set the property value
 Pass	e.style['animation'] = "cubic-bezier( 0, -2, 1, 3 )" should set the property value
@@ -14,5 +13,5 @@ Pass	e.style['animation'] = "both" should set the property value
 Pass	e.style['animation'] = "paused" should set the property value
 Pass	e.style['animation'] = "none" should set the property value
 Pass	e.style['animation'] = "anim" should set the property value
-Fail	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set the property value
-Fail	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set the property value
+Pass	e.style['animation'] = "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set the property value
+Pass	e.style['animation'] = "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 263 tests
 
-256 Pass
-7 Fail
+257 Pass
+6 Fail
 Pass	accent-color
 Pass	border-collapse
 Pass	border-spacing
@@ -82,7 +82,7 @@ Pass	animation-direction
 Pass	animation-duration
 Pass	animation-fill-mode
 Pass	animation-iteration-count
-Fail	animation-name
+Pass	animation-name
 Pass	animation-play-state
 Pass	animation-timing-function
 Pass	appearance

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 21 tests
 
-19 Pass
-2 Fail
+20 Pass
+1 Fail
 Pass	Property animation-timing-function value 'linear'
 Pass	Property animation-timing-function value 'ease'
 Pass	Property animation-timing-function value 'ease-in'
@@ -23,5 +23,5 @@ Pass	Property animation-timing-function value 'steps(2, jump-none)'
 Pass	Property animation-timing-function value 'steps(calc(-10), start)'
 Pass	Property animation-timing-function value 'steps(calc(5 / 2), start)'
 Pass	Property animation-timing-function value 'steps(calc(1), jump-none)'
-Fail	Property animation-timing-function value 'linear, ease, linear'
+Pass	Property animation-timing-function value 'linear, ease, linear'
 Fail	Property animation-timing-function value 'steps(calc(2 + sign(100em - 1px)), end)'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-easing/timing-functions-syntax-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 22 tests
 
-20 Pass
-2 Fail
+21 Pass
+1 Fail
 Pass	e.style['animation-timing-function'] = "linear" should set the property value
 Pass	e.style['animation-timing-function'] = "ease" should set the property value
 Pass	e.style['animation-timing-function'] = "ease-in" should set the property value
@@ -24,5 +24,5 @@ Pass	e.style['animation-timing-function'] = "steps(2, jump-none)" should set the
 Pass	e.style['animation-timing-function'] = "steps(calc(-10), start)" should set the property value
 Pass	e.style['animation-timing-function'] = "steps(calc(5 / 2), start)" should set the property value
 Pass	e.style['animation-timing-function'] = "steps(calc(1), jump-none)" should set the property value
-Fail	e.style['animation-timing-function'] = "linear, ease, linear" should set the property value
+Pass	e.style['animation-timing-function'] = "linear, ease, linear" should set the property value
 Pass	e.style['animation-timing-function'] = "steps(calc(2 + sign(100em - 1px)))" should set the property value

--- a/Tests/LibWeb/Text/input/css/animation-name-is-valid-other-property-value.html
+++ b/Tests/LibWeb/Text/input/css/animation-name-is-valid-other-property-value.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <style>
+            #timing-function {
+                animation: none;
+                animation-name: eAsE-In-OuT;
+            }
+            #direction {
+                animation: none;
+                animation-name: rEvErSe;
+            }
+            #fill-mode {
+                animation: none;
+                animation-name: fOrWaRdS;
+            }
+            #running-state {
+                animation: none;
+                animation-name: pAuSeD;
+            }
+        </style>
+        <script src="../include.js"></script>
+        <script>
+            test(() => {
+                for (const rule of document.styleSheets[0].cssRules) {
+                    println(rule.cssText);
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-computed.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animation</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation">
+<meta name="assert" content="animation computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+// <single-animation> = <time> || <easing-function> || <time> ||
+// <single-animation-iteration-count> || <single-animation-direction> ||
+// <single-animation-fill-mode> || <single-animation-play-state> ||
+// [ none | <keyframes-name> ]
+
+test(() => {
+  assert_equals(getComputedStyle(document.getElementById('target')).animation, "none");
+}, "Default animation value");
+
+test_computed_value("animation", "1s", "1s");
+test_computed_value("animation", "cubic-bezier(0, -2, 1, 3)", "cubic-bezier(0, -2, 1, 3)");
+test_computed_value("animation", "ease-in-out", "ease-in-out");
+test_computed_value("animation", "1s -3s", "1s -3s");
+test_computed_value("animation", "4", "4");
+test_computed_value("animation", "reverse", "reverse");
+test_computed_value("animation", "both", "both");
+test_computed_value("animation", "paused", "paused");
+test_computed_value("animation", "none", "none");
+test_computed_value("animation", "anim", "anim");
+
+test_computed_value("animation", "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)",
+  "1s cubic-bezier(0, -2, 1, 3) -3s 4 reverse both paused anim");
+
+test_computed_value("animation", "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)",
+  "reverse both paused anim, 1s cubic-bezier(0, -2, 1, 3) -3s 4");
+
+test_computed_value("animation", "none, none", "none, none");
+
+test(() => {
+  const target = document.getElementById('target');
+  target.style.animation = "initial";
+  target.style.animationDelay = "1s";
+  assert_equals(getComputedStyle(target).animation, "0s 1s");
+}, "Animation with a delay but no duration");
+
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-delay-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-delay-computed.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animationDelay</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-delay">
+<meta name="assert" content="animation-delay converts to seconds.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 100px;
+  }
+</style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+test_computed_value("animation-delay", "-500ms", "-0.5s");
+test_computed_value("animation-delay", "calc(2 * 3s)", "6s");
+test_computed_value("animation-delay", "20s, 10s");
+test_computed_value("animation-delay", 'calc(10s + (sign(2cqw - 10px) * 5s))', '5s');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-delay-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-delay-invalid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-delay with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-delay">
+<meta name="assert" content="animation-delay supports only the grammar '<single-animation-play-state> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-delay", "infinite");
+test_invalid_value("animation-delay", "0");
+test_invalid_value("animation-delay", "1s 2s 3s");
+
+test_invalid_value("animation-delay", "initial, -3s");
+test_invalid_value("animation-delay", "-3s, initial");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-delay-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-delay-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-delay with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-delay">
+<meta name="assert" content="animation-delay supports the full grammar '<single-animation-play-state> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-delay", "-5ms");
+test_valid_value("animation-delay", "0s");
+test_valid_value("animation-delay", "10s");
+test_valid_value("animation-delay", "20s, 10s");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-direction-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-direction-computed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animationDirection</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-direction">
+<meta name="assert" content="animation-direction computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("animation-direction", "normal, reverse, alternate, alternate-reverse");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-direction-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-direction-invalid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-direction with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-direction">
+<meta name="assert" content="animation-direction supports only the grammar '<single-animation-direction> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-direction", "auto");
+test_invalid_value("animation-direction", "normal reverse");
+
+test_invalid_value("animation-direction", "reverse, initial");
+test_invalid_value("animation-direction", "initial, reverse");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-direction-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-direction-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-direction with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-direction">
+<meta name="assert" content="animation-direction supports the full grammar '<single-animation-direction> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-direction", "normal");
+test_valid_value("animation-direction", "reverse");
+test_valid_value("animation-direction", "alternate");
+test_valid_value("animation-direction", "alternate-reverse");
+test_valid_value("animation-direction", "normal, reverse, alternate, alternate-reverse");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-duration-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-duration-computed.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animationDuration</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-duration">
+<meta name="assert" content="animation-duration converts to seconds.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 100px;
+  }
+</style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+test_computed_value("animation-duration", "500ms", "0.5s");
+test_computed_value("animation-duration", "calc(2 * 3s)", "6s");
+test_computed_value("animation-duration", 'calc(10s + (sign(2cqw - 10px) * 5s))', '5s');
+test_computed_value("animation-duration", "20s, 10s");
+
+// https://github.com/w3c/csswg-drafts/issues/6530
+test_computed_value("animation-duration", "auto", "0s");
+test_computed_value("animation-duration", "auto, auto", "0s, 0s");
+
+// Test that the resolved value of the specified animation-duration
+// is as expected given some value for animation-timeline.
+function test_auto_duration(duration, timeline, expected) {
+  test((t) => {
+    t.add_cleanup(() => {
+      target.style = "";
+    });
+    target.style.animationDuration = duration;
+    target.style.animationTimeline = timeline;
+    assert_equals(expected, getComputedStyle(target).animationDuration);
+  }, `Resolved value of animation-duration:${duration} with animation-timeline:${timeline}`);
+}
+
+test_auto_duration("auto", "auto", "0s");
+test_auto_duration("auto", "auto, auto", "auto");
+test_auto_duration("auto", "--t", "auto");
+test_auto_duration("auto", "--t, --t2", "auto");
+test_auto_duration("auto", "none", "auto");
+test_auto_duration("auto", "scroll()", "auto");
+test_auto_duration("auto", "view()", "auto");
+test_auto_duration("0s", "auto", "0s");
+test_auto_duration("0s", "auto, auto", "0s");
+
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-duration-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-duration-invalid.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-duration with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-duration">
+<meta name="assert" content="animation-duration supports only the grammar '<time> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-duration", '-3s');
+test_invalid_value("animation-duration", '0');
+test_invalid_value("animation-duration", 'infinite');
+test_invalid_value("animation-duration", '1s 2s');
+
+test_invalid_value("animation-duration", 'initial, 1s');
+test_invalid_value("animation-duration", '1s, initial');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-duration-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-duration-valid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-duration with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-duration">
+<meta name="assert" content="animation-duration supports the full grammar '<time> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-duration", '3s');
+test_valid_value("animation-duration", '500ms');
+test_valid_value("animation-duration", '1s, 2s, 3s');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-fill-mode-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-fill-mode-computed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animationFillMode</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-fill-mode">
+<meta name="assert" content="animation-fill-mode computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("animation-fill-mode", "none, forwards, backwards, both");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-fill-mode-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-fill-mode-invalid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-fill-mode with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-fill-mode">
+<meta name="assert" content="animation-fill-mode supports only the grammar '<single-animation-fill-mode> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-fill-mode", "auto");
+test_invalid_value("animation-fill-mode", "forwards backwards");
+
+test_invalid_value("animation-fill-mode", "both, initial");
+test_invalid_value("animation-fill-mode", "initial, both");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-fill-mode-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-fill-mode-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-fill-mode with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-fill-mode">
+<meta name="assert" content="animation-fill-mode supports the full grammar '<single-animation-fill-mode> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-fill-mode", "none");
+test_valid_value("animation-fill-mode", "forwards");
+test_valid_value("animation-fill-mode", "backwards");
+test_valid_value("animation-fill-mode", "both");
+test_valid_value("animation-fill-mode", "none, forwards, backwards, both");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-invalid.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation">
+<meta name="assert" content="animation supports only the grammar '<single-animation> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation", "1s 2s 3s");
+test_invalid_value("animation", "-1s -2s");
+
+test_invalid_value("animation", "steps(1) steps(2)");
+
+test_invalid_value("animation", "1 2");
+
+test_invalid_value("animation", "reverse alternate alternate-reverse anim");
+
+test_invalid_value("animation", "both backwards forwards anim");
+
+test_invalid_value("animation", "paused running paused anim");
+
+test_invalid_value("animation", "anim1 timeline1 anim2");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-iteration-count-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-iteration-count-computed.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animationIterationCount</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-iteration-count">
+<meta name="assert" content="animation-iteration-count computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+<style>
+  #container {
+    container-type: inline-size;
+    width: 100px;
+  }
+</style>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+test_computed_value("animation-iteration-count", "0, infinite, 3");
+test_computed_value("animation-iteration-count", "calc(10 + (sign(2cqw - 10px) * 5))", "5");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-iteration-count-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-iteration-count-invalid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-iteration-count with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-iteration-count">
+<meta name="assert" content="animation-iteration-count supports only the grammar '<single-animation-iteration-count> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-iteration-count", "auto");
+test_invalid_value("animation-iteration-count", "-2");
+test_invalid_value("animation-iteration-count", "3 4");
+
+test_invalid_value("animation-iteration-count", "initial, 4");
+test_invalid_value("animation-iteration-count", "4, initial");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-iteration-count-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-iteration-count-valid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-iteration-count with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-iteration-count">
+<meta name="assert" content="animation-iteration-count supports the full grammar '<single-animation-iteration-count> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-iteration-count", "0");
+test_valid_value("animation-iteration-count", "3");
+test_valid_value("animation-iteration-count", "4.5");
+test_valid_value("animation-iteration-count", "infinite");
+
+test_valid_value("animation-iteration-count", "0, infinite, 3");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-name-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-name-computed.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animationName</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
+<meta name="assert" content="animation-name computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("animation-name", 'none');
+test_computed_value("animation-name", 'NONE', 'none');
+
+test_computed_value("animation-name", 'foo');
+test_computed_value("animation-name", 'Both');
+test_computed_value("animation-name", 'ease-in');
+test_computed_value("animation-name", 'infinite');
+test_computed_value("animation-name", 'paused');
+test_computed_value("animation-name", 'first, second, third');
+
+test_computed_value("animation-name", '"something"', 'something');
+test_computed_value("animation-name", '"---\\22---"', '---\\\"---');
+test_computed_value("animation-name", '"multi word string"', 'multi\\ word\\ string');
+
+// Restricted keywords as strings
+test_computed_value("animation-name", '"none"');
+test_computed_value("animation-name", '"none", "INITIAL", "inherit"');
+test_computed_value("animation-name", '"none", both, ease-in');
+test_computed_value("animation-name", '"NoNe"');
+test_computed_value("animation-name", '"initial"');
+test_computed_value("animation-name", '"INITIAL"');
+test_computed_value("animation-name", '"inherit"');
+test_computed_value("animation-name", '"INHERIT"');
+test_computed_value("animation-name", '"revert"');
+test_computed_value("animation-name", '"REVERT"');
+test_computed_value("animation-name", '"revert-layer"');
+test_computed_value("animation-name", '"REVERT-LAYER"');
+test_computed_value("animation-name", '"unset"');
+test_computed_value("animation-name", '"UNSET"');
+test_computed_value("animation-name", '"default"');
+test_computed_value("animation-name", '"DEFAULT"');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-name-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-name-invalid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-name with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
+<meta name="assert" content="animation-name supports only the grammar '[ none | <keyframes-name> ]#'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-name", '12');
+test_invalid_value("animation-name", 'one two');
+
+test_invalid_value("animation-name", 'one, initial');
+test_invalid_value("animation-name", 'one, inherit');
+test_invalid_value("animation-name", 'one, unset');
+test_invalid_value("animation-name", 'default, two');
+test_invalid_value("animation-name", 'revert, three');
+test_invalid_value("animation-name", 'revert-layer, four');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-name-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-name-valid.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-name with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-name">
+<meta name="assert" content="animation-name supports the full grammar '[ none | <keyframes-name> ]#'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-name", 'none');
+test_valid_value("animation-name", 'NONE', 'none');
+
+test_valid_value("animation-name", 'foo');
+test_valid_value("animation-name", 'Both');
+test_valid_value("animation-name", 'ease-in');
+test_valid_value("animation-name", 'infinite');
+test_valid_value("animation-name", 'paused');
+test_valid_value("animation-name", 'first, second, third');
+
+test_valid_value("animation-name", '"something"', 'something');
+test_valid_value("animation-name", '"---\\22---"', '---\\\"---');
+test_valid_value("animation-name", '"multi word string"', 'multi\\ word\\ string');
+
+// Restricted keywords as strings
+test_valid_value("animation-name", '"none"');
+test_valid_value("animation-name", '"none", "INITIAL", "inherit"');
+test_valid_value("animation-name", '"none", both, ease-in');
+test_valid_value("animation-name", '"NoNe"');
+test_valid_value("animation-name", '"initial"');
+test_valid_value("animation-name", '"INITIAL"');
+test_valid_value("animation-name", '"inherit"');
+test_valid_value("animation-name", '"INHERIT"');
+test_valid_value("animation-name", '"revert"');
+test_valid_value("animation-name", '"REVERT"');
+test_valid_value("animation-name", '"revert-layer"');
+test_valid_value("animation-name", '"REVERT-LAYER"');
+test_valid_value("animation-name", '"unset"');
+test_valid_value("animation-name", '"UNSET"');
+test_valid_value("animation-name", '"default"');
+test_valid_value("animation-name", '"DEFAULT"');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-play-state-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-play-state-computed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: getComputedStyle().animationPlayState</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-play-state">
+<meta name="assert" content="animation-play-state computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("animation-play-state", "running, paused");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-play-state-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-play-state-invalid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-play-state with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-play-state">
+<meta name="assert" content="animation-play-state supports only the grammar '<single-animation-play-state> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-play-state", "auto");
+test_invalid_value("animation-play-state", "paused running");
+
+test_invalid_value("animation-play-state", "paused, initial");
+test_invalid_value("animation-play-state", "initial, paused");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-play-state-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-play-state-valid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation-play-state with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation-play-state">
+<meta name="assert" content="animation-play-state supports the full grammar '<single-animation-play-state> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-play-state", "running");
+test_valid_value("animation-play-state", "paused");
+test_valid_value("animation-play-state", "running, paused");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-shorthand.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-shorthand.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: animation sets longhands</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation">
+<meta name="assert" content="animation supports the full grammar '<single-animation> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/shorthand-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_shorthand_value('animation', 'anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)', {
+  'animation-duration': '1s',
+  'animation-timing-function': 'cubic-bezier(0, -2, 1, 3)',
+  'animation-delay': '-3s',
+  'animation-iteration-count': '4',
+  'animation-direction': 'reverse',
+  'animation-fill-mode': 'both',
+  'animation-play-state': 'paused',
+  'animation-name': 'anim',
+  'animation-timeline': 'auto',
+  'animation-range-start': 'normal',
+  'animation-range-end': 'normal',
+});
+
+test_shorthand_value('animation', 'anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)', {
+  'animation-duration': 'auto, 1s',
+  'animation-timing-function': 'ease, cubic-bezier(0, -2, 1, 3)',
+  'animation-delay': '0s, -3s',
+  'animation-iteration-count': '1, 4',
+  'animation-direction': 'reverse, normal',
+  'animation-fill-mode': 'both, none',
+  'animation-play-state': 'paused, running',
+  'animation-name': 'anim, none',
+  'animation-timeline': 'auto',
+  'animation-range-start': 'normal',
+  'animation-range-end': 'normal',
+});
+
+test_shorthand_value('animation', '4 1s -3s cubic-bezier(0, -2, 1, 3), anim paused both reverse', {
+  'animation-duration': '1s, auto',
+  'animation-timing-function': 'cubic-bezier(0, -2, 1, 3), ease',
+  'animation-delay': '-3s, 0s',
+  'animation-iteration-count': '4, 1',
+  'animation-direction': 'normal, reverse',
+  'animation-fill-mode': 'none, both',
+  'animation-play-state': 'running, paused',
+  'animation-name': 'none, anim',
+  'animation-timeline': 'auto',
+  'animation-range-start': 'normal',
+  'animation-range-end': 'normal',
+});
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-timing-function-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-timing-function-invalid.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Animations: animation-timing-function parsing (invalid)</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-timing-function">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+<script>
+test_invalid_value("animation-timing-function", "steps(2,()start)");
+test_invalid_value("animation-timing-function", "steps(2,() start)");
+test_invalid_value("animation-timing-function", "steps(2, ()start)");
+test_invalid_value("animation-timing-function", "steps(2())");
+test_invalid_value("animation-timing-function", "steps(2 ())");
+test_invalid_value("animation-timing-function", "steps(2,())");
+test_invalid_value("animation-timing-function", "steps(2, ())");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/parsing/animation-valid.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Animations: parsing animation with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/#propdef-animation">
+<meta name="assert" content="animation supports the full grammar '<single-animation> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+// <single-animation> = <time> || <easing-function> || <time> ||
+// <single-animation-iteration-count> || <single-animation-direction> ||
+// <single-animation-fill-mode> || <single-animation-play-state> ||
+// [ none | <keyframes-name> ]
+test_valid_value("animation", "1s", ["1s", "1s ease 0s 1 normal none running none"]);
+test_valid_value("animation", "cubic-bezier(0, -2, 1, 3)", ["cubic-bezier(0, -2, 1, 3)", "auto cubic-bezier(0, -2, 1, 3) 0s 1 normal none running none"]);
+test_valid_value("animation", "cubic-bezier( 0, -2, 1, 3 )", ["cubic-bezier(0, -2, 1, 3)", "auto cubic-bezier(0, -2, 1, 3) 0s 1 normal none running none"]);
+test_valid_value("animation", "1s -3s", ["1s -3s", "1s ease -3s 1 normal none running none"]);
+test_valid_value("animation", "4", ["4", "auto ease 0s 4 normal none running none"]);
+test_valid_value("animation", "reverse", ["reverse", "auto ease 0s 1 reverse none running none"]);
+test_valid_value("animation", "both", ["both", "auto ease 0s 1 normal both running none"]);
+test_valid_value("animation", "paused", ["paused", "auto ease 0s 1 normal none paused none"]);
+test_valid_value("animation", "none", ["auto", "none", "auto ease 0s 1 normal none running none"]);
+test_valid_value("animation", "anim", ["anim", "auto ease 0s 1 normal none running anim"]);
+
+test_valid_value("animation", "anim paused both reverse 4 1s -3s cubic-bezier(0, -2, 1, 3)",
+  "1s cubic-bezier(0, -2, 1, 3) -3s 4 reverse both paused anim");
+
+test_valid_value("animation", "anim paused both reverse, 4 1s -3s cubic-bezier(0, -2, 1, 3)",
+  ["reverse both paused anim, 1s cubic-bezier(0, -2, 1, 3) -3s 4", "auto ease 0s 1 reverse both paused anim, 1s cubic-bezier(0, -2, 1, 3) -3s 4 normal none running none"]);
+
+// TODO: Add test with a single negative time.
+// TODO: Add test with a single timing-function keyword.
+</script>
+</body>
+</html>


### PR DESCRIPTION
This PR improves our parsing and serialization of the `animation` property and it's longhands - see individual commits.

Gains us ~50 WPT tests.

There is still work to be done to implement actually triggering multiple animations from a single `animation` property.