### PR TITLE
Meta: Fix libjs-test262 CI workflow

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y ninja-build unzip clang-20 clang++-20 jq curl zip tar autoconf autoconf-archive automake nasm pkg-config libgl1-mesa-dev rsync
+          sudo apt-get install -y ninja-build unzip clang-20 clang++-20 jq curl zip tar autoconf autoconf-archive automake nasm pkg-config libgl1-mesa-dev rsync libtool
 
           test -e /opt/wabt-1.0.35 || (
             cd /tmp


### PR DESCRIPTION
libtool is required to build gperf