### PR TITLE
LibDevTools: Don't assume computed layout values are strings

### DIFF
--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -30,7 +30,7 @@ static void received_layout(JsonObject& response, JsonValue const& node_box_sizi
         response.set(key, MUST(String::formatted("{}px", pixel_value(key))));
     };
     auto set_computed_value = [&](auto key) {
-        response.set(key, node_box_sizing.as_object().get_string(key).value_or(String {}));
+        response.set(key, node_box_sizing.as_object().get(key).value_or(String {}));
     };
 
     // FIXME: This response should also contain "top", "right", "bottom", and "left", but our box model metrics in


### PR DESCRIPTION
Width and height are doubles, so get_string() will return nothing and fail. We just want a JsonValue here without caring what type it is, so let's just use get() instead.

Before:
<img width="963" height="467" alt="image" src="https://github.com/user-attachments/assets/75f37e30-f7f9-4290-8ec8-5b8a90ed7f48" />

After:
<img width="984" height="459" alt="image" src="https://github.com/user-attachments/assets/906d7056-3b4a-4468-a57d-b28995cae735" />
