### PR TITLE
LibWeb: Improve parsing and serialization of `grid-area`

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1846,7 +1846,7 @@
       "auto"
     ],
     "valid-types": [
-      "string"
+      "custom-ident ![auto,span]"
     ],
     "longhands": [
       "grid-column-end",
@@ -1895,7 +1895,7 @@
       "auto"
     ],
     "valid-types": [
-      "string"
+      "custom-ident ![auto,span]"
     ],
     "longhands": [
       "grid-column-end",
@@ -1910,7 +1910,7 @@
       "auto"
     ],
     "valid-types": [
-      "string"
+      "custom-ident ![auto,span]"
     ]
   },
   "grid-column-gap": {
@@ -1924,7 +1924,7 @@
       "auto"
     ],
     "valid-types": [
-      "string"
+      "custom-ident ![auto,span]"
     ]
   },
   "grid-gap": {
@@ -1937,7 +1937,7 @@
       "auto"
     ],
     "valid-types": [
-      "string"
+      "custom-ident ![auto,span]"
     ],
     "longhands": [
       "grid-row-end",
@@ -1952,7 +1952,7 @@
       "auto"
     ],
     "valid-types": [
-      "string"
+      "custom-ident ![auto,span]"
     ]
   },
   "grid-row-gap": {
@@ -1966,7 +1966,7 @@
       "auto"
     ],
     "valid-types": [
-      "string"
+      "custom-ident ![auto,span]"
     ]
   },
   "grid-template": {

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -535,9 +535,8 @@ String ShorthandStyleValue::to_string(SerializationMode mode) const
 
         // When grid-column-end is omitted, if grid-column-start is a <custom-ident>, grid-column-end is set to that
         // <custom-ident>; otherwise, it is set to auto.
-        if (is_auto(column_end) && column_start->is_custom_ident()) {
+        if (is_auto(column_end) && column_start->is_custom_ident())
             column_end = column_start;
-        }
 
         // When grid-column-start is omitted, if grid-row-start is a <custom-ident>, all four longhands are set to
         // that value. Otherwise, it is set to auto.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 33 tests
 
-27 Pass
-6 Fail
+29 Pass
+4 Fail
 Pass	Property grid-area value 'auto / auto / auto / auto'
 Pass	Property grid-row value 'auto / auto'
 Pass	Property grid-column-end value 'auto'
@@ -11,7 +11,7 @@ Pass	Property grid-row value '-zπ'
 Pass	Property grid-row-start value 'AZ'
 Pass	Property grid-column-start value '-_π'
 Pass	Property grid-row-end value '_9'
-Fail	Property grid-area value '1 / 90 -a- / auto / auto'
+Pass	Property grid-area value '1 / 90 -a- / auto / auto'
 Pass	Property grid-row value '2 az / auto'
 Pass	Property grid-column value '9 / -19 zA'
 Pass	Property grid-row-start value '-19'
@@ -20,7 +20,7 @@ Pass	Property grid-column-start value '-44 Z'
 Pass	Property grid-row-end value '1 -πA'
 Pass	Property grid-column-end value '5 π_'
 Fail	Property grid-row-start value 'calc(1.1) -a-'
-Fail	Property grid-row-start value 'calc(10) -a-'
+Pass	Property grid-row-start value 'calc(10) -a-'
 Fail	Property grid-row-start value 'calc(10 + (sign(2cqw - 10px) * 5)) -a-'
 Pass	Property grid-area value 'span 2 i / auto / auto / auto'
 Pass	Property grid-row value 'span 2 / auto'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 33 tests
 
-24 Pass
-9 Fail
+27 Pass
+6 Fail
 Pass	Property grid-area value 'auto / auto / auto / auto'
 Pass	Property grid-row value 'auto / auto'
 Pass	Property grid-column-end value 'auto'
@@ -30,9 +30,9 @@ Pass	Property grid-row-end value 'span 2 i'
 Pass	Property grid-column-end value 'span 2'
 Pass	Property grid-row-start value 'span i'
 Pass	Property grid-row value 'span i / auto'
-Fail	Property grid-area value 'auto / i / auto / i'
-Fail	Property grid-area value 'auto / i / 2 j'
-Fail	Property grid-area value 'auto / i / 2 j / span 3 k'
+Pass	Property grid-area value 'auto / i / auto / i'
+Pass	Property grid-area value 'auto / i / 2 j'
+Pass	Property grid-area value 'auto / i / 2 j / span 3 k'
 Pass	Property grid-row value 'auto / i'
 Pass	Property grid-column value '2 j / span 3 k'
 Fail	Property grid-column-end value '\31st'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-shorthand.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 53 tests
 
-48 Pass
-5 Fail
+53 Pass
 Pass	e.style['grid-area'] = "auto" should set grid-column-end
 Pass	e.style['grid-area'] = "auto" should set grid-column-start
 Pass	e.style['grid-area'] = "auto" should set grid-row-end
@@ -29,11 +28,11 @@ Pass	e.style['grid-area'] = "a / b / c / d" should set grid-column-start
 Pass	e.style['grid-area'] = "a / b / c / d" should set grid-row-end
 Pass	e.style['grid-area'] = "a / b / c / d" should set grid-row-start
 Pass	e.style['grid-area'] = "a / b / c / d" should not set unrelated longhands
-Fail	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-column-end
-Fail	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-column-start
-Fail	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-row-end
-Fail	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-row-start
-Fail	e.style['grid-area'] = "+90 -a- / 2 i span" should not set unrelated longhands
+Pass	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-column-end
+Pass	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-column-start
+Pass	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-row-end
+Pass	e.style['grid-area'] = "+90 -a- / 2 i span" should set grid-row-start
+Pass	e.style['grid-area'] = "+90 -a- / 2 i span" should not set unrelated longhands
 Pass	e.style['grid-area'] = "1 / 2 / 3 / 4" should set grid-column-end
 Pass	e.style['grid-area'] = "1 / 2 / 3 / 4" should set grid-column-start
 Pass	e.style['grid-area'] = "1 / 2 / 3 / 4" should set grid-row-end

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 57 tests
 
-52 Pass
-5 Fail
+53 Pass
+4 Fail
 Pass	e.style['grid-area'] = "auto" should set the property value
 Pass	e.style['grid-area'] = "auto / auto" should set the property value
 Pass	e.style['grid-area'] = "auto / auto / auto" should set the property value
@@ -20,7 +20,7 @@ Pass	e.style['grid-row-start'] = "AZ" should set the property value
 Pass	e.style['grid-column-start'] = "-_π" should set the property value
 Pass	e.style['grid-row-end'] = "_9" should set the property value
 Pass	e.style['grid-area'] = "1" should set the property value
-Fail	e.style['grid-area'] = "+90 -a-" should set the property value
+Pass	e.style['grid-area'] = "+90 -a-" should set the property value
 Pass	e.style['grid-row'] = "az 2" should set the property value
 Pass	e.style['grid-column'] = "9" should set the property value
 Pass	e.style['grid-column'] = "-19 zA" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 57 tests
 
-40 Pass
-17 Fail
+52 Pass
+5 Fail
 Pass	e.style['grid-area'] = "auto" should set the property value
 Pass	e.style['grid-area'] = "auto / auto" should set the property value
 Pass	e.style['grid-area'] = "auto / auto / auto" should set the property value
@@ -12,7 +12,7 @@ Pass	e.style['grid-area'] = "AuTo" should set the property value
 Pass	e.style['grid-row'] = "auto" should set the property value
 Pass	e.style['grid-row'] = "auto/auto" should set the property value
 Pass	e.style['grid-column-end'] = "AuTo" should set the property value
-Fail	e.style['grid-area'] = "--a" should set the property value
+Pass	e.style['grid-area'] = "--a" should set the property value
 Pass	e.style['grid-row'] = "-zπ" should set the property value
 Pass	e.style['grid-row'] = "-zπ/-zπ" should set the property value
 Pass	e.style['grid-row'] = "i / i" should set the property value
@@ -40,19 +40,19 @@ Pass	e.style['grid-row-start'] = "span i" should set the property value
 Pass	e.style['grid-column-start'] = "SpAn i 2" should set the property value
 Pass	e.style['grid-row-end'] = "2 i span" should set the property value
 Pass	e.style['grid-column-end'] = "2 SpAn" should set the property value
-Fail	e.style['grid-area'] = "auto / i" should set the property value
-Fail	e.style['grid-area'] = "auto / i / auto / i" should set the property value
-Fail	e.style['grid-area'] = "auto / i / auto / 2 i" should set the property value
-Fail	e.style['grid-area'] = "1 / i  / auto / i" should set the property value
+Pass	e.style['grid-area'] = "auto / i" should set the property value
+Pass	e.style['grid-area'] = "auto / i / auto / i" should set the property value
+Pass	e.style['grid-area'] = "auto / i / auto / 2 i" should set the property value
+Pass	e.style['grid-area'] = "1 / i  / auto / i" should set the property value
 Pass	e.style['grid-area'] = "1 / auto / auto / auto" should set the property value
-Fail	e.style['grid-area'] = "1 / auto / i / auto" should set the property value
+Pass	e.style['grid-area'] = "1 / auto / i / auto" should set the property value
 Pass	e.style['grid-area'] = "1 / j / i / k" should set the property value
-Fail	e.style['grid-area'] = "1 / auto / 2 / auto" should set the property value
-Fail	e.style['grid-area'] = "1 / i / 2 / auto" should set the property value
-Fail	e.style['grid-area'] = "i / i / auto / auto" should set the property value
-Fail	e.style['grid-area'] = "i / auto / i / auto" should set the property value
-Fail	e.style['grid-area'] = "auto / i / 2 j" should set the property value
-Fail	e.style['grid-area'] = "auto / i / 2 j / span 3 k" should set the property value
+Pass	e.style['grid-area'] = "1 / auto / 2 / auto" should set the property value
+Pass	e.style['grid-area'] = "1 / i / 2 / auto" should set the property value
+Pass	e.style['grid-area'] = "i / i / auto / auto" should set the property value
+Pass	e.style['grid-area'] = "i / auto / i / auto" should set the property value
+Pass	e.style['grid-area'] = "auto / i / 2 j" should set the property value
+Pass	e.style['grid-area'] = "auto / i / 2 j / span 3 k" should set the property value
 Pass	e.style['grid-row'] = "auto / i" should set the property value
 Fail	e.style['grid-row'] = "i / auto" should set the property value
 Pass	e.style['grid-row'] = "2 i / auto" should set the property value


### PR DESCRIPTION
This PR implements spec-compliant serialization for `grid-area` and ensures `grid-area` and longhands don't fail to parse when they contain a custom-ident.

I *think* the remaining subtest failures should be fixed by the custom-ident escaping implemented in #6267.

Fixes 23 WPT subtests in the `css/css-grid` directory.