### PR TITLE
CSS: StepsEasingFunction use i64 instead of long

### DIFF
--- a/Libraries/LibWeb/CSS/EasingFunction.h
+++ b/Libraries/LibWeb/CSS/EasingFunction.h
@@ -42,7 +42,7 @@ struct CubicBezierEasingFunction {
 };
 
 struct StepsEasingFunction {
-    long interval_count;
+    i64 interval_count;
     StepPosition position;
     String stringified;
 


### PR DESCRIPTION
Unbreaks windows build. 32bit long on Windows strikes back. resolve_integer returns an i64 making creation of a StepsEasingFunction with its result a narrowing conversion before this change.