### PR TITLE
LibJS: A couple stage 4 proposal and normative updates

### DIFF
--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1897,7 +1897,7 @@ ThrowCompletionOr<Value> perform_import_call(VM& vm, Value specifier, Value opti
     return promise_capability->promise();
 }
 
-// 14.5.2.1 GetOptionsObject ( options ), https://tc39.es/proposal-temporal/#sec-getoptionsobject
+// 7.3.36 GetOptionsObject ( options ), https://tc39.es/ecma262/#sec-getoptionsobject
 ThrowCompletionOr<GC::Ref<Object>> get_options_object(VM& vm, Value options)
 {
     auto& realm = *vm.current_realm();

--- a/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -123,13 +123,15 @@ ThrowCompletionOr<GC::Ref<Object>> ErrorConstructor::construct(FunctionObject& n
 JS_ENUMERATE_NATIVE_ERRORS
 #undef __JS_ENUMERATE
 
-// 20.5.2.1 Error.isError ( arg ), https://tc39.es/proposal-is-error/#sec-error.iserror
+// 20.5.2.1 Error.isError ( arg ), https://tc39.es/ecma262/#sec-error.iserror
 JS_DEFINE_NATIVE_FUNCTION(ErrorConstructor::is_error)
 {
     auto arg = vm.argument(0);
 
-    // 1. Return IsError(arg).
-    return Value(arg.is_error());
+    // 1. If arg is not an Object, return false.
+    // 2. If arg does not have an [[ErrorData]] internal slot, return false.
+    // 3. Return true.
+    return arg.is_object() && is<Error>(arg.as_object());
 }
 
 }

--- a/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Libraries/LibJS/Runtime/StringPrototype.h
@@ -18,6 +18,7 @@ struct CodePoint {
 };
 
 Optional<size_t> string_index_of(Utf16View const& string, Utf16View const& search_value, size_t from_index);
+Optional<size_t> string_last_index_of(Utf16View const& string, Utf16View const& search_value, size_t from_index);
 CodePoint code_point_at(Utf16View const& string, size_t position);
 static constexpr Utf8View whitespace_characters = Utf8View("\x09\x0A\x0B\x0C\x0D\x20\xC2\xA0\xE1\x9A\x80\xE2\x80\x80\xE2\x80\x81\xE2\x80\x82\xE2\x80\x83\xE2\x80\x84\xE2\x80\x85\xE2\x80\x86\xE2\x80\x87\xE2\x80\x88\xE2\x80\x89\xE2\x80\x8A\xE2\x80\xAF\xE2\x81\x9F\xE3\x80\x80\xE2\x80\xA8\xE2\x80\xA9\xEF\xBB\xBF"sv);
 ThrowCompletionOr<String> trim_string(VM&, Value string, TrimMode where);

--- a/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Libraries/LibJS/Runtime/Uint8Array.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -31,10 +31,10 @@ public:
     static void initialize(Realm&, Object& prototype);
 
 private:
-    JS_DECLARE_NATIVE_FUNCTION(to_base64);
-    JS_DECLARE_NATIVE_FUNCTION(to_hex);
     JS_DECLARE_NATIVE_FUNCTION(set_from_base64);
     JS_DECLARE_NATIVE_FUNCTION(set_from_hex);
+    JS_DECLARE_NATIVE_FUNCTION(to_base64);
+    JS_DECLARE_NATIVE_FUNCTION(to_hex);
 };
 
 enum class Alphabet {

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -260,15 +260,6 @@ Array& Value::as_array()
     return static_cast<Array&>(as_object());
 }
 
-// 20.5.8.2 IsError ( argument ), https://tc39.es/proposal-is-error/#sec-iserror
-bool Value::is_error() const
-{
-    // 1. If argument is not an Object, return false.
-    // 2. If argument has an [[ErrorData]] internal slot, return true.
-    // 3. Return false.
-    return is_object() && is<Error>(as_object());
-}
-
 // 7.2.3 IsCallable ( argument ), https://tc39.es/ecma262/#sec-iscallable
 bool Value::is_function() const
 {

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -110,7 +110,6 @@ public:
     ThrowCompletionOr<bool> is_array(VM&) const;
     bool is_function() const;
     bool is_constructor() const;
-    bool is_error() const;
     ThrowCompletionOr<bool> is_regexp(VM&) const;
 
     bool is_infinity() const

--- a/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.copyWithin.js
+++ b/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.copyWithin.js
@@ -133,4 +133,26 @@ describe("normal behavior", () => {
             expect(array).toEqual(new T([0n, 54n, 999n, 999n, 1000n, 0n]));
         });
     });
+
+    test("resizing during copyWithin", () => {
+        TYPED_ARRAYS.forEach(T => {
+            let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 4, {
+                maxByteLength: T.BYTES_PER_ELEMENT * 8,
+            });
+
+            let typedArray = new T(arrayBuffer);
+            typedArray[0] = 1;
+            typedArray[1] = 2;
+            typedArray[2] = 3;
+            typedArray[3] = 4;
+
+            const resize = () => {
+                arrayBuffer.resize(3 * T.BYTES_PER_ELEMENT);
+                return 2;
+            };
+
+            typedArray.copyWithin({ valueOf: resize }, 1);
+            expect(typedArray).toEqual(new T([1, 2, 2]));
+        });
+    });
 });


### PR DESCRIPTION
A few proposals reached stage 4 and were merged to ECMA-262 with some editorial changes. There have also been a couple of normative spec changes.

test262 diff:
```
Diff Tests:
    test/built-ins/TypedArray/prototype/copyWithin/coerced-target-start-end-shrink.js   ❌ -> ✅
    test/built-ins/TypedArray/prototype/copyWithin/coerced-values-end.js                ❌ -> ✅
    test/built-ins/TypedArray/prototype/copyWithin/non-negative-target-start-and-end.js ❌ -> ✅
```
(which brings us back to 100% `test/built-ins/TypedArray` passing)