### PR TITLE
LibWeb: Add missing SVG presentation attributes

### DIFF
--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -34,10 +34,14 @@ void SVGElement::initialize(JS::Realm& realm)
 }
 
 struct NamedPropertyID {
-    NamedPropertyID(CSS::PropertyID property_id, Vector<FlyString> supported_elements = {})
+    NamedPropertyID(CSS::PropertyID property_id, FlyString name, Vector<FlyString> supported_elements = {})
         : id(property_id)
-        , name(CSS::string_from_property_id(property_id))
+        , name(move(name))
         , supported_elements(move(supported_elements))
+    {
+    }
+    NamedPropertyID(CSS::PropertyID property_id, Vector<FlyString> supported_elements = {})
+        : NamedPropertyID(property_id, CSS::string_from_property_id(property_id), move(supported_elements))
     {
     }
 
@@ -72,6 +76,7 @@ static ReadonlySpan<NamedPropertyID> attribute_style_properties()
         NamedPropertyID(CSS::PropertyID::FontStyle),
         NamedPropertyID(CSS::PropertyID::FontVariant),
         NamedPropertyID(CSS::PropertyID::FontWeight),
+        NamedPropertyID(CSS::PropertyID::FontWidth, "font-stretch"_fly_string),
         NamedPropertyID(CSS::PropertyID::Height, { SVG::TagNames::foreignObject, SVG::TagNames::image, SVG::TagNames::rect, SVG::TagNames::svg, SVG::TagNames::symbol, SVG::TagNames::use }),
         NamedPropertyID(CSS::PropertyID::ImageRendering),
         NamedPropertyID(CSS::PropertyID::LetterSpacing),

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-irrelevant.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-irrelevant.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 48 tests
 
-47 Pass
-1 Fail
+48 Pass
 Pass	clip-path presentation attribute supported on an irrelevant element
 Pass	clip-rule presentation attribute supported on an irrelevant element
 Pass	color presentation attribute supported on an irrelevant element
@@ -19,7 +18,7 @@ Pass	flood-color presentation attribute supported on an irrelevant element
 Pass	flood-opacity presentation attribute supported on an irrelevant element
 Pass	font-family presentation attribute supported on an irrelevant element
 Pass	font-size presentation attribute supported on an irrelevant element
-Fail	font-stretch presentation attribute supported on an irrelevant element
+Pass	font-stretch presentation attribute supported on an irrelevant element
 Pass	font-style presentation attribute supported on an irrelevant element
 Pass	font-variant presentation attribute supported on an irrelevant element
 Pass	font-weight presentation attribute supported on an irrelevant element

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 58 tests
 
-56 Pass
-2 Fail
+57 Pass
+1 Fail
 Pass	clip-path presentation attribute supported on a relevant element
 Pass	clip-rule presentation attribute supported on a relevant element
 Pass	color presentation attribute supported on a relevant element
@@ -21,7 +21,7 @@ Pass	flood-color presentation attribute supported on a relevant element
 Pass	flood-opacity presentation attribute supported on a relevant element
 Pass	font-family presentation attribute supported on a relevant element
 Pass	font-size presentation attribute supported on a relevant element
-Fail	font-stretch presentation attribute supported on a relevant element
+Pass	font-stretch presentation attribute supported on a relevant element
 Pass	font-style presentation attribute supported on a relevant element
 Pass	font-variant presentation attribute supported on a relevant element
 Pass	font-weight presentation attribute supported on a relevant element

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-unknown.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-unknown.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 48 tests
 
-47 Pass
-1 Fail
+48 Pass
 Pass	clip-path presentation attribute supported on an unknown SVG element
 Pass	clip-rule presentation attribute supported on an unknown SVG element
 Pass	color presentation attribute supported on an unknown SVG element
@@ -19,7 +18,7 @@ Pass	flood-color presentation attribute supported on an unknown SVG element
 Pass	flood-opacity presentation attribute supported on an unknown SVG element
 Pass	font-family presentation attribute supported on an unknown SVG element
 Pass	font-size presentation attribute supported on an unknown SVG element
-Fail	font-stretch presentation attribute supported on an unknown SVG element
+Pass	font-stretch presentation attribute supported on an unknown SVG element
 Pass	font-style presentation attribute supported on an unknown SVG element
 Pass	font-variant presentation attribute supported on an unknown SVG element
 Pass	font-weight presentation attribute supported on an unknown SVG element


### PR DESCRIPTION
This allows `font-variant` and `text-decoration` to be used as presentation attributes in SVGs.