### PR TITLE
String performance work for Discord (1 of N)

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -323,7 +323,7 @@ ErrorOr<String> String::reverse() const
     for (auto code_point : this->code_points())
         code_points.unchecked_append(code_point);
 
-    auto builder = TRY(StringBuilder::create(code_point_length * sizeof(u32)));
+    StringBuilder builder(code_point_length * sizeof(u32));
     while (!code_points.is_empty())
         TRY(builder.try_append_code_point(code_points.take_last()));
 

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -14,6 +14,7 @@
 #include <AK/MemMem.h>
 #include <AK/Stream.h>
 #include <AK/String.h>
+#include <AK/StringNumber.h>
 #include <AK/Utf16View.h>
 #include <AK/Vector.h>
 #include <stdlib.h>
@@ -563,42 +564,7 @@ String String::roman_number_from(size_t value, Case target_case)
 template<Integral T>
 String String::number(T value)
 {
-    // Maximum number of base-10 digits for T + sign
-    constexpr size_t max_digits = sizeof(T) * 3 + 2;
-    char buffer[max_digits];
-    char* ptr = buffer + max_digits;
-    bool is_negative = false;
-
-    using UnsignedT = MakeUnsigned<T>;
-
-    UnsignedT unsigned_value;
-    if constexpr (IsSigned<T>) {
-        if (value < 0) {
-            is_negative = true;
-            // Handle signed min correctly
-            unsigned_value = static_cast<UnsignedT>(0) - static_cast<UnsignedT>(value);
-        } else {
-            unsigned_value = static_cast<UnsignedT>(value);
-        }
-    } else {
-        unsigned_value = value;
-    }
-
-    if (unsigned_value == 0) {
-        *--ptr = '0';
-    } else {
-        while (unsigned_value != 0) {
-            *--ptr = '0' + (unsigned_value % 10);
-            unsigned_value /= 10;
-        }
-    }
-
-    if (is_negative) {
-        *--ptr = '-';
-    }
-
-    size_t size = buffer + max_digits - ptr;
-    return from_utf8_without_validation(ReadonlyBytes { ptr, size });
+    return create_string_from_number<String, T>(value);
 }
 
 template String String::number(char);

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -55,6 +55,11 @@ String String::from_utf8_without_validation(ReadonlyBytes bytes)
     return result;
 }
 
