### PR TITLE
LibWeb: Avoid crash evaluating media query in document lacking window

### DIFF
--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -99,7 +99,12 @@ String MediaFeature::to_string() const
 MatchResult MediaFeature::evaluate(DOM::Document const* document) const
 {
     VERIFY(document);
-    VERIFY(document->window());
+
+    // FIXME: In some cases (e.g. when parsing HTML using DOMParser::parse_from_string()) a document may not be associated with a window -
+    //        for now we just return false but perhaps there are some media queries we should still attempt to resolve.
+    if (!document->window())
+        return MatchResult::False;
+
     auto maybe_queried_value = document->window()->query_media_feature(m_id);
     if (!maybe_queried_value.has_value())
         return MatchResult::False;

--- a/Tests/LibWeb/Crash/CSS/media-query-evaluation-without-window.html
+++ b/Tests/LibWeb/Crash/CSS/media-query-evaluation-without-window.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <script>
+        const dom = new DOMParser().parseFromString(`<style media="width < 50px">`, "text/html");
+    </script>
+</html>


### PR DESCRIPTION
In some cases a document may lack an associated window - to fix this for now we just return false but perhaps there are some media queries we should still attempt to resolve.

Fixes a crash introduced in 05c336e