### PR TITLE
LibWeb: Calculate and use bounds for "simple" stacking contexts

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -94,10 +94,20 @@ public:
         DisplayListCommand command;
     };
 
-    AK::SegmentedVector<DisplayListCommandWithScrollAndClip, 512> const& commands() const { return m_commands; }
+    auto& commands(Badge<DisplayListRecorder>) { return m_commands; }
+    auto const& commands() const { return m_commands; }
     double device_pixels_per_css_pixel() const { return m_device_pixels_per_css_pixel; }
 
     String dump() const;
+
+    template<typename Callback>
+    void for_each_command_in_range(size_t start, size_t end, Callback callback)
+    {
+        for (auto index = start; index < end; ++index) {
+            if (callback(m_commands[index].command, m_commands[index].scroll_frame_id) == IterationDecision::Break)
+                break;
+        }
+    }
 
 private:
     DisplayList(double device_pixels_per_css_pixel)

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -145,6 +145,10 @@ struct PushStackingContext {
     StackingContextTransform transform;
     Optional<Gfx::Path> clip_path = {};
 
+    size_t matching_pop_index { 0 };
+    bool can_aggregate_children_bounds { false };
+    Optional<Gfx::IntRect> bounding_rect {};
+
     void translate_by(Gfx::IntPoint const& offset)
     {
         transform.origin.translate_by(offset.to_type<float>());

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -216,9 +216,12 @@ void DisplayListPlayerSkia::push_stacking_context(PushStackingContext const& com
         paint.setAlphaf(command.opacity);
         paint.setBlender(Gfx::to_skia_blender(command.compositing_and_blending_operator));
 
-        // FIXME: If we knew the bounds of the stacking context including any transformed descendants etc,
-        //        we could use saveLayer with a bounds rect. For now, we pass nullptr and let Skia figure it out.
-        canvas.saveLayer(nullptr, &paint);
+        if (command.bounding_rect.has_value()) {
+            auto bounds = to_skia_rect(command.bounding_rect.value());
+            canvas.saveLayer(bounds, &paint);
+        } else {
+            canvas.saveLayer(nullptr, &paint);
+        }
     } else {
         canvas.save();
     }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -148,6 +148,7 @@ public:
 private:
     Vector<Optional<i32>> m_scroll_frame_id_stack;
     Vector<RefPtr<ClipFrame const>> m_clip_frame_stack;
+    Vector<size_t> m_push_sc_index_stack;
     DisplayList& m_display_list;
 };
 


### PR DESCRIPTION
Teach the display list executor to derive a bounding rectangle for stacking contexts whose inner commands can all report bounds, that is, most contexts without nested stacking contexts.

This yields a large performance improvement on https://tc39.es/ecma262/ where the display list contains thousands of groups like:
```
PushStackingContext blending=Multiply
    DrawGlyphRun
PopStackingContext
```
Previously, `PushStackingContext` triggered an unbounded `saveLayer()` even when the glyph run lies wholly outside the viewport. With this change, we (1) cull stacking contexts that fall outside the viewport and (2) provide bounds to `saveLayer()` when they are visible.

With this change rendering thread goes from 70% to 1% in profiles of https://tc39.es/ecma262/. Also makes a huge performance difference on Discord.