### PR TITLE
LibWeb: Check if transform is identity instead of `has_css_transform()`

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -326,10 +326,8 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
         push_stacking_context_params.clip_path = path.copy_transformed(Gfx::AffineTransform {}.set_scale(device_pixel_scale, device_pixel_scale).set_translation(source_paintable_rect.location().to_type<float>()));
     }
 
-    auto has_css_transform = paintable_box().has_css_transform();
-    if (has_css_transform) {
+    if (!transform_matrix.is_identity())
         paintable_box().apply_clip_overflow_rect(context, PaintPhase::Foreground);
-    }
     paintable_box().apply_scroll_offset(context);
 
     auto mask_image = computed_values.mask_image();
@@ -376,7 +374,7 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
         context.display_list_recorder().restore();
     }
     paintable_box().reset_scroll_offset(context);
-    if (has_css_transform)
+    if (!transform_matrix.is_identity())
         paintable_box().clear_clip_overflow_rect(context, PaintPhase::Foreground);
 }
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -147,9 +147,8 @@ void ViewportPaintable::assign_clip_frames()
                 }
                 break;
             }
-            if (block->has_css_transform()) {
+            if (!block->transform().is_identity())
                 break;
-            }
         }
         return TraversalDecision::Continue;
     });
@@ -213,9 +212,8 @@ void ViewportPaintable::assign_clip_frames()
                     clip_frame.add_clip_rect(clip_rect, {}, block_paintable_box.enclosing_scroll_frame());
                 }
             }
-            if (block->has_css_transform()) {
+            if (!block_paintable_box.transform().is_identity())
                 break;
-            }
         }
     }
 }

--- a/Tests/LibWeb/Ref/expected/overflow-hidden-8-ref.html
+++ b/Tests/LibWeb/Ref/expected/overflow-hidden-8-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><style>
+#inner {
+    background-color: blueviolet;
+    width: 100px;
+    height: 100px;
+    border-radius: 9999px;
+}
+</style><div id="inner">

--- a/Tests/LibWeb/Ref/input/overflow-hidden-8.html
+++ b/Tests/LibWeb/Ref/input/overflow-hidden-8.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/overflow-hidden-8-ref.html" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-70">
+<style>
+#outer {
+    width: 100px;
+    height: 100px;
+    overflow: hidden;
+    position: absolute;
+    border-radius: 9999px;
+}
+#middle {
+    overflow: hidden;
+    position: absolute;
+    transform: translateZ(0px);
+    right: 0;
+    bottom: 0;
+    left: 0;
+    top: 0;
+}
+#inner {
+    background-color: blueviolet;
+    position: absolute;
+    height: 100%;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+}
+</style><div id="outer"><div id="middle"><div id="inner">


### PR DESCRIPTION
...in clip and scroll frames calculation algorithm.

Fix a regression from 719a50c where display-list recording disagreed with the clipping logic about whether a stacking context is transformed. `has_css_transform()` returns true whenever the computed transform is not `none`, which differs from an identity-matrix check. These yield different results for cases like `translate(0, 0)`.