### PR TITLE
LibWeb: Compute bounds for paint-contained stacking contexts

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -193,7 +193,7 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
 
         if (command.has<PushStackingContext>()) {
             auto& push_stacking_context = command.get<PushStackingContext>();
-            if (push_stacking_context.can_aggregate_children_bounds) {
+            if (push_stacking_context.can_aggregate_children_bounds && !push_stacking_context.bounding_rect.has_value()) {
                 bounding_rect = compute_stacking_context_bounds(push_stacking_context, command_index);
                 push_stacking_context.bounding_rect = bounding_rect;
             }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -111,6 +111,7 @@ public:
         bool isolate;
         StackingContextTransform transform;
         Optional<Gfx::Path> clip_path = {};
+        Optional<Gfx::IntRect> bounding_rect {};
 
         bool has_effect() const { return opacity != 1.0f || compositing_and_blending_operator != Gfx::CompositingAndBlendingOperator::Normal || isolate || clip_path.has_value() || !transform.is_identity(); }
     };

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -326,6 +326,10 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
         push_stacking_context_params.clip_path = path.copy_transformed(Gfx::AffineTransform {}.set_scale(device_pixel_scale, device_pixel_scale).set_translation(source_paintable_rect.location().to_type<float>()));
     }
 
+    if (paintable_box().layout_node().has_paint_containment()) {
+        push_stacking_context_params.bounding_rect = context.enclosing_device_rect(paintable_box().overflow_clip_edge_rect());
+    }
+
     if (!transform_matrix.is_identity())
         paintable_box().apply_clip_overflow_rect(context, PaintPhase::Foreground);
     paintable_box().apply_scroll_offset(context);


### PR DESCRIPTION
This makes it so that the bounds for any paint-contained stacking context are not derived from its children, but rather just set to the rectangle that they will be clipped to anyways due to the paint containment. Should make rendering faster on pages that use paint containment.

This is what I meant when I wrote my comment on  #6291.