### PR TITLE
LibGfx: Check for Vulkan device extension drm availability on Linux

### DIFF
--- a/Libraries/LibGfx/VulkanContext.cpp
+++ b/Libraries/LibGfx/VulkanContext.cpp
@@ -100,13 +100,15 @@ static ErrorOr<VkDevice> create_logical_device(VkPhysicalDevice physical_device,
 
     VkPhysicalDeviceFeatures deviceFeatures {};
 #ifdef USE_VULKAN_IMAGES
+    dbgln("Using shareable Vulcan images");
     char const* device_extensions[] = {
         VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
         VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME
     };
     uint32_t device_extension_count = array_size(device_extensions);
 #else
-    const char** device_extensions = nullptr;
+    dbgln("Not using shareable Vulcan images");
+    char const** device_extensions = nullptr;
     uint32_t device_extension_count = 0;
 #endif
     VkDeviceCreateInfo create_device_info {};

--- a/Libraries/LibGfx/VulkanContext.h
+++ b/Libraries/LibGfx/VulkanContext.h
@@ -7,15 +7,13 @@
 #pragma once
 
 #ifdef USE_VULKAN
-
-#    include <AK/Assertions.h>
-#    include <AK/NonnullRefPtr.h>
-#    include <AK/RefCounted.h>
 #    include <vulkan/vulkan.h>
-#    ifdef AK_OS_LINUX
+
+#    ifdef USE_VULKAN_IMAGES
+#        include <AK/Assertions.h>
+#        include <AK/NonnullRefPtr.h>
+#        include <AK/RefCounted.h>
 #        include <libdrm/drm_fourcc.h>
-// Sharable Vulkan images are currently only implemented on Linux
-#        define USE_VULKAN_IMAGES 1
 #    endif
 
 namespace Gfx {

--- a/Meta/CMake/vulkan-drm-checker.cpp
+++ b/Meta/CMake/vulkan-drm-checker.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <expected>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <vulkan/vulkan.h>
+
+using std::cout;
+using std::expected;
+using std::string;
+using std::unexpected;
+using std::vector;
+
+static expected<VkInstance, string> create_instance(uint32_t api_version)
+{
+    VkInstance instance;
+
+    VkApplicationInfo app_info {};
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = "Ladybird";
+    app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.pEngineName = nullptr;
+    app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.apiVersion = api_version;
+
+    VkInstanceCreateInfo create_info {};
+    create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    create_info.pApplicationInfo = &app_info;
+
+    auto result = vkCreateInstance(&create_info, nullptr, &instance);
+    if (result != VK_SUCCESS) {
+        cout << "vkCreateInstance returned: " << result << "\n";
+        return unexpected(string("Application instance creation failed"));
+    }
+
+    return instance;
+}
+
+static expected<VkPhysicalDevice, string> pick_physical_device(VkInstance instance)
+{
+    uint32_t device_count = 0;
+    vkEnumeratePhysicalDevices(instance, &device_count, nullptr);
+
+    if (device_count == 0)
+        return unexpected(string("Can't find any physical devices available"));
+
+    vector<VkPhysicalDevice> devices;
+    devices.resize(device_count);
+    vkEnumeratePhysicalDevices(instance, &device_count, devices.data());
+
+    VkPhysicalDevice picked_device = VK_NULL_HANDLE;
+    // Pick discrete GPU or the first device in the list
+    for (auto const& device : devices) {
+        if (picked_device == VK_NULL_HANDLE)
+            picked_device = device;
+
+        VkPhysicalDeviceProperties device_properties;
+        vkGetPhysicalDeviceProperties(device, &device_properties);
+        if (device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+            picked_device = device;
+    }
+
+    if (picked_device != VK_NULL_HANDLE) {
+        VkPhysicalDeviceProperties device_properties;
+        vkGetPhysicalDeviceProperties(picked_device, &device_properties);
+
+        cout << "Selected Vulkan graphical device: " << device_properties.deviceName << "\n";
+        return picked_device;
+    }
+
+    return unexpected(string("No physical graphical device selected"));
+}
+
+static bool check_device_extension_support(VkPhysicalDevice physicalDevice, vector<string> requiredExtensions)
+{
+    uint32_t extensionCount = 0;
+    // First, get the number of available extensions.
+    vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount, nullptr);
+
+    // Then, retrieve the available extensions.
+    vector<VkExtensionProperties> availableExtensions;
+    availableExtensions.resize(extensionCount);
+    vkEnumerateDeviceExtensionProperties(physicalDevice, nullptr, &extensionCount, availableExtensions.data());
+
+    // Check if all required extensions are in the list of available extensions.
+    bool all_found { true };
+    for (auto const& requiredExtension : requiredExtensions) {
+        bool found { false };
+        for (auto const& availableExtension : availableExtensions) {
+            if (requiredExtension == string(availableExtension.extensionName)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            cout << "Required device extension not supported: " << requiredExtension << "\n";
+            all_found = false;
+        }
+    }
+
+    return all_found;
+}
+
+int main()
+{
+    uint32_t const api_version = VK_API_VERSION_1_1; // v1.1 needed for vkGetPhysicalDeviceFormatProperties2
+    auto instance = create_instance(api_version);
+    if (!instance.has_value()) {
+        cout << "create_instance failed: " << instance.error() << "\n";
+        return (99);
+    }
+
+    auto physical_device = pick_physical_device(instance.value());
+    if (!physical_device.has_value()) {
+        cout << "pick_physical_device failed: " << physical_device.error() << "\n";
+        return (98);
+    }
+
+    vector<string> device_extensions = {
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+        VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
+    };
+
+    if (!check_device_extension_support(physical_device.value(), device_extensions))
+        return (1);
+
+    return (0);
+}

--- a/Meta/CMake/vulkan.cmake
+++ b/Meta/CMake/vulkan.cmake
@@ -6,5 +6,32 @@ if (NOT APPLE)
     if (VulkanHeaders_FOUND AND Vulkan_FOUND)
         set(HAS_VULKAN ON CACHE BOOL "" FORCE)
         add_cxx_compile_definitions(USE_VULKAN=1)
+
+        set(TRY_RUN_BINARY_DIR "${CMAKE_SOURCE_DIR}/Meta/CMake/TryRunChecks")
+        set(CMAKE_REQUIRED_FLAGS "-fsanitize=fuzzer-no-link")
+        try_run(
+            DRM_CHECK_RUN_RESULT
+            DRM_CHECK_COMPILE_RESULT
+            "${TRY_RUN_BINARY_DIR}"
+            "${CMAKE_SOURCE_DIR}/Meta/CMake/vulkan-drm-checker.cpp"
+            LINK_LIBRARIES Vulkan::Vulkan
+            CMAKE_FLAGS
+                "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
+            OUTPUT_VARIABLE DRM_CHECK_TRY_RUN_OUTPUT
+        )
+        unset(CMAKE_REQUIRED_FLAGS)
+
+        message(STATUS "${DRM_CHECK_TRY_RUN_OUTPUT}")
+
+        if (NOT DRM_CHECK_COMPILE_RESULT)
+           message(FATAL_ERROR "Could not build Vulkan DRM checker")
+        endif()
+
+        if (DRM_CHECK_RUN_RESULT EQUAL 0)
+            message(STATUS "Shareable Vulkan Images available")
+            add_cxx_compile_definitions(USE_VULKAN_IMAGES=1)
+        else()
+            message(STATUS "Shareable Vulkan Images NOT available")
+        endif()
     endif()
 endif()


### PR DESCRIPTION
Add physical device extension availablity check to exclude the usage of sharable Vulkan image if extension is not available.

Currently on many Linux distributions the sharable Vulkan image device extension is not available. Due to this, the VulkanContext fails to be created and ladybird falls back to the CPU backend painter.

Adding a configure tool to check if the required extensions are available and set appropriate variables.

Issue was first introduce when the shareable Vulkan images where incorporated in #5864 specifically in this commit 60a7359f0f6827799621db8320b43e5d60d08ef2

Even on Ubuntu 24.04 it fails and the following error will be seen. 
```
1738.682 WebContent(100803): Vulkan context creation failed: Logical device creation failed
1738.769 WebContent(100808): Vulkan context creation failed: Logical device creation failed
```
The above error message does not reveal the real reason for the issue, but in many instances the cause is lack of support for the device extension: `VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME` 


fixes: #6163

Related to: #5963, #6031, #6322, #6392, #6503

Tool is based on content in `Libraries/LibGfx/VulkanContext.cpp`, but has been reworked to remove dependency on AK library code. It is using just standard c++23 code.

An attempt was made to use the AK library code as part of the solution, as can be seen in this branch https://github.com/LadybirdBrowser/ladybird/compare/master...rcorsi:ladybird:vulkan_extension_check , but encountered issues with TRY macro initially (which is removed) and then undefined references to ak_verification_failed, so AK/Assertions.cpp was added to the list of SOURCES, and then the problem was AK/Backtrace.h that had to be generated. I did try to remove reliance on AK/Vector by switching to std::vector, helped a bit, but not completely. It was getting out of hand, so I didn't continue on this avenue.  Maybe someone can help out if that would be the better way.