### PR TITLE
CI+Meta: Enable tests for All_Debug CI job, excluding some tests

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -212,7 +212,7 @@ jobs:
           UBSAN_OPTIONS: 'log_path=ubsan.log'
 
       - name: Test
-        if: ${{ inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'All_Debug' && inputs.build_preset != 'Sanitizer' }}
+        if: ${{ inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: ctest --output-on-failure --test-dir Build --timeout 1800
         env:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,6 +51,14 @@
       "configurePreset": "Debug"
     },
     {
+      "name": "All_Debug",
+      "inherits": "root_base",
+      "configurePreset": "All_Debug",
+      "environment": {
+        "TESTS_ONLY": "1"
+      }
+    },
+    {
       "name": "Sanitizer",
       "inherits": "root_base",
       "configurePreset": "Sanitizer",

--- a/Meta/CMake/presets/CMakeWindowsPresets.json
+++ b/Meta/CMake/presets/CMakeWindowsPresets.json
@@ -57,6 +57,15 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
+    },
+    {
+      "name": "All_Debug",
+      "inherits": [
+        "windows_base",
+        "All_Debug_base"
+      ],
+      "displayName": "Windows Experimental All Debug Config",
+      "description": "Experimental Windows All Debug build. Not all targets in this preset are built and there is minimal runtime support"
     }
   ]
 }

--- a/Meta/Utils/shell_include.sh
+++ b/Meta/Utils/shell_include.sh
@@ -54,6 +54,9 @@ get_build_dir() {
         "Debug")
             BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/debug"
             ;;
+        "All_Debug")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/alldebug"
+            ;;
         "Sanitizer")
             BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/sanitizers"
             ;;

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -5,7 +5,9 @@ ladybird_test(test-bytecode-cache.cpp LibJS LIBS LibCrypto LibGC LibJS)
 ladybird_testjs_test(test-js.cpp test-js LIBS LibGC)
 set_tests_properties(test-js PROPERTIES ENVIRONMENT "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}")
 
-if (NOT WIN32)
+# test-js-bytecode and test-js-ast disabled in All_Debug as the extra
+# debug output causes the expected baseline compares to fail.
+if (NOT WIN32 AND NOT ENABLE_ALL_THE_DEBUG_MACROS)
     add_custom_target(test-js-bytecode ALL DEPENDS test-js "${CMAKE_BINARY_DIR}/bin/test-js-bytecode")
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/bin/test-js-bytecode"

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(TestFetchURL PRIVATE LibURL)
 target_link_libraries(TestSecureContexts PRIVATE LibURL)
 target_link_libraries(TestSourceHighlighter PRIVATE LibURL LibWebView)
 
-if (NOT WIN32)
+if (NOT WIN32 AND NOT ENABLE_ALL_THE_DEBUG_MACROS)
     add_custom_target(test-css-tokenizer ALL DEPENDS css-tokenizer "${CMAKE_BINARY_DIR}/bin/test-css-tokenizer")
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/bin/test-css-tokenizer"

--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -27,7 +27,11 @@ if (WIN32)
     return()
 endif()
 
-if (BUILD_TESTING)
+# Exclude test-web tests when all the debug macros are enabled, as there
+# is too much output for ctest to handle and it takes too long to run
+if (BUILD_TESTING AND NOT ENABLE_ALL_THE_DEBUG_MACROS)
+    find_package(Python3 REQUIRED)
+
     add_test(
         NAME LibWeb
         COMMAND $<TARGET_FILE:test-web> --python-executable ${Python3_EXECUTABLE} --per-test-timeout 120 -v -v


### PR DESCRIPTION
This issue is a follow up to #6577 to see if it would be possible to run testing in All_Debug CI job.

Add testing step to All_Debug CI in order to avoid introduction of debug macro related faults. Currently these might sneak by if a developer makes changes to some code that uses debug macros, but doesn't run the tests with those debug macros enabled.
    
Several issues have already been identified and solved using All_Debug test verification.
    
see ladybird PRs: #6263, #6264, #6953, #7535, #8567
and ladybird Issues: #7129

LibJS and LibRegex are the main problem areas detected so far.

```
Tests excluded:
       test-web (LibWeb)
       All Benchmarks, TestRegex is the most problematic test
       test-js-bytecode
       test-js-ast
```
    
LibWeb is excluded as it takes too long to run, there are several tests that always fail, and under ctest too much output is generated resulting in ctest crashing due to failed memory allocation, even on a system with 64GB of RAM. Ctest crashes using about 41GB, with RAM still available and swap not used at all.
    
Benchmark tests have similar issues taking too long or using too much memory, so they must be excluded using TESTS_ONLY env variable.
    
test-js-bytecode, test-js-ast, and test-css-tokenizer currently excluded as they fail due to the debug macro output in the comparison file vs baseline diffs. It might be possible to re-enable these if the output can be cleaned up.
    
On our current CI setup, All_Debug tests take approximately 3 minutes.