### PR TITLE
LibDevTools: Some fixes to the style sheets list

### DIFF
--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -161,10 +161,13 @@ void FrameActor::style_sheets_available(JsonObject& response, Vector<Web::CSS::S
         JsonValue title;
 
         if (style_sheet.url.has_value()) {
-            // LibWeb sets the URL to a style sheet name for UA style sheets. DevTools would reject these invalid URLs.
             if (style_sheet.type == Web::CSS::StyleSheetIdentifier::Type::UserAgent) {
+                // LibWeb sets the URL to a style sheet name for UA style sheets. DevTools would reject these invalid URLs.
+                href = MUST(String::formatted("resource://{}", style_sheet.url.value()));
                 title = *style_sheet.url;
                 source_map_base_url = tab_url;
+            } else if (style_sheet.type == Web::CSS::StyleSheetIdentifier::Type::StyleElement) {
+                source_map_base_url = *style_sheet.url;
             } else {
                 href = *style_sheet.url;
                 source_map_base_url = *style_sheet.url;
@@ -186,7 +189,7 @@ void FrameActor::style_sheets_available(JsonObject& response, Vector<Web::CSS::S
         sheet.set("sourceMapBaseURL"sv, move(source_map_base_url));
         sheet.set("sourceMapURL"sv, ""sv);
         sheet.set("styleSheetIndex"sv, i);
-        sheet.set("system"sv, false);
+        sheet.set("system"sv, style_sheet.type == Web::CSS::StyleSheetIdentifier::Type::UserAgent);
         sheet.set("title"sv, move(title));
 
         sheets.must_append(move(sheet));

--- a/Libraries/LibDevTools/Actors/StyleSheetsActor.cpp
+++ b/Libraries/LibDevTools/Actors/StyleSheetsActor.cpp
@@ -69,9 +69,7 @@ void StyleSheetsActor::set_style_sheets(Vector<Web::CSS::StyleSheetIdentifier> s
 
 void StyleSheetsActor::style_sheet_source_received(Web::CSS::StyleSheetIdentifier const& style_sheet, String source)
 {
-    auto index = m_style_sheets.find_first_index_if([&](auto const& candidate) {
-        return candidate.type == style_sheet.type && candidate.url == style_sheet.url;
-    });
+    auto index = m_style_sheets.find_first_index(style_sheet);
     if (!index.has_value())
         return;
 

--- a/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
+++ b/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
@@ -26,6 +26,11 @@ struct StyleSheetIdentifier {
     Optional<UniqueNodeID> dom_element_unique_id {};
     Optional<String> url {};
     size_t rule_count { 0 };
+
+    bool operator==(StyleSheetIdentifier const& other) const
+    {
+        return type == other.type && dom_element_unique_id == other.dom_element_unique_id && url == other.url;
+    }
 };
 
 StringView style_sheet_identifier_type_to_string(StyleSheetIdentifier::Type);


### PR DESCRIPTION
This makes our style sheets appear more like how Firefox displays its own, and also fixes a bug where the style sheet list wouldn't appear at all if there were multiple inline style sheets on the page.