### PR TITLE
Meta: Pin Wasm spec testsuite to a known commit

### DIFF
--- a/Meta/CMake/wasm_spec_tests.cmake
+++ b/Meta/CMake/wasm_spec_tests.cmake
@@ -3,7 +3,8 @@
 #
 
 if(INCLUDE_WASM_SPEC_TESTS)
-    set(WASM_SPEC_TEST_GZ_URL https://github.com/WebAssembly/testsuite/archive/refs/heads/main.tar.gz)
+    set(WASM_SPEC_TEST_COMMIT a8101597d3c3c660086c3cd1eedee608ff18d3c3) # 2025-09-10
+    set(WASM_SPEC_TEST_GZ_URL https://github.com/WebAssembly/testsuite/archive/${WASM_SPEC_TEST_COMMIT}.tar.gz)
     set(WASM_SPEC_TEST_GZ_PATH ${CMAKE_BINARY_DIR}/wasm-spec-testsuite.tar.gz CACHE PATH "")
     set(WASM_SPEC_TEST_PATH ${CMAKE_CURRENT_BINARY_DIR}/Tests/Fixtures/SpecTests CACHE PATH "")
 
@@ -22,15 +23,15 @@ if(INCLUDE_WASM_SPEC_TESTS)
 
     if(EXISTS ${WASM_SPEC_TEST_GZ_PATH} AND NOT EXISTS ${WASM_SPEC_TEST_PATH}/const_0.wasm)
         message(STATUS "Extracting the WebAssembly testsuite from ${WASM_SPEC_TEST_GZ_PATH}...")
-        extract_path("${CMAKE_CURRENT_BINARY_DIR}" "${WASM_SPEC_TEST_GZ_PATH}" "testsuite-main/*.wast" "${WASM_SPEC_TEST_PATH}")
+        extract_path("${CMAKE_CURRENT_BINARY_DIR}" "${WASM_SPEC_TEST_GZ_PATH}" "testsuite-${WASM_SPEC_TEST_COMMIT}/*.wast" "${WASM_SPEC_TEST_PATH}")
         file(MAKE_DIRECTORY ${WASM_SPEC_TEST_PATH})
-        file(GLOB WASM_TESTS "${CMAKE_CURRENT_BINARY_DIR}/testsuite-main/*.wast")
+        file(GLOB WASM_TESTS "${CMAKE_CURRENT_BINARY_DIR}/testsuite-${WASM_SPEC_TEST_COMMIT}/*.wast")
         foreach(PATH ${WASM_TESTS})
             get_filename_component(NAME ${PATH} NAME_WLE)
             message(STATUS "Generating test cases for WebAssembly test ${NAME}...")
             execute_process(
                 COMMAND env SKIP_PRETTIER=${SKIP_PRETTIER} bash ${SerenityOS_SOURCE_DIR}/Meta/generate-libwasm-spec-test.sh "${PATH}" "${CMAKE_CURRENT_BINARY_DIR}/Tests/Spec" "${NAME}" "${WASM_SPEC_TEST_PATH}")
         endforeach()
-        file(REMOVE testsuite-main)
+        file(REMOVE testsuite-${WASM_SPEC_TEST_COMMIT})
     endif()
 endif()


### PR DESCRIPTION
The current HEAD contains a bunch of stuff not supported by wabt (or us), that also appear to not be fully merged yet; stick to the last known commit for now.