### PR TITLE
LibWeb: Execute rasterization callback on the rendering thread

### DIFF
--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -71,9 +71,7 @@ void RenderingThread::rendering_thread_loop()
         m_skia_player->execute(*task->display_list, move(task->scroll_state_snapshot_by_display_list), task->painting_surface);
         if (m_exit)
             break;
-        m_main_thread_event_loop.deferred_invoke([callback = move(task->callback)] {
-            callback();
-        });
+        task->callback();
     }
 }
 


### PR DESCRIPTION
Previously, we enqueued a task on the main thread's event loop to execute the callback. This meant that even though the rendering thread had finished producing the next frame, there was still a delay before the main thread notified the UI process.

This change makes the rendering thread execute the callback directly. This should be safe, as the only pointer captured by the callback is the traversable `PageClient`, which is expected to remain alive for as long as the rendering thread exists. The callback then invokes either `page_did_paint()` or `page_did_take_screenshot()`, both of which enqueue an IPC message, which is safe to do since `SendQueue` is protected by a mutex.