+String String::from_ascii_without_validation(ReadonlyBytes bytes)
+{
+    return from_utf8_without_validation(bytes);
+}
+
 ErrorOr<String> String::from_utf8(StringView view)
 {
     if (!Utf8View { view }.validate())

--- a/AK/String.h
+++ b/AK/String.h
@@ -64,6 +64,7 @@ public:
     static ErrorOr<String> from_utf8(T&&) = delete;
 
     [[nodiscard]] static String from_utf8_without_validation(ReadonlyBytes);
+    [[nodiscard]] static String from_ascii_without_validation(ReadonlyBytes);
 
     static ErrorOr<String> from_string_builder(Badge<StringBuilder>, StringBuilder&);
     [[nodiscard]] static String from_string_builder_without_validation(Badge<StringBuilder>, StringBuilder&);

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -46,12 +46,6 @@ static ErrorOr<StringBuilder::Buffer> create_buffer(StringBuilder::Mode mode, si
     return buffer;
 }
 
-ErrorOr<StringBuilder> StringBuilder::create(size_t initial_capacity)
-{
-    auto buffer = TRY(create_buffer(DEFAULT_MODE, initial_capacity));
-    return StringBuilder { move(buffer), DEFAULT_MODE };
-}
-
 StringBuilder::StringBuilder()
 {
     static constexpr auto prefix_size = string_builder_prefix_size(DEFAULT_MODE);
@@ -73,12 +67,6 @@ StringBuilder::StringBuilder(Mode mode)
 
 StringBuilder::StringBuilder(Mode mode, size_t initial_capacity_in_code_units)
     : m_buffer(MUST(create_buffer(mode, initial_capacity_in_code_units * (mode == Mode::UTF8 ? 1 : 2))))
-    , m_mode(mode)
-{
-}
-
-StringBuilder::StringBuilder(Buffer buffer, Mode mode)
-    : m_buffer(move(buffer))
     , m_mode(mode)
 {
 }

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -47,6 +47,7 @@ public:
     ErrorOr<void> try_append_repeated(StringView, size_t);
     ErrorOr<void> try_append_repeated(Utf16View const&, size_t);
     ErrorOr<void> try_append_escaped_for_json(StringView);
+    ErrorOr<void> try_append_ascii_without_validation(ReadonlyBytes);
 
     template<typename... Parameters>
     ErrorOr<void> try_appendff(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
@@ -68,6 +69,7 @@ public:
     void append_repeated(Utf16View const&, size_t);
     void append_escaped_for_json(StringView);
     void append_as_lowercase(char);
+    void append_ascii_without_validation(ReadonlyBytes);
 
     template<typename... Parameters>
     void appendff(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -26,8 +26,6 @@ public:
 
     using Buffer = Detail::ByteBuffer<inline_capacity>;
 
-    static ErrorOr<StringBuilder> create(size_t initial_capacity = inline_capacity);
-
     StringBuilder();
     explicit StringBuilder(size_t initial_capacity);
 
@@ -121,8 +119,6 @@ public:
     Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction(Badge<Detail::Utf16StringData>) { return leak_buffer_for_string_construction(); }
 
 private:
-    StringBuilder(Buffer, Mode);
-
     Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction();
 
     ErrorOr<void> will_append(size_t);

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -119,6 +119,8 @@ public:
     Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction(Badge<Detail::Utf16StringData>) { return leak_buffer_for_string_construction(); }
 
 private:
+    void initialize_buffer(Mode, size_t capacity);
+
     Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction();
 
     ErrorOr<void> will_append(size_t);

--- a/AK/StringNumber.h
+++ b/AK/StringNumber.h
@@ -46,7 +46,7 @@ StringType create_string_from_number(T value)
     }
 
     size_t size = buffer + max_digits - ptr;
-    return StringType::from_utf8_without_validation(ReadonlyBytes { ptr, size });
+    return StringType::from_ascii_without_validation(ReadonlyBytes { ptr, size });
 }
 
 }

--- a/AK/StringNumber.h
+++ b/AK/StringNumber.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace AK {
+
+template<class StringType, Integral T>
+StringType create_string_from_number(T value)
+{
+    // Maximum number of base-10 digits for T + sign
+    constexpr size_t max_digits = sizeof(T) * 3 + 2;
+    char buffer[max_digits];
+    char* ptr = buffer + max_digits;
+    bool is_negative = false;
+
+    using UnsignedT = MakeUnsigned<T>;
+
+    UnsignedT unsigned_value;
+    if constexpr (IsSigned<T>) {
+        if (value < 0) {
+            is_negative = true;
+            // Handle signed min correctly
+            unsigned_value = static_cast<UnsignedT>(0) - static_cast<UnsignedT>(value);
+        } else {
+            unsigned_value = static_cast<UnsignedT>(value);
+        }
+    } else {
+        unsigned_value = value;
+    }
+
+    if (unsigned_value == 0) {
+        *--ptr = '0';
+    } else {
+        while (unsigned_value != 0) {
+            *--ptr = '0' + (unsigned_value % 10);
+            unsigned_value /= 10;
+        }
+    }
+
+    if (is_negative) {
+        *--ptr = '-';
+    }
+
+    size_t size = buffer + max_digits - ptr;
+    return StringType::from_utf8_without_validation(ReadonlyBytes { ptr, size });
+}
+
+}

--- a/AK/Utf16String.cpp
+++ b/AK/Utf16String.cpp
@@ -37,6 +37,21 @@ Utf16String Utf16String::from_utf8_with_replacement_character(StringView utf8_st
     return builder.to_utf16_string();
 }
 
+Utf16String Utf16String::from_ascii_without_validation(ReadonlyBytes ascii_string)
+{
+    if (ascii_string.size() <= Detail::MAX_SHORT_STRING_BYTE_COUNT) {
+        Utf16String string;
+        string.m_value.short_ascii_string = Detail::ShortString::create_with_byte_count(ascii_string.size());
+
+        auto result = ascii_string.copy_to(string.m_value.short_ascii_string.storage);
+        VERIFY(result == ascii_string.size());
+
+        return string;
+    }
+
+    return Utf16String { Detail::Utf16StringData::from_ascii(ascii_string) };
+}
+
 Utf16String Utf16String::from_utf8_without_validation(StringView utf8_string)
 {
     if (utf8_string.length() <= Detail::MAX_SHORT_STRING_BYTE_COUNT && utf8_string.is_ascii()) {

--- a/AK/Utf16String.cpp
+++ b/AK/Utf16String.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Stream.h>
+#include <AK/StringNumber.h>
 #include <AK/Utf16String.h>
 #include <AK/Utf32View.h>
 
@@ -165,5 +166,23 @@ ErrorOr<void> Formatter<Utf16String>::format(FormatBuilder& builder, Utf16String
         return builder.builder().try_append(utf16_string.utf16_view());
     return builder.put_string(utf16_string.ascii_view());
 }
+
+template<Integral T>
+Utf16String Utf16String::number(T value)
+{
+    return create_string_from_number<Utf16String, T>(value);
+}
+
+template Utf16String Utf16String::number(char);
+template Utf16String Utf16String::number(signed char);
+template Utf16String Utf16String::number(unsigned char);
+template Utf16String Utf16String::number(signed short);
+template Utf16String Utf16String::number(unsigned short);
+template Utf16String Utf16String::number(int);
+template Utf16String Utf16String::number(unsigned int);
+template Utf16String Utf16String::number(long);
+template Utf16String Utf16String::number(unsigned long);
+template Utf16String Utf16String::number(long long);
+template Utf16String Utf16String::number(unsigned long long);
 
 }

--- a/AK/Utf16String.h
+++ b/AK/Utf16String.h
@@ -96,8 +96,11 @@ public:
         return builder.to_utf16_string();
     }
 
-    template<Arithmetic T>
-    ALWAYS_INLINE static Utf16String number(T value)
+    template<Integral T>
+    [[nodiscard]] static Utf16String number(T);
+
+    template<FloatingPoint T>
+    [[nodiscard]] static Utf16String number(T value)
     {
         return formatted("{}", value);
     }

--- a/AK/Utf16String.h
+++ b/AK/Utf16String.h
@@ -64,6 +64,7 @@ public:
     }
 
     static Utf16String from_utf8_without_validation(StringView);
