### PR TITLE
LibWeb: Absolutization simplifications

### DIFF
--- a/Libraries/LibWeb/CSS/CalculatedOr.h
+++ b/Libraries/LibWeb/CSS/CalculatedOr.h
@@ -79,20 +79,6 @@ public:
             });
     }
 
-    Self absolutized(ComputationContext const& computation_context) const
-    {
-        return m_value.visit(
-            [&](T const& value) {
-                if constexpr (IsSame<T, Length>)
-                    return Self { value.absolutized(computation_context.length_resolution_context.viewport_rect, computation_context.length_resolution_context.font_metrics, computation_context.length_resolution_context.root_font_metrics) };
-                else
-                    return *static_cast<Self const*>(this);
-            },
-            [&](NonnullRefPtr<CalculatedStyleValue const> const& value) {
-                return Self { value->absolutized(computation_context)->as_calculated() };
-            });
-    }
-
     bool operator==(CalculatedOr<Self, T> const& other) const
     {
         if (is_calculated() || other.is_calculated())

--- a/Libraries/LibWeb/CSS/CalculatedOr.h
+++ b/Libraries/LibWeb/CSS/CalculatedOr.h
@@ -79,17 +79,17 @@ public:
             });
     }
 
-    Self absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+    Self absolutized(ComputationContext const& computation_context) const
     {
         return m_value.visit(
             [&](T const& value) {
                 if constexpr (IsSame<T, Length>)
-                    return Self { value.absolutized(viewport_rect, font_metrics, root_font_metrics) };
+                    return Self { value.absolutized(computation_context.length_resolution_context.viewport_rect, computation_context.length_resolution_context.font_metrics, computation_context.length_resolution_context.root_font_metrics) };
                 else
                     return *static_cast<Self const*>(this);
             },
             [&](NonnullRefPtr<CalculatedStyleValue const> const& value) {
-                return Self { value->absolutized(viewport_rect, font_metrics, root_font_metrics)->as_calculated() };
+                return Self { value->absolutized(computation_context)->as_calculated() };
             });
     }
 

--- a/Libraries/LibWeb/CSS/CalculationResolutionContext.h
+++ b/Libraries/LibWeb/CSS/CalculationResolutionContext.h
@@ -9,13 +9,24 @@
 #include <LibWeb/CSS/Angle.h>
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/StyleValues/ComputationContext.h>
 #include <LibWeb/CSS/Time.h>
 
 namespace Web::CSS {
 
 struct CalculationResolutionContext {
-    Variant<Empty, Angle, Frequency, Length, Time> percentage_basis {};
+    using PercentageBasis = Variant<Empty, Angle, Frequency, Length, Time>;
+
+    PercentageBasis percentage_basis {};
     Optional<Length::ResolutionContext> length_resolution_context;
+
+    static CalculationResolutionContext from_computation_context(ComputationContext const& computation_context, PercentageBasis percentage_basis = {})
+    {
+        return {
+            .percentage_basis = percentage_basis,
+            .length_resolution_context = computation_context.length_resolution_context,
+        };
+    }
 };
 
 }

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -179,16 +179,7 @@ Variant<LengthPercentage, NormalGap> ComputedProperties::gap_value(PropertyID id
         return NormalGap {};
     }
 
-    if (value.is_calculated())
-        return LengthPercentage { value.as_calculated() };
-
-    if (value.is_percentage())
-        return LengthPercentage { value.as_percentage().percentage() };
-
-    if (value.is_length())
-        return LengthPercentage { value.as_length().length() };
-
-    VERIFY_NOT_REACHED();
+    return LengthPercentage::from_style_value(value);
 }
 
 Size ComputedProperties::size_value(PropertyID id) const
@@ -674,17 +665,6 @@ Optional<Transformation> ComputedProperties::scale() const
     return value.as_transformation().to_transformation();
 }
 
-static Optional<LengthPercentage> length_percentage_for_style_value(StyleValue const& value)
-{
-    if (value.is_length())
-        return value.as_length().length();
-    if (value.is_percentage())
-        return value.as_percentage().percentage();
-    if (value.is_calculated())
-        return LengthPercentage { value.as_calculated() };
-    return {};
-}
-
 TransformBox ComputedProperties::transform_box() const
 {
     auto const& value = property(PropertyID::TransformBox);
@@ -693,7 +673,7 @@ TransformBox ComputedProperties::transform_box() const
 
 TransformOrigin ComputedProperties::transform_origin() const
 {
-    auto length_percentage_with_keywords_resolved = [](StyleValue const& value) -> Optional<LengthPercentage> {
+    auto length_percentage_with_keywords_resolved = [](StyleValue const& value) -> LengthPercentage {
         if (value.is_keyword()) {
             auto keyword = value.to_keyword();
             if (keyword == Keyword::Left || keyword == Keyword::Top)
@@ -705,7 +685,7 @@ TransformOrigin ComputedProperties::transform_origin() const
 
             VERIFY_NOT_REACHED();
         }
-        return length_percentage_for_style_value(value);
+        return LengthPercentage::from_style_value(value);
     };
 
     auto const& value = property(PropertyID::TransformOrigin);
@@ -715,10 +695,8 @@ TransformOrigin ComputedProperties::transform_origin() const
 
     auto x_value = length_percentage_with_keywords_resolved(list.values()[0]);
     auto y_value = length_percentage_with_keywords_resolved(list.values()[1]);
-    auto z_value = length_percentage_for_style_value(list.values()[2]);
-    if (!x_value.has_value() || !y_value.has_value() || !z_value.has_value())
-        return {};
-    return { x_value.value(), y_value.value(), z_value.value() };
+    auto z_value = LengthPercentage::from_style_value(list.values()[2]);
+    return { x_value, y_value, z_value };
 }
 
 Optional<Color> ComputedProperties::accent_color(Layout::NodeWithStyle const& node) const
@@ -1222,13 +1200,8 @@ TextDecorationThickness ComputedProperties::text_decoration_thickness() const
             VERIFY_NOT_REACHED();
         }
     }
-    if (value.is_length())
-        return TextDecorationThickness { LengthPercentage { value.as_length().length() } };
-    if (value.is_percentage())
-        return TextDecorationThickness { LengthPercentage { value.as_percentage().percentage() } };
-    if (value.is_calculated())
-        return TextDecorationThickness { LengthPercentage { value.as_calculated() } };
-    VERIFY_NOT_REACHED();
+
+    return TextDecorationThickness { LengthPercentage::from_style_value(value) };
 }
 
 TextTransform ComputedProperties::text_transform() const
@@ -1356,16 +1329,7 @@ Variant<VerticalAlign, LengthPercentage> ComputedProperties::vertical_align() co
     if (value.is_keyword())
         return keyword_to_vertical_align(value.to_keyword()).release_value();
 
