### PR TITLE
LibWeb: Check font family is present to avoid NPD when serializing CSS

### DIFF
--- a/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -58,83 +58,102 @@ String CSSFontFaceRule::serialized() const
     // The result of concatenating the following:
 
     // 1. The string "@font-face {", followed by a single SPACE (U+0020).
+    auto is_empty = true;
     builder.append("@font-face { "sv);
 
-    // 2. The string "font-family:", followed by a single SPACE (U+0020).
-    builder.append("font-family: "sv);
-
-    // 3. The result of performing serialize a string on the rule’s font family name.
-    builder.append(descriptors.descriptor(DescriptorID::FontFamily)->to_string(SerializationMode::Normal));
-
-    // 4. The string ";", i.e., SEMICOLON (U+003B).
-    builder.append(';');
-
-    // 5. If the rule’s associated source list is not empty, follow these substeps:
-    if (auto sources = descriptors.descriptor(DescriptorID::Src)) {
-        // 1. A single SPACE (U+0020), followed by the string "src:", followed by a single SPACE (U+0020).
-        builder.append(" src: "sv);
-
-        // 2. The result of invoking serialize a comma-separated list on performing serialize a URL or serialize a LOCAL for each source on the source list.
-        builder.append(sources->to_string(SerializationMode::Normal));
-
-        // 3. The string ";", i.e., SEMICOLON (U+003B).
+    // 2. If the rule’s associated font-family is present, follow these substeps:
+    //    The string "font-family:", followed by a single SPACE (U+0020).
+    //    followed by the result of performing serialize a string on the rule’s font family name.
+    //    followed by the string ";", i.e., SEMICOLON (U+003B).
+    if (auto font_family = descriptors.descriptor(DescriptorID::FontFamily)) {
+        builder.append("font-family: "sv);
+        builder.append(descriptors.descriptor(DescriptorID::FontFamily)->to_string(SerializationMode::Normal));
         builder.append(';');
+        is_empty = false;
     }
 
-    // 6. If rule’s associated unicode-range descriptor is present, a single SPACE (U+0020), followed by the string "unicode-range:", followed by a single SPACE (U+0020), followed by the result of performing serialize a <'unicode-range'>, followed by the string ";", i.e., SEMICOLON (U+003B).
+    // 3. If the rule’s associated source list is not empty, a single SPACE (U+0020),
+    //    followed by the string "src:", followed by a single SPACE (U+0020).
+    //    followed by the result of invoking serialize a comma-separated list on performing serialize a URL or serialize a LOCAL for each source on the source list.
+    //    followed by the string ";", i.e., SEMICOLON (U+003B).
+    if (auto sources = descriptors.descriptor(DescriptorID::Src)) {
+        if (!is_empty)
+            builder.append(' ');
+        builder.append("src: "sv);
+        builder.append(sources->to_string(SerializationMode::Normal));
+        builder.append(';');
+        is_empty = false;
+    }
+
+    // 4. If rule’s associated unicode-range descriptor is present, a single SPACE (U+0020), followed by the string "unicode-range:", followed by a single SPACE (U+0020), followed by the result of performing serialize a <'unicode-range'>, followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto unicode_range = descriptors.descriptor(DescriptorID::UnicodeRange)) {
+        if (!is_empty)
+            builder.append(' ');
         builder.append(" unicode-range: "sv);
         builder.append(unicode_range->to_string(SerializationMode::Normal));
         builder.append(';');
+        is_empty = false;
     }
 
-    // FIXME: 7. If rule’s associated font-variant descriptor is present, a single SPACE (U+0020),
+    // FIXME: 5. If rule’s associated font-variant descriptor is present, a single SPACE (U+0020),
     // followed by the string "font-variant:", followed by a single SPACE (U+0020),
     // followed by the result of performing serialize a <'font-variant'>,
     // followed by the string ";", i.e., SEMICOLON (U+003B).
 
-    // 8. If rule’s associated font-feature-settings descriptor is present, a single SPACE (U+0020),
+    // 6. If rule’s associated font-feature-settings descriptor is present, a single SPACE (U+0020),
     //    followed by the string "font-feature-settings:", followed by a single SPACE (U+0020),
     //    followed by the result of performing serialize a <'font-feature-settings'>,
     //    followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto font_feature_settings = descriptors.descriptor(DescriptorID::FontFeatureSettings)) {
+        if (!is_empty)
+            builder.append(' ');
         builder.append(" font-feature-settings: "sv);
         builder.append(font_feature_settings->to_string(SerializationMode::Normal));
         builder.append(";"sv);
+        is_empty = false;
     }
 
-    // 9. If rule’s associated font-stretch descriptor is present, a single SPACE (U+0020),
+    // 7. If rule’s associated font-stretch descriptor is present, a single SPACE (U+0020),
     //    followed by the string "font-stretch:", followed by a single SPACE (U+0020),
     //    followed by the result of performing serialize a <'font-stretch'>,
     //    followed by the string ";", i.e., SEMICOLON (U+003B).
     // NOTE: font-stretch is now an alias for font-width, so we use that instead.
     if (auto font_width = descriptors.descriptor(DescriptorID::FontWidth)) {
+        if (!is_empty)
+            builder.append(' ');
         builder.append(" font-stretch: "sv);
         builder.append(font_width->to_string(SerializationMode::Normal));
         builder.append(";"sv);
+        is_empty = false;
     }
 
-    // 10. If rule’s associated font-weight descriptor is present, a single SPACE (U+0020),
+    // 8. If rule’s associated font-weight descriptor is present, a single SPACE (U+0020),
     //     followed by the string "font-weight:", followed by a single SPACE (U+0020),
     //     followed by the result of performing serialize a <'font-weight'>,
     //     followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto font_weight = descriptors.descriptor(DescriptorID::FontWeight)) {
+        if (!is_empty)
+            builder.append(' ');
         builder.append(" font-weight: "sv);
         builder.append(font_weight->to_string(SerializationMode::Normal));
         builder.append(";"sv);
+        is_empty = false;
     }
 
-    // 11. If rule’s associated font-style descriptor is present, a single SPACE (U+0020),
+    // 9. If rule’s associated font-style descriptor is present, a single SPACE (U+0020),
     //     followed by the string "font-style:", followed by a single SPACE (U+0020),
     //     followed by the result of performing serialize a <'font-style'>,
     //     followed by the string ";", i.e., SEMICOLON (U+003B).
     if (auto font_style = descriptors.descriptor(DescriptorID::FontStyle)) {
+        if (!is_empty)
+            builder.append(' ');
         builder.append(" font-style: "sv);
         builder.append(font_style->to_string(SerializationMode::Normal));
         builder.append(";"sv);
+        is_empty = false;
     }
 
-    // 12. A single SPACE (U+0020), followed by the string "}", i.e., RIGHT CURLY BRACKET (U+007D).
+    // 10. A single SPACE (U+0020), followed by the string "}", i.e., RIGHT CURLY BRACKET (U+007D).
     builder.append(" }"sv);
 
     return MUST(builder.to_string());


### PR DESCRIPTION
## Issue 
When serializing CSS with missing `Font-Family` the current implementation would crash due to a `Null Pointer Dereference` on missing attribute

## Fix
Ensure presence of `Font-Family` is checked to avoid the occurrence of the `NPD` 

## Additional
Refactor comments to stay coherent with the current spec

Fixes: #6259 