### PR TITLE
LibWeb: Don't assume ImageBox's image provider is the DOM node

### DIFF
--- a/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -65,10 +65,7 @@ void ImageBox::dom_node_did_update_alt_text(Badge<ImageProvider>)
 
 bool ImageBox::renders_as_alt_text() const
 {
-    if (auto const* image_provider = as_if<ImageProvider>(dom_node().ptr()))
-        return !image_provider->is_image_available();
-
-    return false;
+    return !m_image_provider.is_image_available();
 }
 
 GC::Ptr<Painting::Paintable> ImageBox::create_paintable() const


### PR DESCRIPTION
This gets rid of the assumption that the DOM node of an ImageBox is also its image provider. This will become necessary when generating the image boxes for view transition pseudos, for which the DOM node won't be the image provider. (that'll be the pseudo element itself)