### PR TITLE
LibGfx: Add robust collinear line intersection

### DIFF
--- a/Libraries/LibGfx/Line.h
+++ b/Libraries/LibGfx/Line.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/Format.h>
+#include <AK/Math.h>
 #include <AK/Optional.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Point.h>
@@ -54,40 +55,33 @@ public:
         auto delta_a = other.m_a - m_a;
         auto num = cross_product(delta_a, r);
         auto denom = cross_product(r, s);
-        if (denom == 0) {
-            if (num == 0) {
-                // Lines are collinear, check if line ends are touching
-                if (m_a == other.m_a || m_a == other.m_b)
-                    return m_a;
-                if (m_b == other.m_a || m_b == other.m_b)
-                    return m_b;
-                // Check if they're overlapping
-                if (!(m_b.x() - m_a.x() < 0 && m_b.x() - other.m_a.x() < 0 && other.m_b.x() - m_a.x() && other.m_b.x() - other.m_a.x())) {
-                    // Overlapping
-                    // TODO find center point?
-                }
-                if (!(m_b.y() - m_a.y() < 0 && m_b.y() - other.m_a.y() < 0 && other.m_b.y() - m_a.y() && other.m_b.y() - other.m_a.y())) {
-                    // Overlapping
-                    // TODO find center point?
-                }
-                return {};
-            } else {
-                // Lines are parallel and not intersecting
-                return {};
-            }
+
+        bool parallel = denom == 0;
+        bool collinear = num == 0;
+        if (parallel) {
+            if (collinear)
+                return collinear_intersection_point(other);
+            return {};
         }
-        auto u = static_cast<float>(num) / static_cast<float>(denom);
-        if (u < 0.0f || u > 1.0f) {
+
+        using Calc = Conditional<IsFloatingPoint<T>, T, double>;
+
+        auto u = static_cast<Calc>(num) / static_cast<Calc>(denom);
+        if (u < static_cast<Calc>(0) || u > static_cast<Calc>(1)) {
             // Lines are not parallel and don't intersect
             return {};
         }
-        auto t = static_cast<float>(cross_product(delta_a, s)) / static_cast<float>(denom);
-        if (t < 0.0f || t > 1.0f) {
+        auto t = static_cast<Calc>(cross_product(delta_a, s)) / static_cast<Calc>(denom);
+        if (t < static_cast<Calc>(0) || t > static_cast<Calc>(1)) {
             // Lines are not parallel and don't intersect
             return {};
         }
-        // TODO: round if we're dealing with int
-        return Point<T> { m_a.x() + static_cast<T>(t * r.x()), m_a.y() + static_cast<T>(t * r.y()) };
+        auto x = static_cast<Calc>(m_a.x()) + t * static_cast<Calc>(r.x());
+        auto y = static_cast<Calc>(m_a.y()) + t * static_cast<Calc>(r.y());
+        if constexpr (IsFloatingPoint<T>)
+            return Point<T> { static_cast<T>(x), static_cast<T>(y) };
+        else
+            return Point<T> { round_to<T>(x), round_to<T>(y) };
     }
 
     float length() const
@@ -104,15 +98,20 @@ public:
         auto delta_c = m_b.x() - m_a.x();
         auto delta_d = m_b.y() - m_a.y();
         auto len_sq = delta_c * delta_c + delta_d * delta_d;
-        float param = -1.0;
+        using Calc = Conditional<IsFloatingPoint<T>, T, double>;
+        Calc param = static_cast<Calc>(-1);
         if (len_sq != 0)
-            param = static_cast<float>(delta_a * delta_c + delta_b * delta_d) / static_cast<float>(len_sq);
-        if (param < 0)
+            param = static_cast<Calc>(delta_a * delta_c + delta_b * delta_d) / static_cast<Calc>(len_sq);
+        if (param < static_cast<Calc>(0))
             return m_a;
-        if (param > 1)
+        if (param > static_cast<Calc>(1))
             return m_b;
-        // TODO: round if we're dealing with int
-        return { static_cast<T>(m_a.x() + param * delta_c), static_cast<T>(m_a.y() + param * delta_d) };
+        auto rx = static_cast<Calc>(m_a.x()) + param * static_cast<Calc>(delta_c);
+        auto ry = static_cast<Calc>(m_a.y()) + param * static_cast<Calc>(delta_d);
+        if constexpr (IsFloatingPoint<T>)
+            return { static_cast<T>(rx), static_cast<T>(ry) };
+        else
+            return { round_to<T>(rx), round_to<T>(ry) };
     }
 
     Line<T> shortest_line_to(Point<T> const& point) const
@@ -168,6 +167,57 @@ public:
     ByteString to_byte_string() const;
 
 private:
+    /*
+     * @brief Return a single point representing the intersection of two collinear segments.
+     * Compute the midpoint of the overlap in X and Y independently, which maps to the
+     * midpoint of the overlapping segment for collinear lines. If there is no overlap,
+     * return empty.
+     */
+    Optional<Point<T>> collinear_intersection_point(Line const& other) const
+    {
+        // Handle degenerate: A is a point
+        if (m_a == m_b) {
+            // If A lies on B's span (collinearity is already known), it must also be within B's box
+            auto bx0 = min(other.m_a.x(), other.m_b.x());
+            auto bx1 = max(other.m_a.x(), other.m_b.x());
+            auto by0 = min(other.m_a.y(), other.m_b.y());
+            auto by1 = max(other.m_a.y(), other.m_b.y());
+            if (m_a.x() < bx0 || m_a.x() > bx1 || m_a.y() < by0 || m_a.y() > by1)
+                return {};
+            return m_a;
+        }
+
+        // Overlap ranges for X and Y
+        auto ax0 = min(m_a.x(), m_b.x());
+        auto ax1 = max(m_a.x(), m_b.x());
+        auto ay0 = min(m_a.y(), m_b.y());
+        auto ay1 = max(m_a.y(), m_b.y());
+
+        auto bx0 = min(other.m_a.x(), other.m_b.x());
+        auto bx1 = max(other.m_a.x(), other.m_b.x());
+        auto by0 = min(other.m_a.y(), other.m_b.y());
+        auto by1 = max(other.m_a.y(), other.m_b.y());
+
+        auto ox0 = max(ax0, bx0);
+        auto ox1 = min(ax1, bx1);
+        auto oy0 = max(ay0, by0);
+        auto oy1 = min(ay1, by1);
+
+        if (ox1 < ox0 || oy1 < oy0)
+            return {};
+
+        // midpoint helper avoiding overflow for integers: start + (end - start) / 2
+        auto midpoint = [](auto const& start, auto const& end) {
+            if constexpr (IsFloatingPoint<T>)
+                return static_cast<T>((start + end) / static_cast<T>(2));
+            else
+                return static_cast<T>(start + (end - start) / 2);
+        };
+
+        T mx = midpoint(ox0, ox1);
+        T my = midpoint(oy0, oy1);
+        return Point<T> { mx, my };
+    }
     Point<T> m_a;
     Point<T> m_b;
 };

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_SOURCES
     TestImageWriter.cpp
     TestQuad.cpp
     TestRect.cpp
