### PR TITLE
LibWeb: Clamp interpolated `font-style` angle

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -551,7 +551,6 @@ private:
         DescriptorID descriptor;
     };
     enum SpecialContext : u8 {
-        FontStyleObliqueAngle,
         ShadowBlurRadius,
         TranslateZArgument
     };

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -2979,7 +2979,6 @@ RefPtr<StyleValue const> Parser::parse_font_style_value(TokenStream<ComponentVal
     auto font_style = keyword_to_font_style(keyword_value->to_keyword());
     VERIFY(font_style.has_value());
     if (tokens.has_next_token() && keyword_value->to_keyword() == Keyword::Oblique) {
-        auto context_guard = push_temporary_value_parsing_context(SpecialContext::FontStyleObliqueAngle);
         if (auto angle_value = parse_angle_value(tokens)) {
             if (angle_value->is_angle()) {
                 auto angle = angle_value->as_angle().angle();

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -2974,7 +2974,7 @@ RefPtr<StyleValue const> Parser::parse_font_style_value(TokenStream<ComponentVal
     // normal | italic | left | right | oblique <angle [-90deg,90deg]>?
     auto transaction = tokens.begin_transaction();
     auto keyword_value = parse_css_value_for_property(PropertyID::FontStyle, tokens);
-    if (!keyword_value)
+    if (!keyword_value || !keyword_value->is_keyword())
         return nullptr;
     auto font_style = keyword_to_font_style(keyword_value->to_keyword());
     VERIFY(font_style.has_value());

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -4107,10 +4107,6 @@ RefPtr<StyleValue const> Parser::parse_calculated_value(ComponentValue const& co
             },
             [](SpecialContext special_context) -> Optional<CalculationContext> {
                 switch (special_context) {
-                case SpecialContext::FontStyleObliqueAngle:
-                    return CalculationContext {
-                        .accepted_type_ranges = { { ValueType::Angle, { -90, 90 } } }
-                    };
                 case SpecialContext::ShadowBlurRadius:
                     return CalculationContext { .accepted_type_ranges = { { ValueType::Length, { 0, NumericLimits<float>::max() } } } };
                 case SpecialContext::TranslateZArgument:

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1694,7 +1694,8 @@
     "inherited": true,
     "initial": "normal",
     "valid-types": [
-      "font-style"
+      "font-style",
+      "angle [-90,90]"
     ]
   },
   "font-variant": {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/animations/font-style-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/animations/font-style-interpolation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 129 tests
 
-116 Pass
-13 Fail
+128 Pass
+1 Fail
 Pass	CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg]
 Pass	CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg]
 Pass	CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (0) should be [normal]
@@ -108,28 +108,28 @@ Pass	Web Animations: property <font-style> from [oblique 20deg] to [normal] at (
 Pass	Web Animations: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg]
 Pass	Web Animations: property <font-style> from [oblique 20deg] to [normal] at (1) should be [normal]
 Pass	Web Animations: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg]
-Fail	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
-Fail	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+Pass	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+Pass	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
 Pass	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 Pass	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 Pass	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-Fail	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
-Fail	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
-Fail	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+Pass	CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+Pass	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+Pass	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
 Pass	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 Pass	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 Pass	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-Fail	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
-Fail	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
-Fail	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+Pass	CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+Pass	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+Pass	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
 Pass	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 Pass	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 Pass	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-Fail	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
-Fail	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
-Fail	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+Pass	CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+Pass	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+Pass	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
 Pass	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 Pass	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 Pass	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-Fail	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+Pass	Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
 Fail	An interpolation to inherit updates correctly on a parent style change.


### PR DESCRIPTION
This change adds the allowed angle range to the `font-style` property definition. This allows these angles to be clamped after interpolation.

Ideally, the generator should be updated so that we can specify the angle is in degrees. This would allow us to make use of this information during parsing, which we can't do currently because we don't know what the unit is. Using this value for interpolation purposes is fine because the angle has been converted to its canonical unit by this point.