### PR TITLE
UI: Fix transparent or artifacting tab painting

### DIFF
--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -504,7 +504,7 @@ void WebContentView::paintEvent(QPaintEvent*)
     }
 
     if (bitmap) {
-        QImage q_image(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), bitmap->pitch(), QImage::Format_RGB32);
+        QImage q_image(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), bitmap->pitch(), QImage::Format_ARGB32);
         painter.drawImage(QPoint(0, 0), q_image, QRect(0, 0, bitmap_size.width(), bitmap_size.height()));
 
         if (bitmap_size.width() < width()) {


### PR DESCRIPTION
When ladybird falls back to CPU backend painter, same as using --force-cpu-painting, resizing or moving a window causes all types of artifacts.  On WSL2 (with Ubuntu 24.04 for example) the window will be transparent on startup.

I can't completely say why I tried to change from Format_RGB32 to Format_ARGB32, but I noticed it was used in other places and gave it a try.  It seems to work, but is it the appropriate fix, I don't know.

fixes: #5963 
fixes: #6031
fixes: #6322
fixes: #6392
