### PR TITLE
Meta+Tests: Update vcpkg dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -117,7 +117,7 @@ runs:
       run: |
         set -e
         brew update
-        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@20 nasm ninja pkg-config qt unzip wabt
+        brew install autoconf autoconf-archive automake bash ccache coreutils libtool llvm@20 nasm ninja pkg-config qt unzip wabt
 
     - name: 'Set required environment variables'
       if: ${{ inputs.os == 'Linux' && inputs.arch == 'arm64' }}

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -133,7 +133,7 @@ Xcode 15 or clang from homebrew is required to successfully build ladybird.
 
 ```
 xcode-select --install
-brew install autoconf autoconf-archive automake ccache cmake nasm ninja pkg-config
+brew install autoconf autoconf-archive automake ccache cmake libtool nasm ninja pkg-config
 ```
 
 If you wish to use clang from homebrew instead:

--- a/Tests/AK/TestStringConversions.cpp
+++ b/Tests/AK/TestStringConversions.cpp
@@ -611,6 +611,32 @@ TEST_CASE(unsigned_integer)
     EXPECT(!actual_u64.has_value());
 }
 
+TEST_CASE(unicode_emojis_with_low_byte_in_UTF_16_matching_the_value_of_an_ascii_digit)
+{
+#define EXPECT_PARSE_TO_FAIL_FOR_EMOJI(string_value)                     \
+    do {                                                                 \
+        EXPECT(!AK::parse_number<u32>(string_value##sv).has_value());    \
+        EXPECT(!AK::parse_number<u32>(u##string_value##sv).has_value()); \
+    } while (false)
+
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("ℹ");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("ℹ️");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("☸");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("☸️");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("☹");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("☹️");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("✳");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("✳️");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("✴");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("✴️");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("⤴");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("⤴️");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("⤵");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("⤵️");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("〰");
+    EXPECT_PARSE_TO_FAIL_FOR_EMOJI("〰️");
+}
+
 TEST_CASE(octal)
 {
     auto value = AK::parse_number<u16>(StringView(), AK::TrimWhitespace::No, 8);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -216,7 +216,7 @@
     },
     {
       "name": "dirent",
-      "version": "1.25#0"
+      "version": "1.26#0"
     },
     {
       "name": "fast-float",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -264,7 +264,7 @@
     },
     {
       "name": "libwebp",
-      "version": "1.6.0#0"
+      "version": "1.6.0#1"
     },
     {
       "name": "mman",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "120deac3062162151622ca4860575a33844ba10b",
+  "builtin-baseline": "b0b3de1b1a0aa4b8f2822460aa7f42f991629b3f",
   "dependencies": [
     {
       "name": "angle",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -220,7 +220,7 @@
     },
     {
       "name": "fast-float",
-      "version": "8.0.2#0"
+      "version": "8.1.0#0"
     },
     {
       "name": "ffmpeg",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -224,7 +224,7 @@
     },
     {
       "name": "ffmpeg",
-      "version": "7.1.1#4"
+      "version": "7.1.1#5"
     },
     {
       "name": "fontconfig",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -212,7 +212,7 @@
     },
     {
       "name": "dbus",
-      "version": "1.16.2#1"
+      "version": "1.16.2#2"
     },
     {
       "name": "dirent",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -208,7 +208,7 @@
     },
     {
       "name": "curl",
-      "version": "8.15.0#1"
+      "version": "8.16.0#0"
     },
     {
       "name": "dbus",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -272,7 +272,7 @@
     },
     {
       "name": "openssl",
-      "version": "3.5.2#0"
+      "version": "3.5.3#0"
     },
     {
       "name": "qtbase",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -284,7 +284,7 @@
     },
     {
       "name": "sdl3",
-      "version": "3.2.20#0"
+      "version": "3.2.22#0"
     },
     {
       "name": "simdutf",


### PR DESCRIPTION
The primary motivation for this is version 8.1.0 of `fast_float`, which contains a change that fixes #6205.

Since the baseline update already caused everything to rebuild, I've also bumped all other dependencies that were a straightforward version change. There is nothing super relevant in the changelogs for these versions as far as I can tell. The most interesting thing might be some security fixes in the curl update, which are probably good to have.