### PR TITLE
LibJS: Invalidate PrototypeChainValidity when prototype shape is a dict

### DIFF
--- a/Libraries/LibJS/Runtime/Shape.h
+++ b/Libraries/LibJS/Runtime/Shape.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -113,6 +114,7 @@ private:
     Shape(Shape& previous_shape, Object* new_prototype);
 
     void invalidate_prototype_if_needed_for_new_prototype(GC::Ref<Shape> new_prototype_shape);
+    void invalidate_prototype_if_needed_for_change_without_transition();
     void invalidate_all_prototype_chains_leading_to_this();
 
     virtual void visit_edges(Visitor&) override;

--- a/Libraries/LibJS/Tests/regress/inline-caching.js
+++ b/Libraries/LibJS/Tests/regress/inline-caching.js
@@ -32,3 +32,62 @@ test("Overriding an inherited getter with a data property on an intermediate pro
     Object.defineProperty(proto, "hm", { value: 321 });
     f(obj, 321);
 });
+
+test("Modifying prototype in dictionary mode should cause prototype-chain validity invalidation (dict-mode prototype is in the middle of prototype chain)", () => {
+    function f(obj, expected) {
+        expect(obj.hm).toBe(expected);
+    }
+
+    const midProto = {};
+    midProto.__proto__ = {
+        get hm() {
+            return 321;
+        },
+    };
+
+    const proto = {};
+    proto.__proto__ = midProto;
+
+    const obj = Object.create(proto);
+    // put midProto into dictionary mode
+    for (let i = 0; i < 1000; i++) {
+        midProto["i" + i] = i;
+    }
+
+    f(obj, 321);
+    Object.defineProperty(midProto, "hm", {
+        get() {
+            return 123;
+        },
+        configurable: true,
+    });
+    f(obj, 123);
+});
+
+test("Modifying prototype in dictionary mode should cause prototype-chain validity invalidation (dict-mode prototype is direct prototype of target object)", () => {
+    function f(obj, expected) {
+        expect(obj.hm).toBe(expected);
+    }
+
+    const proto = {};
+    proto.__proto__ = {
+        get hm() {
+            return 321;
+        },
+    };
+
+    const obj = Object.create(proto);
+    // put proto into dictionary mode
+    for (let i = 0; i < 1000; i++) {
+        proto["i" + i] = i;
+    }
+
+    f(obj, 321);
+    Object.defineProperty(proto, "hm", {
+        get() {
+            return 123;
+        },
+        configurable: true,
+    });
+    f(obj, 123);
+});


### PR DESCRIPTION
Adds missing PrototypeChainValidity invalidation for add/set/delete operations on dictionary-mode prototype shapes.