### PR TITLE
LibWeb/CSS: Check overflow value before determining box baseline

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1827,7 +1827,10 @@ CSSPixels FormattingContext::box_baseline(Box const& box) const
         }
     }
 
-    if (!box_state.line_boxes.is_empty())
+    auto const& overflow_x = box.computed_values().overflow_x();
+    auto const& overflow_y = box.computed_values().overflow_y();
+
+    if (!box_state.line_boxes.is_empty() && overflow_x == CSS::Overflow::Visible && overflow_y == CSS::Overflow::Visible)
         return box_state.margin_box_top() + box_state.offset.y() + box_state.line_boxes.last().baseline();
     if (auto const* child_box = box_child_to_derive_baseline_from(box)) {
         return box_state.margin_box_top() + box_state.offset.y() + box_baseline(*child_box);

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-align/reference/baseline-of-scrollable-1-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-align/reference/baseline-of-scrollable-1-ref.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>
+    CSS Reference Case
+  </title>
+  <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+  <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+  <link rel="help" href="https://drafts.csswg.org/css-align/#baseline-export">
+  <style>
+    .container {
+      /* In this reference case, we leave 'overflow' at its initial value. */
+      height: 50px;
+      width: 100px;
+      border-style: solid;
+      border-width: 2px 3px 4px 5px;
+      padding: 4px 5px 7px 8px;
+      margin: 1px 2px 3px 4px;
+    }
+    .inline-block {
+      display: inline-block;
+    }
+    .inline-flex {
+      display: inline-flex;
+    }
+    .inline-grid {
+      display: inline-grid;
+    }
+</style>
+</head>
+<body>
+  Test passes if the a/b text aligns with the bottom margin-edge of the "block"
+  rect and baseline-aligns with the "flex" and "grid" text.
+  <br><br>
+
+  <!-- Note: for this first "inline-block" case, we take the inner text out of
+       flow, to force the inline-block to synthesize its baseline from its
+       margin box.  (This is how the corresponding piece of the testcase is
+       supposed to render). -->
+  a
+  <div class="container inline-block">
+    <div style="position: absolute">block</div>
+  </div>
+  b
+  <br>
+
+  a
+  <div class="container inline-flex">flex</div>
+  b
+  <br>
+
+  a
+  <div class="container inline-grid">grid</div>
+  b
+
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-align/baseline-of-scrollable-1a.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-align/baseline-of-scrollable-1a.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>
+    CSS Test: baseline of scrollable element should be taken from its
+    contents. (Except if the scrollable element is an inline-block, which gets
+    baseline from its margin-box.)
+  </title>
+  <link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+  <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+  <link rel="help" href="https://drafts.csswg.org/css-align/#baseline-export">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-align/reference/baseline-of-scrollable-1-ref.html">
+  <style>
+    .container {
+      overflow: hidden;
+      height: 50px;
+      width: 100px;
+      border-style: solid;
+      border-width: 2px 3px 4px 5px;
+      padding: 4px 5px 7px 8px;
+      margin: 1px 2px 3px 4px;
+    }
+    .inline-block {
+      display: inline-block;
+    }
+    .inline-flex {
+      display: inline-flex;
+    }
+    .inline-grid {
+      display: inline-grid;
+    }
+</style>
+</head>
+<body>
+  Test passes if the a/b text aligns with the bottom margin-edge of the "block"
+  rect and baseline-aligns with the "flex" and "grid" text.
+  <br><br>
+
+  <!-- Note: for this first "inline-block" case, the element's baseline is
+       synthesized from its margin box.  For the other cases, the element's
+       baseline is taken from its contents, i.e. the text inside of it. -->
+  a
+  <div class="container inline-block">block</div>
+  b
+  <br>
+
+  a
+  <div class="container inline-flex">flex</div>
+  b
+  <br>
+
+  a
+  <div class="container inline-grid">grid</div>
+  b
+
+</body>
+</html>


### PR DESCRIPTION
The CSS spec says the baseline of an inline-block should be the bottom margin when either the overflow property is not 'visible' or there are no in-flow line boxes. Previously, only the latter case was checked.

This fixes 1 WPT test:
https://wpt.live/css/css-align/baseline-of-scrollable-1a.html