### PR TITLE
LibGfx: Free the harfbuzz buffer when measuring text width

### DIFF
--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -191,6 +191,7 @@ float measure_text_width(Utf16View const& string, Font const& font, ShapeFeature
     for (size_t i = 0; i < glyph_count; ++i)
         point_x += positions[i].x_advance;
 
+    hb_buffer_destroy(buffer);
     return point_x / text_shaping_resolution;
 }
 


### PR DESCRIPTION
I spotted this leak when WebContent was exiting with ASan enabled on a page with a media element. MediaPaintable calls Gfx::Font::width(), which calls through to measure_text_width(), which then drops an hb_buffer_t* without freeing it.