### PR TITLE
CI: Add manual workflow dispatch to JS/WASM artifacts build

### DIFF
--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -3,6 +3,12 @@ name: Package the js repl as a binary artifact
 on:
   push:
     branches: [master]
+  workflow_dispatch:
+    inputs:
+      reference_to_build:
+        description: 'Branch, tag or commit hash to build'
+        required: true
+        type: string
 
 env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
@@ -40,6 +46,8 @@ jobs:
     steps:
       - name: Checkout LadybirdBrowser/ladybird
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.reference_to_build }}
 
       - name: "Set up environment"
         uses: ./.github/actions/setup


### PR DESCRIPTION
This allows us to manually kick off jobs for the JS/WASM artifacts build with an explicit reference to build, which is useful if we want to generate benchmark results for older commits.

Note that this workflow does not actually produce benchmark results - that's the job of another workflow. The webhook storing the benchmark results only appends new benchmarks; existing ones will be kept.

Also note that the GitHub checkout action defaults to the default reference if `inputs.reference_to_build` is not provided, such as in the case of a push to the master branch.