### PR TITLE
LibJS: Handle relativeTo ZDTs that fall within second DST wallclock time

### DIFF
--- a/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -137,12 +137,12 @@ i8 time_duration_sign(TimeDuration const&);
 ThrowCompletionOr<double> date_duration_days(VM&, DateDuration const&, PlainDate const&);
 ThrowCompletionOr<TimeDuration> round_time_duration(VM&, TimeDuration const&, Crypto::UnsignedBigInteger const& increment, Unit, RoundingMode);
 Crypto::BigFraction total_time_duration(TimeDuration const&, Unit);
-ThrowCompletionOr<CalendarNudgeResult> nudge_to_calendar_unit(VM&, i8 sign, InternalDuration const&, Crypto::SignedBigInteger const& dest_epoch_ns, ISODateTime const&, Optional<StringView> time_zone, StringView calendar, u64 increment, Unit, RoundingMode);
+ThrowCompletionOr<CalendarNudgeResult> nudge_to_calendar_unit(VM&, i8 sign, InternalDuration const&, Crypto::SignedBigInteger const& origin_epoch_ns, Crypto::SignedBigInteger const& dest_epoch_ns, ISODateTime const&, Optional<StringView> time_zone, StringView calendar, u64 increment, Unit, RoundingMode);
 ThrowCompletionOr<DurationNudgeResult> nudge_to_zoned_time(VM&, i8 sign, InternalDuration const&, ISODateTime const&, StringView time_zone, StringView calendar, u64 increment, Unit, RoundingMode);
 ThrowCompletionOr<DurationNudgeResult> nudge_to_day_or_time(VM&, InternalDuration const&, Crypto::SignedBigInteger const& dest_epoch_ns, Unit largest_unit, u64 increment, Unit smallest_unit, RoundingMode);
 ThrowCompletionOr<InternalDuration> bubble_relative_duration(VM&, i8 sign, InternalDuration, Crypto::SignedBigInteger const& nudged_epoch_ns, ISODateTime const&, Optional<StringView> time_zone, StringView calendar, Unit largest_unit, Unit smallest_unit);
-ThrowCompletionOr<InternalDuration> round_relative_duration(VM&, InternalDuration, Crypto::SignedBigInteger const& dest_epoch_ns, ISODateTime const&, Optional<StringView> time_zone, StringView calendar, Unit largest_unit, u64 increment, Unit smallest_unit, RoundingMode);
-ThrowCompletionOr<Crypto::BigFraction> total_relative_duration(VM&, InternalDuration const&, TimeDuration const&, ISODateTime const&, Optional<StringView> time_zone, StringView calendar, Unit);
+ThrowCompletionOr<InternalDuration> round_relative_duration(VM&, InternalDuration, Crypto::SignedBigInteger const& origin_epoch_ns, Crypto::SignedBigInteger const& dest_epoch_ns, ISODateTime const&, Optional<StringView> time_zone, StringView calendar, Unit largest_unit, u64 increment, Unit smallest_unit, RoundingMode);
+ThrowCompletionOr<Crypto::BigFraction> total_relative_duration(VM&, InternalDuration const&, Crypto::SignedBigInteger const& origin_epoch_ns, Crypto::SignedBigInteger const& dest_epoch_ns, ISODateTime const&, Optional<StringView> time_zone, StringView calendar, Unit);
 String temporal_duration_to_string(Duration const&, Precision);
 ThrowCompletionOr<GC::Ref<Duration>> add_durations(VM&, ArithmeticOperation, Duration const&, Value);
 

--- a/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -369,7 +369,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
         // f. Set internalDuration to ? DifferenceZonedDateTimeWithRounding(relativeEpochNs, targetEpochNs, timeZone, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode).
         internal_duration = TRY(difference_zoned_date_time_with_rounding(vm, relative_epoch_nanoseconds, target_epoch_nanoseconds, time_zone, calendar, largest_unit_value, rounding_increment, smallest_unit_value, rounding_mode));
 
