### PR TITLE
CI: Update .github/actions/ folder to latest when building older commits

### DIFF
--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -55,6 +55,13 @@ jobs:
         run: |
           echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
+      - name: 'Use latest custom actions'
+        if: ${{ inputs.reference_to_build != '' && github.sha != steps.build-commit.outputs.sha }}
+        shell: bash
+        run: |
+          git fetch origin master
+          git checkout origin/master -- .github/actions
+
       - name: "Set up environment"
         uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
Older commits also have older setup code, such as requiring older XCode versions - which fails on newer macOS systems. Let's always use the latest custom actions so we can retroactively support these older builds.