### PR TITLE
Meta: Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ output/
 .venv/
 .venv*/
 venv*/
+.env
 
 # Gradle/AndroidStudio
 .gradle/


### PR DESCRIPTION
It is convenient to have a local .env file to store variables to avoid a long startup command like `CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ ./Meta/ladybird.py run`