### PR TITLE
LibRegex: Properly track code units in unicode mode

### DIFF
--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
@@ -156,3 +156,37 @@ test("Unicode properties of strings", () => {
         expect(re.test(str)).toBeFalse();
     }
 });
+
+test("Unicode matching with u and v flags", () => {
+    const text = "𠮷a𠮷b𠮷";
+    const complexText = "a\u{20BB7}b\u{10FFFF}c";
+
+    const cases = [
+        { pattern: /𠮷/, match: text, expected: ["𠮷"] },
+        { pattern: /𠮷/u, match: text, expected: ["𠮷"] },
+        { pattern: /𠮷/v, match: text, expected: ["𠮷"] },
+        { pattern: /\p{Script=Han}/u, match: text, expected: ["𠮷"] },
+        { pattern: /\p{Script=Han}/v, match: text, expected: ["𠮷"] },
+        { pattern: /./u, match: text, expected: ["𠮷"] },
+        { pattern: /./v, match: text, expected: ["𠮷"] },
+        { pattern: /\p{ASCII}/u, match: text, expected: ["a"] },
+        { pattern: /\p{ASCII}/v, match: text, expected: ["a"] },
+        { pattern: /x/u, match: text, expected: null },
+        { pattern: /x/v, match: text, expected: null },
+        { pattern: /\p{Script=Han}(.)/gu, match: text, expected: ["𠮷a", "𠮷b"] },
+        { pattern: /\p{Script=Han}(.)/gv, match: text, expected: ["𠮷a", "𠮷b"] },
+        { pattern: /\P{ASCII}/u, match: complexText, expected: ["\u{20BB7}"] },
+        { pattern: /\P{ASCII}/v, match: complexText, expected: ["\u{20BB7}"] },
+        { pattern: /\P{ASCII}/gu, match: complexText, expected: ["\u{20BB7}", "\u{10FFFF}"] },
+        { pattern: /\P{ASCII}/gv, match: complexText, expected: ["\u{20BB7}", "\u{10FFFF}"] },
+        { pattern: /./gu, match: text, expected: ["𠮷", "a", "𠮷", "b", "𠮷"] },
+        { pattern: /./gv, match: text, expected: ["𠮷", "a", "𠮷", "b", "𠮷"] },
+        { pattern: /(?:)/gu, match: text, expected: ["", "", "", "", "", ""] },
+        { pattern: /(?:)/gv, match: text, expected: ["", "", "", "", "", ""] },
+    ];
+
+    for (const test of cases) {
+        const result = test.match.match(test.pattern);
+        expect(result).toEqual(test.expected);
+    }
+});

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -237,10 +237,17 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
         input.view = view;
         dbgln_if(REGEX_DEBUG, "[match] Starting match with view ({}): _{}_", view.length(), view);
 
-        auto view_length = view.length_in_code_units();
+        auto view_length = view.length();
         size_t view_index = m_pattern->start_offset;
         state.string_position = view_index;
-        state.string_position_in_code_units = view_index;
+        if (view.unicode()) {
+            if (view_index < view_length)
+                state.string_position_in_code_units = view.code_unit_offset_of(view_index);
+            else
+                state.string_position_in_code_units = view.length_in_code_units();
+        } else {
+            state.string_position_in_code_units = view_index;
+        }
         bool succeeded = false;
 
         if (view_index == view_length && m_pattern->parser_result.match_length_minimum == 0) {
@@ -303,7 +310,14 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             input.match_index = match_count;
 
             state.string_position = view_index;
-            state.string_position_in_code_units = view_index;
+            if (input.view.unicode()) {
+                if (view_index < view_length)
+                    state.string_position_in_code_units = input.view.code_unit_offset_of(view_index);
+                else
+                    state.string_position_in_code_units = input.view.length_in_code_units();
+            } else {
+                state.string_position_in_code_units = view_index;
+            }
             state.instruction_position = 0;
             state.repetition_marks.clear();
 


### PR DESCRIPTION
We were incorrectly tracking code units before this change, for example for string `"𠮷a𠮷b𠮷"`, we were getting:
```
state.string_position=0, (in code units: 0)
state.string_position=1, (in code units: 1)
state.string_position=2, (in code units: 2)
```
which resulted in incorrect matches, now code units update properly:
```
state.string_position=0, (in code units: 0)
state.string_position=1, (in code units: 2)
```
Test 262 diff:
        +3 ✅    -3 ❌   

Diff Tests:
    test/built-ins/RegExp/prototype/exec/regexp-builtin-exec-v-u-flag.js           ❌ -> ✅
    test/built-ins/String/prototype/matchAll/regexp-prototype-matchAll-v-u-flag.js ❌ -> ✅
    test/built-ins/String/prototype/replace/regexp-prototype-replace-v-u-flag.js   ❌ -> ✅
