### PR TITLE
CI: Add All_Debug CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
             clang_plugins: false
             runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
 
+          - os_name: 'Linux'
+            arch: 'x86_64'
+            build_preset: 'All_Debug'
+            toolchain: 'Clang'
+            clang_plugins: false
+            runner_labels: '["blacksmith-16vcpu-ubuntu-2404"]'
+
     secrets: inherit
     uses: ./.github/workflows/lagom-template.yml
     with:

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -203,14 +203,14 @@ jobs:
           UBSAN_OPTIONS: 'log_path="${{ github.workspace }}/ubsan.log"'
 
       - name: Test
-        if: ${{ inputs.build_preset != 'Fuzzers' && !contains(inputs.build_preset, 'Sanitizer') }}
+        if: ${{ inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'All_Debug' && !contains(inputs.build_preset, 'Sanitizer') }}
         working-directory: ${{ github.workspace }}
         run: ctest --output-on-failure --test-dir Build --timeout 1800
         env:
           TESTS_ONLY: 1
 
       - name: Upload LibWeb Test Artifacts
-        if: ${{ always() && inputs.build_preset != 'Fuzzers' }}
+        if: ${{ always() && inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'All_Debug' }}
         uses: actions/upload-artifact@v4
         with:
           name: libweb-test-artifacts-${{ inputs.os_name }}-${{ inputs.build_preset }}-${{ inputs.toolchain }}-${{ inputs.clang-plugins }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -83,6 +83,18 @@
       }
     },
     {
+      "name": "All_Debug",
+      "inherits": "unix_base",
+      "displayName": "All Debug Config",
+      "description": "All Debug Unix build",
+      "binaryDir": "${fileDir}/Build/alldebug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/debug-triplets",
+        "ENABLE_ALL_THE_DEBUG_MACROS": "ON"
+      }
+    },
+    {
       "name": "Windows_Experimental",
       "inherits": "windows_base",
       "displayName": "Windows Experimental Config",

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -271,6 +271,7 @@ def configure_build_env(platform: Platform, preset: str) -> tuple[Path, Path]:
 
     known_presets = {
         "Debug": build_root_dir / "debug",
+        "All_Debug": build_root_dir / "alldebug",
         "Distribution": build_root_dir / "distribution",
         "Release": build_root_dir / "release",
         "Sanitizer": build_root_dir / "sanitizers",


### PR DESCRIPTION
Add missing All_Debug CI job to verify ladybird build when all the DEBUG macros are enabled.

fixes: #2307