### PR TITLE
LibWeb: Fix MediaQuery crash

### DIFF
--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -99,7 +99,13 @@ String MediaFeature::to_string() const
 MatchResult MediaFeature::evaluate(DOM::Document const* document) const
 {
     VERIFY(document);
-    VERIFY(document->window());
+
+    // Documents without a window (e.g., those created by DOMParser) don't have a browsing context,
+    // so media queries cannot be evaluated against them and should return False.
+    // See: https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring
+    if (!document->window())
+        return MatchResult::False;
+
     auto maybe_queried_value = document->window()->query_media_feature(m_id);
     if (!maybe_queried_value.has_value())
         return MatchResult::False;


### PR DESCRIPTION
Fixes crashes like this:

```
VERIFICATION FAILED: document->window() at /home/edwin/ladybird/Libraries/LibWeb/CSS/MediaQuery.cpp:102
Stack trace (most recent call first):
#0   0x00007abec7640039 in evaluate at /home/edwin/ladybird/Libraries/LibWeb/CSS/MediaQuery.cpp:102:5
#1   0x00007abec7640a5d in evaluate at /home/edwin/ladybird/Libraries/LibWeb/CSS/MediaQuery.cpp:307:47
#2   0x00007abec763ec45 in evaluate at /home/edwin/ladybird/Libraries/LibWeb/CSS/MediaList.cpp:115:16
#3   (inlined)          in evaluate at /home/edwin/ladybird/Libraries/LibWeb/CSS/CSSMediaRule.h:33:68
#4   0x00007abec75ea14b in evaluate_media_queries at /home/edwin/ladybird/Libraries/LibWeb/CSS/CSSRuleList.cpp:248:43
#5   0x00007abec7601da3 in evaluate_media_queries at /home/edwin/ladybird/Libraries/LibWeb/CSS/CSSStyleSheet.cpp:363:33
#6   0x00007abec774f523 in add_sheet at /home/edwin/ladybird/Libraries/LibWeb/CSS/StyleSheetList.cpp:112:11
#7   0x00007abec774f176 in add_a_css_style_sheet at /home/edwin/ladybird/Libraries/LibWeb/CSS/StyleSheetList.cpp:35:5
#8   0x00007abec774f9a9 in create_a_css_style_sheet at /home/edwin/ladybird/Libraries/LibWeb/CSS/StyleSheetList.cpp:81:5
#9   0x00007abec784a7da in update_a_style_block at /home/edwin/ladybird/Libraries/LibWeb/DOM/StyleElementUtils.cpp:80:56
#10  0x00007abec77a7a25 in replace_data at /home/edwin/ladybird/Libraries/LibWeb/DOM/CharacterData.cpp:125:19
#11  0x00007abec77a726b in set_data at /home/edwin/ladybird/Libraries/LibWeb/DOM/CharacterData.cpp:41:5
#12  0x00007abec7a3d507 in flush_character_insertions at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:1423:37
#13  (inlined)          in insert_character at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:1441:5
#14  0x00007abec7a420e4 in handle_text at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:3218:9
#15  0x00007abec7a3c544 in run at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:243:13
#16  0x00007abec7a3d6fd in run at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:267:5
#17  0x00007abec77c7c62 in parse_html_from_a_string at /home/edwin/ladybird/Libraries/LibWeb/DOM/Document.cpp:6336:13
#18  0x00007abec7941df8 in parse_from_string at /home/edwin/ladybird/Libraries/LibWeb/HTML/DOMParser.cpp:56:19
#19  (inlined)          in operator() at /home/edwin/ladybird/Build/release/Lagom/Libraries/LibWeb/Bindings/DOMParserPrototype.cpp:560:36
#20  (inlined)          in throw_dom_exception_if_needed<(lambda at /home/edwin/ladybird/Build/release/Lagom/Libraries/LibWeb/Bindings/DOMParserPrototype.cpp:560:36), GC::Ref<Web::DOM::Document>, GC::Ref<Web::DOM::Document> > at /home/edwin/ladybird/Libraries/LibWeb/Bindings/ExceptionOrUtils.h:110:16
#21  0x00007abec827655e in parse_from_string at /home/edwin/ladybird/Build/release/Lagom/Libraries/LibWeb/Bindings/DOMParserPrototype.cpp:560:36
#22  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#23  0x00007abec6cd4b37 in call at /home/edwin/ladybird/Libraries/LibJS/Runtime/NativeFunction.cpp:228:12
#24  0x00007abec6cd495e in internal_call at /home/edwin/ladybird/Libraries/LibJS/Runtime/NativeFunction.cpp:163:19
#25  0x00007abec6b58932 in execute_call<(JS::Bytecode::Op::CallType)0> at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2844:18
#26  (inlined)          in execute_impl at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2852:12
#27  0x00007abec6b2c9af in run_bytecode at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:562:13
#28  0x00007abec6b2a825 in run_executable at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:747:5
#29  (inlined)          in ordinary_call_evaluate_body at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:885:55
#30  0x00007abec6c4e442 in internal_call at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:540:19
#31  0x00007abec6b58932 in execute_call<(JS::Bytecode::Op::CallType)0> at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2844:18
#32  (inlined)          in execute_impl at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2852:12
#33  0x00007abec6b2c9af in run_bytecode at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:562:13
#34  0x00007abec6b2a825 in run_executable at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:747:5
#35  (inlined)          in ordinary_call_evaluate_body at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:885:55
#36  0x00007abec6c4e442 in internal_call at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:540:19
#37  0x00007abec6b58932 in execute_call<(JS::Bytecode::Op::CallType)0> at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2844:18
#38  (inlined)          in execute_impl at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2852:12
#39  0x00007abec6b2c9af in run_bytecode at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:562:13
#40  0x00007abec6b2a825 in run_executable at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:747:5
#41  (inlined)          in ordinary_call_evaluate_body at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:885:55
#42  0x00007abec6c4e442 in internal_call at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:540:19
#43  0x00007abec6b58932 in execute_call<(JS::Bytecode::Op::CallType)0> at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2844:18
#44  (inlined)          in execute_impl at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2852:12
#45  0x00007abec6b2c9af in run_bytecode at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:562:13
#46  0x00007abec6b2a825 in run_executable at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:747:5
#47  0x00007abec6c62e89 in execute at /home/edwin/ladybird/Libraries/LibJS/Runtime/GeneratorObject.cpp:111:45
#48  0x00007abec6c630b7 in resume at /home/edwin/ladybird/Libraries/LibJS/Runtime/GeneratorObject.cpp:159:19
#49  0x00007abec6c111fb in continue_async_execution at /home/edwin/ladybird/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp:127:31
#50  0x00007abec6c1119b in create at /home/edwin/ladybird/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp:27:14
#51  (inlined)          in ordinary_call_evaluate_body at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:909:16
#52  0x00007abec6c4e581 in internal_call at /home/edwin/ladybird/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp:540:19
#53  0x00007abec6b58932 in execute_call<(JS::Bytecode::Op::CallType)0> at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2844:18
#54  (inlined)          in execute_impl at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2852:12
#55  0x00007abec6b2c9af in run_bytecode at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:562:13
#56  0x00007abec6b2a825 in run_executable at /home/edwin/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:747:5
#57  0x00007abec6c62e89 in execute at /home/edwin/ladybird/Libraries/LibJS/Runtime/GeneratorObject.cpp:111:45
#58  0x00007abec6c630b7 in resume at /home/edwin/ladybird/Libraries/LibJS/Runtime/GeneratorObject.cpp:159:19
#59  0x00007abec6c111fb in continue_async_execution at /home/edwin/ladybird/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp:127:31
#60  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp:66:9
#61  0x00007abec6c11a17 in call at /home/edwin/ladybird/AK/Function.h:225:20
#62  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#63  0x00007abec6cd4b37 in call at /home/edwin/ladybird/Libraries/LibJS/Runtime/NativeFunction.cpp:228:12
#64  0x00007abec6cd495e in internal_call at /home/edwin/ladybird/Libraries/LibJS/Runtime/NativeFunction.cpp:163:19
#65  0x00007abec6be75b3 in call_impl at /home/edwin/ladybird/Libraries/LibJS/Runtime/AbstractOperations.cpp:95:21
#66  (inlined)          in call at /home/edwin/ladybird/Libraries/LibJS/Runtime/AbstractOperations.h:115:12
#67  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Bindings/MainThreadVM.cpp:230:23
#68  0x00007abec74eb158 in call at /home/edwin/ladybird/AK/Function.h:225:20
#69  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#70  (inlined)          in run_reaction_job at /home/edwin/ladybird/Libraries/LibJS/Runtime/PromiseJobs.cpp:55:26
#71  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibJS/Runtime/PromiseJobs.cpp:92:16
#72  0x00007abec6cf61e3 in call at /home/edwin/ladybird/AK/Function.h:225:20
#73  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#74  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Bindings/MainThreadVM.cpp:320:27
#75  0x00007abec74eb7f8 in call at /home/edwin/ladybird/AK/Function.h:225:20
#76  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#77  0x00007abec794a5e7 in execute at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/Task.cpp:47:5
#78  0x00007abec7946d62 in perform_a_microtask_checkpoint at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:598:27
#79  (inlined)          in invoke_callback_impl<(lambda at /home/edwin/ladybird/Libraries/LibWeb/WebIDL/AbstractOperations.cpp:319:70)> at /home/edwin/ladybird/Libraries/LibWeb/WebIDL/AbstractOperations.cpp:303:9
#80  0x00007abec7d4d742 in invoke_callback at /home/edwin/ladybird/Libraries/LibWeb/WebIDL/AbstractOperations.cpp:319:12
#81  0x00007abec7d4d88b in invoke_callback at /home/edwin/ladybird/Libraries/LibWeb/WebIDL/AbstractOperations.cpp:357:12
#82  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/HTML/Window.cpp:1646:23
#83  0x00007abec7ac9d21 in call at /home/edwin/ladybird/AK/Function.h:225:20
#84  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#85  0x00007abec790ff71 in run at /home/edwin/ladybird/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.cpp:46:9
#86  0x00007abec7948630 in update_the_rendering at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:400:9
#87  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#88  0x00007abec794a5e7 in execute at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/Task.cpp:47:5
#89  0x00007abec7947212 in process at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:182:22
#90  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#91  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Platform/TimerSerenity.cpp:24:13
#92  0x00007abec7c27510 in call at /home/edwin/ladybird/AK/Function.h:225:20
#93  (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#94  0x00007abec6f59ea3 in timer_event at /home/edwin/ladybird/Libraries/LibCore/Timer.cpp:94:9
#95  0x00007abec6f58e42 in process at /home/edwin/ladybird/Libraries/LibCore/ThreadEventQueue.cpp:121:23
#96  (inlined)          in pump at /home/edwin/ladybird/Libraries/LibCore/EventLoopImplementationUnix.cpp:318:40
#97  0x00007abec6f5e37b in exec at /home/edwin/ladybird/Libraries/LibCore/EventLoopImplementationUnix.cpp:310:9
#98  0x00007abec6f51006 in exec at /home/edwin/ladybird/Libraries/LibCore/EventLoop.cpp:90:20
#99  0x00005865ac73d066 in ladybird_main at /home/edwin/ladybird/Services/WebContent/main.cpp:227:23
#100 0x00005865ac810c1f in main at /home/edwin/ladybird/Libraries/LibMain/Main.cpp:39:19
#101 0x00007abec542a1c9 in __libc_start_call_main at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
#102 0x00007abec542a28a in __libc_start_main_impl at ./csu/../csu/libc-start.c:360:3
#103 0x00005865ac73ba74 in _start at /home/edwin/ladybird/Build/release/libexec/WebContent
```

You can reproduce this crash by doing a search on github.com