### PR TITLE
LibWeb: Remove redundant SVG presentation attribute handling

### DIFF
--- a/Libraries/LibWeb/SVG/SVGFilterElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGFilterElement.cpp
@@ -42,36 +42,6 @@ void SVGFilterElement::visit_edges(Cell::Visitor& visitor)
     SVGURIReferenceMixin::visit_edges(visitor);
 }
 
-void SVGFilterElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
-{
-    Base::apply_presentational_hints(cascaded_properties);
-    auto parsing_context = CSS::Parser::ParsingParams { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
-
-    auto x_attribute = attribute(AttributeNames::x);
-    if (auto x_value = parse_css_value(parsing_context, x_attribute.value_or(String {}), CSS::PropertyID::X))
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::X, x_value.release_nonnull());
-
-    auto y_attribute = attribute(AttributeNames::y);
-    if (auto y_value = parse_css_value(parsing_context, y_attribute.value_or(String {}), CSS::PropertyID::Y))
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Y, y_value.release_nonnull());
-
-    auto width_attribute = attribute(AttributeNames::width);
-    if (auto width_value = parse_css_value(parsing_context, width_attribute.value_or(String {}), CSS::PropertyID::Width))
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Width, width_value.release_nonnull());
-
-    auto height_attribute = attribute(AttributeNames::height);
-    if (auto height_value = parse_css_value(parsing_context, height_attribute.value_or(String {}), CSS::PropertyID::Height))
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Height, height_value.release_nonnull());
-}
-
-bool SVGFilterElement::is_presentational_hint(FlyString const& name) const
-{
-    if (Base::is_presentational_hint(name))
-        return true;
-
-    return name.is_one_of(AttributeNames::x, AttributeNames::y, AttributeNames::width, AttributeNames::height);
-}
-
 void SVGFilterElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGFilterElement.h
+++ b/Libraries/LibWeb/SVG/SVGFilterElement.h
@@ -25,10 +25,6 @@ class SVGFilterElement final
 public:
     virtual ~SVGFilterElement() override = default;
 
-    // ^DOM::Element
-    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
-    virtual bool is_presentational_hint(AK::FlyString const&) const override;
-
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     Optional<Gfx::Filter> gfx_filter(Layout::NodeWithStyle const& referenced_node);

--- a/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -52,27 +52,6 @@ GC::Ptr<Layout::Node> SVGForeignObjectElement::create_layout_node(GC::Ref<CSS::C
     return heap().allocate<Layout::SVGForeignObjectBox>(document(), *this, move(style));
 }
 
-bool SVGForeignObjectElement::is_presentational_hint(FlyString const& name) const
-{
-    if (Base::is_presentational_hint(name))
-        return true;
-
-    return first_is_one_of(name,
-        SVG::AttributeNames::width,
-        SVG::AttributeNames::height);
-}
-
-void SVGForeignObjectElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
-{
-    Base::apply_presentational_hints(cascaded_properties);
-    auto parsing_context = CSS::Parser::ParsingParams { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
-    if (auto width_value = parse_css_value(parsing_context, get_attribute_value(Web::HTML::AttributeNames::width), CSS::PropertyID::Width))
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Width, width_value.release_nonnull());
-
-    if (auto height_value = parse_css_value(parsing_context, get_attribute_value(Web::HTML::AttributeNames::height), CSS::PropertyID::Height))
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Height, height_value.release_nonnull());
-}
-
 GC::Ref<SVG::SVGAnimatedLength> SVGForeignObjectElement::x()
 {
     return *m_x;

--- a/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
+++ b/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
@@ -33,9 +33,6 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual bool is_presentational_hint(FlyString const&) const override;
-    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
-
     GC::Ptr<SVG::SVGAnimatedLength> m_x;
     GC::Ptr<SVG::SVGAnimatedLength> m_y;
     GC::Ptr<SVG::SVGAnimatedLength> m_width;

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -81,42 +81,6 @@ RefPtr<CSS::StyleValue const> SVGSVGElement::height_style_value_from_attribute()
     return nullptr;
 }
 
-bool SVGSVGElement::is_presentational_hint(FlyString const& name) const
-{
-    if (Base::is_presentational_hint(name))
-        return true;
-
-    return first_is_one_of(name,
-        SVG::AttributeNames::x,
-        SVG::AttributeNames::y,
-        SVG::AttributeNames::width,
-        SVG::AttributeNames::height,
-        SVG::AttributeNames::viewBox,
-        SVG::AttributeNames::preserveAspectRatio);
-}
-
-void SVGSVGElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
-{
-    Base::apply_presentational_hints(cascaded_properties);
-    auto parsing_context = CSS::Parser::ParsingParams { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
-
-    auto x_attribute = attribute(SVG::AttributeNames::x);
-    if (auto x_value = parse_css_value(parsing_context, x_attribute.value_or(String {}), CSS::PropertyID::X)) {
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::X, x_value.release_nonnull());
-    }
-
-    auto y_attribute = attribute(SVG::AttributeNames::y);
-    if (auto y_value = parse_css_value(parsing_context, y_attribute.value_or(String {}), CSS::PropertyID::Y)) {
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Y, y_value.release_nonnull());
-    }
-
-    if (auto width = width_style_value_from_attribute())
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Width, width.release_nonnull());
-
-    if (auto height = height_style_value_from_attribute())
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Height, height.release_nonnull());
-}
-
 void SVGSVGElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -27,9 +27,6 @@ class SVGSVGElement final : public SVGGraphicsElement
 public:
     virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
 
-    virtual bool is_presentational_hint(FlyString const&) const override;
-    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
-
     virtual bool requires_svg_container() const override { return false; }
     virtual bool is_svg_container() const override { return true; }
 

--- a/Libraries/LibWeb/SVG/SVGViewElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGViewElement.cpp
@@ -33,22 +33,6 @@ void SVGViewElement::visit_edges(Visitor& visitor)
     SVGFitToViewBox::visit_edges(visitor);
 }
 
-bool SVGViewElement::is_presentational_hint(FlyString const& name) const
-{
-    if (Base::is_presentational_hint(name))
-        return true;
-
-    return first_is_one_of(name,
-        SVG::AttributeNames::viewBox,
-        SVG::AttributeNames::preserveAspectRatio);
-}
-
-void SVGViewElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
-{
-    Base::apply_presentational_hints(cascaded_properties);
-    auto parsing_context = CSS::Parser::ParsingParams { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
-}
-
 void SVGViewElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGViewElement.h
+++ b/Libraries/LibWeb/SVG/SVGViewElement.h
@@ -16,10 +16,6 @@ class SVGViewElement final : public SVGGraphicsElement
     WEB_PLATFORM_OBJECT(SVGViewElement, SVGGraphicsElement);
     GC_DECLARE_ALLOCATOR(SVGViewElement);
 
-public:
-    virtual bool is_presentational_hint(FlyString const&) const override;
-    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
-
 private:
     SVGViewElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
Most presentation attributes are parsed by `SVGElement`.  The code deleted in this PR was redundant.

This is a non-functional change.