### PR TITLE
LibWeb: Resolve `stroke-dasharray` percentages as lengths

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -3268,7 +3268,8 @@
     "animation-type": "custom",
     "inherited": true,
     "initial": "none",
-    "affects-layout": false
+    "affects-layout": false,
+    "percentages-resolve-to": "length"
   },
   "stroke-dashoffset": {
     "affects-layout": false,

--- a/Tests/LibWeb/Crash/CSS/calculated-stroke-dash-array-with-percentage.html
+++ b/Tests/LibWeb/Crash/CSS/calculated-stroke-dash-array-with-percentage.html
@@ -1,0 +1,5 @@
+<html>
+    <svg>
+        <line stroke-dasharray="calc(0%)"></line>
+    </svg>
+</html>


### PR DESCRIPTION
Fixes a crash on https://collabskus.github.io/