-        // g. If TemporalUnitCategory(largestUnit) is date, set largestUnit to hour.
+        // g. If TemporalUnitCategory(largestUnit) is DATE, set largestUnit to HOUR.
         if (temporal_unit_category(largest_unit_value) == UnitCategory::Date)
             largest_unit_value = Unit::Hour;
 

--- a/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -413,14 +413,17 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_date(VM& vm, Dura
         // a. Let isoDateTime be CombineISODateAndTimeRecord(temporalDate.[[ISODate]], MidnightTimeRecord()).
         auto iso_date_time = combine_iso_date_and_time_record(temporal_date.iso_date(), midnight_time_record());
 
-        // b. Let isoDateTimeOther be CombineISODateAndTimeRecord(other.[[ISODate]], MidnightTimeRecord()).
+        // b. Let originEpochNs be GetUTCEpochNanoseconds(isoDateTime).
+        auto origin_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time);
+
+        // c. Let isoDateTimeOther be CombineISODateAndTimeRecord(other.[[ISODate]], MidnightTimeRecord()).
         auto iso_date_time_other = combine_iso_date_and_time_record(other->iso_date(), midnight_time_record());
 
-        // c. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTimeOther).
+        // d. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTimeOther).
         auto dest_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time_other);
 
-        // d. Set duration to ? RoundRelativeDuration(duration, destEpochNs, isoDateTime, UNSET, temporalDate.[[Calendar]], settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-        duration = TRY(round_relative_duration(vm, move(duration), dest_epoch_ns, iso_date_time, {}, temporal_date.calendar(), settings.largest_unit, settings.rounding_increment, settings.smallest_unit, settings.rounding_mode));
+        // e. Set duration to ? RoundRelativeDuration(duration, originEpochNs, destEpochNs, isoDateTime, UNSET, temporalDate.[[Calendar]], settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
+        duration = TRY(round_relative_duration(vm, move(duration), origin_epoch_ns, dest_epoch_ns, iso_date_time, {}, temporal_date.calendar(), settings.largest_unit, settings.rounding_increment, settings.smallest_unit, settings.rounding_mode));
     }
 
     // 9. Let result be ! TemporalDurationFromInternal(duration, DAY).

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -369,11 +369,14 @@ ThrowCompletionOr<InternalDuration> difference_plain_date_time_with_rounding(VM&
     if (smallest_unit == Unit::Nanosecond && rounding_increment == 1)
         return diff;
 
-    // 5. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTime2).
+    // 5. Let originEpochNs be GetUTCEpochNanoseconds(isoDateTime1).
+    auto origin_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time1);
+
+    // 6. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTime2).
     auto dest_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time2);
 
-    // 6. Return ? RoundRelativeDuration(diff, destEpochNs, isoDateTime1, UNSET, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode).
-    return TRY(round_relative_duration(vm, diff, dest_epoch_ns, iso_date_time1, {}, calendar, largest_unit, rounding_increment, smallest_unit, rounding_mode));
+    // 7. Return ? RoundRelativeDuration(diff, originEpochNs, destEpochNs, isoDateTime1, UNSET, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode).
+    return TRY(round_relative_duration(vm, diff, origin_epoch_ns, dest_epoch_ns, iso_date_time1, {}, calendar, largest_unit, rounding_increment, smallest_unit, rounding_mode));
 }
 
 // 5.5.14 DifferencePlainDateTimeWithTotal ( isoDateTime1, isoDateTime2, calendar, unit ), https://tc39.es/proposal-temporal/#sec-temporal-differenceplaindatetimewithtotal
@@ -397,11 +400,14 @@ ThrowCompletionOr<Crypto::BigFraction> difference_plain_date_time_with_total(VM&
     if (unit == Unit::Nanosecond)
         return move(diff.time);
 
-    // 5. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTime2).
+    // 5. Let originEpochNs be GetUTCEpochNanoseconds(isoDateTime1).
+    auto origin_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time1);
+
+    // 6. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTime2).
     auto dest_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time2);
 
