### PR TITLE
LibJS: Deprecate the old, non-bytecode await implementation

### DIFF
--- a/Libraries/LibJS/Runtime/Agent.h
+++ b/Libraries/LibJS/Runtime/Agent.h
@@ -26,8 +26,6 @@ public:
 
     CanBlock can_block() const { return m_can_block; }
 
-    virtual void spin_event_loop_until(GC::Root<GC::Function<bool()>> goal_condition) = 0;
-
 protected:
     explicit Agent(CanBlock can_block)
         : m_can_block(can_block)

--- a/Libraries/LibJS/Runtime/Completion.cpp
+++ b/Libraries/LibJS/Runtime/Completion.cpp
@@ -31,98 +31,10 @@ Completion::Completion(ThrowCompletionOr<Value> const& throw_completion_or_value
 }
 
 // 6.2.3.1 Await, https://tc39.es/ecma262/#await
-// FIXME: This no longer matches the spec!
-ThrowCompletionOr<Value> await(VM& vm, Value value)
+// FIXME: Replace this with the bytecode implementation (e.g. by converting users to bytecode)
+ThrowCompletionOr<Value> await(VM& vm, Value)
 {
-    auto& realm = *vm.current_realm();
-
-    // 1. Let asyncContext be the running execution context.
-    // NOTE: This is not needed, as we don't suspend anything.
-
-    // 2. Let promise be ? PromiseResolve(%Promise%, value).
-    auto* promise_object = TRY(promise_resolve(vm, realm.intrinsics().promise_constructor(), value));
-
-    IGNORE_USE_IN_ESCAPING_LAMBDA Optional<bool> success;
-    IGNORE_USE_IN_ESCAPING_LAMBDA Value result;
-
-    // 3. Let fulfilledClosure be a new Abstract Closure with parameters (value) that captures asyncContext and performs the following steps when called:
-    auto fulfilled_closure = [&success, &result](VM& vm) -> ThrowCompletionOr<Value> {
-        // a. Let prevContext be the running execution context.
-        // b. Suspend prevContext.
-        // FIXME: We don't have this concept yet.
-
-        // NOTE: Since we don't support context suspension, we exfiltrate the result to await()'s scope instead
-        success = true;
-        result = vm.argument(0);
-
-        // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
-        // NOTE: This is not done, because we're not suspending anything (see above).
-
-        // d. Resume the suspended evaluation of asyncContext using NormalCompletion(value) as the result of the operation that suspended it.
-        // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
-        // FIXME: We don't have this concept yet.
-
-        // f. Return undefined.
-        return js_undefined();
-    };
-
-    // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-    auto on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
-
-    // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the following steps when called:
-    auto rejected_closure = [&success, &result](VM& vm) -> ThrowCompletionOr<Value> {
-        // a. Let prevContext be the running execution context.
-        // b. Suspend prevContext.
-        // FIXME: We don't have this concept yet.
-
-        // NOTE: Since we don't support context suspension, we exfiltrate the result to await()'s scope instead
-        success = false;
-        result = vm.argument(0);
-
-        // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
-        // NOTE: This is not done, because we're not suspending anything (see above).
-
-        // d. Resume the suspended evaluation of asyncContext using ThrowCompletion(reason) as the result of the operation that suspended it.
-        // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
-        // FIXME: We don't have this concept yet.
-
-        // f. Return undefined.
-        return js_undefined();
-    };
-
-    // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    auto on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
-
-    // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
-    auto promise = as<Promise>(promise_object);
-    promise->perform_then(on_fulfilled, on_rejected, {});
-
-    // FIXME: Since we don't support context suspension, we attempt to "wait" for the promise to resolve
-    //        by synchronously running all queued promise jobs.
-    if (auto* agent = vm.agent()) {
-        // Embedder case (i.e. LibWeb). Runs all promise jobs by performing a microtask checkpoint.
-        agent->spin_event_loop_until(GC::create_function(vm.heap(), [success] {
-            return success.has_value();
-        }));
-    } else {
-        // No embbedder, standalone LibJS implementation
-        vm.run_queued_promise_jobs();
-    }
-
-    // 8. Remove asyncContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
-    // NOTE: Since we don't push any EC, this step is not performed.
-
-    // 9. Set the code evaluation state of asyncContext such that when evaluation is resumed with a Completion Record completion, the following steps of the algorithm that invoked Await will be performed, with completion available.
-    // 10. Return NormalCompletion(unused).
-    // 11. NOTE: This returns to the evaluation of the operation that had most previously resumed evaluation of asyncContext.
-
-    // Make sure that the promise _actually_ resolved.
-    // Note that this is checked down the chain (result.is_empty()) anyway, but let's make the source of the issue more clear.
-    VERIFY(success.has_value());
-
-    if (success.value())
-        return result;
-    return throw_completion(result);
+    return vm.throw_completion<InternalError>(ErrorType::NotImplemented, "Migrating old await implementation to Bytecode"sv);
 }
 
 static void log_exception(Value value)