-    if (value.is_length())
-        return LengthPercentage(value.as_length().length());
-
-    if (value.is_percentage())
-        return LengthPercentage(value.as_percentage().percentage());
-
-    if (value.is_calculated())
-        return LengthPercentage { value.as_calculated() };
-
-    VERIFY_NOT_REACHED();
+    return LengthPercentage::from_style_value(value);
 }
 
 FontKerning ComputedProperties::font_kerning() const

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -1501,13 +1501,11 @@ static RefPtr<StyleValue const> interpolate_value_impl(DOM::Element& element, Ca
         auto const& to_horizontal_radius = to.as_border_radius().horizontal_radius();
         auto const& from_vertical_radius = from.as_border_radius().vertical_radius();
         auto const& to_vertical_radius = to.as_border_radius().vertical_radius();
-        auto const interpolated_horizontal_radius = interpolate_length_percentage(calculation_context, from_horizontal_radius, to_horizontal_radius, delta);
-        auto const interpolated_vertical_radius = interpolate_length_percentage(calculation_context, from_vertical_radius, to_vertical_radius, delta);
-        if (!interpolated_horizontal_radius.has_value() || !interpolated_vertical_radius.has_value())
+        auto interpolated_horizontal_radius = interpolate_value_impl(element, calculation_context, from_horizontal_radius, to_horizontal_radius, delta, allow_discrete);
+        auto interpolated_vertical_radius = interpolate_value_impl(element, calculation_context, from_vertical_radius, to_vertical_radius, delta, allow_discrete);
+        if (!interpolated_horizontal_radius || !interpolated_vertical_radius)
             return {};
-        return BorderRadiusStyleValue::create(
-            interpolated_horizontal_radius.value(),
-            interpolated_vertical_radius.value());
+        return BorderRadiusStyleValue::create(interpolated_horizontal_radius.release_nonnull(), interpolated_vertical_radius.release_nonnull());
     }
     case StyleValue::Type::Color: {
         ColorResolutionContext color_resolution_context {};
@@ -1730,18 +1728,6 @@ static T composite_raw_values(T underlying_raw_value, T animated_raw_value)
 
 RefPtr<StyleValue const> composite_value(StyleValue const& underlying_value, StyleValue const& animated_value, Bindings::CompositeOperation composite_operation)
 {
-    auto composite_length_percentage = [](auto const& underlying_length_percentage, auto const& animated_length_percentage) -> Optional<LengthPercentage> {
-        if (underlying_length_percentage.is_length() && animated_length_percentage.is_length()) {
-            auto result = composite_raw_values(underlying_length_percentage.length().raw_value(), animated_length_percentage.length().raw_value());
-            return Length { result, underlying_length_percentage.length().unit() };
-        }
-        if (underlying_length_percentage.is_percentage() && animated_length_percentage.is_percentage()) {
-            auto result = composite_raw_values(underlying_length_percentage.percentage().value(), animated_length_percentage.percentage().value());
-            return Percentage { result };
-        }
-        return {};
-    };
-
     auto composite_dimension_value = [](StyleValue const& underlying_value, StyleValue const& animated_value) -> Optional<double> {
         auto const& underlying_dimension = as<DimensionStyleValue>(underlying_value);
         auto const& animated_dimension = as<DimensionStyleValue>(animated_value);
@@ -1777,11 +1763,11 @@ RefPtr<StyleValue const> composite_value(StyleValue const& underlying_value, Sty
         return BorderImageSliceStyleValue::create(composited_top.release_nonnull(), composited_right.release_nonnull(), composited_bottom.release_nonnull(), composited_left.release_nonnull(), underlying_border_image_slice_value.fill());
     }
     case StyleValue::Type::BorderRadius: {
-        auto composited_horizontal_radius = composite_length_percentage(underlying_value.as_border_radius().horizontal_radius(), animated_value.as_border_radius().horizontal_radius());
-        auto composited_vertical_radius = composite_length_percentage(underlying_value.as_border_radius().vertical_radius(), animated_value.as_border_radius().vertical_radius());
-        if (!composited_horizontal_radius.has_value() || !composited_vertical_radius.has_value())
+        auto composited_horizontal_radius = composite_value(underlying_value.as_border_radius().horizontal_radius(), animated_value.as_border_radius().horizontal_radius(), composite_operation);
+        auto composited_vertical_radius = composite_value(underlying_value.as_border_radius().vertical_radius(), animated_value.as_border_radius().vertical_radius(), composite_operation);
+        if (!composited_horizontal_radius || !composited_vertical_radius)
             return {};
-        return BorderRadiusStyleValue::create(*composited_horizontal_radius, *composited_vertical_radius);
+        return BorderRadiusStyleValue::create(composited_horizontal_radius.release_nonnull(), composited_vertical_radius.release_nonnull());
     }
     case StyleValue::Type::Integer: {
         auto result = composite_raw_values(underlying_value.as_integer().integer(), animated_value.as_integer().integer());

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -1364,9 +1364,9 @@ static RefPtr<StyleValue const> interpolate_value_impl(DOM::Element& element, Ca
         return AngleStyleValue::create(Angle::make_degrees(interpolated_value));
     }
     case StyleValue::Type::BackgroundSize: {
-        auto interpolated_x = interpolate_length_percentage_or_auto(calculation_context, from.as_background_size().size_x(), to.as_background_size().size_x(), delta);
-        auto interpolated_y = interpolate_length_percentage_or_auto(calculation_context, from.as_background_size().size_y(), to.as_background_size().size_y(), delta);
-        if (!interpolated_x.has_value() || !interpolated_y.has_value())
+        auto interpolated_x = interpolate_value(element, calculation_context, from.as_background_size().size_x(), to.as_background_size().size_x(), delta, allow_discrete);
+        auto interpolated_y = interpolate_value(element, calculation_context, from.as_background_size().size_y(), to.as_background_size().size_y(), delta, allow_discrete);
+        if (!interpolated_x || !interpolated_y)
             return {};
 
         return BackgroundSizeStyleValue::create(*interpolated_x, *interpolated_y);

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -1330,13 +1330,7 @@ Optional<LengthPercentage> interpolate_length_percentage(CalculationContext cons
     auto interpolated_style_value = interpolate_mixed_value(calculation_context, from_style_value, to_style_value, delta);
     if (!interpolated_style_value)
         return {};
-    if (interpolated_style_value->is_length())
-        return interpolated_style_value->as_length().length();
-    if (interpolated_style_value->is_percentage())
-        return interpolated_style_value->as_percentage().percentage();
-    if (interpolated_style_value->is_calculated())
-        return LengthPercentage { interpolated_style_value->as_calculated() };
-    VERIFY_NOT_REACHED();
+    return LengthPercentage::from_style_value(*interpolated_style_value);
 }
 
 Optional<LengthPercentageOrAuto> interpolate_length_percentage_or_auto(CalculationContext const& calculation_context, LengthPercentageOrAuto const& from, LengthPercentageOrAuto const& to, float delta)
@@ -1353,15 +1347,7 @@ Optional<LengthPercentageOrAuto> interpolate_length_percentage_or_auto(Calculati
     auto interpolated_style_value = interpolate_mixed_value(calculation_context, from_style_value, to_style_value, delta);
     if (!interpolated_style_value)
         return {};
-    if (interpolated_style_value->to_keyword() == Keyword::Auto)
-        return LengthPercentageOrAuto::make_auto();
-    if (interpolated_style_value->is_length())
-        return interpolated_style_value->as_length().length();
-    if (interpolated_style_value->is_percentage())
-        return interpolated_style_value->as_percentage().percentage();
-    if (interpolated_style_value->is_calculated())
-        return LengthPercentage { interpolated_style_value->as_calculated() };
-    VERIFY_NOT_REACHED();
+    return LengthPercentageOrAuto::from_style_value(*interpolated_style_value);
 }
 
 static RefPtr<StyleValue const> interpolate_value_impl(DOM::Element& element, CalculationContext const& calculation_context, StyleValue const& from, StyleValue const& to, float delta, AllowDiscrete allow_discrete)

--- a/Libraries/LibWeb/CSS/ParsedFontFace.cpp
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.cpp
@@ -76,6 +76,10 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
     if (auto value = descriptors.descriptor_or_initial_value(DescriptorID::FontFamily))
         font_family = extract_font_name(*value);
 
+    ComputationContext computation_context {
+        .length_resolution_context = Length::ResolutionContext::for_window(*descriptors.parent_rule()->parent_style_sheet()->owning_document()->window())
+    };
+
     Optional<int> weight;
     if (auto value = descriptors.descriptor_or_initial_value(DescriptorID::FontWeight)) {
         // https://drafts.csswg.org/css-fonts-4/#font-prop-desc
@@ -86,7 +90,7 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
             weight = 400;
         else
             // NOTE: The value we pass here for inherited_font_weight is irrelevant as relative keywords (lighter, bolder) should be disallowed at parse time
-            weight = StyleComputer::compute_font_weight(*value, 0, Length::ResolutionContext::for_window(*descriptors.parent_rule()->parent_style_sheet()->owning_document()->window()))->as_number().number();
+            weight = StyleComputer::compute_font_weight(*value, 0, computation_context)->as_number().number();
     }
 
     Optional<int> slope;
@@ -98,7 +102,7 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
         if (value->to_keyword() == Keyword::Auto)
             slope = 0;
         else
-            slope = StyleComputer::compute_font_style(*value, Length::ResolutionContext::for_window(*descriptors.parent_rule()->parent_style_sheet()->owning_document()->window()))->as_font_style().to_font_slope();
+            slope = StyleComputer::compute_font_style(*value, computation_context)->as_font_style().to_font_slope();
     }
 
     Optional<int> width;
@@ -110,7 +114,7 @@ ParsedFontFace ParsedFontFace::from_descriptors(CSSFontFaceDescriptors const& de
         if (value->to_keyword() == Keyword::Auto)
             width = 100;
         else
-            width = StyleComputer::compute_font_width(*value, Length::ResolutionContext::for_window(*descriptors.parent_rule()->parent_style_sheet()->owning_document()->window()))->as_percentage().raw_value();
+            width = StyleComputer::compute_font_width(*value, computation_context)->as_percentage().raw_value();
     }
 
     Vector<Source> sources;

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -147,7 +147,7 @@ public:
 
     NonnullRefPtr<StyleValue const> parse_with_a_syntax(Vector<ComponentValue> const& input, SyntaxNode const& syntax, Optional<DOM::AbstractElement> const& element = {});
 
-    RefPtr<StyleValue const> parse_calculated_value(ComponentValue const&);
+    RefPtr<CalculatedStyleValue const> parse_calculated_value(ComponentValue const&);
 
 private:
     Parser(ParsingParams const&, Vector<Token>);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1934,20 +1934,20 @@ RefPtr<StyleValue const> Parser::parse_border_radius_value(TokenStream<Component
 {
     if (tokens.remaining_token_count() == 2) {
         auto transaction = tokens.begin_transaction();
-        auto horizontal = parse_length_percentage(tokens);
-        auto vertical = parse_length_percentage(tokens);
-        if (horizontal.has_value() && vertical.has_value()) {
+        auto horizontal = parse_length_percentage_value(tokens);
+        auto vertical = parse_length_percentage_value(tokens);
+        if (horizontal && vertical) {
             transaction.commit();
-            return BorderRadiusStyleValue::create(horizontal.release_value(), vertical.release_value());
+            return BorderRadiusStyleValue::create(horizontal.release_nonnull(), vertical.release_nonnull());
         }
     }
 
     if (tokens.remaining_token_count() == 1) {
         auto transaction = tokens.begin_transaction();
-        auto radius = parse_length_percentage(tokens);
-        if (radius.has_value()) {
+        auto radius = parse_length_percentage_value(tokens);
+        if (radius) {
             transaction.commit();
-            return BorderRadiusStyleValue::create(radius.value(), radius.value());
+            return BorderRadiusStyleValue::create(*radius, *radius);
         }
     }
 
@@ -1956,8 +1956,8 @@ RefPtr<StyleValue const> Parser::parse_border_radius_value(TokenStream<Component
 
 RefPtr<StyleValue const> Parser::parse_border_radius_shorthand_value(TokenStream<ComponentValue>& tokens)
 {
-    auto top_left = [&](Vector<LengthPercentage>& radii) { return radii[0]; };
-    auto top_right = [&](Vector<LengthPercentage>& radii) {
+    auto top_left = [&](StyleValueVector& radii) { return radii[0]; };
+    auto top_right = [&](StyleValueVector& radii) {
         switch (radii.size()) {
         case 4:
         case 3:
@@ -1969,7 +1969,7 @@ RefPtr<StyleValue const> Parser::parse_border_radius_shorthand_value(TokenStream
             VERIFY_NOT_REACHED();
         }
     };
-    auto bottom_right = [&](Vector<LengthPercentage>& radii) {
+    auto bottom_right = [&](StyleValueVector& radii) {
         switch (radii.size()) {
         case 4:
         case 3:
@@ -1981,7 +1981,7 @@ RefPtr<StyleValue const> Parser::parse_border_radius_shorthand_value(TokenStream
             VERIFY_NOT_REACHED();
         }
     };
-    auto bottom_left = [&](Vector<LengthPercentage>& radii) {
+    auto bottom_left = [&](StyleValueVector& radii) {
         switch (radii.size()) {
         case 4:
             return radii[3];
@@ -1995,8 +1995,8 @@ RefPtr<StyleValue const> Parser::parse_border_radius_shorthand_value(TokenStream
         }
     };
 
-    Vector<LengthPercentage> horizontal_radii;
-    Vector<LengthPercentage> vertical_radii;
+    StyleValueVector horizontal_radii;
+    StyleValueVector vertical_radii;
     bool reading_vertical = false;
     auto transaction = tokens.begin_transaction();
 
@@ -2010,17 +2010,17 @@ RefPtr<StyleValue const> Parser::parse_border_radius_shorthand_value(TokenStream
             continue;
         }
 
-        auto maybe_dimension = parse_length_percentage(tokens);
-        if (!maybe_dimension.has_value())
+        auto maybe_dimension = parse_length_percentage_value(tokens);
+        if (!maybe_dimension)
             return nullptr;
-        if (maybe_dimension->is_length() && !property_accepts_length(PropertyID::BorderRadius, maybe_dimension->length()))
+        if (maybe_dimension->is_length() && !property_accepts_length(PropertyID::BorderRadius, maybe_dimension->as_length().length()))
             return nullptr;
-        if (maybe_dimension->is_percentage() && !property_accepts_percentage(PropertyID::BorderRadius, maybe_dimension->percentage()))
+        if (maybe_dimension->is_percentage() && !property_accepts_percentage(PropertyID::BorderRadius, maybe_dimension->as_percentage().percentage()))
             return nullptr;
         if (reading_vertical) {
-            vertical_radii.append(maybe_dimension.release_value());
+            vertical_radii.append(maybe_dimension.release_nonnull());
         } else {
-            horizontal_radii.append(maybe_dimension.release_value());
+            horizontal_radii.append(maybe_dimension.release_nonnull());
         }
     }
 

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1161,14 +1161,14 @@ RefPtr<StyleValue const> Parser::parse_cursor_value(TokenStream<ComponentValue>&
 
             if (part_tokens.has_next_token()) {
                 // <number>{2}, which are the x and y coordinates of the hotspot
-                auto x = parse_number(part_tokens);
+                auto x = parse_number_value(part_tokens);
                 part_tokens.discard_whitespace();
-                auto y = parse_number(part_tokens);
+                auto y = parse_number_value(part_tokens);
                 part_tokens.discard_whitespace();
-                if (!x.has_value() || !y.has_value() || part_tokens.has_next_token())
+                if (!x || !y || part_tokens.has_next_token())
                     return nullptr;
 
-                cursors.append(CursorStyleValue::create(image_value.release_nonnull(), x.release_value(), y.release_value()));
+                cursors.append(CursorStyleValue::create(image_value.release_nonnull(), x, y));
                 continue;
             }
 

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -778,9 +778,8 @@ RefPtr<StyleValue const> Parser::parse_integer_value(TokenStream<ComponentValue>
         tokens.discard_a_token(); // integer
         return IntegerStyleValue::create(peek_token.token().number().integer_value());
     }
-    if (auto calc = parse_calculated_value(peek_token); calc
-        && (calc->is_integer() || (calc->is_calculated() && calc->as_calculated().resolves_to_number()))) {
 
+    if (auto calc = parse_calculated_value(peek_token); calc && calc->as_calculated().resolves_to_number()) {
         tokens.discard_a_token(); // calc
         return calc;
     }
@@ -795,9 +794,8 @@ RefPtr<StyleValue const> Parser::parse_number_value(TokenStream<ComponentValue>&
         tokens.discard_a_token(); // number
         return NumberStyleValue::create(peek_token.token().number().value());
     }
-    if (auto calc = parse_calculated_value(peek_token); calc
-        && (calc->is_number() || (calc->is_calculated() && calc->as_calculated().resolves_to_number()))) {
 
+    if (auto calc = parse_calculated_value(peek_token); calc && calc->as_calculated().resolves_to_number()) {
         tokens.discard_a_token(); // calc
         return calc;
     }
@@ -838,9 +836,8 @@ RefPtr<StyleValue const> Parser::parse_percentage_value(TokenStream<ComponentVal
         tokens.discard_a_token(); // percentage
         return PercentageStyleValue::create(Percentage(peek_token.token().percentage()));
     }
-    if (auto calc = parse_calculated_value(peek_token); calc
-        && (calc->is_percentage() || (calc->is_calculated() && calc->as_calculated().resolves_to_percentage()))) {
 
+    if (auto calc = parse_calculated_value(peek_token); calc && calc->as_calculated().resolves_to_percentage()) {
         tokens.discard_a_token(); // calc
         return calc;
     }
@@ -1045,9 +1042,7 @@ RefPtr<StyleValue const> Parser::parse_angle_value(TokenStream<ComponentValue>& 
     }
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_angle() || (calc->is_calculated() && calc->as_calculated().resolves_to_angle()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_angle()) {
         transaction.commit();
         return calc;
     }
@@ -1079,9 +1074,7 @@ RefPtr<StyleValue const> Parser::parse_angle_percentage_value(TokenStream<Compon
     }
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_angle() || calc->is_percentage() || (calc->is_calculated() && calc->as_calculated().resolves_to_angle_percentage()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_angle_percentage()) {
         transaction.commit();
         return calc;
     }
@@ -1101,9 +1094,7 @@ RefPtr<StyleValue const> Parser::parse_flex_value(TokenStream<ComponentValue>& t
     }
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_flex() || (calc->is_calculated() && calc->as_calculated().resolves_to_flex()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_flex()) {
         transaction.commit();
         return calc;
     }
@@ -1123,9 +1114,7 @@ RefPtr<StyleValue const> Parser::parse_frequency_value(TokenStream<ComponentValu
     }
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_frequency() || (calc->is_calculated() && calc->as_calculated().resolves_to_frequency()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_frequency()) {
         transaction.commit();
         return calc;
     }
@@ -1148,9 +1137,7 @@ RefPtr<StyleValue const> Parser::parse_frequency_percentage_value(TokenStream<Co
         return PercentageStyleValue::create(Percentage { tokens.consume_a_token().token().percentage() });
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_frequency() || calc->is_percentage() || (calc->is_calculated() && calc->as_calculated().resolves_to_frequency_percentage()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_frequency_percentage()) {
         transaction.commit();
         return calc;
     }
@@ -1195,9 +1182,7 @@ RefPtr<StyleValue const> Parser::parse_length_value(TokenStream<ComponentValue>&
         return parse_anchor_size(tokens);
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_length() || (calc->is_calculated() && calc->as_calculated().resolves_to_length()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_length()) {
         transaction.commit();
         return calc;
     }
@@ -1245,9 +1230,7 @@ RefPtr<StyleValue const> Parser::parse_length_percentage_value(TokenStream<Compo
         return parse_anchor_size(tokens);
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_length() || calc->is_percentage() || (calc->is_calculated() && calc->as_calculated().resolves_to_length_percentage()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_length_percentage()) {
         transaction.commit();
         return calc;
     }
@@ -1272,9 +1255,7 @@ RefPtr<StyleValue const> Parser::parse_resolution_value(TokenStream<ComponentVal
     }
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_resolution() || (calc->is_calculated() && calc->as_calculated().resolves_to_resolution()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_resolution()) {
         transaction.commit();
         return calc;
     }
@@ -1294,9 +1275,7 @@ RefPtr<StyleValue const> Parser::parse_time_value(TokenStream<ComponentValue>& t
     }
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_time() || (calc->is_calculated() && calc->as_calculated().resolves_to_time()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_time()) {
         transaction.commit();
         return calc;
     }
@@ -1319,9 +1298,7 @@ RefPtr<StyleValue const> Parser::parse_time_percentage_value(TokenStream<Compone
         return PercentageStyleValue::create(Percentage { tokens.consume_a_token().token().percentage() });
 
     auto transaction = tokens.begin_transaction();
-    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc
-        && (calc->is_time() || calc->is_percentage() || (calc->is_calculated() && calc->as_calculated().resolves_to_time_percentage()))) {
-
+    if (auto calc = parse_calculated_value(tokens.consume_a_token()); calc && calc->as_calculated().resolves_to_time_percentage()) {
         transaction.commit();
         return calc;
     }
@@ -4060,7 +4037,7 @@ RefPtr<GridTrackPlacementStyleValue const> Parser::parse_grid_track_placement(To
     return nullptr;
 }
 
-RefPtr<StyleValue const> Parser::parse_calculated_value(ComponentValue const& component_value)
+RefPtr<CalculatedStyleValue const> Parser::parse_calculated_value(ComponentValue const& component_value)
 {
     if (!component_value.is_function())
         return nullptr;

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -141,18 +141,18 @@ public:
         return (m_value.template get<T>() == other.m_value.template get<T>());
     }
 
-    Self absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+    Self absolutized(ComputationContext const& computation_context) const
     {
         return m_value.visit(
             [&](T const& value) {
                 if constexpr (IsSame<T, Length>)
-                    return Self { value.absolutized(viewport_rect, font_metrics, root_font_metrics) };
+                    return Self { value.absolutized(computation_context.length_resolution_context.viewport_rect, computation_context.length_resolution_context.font_metrics, computation_context.length_resolution_context.root_font_metrics) };
                 else
                     return *static_cast<Self const*>(this);
             },
             [&](Percentage const&) { return *static_cast<Self const*>(this); },
             [&](NonnullRefPtr<CalculatedStyleValue const> const& value) {
-                return Self { value->absolutized(viewport_rect, font_metrics, root_font_metrics)->as_calculated() };
+                return Self { value->absolutized(computation_context)->as_calculated() };
             });
     }
 

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -14,6 +14,8 @@
 #include <LibWeb/CSS/Number.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
+#include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
+#include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
 #include <LibWeb/CSS/Time.h>
 
 namespace Web::CSS {
@@ -208,6 +210,18 @@ class LengthPercentage : public PercentageOr<Length, LengthPercentage> {
 public:
     using PercentageOr<Length, LengthPercentage>::PercentageOr;
 
+    static LengthPercentage from_style_value(NonnullRefPtr<StyleValue const> const& style_value)
+    {
+        if (style_value->is_percentage())
+            return LengthPercentage { style_value->as_percentage().percentage() };
+        if (style_value->is_length())
+            return LengthPercentage { style_value->as_length().length() };
+        if (style_value->is_calculated())
+            return LengthPercentage { style_value->as_calculated() };
+
+        VERIFY_NOT_REACHED();
+    }
+
     bool is_length() const { return is_t(); }
     Length const& length() const { return get_t(); }
 };
@@ -232,6 +246,14 @@ public:
     static LengthPercentageOrAuto make_auto()
     {
         return LengthPercentageOrAuto();
+    }
+
+    static LengthPercentageOrAuto from_style_value(NonnullRefPtr<StyleValue const> const& style_value)
+    {
+        if (style_value->has_auto())
+            return LengthPercentageOrAuto::make_auto();
+
+        return LengthPercentage::from_style_value(style_value);
     }
 
     bool is_auto() const { return !m_length_percentage.has_value(); }

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -20,7 +20,7 @@
 
 namespace Web::CSS {
 
-template<typename T, typename Self>
+template<typename T>
 class PercentageOr {
 public:
     PercentageOr(T t)
@@ -40,13 +40,13 @@ public:
 
     ~PercentageOr() = default;
 
-    PercentageOr<T, Self>& operator=(T t)
+    PercentageOr<T>& operator=(T t)
     {
         m_value = move(t);
         return *this;
     }
 
-    PercentageOr<T, Self>& operator=(Percentage percentage)
+    PercentageOr<T>& operator=(Percentage percentage)
     {
         m_value = move(percentage);
         return *this;
@@ -130,7 +130,7 @@ public:
         return m_value.template get<T>().to_string();
     }
 
-    bool operator==(PercentageOr<T, Self> const& other) const
+    bool operator==(PercentageOr<T> const& other) const
     {
         if (is_calculated() != other.is_calculated())
             return false;
@@ -143,21 +143,6 @@ public:
         return (m_value.template get<T>() == other.m_value.template get<T>());
     }
 
-    Self absolutized(ComputationContext const& computation_context) const
-    {
-        return m_value.visit(
-            [&](T const& value) {
-                if constexpr (IsSame<T, Length>)
-                    return Self { value.absolutized(computation_context.length_resolution_context.viewport_rect, computation_context.length_resolution_context.font_metrics, computation_context.length_resolution_context.root_font_metrics) };
-                else
-                    return *static_cast<Self const*>(this);
-            },
-            [&](Percentage const&) { return *static_cast<Self const*>(this); },
-            [&](NonnullRefPtr<CalculatedStyleValue const> const& value) {
-                return Self { value->absolutized(computation_context)->as_calculated() };
-            });
-    }
-
 protected:
     bool is_t() const { return m_value.template has<T>(); }
     T const& get_t() const { return m_value.template get<T>(); }
@@ -166,49 +151,49 @@ private:
     Variant<T, Percentage, NonnullRefPtr<CalculatedStyleValue const>> m_value;
 };
 
-template<typename T, typename Self>
-bool operator==(PercentageOr<T, Self> const& percentage_or, T const& t)
+template<typename T>
+bool operator==(PercentageOr<T> const& percentage_or, T const& t)
 {
-    return percentage_or == PercentageOr<T, Self> { t };
+    return percentage_or == PercentageOr<T> { t };
 }
 
-template<typename T, typename Self>
-bool operator==(T const& t, PercentageOr<T, Self> const& percentage_or)
+template<typename T>
+bool operator==(T const& t, PercentageOr<T> const& percentage_or)
 {
     return t == percentage_or;
 }
 
-template<typename T, typename Self>
-bool operator==(PercentageOr<T, Self> const& percentage_or, Percentage const& percentage)
+template<typename T>
+bool operator==(PercentageOr<T> const& percentage_or, Percentage const& percentage)
 {
-    return percentage_or == PercentageOr<T, Self> { percentage };
+    return percentage_or == PercentageOr<T> { percentage };
 }
 
-template<typename T, typename Self>
-bool operator==(Percentage const& percentage, PercentageOr<T, Self> const& percentage_or)
+template<typename T>
+bool operator==(Percentage const& percentage, PercentageOr<T> const& percentage_or)
 {
     return percentage == percentage_or;
 }
 
-class AnglePercentage : public PercentageOr<Angle, AnglePercentage> {
+class AnglePercentage : public PercentageOr<Angle> {
 public:
-    using PercentageOr<Angle, AnglePercentage>::PercentageOr;
+    using PercentageOr<Angle>::PercentageOr;
 
     bool is_angle() const { return is_t(); }
     Angle const& angle() const { return get_t(); }
 };
 
-class FrequencyPercentage : public PercentageOr<Frequency, FrequencyPercentage> {
+class FrequencyPercentage : public PercentageOr<Frequency> {
 public:
-    using PercentageOr<Frequency, FrequencyPercentage>::PercentageOr;
+    using PercentageOr<Frequency>::PercentageOr;
 
     bool is_frequency() const { return is_t(); }
     Frequency const& frequency() const { return get_t(); }
 };
 
-class LengthPercentage : public PercentageOr<Length, LengthPercentage> {
+class LengthPercentage : public PercentageOr<Length> {
 public:
-    using PercentageOr<Length, LengthPercentage>::PercentageOr;
+    using PercentageOr<Length>::PercentageOr;
 
     static LengthPercentage from_style_value(NonnullRefPtr<StyleValue const> const& style_value)
     {
@@ -297,17 +282,17 @@ private:
     Optional<LengthPercentage> m_length_percentage;
 };
 
-class TimePercentage : public PercentageOr<Time, TimePercentage> {
+class TimePercentage : public PercentageOr<Time> {
 public:
-    using PercentageOr<Time, TimePercentage>::PercentageOr;
+    using PercentageOr<Time>::PercentageOr;
 
     bool is_time() const { return is_t(); }
     Time const& time() const { return get_t(); }
 };
 
-struct NumberPercentage : public PercentageOr<Number, NumberPercentage> {
+struct NumberPercentage : public PercentageOr<Number> {
 public:
-    using PercentageOr<Number, NumberPercentage>::PercentageOr;
+    using PercentageOr<Number>::PercentageOr;
 
     bool is_number() const { return is_t(); }
     Number const& number() const { return get_t(); }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1069,7 +1069,9 @@ void StyleComputer::collect_animation_into(DOM::AbstractElement abstract_element
 
         auto const& inheritance_parent = abstract_element.element_to_inherit_style_from();
         auto inheritance_parent_has_computed_properties = inheritance_parent.has_value() && inheritance_parent->computed_properties();
-        auto parent_length_resolution_context = inheritance_parent_has_computed_properties ? Length::ResolutionContext::for_element(inheritance_parent.value()) : Length::ResolutionContext::for_window(*m_document->window());
+        ComputationContext font_computation_context {
+            .length_resolution_context = inheritance_parent_has_computed_properties ? Length::ResolutionContext::for_element(inheritance_parent.value()) : Length::ResolutionContext::for_window(*m_document->window())
+        };
 
         if (auto const& font_size_specified_value = specified_values.get(PropertyID::FontSize); font_size_specified_value.has_value()) {
             // FIXME: We need to respect the math-depth of this computed keyframe if it is present
@@ -1082,7 +1084,7 @@ void StyleComputer::collect_animation_into(DOM::AbstractElement abstract_element
                 computed_math_depth,
                 inherited_font_size,
                 inherited_math_depth,
-                parent_length_resolution_context);
+                font_computation_context);
 
             result.set(PropertyID::FontSize, font_size_in_computed_form);
         }
@@ -1093,32 +1095,36 @@ void StyleComputer::collect_animation_into(DOM::AbstractElement abstract_element
             auto const& font_weight_in_computed_form = compute_font_weight(
                 *font_weight_specified_value.value(),
                 inherited_font_weight,
-                parent_length_resolution_context);
+                font_computation_context);
 
             result.set(PropertyID::FontWeight, font_weight_in_computed_form);
         }
 
         if (auto const& font_width_specified_value = specified_values.get(PropertyID::FontWidth); font_width_specified_value.has_value())
-            result.set(PropertyID::FontWidth, compute_font_width(*font_width_specified_value.value(), parent_length_resolution_context));
+            result.set(PropertyID::FontWidth, compute_font_width(*font_width_specified_value.value(), font_computation_context));
 
         if (auto const& font_style_specified_value = specified_values.get(PropertyID::FontStyle); font_style_specified_value.has_value())
-            result.set(PropertyID::FontStyle, compute_font_style(*font_style_specified_value.value(), parent_length_resolution_context));
+            result.set(PropertyID::FontStyle, compute_font_style(*font_style_specified_value.value(), font_computation_context));
 
         if (auto const& line_height_specified_value = specified_values.get(PropertyID::LineHeight); line_height_specified_value.has_value()) {
-            Length::FontMetrics line_height_font_metrics {
-                computed_properties.font_size(),
-                computed_properties.first_available_computed_font().pixel_metrics(),
-                inheritance_parent_has_computed_properties ? inheritance_parent->computed_properties()->line_height() : InitialValues::line_height()
+            ComputationContext line_height_computation_context {
+                .length_resolution_context = {
+                    .viewport_rect = viewport_rect(),
+                    .font_metrics = {
+                        computed_properties.font_size(),
+                        computed_properties.first_available_computed_font().pixel_metrics(),
+                        inheritance_parent_has_computed_properties ? inheritance_parent->computed_properties()->line_height() : InitialValues::line_height() },
+                    .root_font_metrics = m_root_element_font_metrics }
             };
-            result.set(PropertyID::LineHeight, compute_line_height(*line_height_specified_value.value(), { .viewport_rect = viewport_rect(), .font_metrics = line_height_font_metrics, .root_font_metrics = m_root_element_font_metrics }));
+
+            result.set(PropertyID::LineHeight, compute_line_height(*line_height_specified_value.value(), line_height_computation_context));
         }
 
-        PropertyValueComputationContext property_value_computation_context {
+        ComputationContext computation_context {
             .length_resolution_context = {
                 .viewport_rect = viewport_rect(),
                 .font_metrics = font_metrics,
                 .root_font_metrics = m_root_element_font_metrics },
-            .device_pixels_per_css_pixel = m_document->page().client().device_pixels_per_css_pixel()
         };
 
         // NOTE: This doesn't necessarily return the specified value if we reach into computed_properties but that
@@ -1137,7 +1143,7 @@ void StyleComputer::collect_animation_into(DOM::AbstractElement abstract_element
             if (first_is_one_of(property_id, PropertyID::FontSize, PropertyID::FontWeight, PropertyID::FontWidth, PropertyID::FontStyle, PropertyID::LineHeight))
                 continue;
 
-            result.set(property_id, compute_value_of_property(property_id, *style_value, get_property_specified_value, property_value_computation_context));
+            result.set(property_id, compute_value_of_property(property_id, *style_value, get_property_specified_value, computation_context, m_document->page().client().device_pixels_per_css_pixel()));
         }
 
         return result;
@@ -2024,13 +2030,15 @@ void StyleComputer::compute_font(ComputedProperties& style, Optional<DOM::Abstra
 
     auto inherited_font_size = inheritance_parent_has_computed_properties ? inheritance_parent->computed_properties()->font_size() : InitialValues::font_size();
     auto inherited_math_depth = inheritance_parent_has_computed_properties ? inheritance_parent->computed_properties()->math_depth() : InitialValues::math_depth();
-    auto length_resolution_context = inheritance_parent_has_computed_properties ? Length::ResolutionContext::for_element(inheritance_parent.value()) : Length::ResolutionContext::for_window(*m_document->window());
+    ComputationContext font_computation_context {
+        .length_resolution_context = inheritance_parent_has_computed_properties ? Length::ResolutionContext::for_element(inheritance_parent.value()) : Length::ResolutionContext::for_window(*m_document->window())
+    };
 
     auto const& font_size_specified_value = style.property(PropertyID::FontSize, ComputedProperties::WithAnimationsApplied::No);
 
     style.set_property(
         PropertyID::FontSize,
-        compute_font_size(font_size_specified_value, style.math_depth(), inherited_font_size, inherited_math_depth, length_resolution_context),
+        compute_font_size(font_size_specified_value, style.math_depth(), inherited_font_size, inherited_math_depth, font_computation_context),
         style.is_property_inherited(PropertyID::FontSize) ? ComputedProperties::Inherited::Yes : ComputedProperties::Inherited::No);
 
     auto inherited_font_weight = inheritance_parent_has_computed_properties ? inheritance_parent->computed_properties()->font_weight() : InitialValues::font_weight();
@@ -2039,21 +2047,21 @@ void StyleComputer::compute_font(ComputedProperties& style, Optional<DOM::Abstra
 
     style.set_property(
         PropertyID::FontWeight,
-        compute_font_weight(font_weight_specified_value, inherited_font_weight, length_resolution_context),
+        compute_font_weight(font_weight_specified_value, inherited_font_weight, font_computation_context),
         style.is_property_inherited(PropertyID::FontWeight) ? ComputedProperties::Inherited::Yes : ComputedProperties::Inherited::No);
 
     auto const& font_width_specified_value = style.property(PropertyID::FontWidth, ComputedProperties::WithAnimationsApplied::No);
 
     style.set_property(
         PropertyID::FontWidth,
-        compute_font_width(font_width_specified_value, length_resolution_context),
+        compute_font_width(font_width_specified_value, font_computation_context),
         style.is_property_inherited(PropertyID::FontWidth) ? ComputedProperties::Inherited::Yes : ComputedProperties::Inherited::No);
 
     auto const& font_style_specified_value = style.property(PropertyID::FontStyle, ComputedProperties::WithAnimationsApplied::No);
 
     style.set_property(
         PropertyID::FontStyle,
-        compute_font_style(font_style_specified_value, length_resolution_context),
+        compute_font_style(font_style_specified_value, font_computation_context),
         style.is_property_inherited(PropertyID::FontStyle) ? ComputedProperties::Inherited::Yes : ComputedProperties::Inherited::No);
 
     auto const& font_family = style.property(CSS::PropertyID::FontFamily);
@@ -2072,17 +2080,19 @@ void StyleComputer::compute_font(ComputedProperties& style, Optional<DOM::Abstra
         inheritance_parent_has_computed_properties ? inheritance_parent->computed_properties()->line_height() : InitialValues::line_height()
     };
 
-    auto line_height_length_resolution_context = Length::ResolutionContext {
-        .viewport_rect = viewport_rect(),
-        .font_metrics = line_height_font_metrics,
-        .root_font_metrics = abstract_element.has_value() && is<HTML::HTMLHtmlElement>(abstract_element->element()) ? line_height_font_metrics : m_root_element_font_metrics,
+    ComputationContext line_height_computation_context {
+        .length_resolution_context = {
+            .viewport_rect = viewport_rect(),
+            .font_metrics = line_height_font_metrics,
+            .root_font_metrics = abstract_element.has_value() && is<HTML::HTMLHtmlElement>(abstract_element->element()) ? line_height_font_metrics : m_root_element_font_metrics,
+        }
     };
 
     auto const& line_height_specified_value = style.property(CSS::PropertyID::LineHeight, ComputedProperties::WithAnimationsApplied::No);
 
     style.set_property(
         PropertyID::LineHeight,
-        compute_line_height(line_height_specified_value, line_height_length_resolution_context),
+        compute_line_height(line_height_specified_value, line_height_computation_context),
         style.is_property_inherited(PropertyID::LineHeight) ? ComputedProperties::Inherited::Yes : ComputedProperties::Inherited::No);
 
     if (abstract_element.has_value() && is<HTML::HTMLHtmlElement>(abstract_element->element())) {
@@ -2144,13 +2154,12 @@ void StyleComputer::compute_property_values(ComputedProperties& style) const
         style.line_height()
     };
 
-    PropertyValueComputationContext computation_context {
+    ComputationContext computation_context {
         .length_resolution_context = {
             .viewport_rect = viewport_rect(),
             .font_metrics = font_metrics,
             .root_font_metrics = m_root_element_font_metrics,
         },
-        .device_pixels_per_css_pixel = m_document->page().client().device_pixels_per_css_pixel()
     };
 
     // NOTE: This doesn't necessarily return the specified value if we have already computed this property but that
@@ -2160,7 +2169,7 @@ void StyleComputer::compute_property_values(ComputedProperties& style) const
     };
 
     style.for_each_property([&](PropertyID property_id, auto& specified_value) {
-        auto const& computed_value = compute_value_of_property(property_id, specified_value, get_property_specified_value, computation_context);
+        auto const& computed_value = compute_value_of_property(property_id, specified_value, get_property_specified_value, computation_context, m_document->page().client().device_pixels_per_css_pixel());
 
         auto const& is_inherited = style.is_property_inherited(property_id) ? ComputedProperties::Inherited::Yes : ComputedProperties::Inherited::No;
 
@@ -3210,23 +3219,23 @@ static NonnullRefPtr<StyleValue const> compute_style_value_list(NonnullRefPtr<St
     return compute_entry(style_value);
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_property(PropertyID property_id, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, PropertyValueComputationContext const& computation_context)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_value_of_property(PropertyID property_id, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, ComputationContext const& computation_context, double device_pixels_per_css_pixel)
 {
-    auto const& absolutized_value = specified_value->absolutized(computation_context.length_resolution_context.viewport_rect, computation_context.length_resolution_context.font_metrics, computation_context.length_resolution_context.root_font_metrics);
+    auto const& absolutized_value = specified_value->absolutized(computation_context);
 
     switch (property_id) {
     case PropertyID::AnimationName:
         return compute_animation_name(absolutized_value);
     case PropertyID::BorderBottomWidth:
-        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderBottomStyle), computation_context);
+        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderBottomStyle), device_pixels_per_css_pixel);
     case PropertyID::BorderLeftWidth:
-        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderLeftStyle), computation_context);
+        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderLeftStyle), device_pixels_per_css_pixel);
     case PropertyID::BorderRightWidth:
-        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderRightStyle), computation_context);
+        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderRightStyle), device_pixels_per_css_pixel);
     case PropertyID::BorderTopWidth:
-        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderTopStyle), computation_context);
+        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::BorderTopStyle), device_pixels_per_css_pixel);
     case PropertyID::OutlineWidth:
-        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::OutlineStyle), computation_context);
+        return compute_border_or_outline_width(absolutized_value, get_property_specified_value(PropertyID::OutlineStyle), device_pixels_per_css_pixel);
     case PropertyID::FontVariationSettings:
         return compute_font_variation_settings(absolutized_value);
     case PropertyID::LetterSpacing:
@@ -3303,7 +3312,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_variation_settings(N
     return StyleValueList::create(move(axis_tags), StyleValueList::Separator::Comma);
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& absolutized_value, NonnullRefPtr<StyleValue const> const& style_specified_value, PropertyValueComputationContext const& computation_context)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& absolutized_value, NonnullRefPtr<StyleValue const> const& style_specified_value, double device_pixels_per_css_pixel)
 {
     // https://drafts.csswg.org/css-backgrounds/#border-width
     // absolute length, snapped as a border width; zero if the border style is none or hidden
@@ -3323,10 +3332,10 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_border_or_outline_width(N
         VERIFY_NOT_REACHED();
     }();
 
-    return LengthStyleValue::create(Length::make_px(snap_a_length_as_a_border_width(computation_context.device_pixels_per_css_pixel, absolute_length)));
+    return LengthStyleValue::create(Length::make_px(snap_a_length_as_a_border_width(device_pixels_per_css_pixel, absolute_length)));
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_font_size(NonnullRefPtr<StyleValue const> const& specified_value, int computed_math_depth, CSSPixels inherited_font_size, int inherited_math_depth, Length::ResolutionContext const& parent_length_resolution_context)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_font_size(NonnullRefPtr<StyleValue const> const& specified_value, int computed_math_depth, CSSPixels inherited_font_size, int inherited_math_depth, ComputationContext const& computation_context)
 {
     // https://drafts.csswg.org/css-fonts/#font-size-prop
     // an absolute length
@@ -3342,14 +3351,14 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_size(NonnullRefPtr<S
     // <length-percentage [0,∞]>
     // A length value specifies an absolute font size (independent of the user agent’s font table). Negative lengths are invalid.
     if (specified_value->is_length())
-        return LengthStyleValue::create(Length::make_px(max(CSSPixels { 0 }, specified_value->as_length().length().to_px(parent_length_resolution_context))));
+        return LengthStyleValue::create(Length::make_px(max(CSSPixels { 0 }, specified_value->as_length().length().to_px(computation_context.length_resolution_context))));
 
     // A percentage value specifies an absolute font size relative to the parent element’s computed font-size. Negative percentages are invalid.
     if (specified_value->is_percentage())
         return LengthStyleValue::create(Length::make_px(inherited_font_size * specified_value->as_percentage().percentage().as_fraction()));
 
     if (specified_value->is_calculated())
-        return LengthStyleValue::create(specified_value->as_calculated().resolve_length({ .percentage_basis = Length(1, LengthUnit::Em), .length_resolution_context = parent_length_resolution_context }).value());
+        return LengthStyleValue::create(specified_value->as_calculated().resolve_length(CalculationResolutionContext::from_computation_context(computation_context, Length(1, LengthUnit::Em))).value());
 
     // math
     // Special mathematical scaling rules must be applied when determining the computed value of the font-size property.
@@ -3395,7 +3404,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_size(NonnullRefPtr<S
     VERIFY_NOT_REACHED();
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_font_style(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& parent_length_resolution_context)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_font_style(NonnullRefPtr<StyleValue const> const& specified_value, ComputationContext const& computation_context)
 {
     // https://drafts.csswg.org/css-fonts-4/#font-style-prop
     // the keyword specified, plus angle in degrees if specified
@@ -3409,12 +3418,12 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_style(NonnullRefPtr<
         return FontStyleStyleValue::create(specified_value->as_font_style().font_style(), AngleStyleValue::create(Angle::make_degrees(angle_value->as_angle().angle().to_degrees())));
 
     if (angle_value->is_calculated())
-        return FontStyleStyleValue::create(specified_value->as_font_style().font_style(), AngleStyleValue::create(angle_value->as_calculated().resolve_angle({ .length_resolution_context = parent_length_resolution_context }).value()));
+        return FontStyleStyleValue::create(specified_value->as_font_style().font_style(), AngleStyleValue::create(angle_value->as_calculated().resolve_angle(CalculationResolutionContext::from_computation_context(computation_context)).value()));
 
     VERIFY_NOT_REACHED();
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_font_weight(NonnullRefPtr<StyleValue const> const& specified_value, double inherited_font_weight, Length::ResolutionContext const& parent_length_resolution_context)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_font_weight(NonnullRefPtr<StyleValue const> const& specified_value, double inherited_font_weight, ComputationContext const& computation_context)
 {
     // https://drafts.csswg.org/css-fonts-4/#font-weight-prop
     // a number, see below
@@ -3425,7 +3434,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_weight(NonnullRefPtr
 
     // AD-HOC: Anywhere we support a numbers we should also support calcs
     if (specified_value->is_calculated())
-        return NumberStyleValue::create(specified_value->as_calculated().resolve_number({ .length_resolution_context = parent_length_resolution_context }).value());
+        return NumberStyleValue::create(specified_value->as_calculated().resolve_number(CalculationResolutionContext::from_computation_context(computation_context)).value());
 
     // normal
     // Same as 400.
@@ -3481,7 +3490,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_weight(NonnullRefPtr
     VERIFY_NOT_REACHED();
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_font_width(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& parent_length_resolution_context)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_font_width(NonnullRefPtr<StyleValue const> const& specified_value, ComputationContext const& computation_context)
 {
     // https://drafts.csswg.org/css-fonts-4/#font-width-prop
     // a percentage, see below
@@ -3492,7 +3501,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_width(NonnullRefPtr<
 
     // AD-HOC: We support calculated percentages as well
     if (specified_value->is_calculated())
-        return PercentageStyleValue::create(specified_value->as_calculated().resolve_percentage({ .length_resolution_context = parent_length_resolution_context }).value());
+        return PercentageStyleValue::create(specified_value->as_calculated().resolve_percentage(CalculationResolutionContext::from_computation_context(computation_context)).value());
 
     switch (specified_value->to_keyword()) {
     // ultra-condensed 50%
@@ -3527,7 +3536,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_width(NonnullRefPtr<
     }
 }
 
-NonnullRefPtr<StyleValue const> StyleComputer::compute_line_height(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& length_resolution_context)
+NonnullRefPtr<StyleValue const> StyleComputer::compute_line_height(NonnullRefPtr<StyleValue const> const& specified_value, ComputationContext const& computation_context)
 {
     // https://drafts.csswg.org/css-inline-3/#line-height-property
     // normal
@@ -3536,11 +3545,11 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_line_height(NonnullRefPtr
 
     // <length [0,∞]>
     if (specified_value->is_length())
-        return specified_value->as_length().absolutized(length_resolution_context.viewport_rect, length_resolution_context.font_metrics, length_resolution_context.root_font_metrics);
+        return specified_value->absolutized(computation_context);
 
     // NOTE: We also support calc()'d lengths (percentages resolve to lengths so we don't have to handle them separately)
     if (specified_value->is_calculated() && specified_value->as_calculated().resolves_to_length())
-        return LengthStyleValue::create(specified_value->as_calculated().resolve_length({ .percentage_basis = Length(1, LengthUnit::Em), .length_resolution_context = length_resolution_context }).value());
+        return LengthStyleValue::create(specified_value->as_calculated().resolve_length(CalculationResolutionContext::from_computation_context(computation_context, Length(1, LengthUnit::Em))).value());
 
     // <number [0,∞]>
     if (specified_value->is_number())
@@ -3548,11 +3557,11 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_line_height(NonnullRefPtr
 
     // NOTE: We also support calc()'d numbers
     if (specified_value->is_calculated() && specified_value->as_calculated().resolves_to_number())
-        return NumberStyleValue::create(specified_value->as_calculated().resolve_number({ .length_resolution_context = length_resolution_context }).value());
+        return NumberStyleValue::create(specified_value->as_calculated().resolve_number(CalculationResolutionContext::from_computation_context(computation_context)).value());
 
     // <percentage [0,∞]>
     if (specified_value->is_percentage())
-        return LengthStyleValue::create(Length::make_px(length_resolution_context.font_metrics.font_size * specified_value->as_percentage().percentage().as_fraction()));
+        return LengthStyleValue::create(Length::make_px(computation_context.length_resolution_context.font_metrics.font_size * specified_value->as_percentage().percentage().as_fraction()));
 
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -203,17 +203,16 @@ public:
         double device_pixels_per_css_pixel;
     };
     static NonnullRefPtr<StyleValue const> compute_value_of_property(PropertyID, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, PropertyValueComputationContext const&);
-    static NonnullRefPtr<StyleValue const> compute_animation_name(NonnullRefPtr<StyleValue const> const& specified_value, PropertyValueComputationContext const&);
-    static NonnullRefPtr<StyleValue const> compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& specified_value, NonnullRefPtr<StyleValue const> const& style_specified_value, PropertyValueComputationContext const&);
+    static NonnullRefPtr<StyleValue const> compute_animation_name(NonnullRefPtr<StyleValue const> const& absolutized_value);
+    static NonnullRefPtr<StyleValue const> compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& absolutized_value, NonnullRefPtr<StyleValue const> const& style_specified_value, PropertyValueComputationContext const&);
     static NonnullRefPtr<StyleValue const> compute_font_size(NonnullRefPtr<StyleValue const> const& specified_value, int computed_math_depth, CSSPixels inherited_font_size, int inherited_math_depth, Length::ResolutionContext const& parent_length_resolution_context);
     static NonnullRefPtr<StyleValue const> compute_font_style(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& parent_length_resolution_context);
     static NonnullRefPtr<StyleValue const> compute_font_weight(NonnullRefPtr<StyleValue const> const& specified_value, double inherited_font_weight, Length::ResolutionContext const& parent_length_resolution_context);
     static NonnullRefPtr<StyleValue const> compute_font_width(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& parent_length_resolution_context);
-    static NonnullRefPtr<StyleValue const> compute_font_variation_settings(NonnullRefPtr<StyleValue const> const& specified_value);
+    static NonnullRefPtr<StyleValue const> compute_font_variation_settings(NonnullRefPtr<StyleValue const> const& absolutized_value);
     static NonnullRefPtr<StyleValue const> compute_line_height(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const&);
-    static NonnullRefPtr<StyleValue const> compute_opacity(NonnullRefPtr<StyleValue const> const& specified_value, PropertyValueComputationContext const&);
-    static NonnullRefPtr<StyleValue const> compute_position_area(NonnullRefPtr<StyleValue const> const& specified_value);
-    static NonnullRefPtr<StyleValue const> compute_text_underline_offset(NonnullRefPtr<StyleValue const> const& specified_value, PropertyValueComputationContext const&);
+    static NonnullRefPtr<StyleValue const> compute_opacity(NonnullRefPtr<StyleValue const> const& absolutized_value);
+    static NonnullRefPtr<StyleValue const> compute_position_area(NonnullRefPtr<StyleValue const> const& absolutized_value);
 
 private:
     virtual void visit_edges(Visitor&) override;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -198,19 +198,15 @@ public:
 
     static NonnullRefPtr<StyleValue const> compute_value_of_custom_property(DOM::AbstractElement, FlyString const& custom_property, Optional<Parser::GuardedSubstitutionContexts&> = {});
 
-    struct PropertyValueComputationContext {
-        Length::ResolutionContext length_resolution_context;
-        double device_pixels_per_css_pixel;
-    };
-    static NonnullRefPtr<StyleValue const> compute_value_of_property(PropertyID, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, PropertyValueComputationContext const&);
+    static NonnullRefPtr<StyleValue const> compute_value_of_property(PropertyID, NonnullRefPtr<StyleValue const> const& specified_value, Function<NonnullRefPtr<StyleValue const>(PropertyID)> const& get_property_specified_value, ComputationContext const&, double device_pixels_per_css_pixel);
     static NonnullRefPtr<StyleValue const> compute_animation_name(NonnullRefPtr<StyleValue const> const& absolutized_value);
-    static NonnullRefPtr<StyleValue const> compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& absolutized_value, NonnullRefPtr<StyleValue const> const& style_specified_value, PropertyValueComputationContext const&);
-    static NonnullRefPtr<StyleValue const> compute_font_size(NonnullRefPtr<StyleValue const> const& specified_value, int computed_math_depth, CSSPixels inherited_font_size, int inherited_math_depth, Length::ResolutionContext const& parent_length_resolution_context);
-    static NonnullRefPtr<StyleValue const> compute_font_style(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& parent_length_resolution_context);
-    static NonnullRefPtr<StyleValue const> compute_font_weight(NonnullRefPtr<StyleValue const> const& specified_value, double inherited_font_weight, Length::ResolutionContext const& parent_length_resolution_context);
-    static NonnullRefPtr<StyleValue const> compute_font_width(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const& parent_length_resolution_context);
+    static NonnullRefPtr<StyleValue const> compute_border_or_outline_width(NonnullRefPtr<StyleValue const> const& absolutized_value, NonnullRefPtr<StyleValue const> const& style_specified_value, double device_pixels_per_css_pixel);
+    static NonnullRefPtr<StyleValue const> compute_font_size(NonnullRefPtr<StyleValue const> const& specified_value, int computed_math_depth, CSSPixels inherited_font_size, int inherited_math_depth, ComputationContext const&);
+    static NonnullRefPtr<StyleValue const> compute_font_style(NonnullRefPtr<StyleValue const> const& specified_value, ComputationContext const&);
+    static NonnullRefPtr<StyleValue const> compute_font_weight(NonnullRefPtr<StyleValue const> const& specified_value, double inherited_font_weight, ComputationContext const&);
+    static NonnullRefPtr<StyleValue const> compute_font_width(NonnullRefPtr<StyleValue const> const& specified_value, ComputationContext const&);
     static NonnullRefPtr<StyleValue const> compute_font_variation_settings(NonnullRefPtr<StyleValue const> const& absolutized_value);
-    static NonnullRefPtr<StyleValue const> compute_line_height(NonnullRefPtr<StyleValue const> const& specified_value, Length::ResolutionContext const&);
+    static NonnullRefPtr<StyleValue const> compute_line_height(NonnullRefPtr<StyleValue const> const& specified_value, ComputationContext const&);
     static NonnullRefPtr<StyleValue const> compute_opacity(NonnullRefPtr<StyleValue const> const& absolutized_value);
     static NonnullRefPtr<StyleValue const> compute_position_area(NonnullRefPtr<StyleValue const> const& absolutized_value);
 

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.cpp
@@ -26,12 +26,12 @@ String BackgroundSizeStyleValue::to_string(SerializationMode mode) const
     return MUST(String::formatted("{} {}", m_properties.size_x.to_string(mode), m_properties.size_y.to_string(mode)));
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> BackgroundSizeStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> BackgroundSizeStyleValue::absolutized(ComputationContext const& computation_context) const
 {
     auto absolutize = [&](auto& size) -> LengthPercentageOrAuto {
         if (size.is_auto())
             return size;
-        return size.length_percentage().absolutized(viewport_rect, font_metrics, root_font_metrics);
+        return size.length_percentage().absolutized(computation_context);
     };
 
     auto absolutized_size_x = absolutize(m_properties.size_x);

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::CSS {
 
-BackgroundSizeStyleValue::BackgroundSizeStyleValue(LengthPercentageOrAuto size_x, LengthPercentageOrAuto size_y)
+BackgroundSizeStyleValue::BackgroundSizeStyleValue(ValueComparingNonnullRefPtr<StyleValue const> size_x, ValueComparingNonnullRefPtr<StyleValue const> size_y)
     : StyleValueWithDefaultOperators(Type::BackgroundSize)
     , m_properties { .size_x = move(size_x), .size_y = move(size_y) }
 {
@@ -21,21 +21,15 @@ BackgroundSizeStyleValue::~BackgroundSizeStyleValue() = default;
 
 String BackgroundSizeStyleValue::to_string(SerializationMode mode) const
 {
-    if (m_properties.size_x.is_auto() && m_properties.size_y.is_auto())
+    if (m_properties.size_x->has_auto() && m_properties.size_y->has_auto())
         return "auto"_string;
-    return MUST(String::formatted("{} {}", m_properties.size_x.to_string(mode), m_properties.size_y.to_string(mode)));
+    return MUST(String::formatted("{} {}", m_properties.size_x->to_string(mode), m_properties.size_y->to_string(mode)));
 }
 
 ValueComparingNonnullRefPtr<StyleValue const> BackgroundSizeStyleValue::absolutized(ComputationContext const& computation_context) const
 {
-    auto absolutize = [&](auto& size) -> LengthPercentageOrAuto {
-        if (size.is_auto())
-            return size;
-        return size.length_percentage().absolutized(computation_context);
-    };
-
-    auto absolutized_size_x = absolutize(m_properties.size_x);
-    auto absolutized_size_y = absolutize(m_properties.size_y);
+    auto absolutized_size_x = m_properties.size_x->absolutized(computation_context);
+    auto absolutized_size_y = m_properties.size_y->absolutized(computation_context);
 
     if (absolutized_size_x == m_properties.size_x && absolutized_size_y == m_properties.size_y)
         return *this;

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
@@ -18,14 +18,14 @@ namespace Web::CSS {
 // NOTE: This is not used for identifier sizes, like `cover` and `contain`.
 class BackgroundSizeStyleValue final : public StyleValueWithDefaultOperators<BackgroundSizeStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<BackgroundSizeStyleValue const> create(LengthPercentageOrAuto size_x, LengthPercentageOrAuto size_y)
+    static ValueComparingNonnullRefPtr<BackgroundSizeStyleValue const> create(ValueComparingNonnullRefPtr<StyleValue const> size_x, ValueComparingNonnullRefPtr<StyleValue const> size_y)
     {
-        return adopt_ref(*new (nothrow) BackgroundSizeStyleValue(size_x, size_y));
+        return adopt_ref(*new (nothrow) BackgroundSizeStyleValue(move(size_x), move(size_y)));
     }
     virtual ~BackgroundSizeStyleValue() override;
 
-    LengthPercentageOrAuto size_x() const { return m_properties.size_x; }
-    LengthPercentageOrAuto size_y() const { return m_properties.size_y; }
+    ValueComparingNonnullRefPtr<StyleValue const> size_x() const { return m_properties.size_x; }
+    ValueComparingNonnullRefPtr<StyleValue const> size_y() const { return m_properties.size_y; }
 
     virtual String to_string(SerializationMode) const override;
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
@@ -33,11 +33,11 @@ public:
     bool properties_equal(BackgroundSizeStyleValue const& other) const { return m_properties == other.m_properties; }
 
 private:
-    BackgroundSizeStyleValue(LengthPercentageOrAuto size_x, LengthPercentageOrAuto size_y);
+    BackgroundSizeStyleValue(ValueComparingNonnullRefPtr<StyleValue const> size_x, ValueComparingNonnullRefPtr<StyleValue const> size_y);
 
     struct Properties {
-        LengthPercentageOrAuto size_x;
-        LengthPercentageOrAuto size_y;
+        ValueComparingNonnullRefPtr<StyleValue const> size_x;
+        ValueComparingNonnullRefPtr<StyleValue const> size_y;
         bool operator==(Properties const&) const = default;
     } m_properties;
 };

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
@@ -28,7 +28,7 @@ public:
     LengthPercentageOrAuto size_y() const { return m_properties.size_y; }
 
     virtual String to_string(SerializationMode) const override;
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
 
     bool properties_equal(BackgroundSizeStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
@@ -14,14 +14,14 @@ namespace Web::CSS {
 String BorderRadiusStyleValue::to_string(SerializationMode mode) const
 {
     if (m_properties.horizontal_radius == m_properties.vertical_radius)
-        return m_properties.horizontal_radius.to_string(mode);
-    return MUST(String::formatted("{} {}", m_properties.horizontal_radius.to_string(mode), m_properties.vertical_radius.to_string(mode)));
+        return m_properties.horizontal_radius->to_string(mode);
+    return MUST(String::formatted("{} {}", m_properties.horizontal_radius->to_string(mode), m_properties.vertical_radius->to_string(mode)));
 }
 
 ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(ComputationContext const& computation_context) const
 {
-    auto absolutized_horizontal_radius = m_properties.horizontal_radius.absolutized(computation_context);
-    auto absolutized_vertical_radius = m_properties.vertical_radius.absolutized(computation_context);
+    auto absolutized_horizontal_radius = m_properties.horizontal_radius->absolutized(computation_context);
+    auto absolutized_vertical_radius = m_properties.vertical_radius->absolutized(computation_context);
 
     if (absolutized_vertical_radius == m_properties.vertical_radius && absolutized_horizontal_radius == m_properties.horizontal_radius)
         return *this;

--- a/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
@@ -18,10 +18,10 @@ String BorderRadiusStyleValue::to_string(SerializationMode mode) const
     return MUST(String::formatted("{} {}", m_properties.horizontal_radius.to_string(mode), m_properties.vertical_radius.to_string(mode)));
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> BorderRadiusStyleValue::absolutized(ComputationContext const& computation_context) const
 {
-    auto absolutized_horizontal_radius = m_properties.horizontal_radius.absolutized(viewport_rect, font_metrics, root_font_metrics);
-    auto absolutized_vertical_radius = m_properties.vertical_radius.absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_horizontal_radius = m_properties.horizontal_radius.absolutized(computation_context);
+    auto absolutized_vertical_radius = m_properties.vertical_radius.absolutized(computation_context);
 
     if (absolutized_vertical_radius == m_properties.vertical_radius && absolutized_horizontal_radius == m_properties.horizontal_radius)
         return *this;

--- a/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
@@ -17,14 +17,14 @@ namespace Web::CSS {
 
 class BorderRadiusStyleValue final : public StyleValueWithDefaultOperators<BorderRadiusStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> create(LengthPercentage const& horizontal_radius, LengthPercentage const& vertical_radius)
+    static ValueComparingNonnullRefPtr<BorderRadiusStyleValue const> create(ValueComparingNonnullRefPtr<StyleValue const> const& horizontal_radius, ValueComparingNonnullRefPtr<StyleValue const> const& vertical_radius)
     {
         return adopt_ref(*new (nothrow) BorderRadiusStyleValue(horizontal_radius, vertical_radius));
     }
     virtual ~BorderRadiusStyleValue() override = default;
 
-    LengthPercentage const& horizontal_radius() const { return m_properties.horizontal_radius; }
-    LengthPercentage const& vertical_radius() const { return m_properties.vertical_radius; }
+    ValueComparingNonnullRefPtr<StyleValue const> const& horizontal_radius() const { return m_properties.horizontal_radius; }
+    ValueComparingNonnullRefPtr<StyleValue const> const& vertical_radius() const { return m_properties.vertical_radius; }
     bool is_elliptical() const { return m_properties.is_elliptical; }
 
     virtual String to_string(SerializationMode) const override;
@@ -32,7 +32,7 @@ public:
     bool properties_equal(BorderRadiusStyleValue const& other) const { return m_properties == other.m_properties; }
 
 private:
-    BorderRadiusStyleValue(LengthPercentage const& horizontal_radius, LengthPercentage const& vertical_radius)
+    BorderRadiusStyleValue(ValueComparingNonnullRefPtr<StyleValue const> const& horizontal_radius, ValueComparingNonnullRefPtr<StyleValue const> const& vertical_radius)
         : StyleValueWithDefaultOperators(Type::BorderRadius)
         , m_properties { .is_elliptical = horizontal_radius != vertical_radius, .horizontal_radius = horizontal_radius, .vertical_radius = vertical_radius }
     {
@@ -41,8 +41,8 @@ private:
     virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     struct Properties {
         bool is_elliptical;
-        LengthPercentage horizontal_radius;
-        LengthPercentage vertical_radius;
+        ValueComparingNonnullRefPtr<StyleValue const> horizontal_radius;
+        ValueComparingNonnullRefPtr<StyleValue const> vertical_radius;
         bool operator==(Properties const&) const = default;
     } m_properties;
 };

--- a/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
@@ -38,8 +38,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
-
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     struct Properties {
         bool is_elliptical;
         LengthPercentage horizontal_radius;

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -728,30 +728,6 @@ static Optional<double> try_get_number(CalculationNode const& child)
     return maybe_number->value();
 }
 
-RefPtr<StyleValue const> NumericCalculationNode::to_style_value(CalculationContext const& context) const
-{
-    // TODO: Clamp values to the range allowed by the context.
-    return m_value.visit(
-        [&](Number const& number) -> RefPtr<StyleValue const> {
-            // FIXME: Returning infinity or NaN as a NumberStyleValue isn't valid.
-            //        This is a temporary fix until value-clamping is implemented here.
-            //        In future, we can remove these two lines and return NonnullRefPtr again.
-            if (!isfinite(number.value()))
-                return nullptr;
-
-            if (context.resolve_numbers_as_integers)
-                return IntegerStyleValue::create(llround(number.value()));
-            return NumberStyleValue::create(number.value());
-        },
-        [](Angle const& angle) -> RefPtr<StyleValue const> { return AngleStyleValue::create(angle); },
-        [](Flex const& flex) -> RefPtr<StyleValue const> { return FlexStyleValue::create(flex); },
-        [](Frequency const& frequency) -> RefPtr<StyleValue const> { return FrequencyStyleValue::create(frequency); },
-        [](Length const& length) -> RefPtr<StyleValue const> { return LengthStyleValue::create(length); },
-        [](Percentage const& percentage) -> RefPtr<StyleValue const> { return PercentageStyleValue::create(percentage); },
-        [](Resolution const& resolution) -> RefPtr<StyleValue const> { return ResolutionStyleValue::create(resolution); },
-        [](Time const& time) -> RefPtr<StyleValue const> { return TimeStyleValue::create(time); });
-}
-
 Optional<NonFiniteValue> NumericCalculationNode::infinite_or_nan_value() const
 {
     auto raw_value = m_value.visit(

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -2533,15 +2533,9 @@ String CalculatedStyleValue::to_string(SerializationMode serialization_mode) con
     return serialize_a_math_function(m_calculation, m_context, serialization_mode);
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> CalculatedStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> CalculatedStyleValue::absolutized(ComputationContext const& computation_context) const
 {
-    Length::ResolutionContext length_resolution_context {
-        .viewport_rect = viewport_rect,
-        .font_metrics = font_metrics,
-        .root_font_metrics = root_font_metrics
-    };
-
-    auto simplified_calculation_tree = simplify_a_calculation_tree(m_calculation, m_context, { .length_resolution_context = length_resolution_context });
+    auto simplified_calculation_tree = simplify_a_calculation_tree(m_calculation, m_context, CalculationResolutionContext::from_computation_context(computation_context));
 
     auto const simplified_percentage_dimension_mix = [&]() -> Optional<ValueComparingNonnullRefPtr<StyleValue const>> {
         // NOTE: A percentage dimension mix is a SumCalculationNode with two NumericCalculationNode children which have

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -70,7 +70,7 @@ public:
     }
 
     virtual String to_string(SerializationMode) const override;
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     virtual bool equals(StyleValue const& other) const override;
 
     NonnullRefPtr<CalculationNode const> calculation() const { return m_calculation; }

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -269,8 +269,6 @@ public:
     bool is_in_canonical_unit() const;
     virtual NonnullRefPtr<CalculationNode const> with_simplified_children(CalculationContext const&, CalculationResolutionContext const&) const override { return *this; }
 
-    RefPtr<StyleValue const> to_style_value(CalculationContext const&) const;
-
     virtual Vector<NonnullRefPtr<CalculationNode const>> children() const override { return {}; }
     NumericValue const& value() const { return m_value; }
     String value_to_string() const;

--- a/Libraries/LibWeb/CSS/StyleValues/ComputationContext.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ComputationContext.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025, Callum Law <callumlaw1709@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/Length.h>
+
+namespace Web::CSS {
+
+struct ComputationContext {
+    Length::ResolutionContext length_resolution_context;
+};
+
+}

--- a/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.cpp
@@ -29,6 +29,26 @@ String CounterDefinitionsStyleValue::to_string(SerializationMode mode) const
     return stb.to_string_without_validation();
 }
 
+ValueComparingNonnullRefPtr<StyleValue const> CounterDefinitionsStyleValue::absolutized(ComputationContext const& computation_context) const
+{
+    Vector<CounterDefinition> computed_definitions;
+
+    for (auto specified_definition : m_counter_definitions) {
+        CounterDefinition computed_definition {
+            .name = specified_definition.name,
+            .is_reversed = specified_definition.is_reversed,
+            .value = nullptr
+        };
+
+        if (specified_definition.value)
+            computed_definition.value = specified_definition.value->absolutized(computation_context);
+
+        computed_definitions.append(computed_definition);
+    }
+
+    return CounterDefinitionsStyleValue::create(computed_definitions);
+}
+
 bool CounterDefinitionsStyleValue::properties_equal(CounterDefinitionsStyleValue const& other) const
 {
     if (m_counter_definitions.size() != other.counter_definitions().size())

--- a/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
@@ -31,6 +31,7 @@ public:
 
     auto const& counter_definitions() const { return m_counter_definitions; }
     virtual String to_string(SerializationMode) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
 
     bool properties_equal(CounterDefinitionsStyleValue const& other) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -28,12 +28,12 @@ String CursorStyleValue::to_string(SerializationMode mode) const
     return builder.to_string_without_validation();
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> CursorStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> CursorStyleValue::absolutized(ComputationContext const& computation_context) const
 {
     return CursorStyleValue::create(
-        m_properties.image->absolutized(viewport_rect, font_metrics, root_font_metrics)->as_abstract_image(),
-        m_properties.x.map([&](NumberOrCalculated const& value) { return value.absolutized(viewport_rect, font_metrics, root_font_metrics); }),
-        m_properties.y.map([&](NumberOrCalculated const& value) { return value.absolutized(viewport_rect, font_metrics, root_font_metrics); }));
+        m_properties.image->absolutized(computation_context)->as_abstract_image(),
+        m_properties.x.map([&](NumberOrCalculated const& value) { return value.absolutized(computation_context); }),
+        m_properties.y.map([&](NumberOrCalculated const& value) { return value.absolutized(computation_context); }));
 }
 
 Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithStyle const& layout_node) const

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
@@ -33,7 +33,7 @@ public:
 
     virtual String to_string(SerializationMode) const override;
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
 
     bool properties_equal(CursorStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
@@ -18,16 +18,13 @@ namespace Web::CSS {
 
 class CursorStyleValue final : public StyleValueWithDefaultOperators<CursorStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<CursorStyleValue const> create(ValueComparingNonnullRefPtr<AbstractImageStyleValue const> image, Optional<NumberOrCalculated> x, Optional<NumberOrCalculated> y)
+    static ValueComparingNonnullRefPtr<CursorStyleValue const> create(ValueComparingNonnullRefPtr<AbstractImageStyleValue const> image, RefPtr<StyleValue const> x, RefPtr<StyleValue const> y)
     {
-        VERIFY(x.has_value() == y.has_value());
+        // We require either both or neither the X and Y parameters
+        VERIFY((!x && !y) || (x && y));
         return adopt_ref(*new (nothrow) CursorStyleValue(move(image), move(x), move(y)));
     }
     virtual ~CursorStyleValue() override = default;
-
-    ValueComparingNonnullRefPtr<AbstractImageStyleValue const> image() const { return m_properties.image; }
-    Optional<NumberOrCalculated> const& x() const { return m_properties.x; }
-    Optional<NumberOrCalculated> const& y() const { return m_properties.y; }
 
     Optional<Gfx::ImageCursor> make_image_cursor(Layout::NodeWithStyle const&) const;
 
@@ -39,8 +36,8 @@ public:
 
 private:
     CursorStyleValue(ValueComparingNonnullRefPtr<AbstractImageStyleValue const> image,
-        Optional<NumberOrCalculated> x,
-        Optional<NumberOrCalculated> y)
+        RefPtr<StyleValue const> x,
+        RefPtr<StyleValue const> y)
         : StyleValueWithDefaultOperators(Type::Cursor)
         , m_properties { .image = move(image), .x = move(x), .y = move(y) }
     {
@@ -48,8 +45,8 @@ private:
 
     struct Properties {
         ValueComparingNonnullRefPtr<AbstractImageStyleValue const> image;
-        Optional<NumberOrCalculated> x;
-        Optional<NumberOrCalculated> y;
+        RefPtr<StyleValue const> x;
+        RefPtr<StyleValue const> y;
         bool operator==(Properties const&) const = default;
     } m_properties;
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -186,7 +186,7 @@ void ImageStyleValue::set_style_sheet(GC::Ptr<CSSStyleSheet> style_sheet)
     m_style_sheet = style_sheet;
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> ImageStyleValue::absolutized(CSSPixelRect const&, Length::FontMetrics const&, Length::FontMetrics const&) const
+ValueComparingNonnullRefPtr<StyleValue const> ImageStyleValue::absolutized(ComputationContext const&) const
 {
     if (m_url.url().is_empty())
         return *this;

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -70,8 +70,8 @@ private:
     void unregister_client(Client&);
 
     virtual void set_style_sheet(GC::Ptr<CSSStyleSheet>) override;
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     void animate();
     Gfx::ImmutableBitmap const* bitmap(size_t frame_index, Gfx::IntSize = {}) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.cpp
@@ -26,9 +26,9 @@ ValueComparingNonnullRefPtr<LengthStyleValue const> LengthStyleValue::create(Len
     return adopt_ref(*new (nothrow) LengthStyleValue(length));
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> LengthStyleValue::absolutized(ComputationContext const& computation_context) const
 {
-    if (auto length = m_length.absolutize(viewport_rect, font_metrics, root_font_metrics); length.has_value())
+    if (auto length = m_length.absolutize(computation_context.length_resolution_context.viewport_rect, computation_context.length_resolution_context.font_metrics, computation_context.length_resolution_context.root_font_metrics); length.has_value())
         return LengthStyleValue::create(length.release_value());
     return *this;
 }

--- a/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -25,7 +25,7 @@ public:
     virtual FlyString unit_name() const override { return m_length.unit_name(); }
 
     virtual String to_string(SerializationMode serialization_mode) const override { return m_length.to_string(serialization_mode); }
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
 
     bool equals(StyleValue const& other) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.cpp
@@ -9,6 +9,16 @@
 
 namespace Web::CSS {
 
+ValueComparingNonnullRefPtr<StyleValue const> OpenTypeTaggedStyleValue::absolutized(ComputationContext const& computation_context) const
+{
+    auto const& absolutized_value = m_value->absolutized(computation_context);
+
+    if (absolutized_value == m_value)
+        return *this;
+
+    return OpenTypeTaggedStyleValue::create(m_mode, m_tag, absolutized_value);
+}
+
 String OpenTypeTaggedStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;

--- a/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.h
@@ -29,6 +29,8 @@ public:
     FlyString const& tag() const { return m_tag; }
     ValueComparingNonnullRefPtr<StyleValue const> const& value() const { return m_value; }
 
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
+
     virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(OpenTypeTaggedStyleValue const&) const;

--- a/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
@@ -56,12 +56,12 @@ ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::spread_distance(
     return *m_properties.spread_distance;
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> ShadowStyleValue::absolutized(ComputationContext const& computation_context) const
 {
-    auto absolutized_offset_x = offset_x()->absolutized(viewport_rect, font_metrics, root_font_metrics);
-    auto absolutized_offset_y = offset_y()->absolutized(viewport_rect, font_metrics, root_font_metrics);
-    auto absolutized_blur_radius = blur_radius()->absolutized(viewport_rect, font_metrics, root_font_metrics);
-    auto absolutized_spread_distance = spread_distance()->absolutized(viewport_rect, font_metrics, root_font_metrics);
+    auto absolutized_offset_x = offset_x()->absolutized(computation_context);
+    auto absolutized_offset_y = offset_y()->absolutized(computation_context);
+    auto absolutized_blur_radius = blur_radius()->absolutized(computation_context);
+    auto absolutized_spread_distance = spread_distance()->absolutized(computation_context);
     return create(m_properties.shadow_type, color(), absolutized_offset_x, absolutized_offset_y, absolutized_blur_radius, absolutized_spread_distance, placement());
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
@@ -76,8 +76,7 @@ private:
     {
     }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
-
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
     struct Properties {
         ShadowType shadow_type;
         ValueComparingRefPtr<StyleValue const> color;

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -374,7 +374,7 @@ String ShorthandStyleValue::to_string(SerializationMode mode) const
 
         auto horizontal_radius = [&](auto& style_value) -> String {
             if (style_value->is_border_radius())
-                return style_value->as_border_radius().horizontal_radius().to_string(mode);
+                return style_value->as_border_radius().horizontal_radius()->to_string(mode);
             return style_value->to_string(mode);
         };
 
@@ -385,7 +385,7 @@ String ShorthandStyleValue::to_string(SerializationMode mode) const
 
         auto vertical_radius = [&](auto& style_value) -> String {
             if (style_value->is_border_radius())
-                return style_value->as_border_radius().vertical_radius().to_string(mode);
+                return style_value->as_border_radius().vertical_radius()->to_string(mode);
             return style_value->to_string(mode);
         };
 

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -127,7 +127,7 @@ DimensionStyleValue const& StyleValue::as_dimension() const
 ENUMERATE_CSS_STYLE_VALUE_TYPES
 #undef __ENUMERATE_CSS_STYLE_VALUE_TYPE
 
-ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(CSSPixelRect const&, Length::FontMetrics const&, Length::FontMetrics const&) const
+ValueComparingNonnullRefPtr<StyleValue const> StyleValue::absolutized(ComputationContext const&) const
 {
     return *this;
 }

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -202,7 +202,7 @@ public:
     bool has_auto() const;
     virtual bool has_color() const { return false; }
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const;
 
     virtual Optional<Color> to_color(ColorResolutionContext) const { return {}; }
     Keyword to_keyword() const;

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
@@ -22,13 +22,13 @@ bool StyleValueList::Properties::operator==(Properties const& other) const
     return separator == other.separator && values.span() == other.values.span();
 }
 
-ValueComparingNonnullRefPtr<StyleValue const> StyleValueList::absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const
+ValueComparingNonnullRefPtr<StyleValue const> StyleValueList::absolutized(ComputationContext const& computation_context) const
 {
     StyleValueVector absolutized_style_values;
     absolutized_style_values.ensure_capacity(m_properties.values.size());
 
     for (auto const& value : m_properties.values)
-        absolutized_style_values.append(value->absolutized(viewport_rect, font_metrics, root_font_metrics));
+        absolutized_style_values.append(value->absolutized(computation_context));
 
     return StyleValueList::create(move(absolutized_style_values), m_properties.separator);
 }

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
@@ -37,7 +37,7 @@ public:
     virtual Vector<Parser::ComponentValue> tokenize() const override;
     virtual GC::Ref<CSSStyleValue> reify(JS::Realm&, FlyString const& associated_property) const override;
 
-    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
 
     bool properties_equal(StyleValueList const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
@@ -375,6 +375,27 @@ GC::Ref<CSSTransformComponent> TransformationStyleValue::reify_a_transform_funct
     VERIFY_NOT_REACHED();
 }
 
+ValueComparingNonnullRefPtr<StyleValue const> TransformationStyleValue::absolutized(ComputationContext const& computation_context) const
+{
+    StyleValueVector absolutized_values;
+
+    bool absolutized_values_different = false;
+
+    for (auto const& value : m_properties.values) {
+        auto const& absolutized_value = value->absolutized(computation_context);
+
+        if (absolutized_value != value)
+            absolutized_values_different = true;
+
+        absolutized_values.append(absolutized_value);
+    }
+
+    if (!absolutized_values_different)
+        return *this;
+
+    return TransformationStyleValue::create(m_properties.property, m_properties.transform_function, move(absolutized_values));
+}
+
 bool TransformationStyleValue::Properties::operator==(Properties const& other) const
 {
     return property == other.property

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
@@ -30,6 +30,8 @@ public:
     virtual String to_string(SerializationMode) const override;
     GC::Ref<CSSTransformComponent> reify_a_transform_function(JS::Realm&) const;
 
+    virtual ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const override;
+
     bool properties_equal(TransformationStyleValue const& other) const { return m_properties == other.m_properties; }
 
 private:

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -126,10 +126,14 @@ public:
                     }
                 }
 
-                auto const& computed_font_size = CSS::StyleComputer::compute_font_size(font_size, computed_math_depth, inherited_font_size, inherited_math_depth, length_resolution_context);
-                auto const& computed_font_weight = CSS::StyleComputer::compute_font_weight(font_weight, inherited_font_weight, length_resolution_context);
-                auto const& computed_font_width = CSS::StyleComputer::compute_font_width(font_width, length_resolution_context);
-                auto const& computed_font_style = CSS::StyleComputer::compute_font_style(font_style, length_resolution_context);
+                CSS::ComputationContext computation_context {
+                    .length_resolution_context = length_resolution_context
+                };
+
+                auto const& computed_font_size = CSS::StyleComputer::compute_font_size(font_size, computed_math_depth, inherited_font_size, inherited_math_depth, computation_context);
+                auto const& computed_font_weight = CSS::StyleComputer::compute_font_weight(font_weight, inherited_font_weight, computation_context);
+                auto const& computed_font_width = CSS::StyleComputer::compute_font_width(font_width, computation_context);
+                auto const& computed_font_style = CSS::StyleComputer::compute_font_style(font_style, computation_context);
 
                 return document->style_computer().compute_font_for_style_values(
                     font_family,

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -546,29 +546,29 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     if (border_bottom_left_radius.is_border_radius()) {
         computed_values.set_border_bottom_left_radius(
             CSS::BorderRadiusData {
-                border_bottom_left_radius.as_border_radius().horizontal_radius(),
-                border_bottom_left_radius.as_border_radius().vertical_radius() });
+                CSS::LengthPercentage::from_style_value(border_bottom_left_radius.as_border_radius().horizontal_radius()),
+                CSS::LengthPercentage::from_style_value(border_bottom_left_radius.as_border_radius().vertical_radius()) });
     }
     auto const& border_bottom_right_radius = computed_style.property(CSS::PropertyID::BorderBottomRightRadius);
     if (border_bottom_right_radius.is_border_radius()) {
         computed_values.set_border_bottom_right_radius(
             CSS::BorderRadiusData {
-                border_bottom_right_radius.as_border_radius().horizontal_radius(),
-                border_bottom_right_radius.as_border_radius().vertical_radius() });
+                CSS::LengthPercentage::from_style_value(border_bottom_right_radius.as_border_radius().horizontal_radius()),
+                CSS::LengthPercentage::from_style_value(border_bottom_right_radius.as_border_radius().vertical_radius()) });
     }
     auto const& border_top_left_radius = computed_style.property(CSS::PropertyID::BorderTopLeftRadius);
     if (border_top_left_radius.is_border_radius()) {
         computed_values.set_border_top_left_radius(
             CSS::BorderRadiusData {
-                border_top_left_radius.as_border_radius().horizontal_radius(),
-                border_top_left_radius.as_border_radius().vertical_radius() });
+                CSS::LengthPercentage::from_style_value(border_top_left_radius.as_border_radius().horizontal_radius()),
+                CSS::LengthPercentage::from_style_value(border_top_left_radius.as_border_radius().vertical_radius()) });
     }
     auto const& border_top_right_radius = computed_style.property(CSS::PropertyID::BorderTopRightRadius);
     if (border_top_right_radius.is_border_radius()) {
         computed_values.set_border_top_right_radius(
             CSS::BorderRadiusData {
-                border_top_right_radius.as_border_radius().horizontal_radius(),
-                border_top_right_radius.as_border_radius().vertical_radius() });
+                CSS::LengthPercentage::from_style_value(border_top_right_radius.as_border_radius().horizontal_radius()),
+                CSS::LengthPercentage::from_style_value(border_top_right_radius.as_border_radius().vertical_radius()) });
     }
     computed_values.set_display(computed_style.display());
     computed_values.set_display_before_box_type_transformation(computed_style.display_before_box_type_transformation());

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -492,8 +492,8 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
                 if (size_value->is_background_size()) {
                     auto& size = size_value->as_background_size();
                     layer.size_type = CSS::BackgroundSize::LengthPercentage;
-                    layer.size_x = size.size_x();
-                    layer.size_y = size.size_y();
+                    layer.size_x = CSS::LengthPercentageOrAuto::from_style_value(size.size_x());
+                    layer.size_y = CSS::LengthPercentageOrAuto::from_style_value(size.size_y());
                 } else if (size_value->is_keyword()) {
                     switch (size_value->to_keyword()) {
                     case CSS::Keyword::Contain:

--- a/Tests/LibWeb/Crash/CSS/counter-definition-with-relative-units.html
+++ b/Tests/LibWeb/Crash/CSS/counter-definition-with-relative-units.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <style>
+            #foo {
+                counter-set: foo calc(sign(1em - 1px));
+                counter-increment: bar calc(sign(1em - 1px));
+                counter-reset: baz calc(sign(1em - 1px));
+            }
+        </style>
+        <div>
+            <div id="foo"></div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/font-variation-settings-calc.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/font-variation-settings-calc.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 8 tests
+
+6 Pass
+2 Fail
+Pass	e.style['font-variation-settings'] = "\"wght\" sign(1em - 1px)" should set the property value
+Fail	e.style['font-variation-settings'] = "\"wght\" sibling-index()" should set the property value
+Pass	e.style['font-variation-settings'] = "\"wght\" calc(10)" should set the property value
+Pass	e.style['font-variation-settings'] = "\"wght\" sign(2px)" should set the property value
+Pass	Property font-variation-settings value '"wght" sign(1em - 1px)'
+Fail	Property font-variation-settings value '"wght" sibling-index()'
+Pass	Property font-variation-settings value '"wght" calc(10)'
+Pass	Property font-variation-settings value '"wght" sign(2px)'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/translate-parsing-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/translate-parsing-computed.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 19 tests
 
-18 Pass
-1 Fail
+19 Pass
 Pass	Property translate value 'none'
 Pass	Property translate value '0px'
 Pass	Property translate value '100%'
@@ -20,6 +19,6 @@ Pass	Property translate value '100px 200px 300px'
 Pass	Property translate value '100% 200% 300px'
 Pass	Property translate value '100% 0% 200px'
 Pass	Property translate value '0% 0% 100px'
-Fail	Property translate value '0em 0em 100px'
+Pass	Property translate value '0em 0em 100px'
 Pass	Property translate value '0'
 Pass	Property translate value '1px 2px 0'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/acos-asin-atan-atan2-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/acos-asin-atan-atan2-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 45 tests
 
-34 Pass
-11 Fail
+36 Pass
+9 Fail
 Pass	acos(1) should be used-value-equivalent to 0deg
 Pass	atan(0) should be used-value-equivalent to 0deg
 Pass	asin(0) should be used-value-equivalent to 0deg
@@ -39,9 +39,9 @@ Fail	atan2(1em, -1em) should be used-value-equivalent to 135deg
 Fail	atan2(1ex, -1ex) should be used-value-equivalent to 135deg
 Fail	atan2(1ch, -1ch) should be used-value-equivalent to 135deg
 Fail	atan2(1rem, -1rem) should be used-value-equivalent to 135deg
-Fail	atan2(1rem + 1px - 1px, -1rem) should be used-value-equivalent to 135deg
+Pass	atan2(1rem + 1px - 1px, -1rem) should be used-value-equivalent to 135deg
 Fail	atan2(1vh, -1vh) should be used-value-equivalent to 135deg
-Fail	atan2(1vh + 0px, -1vh + 0px) should be used-value-equivalent to 135deg
+Pass	atan2(1vh + 0px, -1vh + 0px) should be used-value-equivalent to 135deg
 Fail	atan2(1vw, -1vw) should be used-value-equivalent to 135deg
 Pass	atan2(1deg, -1deg) should be used-value-equivalent to 135deg
 Pass	atan2(1grad, -1grad) should be used-value-equivalent to 135deg

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signs-abs-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/signs-abs-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 233 tests
 
-212 Pass
-21 Fail
+221 Pass
+12 Fail
 Pass	abs(1) should be used-value-equivalent to 1
 Pass	sign(1) should be used-value-equivalent to 1
 Pass	abs(-1) should be used-value-equivalent to 1
@@ -210,18 +210,18 @@ Pass	abs(-1turn) should be used-value-equivalent to 1turn
 Pass	sign(10px - 1em) should be used-value-equivalent to 0; fontSize=10px
 Pass	sign(10px - 2em) should be used-value-equivalent to -1; fontSize=10px
 Pass	calc(sign(10%) * 100px) should be used-value-equivalent to 100px
-Fail	calc(2.5 - sign(41px - 2em) / 2) should be used-value-equivalent to 2
-Fail	calc(2.5 - sign(40px - 2em) / 2) should be used-value-equivalent to 2.5
-Fail	calc(2.5 - sign(39px - 2em) / 2) should be used-value-equivalent to 3
+Pass	calc(2.5 - sign(41px - 2em) / 2) should be used-value-equivalent to 2
+Pass	calc(2.5 - sign(40px - 2em) / 2) should be used-value-equivalent to 2.5
+Pass	calc(2.5 - sign(39px - 2em) / 2) should be used-value-equivalent to 3
 Pass	calc(3 + sign(42px - 2em)) should be used-value-equivalent to 4
 Pass	calc(3 + sign(40px - 2em)) should be used-value-equivalent to 3
 Pass	calc(3 + sign(38px - 2em)) should be used-value-equivalent to 2
 Pass	calc(50px + 100px * sign(42px - 2em)) should be used-value-equivalent to 150px
 Pass	calc(50px + 100px * sign(40px - 2em)) should be used-value-equivalent to 50px
 Pass	calc(50px + 100px * sign(38px - 2em)) should be used-value-equivalent to -50px
-Fail	calc(90deg + 30deg * sign(42px - 2em)) should be used-value-equivalent to 120deg
-Fail	calc(90deg + 30deg * sign(40px - 2em)) should be used-value-equivalent to 90deg
-Fail	calc(90deg + 30deg * sign(38px - 2em)) should be used-value-equivalent to 60deg
+Pass	calc(90deg + 30deg * sign(42px - 2em)) should be used-value-equivalent to 120deg
+Pass	calc(90deg + 30deg * sign(40px - 2em)) should be used-value-equivalent to 90deg
+Pass	calc(90deg + 30deg * sign(38px - 2em)) should be used-value-equivalent to 60deg
 Pass	calc(5s + 15s * sign(42px - 2em)) should be used-value-equivalent to 20s
 Pass	calc(5s + 15s * sign(40px - 2em)) should be used-value-equivalent to 5s
 Pass	calc(5s + 15s * sign(38px - 2em)) should be used-value-equivalent to -10s
@@ -231,9 +231,9 @@ Fail	calc(100dpi + 20dpi * sign(38px - 2em)) should be used-value-equivalent to 
 Fail	calc(3fr + 1fr * sign(42px - 2em)) should be used-value-equivalent to 4fr
 Fail	calc(3fr + 1fr * sign(40px - 2em)) should be used-value-equivalent to 3fr
 Fail	calc(3fr + 1fr * sign(38px - 2em)) should be used-value-equivalent to 2fr
-Fail	calc(2.5 - sign(33px - 2rem) / 2) should be used-value-equivalent to 2
-Fail	calc(2.5 - sign(32px - 2rem) / 2) should be used-value-equivalent to 2.5
-Fail	calc(2.5 - sign(31px - 2rem) / 2) should be used-value-equivalent to 3
+Pass	calc(2.5 - sign(33px - 2rem) / 2) should be used-value-equivalent to 2
+Pass	calc(2.5 - sign(32px - 2rem) / 2) should be used-value-equivalent to 2.5
+Pass	calc(2.5 - sign(31px - 2rem) / 2) should be used-value-equivalent to 3
 Pass	calc(50px + 100px * sign(34px - 2rem)) should be used-value-equivalent to 150px
 Pass	calc(50px + 100px * sign(32px - 2rem)) should be used-value-equivalent to 50px
 Pass	calc(50px + 100px * sign(30px - 2rem)) should be used-value-equivalent to -50px

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/font-variation-settings-calc.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/font-variation-settings-calc.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>CSS Fonts Test: Allow complex calc expressions in font-variation-settings</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variation-settings">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/support/parsing-testcommon.js"></script>
+<script src="../../css/support/computed-testcommon.js"></script>
+<div>
+  <div id="target"></div>
+</div>
+<script>
+  test_valid_value('font-variation-settings', '"wght" sign(1em - 1px)');
+  test_valid_value('font-variation-settings', '"wght" sibling-index()');
+  test_valid_value('font-variation-settings', '"wght" calc(10)');
+  test_valid_value('font-variation-settings', '"wght" sign(2px)', '"wght" calc(1)');
+  test_computed_value('font-variation-settings', '"wght" sign(1em - 1px)', '"wght" 1');
+  test_computed_value('font-variation-settings', '"wght" sibling-index()', '"wght" 1');
+  test_computed_value('font-variation-settings', '"wght" calc(10)', '"wght" 10');
+  test_computed_value('font-variation-settings', '"wght" sign(2px)', '"wght" 1');
+</script>


### PR DESCRIPTION
This PR includes a couple of simplifications to the `StyleValue` absolutization process:
 - Absolutize all values at the start of `compute_value_of_property`
 - Update `absolutized` to take a single struct as a param rather than multiple individual params.
 - Update some `StyleValue` classes to store their sub-values directly as `StyleValue`s rather than {Percentage,Calculated}Or wrappers

There are also a couple of drive-by improvements and I added `absolutized` methods to a couple of `StyleValue` classes for which it was missing.

See individual commits for details.