-    // 6. Return ? TotalRelativeDuration(diff, destEpochNs, isoDateTime1, UNSET, calendar, unit).
-    return TRY(total_relative_duration(vm, diff, dest_epoch_ns, iso_date_time1, {}, calendar, unit));
+    // 7. Return ? TotalRelativeDuration(diff, originEpochNs, destEpochNs, isoDateTime1, UNSET, calendar, unit).
+    return TRY(total_relative_duration(vm, diff, origin_epoch_ns, dest_epoch_ns, iso_date_time1, {}, calendar, unit));
 }
 
 // 5.5.15 DifferenceTemporalPlainDateTime ( operation, dateTime, other, options ), https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaindatetime

--- a/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -254,14 +254,17 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_year_month(VM& vm
         // a. Let isoDateTime be CombineISODateAndTimeRecord(thisDate, MidnightTimeRecord()).
         auto iso_date_time = combine_iso_date_and_time_record(this_date, midnight_time_record());
 
-        // b. Let isoDateTimeOther be CombineISODateAndTimeRecord(otherDate, MidnightTimeRecord()).
+        // b. Let originEpochNs be GetUTCEpochNanoseconds(isoDateTime).
+        auto origin_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time);
+
+        // c. Let isoDateTimeOther be CombineISODateAndTimeRecord(otherDate, MidnightTimeRecord()).
         auto iso_date_time_other = combine_iso_date_and_time_record(other_date, midnight_time_record());
 
-        // c. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTimeOther).
+        // d. Let destEpochNs be GetUTCEpochNanoseconds(isoDateTimeOther).
         auto dest_epoch_ns = get_utc_epoch_nanoseconds(iso_date_time_other);
 
-        // d. Set duration to ? RoundRelativeDuration(duration, destEpochNs, isoDateTime, UNSET, calendar, settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
-        duration = TRY(round_relative_duration(vm, move(duration), dest_epoch_ns, iso_date_time, {}, calendar, settings.largest_unit, settings.rounding_increment, settings.smallest_unit, settings.rounding_mode));
+        // e. Set duration to ? RoundRelativeDuration(duration, originEpochNs, destEpochNs, isoDateTime, UNSET, calendar, settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
+        duration = TRY(round_relative_duration(vm, move(duration), origin_epoch_ns, dest_epoch_ns, iso_date_time, {}, calendar, settings.largest_unit, settings.rounding_increment, settings.smallest_unit, settings.rounding_mode));
     }
 
     // 17. Let result be ! TemporalDurationFromInternal(duration, DAY).

--- a/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.round.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.round.js
@@ -112,6 +112,17 @@ describe("correct behavior", () => {
             expect(result.months).toBe(1);
         });
     });
+
+    test("relativeTo falls within second wallclock occurence of DST transition", () => {
+        const duration = Temporal.Duration.from({ minutes: -59 });
+
+        const result = duration.round({
+            smallestUnit: "days",
+            relativeTo: "2025-11-02T01:00:00-08:00[America/Vancouver]",
+        });
+
+        expect(result.toString()).toBe("PT0S");
+    });
 });
 
 describe("errors", () => {

--- a/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
@@ -57,6 +57,17 @@ describe("correct behavior", () => {
         });
         expect(result).toBe(366);
     });
+
+    test("relativeTo falls within second wallclock occurence of DST transition", () => {
+        const duration = Temporal.Duration.from({ minutes: -59 });
+
+        const result = duration.total({
+            unit: "days",
+            relativeTo: "2025-11-02T01:00:00-08:00[America/Vancouver]",
+        });
+
+        expect(result).toBeCloseTo(-59 / (60 * 25));
+    });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
This is a normative change in the Temporal proposal. See:
https://github.com/tc39/proposal-temporal/commit/1a089eb

test262 diff:
```
test/intl402/Temporal/Duration/prototype/round/relativeto-dst-back-transition.js   ❌ -> ✅
test/intl402/Temporal/Duration/prototype/total/relativeto-dst-back-transition.js   ❌ -> ✅
test/intl402/Temporal/ZonedDateTime/prototype/since/same-date-reverse-wallclock.js 💥️ -> ✅
test/intl402/Temporal/ZonedDateTime/prototype/until/same-date-reverse-wallclock.js 💥️ -> ✅
```