--- a/Libraries/LibJS/Tests/builtins/Array/Array.fromAsync.js
+++ b/Libraries/LibJS/Tests/builtins/Array/Array.fromAsync.js
@@ -23,13 +23,13 @@ describe("normal behavior", () => {
         expect(passed).toBeTrue();
     }
 
-    test("async from sync iterable no mapfn", () => {
+    test.skip("async from sync iterable no mapfn", () => {
         const input = [0, Promise.resolve(2), Promise.resolve(4)].values();
         const promise = Array.fromAsync(input);
         checkResult(promise);
     });
 
-    test("from object of promises no mapfn", () => {
+    test.skip("from object of promises no mapfn", () => {
         let promise = Array.fromAsync({
             length: 3,
             0: Promise.resolve(0),
@@ -39,13 +39,13 @@ describe("normal behavior", () => {
         checkResult(promise);
     });
 
-    test("async from sync iterable with mapfn", () => {
+    test.skip("async from sync iterable with mapfn", () => {
         const input = [Promise.resolve(0), 1, Promise.resolve(2)].values();
         const promise = Array.fromAsync(input, async element => element * 2);
         checkResult(promise);
     });
 
-    test("from object of promises with mapfn", () => {
+    test.skip("from object of promises with mapfn", () => {
         let promise = Array.fromAsync(
             {
                 length: 3,
@@ -58,7 +58,7 @@ describe("normal behavior", () => {
         checkResult(promise);
     });
 
-    test("does not double construct from array like object", () => {
+    test.skip("does not double construct from array like object", () => {
         let callCount = 0;
 
         class TestArray {

--- a/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.adopt.js
+++ b/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.adopt.js
@@ -3,7 +3,7 @@ test("length is 2", () => {
 });
 
 describe("basic functionality", () => {
-    test("adopted dispose method gets called when stack is disposed", async () => {
+    test.skip("adopted dispose method gets called when stack is disposed", async () => {
         const stack = new AsyncDisposableStack();
         let disposedCalled = 0;
         let disposeArgument = undefined;
@@ -22,7 +22,7 @@ describe("basic functionality", () => {
         expect(disposedCalled).toBe(1);
     });
 
-    test("can adopt any value", async () => {
+    test.skip("can adopt any value", async () => {
         const stack = new AsyncDisposableStack();
         const disposed = [];
         function dispose(value) {
@@ -40,7 +40,7 @@ describe("basic functionality", () => {
         expect(disposed).toEqual(values.reverse());
     });
 
-    test("adopted stack is already disposed", async () => {
+    test.skip("adopted stack is already disposed", async () => {
         const stack = new AsyncDisposableStack();
         stack.adopt(stack, value => {
             expect(stack).toBe(value);
@@ -51,7 +51,7 @@ describe("basic functionality", () => {
 });
 
 describe("throws errors", () => {
-    test("if call back is not a function throws type error", () => {
+    test.skip("if call back is not a function throws type error", () => {
         const stack = new AsyncDisposableStack();
         [
             1,
@@ -76,7 +76,7 @@ describe("throws errors", () => {
         expect(stack.disposed).toBeFalse();
     });
 
-    test("adopt throws if stack is already disposed (over type errors)", async () => {
+    test.skip("adopt throws if stack is already disposed (over type errors)", async () => {
         const stack = new AsyncDisposableStack();
         await stack.disposeAsync();
         expect(stack.disposed).toBeTrue();

--- a/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.defer.js
+++ b/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.defer.js
@@ -3,7 +3,7 @@ test("length is 1", () => {
 });
 
 describe("basic functionality", () => {
-    test("deferred function gets called when stack is disposed", async () => {
+    test.skip("deferred function gets called when stack is disposed", async () => {
         const stack = new AsyncDisposableStack();
         let disposedCalled = 0;
         expect(disposedCalled).toBe(0);
@@ -20,7 +20,7 @@ describe("basic functionality", () => {
         expect(disposedCalled).toBe(1);
     });
 
-    test("deferred stack is already disposed", async () => {
+    test.skip("deferred stack is already disposed", async () => {
         const stack = new AsyncDisposableStack();
         stack.defer(() => {
             expect(stack.disposed).toBeTrue();
@@ -55,7 +55,7 @@ describe("throws errors", () => {
         expect(stack.disposed).toBeFalse();
     });
 
-    test("defer throws if stack is already disposed (over type errors)", async () => {
+    test.skip("defer throws if stack is already disposed (over type errors)", async () => {
         const stack = new AsyncDisposableStack();
         await stack.disposeAsync();
         expect(stack.disposed).toBeTrue();

--- a/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.disposeAsync.js
+++ b/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.disposeAsync.js
@@ -3,14 +3,14 @@ test("length is 0", () => {
 });
 
 describe("basic functionality", () => {
-    test("make the stack marked as disposed", async () => {
+    test.skip("make the stack marked as disposed", async () => {
         const stack = new AsyncDisposableStack();
         const result = await stack.disposeAsync();
         expect(stack.disposed).toBeTrue();
         expect(result).toBeUndefined();
     });
 
-    test("call dispose on objects in stack when called", async () => {
+    test.skip("call dispose on objects in stack when called", async () => {
         const stack = new AsyncDisposableStack();
         let disposedCalled = false;
         stack.use({
@@ -25,7 +25,7 @@ describe("basic functionality", () => {
         expect(result).toBeUndefined();
     });
 
-    test("disposed the objects added to the stack in reverse order", async () => {
+    test.skip("disposed the objects added to the stack in reverse order", async () => {
         const disposed = [];
         const stack = new AsyncDisposableStack();
         stack.use({
@@ -45,7 +45,7 @@ describe("basic functionality", () => {
         expect(result).toBeUndefined();
     });
 
-    test("does not dispose anything if already disposed", async () => {
+    test.skip("does not dispose anything if already disposed", async () => {
         const disposed = [];
         const stack = new AsyncDisposableStack();
         stack.use({
@@ -70,7 +70,7 @@ describe("basic functionality", () => {
         expect(disposed).toEqual(["a"]);
     });
 
-    test("throws if dispose method throws", async () => {
+    test.skip("throws if dispose method throws", async () => {
         const stack = new AsyncDisposableStack();
         let disposedCalled = false;
         stack.use({

--- a/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.disposed.js
+++ b/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.disposed.js
@@ -16,7 +16,7 @@ describe("basic functionality", () => {
         expect(stack.disposed).toBeFalse();
     });
 
-    test("becomes true after being disposed", async () => {
+    test.skip("becomes true after being disposed", async () => {
         const stack = new AsyncDisposableStack();
         await stack.disposeAsync();
         expect(stack.disposed).toBeTrue();

--- a/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.move.js
+++ b/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.move.js
@@ -12,7 +12,7 @@ describe("basic functionality", () => {
         expect(newStack.disposed).toBeFalse();
     });
 
-    test("move does not dispose resource but only move them", async () => {
+    test.skip("move does not dispose resource but only move them", async () => {
         const stack = new AsyncDisposableStack();
         let disposeCalled = false;
         stack.defer(() => {
@@ -41,7 +41,7 @@ describe("basic functionality", () => {
         expect(newStack.disposed).toBeTrue();
     });
 
-    test("can add stack to itself", async () => {
+    test.skip("can add stack to itself", async () => {
         const stack = new AsyncDisposableStack();
         stack.move(stack);
         await stack.disposeAsync();
@@ -49,7 +49,7 @@ describe("basic functionality", () => {
 });
 
 describe("throws errors", () => {
-    test("move throws if stack is already disposed (over type errors)", async () => {
+    test.skip("move throws if stack is already disposed (over type errors)", async () => {
         const stack = new AsyncDisposableStack();
         await stack.disposeAsync();
         expect(stack.disposed).toBeTrue();

--- a/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.use.js
+++ b/Libraries/LibJS/Tests/builtins/AsyncDisposableStack/AsyncDisposableStack.prototype.use.js
@@ -3,7 +3,7 @@ test("length is 1", () => {
 });
 
 describe("basic functionality", () => {
-    test("added objects dispose method gets when stack is disposed", async () => {
+    test.skip("added objects dispose method gets when stack is disposed", async () => {
         const stack = new AsyncDisposableStack();
         let disposedCalled = 0;
         const obj = {
@@ -22,7 +22,7 @@ describe("basic functionality", () => {
         expect(disposedCalled).toBe(1);
     });
 
-    test("can add null and undefined", async () => {
+    test.skip("can add null and undefined", async () => {
         const stack = new AsyncDisposableStack();
 
         expect(stack.use(null)).toBeNull();
@@ -33,7 +33,7 @@ describe("basic functionality", () => {
         expect(stack.disposed).toBeTrue();
     });
 
-    test("can add stack to itself", async () => {
+    test.skip("can add stack to itself", async () => {
         const stack = new AsyncDisposableStack();
         stack.use(stack);
         await stack.disposeAsync();
@@ -81,7 +81,7 @@ describe("throws errors", () => {
         expect(calledGetter).toBeTrue();
     });
 
-    test("use throws if stack is already disposed (over type errors)", async () => {
+    test.skip("use throws if stack is already disposed (over type errors)", async () => {
         const stack = new AsyncDisposableStack();
         await stack.disposeAsync();
         expect(stack.disposed).toBeTrue();

--- a/Libraries/LibWeb/HTML/Scripting/Agent.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Agent.cpp
@@ -11,11 +11,6 @@
 
 namespace Web::HTML {
 
-void Agent::spin_event_loop_until(GC::Root<GC::Function<bool()>> goal_condition)
-{
-    Platform::EventLoopPlugin::the().spin_until(move(goal_condition));
-}
-
 // https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent
 Agent& relevant_agent(JS::Object const& object)
 {

--- a/Libraries/LibWeb/HTML/Scripting/Agent.h
+++ b/Libraries/LibWeb/HTML/Scripting/Agent.h
@@ -20,8 +20,6 @@ struct Agent : public JS::Agent {
     // And the event loop of a worklet agent is known as a worklet event loop.
     GC::Root<HTML::EventLoop> event_loop;
 
-    virtual void spin_event_loop_until(GC::Root<GC::Function<bool()>> goal_condition) override;
-
 protected:
     using JS::Agent::Agent;
 };


### PR DESCRIPTION
This removes a user of spin_until and makes it obvious that this incomplete migration work exists.