### PR TITLE
Fix issue #6038 (honor important CSS property declarations)

### DIFF
--- a/Tests/LibWeb/Layout/expected/important-custom-properties-resolution.txt
+++ b/Tests/LibWeb/Layout/expected/important-custom-properties-resolution.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 66 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 50 0+0+8] children: not-inline
+      BlockContainer <main> at [8,8] [0+0+0 50 0+0+734] [0+0+0 50 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableWithLines (BlockContainer<MAIN>) [8,8 50x50]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x66] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/important-custom-properties-resolution.html
+++ b/Tests/LibWeb/Layout/input/important-custom-properties-resolution.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><style>
+    main {
+        --size: 50px !important;
+        --bg: green !important;
+    }   
+    main {
+        --size: 200px;
+        width: var(--size);
+        height: var(--size);
+        --bg: red;
+        background: var(--bg);
+    }   
+</style><body><main>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-variables/css-vars-custom-property-inheritance.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-variables/css-vars-custom-property-inheritance.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Variables Test: custom properties use normal inheritance and cascade rules</title>
+    <link rel="author" title="Noah Collins" href="mailto:noahcollins@gmail.com">
+    <link rel="help" href="http://www.w3.org/TR/css-variables-1/#using-variables">
+    <meta name="assert" content="custom properties are resolved with the normal inheritance and cascade rules">
+    <link rel="match" href="../../../../expected/wpt-import//css/reference/ref-filled-green-100px-square.xht">
+    <style type="text/css">
+
+        /* test cascade importance */
+        :root { --color-1: green !important; }
+        :root { --color-1: red; }
+        div.color1 { background-color: var(--color-1); }
+
+        /* test cascade order */
+        :root { --color-2: green; }
+        div.color2 { background-color: red; }
+        div.color2 { background-color: var(--color-2); }
+
+        div { width: 100px; height: 50px; }
+    </style>
+</head>
+<body>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <div class=color1></div>
+    <div class=color2></div>
+</body>
+</html>


### PR DESCRIPTION
This fixes the issue https://github.com/LadybirdBrowser/ladybird/issues/6038, in which the problem was reported.

I applied a solution similar to the one described, making sure that !important properties would override normal ones in inside `cascade_custom_properties` 

This fixes the search field that is too wide on brave.com, as was described in the report, but to see it in action is necessary to apply the fix from the PR https://github.com/LadybirdBrowser/ladybird/pull/6328 first.

I made a simplified test based on the reduced example from the issue. But I also found a WPT test this apparently fixed, so I imported it too.