### PR TITLE
LibWeb: Implement CanvasRenderingContext2D direction property

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -103,6 +103,7 @@ public:
         RefPtr<Gfx::FontCascadeList const> current_font_cascade_list { nullptr };
         Bindings::CanvasTextAlign text_align { Bindings::CanvasTextAlign::Start };
         Bindings::CanvasTextBaseline text_baseline { Bindings::CanvasTextBaseline::Alphabetic };
+        Bindings::CanvasDirection direction { Bindings::CanvasDirection::Inherit };
     };
     DrawingState& drawing_state() { return m_drawing_state; }
     DrawingState const& drawing_state() const { return m_drawing_state; }

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -155,6 +155,9 @@ public:
     Bindings::CanvasTextBaseline text_baseline() const { return my_drawing_state().text_baseline; }
     void set_text_baseline(Bindings::CanvasTextBaseline text_baseline) { my_drawing_state().text_baseline = text_baseline; }
 
+    Bindings::CanvasDirection direction() const { return my_drawing_state().direction; }
+    void set_direction(Bindings::CanvasDirection direction) { my_drawing_state().direction = direction; }
+
 protected:
     CanvasTextDrawingStyles() = default;
 

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.idl
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.idl
@@ -3,7 +3,7 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#canvastextalign
 // enum CanvasTextAlign { "start", "end", "left", "right", "center" };
 // enum CanvasTextBaseline { "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" };
-enum CanvasDirection { "ltr", "rtl", "inherit" };
+// enum CanvasDirection { "ltr", "rtl", "inherit" };
 enum CanvasFontKerning { "auto", "normal", "none" };
 enum CanvasFontStretch { "ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "normal", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded" };
 enum CanvasFontVariantCaps { "normal", "small-caps", "all-small-caps", "petite-caps", "all-petite-caps", "unicase", "titling-caps" };
@@ -16,7 +16,7 @@ interface mixin CanvasTextDrawingStyles {
     attribute DOMString font; // (default 10px sans-serif)
     attribute CanvasTextAlign textAlign; // (default: "start")
     attribute CanvasTextBaseline textBaseline; // (default: "alphabetic")
-    [FIXME] attribute CanvasDirection direction; // (default: "inherit")
+    attribute CanvasDirection direction; // (default: "inherit")
     [FIXME] attribute DOMString letterSpacing; // (default: "0px")
     [FIXME] attribute CanvasFontKerning fontKerning; // (default: "auto")
     [FIXME] attribute CanvasFontStretch fontStretch; // (default: "normal")

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -41,6 +41,7 @@ enum CanvasLineJoin { "round", "bevel", "miter" };
 // FIXME: This should be in CanvasTextDrawingStyles.idl but then it is not exported
 enum CanvasTextAlign { "start", "end", "left", "right", "center" };
 enum CanvasTextBaseline { "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" };
+enum CanvasDirection { "ltr", "rtl", "inherit" };
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d
 [Exposed=Window]


### PR DESCRIPTION
Hey, my first time here - hope I didn't miss any contribution guidelines

When direction is 'rtl':
  - textAlign='start' now aligns text to the right
  - textAlign='end' now aligns text to the left

You can compare behavior with this example:
[rtl-canvas-test.html](https://github.com/user-attachments/files/22709575/rtl-canvas-test.html)
