### PR TITLE
LibWeb/IDB: Adjust how negative numbers increment the key generator

### DIFF
--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -1293,20 +1293,21 @@ void possibly_update_the_key_generator(GC::Ref<ObjectStore> store, GC::Ref<Key> 
         return;
 
     // 2. Let value be the value of key.
-    auto temp_value = key->value_as_double();
+    auto value = key->value_as_double();
 
     // 3. Set value to the minimum of value and 2^53 (9007199254740992).
-    temp_value = min(temp_value, MAX_KEY_GENERATOR_VALUE);
+    value = min(value, MAX_KEY_GENERATOR_VALUE);
 
     // 4. Set value to the largest integer not greater than value.
-    u64 value = floor(temp_value);
+    value = floor(value);
 
     // 5. Let generator be store’s key generator.
     auto& generator = store->key_generator();
 
     // 6. If value is greater than or equal to generator’s current number, then set generator’s current number to value + 1.
-    if (value >= generator.current_number())
-        generator.set(value + 1);
+    if (value >= static_cast<double>(generator.current_number())) {
+        generator.set(static_cast<u64>(value + 1));
+    }
 }
 
 // https://w3c.github.io/IndexedDB/#inject-a-key-into-a-value-using-a-key-path


### PR DESCRIPTION
Directly mapping a negative double to a u64 causes it to wrap around to the max value.
We work around this here by comparing as doubles, and only incrementing the generator if the new value is greater

Fixes #6455