### PR TITLE
LibWeb: Call `saveLayer()` after applying matrix in PushStackingContext

### DIFF
--- a/Tests/LibWeb/Ref/expected/transform-and-opacity-ref.html
+++ b/Tests/LibWeb/Ref/expected/transform-and-opacity-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+#outer {
+    position: relative;
+}
+#inner {
+    top: 100px;
+    left: 100px;
+    width: 100px;
+    height: 100px;
+    opacity: 0.5;
+    position: relative;
+    background-color: green;
+}
+</style>
+<div id="outer">
+  <div id="inner"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/transform-and-opacity.html
+++ b/Tests/LibWeb/Ref/input/transform-and-opacity.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/transform-and-opacity-ref.html" />
+<style>
+#outer {
+    opacity: 0.5;
+    transform: translate(100px, 100px);
+}
+#inner {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+</style>
+<div id="outer">
+  <div id="inner"></div>
+</div>


### PR DESCRIPTION
This is required because bounding rect used in `saveLayer()` is computed in stacking context's coordinate space.

Fixes regression introduced in ba2926f