### PR TITLE
LibWeb: Escape custom-ident when serializing grid track placement values

### DIFF
--- a/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -19,11 +19,11 @@ String GridTrackPlacement::to_string(SerializationMode mode) const
         },
         [&](AreaOrLine const& area_or_line) {
             if (area_or_line.line_number.has_value() && area_or_line.name.has_value()) {
-                builder.appendff("{} {}", area_or_line.line_number->to_string(mode), *area_or_line.name);
+                builder.appendff("{} {}", area_or_line.line_number->to_string(mode), serialize_an_identifier(*area_or_line.name));
             } else if (area_or_line.line_number.has_value()) {
                 builder.appendff("{}", area_or_line.line_number->to_string(mode));
             } else if (area_or_line.name.has_value()) {
-                builder.appendff("{}", *area_or_line.name);
+                builder.appendff("{}", serialize_an_identifier(*area_or_line.name));
             }
         },
         [&](Span const& span) {

--- a/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -21,12 +21,12 @@ public:
 
     static GridTrackPlacement make_line(Optional<IntegerOrCalculated> line_number, Optional<String> name)
     {
-        return GridTrackPlacement(AreaOrLine { .line_number = line_number, .name = name });
+        return GridTrackPlacement(AreaOrLine { .line_number = move(line_number), .name = move(name) });
     }
 
     static GridTrackPlacement make_span(IntegerOrCalculated value, Optional<String> name)
     {
-        return GridTrackPlacement(Span { .value = value, .name = name });
+        return GridTrackPlacement(Span { .value = move(value), .name = move(name) });
     }
 
     bool is_auto() const { return m_value.has<Auto>(); }
@@ -79,11 +79,11 @@ private:
     {
     }
     GridTrackPlacement(AreaOrLine value)
-        : m_value(value)
+        : m_value(move(value))
     {
     }
     GridTrackPlacement(Span value)
-        : m_value(value)
+        : m_value(move(value))
     {
     }
 

--- a/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.cpp
@@ -13,7 +13,7 @@ namespace Web::CSS {
 
 ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue const> GridTrackPlacementStyleValue::create(CSS::GridTrackPlacement grid_track_placement)
 {
-    return adopt_ref(*new (nothrow) GridTrackPlacementStyleValue(grid_track_placement));
+    return adopt_ref(*new (nothrow) GridTrackPlacementStyleValue(move(grid_track_placement)));
 }
 
 String GridTrackPlacementStyleValue::to_string(SerializationMode mode) const

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 33 tests
 
-29 Pass
-4 Fail
+31 Pass
+2 Fail
 Pass	Property grid-area value 'auto / auto / auto / auto'
 Pass	Property grid-row value 'auto / auto'
 Pass	Property grid-column-end value 'auto'
@@ -35,5 +35,5 @@ Pass	Property grid-area value 'auto / i / 2 j'
 Pass	Property grid-area value 'auto / i / 2 j / span 3 k'
 Pass	Property grid-row value 'auto / i'
 Pass	Property grid-column value '2 j / span 3 k'
-Fail	Property grid-column-end value '\31st'
-Fail	Property grid-column-end value '\31 st'
+Pass	Property grid-column-end value '\31st'
+Pass	Property grid-column-end value '\31 st'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 57 tests
 
-53 Pass
-4 Fail
+56 Pass
+1 Fail
 Pass	e.style['grid-area'] = "auto" should set the property value
 Pass	e.style['grid-area'] = "auto / auto" should set the property value
 Pass	e.style['grid-area'] = "auto / auto / auto" should set the property value
@@ -58,6 +58,6 @@ Fail	e.style['grid-row'] = "i / auto" should set the property value
 Pass	e.style['grid-row'] = "2 i / auto" should set the property value
 Pass	e.style['grid-row'] = "1 / auto" should set the property value
 Pass	e.style['grid-column'] = "2 j / span 3 k" should set the property value
-Fail	e.style['grid-column-end'] = "\\31st" should set the property value
-Fail	e.style['grid-column-end'] = "\\31 st" should set the property value
-Fail	e.style['grid-column'] = "\\31st / \\31 st" should set the property value
+Pass	e.style['grid-column-end'] = "\\31st" should set the property value
+Pass	e.style['grid-column-end'] = "\\31 st" should set the property value
+Pass	e.style['grid-column'] = "\\31st / \\31 st" should set the property value


### PR DESCRIPTION
With this change we ensure that custom-idents used by `grid-area` and its longhands are correctly escaped.

I've also included a drive-by commit to avoid some copies in `GridTrackPlacement`.
