### PR TITLE
AK: Fix edge cases in is_within_range when checking float to int

### DIFF
--- a/AK/ExactRepresentation.h
+++ b/AK/ExactRepresentation.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/NumericLimits.h>
+#include <AK/StdLibExtras.h>
+
+namespace AK {
+
+constexpr __uint128_t int_with_n_1s(size_t n)
+{
+    if (n == 0)
+        return 0;
+
+    __uint128_t out = 1;
+    for (size_t i = 1; i < n; i++) {
+        out = out << 1;
+        out |= 1;
+    }
+    return out;
+}
+
+template<FloatingPoint F, Integral I>
+constexpr bool has_exact_representation(I value)
+{
+    constexpr size_t mantissa_length = NumericLimits<F>::mantissa_length();
+
+    if constexpr ((mantissa_length >= (sizeof(I) * 8) && NumericLimits<I>::is_signed()) || (mantissa_length > (sizeof(I) * 8))) {
+        return true;
+    }
+
+    constexpr __uint128_t max_representable_value_no_exp = int_with_n_1s(mantissa_length);
+
+    __uint128_t value_in_processing;
+    if constexpr (NumericLimits<I>::is_signed()) {
+        if (value == NumericLimits<I>::min()) {
+            // hacky fix for the fact that in a signed integer
+            // the minimum value of an integer has no positive counterpart
+            value_in_processing = AK::abs(value / 2);
+        } else {
+            value_in_processing = AK::abs(value);
+        }
+    } else {
+        value_in_processing = value;
+    }
+
+    while (true) {
+        if ((value_in_processing & ~max_representable_value_no_exp) == 0) {
+            return true;
+        }
+
+        if (value_in_processing % 2 == 0) {
+            value_in_processing = value_in_processing >> 1;
+        } else {
+            return false;
+        }
+    }
+}
+
+}

--- a/AK/NumericLimits.h
+++ b/AK/NumericLimits.h
@@ -119,6 +119,8 @@ struct NumericLimits<float> {
     static constexpr float epsilon() { return __FLT_EPSILON__; }
     static constexpr bool is_signed() { return true; }
     static constexpr size_t digits() { return __FLT_MANT_DIG__; }
+    static constexpr size_t exponent_length() { return 8; }
+    static constexpr size_t mantissa_length() { return 23; }
 };
 
 template<>
@@ -130,6 +132,8 @@ struct NumericLimits<double> {
     static constexpr double epsilon() { return __DBL_EPSILON__; }
     static constexpr bool is_signed() { return true; }
     static constexpr size_t digits() { return __DBL_MANT_DIG__; }
+    static constexpr size_t exponent_length() { return 11; }
+    static constexpr size_t mantissa_length() { return 52; }
 };
 
 template<>
@@ -141,6 +145,15 @@ struct NumericLimits<long double> {
     static constexpr long double epsilon() { return __LDBL_EPSILON__; }
     static constexpr bool is_signed() { return true; }
     static constexpr size_t digits() { return __LDBL_MANT_DIG__; }
+    static constexpr size_t exponent_length() { return 15; }
+    static constexpr size_t mantissa_length()
+    {
+#if defined(AK_HAS_FLOAT_128)
+        return 63;
+#else
+        return 112;
+#endif
+    }
 };
 
 template<>

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -44,6 +44,7 @@ set(AK_TEST_SOURCES
     TestIntrusiveRedBlackTree.cpp
     TestJSON.cpp
     TestLEB128.cpp
+    TestExactRepresentation.cpp
     TestMemory.cpp
     TestMemoryStream.cpp
     TestNeverDestroyed.cpp

--- a/Tests/AK/TestChecked.cpp
+++ b/Tests/AK/TestChecked.cpp
@@ -457,6 +457,9 @@ TEST_CASE(is_within_range_float_to_int)
     static_assert(!AK::is_within_range<int>(NumericLimits<long double>::max()));
     static_assert(!AK::is_within_range<int>(NumericLimits<float>::lowest()));
 
+    static_assert(!AK::is_within_range<int>((float)NumericLimits<int>::max()));
+    static_assert(AK::is_within_range<int>((float)NumericLimits<int>::min()));
+
     static_assert(AK::is_within_range<long>(0.0));
     static_assert(AK::is_within_range<long long>(0.0));
 

--- a/Tests/AK/TestExactRepresentation.cpp
+++ b/Tests/AK/TestExactRepresentation.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Ladybird contributors
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NumericLimits.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(Generate_ints_with_n_1s)
+{
+    EXPECT_EQ(AK::int_with_n_1s(0), 0u);
+    EXPECT_EQ(AK::int_with_n_1s(1), 1u);
+    EXPECT_EQ(AK::int_with_n_1s(10), 0b1111111111u);
+    EXPECT_EQ(AK::int_with_n_1s(64), NumericLimits<unsigned long>::max());
+}
+
+TEST_CASE(has_exact_floatingpoint_representation)
+{
+    static_assert(AK::has_exact_representation<float>(0));
+    static_assert(AK::has_exact_representation<float>(NumericLimits<int>::min()));
+    static_assert(!AK::has_exact_representation<float>(NumericLimits<int>::max()));
+    static_assert(AK::has_exact_representation<float>(999));
+    static_assert(AK::has_exact_representation<double>(NumericLimits<int>::min()));
+    static_assert(AK::has_exact_representation<double>(NumericLimits<int>::max()));
+    static_assert(AK::has_exact_representation<double>(NumericLimits<long>::min()));
+    static_assert(!AK::has_exact_representation<double>(NumericLimits<long>::max()));
+}


### PR DESCRIPTION
In the past when checking if a float of INT_MAX + 1 could be converted to a int it would return true.

This should also fix all broken tests in
https://wpt.live/wasm/core/conversions.wast.js.html