### PR TITLE
CI: Trigger Flatpak CI builds with 'flatpak' PR label

### DIFF
--- a/.github/workflows/ci-flatpak.yml
+++ b/.github/workflows/ci-flatpak.yml
@@ -1,0 +1,40 @@
+name: CI (Flatpak)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Do not cancel in-progress runs if a labeling action took place (other than 'flatpak'). Otherwise, adding irrelevant
+  # labels causes existing runs to be canceled and a new (identical) run to be started.
+  cancel-in-progress: ${{ (github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'flatpak' }}
+
+jobs:
+  CI-Flatpak:
+    # Only run this job if the PR has the 'flatpak' label.
+    if: |
+      github.repository == 'LadybirdBrowser/ladybird'
+      && contains(github.event.pull_request.labels.*.name, 'flatpak')
+    name: Flatpak ${{ matrix.arch }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['x86_64']
+        runner_labels: ['["blacksmith-8vcpu-ubuntu-2404"]']
+
+        include:
+          - arch: 'aarch64'
+            runner_labels: '["blacksmith-8vcpu-ubuntu-2404-arm"]'
+
+    secrets: inherit
+    uses: ./.github/workflows/flatpak-template.yml
+    with:
+      arch: ${{ matrix.arch }}
+      runner_labels: ${{ matrix.runner_labels }}


### PR DESCRIPTION
Similar to the 'windows' label, this triggers Flatpak builds for x86_64 and aarch64.