### PR TITLE
Documentation: Update EventLoop.md

### DIFF
--- a/Documentation/EventLoop.md
+++ b/Documentation/EventLoop.md
@@ -41,3 +41,4 @@ Note that all events are registered, and therefore happen, on the event loop of 
 -   DO NOT store an event loop in a global variable. Because the event loop itself relies on global variable initialization, UBSAN will catch an initialization order fiasco. DO create your main event loop in `main` and pass it to classes which need it.
 -   DO NOT access the current event loop if you don't know on which thread you are running. If there is no event loop on your thread, the program will crash. DO receive the specific event loop you need to talk to as an initializer variable.
 -   DO NOT `pump()` and/or `exec()` the event loop of another thread. While handling events is fine, going to sleep and waking up relies on thread-local variables. DO signal events to event loops on other threads.
+-   DO NOT register or unregister notifiers, timers, or signals for event loops of other threads. DO deferred_invoke event loops of other threads.


### PR DESCRIPTION
This updates EventLoop.md with the results of the discussion had on discord regarding the expected behavior when registering or unregistering objects with the event loop from another thread.

For context #6494 originally added mutexes to the register/unregister functions as it was attempting to have the main thread register notifiers for the io thread. The mutex was inside the ThreadData Struct. However, acquiring the mutex inside the ThreadData wouldn't prevent the thread that owns the structure terminating and ThreadData destructing, between acquiring the ThreadData's pointer and taking the mutex. This would lead to a use after free.

This could be solved by acquiring a global read lock for that stretch of time but this has performance implications. More importantly the ownership of resources associated with an event loop becomes difficult to reason about.

As such it was decided not to allow other threads to register/unregister objects with the event loop.

Pull request #6494: https://github.com/LadybirdBrowser/ladybird/pull/6494
Discord message link: https://discord.com/channels/1247070541085671459/1306918361732616212/1430978833447915641