### PR TITLE
LibWeb: Remove unused fields from BrowsingContext

### DIFF
--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -297,10 +297,6 @@ void BrowsingContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_page);
     visitor.visit(m_window_proxy);
     visitor.visit(m_group);
-    visitor.visit(m_first_child);
-    visitor.visit(m_last_child);
-    visitor.visit(m_next_sibling);
-    visitor.visit(m_previous_sibling);
     visitor.visit(m_opener_browsing_context);
 }
 

--- a/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -116,11 +116,6 @@ private:
 
     // https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group
     GC::Ptr<BrowsingContextGroup> m_group;
-
-    GC::Ptr<BrowsingContext> m_first_child;
-    GC::Ptr<BrowsingContext> m_last_child;
-    GC::Ptr<BrowsingContext> m_next_sibling;
-    GC::Ptr<BrowsingContext> m_previous_sibling;
 };
 
 URL::Origin determine_the_origin(Optional<URL::URL const&>, SandboxingFlagSet, Optional<URL::Origin> source_origin);


### PR DESCRIPTION
These were introduced in 83c5ff57d8dfaad4652cd94df834b08d6cdc3db3, but we stopped using them. No functional changes.