### PR TITLE
LibWeb/CSS: Stop rejecting declarations with vendor-prefixed keywords

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -396,10 +396,8 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_css_value(Pr
 {
     auto context_guard = push_temporary_value_parsing_context(property_id);
 
-    // FIXME: Stop removing whitespace here. It's less helpful than it seems.
     Vector<ComponentValue> component_values;
     SubstitutionFunctionsPresence substitution_presence;
-    bool const property_accepts_custom_ident = property_accepts_type(property_id, ValueType::CustomIdent);
 
     while (unprocessed_tokens.has_next_token()) {
         auto const& token = unprocessed_tokens.consume_a_token();
@@ -409,13 +407,9 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_css_value(Pr
             return ParseError::SyntaxError;
         }
 
-        if (property_id != PropertyID::Custom) {
-            if (token.is(Token::Type::Whitespace))
-                continue;
-
-            if (!property_accepts_custom_ident && token.is(Token::Type::Ident) && has_ignored_vendor_prefix(token.token().ident()))
-                return ParseError::IncludesIgnoredVendorPrefix;
-        }
+        // FIXME: Stop removing whitespace here. It's less helpful than it seems.
+        if (property_id != PropertyID::Custom && token.is(Token::Type::Whitespace))
+            continue;
 
         if (token.is_function())
             token.function().contains_arbitrary_substitution_function(substitution_presence);

--- a/Tests/LibWeb/Ref/expected/css/vendor-prefixed-font-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/vendor-prefixed-font-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+    div {
+        font: 5px sans-serif;
+    }
+</style>
+<div>this text should be quite small</div>

--- a/Tests/LibWeb/Ref/input/css/vendor-prefixed-font.html
+++ b/Tests/LibWeb/Ref/input/css/vendor-prefixed-font.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/vendor-prefixed-font-ref.html" />
+<style>
+    div {
+        font: 5px -apple-flibbertigibbet, sans-serif;
+    }
+</style>
+<div>this text should be quite small</div>


### PR DESCRIPTION
property_accepts_type() only looks at the property itself, not any longhands it might have, so we thought that `font` didn't accept `<custom-ident>`s, and seeing "-apple-..." makes us throw out the declaration even though it's valid as a font name.

We'll reject these like any other unrecognized value if it's somewhere that's not supported, so this was really just an optimization for a rare edge case, and removing the check doesn't have any observable effect except fixing this bug and any similar cases.

Changing property_accepts_type() to look at longhands is not straightforward, as not all longhand values are valid in the shorthand.

----

I am *really* hoping there isn't a font in the wild named `-apple-flibbertigibbet`.