### PR TITLE
LibWeb: Update painting backing stores in all cases

### DIFF
--- a/Libraries/LibWeb/Painting/BackingStoreManager.cpp
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.cpp
@@ -59,6 +59,10 @@ BackingStoreManager::BackingStore BackingStoreManager::acquire_store_for_next_fr
 void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
 {
     auto skia_backend_context = m_navigable->skia_backend_context();
+
+    m_front_store = nullptr;
+    m_back_store = nullptr;
+
 #ifdef AK_OS_MACOS
     if (skia_backend_context && s_browser_mach_port.has_value()) {
         auto back_iosurface = Core::IOSurfaceHandle::create(size.width(), size.height());


### PR DESCRIPTION
To consistently update the backing stores in reallocate_backing_stores() the variables storing the backing stores need to be set to nullptr at the start so that they are properly updated later on near the end of the function.

fixes: #6505

also corrects

fixes: #5963
fixes: #6031
fixes: #6322
fixes: #6392
