### PR TITLE
LibJS: Make fast_is use a single source of truth for AST nodes

### DIFF
--- a/Libraries/LibJS/Bytecode/Builtins.cpp
+++ b/Libraries/LibJS/Bytecode/Builtins.cpp
@@ -11,7 +11,7 @@ namespace JS::Bytecode {
 
 Optional<Builtin> get_builtin(MemberExpression const& expression)
 {
-    if (expression.is_computed() || !expression.object().is_identifier() || !expression.property().is_identifier())
+    if (expression.is_computed() || !is<Identifier>(expression.object()) || !is<Identifier>(expression.property()))
         return {};
     auto base_name = static_cast<Identifier const&>(expression.object()).string();
     auto property_name = static_cast<Identifier const&>(expression.property()).string();

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -496,18 +496,15 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
             }
 
             // iii. If d is a FunctionDeclaration, a GeneratorDeclaration, an AsyncFunctionDeclaration, or an AsyncGeneratorDeclaration, then
-            if (declaration.is_function_declaration()) {
-                VERIFY(is<FunctionDeclaration>(declaration));
-                auto const& function_declaration = static_cast<FunctionDeclaration const&>(declaration);
-
+            if (auto const* function_declaration = as_if<FunctionDeclaration>(declaration)) {
                 // 1. Let fo be InstantiateFunctionObject of d with arguments env and privateEnv.
                 // NOTE: Special case if the function is a default export of an anonymous function
                 //       it has name "*default*" but internally should have name "default".
-                auto function_name = function_declaration.name();
+                auto function_name = function_declaration->name();
                 if (function_name == ExportStatement::local_name_for_default)
                     function_name = "default"_utf16_fly_string;
                 auto function = ECMAScriptFunctionObject::create_from_function_node(
-                    function_declaration,
+                    *function_declaration,
                     move(function_name),
                     realm,
                     environment,


### PR DESCRIPTION
This makes it a bit easier to maintain and hides some implementation details behind macros.

In the future this could easily be extended to all AST nodes.

---

mainly a POC, as this could easily be used for other `is_*` heavy types, such as Js objects
adding fast_is to an AST node now is just adding it to the main x-macro and adding the helper to its class prolog