### PR TITLE
LibJS: Make overflowing arithmetic on 2x Int32 values faster

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1949,6 +1949,9 @@ ThrowCompletionOr<void> Add::execute_impl(Bytecode::Interpreter& interpreter) co
                 interpreter.set(m_dst, Value(lhs.as_i32() + rhs.as_i32()));
                 return {};
             }
+            auto result = static_cast<i64>(lhs.as_i32()) + static_cast<i64>(rhs.as_i32());
+            interpreter.set(m_dst, Value(result, Value::CannotFitInInt32::Indeed));
+            return {};
         }
         interpreter.set(m_dst, Value(lhs.as_double() + rhs.as_double()));
         return {};
@@ -1970,6 +1973,9 @@ ThrowCompletionOr<void> Mul::execute_impl(Bytecode::Interpreter& interpreter) co
                 interpreter.set(m_dst, Value(lhs.as_i32() * rhs.as_i32()));
                 return {};
             }
+            auto result = static_cast<i64>(lhs.as_i32()) * static_cast<i64>(rhs.as_i32());
+            interpreter.set(m_dst, Value(result, Value::CannotFitInInt32::Indeed));
+            return {};
         }
         interpreter.set(m_dst, Value(lhs.as_double() * rhs.as_double()));
         return {};
@@ -1991,6 +1997,9 @@ ThrowCompletionOr<void> Sub::execute_impl(Bytecode::Interpreter& interpreter) co
                 interpreter.set(m_dst, Value(lhs.as_i32() - rhs.as_i32()));
                 return {};
             }
+            auto result = static_cast<i64>(lhs.as_i32()) - static_cast<i64>(rhs.as_i32());
+            interpreter.set(m_dst, Value(result, Value::CannotFitInInt32::Indeed));
+            return {};
         }
         interpreter.set(m_dst, Value(lhs.as_double() - rhs.as_double()));
         return {};

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -165,6 +165,13 @@ public:
     {
     }
 
+    enum class CannotFitInInt32 { Indeed };
+    Value(i64 value, CannotFitInInt32)
+    {
+        ASSERT(value < static_cast<i64>(NumericLimits<i32>::min()) || value > static_cast<i64>(NumericLimits<i32>::max()));
+        m_value.as_double = static_cast<double>(value);
+    }
+
     explicit Value(double value)
     {
         bool is_negative_zero = bit_cast<u64>(value) == NEGATIVE_ZERO_BITS;


### PR DESCRIPTION
Instead of converting them to doubles and doing double math, just do the arithmetic operation in i64 space instead.

This gives us a ~1.25x speed-up on this kind of micro-benchmark:

    (() => {
        let a = -2124299999;
        for (let i = 0; i < 100_000_000; ++i) {
            a + a;
        }
    })()

Same idea for Add, Sub, and Mul.

There's a fair bit of overflowing Int32 arithmetic in some of the JetStream benchmarks, and this seems like an obvious improvement.