### PR TITLE
CI: Always run latest version of js-benchmarks

### DIFF
--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           repository: LadybirdBrowser/js-benchmarks
           path: js-benchmarks
+          ref: master
 
       - name: 'Install dependencies'
         if: ${{ matrix.os_name == 'Linux' }}


### PR DESCRIPTION
Currently we default to GITHUB_REF for the checkout of js-benchmarks, and if we've built up a large backlog of benchmark jobs to run, this can mean we're running against a severely outdated version of js-benchmarks.

This new behavior allows us to see a failed js-benchmarks job, fix the bug, and restart the failed job. This is important since we're testing a specific commit and build from the upstream JS/WASM workflow.