### PR TITLE
LibWasm: Avoid revalidating memory/address for every element in memory.*

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -90,6 +90,9 @@ struct WASM_API BytecodeInterpreter final : public Interpreter {
     bool store_to_memory(Configuration&, Instruction::MemoryArgument const&, ReadonlyBytes data, u32 base);
     bool call_address(Configuration&, FunctionAddress, CallAddressSource = CallAddressSource::DirectCall);
 
+    template<typename T>
+    bool store_to_memory(MemoryInstance&, u64 address, T value);
+
     template<typename PopTypeLHS, typename PushType, typename Operator, typename PopTypeRHS = PopTypeLHS, typename... Args>
     bool binary_numeric_operation(Configuration&, SourcesAndDestination const&, Args&&...);
 


### PR DESCRIPTION
This also "fixes" the "address leak" detected by GCC (which is not actually leaked to the tailcalled function).

(doesn't really have much of an effect on perf since memory.* are usually one-off instructions)