### PR TITLE
UI/AppKit: Make project buildable on macOS < 15

### DIFF
--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -94,7 +94,9 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [self.toolbar setDelegate:self];
         [self.toolbar setDisplayMode:NSToolbarDisplayModeIconOnly];
         if (@available(macOS 15, *)) {
-            [self.toolbar setAllowsDisplayModeCustomization:NO];
+            if ([self.toolbar respondsToSelector:@selector(setAllowsDisplayModeCustomization:)]) {
+                [self.toolbar performSelector:@selector(setAllowsDisplayModeCustomization:) withObject:nil];
+            }
         }
         [self.toolbar setAllowsUserCustomization:NO];
         [self.toolbar setSizeMode:NSToolbarSizeModeRegular];


### PR DESCRIPTION
When trying to build Ladybird on macOS 14.3, it fails with the error:

```

No visible @interface for 'NSToolbar' declares the selector 'setAllowsDisplayModeCustomization:' (clang arc_may_not_respond)

```

This is caused by macOS < 15 not having the @interface definition in NSToolbar for setAllowsUserCustomization:(BOOL).

By dynamically calling the method, we can avoid the error altogether.

fixes #6308