+    TestLine.cpp
     TestWOFF.cpp
     TestWOFF2.cpp
 )

--- a/Tests/LibGfx/TestLine.cpp
+++ b/Tests/LibGfx/TestLine.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025, Ladybird contributors.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Line.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(line_endpoint_intersection)
+{
+    Gfx::Line<float> a({ 0.f, 0.f }, { 10.f, 0.f });
+    Gfx::Line<float> b({ 10.f, 0.f }, { 10.f, 10.f });
+
+    EXPECT(a.intersects(b));
+
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 10.f);
+    EXPECT_APPROXIMATE(point->y(), 0.f);
+}
+
+TEST_CASE(line_no_intersection_parallel)
+{
+    Gfx::Line<float> a({ 0.f, 0.f }, { 10.f, 0.f });
+    Gfx::Line<float> b({ 0.f, 1.f }, { 10.f, 1.f });
+
+    EXPECT(!a.intersects(b));
+    EXPECT(!a.intersected(b).has_value());
+}
+
+TEST_CASE(line_proper_intersection)
+{
+    Gfx::Line<float> a({ 0.f, 0.f }, { 10.f, 10.f });
+    Gfx::Line<float> b({ 0.f, 10.f }, { 10.f, 0.f });
+
+    EXPECT(a.intersects(b));
+
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 5.f);
+    EXPECT_APPROXIMATE(point->y(), 5.f);
+}
+
+TEST_CASE(line_overlap_total_containment_horizontal)
+{
+    // A is totally contained within B (horizontal collinear)
+    Gfx::Line<float> a({ 2.f, 0.f }, { 8.f, 0.f });
+    Gfx::Line<float> b({ 0.f, 0.f }, { 10.f, 0.f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 5.f);
+    EXPECT_APPROXIMATE(point->y(), 0.f);
+}
+
+TEST_CASE(line_overlap_total_containment_diagonal)
+{
+    // A is totally contained within B (diagonal collinear)
+    Gfx::Line<float> a({ 2.f, 2.f }, { 8.f, 8.f });
+    Gfx::Line<float> b({ 0.f, 0.f }, { 10.f, 10.f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 5.f);
+    EXPECT_APPROXIMATE(point->y(), 5.f);
+}
+
+TEST_CASE(line_collinear_no_overlap)
+{
+    // 2 horizontal collinear segments that do not overlap
+    Gfx::Line<float> a({ 0.f, 0.f }, { 1.f, 0.f });
+    Gfx::Line<float> b({ 2.f, 0.f }, { 3.f, 0.f });
+
+    EXPECT(!a.intersects(b));
+    EXPECT(!a.intersected(b).has_value());
+}
+
+TEST_CASE(line_collinear_perfect_overlap)
+{
+    // Identical segments (reversed)
+    Gfx::Line<float> a({ -37.25f, 12.0f }, { 18.5f, -9.75f });
+    Gfx::Line<float> b({ 18.5f, -9.75f }, { -37.25f, 12.0f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+
+    // Should intersect at their midpoint
+    float mx = (a.a().x() + a.b().x()) / 2.f;
+    float my = (a.a().y() + a.b().y()) / 2.f;
+    EXPECT_APPROXIMATE(point->x(), mx);
+    EXPECT_APPROXIMATE(point->y(), my);
+}
+
+TEST_CASE(line_overlap_partial_left_extrude)
+{
+    // A overlaps B and extends beyond B's start (left extrude)
+    Gfx::Line<float> a({ -5.f, 0.f }, { 5.f, 0.f });
+    Gfx::Line<float> b({ 0.f, 0.f }, { 10.f, 0.f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 2.5f);
+    EXPECT_APPROXIMATE(point->y(), 0.f);
+}
+
+TEST_CASE(line_overlap_partial_right_extrude)
+{
+    // A overlaps B and extends beyond B's end (right extrude)
+    Gfx::Line<float> a({ 5.f, 0.f }, { 15.f, 0.f });
+    Gfx::Line<float> b({ 0.f, 0.f }, { 10.f, 0.f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 7.5f);
+    EXPECT_APPROXIMATE(point->y(), 0.f);
+}
+
+TEST_CASE(line_collinear_shared_endpoint_horizontal)
+{
+    // Collinear segments touching at one endpoint only
+    Gfx::Line<float> a({ 0.f, 0.f }, { 5.f, 0.f });
+    Gfx::Line<float> b({ 5.f, 0.f }, { 10.f, 0.f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 5.f);
+    EXPECT_APPROXIMATE(point->y(), 0.f);
+}
+
+TEST_CASE(line_collinear_shared_endpoint_diagonal)
+{
+    // Diagonal collinear segments touching at one endpoint only
+    Gfx::Line<float> a({ 0.f, 0.f }, { 5.f, 5.f });
+    Gfx::Line<float> b({ 5.f, 5.f }, { 10.f, 10.f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 5.f);
+    EXPECT_APPROXIMATE(point->y(), 5.f);
+}
+
+TEST_CASE(line_point_on_segment)
+{
+    // Zero-length segment A lies on B
+    Gfx::Line<float> a({ 5.f, 0.f }, { 5.f, 0.f });
+    Gfx::Line<float> b({ 0.f, 0.f }, { 10.f, 0.f });
+
+    EXPECT(a.intersects(b));
+    auto point = a.intersected(b);
+    EXPECT(point.has_value());
+    EXPECT_APPROXIMATE(point->x(), 5.f);
+    EXPECT_APPROXIMATE(point->y(), 0.f);
+}
+
+TEST_CASE(line_point_off_segment)
+{
+    // Zero-length segment A not on B
+    Gfx::Line<float> a({ 11.f, 0.f }, { 11.f, 0.f });
+    Gfx::Line<float> b({ 0.f, 0.f }, { 10.f, 0.f });
+
+    EXPECT(!a.intersects(b));
+    EXPECT(!a.intersected(b).has_value());
+}


### PR DESCRIPTION
# LibGfx: Add robust collinear line intersection + tests for Line

## Summary

Previously, the method `Gfx::Line<T>::intersected` only covered collinear lines (segments lying on the same infinite line) if they had shared endpoints. Leaving completely uncovered the case that two collinear lines can overlap without having two perfectly coexisting endpoints.

This change aims to strengthen this method by handling all collinear-line intersection configurations. Now after the changes, when the two lines are collinear, the will return a single representative point (or no point) out of these 3 paths:
1. The midpoint of the overlap when the overlap has non-zero length
2. The shared endpoint when they only touch endpoints
3. None, if the collinear lines are disjointed

This preserves previous functionality. To guarantee this, a new LibGfx test suite for Gfx::Line was added.

## Changes
- Implemented collinear intersection via parameter-space overlap (see references: [one](https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection#Given_two_points_on_each_line_segment) and [two](https://en.wikipedia.org/wiki/Intersection_(geometry)#Two_line_segments)):
  - Added `collinear_intersection_point` helper using dot-product parameterization `t = dot(p - A0, r) / dot(r, r)`.
  - For two collinear segments:
    - If they overlap with non-zero length, return the midpoint of the overlap (deterministic representative)
    - If they only touch at a single endpoint, return that endpoint
    - If they are disjoint, return empty
  - Effectively replaces previous ad-hoc checks and completes the prior TODO

- Clarified collinearity handling in `intersected`:
  - `denom == 0 && num == 0` -> collinear -> delegated to the new helper.
  - Non-collinear endpoint-only intersections remain handled by the general `t,u ∈ [0,1]` branch

- Tests: Added `Tests/LibGfx/TestLine.cpp` and registered it in `Tests/LibGfx/CMakeLists.txt`
  - Non-collinear:
    - Endpoint intersection (returns shared endpoint)
    - Proper interior intersection
    - Parallel with no intersection
  - Collinear:
    - Total containment (horizontal)
    - Total containment (diagonal)
    - Partial overlaps (left/right extrude)
    - No overlap (collinear)
    - Shared endpoint (horizontal && diagonal)
    - Zero-length (point) on segment (hit) and off segment (miss)
    - Deterministic perfect overlap (identical segments reversed) -> returns midpoint

## Verification
```
/Users/dowsley/Code/ladybird/Build/release/bin/TestLine
[...]
Finished 13 tests and 0 benchmarks in 0ms (0ms tests, 0ms benchmarks, 0ms other).
All 13 tests passed.
```

## Notes
- Existing integer rounding TODO is preserved: integer variants still use truncation when mapping back from `t`. A follow-up could define a rounding policy if needed (?)
- No behavior change for non-collinear intersections
- Usually I'm not a fan of leaving lots of comments, but since this involves non-intuitive math (for non-intuitive purposes), I preferred leaving them justifying the choices at every few lines for the helper function.