### PR TITLE
LibWebView: Add common source loop source for deferred_invoke() on macOS

### DIFF
--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.h
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.h
@@ -43,8 +43,13 @@ public:
     virtual bool was_exit_requested() const override;
     virtual void post_event(Core::EventReceiver& receiver, NonnullOwnPtr<Core::Event>&&) override;
 
+    virtual ~EventLoopImplementationMacOS() override;
+
 private:
-    EventLoopImplementationMacOS() = default;
+    EventLoopImplementationMacOS();
+
+    struct Impl;
+    NonnullOwnPtr<Impl> m_impl;
 
     int m_exit_code { 0 };
 };


### PR DESCRIPTION
Previously, `EventLoopImplementationMacOS` didn't process `deferred_invoke()` callbacks during window resizing because they were scheduled in the "default" run-loop mode, which isn't serviced while the run loop is in "Event Tracking" mode.

Commit 3bbe1b0c changed socket notifiers to schedule in `kCFRunLoopCommonModes`, which kept IPC reads responsive during resizing (we process IPC messages in the notifier's read hook). This change does the same for `deferred_invoke()`: it installs a `CFRunLoopSource` in `kCFRunLoopCommonModes` and signals it whenever a deferred callback is enqueued.