### PR TITLE
WebContent: Show custom properties in DevTools computed tab

### DIFF
--- a/Libraries/LibWeb/CSS/StyleProperty.h
+++ b/Libraries/LibWeb/CSS/StyleProperty.h
@@ -16,11 +16,11 @@ enum class Important : u8 {
     Yes,
 };
 
-struct StyleProperty {
+struct WEB_API StyleProperty {
     ~StyleProperty();
 
     Important important { Important::No };
-    CSS::PropertyID property_id;
+    PropertyID property_id;
     NonnullRefPtr<StyleValue const> value;
     FlyString custom_name {};
 

--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
@@ -60,11 +60,6 @@ EasingStyleValue::Steps EasingStyleValue::Steps::step_end()
     return steps;
 }
 
-bool EasingStyleValue::CubicBezier::operator==(Web::CSS::EasingStyleValue::CubicBezier const& other) const
-{
-    return x1 == other.x1 && y1 == other.y1 && x2 == other.x2 && y2 == other.y2;
-}
-
 // https://drafts.csswg.org/css-easing/#linear-canonicalization
 EasingStyleValue::Linear::Linear(Vector<EasingStyleValue::Linear::Stop> stops)
 {

--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
@@ -61,7 +61,10 @@ public:
 
         mutable Vector<CachedSample> m_cached_x_samples {};
 
-        bool operator==(CubicBezier const&) const;
+        bool operator==(CubicBezier const& other) const
+        {
+            return x1 == other.x1 && y1 == other.y1 && x2 == other.x2 && y2 == other.y2;
+        }
 
         double evaluate_at(double input_progress, bool before_flag) const;
         String to_string(SerializationMode) const;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -484,6 +484,12 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, WebView::DOMNodePropert
                 value.to_string(Web::CSS::SerializationMode::Normal));
         });
 
+        // FIXME: Custom properties are not yet included in ComputedProperties, so add them manually.
+        auto custom_properties = element.custom_properties(pseudo_element);
+        for (auto const& [name, value] : custom_properties) {
+            serialized.set(name, value.value->to_string(Web::CSS::SerializationMode::Normal));
+        }
+
         return serialized;
     };
 


### PR DESCRIPTION
<img width="843" height="656" alt="image" src="https://github.com/user-attachments/assets/33fd0a86-2156-4e50-a0c0-27996d7e2d5b" />

These didn't show up before because they're not included in `ComputedProperties`. They probably should be, but that's a big change and this is a little one.