### PR TITLE
String performance work for Discord (2 of N)

### DIFF
--- a/AK/Utf16String.h
+++ b/AK/Utf16String.h
@@ -74,6 +74,13 @@ public:
 
     static Utf16String from_utf32(Utf32View const&);
 
+    ALWAYS_INLINE static constexpr Utf16String from_ascii_character(u8 character)
+    {
+        auto short_string = Detail::ShortString::create_with_byte_count(1);
+        short_string.storage[0] = character;
+        return Utf16String { short_string };
+    }
+
     ALWAYS_INLINE static Utf16String from_code_point(u32 code_point)
     {
         Array<char16_t, 2> code_units;

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -24,7 +24,7 @@ namespace JS {
 GC_DEFINE_ALLOCATOR(PrimitiveString);
 GC_DEFINE_ALLOCATOR(RopeString);
 
-GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16String string)
+GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16String const& string)
 {
     if (string.is_empty())
         return vm.empty_string();
@@ -53,7 +53,7 @@ GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, Utf16FlyString const& s
     return create(vm, string.to_utf16_string());
 }
 
-GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, String string)
+GC::Ref<PrimitiveString> PrimitiveString::create(VM& vm, String const& string)
 {
     if (string.is_empty())
         return vm.empty_string();

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -250,10 +250,10 @@ void RopeString::resolve(EncodingPreference preference) const
         StringBuilder builder(StringBuilder::Mode::UTF16);
 
         for (auto const* current : pieces) {
-            if (current->has_utf8_string())
-                builder.append(current->utf8_string_view());
-            else
+            if (current->has_utf16_string())
                 builder.append(current->utf16_string_view());
+            else
+                builder.append(current->utf8_string_view());
         }
 
         m_utf16_string = builder.to_utf16_string();

--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -146,7 +146,8 @@ String PrimitiveString::utf8_string() const
 
 StringView PrimitiveString::utf8_string_view() const
 {
-    (void)utf8_string();
+    if (!has_utf8_string())
+        (void)utf8_string();
     return m_utf8_string->bytes_as_string_view();
 }
 
@@ -164,7 +165,8 @@ Utf16String PrimitiveString::utf16_string() const
 
 Utf16View PrimitiveString::utf16_string_view() const
 {
-    (void)utf16_string();
+    if (!has_utf16_string())
+        (void)utf16_string();
     return *m_utf16_string;
 }
 

--- a/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -25,11 +25,11 @@ class JS_API PrimitiveString : public Cell {
     GC_DECLARE_ALLOCATOR(PrimitiveString);
 
 public:
-    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, Utf16String);
+    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, Utf16String const&);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, Utf16View const&);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, Utf16FlyString const&);
 
-    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, String);
+    [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, String const&);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, StringView);
     [[nodiscard]] static GC::Ref<PrimitiveString> create(VM&, FlyString const&);
 

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -58,7 +58,7 @@ NonnullRefPtr<VM> VM::create()
 template<size_t... code_points>
 static constexpr auto make_single_ascii_character_strings(IndexSequence<code_points...>)
 {
-    return AK::Array { (String::from_code_point(static_cast<u32>(code_points)))... };
+    return AK::Array { (Utf16String::from_ascii_character(static_cast<u8>(code_points)))... };
 }
 
 static constexpr auto single_ascii_character_strings = make_single_ascii_character_strings(MakeIndexSequence<128>());


### PR DESCRIPTION
Continuing from #6396 

Here's another handful of optimizations for things we were doing badly on https://discord.com/

In particular, they target this microbenchmark based on Discord behavior:
https://github.com/LadybirdBrowser/js-benchmarks/blob/master/MicroBench/object-set-with-rope-strings.js

```
function go() {
    let o = {};
    for (let j = 0; j < 5000; ++j) {
        for (let i = 0; i < 1000; ++i) {
            o["e" + i] = i;
        }
    }
}
go();
```

These changes yield a 1.05x speedup on the program above.

I have many patches, but will split them up a bit so we get multiple points on the benchmarks graphs.