### PR TITLE
LibJS: Increase the stack limit when ASAN enabled

### DIFF
--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -108,8 +108,8 @@ public:
 
     bool did_reach_stack_space_limit() const
     {
-#if defined(AK_OS_MACOS) && defined(HAS_ADDRESS_SANITIZER)
-        // We hit stack limits sooner on macOS 14 arm64 with ASAN enabled.
+#if defined(HAS_ADDRESS_SANITIZER)
+        // We hit stack limits sooner with ASAN enabled.
         return m_stack_info.size_free() < 96 * KiB;
 #else
         return m_stack_info.size_free() < 32 * KiB;


### PR DESCRIPTION
Linux, x86_64, Sanitizer, GNU runners on GitHub Action fail randomly with a stack overflow on recursive test called:
Libraries/LibJS/Tests/runtime-error-call-stack-size.js

Some local and CI testing done by increasing from 32kb to 36kb and that seems to be enough. 

Don't know how the value of 96kb was determined for macOS arm ASAN, but proposing that we set it to 96kb same as macOS arm requirement, for consistency.

fixes: #4522 