### PR TITLE
LibWeb/IndexedDB: Allow `queryOrOptions` to be null in `getAllKeys`

### DIFF
--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -2365,7 +2365,8 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> create_a_request_to_retrieve_multiple_i
     Bindings::IDBCursorDirection direction;
 
     // 8. If running is a potentially valid key range with queryOrOptions is true, then:
-    if (is_a_potentially_valid_key_range(realm, query_or_options)) {
+    // AD-HOC: Check if query_or_options is null following https://github.com/w3c/IndexedDB/issues/475
+    if (query_or_options.is_nullish() || is_a_potentially_valid_key_range(realm, query_or_options)) {
         // 1. Set range to the result of converting a value to a key range with queryOrOptions. Rethrow any exceptions.
         range = TRY(convert_a_value_to_a_key_range(realm, query_or_options));
 


### PR DESCRIPTION
Motivation: I wanted to see what it takes to get [demo.actualbudget.org](https://demo.actualbudget.org) working. On `master` the page crashes on initial load; this change lets the initial screen load.

Minimal repro of the issue (error in the console without this PR):
```html
<script>
const r = indexedDB.open("t", 1);
r.onupgradeneeded = e => e.target.result.createObjectStore("s", { keyPath: "id" });
r.onsuccess = () => r.result.transaction("s", "readonly").objectStore("s").getAllKeys();
</script>
```

No additional WPT tests pass from this change on its own, because the tests under https://wpt.live/IndexedDB/idbobjectstore_getAllKeys.any.html are currently timing out in `close_a_database_connection` (I think maybe https://github.com/LadybirdBrowser/ladybird/pull/6182 is the fix for that). However, if I disable that function by short-circuiting it, all linked tests now pass (and fail without this change)! Assuming that change or a similar fix is merged it would make sense to import the linked tests.

Interestingly, the [spec](https://www.w3.org/TR/IndexedDB/#create-request-to-retrieve-multiple-items) doesn't explicitly mention handling the `null` case; however, there is a note at the bottom of the linked section stating that `queryOrOptions` could be `null`, and the [definition](https://www.w3.org/TR/IndexedDB/#object-store-interface) also lists the parameter as optional.