### PR TITLE
LibWeb: Allow in-flow flex/grid items to avoid anonymous wrappers

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -25,6 +25,7 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
+#include <LibWeb/Layout/BreakNode.h>
 #include <LibWeb/Layout/FieldSetBox.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/InlineNode.h>
@@ -68,7 +69,7 @@ static bool has_in_flow_block_children(Layout::Node const& layout_node)
 // The insertion_parent_for_*() functions maintain the invariant that the in-flow children of
 // block-level boxes must be either all block-level or all inline-level.
 
-static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& layout_parent)
+static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& layout_parent, Layout::Node& layout_node)
 {
     auto last_child_creating_anonymous_wrapper_if_needed = [](auto& layout_parent) -> Layout::Node& {
         if (!layout_parent.last_child()
@@ -89,8 +90,21 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
     if (layout_parent.display().is_inline_outside() && layout_parent.display().is_flow_inside())
         return layout_parent;
 
-    if (layout_parent.display().is_flex_inside() || layout_parent.display().is_grid_inside())
-        return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
+    if (layout_parent.display().is_flex_inside() || layout_parent.display().is_grid_inside()) {
+        // Wrap inline-level sequences (text, <br>, inline <div>/pseudos/placeholders) as anonymous flex/grid items
+        bool needs_wrapper = is<Layout::TextNode>(layout_node) || is<Layout::BreakNode>(layout_node) || layout_node.display().is_inline_outside();
+
+        if (needs_wrapper) {
+            // Ensure inline-level content is placed in an anonymous inline wrapper
+            Node* last_child_ptr = layout_parent.last_child();
+            if (!last_child_ptr || !last_child_ptr->is_anonymous() || !last_child_ptr->children_are_inline()) {
+                layout_parent.append_child(layout_parent.create_anonymous_wrapper());
+            }
+            return *layout_parent.last_child();
+        }
+        // Place non-inline-level nodes directly as flex/grid items, allowing them to participate in layout without additional wrapping
+        return layout_parent;
+    }
 
     if (!has_in_flow_block_children(layout_parent) || layout_parent.children_are_inline())
         return layout_parent;
@@ -174,7 +188,7 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
         VERIFY_NOT_REACHED();
     }();
 
-    auto& insertion_point = display.is_inline_outside() ? insertion_parent_for_inline_node(nearest_insertion_ancestor)
+    auto& insertion_point = display.is_inline_outside() ? insertion_parent_for_inline_node(nearest_insertion_ancestor, node)
                                                         : insertion_parent_for_block_node(nearest_insertion_ancestor, node);
 
     if (mode == AppendOrPrepend::Prepend)

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-blockification.txt
@@ -2,16 +2,15 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
       Box <div.foo> at [8,8] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
-        BlockContainer <(anonymous)> at [8,8] flex-item [0+0+0 28.40625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        BlockContainer <(anonymous)> at [8,8] flex-item [0+0+0 65.25 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 4, rect: [8,8 28.40625x18] baseline: 13.796875
               "well"
-          TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> at [46.40625,8] flex-item [0+0+0 36.84375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 5, rect: [46.40625,8 36.84375x18] baseline: 13.796875
+          frag 1 from TextNode start: 0, length: 5, rect: [36.40625,8 36.84375x18] baseline: 13.796875
               "hello"
           TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> at [93.25,8] flex-item [0+0+0 55.359375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 7, rect: [93.25,8 55.359375x18] baseline: 13.796875
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [83.25,8] flex-item [0+0+0 55.359375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [83.25,8 55.359375x18] baseline: 13.796875
               "friends"
           TextNode <#text> (not painted)
 
@@ -19,11 +18,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.foo) [8,8 784x18]
-        PaintableWithLines (BlockContainer(anonymous)) [8,8 28.40625x18]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 65.25x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer(anonymous)) [46.40625,8 36.84375x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer(anonymous)) [93.25,8 55.359375x18]
+        PaintableWithLines (BlockContainer(anonymous)) [83.25,8 55.359375x18]
           TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/inline-table-no-anonymous-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/flex/inline-table-no-anonymous-wrapper.txt
@@ -1,0 +1,65 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 98 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 82 0+0+8] children: not-inline
+      Box <div.flex-container> at [15,15] flex-container(row) [0+2+5 770 5+2+0] [0+2+5 68 5+2+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [20,20] flex-item [5+0+0 54.375 0+0+5] [5+0+0 58 0+0+5] [BFC] children: not-inline
+          Box <div.inline-table> at [31,31] table-box [0+1+10 32.375 10+1+0] [0+1+10 36 10+1+0] [TFC] children: inline
+            Box <(anonymous)> at [31,31] table-row [0+0+0 32.375 0+0+0] [0+0+0 36 0+0+0] children: inline
+              BlockContainer <(anonymous)> at [31,31] table-cell [0+0+0 32.375 0+0+0] [0+0+0 36 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [31,31 32.375x18] baseline: 13.796875
+                    "Item"
+                frag 1 from TextNode start: 5, length: 1, rect: [31,49 6.34375x18] baseline: 13.796875
+                    "1"
+                TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [84.375,20] flex-item [5+0+0 54.375 0+0+5] [5+0+0 58 0+0+5] [BFC] children: not-inline
+          Box <div.inline-table> at [95.375,31] table-box [0+1+10 32.375 10+1+0] [0+1+10 36 10+1+0] [TFC] children: inline
+            Box <(anonymous)> at [95.375,31] table-row [0+0+0 32.375 0+0+0] [0+0+0 36 0+0+0] children: inline
+              BlockContainer <(anonymous)> at [95.375,31] table-cell [0+0+0 32.375 0+0+0] [0+0+0 36 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [95.375,31 32.375x18] baseline: 13.796875
+                    "Item"
+                frag 1 from TextNode start: 5, length: 1, rect: [95.375,49 8.8125x18] baseline: 13.796875
+                    "2"
+                TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [148.75,20] flex-item [5+0+0 54.375 0+0+5] [5+0+0 58 0+0+5] [BFC] children: not-inline
+          Box <div.inline-table> at [159.75,31] table-box [0+1+10 32.375 10+1+0] [0+1+10 36 10+1+0] [TFC] children: inline
+            Box <(anonymous)> at [159.75,31] table-row [0+0+0 32.375 0+0+0] [0+0+0 36 0+0+0] children: inline
+              BlockContainer <(anonymous)> at [159.75,31] table-cell [0+0+0 32.375 0+0+0] [0+0+0 36 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [159.75,31 32.375x18] baseline: 13.796875
+                    "Item"
+                frag 1 from TextNode start: 5, length: 1, rect: [159.75,49 9.09375x18] baseline: 13.796875
+                    "3"
+                TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,90] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x98]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x82]
+      PaintableBox (Box<DIV>.flex-container) [8,8 784x82]
+        PaintableWithLines (TableWrapper(anonymous)) [20,20 54.375x58]
+          PaintableBox (Box<DIV>.inline-table) [20,20 54.375x58]
+            PaintableBox (Box(anonymous)) [31,31 32.375x36]
+              PaintableWithLines (BlockContainer(anonymous)) [31,31 32.375x36]
+                TextPaintable (TextNode<#text>)
+        PaintableWithLines (TableWrapper(anonymous)) [84.375,20 54.375x58]
+          PaintableBox (Box<DIV>.inline-table) [84.375,20 54.375x58]
+            PaintableBox (Box(anonymous)) [95.375,31 32.375x36]
+              PaintableWithLines (BlockContainer(anonymous)) [95.375,31 32.375x36]
+                TextPaintable (TextNode<#text>)
+        PaintableWithLines (TableWrapper(anonymous)) [148.75,20 54.375x58]
+          PaintableBox (Box<DIV>.inline-table) [148.75,20 54.375x58]
+            PaintableBox (Box(anonymous)) [159.75,31 32.375x36]
+              PaintableWithLines (BlockContainer(anonymous)) [159.75,31 32.375x36]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,90 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x98] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/inline-table-no-anonymous-wrapper.html
+++ b/Tests/LibWeb/Layout/input/flex/inline-table-no-anonymous-wrapper.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<style>
+    .flex-container {
+        display: flex;
+        border: 2px solid black;
+        padding: 5px;
+    }
+
+    .inline-table {
+        display: inline-table;
+        border: 1px solid red;
+        padding: 10px;
+        margin: 5px;
+    }
+</style>
+<div class="flex-container">
+    <div class="inline-table">Item 1</div>
+    <div class="inline-table">Item 2</div>
+    <div class="inline-table">Item 3</div>
+</div>


### PR DESCRIPTION
This extends the existing fix for absolutely positioned elements (commit 7b4c76788b) to also apply to in-flow elements in flex/grid containers.

Previously, blockified inline-table elements inside flex containers were wrapped in anonymous blocks, preventing them from becoming proper flex items and breaking horizontal layout.

This change allows inline-table and similar elements to become direct flex items as per CSS Flexbox specifications.

Tested locally with inline-table in flex containers; layout now works horizontally as expected.

Relates to #6470 (partial fix).
