### PR TITLE
LibJS+LibWeb: Add some missing `fast_is<>`

### DIFF
--- a/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Libraries/LibJS/Runtime/BoundFunction.h
@@ -36,9 +36,14 @@ private:
     ThrowCompletionOr<void> get_stack_frame_size(size_t& registers_and_constants_and_locals_count, size_t& argument_count) override;
     virtual void visit_edges(Visitor&) override;
 
+    virtual bool is_bound_function() const final { return true; }
+
     GC::Ptr<FunctionObject> m_bound_target_function; // [[BoundTargetFunction]]
     Value m_bound_this;                              // [[BoundThis]]
     Vector<Value> m_bound_arguments;                 // [[BoundArguments]]
 };
+
+template<>
+inline bool FunctionObject::fast_is<BoundFunction>() const { return is_bound_function(); }
 
 }

--- a/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Libraries/LibJS/Runtime/FunctionObject.h
@@ -42,6 +42,9 @@ public:
 
     virtual FunctionParameters const& formal_parameters() const { VERIFY_NOT_REACHED(); }
 
+    template<typename T>
+    bool fast_is() const = delete;
+
 protected:
     explicit FunctionObject(Realm&, Object* prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
     explicit FunctionObject(Object& prototype, MayInterfereWithIndexedPropertyAccess = MayInterfereWithIndexedPropertyAccess::No);
@@ -50,6 +53,7 @@ protected:
 
 private:
     virtual bool is_function() const override { return true; }
+    virtual bool is_bound_function() const { return false; }
 };
 
 template<>

--- a/Libraries/LibJS/Runtime/Map.h
+++ b/Libraries/LibJS/Runtime/Map.h
@@ -25,6 +25,8 @@ public:
 
     virtual ~Map() override = default;
 
+    virtual bool is_map_object() const final { return true; }
+
     void map_clear();
     bool map_remove(Value const&);
     Optional<Value> map_get(Value const&) const;
@@ -115,5 +117,8 @@ private:
     RedBlackTree<size_t, Value> m_keys;
     HashMap<Value, Value, ValueTraits> m_entries;
 };
+
+template<>
+inline bool Object::fast_is<Map>() const { return is_map_object(); }
 
 }

--- a/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Libraries/LibJS/Runtime/NativeFunction.h
@@ -72,4 +72,7 @@ private:
 template<>
 inline bool Object::fast_is<NativeFunction>() const { return is_native_function(); }
 
+template<>
+inline bool FunctionObject::fast_is<NativeFunction>() const { return is_native_function(); }
+
 }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -206,6 +206,7 @@ public:
     void define_native_accessor(Realm&, PropertyKey const&, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> getter, ESCAPING Function<ThrowCompletionOr<Value>(VM&)> setter, PropertyAttributes attributes);
 
     virtual bool is_dom_node() const { return false; }
+    virtual bool is_dom_element() const { return false; }
     virtual bool is_dom_event() const { return false; }
     virtual bool is_html_window() const { return false; }
     virtual bool is_html_window_proxy() const { return false; }

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -227,6 +227,8 @@ public:
     virtual bool is_ecmascript_function_object() const { return false; }
     virtual bool is_array_iterator() const { return false; }
     virtual bool is_raw_json_object() const { return false; }
+    virtual bool is_set_object() const { return false; }
+    virtual bool is_map_object() const { return false; }
 
     virtual bool eligible_for_own_property_enumeration_fast_path() const { return true; }
 

--- a/Libraries/LibJS/Runtime/Set.h
+++ b/Libraries/LibJS/Runtime/Set.h
@@ -24,6 +24,8 @@ public:
     virtual void initialize(Realm&) override;
     virtual ~Set() override = default;
 
+    virtual bool is_set_object() const final { return true; }
+
     // NOTE: Unlike what the spec says, we implement Sets using an underlying map,
     //       so all the functions below do not directly implement the operations as
     //       defined by the specification.
@@ -58,5 +60,8 @@ struct SetRecord {
 
 ThrowCompletionOr<SetRecord> get_set_record(VM&, Value);
 bool set_data_has(GC::Ref<Set>, Value);
+
+template<>
+inline bool Object::fast_is<Set>() const { return is_set_object(); }
 
 }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -113,6 +113,8 @@ class WEB_API Element
 public:
     virtual ~Element() override;
 
+    virtual bool is_dom_element() const final { return true; }
+
     FlyString const& qualified_name() const { return m_qualified_name.as_string(); }
     FlyString const& html_uppercased_qualified_name() const;
 
@@ -710,3 +712,6 @@ enum class ValidationContext {
 WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, FlyString const& qualified_name, ValidationContext context);
 
 }
+
+template<>
+inline bool JS::Object::fast_is<Web::DOM::Element>() const { return is_dom_element(); }


### PR DESCRIPTION
Adds fast_is<> for cases where we previously would do `dynamic_cast`.