### PR TITLE
LibWeb: fix VERIFICATION FAILED: box_used_values.offset.is_zero()

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1195,6 +1195,11 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
 
     auto& box_state = m_state.get_mutable(box);
 
+    // NOTE: We reset the offset to zero here, since we're about to recalculate it.
+    //       This is necessary when layout_absolutely_positioned_element is called multiple times
+    //       (e.g., during nested layout of absolutely positioned elements).
+    box_state.set_content_offset({ 0, 0 });
+
     // The border computed values are not changed by the compute_height & width calculations below.
     // The spec only adjusts and computes sizes, insets and margins.
     box_state.border_left = box.computed_values().border_left().width;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -116,7 +116,9 @@ static GC::Ptr<Box> nearest_ancestor_capable_of_forming_a_containing_block(Node&
             || ancestor->display().is_flex_inside()
             || ancestor->display().is_grid_inside()
             || ancestor->is_svg_svg_box()) {
-            return as<Box>(ancestor);
+            // NOTE: Not all nodes with these properties are boxes, so we need to check.
+            if (is<Box>(*ancestor))
+                return as<Box>(ancestor);
         }
     }
     return nullptr;


### PR DESCRIPTION
When doing a search on Amazon, the following error is encountered:

```
VERIFICATION FAILED: box_used_values.offset.is_zero() at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:1170
Stack trace (most recent call first):
#0   0x00007502eff58f13 in content_box_rect_in_static_position_ancestor_coordinate_space at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:1170:5
#1   0x00007502eff591f5 in layout_absolutely_positioned_element at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:1250:36
#2   0x00007502eff3d893 in parent_context_did_dimension_child_root_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:146:13
#3   0x00007502eff44fda in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/FlexFormattingContext.cpp:210:49
#4   0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#5   (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#6   (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#7   (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#8   0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#9   0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#10  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#11  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#12  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#13  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#14  0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#15  0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#16  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#17  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#18  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#19  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#20  0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#21  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#22  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#23  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#24  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#25  0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#26  0x00007502eff51e48 in layout_inside at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:0:0
#27  0x00007502eff44fc6 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/FlexFormattingContext.cpp:209:55
#28  0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#29  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#30  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#31  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#32  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#33  0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#34  0x00007502eff51e48 in layout_inside at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:0:0
#35  0x00007502eff40969 in layout_floating_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:1089:43
#36  0x00007502eff71bdf in generate_line_boxes at /home/edwin/ladybird/Libraries/LibWeb/Layout/InlineFormattingContext.cpp:322:26
#37  0x00007502eff717ed in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/InlineFormattingContext.cpp:87:5
#38  0x00007502eff3d2b3 in layout_inline_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:574:13
#39  0x00007502eff3ce36 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:82:9
#40  0x00007502eff51e48 in layout_inside at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:0:0
#41  0x00007502eff9a71f in compute_table_height at /home/edwin/ladybird/Libraries/LibWeb/Layout/TableFormattingContext.cpp:985:51
#42  0x00007502eff9fef7 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/TableFormattingContext.cpp:1688:5
#43  0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#44  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#45  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#46  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#47  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#48  0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#49  0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#50  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#51  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#52  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#53  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#54  0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#55  0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#56  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#57  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#58  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#59  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#60  0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#61  0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#62  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#63  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#64  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#65  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#66  0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#67  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#68  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#69  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#70  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#71  0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#72  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#73  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#74  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#75  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#76  0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#77  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#78  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#79  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#80  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#81  0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#82  0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#83  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#84  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#85  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#86  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#87  0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#88  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#89  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#90  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#91  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#92  0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#93  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#94  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#95  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#96  0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#97  0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#98  (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#99  (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#100 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#101 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#102 0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#103 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#104 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#105 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#106 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#107 0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#108 0x00007502eff51e48 in layout_inside at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:0:0
#109 0x00007502eff6b04f in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/GridFormattingContext.cpp:2096:51
#110 0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#111 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#112 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#113 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#114 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#115 0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#116 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#117 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#118 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#119 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#120 0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#121 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#122 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#123 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#124 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#125 0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#126 0x00007502eff51e48 in layout_inside at /home/edwin/ladybird/Libraries/LibWeb/Layout/FormattingContext.cpp:0:0
#127 0x00007502eff44fc6 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/FlexFormattingContext.cpp:209:55
#128 0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#129 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#130 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#131 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#132 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#133 0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#134 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#135 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#136 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#137 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#138 0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#139 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#140 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#141 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#142 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#143 0x00007502eff40465 in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:858:13
#144 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#145 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#146 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#147 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#148 0x00007502eff3ce43 in run at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:84:9
#149 0x00007502eff402ae in layout_block_level_box at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:839:41
#150 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:902:9
#151 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:313:21
#152 (inlined)          in for_each_child_of_type<Web::Layout::Box, (lambda at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:49)> at /home/edwin/ladybird/Libraries/LibWeb/TreeNode.h:322:54
#153 0x00007502eff3d48b in layout_block_level_children at /home/edwin/ladybird/Libraries/LibWeb/Layout/BlockFormattingContext.cpp:901:21
#154 0x00007502efbb98dd in update_layout at /home/edwin/ladybird/Libraries/LibWeb/DOM/Document.cpp:1417:33
#155 0x00007502efd51385 in update_the_rendering at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:414:23
#156 (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#157 0x00007502efd531a7 in execute at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/Task.cpp:47:5
#158 0x00007502efd4ff22 in process at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:182:22
#159 (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#160 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Platform/TimerSerenity.cpp:24:13
#161 0x00007502f002f7d0 in call at /home/edwin/ladybird/AK/Function.h:225:20
#162 (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#163 0x00007502ef359ea3 in timer_event at /home/edwin/ladybird/Libraries/LibCore/Timer.cpp:94:9
#164 0x00007502ef358e42 in process at /home/edwin/ladybird/Libraries/LibCore/ThreadEventQueue.cpp:121:23
#165 (inlined)          in pump at /home/edwin/ladybird/Libraries/LibCore/EventLoop.cpp:102:20
#166 0x00007502ef351171 in spin_until at /home/edwin/ladybird/Libraries/LibCore/EventLoop.cpp:97:9
#167 0x00007502f002ef2d in spin_until at /home/edwin/ladybird/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp:19:32
#168 0x00007502efd4f958 in spin_until at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:100:38
#169 0x00007502efeb93e3 in check_if_unloading_is_canceled at /home/edwin/ladybird/Libraries/LibWeb/HTML/TraversableNavigable.cpp:996:30
#170 0x00007502efeba426 in check_if_unloading_is_canceled at /home/edwin/ladybird/Libraries/LibWeb/HTML/TraversableNavigable.cpp:1006:12
#171 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/HTML/Navigable.cpp:1758:64
#172 0x00007502efe22dcc in call at /home/edwin/ladybird/AK/Function.h:225:20
#173 (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#174 (inlined)          in operator() at /home/edwin/ladybird/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp:29:9
#175 0x00007502f002f2c4 in call at /home/edwin/ladybird/AK/Function.h:225:20
#176 (inlined)          in operator() at /home/edwin/ladybird/AK/Function.h:148:25
#177 0x00007502ef358e7e in process at /home/edwin/ladybird/Libraries/LibCore/ThreadEventQueue.cpp:118:13
#178 (inlined)          in pump at /home/edwin/ladybird/Libraries/LibCore/EventLoop.cpp:102:20
#179 0x00007502ef351171 in spin_until at /home/edwin/ladybird/Libraries/LibCore/EventLoop.cpp:97:9
#180 0x00007502f002ef2d in spin_until at /home/edwin/ladybird/Libraries/LibWeb/Platform/EventLoopPluginSerenity.cpp:19:32
#181 0x00007502efd4f958 in spin_until at /home/edwin/ladybird/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp:100:38
#182 0x00007502efe4a9df in handle_text at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:3320:50
#183 0x00007502efe44a44 in run at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:243:13
#184 0x00007502efe45bfd in run at /home/edwin/ladybird/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp:267:5
```

This happens when `layout_absolutely_positioned_element` is called multiple times on the same element (e.g., during nested layout of absolutely positioned elements). Each call would accumulate or retain offset values from previous layout passes.  To fix this, we reset the offset to zero at the start of the function.

Fixing this exposed a second problem in Node.cpp.  Not all nodes with display properties like flex/grid are actually Box objects, but the code was casting them unconditionally with as<Box>().  We fix that by adding a type check before casting.