### PR TITLE
LibWeb: Add loading event to style element

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4333,4 +4333,35 @@ GC::Ptr<Element const> Element::element_to_inherit_style_from(Optional<CSS::Pseu
     return parent_or_shadow_host_element();
 }
 
+// https://html.spec.whatwg.org/multipage/dom.html#block-rendering
+void Element::block_rendering()
+{
+    // 1. Let document be el's node document.
+    auto& document = this->document();
+
+    // 2. If document allows adding render-blocking elements, then append el to document's render-blocking element set.
+    if (document.allows_adding_render_blocking_elements()) {
+        document.add_render_blocking_element(*this);
+    }
+}
+
+// https://html.spec.whatwg.org/multipage/dom.html#unblock-rendering
+void Element::unblock_rendering()
+{
+    // 1. Let document be el's node document.
+    auto& document = this->document();
+
+    // 2. Remove el from document's render-blocking element set.
+    document.remove_render_blocking_element(*this);
+}
+
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#potentially-render-blocking
+bool Element::is_potentially_render_blocking()
+{
+    // An element is potentially render-blocking if
+    // FIXME: its blocking tokens set contains "render",
+    // or if it is implicitly potentially render-blocking, which will be defined at the individual elements.
+    return is_implicitly_potentially_render_blocking();
+}
+
 }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -511,6 +511,15 @@ public:
 
     GC::Ref<CSS::StylePropertyMapReadOnly> computed_style_map();
 
+    // https://html.spec.whatwg.org/multipage/dom.html#block-rendering
+    void block_rendering();
+    // https://html.spec.whatwg.org/multipage/dom.html#unblock-rendering
+    void unblock_rendering();
+    // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#potentially-render-blocking
+    bool is_potentially_render_blocking();
+    // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#implicitly-potentially-render-blocking
+    virtual bool is_implicitly_potentially_render_blocking() const { return false; }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -77,37 +77,6 @@ void HTMLElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_popover_close_watcher);
 }
 
-// https://html.spec.whatwg.org/multipage/dom.html#block-rendering
-void HTMLElement::block_rendering()
-{
-    // 1. Let document be el's node document.
-    auto& document = this->document();
-
-    // 2. If document allows adding render-blocking elements, then append el to document's render-blocking element set.
-    if (document.allows_adding_render_blocking_elements()) {
-        document.add_render_blocking_element(*this);
-    }
-}
-
-// https://html.spec.whatwg.org/multipage/dom.html#unblock-rendering
-void HTMLElement::unblock_rendering()
-{
-    // 1. Let document be el's node document.
-    auto& document = this->document();
-
-    // 2. Remove el from document's render-blocking element set.
-    document.remove_render_blocking_element(*this);
-}
-
-// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#potentially-render-blocking
-bool HTMLElement::is_potentially_render_blocking()
-{
-    // An element is potentially render-blocking if
-    // FIXME: its blocking tokens set contains "render",
-    // or if it is implicitly potentially render-blocking, which will be defined at the individual elements.
-    return is_implicitly_potentially_render_blocking();
-}
-
 // https://html.spec.whatwg.org/multipage/dom.html#dom-translate
 bool HTMLElement::translate() const
 {

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -207,15 +207,6 @@ protected:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
-    // https://html.spec.whatwg.org/multipage/dom.html#block-rendering
-    void block_rendering();
-    // https://html.spec.whatwg.org/multipage/dom.html#unblock-rendering
-    void unblock_rendering();
-    // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#potentially-render-blocking
-    bool is_potentially_render_blocking();
-    // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#implicitly-potentially-render-blocking
-    virtual bool is_implicitly_potentially_render_blocking() const { return false; }
-
     void set_inert(bool inert) { m_inert = inert; }
     void set_subtree_inertness(bool is_inert);
 

--- a/Tests/LibWeb/Text/expected/HTML/style-on-load-event.txt
+++ b/Tests/LibWeb/Text/expected/HTML/style-on-load-event.txt
@@ -1,0 +1,1 @@
+Onload event fired

--- a/Tests/LibWeb/Text/input/HTML/style-on-load-event.html
+++ b/Tests/LibWeb/Text/input/HTML/style-on-load-event.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const styleE = document.createElement('style');
+        styleE.onload = () => {
+            println("Onload event fired");
+            done();
+        }
+        document.head.append(styleE);
+    });
+</script>


### PR DESCRIPTION
This PR implements only the same part as the link element implements as far as when we fire the load event. The waiting for critical resources is outside of the scope. 

fixes  #1290