### PR TITLE
LibIPC: Simplify IPC read hook

### DIFF
--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -41,7 +41,11 @@ protected:
 
     OwnPtr<IPC::Message> wait_for_specific_endpoint_message_impl(u32 endpoint_magic, int message_id);
     void wait_for_transport_to_become_readable();
-    ErrorOr<void> drain_messages_from_peer();
+    enum class PeerEOF {
+        No,
+        Yes
+    };
+    PeerEOF drain_messages_from_peer();
 
     void handle_messages();
 

--- a/Libraries/LibIPC/ConnectionFromClient.h
+++ b/Libraries/LibIPC/ConnectionFromClient.h
@@ -31,11 +31,6 @@ public:
         , ClientEndpoint::template Proxy<ServerEndpoint>(*this, {})
         , m_client_id(client_id)
     {
-        this->transport().set_up_read_hook([this] {
-            NonnullRefPtr protect = *this;
-            // FIXME: Do something about errors.
-            (void)this->drain_messages_from_peer();
-        });
     }
 
     virtual ~ConnectionFromClient() override = default;


### PR DESCRIPTION
- Return `PeerEOF` enum instead of `Error` containing string from `drain_messages_from_peer()`. There are no other error types to return from this function, so boolean-like enum is sufficient.
- Don't override read hook in `ConnectionFromClient` constructor. It was previously redefined only to suppress EOF error returned by `drain_messages_from_peer()`.
- Remove call to `handle_messages()` from read hook, because it's already called by `drain_messages_from_peer()`.