### PR TITLE
Tests: Adjust timing in abortsignal-timeout test to avoid failure

### DIFF
--- a/Tests/LibWeb/Text/input/abortsignal-timeout.html
+++ b/Tests/LibWeb/Text/input/abortsignal-timeout.html
@@ -7,10 +7,16 @@
         const signal = AbortSignal.timeout(timeout_milliseconds);
         signal.onabort = (event) => {
             const abort_event_time = performance.now();
-            const time_taken_milliseconds = abort_event_time - test_start_time;
+            const time_taken_milliseconds = (abort_event_time - test_start_time) + 1; // Add 1ms for possible coarse clock skew
             println(`Time passed before abort event fired is at least ${timeout_milliseconds} milliseconds: ${time_taken_milliseconds >= timeout_milliseconds}`);
             println(`Reason type: ${signal.reason.name}`);
             println(`onabort event isTrusted: ${event.isTrusted}`);
+            if (time_taken_milliseconds < timeout_milliseconds) {
+               println(`start time: ${test_start_time}`);
+               println(`abort time: ${abort_event_time}`);
+               println(`difference (coarse adjusted): ${time_taken_milliseconds}`);
+               println(`difference (actual): ${time_taken_milliseconds - 1}`);
+            }
             done();
         };
     });


### PR DESCRIPTION
Many clock related functions in Linux (and Ladybird) use the clock type called CLOCK_MONOTONIC_COARSE to obtain timestamps. This is a less precise clock and can be skewed by 1 or more milliseconds. Often coarse clocks are used to defend against timing attacks or for fingerprinting a system.

This less precise clock timing is causing the abortsignal-timeout.html test to fail randomly as it expects the abort signal to arrive after 10ms, but in some cases it arrives at 9ms causing the test to fail. In very rare cases it could even arrive in 7ms or 8ms.

Test is changed to accept 9ms as a good result and if that is still not enough the test also will display the timings so that further adjustments to the test can be made in the future.

Issue discussed further in #6362

fixes: #6362 