+    static Utf16String from_ascii_without_validation(ReadonlyBytes);
 
     static Utf16String from_utf16(Utf16View const& utf16_string);
 

--- a/AK/Utf16StringData.cpp
+++ b/AK/Utf16StringData.cpp
@@ -56,6 +56,14 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::create_from_code_point_iterable(
     return string;
 }
 
+NonnullRefPtr<Utf16StringData> Utf16StringData::from_ascii(ReadonlyBytes ascii_string)
+{
+    VERIFY_UTF16_LENGTH(ascii_string.size());
+    auto string = create_uninitialized(StorageType::ASCII, ascii_string.size());
+    TypedTransfer<char>::copy(string->m_ascii_data, reinterpret_cast<char const*>(ascii_string.data()), ascii_string.size());
+    return string;
+}
+
 NonnullRefPtr<Utf16StringData> Utf16StringData::from_utf8(StringView utf8_string, AllowASCIIStorage allow_ascii_storage)
 {
     RefPtr<Utf16StringData> string;

--- a/AK/Utf16StringData.h
+++ b/AK/Utf16StringData.h
@@ -31,6 +31,7 @@ public:
     };
 
     static NonnullRefPtr<Utf16StringData> from_utf8(StringView, AllowASCIIStorage);
+    static NonnullRefPtr<Utf16StringData> from_ascii(ReadonlyBytes);
     static NonnullRefPtr<Utf16StringData> from_utf16(Utf16View const&);
     static NonnullRefPtr<Utf16StringData> from_utf32(Utf32View const&);
     static NonnullRefPtr<Utf16StringData> from_string_builder(StringBuilder&);

--- a/Libraries/LibCore/Environment.cpp
+++ b/Libraries/LibCore/Environment.cpp
@@ -115,7 +115,7 @@ Optional<StringView> get(StringView name, [[maybe_unused]] SecureOnly secure)
 
 ErrorOr<void> set(StringView name, StringView value, Overwrite overwrite)
 {
-    auto builder = TRY(StringBuilder::create());
+    StringBuilder builder;
     TRY(builder.try_append(name));
     TRY(builder.try_append('\0'));
     TRY(builder.try_append(value));
@@ -137,7 +137,7 @@ ErrorOr<void> set(StringView name, StringView value, Overwrite overwrite)
 
 ErrorOr<void> unset(StringView name)
 {
-    auto builder = TRY(StringBuilder::create());
+    StringBuilder builder;
     TRY(builder.try_append(name));
     TRY(builder.try_append('\0'));
     // Note the explicit null terminator above.

--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -510,7 +510,7 @@ ErrorOr<void> utimensat(int fd, StringView path, struct timespec const times[2],
     if (path.is_null())
         return Error::from_errno(EFAULT);
 
-    auto builder = TRY(StringBuilder::create());
+    StringBuilder builder;
     TRY(builder.try_append(path));
     TRY(builder.try_append('\0'));
 


### PR DESCRIPTION
Here's a handful of optimizations for things we were doing badly on https://discord.com/

In particular, they target this microbenchmark based on Discord behavior:
https://github.com/LadybirdBrowser/js-benchmarks/blob/master/MicroBench/object-set-with-rope-strings.js

```
function go() {
    let o = {};
    for (let j = 0; j < 5000; ++j) {
        for (let i = 0; i < 1000; ++i) {
            o["e" + i] = i;
        }
    }
}
go();
```

I have many patches, but will split them up a bit so we get multiple points on the benchmarks graphs.