### PR TITLE
LibWeb/CSS: Introduce and use a PropertyNameAndID type

### DIFF
--- a/Libraries/LibWeb/CSS/CSS.cpp
+++ b/Libraries/LibWeb/CSS/CSS.cpp
@@ -26,7 +26,7 @@ WebIDL::ExceptionOr<String> escape(JS::VM&, StringView identifier)
 }
 
 // https://www.w3.org/TR/css-conditional-3/#dom-css-supports
-bool supports(JS::VM&, StringView property, StringView value)
+bool supports(JS::VM&, FlyString const& property, StringView value)
 {
     // 1. If property is an ASCII case-insensitive match for any defined CSS property that the UA supports,
     //    and value successfully parses according to that property’s grammar, return true.

--- a/Libraries/LibWeb/CSS/CSS.cpp
+++ b/Libraries/LibWeb/CSS/CSS.cpp
@@ -12,7 +12,7 @@
 #include <LibWeb/CSS/Parser/Syntax.h>
 #include <LibWeb/CSS/Parser/SyntaxParsing.h>
 #include <LibWeb/CSS/PropertyID.h>
-#include <LibWeb/CSS/PropertyName.h>
+#include <LibWeb/CSS/PropertyNameAndID.h>
 #include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/HTML/Window.h>
 
@@ -26,21 +26,16 @@ WebIDL::ExceptionOr<String> escape(JS::VM&, StringView identifier)
 }
 
 // https://www.w3.org/TR/css-conditional-3/#dom-css-supports
