### PR TITLE
LibWeb: Invalidate layout tree after removing element from top layer

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6177,6 +6177,8 @@ void Document::remove_an_element_from_the_top_layer_immediately(GC::Ref<Element>
     // FIXME: 3. Remove the UA !important overlay: auto rule targeting el, if it exists.
     element->set_rendered_in_top_layer(false);
     element->set_needs_style_update(true);
+
+    invalidate_layout_tree(InvalidateLayoutTreeReason::DocumentImmediatelyRemoveElementFromTheTopLayer);
 }
 
 // https://drafts.csswg.org/css-position-4/#process-top-layer-removals
@@ -6196,6 +6198,9 @@ void Document::process_top_layer_removals()
         m_top_layer_elements.remove(element);
         m_top_layer_pending_removals.remove(element);
     }
+
+    if (!elements_to_remove.is_empty())
+        invalidate_layout_tree(InvalidateLayoutTreeReason::DocumentPendingTopLayerRemovalsProcessed);
 }
 
 // https://html.spec.whatwg.org/multipage/popover.html#topmost-auto-popover

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -58,6 +58,8 @@ enum class QuirksMode {
 #define ENUMERATE_INVALIDATE_LAYOUT_TREE_REASONS(X)       \
     X(DocumentAddAnElementToTheTopLayer)                  \
     X(DocumentRequestAnElementToBeRemovedFromTheTopLayer) \
+    X(DocumentImmediatelyRemoveElementFromTheTopLayer)    \
+    X(DocumentPendingTopLayerRemovalsProcessed)           \
     X(ShadowRootSetInnerHTML)
 
 enum class InvalidateLayoutTreeReason {

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/dialog-removal.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/dialog-removal.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: inline
+      TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/layout-tree-update/dialog-removal.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/dialog-removal.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<body>
+</body>
+<script>
+    const dialog = document.createElement("dialog");
+    dialog.innerText = "hello world";
+    document.body.appendChild(dialog);
+    dialog.showModal();
+    document.body.offsetWidth;
+    document.body.removeChild(dialog);
+    document.body.offsetWidth;
+</script>


### PR DESCRIPTION
Otherwise the layout tree will still contain the top layer element(s).

Fixes Steam Events & Announcements `<dialog>` modal visually not fully disappearing upon removal.

Before:

https://github.com/user-attachments/assets/37e55e63-65c2-4320-9796-858ac64c65f7

After:

https://github.com/user-attachments/assets/507df1c7-624a-4ab8-be0e-508930bb0efa
