### PR TITLE
LibGfx: Show selected graphical device or if in CPU painter fallback

### DIFF
--- a/Libraries/LibGfx/MetalContext.mm
+++ b/Libraries/LibGfx/MetalContext.mm
@@ -5,6 +5,7 @@
  */
 
 #include <AK/OwnPtr.h>
+#include <AK/StringView.h>
 #include <LibGfx/MetalContext.h>
 
 #import <Metal/Metal.h>
@@ -74,6 +75,9 @@ RefPtr<MetalContext> get_metal_context()
         dbgln("Failed to create Metal device");
         return {};
     }
+
+    auto device_name = [device.name UTF8String];
+    dbgln("Selected Metal graphical device: {}", StringView(device_name, strlen(device_name)));
 
     auto queue = [device newCommandQueue];
     if (!queue) {

--- a/Libraries/LibGfx/VulkanContext.cpp
+++ b/Libraries/LibGfx/VulkanContext.cpp
@@ -59,8 +59,13 @@ static ErrorOr<VkPhysicalDevice> pick_physical_device(VkInstance instance)
             picked_device = device;
     }
 
-    if (picked_device != VK_NULL_HANDLE)
+    if (picked_device != VK_NULL_HANDLE) {
+        VkPhysicalDeviceProperties device_properties;
+        vkGetPhysicalDeviceProperties(picked_device, &device_properties);
+
+        dbgln("Selected Vulkan graphical device: {}", device_properties.deviceName);
         return picked_device;
+    }
 
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -151,8 +151,11 @@ Navigable::Navigable(GC::Ref<Page> page, bool is_svg_page)
     if (!m_is_svg_page) {
         OwnPtr<Painting::DisplayListPlayerSkia> skia_player;
         if (display_list_player_type == DisplayListPlayerType::SkiaGPUIfAvailable) {
+            if (!m_skia_backend_context)
+                dbgln("Falling back to CPU Backend painter");
             skia_player = make<Painting::DisplayListPlayerSkia>(m_skia_backend_context);
         } else {
+            dbgln("Falling back to CPU Backend painter");
             skia_player = make<Painting::DisplayListPlayerSkia>();
         }
         m_rendering_thread.set_skia_player(move(skia_player));


### PR DESCRIPTION
Clearly show which graphical device is being used or if we are falling back to the CPU painter.

This is so that when GPU or CPU painter issues are reported, that the graphical state of the system is clearly shown in the output logs.

fixed: #6385

Output from vm with Ubuntu 24.04.2 LTS
```
$ ./Meta/ladybird.py run
ninja: Entering directory `/home/ubuno/projects/myladybird/Build/release'
ninja: no work to do.
21853.950 WebContent(113515): Selected Vulkan graphical device: llvmpipe (LLVM 20.1.2, 256 bits)
21853.950 WebContent(113515): Vulkan context creation failed: Logical device creation failed
21853.950 WebContent(113515): Falling back to CPU Backend painter
21854.056 WebContent(113522): Selected Vulkan graphical device: llvmpipe (LLVM 20.1.2, 256 bits)
21854.059 WebContent(113522): Vulkan context creation failed: Logical device creation failed
21854.059 WebContent(113522): Falling back to CPU Backend painter
```

Output from same system using --force-cpu-painting
```
$ ./Meta/ladybird.py run ladybird --force-cpu-painting
ninja: Entering directory `/home/ubuno/projects/myladybird/Build/release'
ninja: no work to do.
Ladybird PID file '/run/user/1000/Ladybird.pid' exists with PID 113497, but process cannot be found
22102.468 WebContent(113573): Falling back to CPU Backend painter
22102.550 WebContent(113578): Falling back to CPU Backend painter
```

Output from vm with Ubuntu 25.04
```
$ ./Meta/ladybird.py run
ninja: Entering directory `/home/bobo/projects/myladybird/Build/release'
ninja: no work to do.
22811.802 WebContent(38678): Selected Vulkan graphical device: llvmpipe (LLVM 20.1.2, 256 bits)
22811.868 WebContent(38682): Selected Vulkan graphical device: llvmpipe (LLVM 20.1.2, 256 bits)
```

Output from real hardware Ubuntu 25.04

```
$ ./Meta/ladybird.py run
ninja: Entering directory `/home/bobo/projects/myladybird/Build/release'
ninja: no work to do.
16791.114 WebContent(26334): Selected Vulkan graphical device: Intel(R) UHD Graphics 630 (CFL GT2)
16791.123 WebContent(26338): Selected Vulkan graphical device: Intel(R) UHD Graphics 630 (CFL GT2)
```

Output from MacOS Intel based with AMD video adapter

```
% ./Meta/ladybird.py run
ninja: Entering directory `/Users/roccocorsi/projects/myladybird/Build/release'
ninja: no work to do.
2025-10-14 15:10:48.553 Ladybird[90303:473813] WARNING <NSToolbarItem: 0x600002599ba0> -> view was automatically measured but had an ambiguous height or width and the view's frame size had a zero height or width. Did you forget to add constraints on your view or its subview(s)? Try adding constraints or give the view an intrinsicContentSize
2025-10-14 15:10:48.553 Ladybird[90303:473813] WARNING <NSToolbarItem: 0x600002599ba0> -> view was automatically measured but had an ambiguous height or width and the view's frame size had a zero height or width. Did you forget to add constraints on your view or its subview(s)? Try adding constraints or give the view an intrinsicContentSize
2025-10-14 15:10:48.666 Ladybird[90303:473813] WARNING <NSToolbarItem: 0x600002599ba0> -> view was automatically measured but had an ambiguous height or width and the view's frame size had a zero height or width. Did you forget to add constraints on your view or its subview(s)? Try adding constraints or give the view an intrinsicContentSize
2025-10-14 15:10:48.667 Ladybird[90303:473813] WARNING <NSToolbarItem: 0x600002599ba0> -> view was automatically measured but had an ambiguous height or width and the view's frame size had a zero height or width. Did you forget to add constraints on your view or its subview(s)? Try adding constraints or give the view an intrinsicContentSize
11824.804 WebContent(90306): Selected Metal graphical device: AMD Radeon Pro 5500M
11825.154 WebContent(90307): Selected Metal graphical device: AMD Radeon Pro 5500M
11851.937 Ladybird(90303): mach_msg failed: (ipc/rcv) port changed
```