### PR TITLE
LibGfx+LibWeb: Implement `GlyphRun::bounding_rect()`

### DIFF
--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -15,6 +15,7 @@
 #include <LibGfx/FontCascadeList.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
 #include <LibGfx/ShapeFeature.h>
 
 namespace Gfx {
@@ -36,11 +37,12 @@ public:
         Rtl,
     };
 
-    GlyphRun(Vector<DrawGlyph>&& glyphs, NonnullRefPtr<Font const> font, TextType text_type, float width)
+    GlyphRun(Vector<DrawGlyph>&& glyphs, NonnullRefPtr<Font const> font, TextType text_type, float width, float line_height)
         : m_glyphs(move(glyphs))
         , m_font(move(font))
         , m_text_type(text_type)
         , m_width(width)
+        , m_line_height(line_height)
     {
     }
 
@@ -50,12 +52,14 @@ public:
     [[nodiscard]] Vector<DrawGlyph>& glyphs() { return m_glyphs; }
     [[nodiscard]] bool is_empty() const { return m_glyphs.is_empty(); }
     [[nodiscard]] float width() const { return m_width; }
+    [[nodiscard]] FloatRect bounding_rect() const;
 
 private:
     Vector<DrawGlyph> m_glyphs;
     NonnullRefPtr<Font const> m_font;
     TextType m_text_type;
     float m_width { 0 };
+    float m_line_height { 0 };
 };
 
 NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, Utf16View const&, Gfx::Font const& font, GlyphRun::TextType, ShapeFeatures const& features);

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -13,6 +13,7 @@ void DrawGlyphRun::translate_by(Gfx::IntPoint const& offset)
 {
     rect.translate_by(offset);
     translation.translate_by(offset.to_type<float>());
+    bounding_rectangle.translate_by(offset);
 }
 
 Gfx::IntRect PaintOuterBoxShadow::bounding_rect() const

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -43,7 +43,9 @@ struct DrawGlyphRun {
     Gfx::FloatPoint translation;
     Color color;
     Gfx::Orientation orientation { Gfx::Orientation::Horizontal };
+    Gfx::IntRect bounding_rectangle;
 
+    [[nodiscard]] Gfx::IntRect bounding_rect() const { return bounding_rectangle; }
     void translate_by(Gfx::IntPoint const& offset);
     void dump(StringBuilder&) const;
 };

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -553,13 +553,12 @@ void DisplayListPlayerSkia::paint_text_shadow(PaintTextShadow const& command)
     SkPaint blur_paint;
     blur_paint.setImageFilter(blur_image_filter);
     canvas.saveLayer(SkCanvas::SaveLayerRec(nullptr, &blur_paint, nullptr, 0));
-    draw_glyph_run({
-        .glyph_run = command.glyph_run,
+    draw_glyph_run({ .glyph_run = command.glyph_run,
         .scale = command.glyph_run_scale,
         .rect = command.text_rect,
         .translation = command.draw_location + command.text_rect.location().to_type<float>(),
         .color = command.color,
-    });
+        .bounding_rectangle = command.bounding_rect() });
     canvas.restore();
 }
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -255,6 +255,7 @@ void DisplayListRecorder::draw_glyph_run(Gfx::FloatPoint baseline_start, Gfx::Gl
         .translation = baseline_start,
         .color = color,
         .orientation = orientation,
+        .bounding_rectangle = glyph_run.bounding_rect().scaled(scale).translated(baseline_start).to_type<int>(),
     });
 }
 


### PR DESCRIPTION
Allows us to skip painting of glyph runs lying outside of viewport.