### PR TITLE
AK: Remove unused Checked<T> code

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -348,14 +348,9 @@ public:
     {
 #if __has_builtin(__builtin_add_overflow_p)
         return __builtin_add_overflow_p(u, v, (T)0);
-#elif __has_builtin(__builtin_add_overflow)
+#else
         T result;
         return __builtin_add_overflow(u, v, &result);
-#else
-        Checked checked;
-        checked = u;
-        checked += v;
-        return checked.has_overflow();
 #endif
     }
 
@@ -364,14 +359,9 @@ public:
     {
 #if __has_builtin(__builtin_sub_overflow_p)
         return __builtin_sub_overflow_p(u, v, (T)0);
-#elif __has_builtin(__builtin_sub_overflow)
+#else
         T result;
         return __builtin_sub_overflow(u, v, &result);
-#else
-        Checked checked;
-        checked = u;
-        checked -= v;
-        return checked.has_overflow();
 #endif
     }
 
@@ -404,25 +394,10 @@ public:
     {
 #if __has_builtin(__builtin_mul_overflow_p)
         return __builtin_mul_overflow_p(u, v, (T)0);
-#elif __has_builtin(__builtin_mul_overflow)
+#else
         T result;
         return __builtin_mul_overflow(u, v, &result);
-#else
-        Checked checked;
-        checked = u;
-        checked *= v;
-        return checked.has_overflow();
 #endif
-    }
-
-    template<typename U, typename V, typename X>
-    [[nodiscard]] static constexpr bool multiplication_would_overflow(U u, V v, X x)
-    {
-        Checked checked;
-        checked = u;
-        checked *= v;
-        checked *= x;
-        return checked.has_overflow();
     }
 
 private:

--- a/Tests/AK/TestChecked.cpp
+++ b/Tests/AK/TestChecked.cpp
@@ -374,7 +374,6 @@ TEST_CASE(should_constexpr_check_for_overflow_addition)
 TEST_CASE(should_constexpr_check_for_overflow_multiplication)
 {
     static_assert(Checked<int>::multiplication_would_overflow(NumericLimits<int>::max(), 2));
-    static_assert(Checked<int>::multiplication_would_overflow(NumericLimits<int>::max(), 1, 2));
 }
 
 TEST_CASE(should_constexpr_add_checked_values)


### PR DESCRIPTION
We could never hit the #else branches for some of these methods, because we already relied on having __builtin_*_overflow() readily available in earlier methods.

multiplication_would_overflow() with three arguments was only used in a test, so let's get rid of that as well.