### PR TITLE
LibWeb: Ignore repaint requests inside iframes with visibility: hidden

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6445,6 +6445,12 @@ void Document::set_needs_display(CSSPixelRect const&, InvalidateDisplayList shou
     // FIXME: Ignore updates outside the visible viewport rect.
     //        This requires accounting for fixed-position elements in the input rect, which we don't do yet.
 
+    // OPTIMIZATION: Ignore set_needs_display() inside navigable containers (i.e frames) with visibility: hidden.
+    if (auto navigable = this->navigable()) {
+        if (navigable->has_inclusive_ancestor_with_visibility_hidden())
+            return;
+    }
+
     if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
         invalidate_display_list();
     }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2766,4 +2766,19 @@ void Navigable::reset_zoom()
     document->visual_viewport()->reset();
 }
 
+bool Navigable::has_inclusive_ancestor_with_visibility_hidden() const
+{
+    if (auto container = this->container()) {
+        if (auto container_computed_properties = container->computed_properties()) {
+            if (container_computed_properties->visibility() == CSS::Visibility::Hidden)
+                return true;
+        }
+        if (auto ancestor_navigable = container->document().navigable()) {
+            if (auto ancestor_container = ancestor_navigable->container())
+                return ancestor_navigable->has_inclusive_ancestor_with_visibility_hidden();
+        }
+    }
+    return false;
+}
+
 }

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -203,6 +203,8 @@ public:
     bool needs_repaint() const { return m_needs_repaint; }
     void set_needs_repaint() { m_needs_repaint = true; }
 
+    [[nodiscard]] bool has_inclusive_ancestor_with_visibility_hidden() const;
+
     RefPtr<Gfx::SkiaBackendContext> skia_backend_context() const;
 
     void set_pending_set_browser_zoom_request(bool value) { m_pending_set_browser_zoom_request = value; }


### PR DESCRIPTION
This reduces idle CPU usage on https://gymgrossisten.com/ from 100% (split between WebContent and Ladybird) to ~4% on my machine.