-bool supports(JS::VM&, FlyString const& property, StringView value)
+bool supports(JS::VM&, FlyString const& property_name, StringView value)
 {
-    // 1. If property is an ASCII case-insensitive match for any defined CSS property that the UA supports,
-    //    and value successfully parses according to that property’s grammar, return true.
-    if (auto property_id = property_id_from_string(property); property_id.has_value()) {
-        if (parse_css_value(Parser::ParsingParams {}, value, property_id.value()))
+    // 1. If property is an ASCII case-insensitive match for any defined CSS property that the UA supports, or is a
+    //    custom property name string, and value successfully parses according to that property’s grammar, return true.
+    if (auto property = PropertyNameAndID::from_name(property_name); property.has_value()) {
+        if (parse_css_value(Parser::ParsingParams {}, value, property->id()))
             return true;
     }
 
-    // 2. Otherwise, if property is a custom property name string, return true.
-    else if (is_a_custom_property_name_string(property)) {
-        return true;
-    }
-
-    // 3. Otherwise, return false.
+    // 2. Otherwise, return false.
     return false;
 }
 

--- a/Libraries/LibWeb/CSS/CSS.h
+++ b/Libraries/LibWeb/CSS/CSS.h
@@ -27,7 +27,7 @@ struct PropertyDefinition {
 
 WEB_API WebIDL::ExceptionOr<String> escape(JS::VM&, StringView identifier);
 
-WEB_API bool supports(JS::VM&, StringView property, StringView value);
+WEB_API bool supports(JS::VM&, FlyString const& property, StringView value);
 WEB_API WebIDL::ExceptionOr<bool> supports(JS::VM&, StringView condition_text);
 
 WEB_API WebIDL::ExceptionOr<void> register_property(JS::VM&, PropertyDefinition definition);

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -62,7 +62,7 @@ bool CSSDescriptors::set_a_css_declaration(DescriptorID descriptor_id, NonnullRe
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
-WebIDL::ExceptionOr<void> CSSDescriptors::set_property(StringView property, StringView value, StringView priority)
+WebIDL::ExceptionOr<void> CSSDescriptors::set_property(FlyString const& property, StringView value, StringView priority)
 {
     // 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
     if (is_readonly())
@@ -128,7 +128,7 @@ WebIDL::ExceptionOr<void> CSSDescriptors::set_property(StringView property, Stri
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
-WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(StringView property)
+WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(FlyString const& property)
 {
     // 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
     if (is_readonly())
@@ -169,7 +169,7 @@ WebIDL::ExceptionOr<String> CSSDescriptors::remove_property(StringView property)
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue
-String CSSDescriptors::get_property_value(StringView property) const
+String CSSDescriptors::get_property_value(FlyString const& property) const
 {
     // 1. If property is not a custom property, follow these substeps: ...
     // NB: These substeps only apply to shorthands, and descriptors cannot be shorthands.
@@ -188,7 +188,7 @@ String CSSDescriptors::get_property_value(StringView property) const
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
-StringView CSSDescriptors::get_property_priority(StringView) const
+StringView CSSDescriptors::get_property_priority(FlyString const&) const
 {
     // AD-HOC: It's not valid for descriptors to be !important.
     return {};
@@ -281,7 +281,7 @@ RefPtr<StyleValue const> CSSDescriptors::descriptor_or_initial_value(DescriptorI
     return descriptor_initial_value(m_at_rule_id, descriptor_id);
 }
 
-bool CSSDescriptors::has_property(StringView property_name) const
+bool CSSDescriptors::has_property(FlyString const& property_name) const
 {
     auto descriptor_id = descriptor_id_from_string(m_at_rule_id, property_name);
     if (!descriptor_id.has_value())
@@ -289,7 +289,7 @@ bool CSSDescriptors::has_property(StringView property_name) const
     return descriptor(*descriptor_id) != nullptr;
 }
 
-RefPtr<StyleValue const> CSSDescriptors::get_property_style_value(StringView property_name) const
+RefPtr<StyleValue const> CSSDescriptors::get_property_style_value(FlyString const& property_name) const
 {
     auto descriptor_id = descriptor_id_from_string(m_at_rule_id, property_name);
     if (!descriptor_id.has_value())

--- a/Libraries/LibWeb/CSS/CSSDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.cpp
@@ -281,22 +281,6 @@ RefPtr<StyleValue const> CSSDescriptors::descriptor_or_initial_value(DescriptorI
     return descriptor_initial_value(m_at_rule_id, descriptor_id);
 }
 
-bool CSSDescriptors::has_property(FlyString const& property_name) const
-{
-    auto descriptor_id = descriptor_id_from_string(m_at_rule_id, property_name);
-    if (!descriptor_id.has_value())
-        return false;
-    return descriptor(*descriptor_id) != nullptr;
-}
-
-RefPtr<StyleValue const> CSSDescriptors::get_property_style_value(FlyString const& property_name) const
-{
-    auto descriptor_id = descriptor_id_from_string(m_at_rule_id, property_name);
-    if (!descriptor_id.has_value())
-        return nullptr;
-    return descriptor(*descriptor_id);
-}
-
 bool is_shorthand(AtRuleID at_rule, DescriptorID descriptor)
 {
     if (at_rule == AtRuleID::Page && descriptor == DescriptorID::Margin)

--- a/Libraries/LibWeb/CSS/CSSDescriptors.h
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.h
@@ -21,10 +21,10 @@ public:
 
     virtual size_t length() const override;
     virtual String item(size_t index) const override;
-    virtual WebIDL::ExceptionOr<void> set_property(StringView property, StringView value, StringView priority) override;
-    virtual WebIDL::ExceptionOr<String> remove_property(StringView property) override;
-    virtual String get_property_value(StringView property) const override;
-    virtual StringView get_property_priority(StringView property) const override;
+    virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property, StringView value, StringView priority) override;
+    virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property) override;
+    virtual String get_property_value(FlyString const& property) const override;
+    virtual StringView get_property_priority(FlyString const& property) const override;
 
     Vector<Descriptor> const& descriptors() const { return m_descriptors; }
     RefPtr<StyleValue const> descriptor(DescriptorID) const;
@@ -33,8 +33,8 @@ public:
 
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;
 
-    virtual bool has_property(StringView property_name) const override;
-    virtual RefPtr<StyleValue const> get_property_style_value(StringView property_name) const override;
+    virtual bool has_property(FlyString const& property_name) const override;
+    virtual RefPtr<StyleValue const> get_property_style_value(FlyString const& property_name) const override;
 
 protected:
     CSSDescriptors(JS::Realm&, AtRuleID, Vector<Descriptor>);

--- a/Libraries/LibWeb/CSS/CSSDescriptors.h
+++ b/Libraries/LibWeb/CSS/CSSDescriptors.h
@@ -33,9 +33,6 @@ public:
 
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;
 
-    virtual bool has_property(FlyString const& property_name) const override;
-    virtual RefPtr<StyleValue const> get_property_style_value(FlyString const& property_name) const override;
-
 protected:
     CSSDescriptors(JS::Realm&, AtRuleID, Vector<Descriptor>);
 

--- a/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceDescriptors.cpp
@@ -33,142 +33,142 @@ void CSSFontFaceDescriptors::initialize(JS::Realm& realm)
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_ascent_override(StringView value)
 {
-    return set_property("ascent-override"sv, value, ""sv);
+    return set_property("ascent-override"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::ascent_override() const
 {
-    return get_property_value("ascent-override"sv);
+    return get_property_value("ascent-override"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_descent_override(StringView value)
 {
-    return set_property("descent-override"sv, value, ""sv);
+    return set_property("descent-override"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::descent_override() const
 {
-    return get_property_value("descent-override"sv);
+    return get_property_value("descent-override"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_display(StringView value)
 {
-    return set_property("font-display"sv, value, ""sv);
+    return set_property("font-display"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_display() const
 {
-    return get_property_value("font-display"sv);
+    return get_property_value("font-display"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_family(StringView value)
 {
-    return set_property("font-family"sv, value, ""sv);
+    return set_property("font-family"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_family() const
 {
-    return get_property_value("font-family"sv);
+    return get_property_value("font-family"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_feature_settings(StringView value)
 {
-    return set_property("font-feature-settings"sv, value, ""sv);
+    return set_property("font-feature-settings"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_feature_settings() const
 {
-    return get_property_value("font-feature-settings"sv);
+    return get_property_value("font-feature-settings"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_language_override(StringView value)
 {
-    return set_property("font-language-override"sv, value, ""sv);
+    return set_property("font-language-override"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_language_override() const
 {
-    return get_property_value("font-language-override"sv);
+    return get_property_value("font-language-override"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_named_instance(StringView value)
 {
-    return set_property("font-named-instance"sv, value, ""sv);
+    return set_property("font-named-instance"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_named_instance() const
 {
-    return get_property_value("font-named-instance"sv);
+    return get_property_value("font-named-instance"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_style(StringView value)
 {
-    return set_property("font-style"sv, value, ""sv);
+    return set_property("font-style"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_style() const
 {
-    return get_property_value("font-style"sv);
+    return get_property_value("font-style"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_variation_settings(StringView value)
 {
-    return set_property("font-variation-settings"sv, value, ""sv);
+    return set_property("font-variation-settings"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_variation_settings() const
 {
-    return get_property_value("font-variation-settings"sv);
+    return get_property_value("font-variation-settings"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_weight(StringView value)
 {
-    return set_property("font-weight"sv, value, ""sv);
+    return set_property("font-weight"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_weight() const
 {
-    return get_property_value("font-weight"sv);
+    return get_property_value("font-weight"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_font_width(StringView value)
 {
-    return set_property("font-width"sv, value, ""sv);
+    return set_property("font-width"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::font_width() const
 {
-    return get_property_value("font-width"sv);
+    return get_property_value("font-width"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_line_gap_override(StringView value)
 {
-    return set_property("line-gap-override"sv, value, ""sv);
+    return set_property("line-gap-override"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::line_gap_override() const
 {
-    return get_property_value("line-gap-override"sv);
+    return get_property_value("line-gap-override"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_src(StringView value)
 {
-    return set_property("src"sv, value, ""sv);
+    return set_property("src"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::src() const
 {
-    return get_property_value("src"sv);
+    return get_property_value("src"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSFontFaceDescriptors::set_unicode_range(StringView value)
 {
-    return set_property("unicode-range"sv, value, ""sv);
+    return set_property("unicode-range"_fly_string, value, ""sv);
 }
 
 String CSSFontFaceDescriptors::unicode_range() const
 {
-    return get_property_value("unicode-range"sv);
+    return get_property_value("unicode-range"_fly_string);
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
+++ b/Libraries/LibWeb/CSS/CSSPageDescriptors.cpp
@@ -33,92 +33,92 @@ void CSSPageDescriptors::initialize(JS::Realm& realm)
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin(StringView value)
 {
-    return set_property("margin"sv, value, ""sv);
+    return set_property("margin"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin() const
 {
-    return get_property_value("margin"sv);
+    return get_property_value("margin"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_top(StringView value)
 {
-    return set_property("margin-top"sv, value, ""sv);
+    return set_property("margin-top"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_top() const
 {
-    return get_property_value("margin-top"sv);
+    return get_property_value("margin-top"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_right(StringView value)
 {
-    return set_property("margin-right"sv, value, ""sv);
+    return set_property("margin-right"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_right() const
 {
-    return get_property_value("margin-right"sv);
+    return get_property_value("margin-right"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_bottom(StringView value)
 {
-    return set_property("margin-bottom"sv, value, ""sv);
+    return set_property("margin-bottom"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_bottom() const
 {
-    return get_property_value("margin-bottom"sv);
+    return get_property_value("margin-bottom"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_margin_left(StringView value)
 {
-    return set_property("margin-left"sv, value, ""sv);
+    return set_property("margin-left"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::margin_left() const
 {
-    return get_property_value("margin-left"sv);
+    return get_property_value("margin-left"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_size(StringView value)
 {
-    return set_property("size"sv, value, ""sv);
+    return set_property("size"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::size() const
 {
-    return get_property_value("size"sv);
+    return get_property_value("size"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_page_orientation(StringView value)
 {
-    return set_property("page-orientation"sv, value, ""sv);
+    return set_property("page-orientation"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::page_orientation() const
 {
-    return get_property_value("page-orientation"sv);
+    return get_property_value("page-orientation"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_marks(StringView value)
 {
-    return set_property("marks"sv, value, ""sv);
+    return set_property("marks"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::marks() const
 {
-    return get_property_value("marks"sv);
+    return get_property_value("marks"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSPageDescriptors::set_bleed(StringView value)
 {
-    return set_property("bleed"sv, value, ""sv);
+    return set_property("bleed"_fly_string, value, ""sv);
 }
 
 String CSSPageDescriptors::bleed() const
 {
-    return get_property_value("bleed"sv);
+    return get_property_value("bleed"_fly_string);
 }
 
 }

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -28,11 +28,11 @@ public:
     virtual size_t length() const = 0;
     virtual String item(size_t index) const = 0;
 
-    virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority) = 0;
-    virtual WebIDL::ExceptionOr<String> remove_property(StringView property_name) = 0;
+    virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property_name, StringView css_text, StringView priority) = 0;
+    virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property_name) = 0;
 
-    virtual String get_property_value(StringView property_name) const = 0;
-    virtual StringView get_property_priority(StringView property_name) const = 0;
+    virtual String get_property_value(FlyString const& property_name) const = 0;
+    virtual StringView get_property_priority(FlyString const& property_name) const = 0;
 
     String css_text() const;
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) = 0;
@@ -57,8 +57,8 @@ public:
     [[nodiscard]] bool is_updating() const { return m_updating; }
     void set_is_updating(bool value) { m_updating = value; }
 
-    virtual bool has_property(StringView property_name) const = 0;
-    virtual RefPtr<StyleValue const> get_property_style_value(StringView property_name) const = 0;
+    virtual bool has_property(FlyString const& property_name) const = 0;
+    virtual RefPtr<StyleValue const> get_property_style_value(FlyString const& property_name) const = 0;
 
 protected:
     enum class Computed : u8 {

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -57,8 +57,8 @@ public:
     [[nodiscard]] bool is_updating() const { return m_updating; }
     void set_is_updating(bool value) { m_updating = value; }
 
-    virtual bool has_property(FlyString const& property_name) const = 0;
-    virtual RefPtr<StyleValue const> get_property_style_value(FlyString const& property_name) const = 0;
+    virtual bool has_property(PropertyNameAndID const&) const { VERIFY_NOT_REACHED(); }
+    virtual RefPtr<StyleValue const> get_property_style_value(PropertyNameAndID const&) const { VERIFY_NOT_REACHED(); }
 
 protected:
     enum class Computed : u8 {

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -385,11 +385,21 @@ bool CSSStyleProperties::has_property(PropertyNameAndID const& property) const
     return get_property_internal(property).has_value();
 }
 
+bool CSSStyleProperties::has_property(PropertyID property_id) const
+{
+    return has_property(PropertyNameAndID::from_id(property_id));
+}
+
 RefPtr<StyleValue const> CSSStyleProperties::get_property_style_value(PropertyNameAndID const& property) const
 {
     if (auto style_property = get_property_internal(property); style_property.has_value())
         return style_property->value;
     return nullptr;
+}
+
+RefPtr<StyleValue const> CSSStyleProperties::get_property_style_value(PropertyID property_id) const
+{
+    return get_property_style_value(PropertyNameAndID::from_id(property_id));
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -380,20 +380,14 @@ StringView CSSStyleProperties::get_property_priority(FlyString const& property_n
     return maybe_property->important == Important::Yes ? "important"sv : ""sv;
 }
 
-bool CSSStyleProperties::has_property(FlyString const& property_name) const
+bool CSSStyleProperties::has_property(PropertyNameAndID const& property) const
 {
-    auto property = PropertyNameAndID::from_name(property_name);
-    if (!property.has_value())
-        return false;
-    return get_property_internal(*property).has_value();
+    return get_property_internal(property).has_value();
 }
 
-RefPtr<StyleValue const> CSSStyleProperties::get_property_style_value(FlyString const& property_name) const
+RefPtr<StyleValue const> CSSStyleProperties::get_property_style_value(PropertyNameAndID const& property) const
 {
-    auto property = PropertyNameAndID::from_name(property_name);
-    if (!property.has_value())
-        return nullptr;
-    if (auto style_property = get_property_internal(*property); style_property.has_value())
+    if (auto style_property = get_property_internal(property); style_property.has_value())
         return style_property->value;
     return nullptr;
 }

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -156,7 +156,7 @@ String CSSStyleProperties::item(size_t index) const
     return CSS::string_from_property_id(m_properties[index - custom_properties_count].property_id).to_string();
 }
 
-Optional<StyleProperty> CSSStyleProperties::property(PropertyID property_id) const
+Optional<StyleProperty> CSSStyleProperties::get_property(PropertyID property_id) const
 {
     if (is_computed()) {
         if (!owner_node().has_value())
@@ -430,7 +430,7 @@ StringView CSSStyleProperties::get_property_priority(FlyString const& property_n
             return {};
         return maybe_custom_property.value().important == Important::Yes ? "important"sv : ""sv;
     }
-    auto maybe_property = property(property_id.value());
+    auto maybe_property = get_property(property_id.value());
     if (!maybe_property.has_value())
         return {};
     return maybe_property->important == Important::Yes ? "important"sv : ""sv;
@@ -494,7 +494,7 @@ Optional<StyleProperty> CSSStyleProperties::get_property_internal(PropertyID pro
         // NOTE: This is handled by the loop.
     }
 
-    return property(property_id);
+    return get_property(property_id);
 }
 
 static RefPtr<StyleValue const> resolve_color_style_value(StyleValue const& style_value, Color computed_color)

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -232,7 +232,7 @@ Optional<StyleProperty const&> CSSStyleProperties::custom_property(FlyString con
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
-WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(StringView property_name, StringView value, StringView priority)
+WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(FlyString const& property_name, StringView value, StringView priority)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
     if (is_computed())
@@ -283,14 +283,13 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property(StringView property_n
     // 9. Otherwise,
     else {
         if (property_id == PropertyID::Custom) {
-            auto custom_name = FlyString::from_utf8_without_validation(property_name.bytes());
             StyleProperty style_property {
                 .important = !priority.is_empty() ? Important::Yes : Important::No,
                 .property_id = property_id,
                 .value = component_value_list.release_nonnull(),
-                .custom_name = custom_name,
+                .custom_name = property_name,
             };
-            m_custom_properties.set(custom_name, style_property);
+            m_custom_properties.set(property_name, style_property);
             updated = true;
         } else {
             // let updated be the result of set the CSS declaration property with value component value list,
@@ -388,15 +387,14 @@ static RefPtr<StyleValue const> style_value_for_shadow(ShadowStyleValue::ShadowT
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue
-String CSSStyleProperties::get_property_value(StringView property_name) const
+String CSSStyleProperties::get_property_value(FlyString const& property_name) const
 {
     auto property_id = property_id_from_string(property_name);
     if (!property_id.has_value())
         return {};
 
     if (property_id.value() == PropertyID::Custom) {
-        auto maybe_custom_property = custom_property(FlyString::from_utf8_without_validation(property_name.bytes()));
-        if (maybe_custom_property.has_value()) {
+        if (auto maybe_custom_property = custom_property(property_name); maybe_custom_property.has_value()) {
             return maybe_custom_property.value().value->to_string(
                 is_computed() ? SerializationMode::ResolvedValue
                               : SerializationMode::Normal);
@@ -413,13 +411,13 @@ String CSSStyleProperties::get_property_value(StringView property_name) const
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
-StringView CSSStyleProperties::get_property_priority(StringView property_name) const
+StringView CSSStyleProperties::get_property_priority(FlyString const& property_name) const
 {
     auto property_id = property_id_from_string(property_name);
     if (!property_id.has_value())
         return {};
     if (property_id.value() == PropertyID::Custom) {
-        auto maybe_custom_property = custom_property(FlyString::from_utf8_without_validation(property_name.bytes()));
+        auto maybe_custom_property = custom_property(property_name);
         if (!maybe_custom_property.has_value())
             return {};
         return maybe_custom_property.value().important == Important::Yes ? "important"sv : ""sv;
@@ -430,7 +428,7 @@ StringView CSSStyleProperties::get_property_priority(StringView property_name) c
     return maybe_property->important == Important::Yes ? "important"sv : ""sv;
 }
 
-bool CSSStyleProperties::has_property(StringView property_name) const
+bool CSSStyleProperties::has_property(FlyString const& property_name) const
 {
     auto property_id = property_id_from_string(property_name);
     if (!property_id.has_value())
@@ -438,7 +436,7 @@ bool CSSStyleProperties::has_property(StringView property_name) const
     return get_property_internal(*property_id).has_value();
 }
 
-RefPtr<StyleValue const> CSSStyleProperties::get_property_style_value(StringView property_name) const
+RefPtr<StyleValue const> CSSStyleProperties::get_property_style_value(FlyString const& property_name) const
 {
     auto property_id = property_id_from_string(property_name);
     if (!property_id.has_value())
@@ -862,7 +860,7 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
-WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(StringView property_name)
+WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(FlyString const& property_name)
 {
     // 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
     if (is_readonly())
@@ -892,8 +890,7 @@ WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(StringView prope
         } else {
             // 6. Otherwise, if property is a case-sensitive match for a property name of a CSS declaration in the declarations, remove that CSS declaration and let removed be true.
             if (property_id == PropertyID::Custom) {
-                auto custom_name = FlyString::from_utf8_without_validation(property_name.bytes());
-                removed = m_custom_properties.remove(custom_name);
+                removed = m_custom_properties.remove(property_name);
             } else {
                 removed = m_properties.remove_first_matching([&](auto& entry) { return entry.property_id == property_id; });
             }
@@ -925,14 +922,14 @@ WebIDL::ExceptionOr<String> CSSStyleProperties::remove_property(PropertyID prope
 String CSSStyleProperties::css_float() const
 {
     // The cssFloat attribute, on getting, must return the result of invoking getPropertyValue() with float as argument.
-    return get_property_value("float"sv);
+    return get_property_value("float"_fly_string);
 }
 
 WebIDL::ExceptionOr<void> CSSStyleProperties::set_css_float(StringView value)
 {
     // On setting, the attribute must invoke setProperty() with float as first argument, as second argument the given value,
     // and no third argument. Any exceptions thrown must be re-thrown.
-    return set_property("float"sv, value, ""sv);
+    return set_property("float"_fly_string, value, ""sv);
 }
 
 // https://www.w3.org/TR/cssom/#serialize-a-css-declaration-block

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -50,8 +50,8 @@ public:
 
     size_t custom_property_count() const { return m_custom_properties.size(); }
 
-    virtual bool has_property(FlyString const& property_name) const override;
-    virtual RefPtr<StyleValue const> get_property_style_value(FlyString const& property_name) const override;
+    virtual bool has_property(PropertyNameAndID const&) const override;
+    virtual RefPtr<StyleValue const> get_property_style_value(PropertyNameAndID const&) const override;
 
     String css_float() const;
     WebIDL::ExceptionOr<void> set_css_float(StringView);

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -75,6 +75,9 @@ private:
     RefPtr<StyleValue const> style_value_for_computed_property(Layout::NodeWithStyle const&, PropertyID) const;
     Optional<StyleProperty> get_property_internal(PropertyID) const;
 
+    WebIDL::ExceptionOr<void> set_property_internal(PropertyNameAndID const&, StringView css_text, StringView priority);
+    WebIDL::ExceptionOr<String> remove_property_internal(Optional<PropertyNameAndID> const&);
+
     bool set_a_css_declaration(PropertyID, NonnullRefPtr<StyleValue const>, Important);
     void empty_the_declarations();
     void set_the_declarations(Vector<StyleProperty> properties, OrderedHashMap<FlyString, StyleProperty> custom_properties);

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -33,7 +33,7 @@ public:
     virtual size_t length() const override;
     virtual String item(size_t index) const override;
 
-    Optional<StyleProperty> property(PropertyID) const;
+    Optional<StyleProperty> get_property(PropertyID) const;
     Optional<StyleProperty const&> custom_property(FlyString const& custom_property_name) const;
 
     WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv);

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -73,8 +73,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     RefPtr<StyleValue const> style_value_for_computed_property(Layout::NodeWithStyle const&, PropertyID) const;
-    Optional<StyleProperty> get_property_internal(PropertyID) const;
-
+    Optional<StyleProperty> get_property_internal(PropertyNameAndID const&) const;
     WebIDL::ExceptionOr<void> set_property_internal(PropertyNameAndID const&, StringView css_text, StringView priority);
     WebIDL::ExceptionOr<String> remove_property_internal(Optional<PropertyNameAndID> const&);
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -39,19 +39,19 @@ public:
     WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv);
     WebIDL::ExceptionOr<String> remove_property(PropertyID);
 
-    virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority) override;
-    virtual WebIDL::ExceptionOr<String> remove_property(StringView property_name) override;
+    virtual WebIDL::ExceptionOr<void> set_property(FlyString const& property_name, StringView css_text, StringView priority) override;
+    virtual WebIDL::ExceptionOr<String> remove_property(FlyString const& property_name) override;
 
-    virtual String get_property_value(StringView property_name) const override;
-    virtual StringView get_property_priority(StringView property_name) const override;
+    virtual String get_property_value(FlyString const& property_name) const override;
+    virtual StringView get_property_priority(FlyString const& property_name) const override;
 
     Vector<StyleProperty> const& properties() const { return m_properties; }
     OrderedHashMap<FlyString, StyleProperty> const& custom_properties() const { return m_custom_properties; }
 
     size_t custom_property_count() const { return m_custom_properties.size(); }
 
-    virtual bool has_property(StringView property_name) const override;
-    virtual RefPtr<StyleValue const> get_property_style_value(StringView property_name) const override;
+    virtual bool has_property(FlyString const& property_name) const override;
+    virtual RefPtr<StyleValue const> get_property_style_value(FlyString const& property_name) const override;
 
     String css_float() const;
     WebIDL::ExceptionOr<void> set_css_float(StringView);

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -74,6 +74,7 @@ private:
 
     RefPtr<StyleValue const> style_value_for_computed_property(Layout::NodeWithStyle const&, PropertyID) const;
     Optional<StyleProperty> get_property_internal(PropertyNameAndID const&) const;
+    Optional<StyleProperty> get_direct_property(PropertyNameAndID const&) const;
     WebIDL::ExceptionOr<void> set_property_internal(PropertyNameAndID const&, StringView css_text, StringView priority);
     WebIDL::ExceptionOr<String> remove_property_internal(Optional<PropertyNameAndID> const&);
 

--- a/Libraries/LibWeb/CSS/CSSStyleProperties.h
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.h
@@ -51,7 +51,10 @@ public:
     size_t custom_property_count() const { return m_custom_properties.size(); }
 
     virtual bool has_property(PropertyNameAndID const&) const override;
+    bool has_property(PropertyID) const;
+
     virtual RefPtr<StyleValue const> get_property_style_value(PropertyNameAndID const&) const override;
+    RefPtr<StyleValue const> get_property_style_value(PropertyID) const;
 
     String css_float() const;
     WebIDL::ExceptionOr<void> set_css_float(StringView);

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -15,7 +15,7 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(CSSStyleValue);
 
-GC::Ref<CSSStyleValue> CSSStyleValue::create(JS::Realm& realm, String associated_property, String constructed_from_string)
+GC::Ref<CSSStyleValue> CSSStyleValue::create(JS::Realm& realm, FlyString associated_property, String constructed_from_string)
 {
     return realm.create<CSSStyleValue>(realm, move(associated_property), move(constructed_from_string));
 }
@@ -25,7 +25,7 @@ CSSStyleValue::CSSStyleValue(JS::Realm& realm)
 {
 }
 
-CSSStyleValue::CSSStyleValue(JS::Realm& realm, String associated_property, String constructed_from_string)
+CSSStyleValue::CSSStyleValue(JS::Realm& realm, FlyString associated_property, String constructed_from_string)
     : PlatformObject(realm)
     , m_associated_property(move(associated_property))
     , m_constructed_from_string(move(constructed_from_string))
@@ -39,7 +39,7 @@ void CSSStyleValue::initialize(JS::Realm& realm)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-parse
-WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> CSSStyleValue::parse(JS::VM& vm, String property, String css_text)
+WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> CSSStyleValue::parse(JS::VM& vm, FlyString const& property, String css_text)
 {
     // The parse(property, cssText) method, when invoked, must parse a CSSStyleValue with property property, cssText
     // cssText, and parseMultiple set to false, and return the result.
@@ -50,7 +50,7 @@ WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> CSSStyleValue::parse(JS::VM& vm, Str
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-parseall
-WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> CSSStyleValue::parse_all(JS::VM& vm, String property, String css_text)
+WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> CSSStyleValue::parse_all(JS::VM& vm, FlyString const& property, String css_text)
 {
     // The parseAll(property, cssText) method, when invoked, must parse a CSSStyleValue with property property, cssText
     // cssText, and parseMultiple set to true, and return the result.
@@ -61,7 +61,7 @@ WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> CSSStyleValue::parse
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#parse-a-cssstylevalue
-WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> CSSStyleValue::parse_a_css_style_value(JS::VM& vm, String property, String css_text, ParseMultiple parse_multiple)
+WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> CSSStyleValue::parse_a_css_style_value(JS::VM& vm, FlyString property, String css_text, ParseMultiple parse_multiple)
 {
     // 1. If property is not a custom property name string, set property to property ASCII lowercased.
     if (!is_a_custom_property_name_string(property))

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 
 namespace Web::CSS {
@@ -16,14 +17,14 @@ class CSSStyleValue : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(CSSStyleValue);
 
 public:
-    [[nodiscard]] static GC::Ref<CSSStyleValue> create(JS::Realm&, String associated_property, String constructed_from_string);
+    [[nodiscard]] static GC::Ref<CSSStyleValue> create(JS::Realm&, FlyString associated_property, String constructed_from_string);
 
     virtual ~CSSStyleValue() override = default;
 
     virtual void initialize(JS::Realm&) override;
 
-    static WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> parse(JS::VM&, String property, String css_text);
-    static WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> parse_all(JS::VM&, String property, String css_text);
+    static WebIDL::ExceptionOr<GC::Ref<CSSStyleValue>> parse(JS::VM&, FlyString const& property, String css_text);
+    static WebIDL::ExceptionOr<GC::RootVector<GC::Ref<CSSStyleValue>>> parse_all(JS::VM&, FlyString const& property, String css_text);
 
     virtual WebIDL::ExceptionOr<String> to_string() const;
 
@@ -31,16 +32,16 @@ protected:
     explicit CSSStyleValue(JS::Realm&);
 
 private:
-    explicit CSSStyleValue(JS::Realm&, String associated_property, String constructed_from_string);
+    explicit CSSStyleValue(JS::Realm&, FlyString associated_property, String constructed_from_string);
 
     enum class ParseMultiple : u8 {
         No,
         Yes,
     };
-    static WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> parse_a_css_style_value(JS::VM&, String property, String css_text, ParseMultiple);
+    static WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, GC::RootVector<GC::Ref<CSSStyleValue>>>> parse_a_css_style_value(JS::VM&, FlyString property, String css_text, ParseMultiple);
 
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-associatedproperty-slot
-    Optional<String> m_associated_property;
+    Optional<FlyString> m_associated_property;
 
     Optional<String> m_constructed_from_string;
 };

--- a/Libraries/LibWeb/CSS/CascadedProperties.cpp
+++ b/Libraries/LibWeb/CSS/CascadedProperties.cpp
@@ -7,8 +7,8 @@
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/PropertyNameAndID.h>
 #include <LibWeb/CSS/StyleComputer.h>
-#include <LibWeb/CSS/StyleValues/ShorthandStyleValue.h>
 #include <LibWeb/DOM/Element.h>
 
 namespace Web::CSS {
@@ -65,7 +65,7 @@ void CascadedProperties::resolve_unresolved_properties(DOM::AbstractElement abst
         for (auto& entry : entries) {
             if (!entry.property.value->is_unresolved())
                 continue;
-            entry.property.value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, property_id, entry.property.value->as_unresolved());
+            entry.property.value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, PropertyNameAndID::from_id(property_id), entry.property.value->as_unresolved());
         }
     }
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -135,7 +135,7 @@ public:
 
     Vector<ComponentValue> parse_as_list_of_component_values();
 
-    static NonnullRefPtr<StyleValue const> resolve_unresolved_style_value(ParsingParams const&, DOM::AbstractElement, PropertyIDOrCustomPropertyName, UnresolvedStyleValue const&, Optional<GuardedSubstitutionContexts&> = {});
+    static NonnullRefPtr<StyleValue const> resolve_unresolved_style_value(ParsingParams const&, DOM::AbstractElement, PropertyNameAndID const&, UnresolvedStyleValue const&, Optional<GuardedSubstitutionContexts&> = {});
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute(DOM::Element const& element, HTML::HTMLImageElement const* img = nullptr);
 
@@ -523,7 +523,7 @@ private:
 
     OwnPtr<BooleanExpression> parse_supports_feature(TokenStream<ComponentValue>&);
 
-    NonnullRefPtr<StyleValue const> resolve_unresolved_style_value(DOM::AbstractElement, GuardedSubstitutionContexts&, PropertyIDOrCustomPropertyName, UnresolvedStyleValue const&);
+    NonnullRefPtr<StyleValue const> resolve_unresolved_style_value(DOM::AbstractElement, GuardedSubstitutionContexts&, PropertyNameAndID const&, UnresolvedStyleValue const&);
 
     RefPtr<StyleValue const> parse_according_to_syntax_node(TokenStream<ComponentValue>& tokens, SyntaxNode const& syntax_node, Optional<DOM::AbstractElement> const& element);
 

--- a/Libraries/LibWeb/CSS/PropertyNameAndID.h
+++ b/Libraries/LibWeb/CSS/PropertyNameAndID.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <AK/GenericShorthands.h>
+#include <AK/Optional.h>
+#include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/PropertyName.h>
+#include <LibWeb/CSS/Serialize.h>
+
+namespace Web::CSS {
+
+class WEB_API PropertyNameAndID {
+public:
+    static Optional<PropertyNameAndID> from_name(FlyString name)
+    {
+        if (is_a_custom_property_name_string(name))
+            return PropertyNameAndID(move(name), PropertyID::Custom);
+
+        if (auto property_id = property_id_from_string(name); property_id.has_value())
+            return PropertyNameAndID(string_from_property_id(property_id.value()), property_id.value());
+
+        return {};
+    }
+
+    static PropertyNameAndID from_id(PropertyID property_id)
+    {
+        VERIFY(!first_is_one_of(property_id, PropertyID::Invalid, PropertyID::Custom));
+        return PropertyNameAndID({}, property_id);
+    }
+
+    bool is_custom_property() const { return m_property_id == PropertyID::Custom; }
+    PropertyID id() const { return m_property_id; }
+
+    FlyString const& name() const
+    {
+        if (!m_name.has_value())
+            m_name = string_from_property_id(m_property_id);
+        return m_name.value();
+    }
+
+    String to_string() const
+    {
+        return serialize_an_identifier(name());
+    }
+
+private:
+    PropertyNameAndID(Optional<FlyString> name, PropertyID id)
+        : m_name(move(name))
+        , m_property_id(id)
+    {
+    }
+
+    mutable Optional<FlyString> m_name;
+    PropertyID m_property_id;
+};
+
+}

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -42,6 +42,7 @@
 #include <LibWeb/CSS/InvalidationSet.h>
 #include <LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/PropertyNameAndID.h>
 #include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleSheet.h>
@@ -790,7 +791,7 @@ void StyleComputer::cascade_declarations(
             auto property_value = property.value;
 
             if (property_value->is_unresolved())
-                property_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, property.property_id, property_value->as_unresolved());
+                property_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, PropertyNameAndID::from_id(property.property_id), property_value->as_unresolved());
 
             if (property_value->is_guaranteed_invalid()) {
                 // https://drafts.csswg.org/css-values-5/#invalid-at-computed-value-time
@@ -1015,7 +1016,7 @@ void StyleComputer::collect_animation_into(DOM::AbstractElement abstract_element
                 continue;
 
             if (style_value->is_unresolved())
-                style_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, property_id, style_value->as_unresolved());
+                style_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, PropertyNameAndID::from_id(property_id), style_value->as_unresolved());
 
             for_each_property_expanding_shorthands(property_id, *style_value, [&](PropertyID longhand_id, StyleValue const& longhand_value) {
                 auto physical_longhand_id = map_logical_alias_to_physical_property(longhand_id, LogicalAliasMappingContext { computed_properties.writing_mode(), computed_properties.direction() });
@@ -3122,7 +3123,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_custom_property(
         return value.release_nonnull();
 
     auto& unresolved = value->as_unresolved();
-    return Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams {}, abstract_element, name, unresolved, guarded_contexts);
+    return Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams {}, abstract_element, PropertyNameAndID::from_name(name).release_value(), unresolved, guarded_contexts);
 }
 
 void StyleComputer::compute_custom_properties(ComputedProperties&, DOM::AbstractElement abstract_element) const

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.h
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.h
@@ -35,7 +35,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    static RefPtr<StyleValue const> get_style_value(Source&, String property);
+    static RefPtr<StyleValue const> get_style_value(Source&, PropertyNameAndID const& property);
 
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-declarations-slot
     // A StylePropertyMapReadOnly object has a [[declarations]] internal slot, which is a map reflecting the CSS

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
@@ -10,7 +10,7 @@
 namespace Web::CSS {
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-stylevalue
-GC::Ref<CSSStyleValue> AbstractImageStyleValue::reify(JS::Realm& realm, String const&) const
+GC::Ref<CSSStyleValue> AbstractImageStyleValue::reify(JS::Realm& realm, FlyString const&) const
 {
     // AD-HOC: There's no spec description of how to reify as a CSSImageValue.
     return CSSImageValue::create(realm, to_string(SerializationMode::Normal));

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -41,7 +41,7 @@ public:
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap() const { return {}; }
 
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 };
 
 // And now, some gradient related things. Maybe these should live somewhere else.

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -2772,7 +2772,7 @@ String CalculatedStyleValue::dump() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-math-expression
-GC::Ref<CSSStyleValue> CalculatedStyleValue::reify(JS::Realm& realm, String const& associated_property) const
+GC::Ref<CSSStyleValue> CalculatedStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
 {
     // NB: This spec algorithm isn't really implementable here - it's incomplete, and assumes we don't already have a
     //     calculation tree. So we have a per-node method instead.

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -110,7 +110,7 @@ public:
 
     String dump() const;
 
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
 private:
     explicit CalculatedStyleValue(NonnullRefPtr<CalculationNode const> calculation, NumericType resolved_type, CalculationContext context)

--- a/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.cpp
@@ -16,7 +16,7 @@ Vector<Parser::ComponentValue> CustomIdentStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-ident
-GC::Ref<CSSStyleValue> CustomIdentStyleValue::reify(JS::Realm& realm, String const&) const
+GC::Ref<CSSStyleValue> CustomIdentStyleValue::reify(JS::Realm& realm, FlyString const&) const
 {
     // 1. Return a new CSSKeywordValue with its value internal slot set to the serialization of ident.
     return CSSKeywordValue::create(realm, m_custom_ident);

--- a/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
@@ -25,7 +25,7 @@ public:
 
     virtual String to_string(SerializationMode) const override { return serialize_an_identifier(m_custom_ident.to_string()); }
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm& realm, String const&) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm& realm, FlyString const&) const override;
 
     bool properties_equal(CustomIdentStyleValue const& other) const { return m_custom_ident == other.m_custom_ident; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.cpp
@@ -15,7 +15,7 @@ Vector<Parser::ComponentValue> DimensionStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value
-GC::Ref<CSSStyleValue> DimensionStyleValue::reify(JS::Realm& realm, String const&) const
+GC::Ref<CSSStyleValue> DimensionStyleValue::reify(JS::Realm& realm, FlyString const&) const
 {
     // NB: Steps 1 and 2 don't apply here.
     // 3. Return a new CSSUnitValue with its value internal slot set to the numeric value of num, and its unit internal

--- a/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/DimensionStyleValue.h
@@ -20,7 +20,7 @@ public:
     virtual double raw_value() const = 0;
     virtual FlyString unit_name() const = 0;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
 protected:
     explicit DimensionStyleValue(Type type)

--- a/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
@@ -21,7 +21,7 @@ Vector<Parser::ComponentValue> IntegerStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value
-GC::Ref<CSSStyleValue> IntegerStyleValue::reify(JS::Realm& realm, String const& associated_property) const
+GC::Ref<CSSStyleValue> IntegerStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
 {
     // NB: Step 1 doesn't apply here.
     // 2. If num is the unitless value 0 and num is a <dimension>, return a new CSSUnitValue with its value internal

--- a/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
@@ -21,7 +21,7 @@ public:
 
     virtual String to_string(SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
     bool equals(StyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
@@ -349,7 +349,7 @@ Vector<Parser::ComponentValue> KeywordStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-ident
-GC::Ref<CSSStyleValue> KeywordStyleValue::reify(JS::Realm& realm, String const&) const
+GC::Ref<CSSStyleValue> KeywordStyleValue::reify(JS::Realm& realm, FlyString const&) const
 {
     // 1. Return a new CSSKeywordValue with its value internal slot set to the serialization of ident.
     return CSSKeywordValue::create(realm, FlyString::from_utf8_without_validation(string_from_keyword(m_keyword).bytes()));

--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.h
@@ -52,7 +52,7 @@ public:
     virtual Optional<Color> to_color(ColorResolutionContext) const override;
     virtual String to_string(SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
     bool properties_equal(KeywordStyleValue const& other) const { return m_keyword == other.m_keyword; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
@@ -25,7 +25,7 @@ Vector<Parser::ComponentValue> NumberStyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value
-GC::Ref<CSSStyleValue> NumberStyleValue::reify(JS::Realm& realm, String const& associated_property) const
+GC::Ref<CSSStyleValue> NumberStyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
 {
     // NB: Step 1 doesn't apply here.
     // 2. If num is the unitless value 0 and num is a <dimension>, return a new CSSUnitValue with its value internal

--- a/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
@@ -24,7 +24,7 @@ public:
 
     virtual String to_string(SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
     bool equals(StyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -145,7 +145,7 @@ Vector<Parser::ComponentValue> StyleValue::tokenize() const
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-as-a-cssstylevalue
-GC::Ref<CSSStyleValue> StyleValue::reify(JS::Realm& realm, String const& associated_property) const
+GC::Ref<CSSStyleValue> StyleValue::reify(JS::Realm& realm, FlyString const& associated_property) const
 {
     // 1. Return a new CSSStyleValue object representing value whose [[associatedProperty]] internal slot is set to property.
     return CSSStyleValue::create(realm, associated_property, to_string(SerializationMode::Normal));

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -209,7 +209,7 @@ public:
 
     virtual String to_string(SerializationMode) const = 0;
     virtual Vector<Parser::ComponentValue> tokenize() const;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const;
 
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) { }
     virtual void visit_edges(JS::Cell::Visitor&) const { }

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
@@ -98,7 +98,7 @@ static GC::Ref<CSSStyleValue> reify_a_transform_list(JS::Realm& realm, StyleValu
     return CSSTransformValue::create(realm, static_cast<Vector<GC::Ref<CSSTransformComponent>>>(move(transform_components)));
 }
 
-GC::Ref<CSSStyleValue> StyleValueList::reify(JS::Realm& realm, String const& associated_property) const
+GC::Ref<CSSStyleValue> StyleValueList::reify(JS::Realm& realm, FlyString const& associated_property) const
 {
     // NB: <transform-list> is a StyleValueList that contains TransformStyleValues. If that's what we are, follow the
     //     steps for reifying that.

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
@@ -35,7 +35,7 @@ public:
 
     virtual String to_string(SerializationMode) const override;
     virtual Vector<Parser::ComponentValue> tokenize() const override;
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
@@ -166,7 +166,7 @@ static GC::Ref<CSSUnparsedValue> reify_a_list_of_component_values(JS::Realm& rea
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#reify-a-list-of-component-values
-GC::Ref<CSSStyleValue> UnresolvedStyleValue::reify(JS::Realm& realm, String const&) const
+GC::Ref<CSSStyleValue> UnresolvedStyleValue::reify(JS::Realm& realm, FlyString const&) const
 {
     return reify_a_list_of_component_values(realm, m_values);
 }

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
@@ -30,7 +30,7 @@ public:
 
     virtual bool equals(StyleValue const& other) const override;
 
-    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, String const& associated_property) const override;
+    virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
 private:
     UnresolvedStyleValue(Vector<Parser::ComponentValue>&& values, Parser::SubstitutionFunctionsPresence, Optional<String> original_source_text);

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGfx/Color.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/PropertyNameAndID.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
@@ -615,11 +616,9 @@ Vector<GC::Ref<DOM::Node>> clear_the_value(FlyString const& command, GC::Ref<DOM
         if (!inline_style)
             return;
 
-        auto style_property = inline_style->get_property(CSS::PropertyID::TextDecoration);
-        if (!style_property.has_value())
+        auto style_value = inline_style->get_property_style_value(CSS::PropertyID::TextDecoration);
+        if (!style_value)
             return;
-
-        auto style_value = style_property.value().value;
         VERIFY(style_value->is_value_list());
         auto const& value_list = style_value->as_value_list();
         auto& old_values = value_list.values();
@@ -2470,20 +2469,20 @@ bool is_simple_modifiable_element(GC::Ref<DOM::Node> node)
     // * It is a b or strong element with exactly one attribute, which is style, and the style attribute sets exactly
     //   one CSS property (including invalid or unrecognized properties), which is "font-weight".
     if (html_element.local_name().is_one_of(HTML::TagNames::b, HTML::TagNames::strong)
-        && inline_style->get_property(CSS::PropertyID::FontWeight).has_value())
+        && inline_style->has_property(CSS::PropertyID::FontWeight))
         return true;
 
     // * It is an i or em element with exactly one attribute, which is style, and the style attribute sets exactly one
     //   CSS property (including invalid or unrecognized properties), which is "font-style".
     if (html_element.local_name().is_one_of(HTML::TagNames::i, HTML::TagNames::em)
-        && inline_style->get_property(CSS::PropertyID::FontStyle).has_value())
+        && inline_style->has_property(CSS::PropertyID::FontStyle))
         return true;
 
     // * It is an a, font, or span element with exactly one attribute, which is style, and the style attribute sets
     //   exactly one CSS property (including invalid or unrecognized properties), and that property is not
     //   "text-decoration".
     if (html_element.local_name().is_one_of(HTML::TagNames::a, HTML::TagNames::font, HTML::TagNames::span)
-        && !inline_style->get_property(CSS::PropertyID::TextDecoration).has_value())
+        && !inline_style->has_property(CSS::PropertyID::TextDecoration))
         return true;
 
     // * It is an a, font, s, span, strike, or u element with exactly one attribute, which is style, and the style
@@ -2491,7 +2490,7 @@ bool is_simple_modifiable_element(GC::Ref<DOM::Node> node)
     //   "text-decoration", which is set to "line-through" or "underline" or "overline" or "none".
     if (html_element.local_name().is_one_of(HTML::TagNames::a, HTML::TagNames::font, HTML::TagNames::s,
             HTML::TagNames::span, HTML::TagNames::strike, HTML::TagNames::u)
-        && inline_style->get_property(CSS::PropertyID::TextDecoration).has_value()) {
+        && inline_style->has_property(CSS::PropertyID::TextDecoration)) {
         auto text_decoration = inline_style->text_decoration();
         if (first_is_one_of(text_decoration,
                 string_from_keyword(CSS::Keyword::LineThrough),
@@ -2713,9 +2712,8 @@ void justify_the_selection(DOM::Document& document, JustifyAlignment alignment)
                     ++number_of_matching_attributes;
                 if (element->has_attribute(HTML::AttributeNames::style) && element->inline_style()
                     && element->inline_style()->length() == 1) {
-                    auto text_align = element->inline_style()->get_property(CSS::PropertyID::TextAlign);
-                    if (text_align.has_value()) {
-                        auto align_value = text_align.value().value->to_string(CSS::SerializationMode::Normal);
+                    if (auto text_align = element->inline_style()->get_property_style_value(CSS::PropertyID::TextAlign)) {
+                        auto align_value = text_align->to_string(CSS::SerializationMode::Normal);
                         if (align_value.equals_ignoring_ascii_case(alignment_keyword))
                             ++number_of_matching_attributes;
                     }

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -4691,7 +4691,6 @@ Optional<NonnullRefPtr<CSS::StyleValue const>> property_in_style_attribute(GC::R
     if (!inline_style)
         return {};
 
-    // FIXME: This doesn't support shorthand properties.
     auto style_property = inline_style->get_property(property_id);
     if (!style_property.has_value())
         return {};

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -631,13 +631,13 @@ Vector<GC::Ref<DOM::Node>> clear_the_value(FlyString const& command, GC::Ref<DOM
         if (!was_removed)
             return;
         if (new_values.is_empty()) {
-            MUST(inline_style->remove_property(string_from_property_id(CSS::PropertyID::TextDecoration)));
+            MUST(inline_style->remove_property(CSS::PropertyID::TextDecoration));
             return;
         }
 
         auto new_style_value = CSS::StyleValueList::create(move(new_values), value_list.separator());
         MUST(inline_style->set_property(
-            string_from_property_id(CSS::PropertyID::TextDecoration),
+            CSS::PropertyID::TextDecoration,
             new_style_value->to_string(CSS::SerializationMode::Normal),
             {}));
     };
@@ -654,7 +654,7 @@ Vector<GC::Ref<DOM::Node>> clear_the_value(FlyString const& command, GC::Ref<DOM
     if (command_definition->relevant_css_property.has_value()) {
         auto property_to_remove = command_definition->relevant_css_property.value();
         if (auto inline_style = element->inline_style())
-            MUST(inline_style->remove_property(string_from_property_id(property_to_remove)));
+            MUST(inline_style->remove_property(property_to_remove));
     }
 
     // 8. If element is a font element:
@@ -2935,9 +2935,9 @@ void outdent(GC::Ref<DOM::Node> node)
 
         // 2. Unset the margin, padding, and border CSS properties of node.
         if (auto inline_style = element.inline_style()) {
-            MUST(inline_style->remove_property(CSS::string_from_property_id(CSS::PropertyID::Border)));
-            MUST(inline_style->remove_property(CSS::string_from_property_id(CSS::PropertyID::Margin)));
-            MUST(inline_style->remove_property(CSS::string_from_property_id(CSS::PropertyID::Padding)));
+            MUST(inline_style->remove_property(CSS::PropertyID::Border));
+            MUST(inline_style->remove_property(CSS::PropertyID::Margin));
+            MUST(inline_style->remove_property(CSS::PropertyID::Padding));
         }
 
         // 3. Set the tag name of node to "div".

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -615,7 +615,7 @@ Vector<GC::Ref<DOM::Node>> clear_the_value(FlyString const& command, GC::Ref<DOM
         if (!inline_style)
             return;
 
-        auto style_property = inline_style->property(CSS::PropertyID::TextDecoration);
+        auto style_property = inline_style->get_property(CSS::PropertyID::TextDecoration);
         if (!style_property.has_value())
             return;
 
@@ -2470,20 +2470,20 @@ bool is_simple_modifiable_element(GC::Ref<DOM::Node> node)
     // * It is a b or strong element with exactly one attribute, which is style, and the style attribute sets exactly
     //   one CSS property (including invalid or unrecognized properties), which is "font-weight".
     if (html_element.local_name().is_one_of(HTML::TagNames::b, HTML::TagNames::strong)
-        && inline_style->property(CSS::PropertyID::FontWeight).has_value())
+        && inline_style->get_property(CSS::PropertyID::FontWeight).has_value())
         return true;
 
     // * It is an i or em element with exactly one attribute, which is style, and the style attribute sets exactly one
     //   CSS property (including invalid or unrecognized properties), which is "font-style".
     if (html_element.local_name().is_one_of(HTML::TagNames::i, HTML::TagNames::em)
-        && inline_style->property(CSS::PropertyID::FontStyle).has_value())
+        && inline_style->get_property(CSS::PropertyID::FontStyle).has_value())
         return true;
 
     // * It is an a, font, or span element with exactly one attribute, which is style, and the style attribute sets
     //   exactly one CSS property (including invalid or unrecognized properties), and that property is not
     //   "text-decoration".
     if (html_element.local_name().is_one_of(HTML::TagNames::a, HTML::TagNames::font, HTML::TagNames::span)
-        && !inline_style->property(CSS::PropertyID::TextDecoration).has_value())
+        && !inline_style->get_property(CSS::PropertyID::TextDecoration).has_value())
         return true;
 
     // * It is an a, font, s, span, strike, or u element with exactly one attribute, which is style, and the style
@@ -2491,7 +2491,7 @@ bool is_simple_modifiable_element(GC::Ref<DOM::Node> node)
     //   "text-decoration", which is set to "line-through" or "underline" or "overline" or "none".
     if (html_element.local_name().is_one_of(HTML::TagNames::a, HTML::TagNames::font, HTML::TagNames::s,
             HTML::TagNames::span, HTML::TagNames::strike, HTML::TagNames::u)
-        && inline_style->property(CSS::PropertyID::TextDecoration).has_value()) {
+        && inline_style->get_property(CSS::PropertyID::TextDecoration).has_value()) {
         auto text_decoration = inline_style->text_decoration();
         if (first_is_one_of(text_decoration,
                 string_from_keyword(CSS::Keyword::LineThrough),
@@ -2713,7 +2713,7 @@ void justify_the_selection(DOM::Document& document, JustifyAlignment alignment)
                     ++number_of_matching_attributes;
                 if (element->has_attribute(HTML::AttributeNames::style) && element->inline_style()
                     && element->inline_style()->length() == 1) {
-                    auto text_align = element->inline_style()->property(CSS::PropertyID::TextAlign);
+                    auto text_align = element->inline_style()->get_property(CSS::PropertyID::TextAlign);
                     if (text_align.has_value()) {
                         auto align_value = text_align.value().value->to_string(CSS::SerializationMode::Normal);
                         if (align_value.equals_ignoring_ascii_case(alignment_keyword))
@@ -4692,7 +4692,7 @@ Optional<NonnullRefPtr<CSS::StyleValue const>> property_in_style_attribute(GC::R
         return {};
 
     // FIXME: This doesn't support shorthand properties.
-    auto style_property = inline_style->property(property_id);
+    auto style_property = inline_style->get_property(property_id);
     if (!style_property.has_value())
         return {};
 
@@ -4726,7 +4726,7 @@ Optional<NonnullRefPtr<CSS::StyleValue const>> resolved_value(GC::Ref<DOM::Node>
 
     // Retrieve resolved style value
     auto resolved_css_style_declaration = CSS::CSSStyleProperties::create_resolved_style(element->realm(), DOM::AbstractElement { static_cast<DOM::Element&>(*element) });
-    auto optional_style_property = resolved_css_style_declaration->property(property_id);
+    auto optional_style_property = resolved_css_style_declaration->get_property(property_id);
     if (!optional_style_property.has_value())
         return {};
     return optional_style_property.value().value;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -347,6 +347,7 @@ class Percentage;
 class PercentageOrCalculated;
 class PercentageStyleValue;
 class PositionStyleValue;
+class PropertyNameAndID;
 class RadialGradientStyleValue;
 class Ratio;
 class RatioStyleValue;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -238,8 +238,6 @@ enum class PropertyID : @property_id_underlying_type@ {
     generator.append(R"~~~(
 };
 
-using PropertyIDOrCustomPropertyName = Variant<PropertyID, FlyString>;
-
 enum class AnimationType {
     Discrete,
     ByComputedValue,

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSStyleProperties.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSStyleProperties.cpp
@@ -110,12 +110,12 @@ namespace Web::Bindings {
         definition_generator.append(R"~~~(
 WebIDL::ExceptionOr<void> GeneratedCSSStyleProperties::set_@name:acceptable_cpp@(StringView value)
 {
-    return generated_style_properties_to_css_style_properties().set_property("@name@"sv, value, ""sv);
+    return generated_style_properties_to_css_style_properties().set_property("@name@"_fly_string, value, ""sv);
 }
 
 String GeneratedCSSStyleProperties::@name:acceptable_cpp@() const
 {
-    return generated_style_properties_to_css_style_properties().get_property_value("@name@"sv);
+    return generated_style_properties_to_css_style_properties().get_property_value("@name@"_fly_string);
 }
 )~~~");
     });

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/declared.tentative.txt
@@ -2,12 +2,12 @@ Harness status: OK
 
 Found 7 tests
 
-4 Pass
-3 Fail
+5 Pass
+2 Fail
 Fail	Declared StylePropertyMap only contains properties in the style rule
 Pass	Declared StylePropertyMap contains CSS property declarations in style rules
 Pass	Declared StylePropertyMap does not contain inline styles
-Fail	Declared StylePropertyMap contains custom property declarations
+Pass	Declared StylePropertyMap contains custom property declarations
 Pass	Declared StylePropertyMap does not contain properties with invalid values
 Pass	Declared StylePropertyMap contains properties with their last valid value
 Fail	Declared StylePropertyMap is live

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/get.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/get.txt
@@ -2,12 +2,12 @@ Harness status: OK
 
 Found 7 tests
 
-5 Pass
-2 Fail
+6 Pass
+1 Fail
 Pass	Getting a custom property not in the CSS rule returns undefined
 Pass	Getting a valid property not in the CSS rule returns undefined
 Pass	Getting a valid property from CSS rule returns the correct entry
-Fail	Getting a valid custom property from CSS rule returns the correct entry
+Pass	Getting a valid custom property from CSS rule returns the correct entry
 Fail	Getting a list-valued property from CSS rule returns only the first value
 Pass	Declared StylePropertyMap.get is not case-sensitive
 Pass	Declared StylePropertyMap.get reflects changes in the CSS rule

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/getAll.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/getAll.tentative.txt
@@ -2,12 +2,12 @@ Harness status: OK
 
 Found 7 tests
 
-5 Pass
-2 Fail
+6 Pass
+1 Fail
 Pass	Calling StylePropertyMap.getAll with an unsupported property throws a TypeError
 Pass	Calling StylePropertyMap.getAll with a property not in the property model returns an empty list
 Pass	Calling StylePropertyMap.getAll with a custom property not in the property model returns an empty list
 Pass	Calling StylePropertyMap.getAll with a valid property returns a single element list with the correct entry
 Pass	StylePropertyMap.getAll is case-insensitive
-Fail	Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry
+Pass	Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry
 Fail	Calling StylePropertyMap.getAll with a list-valued property returns all the values

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/has.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/declared/has.tentative.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 9 tests
 
-8 Pass
-1 Fail
+9 Pass
 Pass	Calling StylePropertyMap.has with an unsupported property throws a TypeError
 Pass	Calling StylePropertyMap.has with a property not in the property model returns false
 Pass	Calling StylePropertyMap.has with a custom property not in the property model returns false
@@ -11,5 +10,5 @@ Pass	Calling StylePropertyMap.has with a valid property returns true
 Pass	Calling StylePropertyMap.has with a valid property in mixed case returns true
 Pass	Calling StylePropertyMap.has with a valid shorthand specified explicitly returns true
 Pass	Calling StylePropertyMap.has with a valid shorthand only partially specified returns false
-Fail	Calling StylePropertyMap.has with a valid custom property returns true
+Pass	Calling StylePropertyMap.has with a valid custom property returns true
 Pass	Calling StylePropertyMap.has with a valid list-valued property returns true

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/inline/get.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/inline/get.txt
@@ -2,12 +2,12 @@ Harness status: OK
 
 Found 7 tests
 
-5 Pass
-2 Fail
+6 Pass
+1 Fail
 Pass	Getting a custom property not in the inline style returns undefined
 Pass	Getting a valid property not in the inline style returns undefined
 Pass	Getting a valid property from inline style returns the correct entry
-Fail	Getting a valid custom property from inline style returns the correct entry
+Pass	Getting a valid custom property from inline style returns the correct entry
 Fail	Getting a list-valued property from inline style returns only the first value
 Pass	Declared StylePropertyMap.get is not case-sensitive
 Pass	Declared StylePropertyMap.get reflects changes in the inline style

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/inline/getAll.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/inline/getAll.tentative.txt
@@ -2,12 +2,12 @@ Harness status: OK
 
 Found 7 tests
 
-5 Pass
-2 Fail
+6 Pass
+1 Fail
 Pass	Calling StylePropertyMap.getAll with an unsupported property throws a TypeError
 Pass	Calling StylePropertyMap.getAll with a property not in the property model returns an empty list
 Pass	Calling StylePropertyMap.getAll with a custom property not in the property model returns an empty list
 Pass	Calling StylePropertyMap.getAll with a valid property returns a single element list with the correct entry
 Pass	StylePropertyMap.getAll is case-insensitive
-Fail	Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry
+Pass	Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry
 Fail	Calling StylePropertyMap.getAll with a list-valued property returns all the values

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/inline/has.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/the-stylepropertymap/inline/has.tentative.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 8 tests
 
-7 Pass
-1 Fail
+8 Pass
 Pass	Calling StylePropertyMap.has with an unsupported property throws a TypeError
 Pass	Calling StylePropertyMap.has with a property not in the property model returns false
 Pass	Calling StylePropertyMap.has with a custom property not in the property model returns false
 Pass	Calling StylePropertyMap.has with a valid property in mixed case returns false
 Pass	Calling StylePropertyMap.has with a valid property returns true
 Pass	Calling StylePropertyMap.has with a valid property in mixed case returns true
-Fail	Calling StylePropertyMap.has with a valid custom property returns true
+Pass	Calling StylePropertyMap.has with a valid custom property returns true
 Pass	Calling StylePropertyMap.has with a valid list-valued property returns true


### PR DESCRIPTION
The name is awkward, but the idea is: in a lot of places a `PropertyID` is not enough, because all custom properties appear as `PropertyID::Custom`. We did have a `Variant<PropertyID, FlyString>` typedef, but that means you can't have both a `PropertyID` and its name as a string at the same time. We often want both, for example with `CSSStyleProperties` methods, where we previously would end up repeatedly converting between strings and `PropertyID`s.

So, `PropertyNameAndID` stores both. If you create it from a `PropertyID`, it avoids producing a string until you ask for it, but then caches that to avoid repeated look-ups. If you create it from a string, it converts that into lowercase for known properties (which is a step requested in all of the spec algorithms I came across) and keeps it as-is for custom properties (again, as the specs require).

Then, using it in all the places that made sense to me.

I also took this as an opportunity to untangle `CSSStyleProperties::property()`. It was both a public "get a value for the PropertyID" method, and an internal "get the directly-stored value for this longhand" one. It now is only internal, also handles custom properties, and the public method also works with shorthands. The custom-property handling gets us some extra WPT passes on `StylePropertyMap` tests.

There are a couple of other related changes. I added some helpers for the Algorithms code and made webdriver able to query custom properties.