### PR TITLE
LibWeb+LibXML: Make `Listener::set_source(ByteString)` fallible

### DIFF
--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -62,9 +62,10 @@ XMLDocumentBuilder::XMLDocumentBuilder(DOM::Document& document, XMLScriptingSupp
     m_namespace_stack.append({ {}, 1 });
 }
 
-void XMLDocumentBuilder::set_source(ByteString source)
+ErrorOr<void> XMLDocumentBuilder::set_source(ByteString source)
 {
-    m_document->set_source(MUST(String::from_byte_string(source)));
+    m_document->set_source(TRY(String::from_byte_string(source)));
+    return {};
 }
 
 void XMLDocumentBuilder::set_doctype(XML::Doctype doctype)

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -30,7 +30,7 @@ public:
     bool has_error() const { return m_has_error; }
 
 private:
-    virtual void set_source(ByteString) override;
+    virtual ErrorOr<void> set_source(ByteString) override;
     virtual void set_doctype(XML::Doctype) override;
     virtual void element_start(XML::Name const& name, OrderedHashMap<XML::Name, ByteString> const& attributes) override;
     virtual void element_end(XML::Name const& name) override;

--- a/Libraries/LibXML/Parser/Parser.h
+++ b/Libraries/LibXML/Parser/Parser.h
@@ -34,7 +34,7 @@ struct ParseError {
 struct Listener {
     virtual ~Listener() { }
 
-    virtual void set_source(ByteString) { }
+    virtual ErrorOr<void> set_source(ByteString) { return {}; }
     virtual void set_doctype(XML::Doctype) { }
     virtual void document_start() { }
     virtual void document_end() { }

--- a/Tests/LibWeb/Text/data/invalid_utf8_corrupt.svg
+++ b/Tests/LibWeb/Text/data/invalid_utf8_corrupt.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">À¯õ</svg>

--- a/Tests/LibWeb/Text/expected/corrupt-svg-favicon.txt
+++ b/Tests/LibWeb/Text/expected/corrupt-svg-favicon.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/corrupt-svg-favicon.html
+++ b/Tests/LibWeb/Text/input/corrupt-svg-favicon.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="icon" href="../data/invalid_utf8_corrupt.svg" type="image/svg+xml">
+</head>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        println("PASS (didn't crash)")
+    });
+</script>
+</html>


### PR DESCRIPTION
`set_source` takes a ByteString but the implementation might require a
specific encoding. Make it fallible so that we don't need to crash in
the case of invalid UTF-8 or similar.

The test includes a sequence of invalid UTF-8 bytes that crash the
browser without this change.

Related issue: #6279, related PR #6348