### PR TITLE
LibWeb/CSS: Remove outdated use of PropertyID::Invalid

### DIFF
--- a/Libraries/LibWeb/CSS/PropertyNameAndID.h
+++ b/Libraries/LibWeb/CSS/PropertyNameAndID.h
@@ -30,7 +30,7 @@ public:
 
     static PropertyNameAndID from_id(PropertyID property_id)
     {
-        VERIFY(!first_is_one_of(property_id, PropertyID::Invalid, PropertyID::Custom));
+        VERIFY(property_id != PropertyID::Custom);
         return PropertyNameAndID({}, property_id);
     }
 


### PR DESCRIPTION
This doesn't exist any more, but did when I submitted the PropertyNameAndID PR. Oops!