### PR TITLE
LibWeb: Add ability to generate tree of view-transition pseudo-elements

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -876,6 +876,7 @@ public:
     void set_rendering_suppression_for_view_transitions(bool value) { m_rendering_suppression_for_view_transitions = value; }
     GC::Ptr<CSS::CSSStyleSheet> dynamic_view_transition_style_sheet() const { return m_dynamic_view_transition_style_sheet; }
     void set_show_view_transition_tree(bool value) { m_show_view_transition_tree = value; }
+    bool show_view_transition_tree() { return m_show_view_transition_tree; }
     Vector<GC::Ptr<ViewTransition::ViewTransition>>& update_callback_queue() { return m_update_callback_queue; }
 
     void reset_cursor_blink_cycle();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3032,7 +3032,7 @@ PseudoElement& Element::ensure_pseudo_element(CSS::PseudoElement type) const
 
     if (!m_pseudo_element_data->get(type).has_value()) {
         if (is_pseudo_element_root(type)) {
-            m_pseudo_element_data->set(type, heap().allocate<PseudoElementTreeNode>());
+            m_pseudo_element_data->set(type, heap().allocate<PseudoElementTreeNode>(type));
         } else {
             m_pseudo_element_data->set(type, heap().allocate<PseudoElement>());
         }

--- a/Libraries/LibWeb/DOM/PseudoElement.cpp
+++ b/Libraries/LibWeb/DOM/PseudoElement.cpp
@@ -44,4 +44,9 @@ void PseudoElement::set_counters_set(OwnPtr<CSS::CountersSet>&& counters_set)
     m_counters_set = move(counters_set);
 }
 
+PseudoElementTreeNode::PseudoElementTreeNode(CSS::PseudoElement type)
+    : m_type(type)
+{
+}
+
 }

--- a/Libraries/LibWeb/DOM/PseudoElement.h
+++ b/Libraries/LibWeb/DOM/PseudoElement.h
@@ -59,6 +59,13 @@ class PseudoElementTreeNode
     , public TreeNode<PseudoElementTreeNode> {
     GC_CELL(PseudoElementTreeNode, PseudoElement);
     GC_DECLARE_ALLOCATOR(PseudoElementTreeNode);
+
+    PseudoElementTreeNode(CSS::PseudoElement);
+
+    CSS::PseudoElement type() const { return m_type; }
+
+private:
+    CSS::PseudoElement m_type;
 };
 
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -37,6 +37,7 @@ private:
         Yes,
     };
     void update_layout_tree(DOM::Node&, Context&, MustCreateSubtree);
+    void build_tree_of_pseudo_elements(DOM::Element&, DOM::PseudoElementTreeNode*);
 
     void push_parent(Layout::NodeWithStyle& node) { m_ancestor_stack.append(node); }
     void pop_parent() { m_ancestor_stack.take_last(); }


### PR DESCRIPTION
This makes it so that the tree builder is capable of generating a layout tree for the view transition pseudo-elements.
This is not testable since all view transitions currently end immediately due to some outstanding FIXMEs. (Still working on that)