### PR TITLE
LibWeb/CSS: Remove `PropertyID::Invalid`

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -820,8 +820,6 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
             return KeywordStyleValue::create(Keyword::Normal);
         return get_computed_value(property_id);
     }
-    case PropertyID::Invalid:
-        return KeywordStyleValue::create(Keyword::Invalid);
     case PropertyID::Custom:
         dbgln_if(LIBWEB_CSS_DEBUG, "Computed style for custom properties was requested (?)");
         return nullptr;

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -578,7 +578,7 @@ namespace Web {
 GC::Ref<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::Parser::ParsingParams const&, StringView, Optional<::URL::URL> location = {}, Vector<NonnullRefPtr<CSS::MediaQuery>> = {});
 CSS::Parser::Parser::PropertiesAndCustomProperties parse_css_property_declaration_block(CSS::Parser::ParsingParams const&, StringView);
 Vector<CSS::Descriptor> parse_css_descriptor_declaration_block(CSS::Parser::ParsingParams const&, CSS::AtRuleID, StringView);
-RefPtr<CSS::StyleValue const> parse_css_value(CSS::Parser::ParsingParams const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
+RefPtr<CSS::StyleValue const> parse_css_value(CSS::Parser::ParsingParams const&, StringView, CSS::PropertyID);
 RefPtr<CSS::StyleValue const> parse_css_descriptor(CSS::Parser::ParsingParams const&, CSS::AtRuleID, CSS::DescriptorID, StringView);
 Optional<CSS::SelectorList> parse_selector(CSS::Parser::ParsingParams const&, StringView);
 Optional<CSS::SelectorList> parse_selector_for_nested_style_rule(CSS::Parser::ParsingParams const&, StringView);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1676,15 +1676,13 @@ RefPtr<StyleValue const> Parser::parse_border_value(PropertyID property_id, Toke
     RefPtr<StyleValue const> border_color;
     RefPtr<StyleValue const> border_style;
 
-    auto color_property = PropertyID::Invalid;
-    auto style_property = PropertyID::Invalid;
-    auto width_property = PropertyID::Invalid;
+    auto color_property = PropertyID::BorderColor;
+    auto style_property = PropertyID::BorderStyle;
+    auto width_property = PropertyID::BorderWidth;
 
     switch (property_id) {
     case PropertyID::Border:
-        color_property = PropertyID::BorderColor;
-        style_property = PropertyID::BorderStyle;
-        width_property = PropertyID::BorderWidth;
+        // Already set above.
         break;
     case PropertyID::BorderBlock:
         color_property = PropertyID::BorderBlockColor;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -172,7 +172,6 @@ ErrorOr<void> generate_header_file(JsonObject& properties, JsonObject& logical_p
 namespace Web::CSS {
 
 enum class PropertyID : @property_id_underlying_type@ {
-    Invalid,
     Custom,
 )~~~");
 

--- a/Tests/LibWeb/TestCSSInheritedProperty.cpp
+++ b/Tests/LibWeb/TestCSSInheritedProperty.cpp
@@ -22,7 +22,6 @@ TEST_CASE(is_inherited_property_test)
     EXPECT(!CSS::is_inherited_property(CSS::PropertyID::Border));
 
     // Edge cases
-    EXPECT(!CSS::is_inherited_property(CSS::PropertyID::Invalid));
     EXPECT(!CSS::is_inherited_property(CSS::PropertyID::All));
 }
 


### PR DESCRIPTION
We were down to only a couple of uses, none of which need it. So now if we have a PropertyID, we know it's a real thing.

There's probably a minor memory benefit to this, because I think we still reserved space for `PropertyID::Invalid`'s value in some places, but the main benefit is just not having this invalid state representable. `Optional<PropertyID>` can be used if we ever do need that.