### PR TITLE
Tests: Disable/hack-fix some regularly-flaking tests

### DIFF
--- a/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/effect-reference-feimage-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/filter-effects/effect-reference-feimage-001.html
@@ -17,3 +17,6 @@
      <feimage xlink:href="support/color-palette.png"/>
   </filter>
 </svg>
+
+<!-- HACK: Force the document to wait for the image to load -->
+<img src="support/color-palette.png" style="opacity: 0"/>

--- a/Tests/LibWeb/Screenshot/input/css-background-blob-url.html
+++ b/Tests/LibWeb/Screenshot/input/css-background-blob-url.html
@@ -13,6 +13,9 @@
     </head>
     <body>
         <div id="background"></div>
+        
+        <!-- HACK: Force the document to wait for the image to load -->
+        <img src="../data/smiley.png" style="opacity: 0"/>
 
         <script>
             fetch("../data/smiley.png")

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -342,3 +342,12 @@ Text/input/input-file.html
 ; Times out due to `document.adoptNode` invocation
 ; https://github.com/LadybirdBrowser/ladybird/issues/6150
 Crash/wpt-import/css/css-view-transitions/first-line-reparent-crash.html
+
+; Flaky: https://github.com/LadybirdBrowser/ladybird/issues/6299
+Text/input/GamepadAPI/gamepad-rumble.html
+
+; Flaky: https://github.com/LadybirdBrowser/ladybird/issues/6300
+Text/input/wpt-import/html/semantics/popovers/popover-toggle-source.tentative.html
+
+; Flaky: https://github.com/LadybirdBrowser/ladybird/issues/5257
+Text/input/selection-over-multiple-code-units.html


### PR DESCRIPTION
I seem to be clicking the "re-run failed jobs" button rather a lot lately. So, I've disabled a few and hacked some others to hopefully flake less. I don't think this is *all* the flakes, by an means, but I went through all the failing CI jobs in the PR queue, and these are the ones that I've seen failing a lot.