### PR TITLE
LibWebView+UI/QT: Support bangs in the URL bar

### DIFF
--- a/Libraries/LibWebView/SearchEngine.cpp
+++ b/Libraries/LibWebView/SearchEngine.cpp
@@ -4,27 +4,46 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Find.h>
 #include <LibURL/URL.h>
 #include <LibWebView/SearchEngine.h>
 
 namespace WebView {
 
 static auto s_builtin_search_engines = to_array<SearchEngine>({
-    { "Bing"_string, "https://www.bing.com/search?q=%s"_string },
-    { "Brave"_string, "https://search.brave.com/search?q=%s"_string },
-    { "DuckDuckGo"_string, "https://duckduckgo.com/?q=%s"_string },
-    { "Ecosia"_string, "https://ecosia.org/search?q=%s"_string },
-    { "Google"_string, "https://www.google.com/search?q=%s"_string },
-    { "Kagi"_string, "https://kagi.com/search?q=%s"_string },
-    { "Mojeek"_string, "https://www.mojeek.com/search?q=%s"_string },
-    { "Startpage"_string, "https://startpage.com/search?q=%s"_string },
-    { "Yahoo"_string, "https://search.yahoo.com/search?p=%s"_string },
-    { "Yandex"_string, "https://yandex.com/search/?text=%s"_string },
+    { "Bing"_string, "https://www.bing.com/search?q=%s"_string, "b"_string },
+    { "Brave"_string, "https://search.brave.com/search?q=%s"_string, "brave"_string },
+    { "DuckDuckGo"_string, "https://duckduckgo.com/?q=%s"_string, "ddg"_string },
+    { "Ecosia"_string, "https://ecosia.org/search?q=%s"_string, "ec"_string },
+    { "Google"_string, "https://www.google.com/search?q=%s"_string, "g"_string },
+    { "Kagi"_string, "https://kagi.com/search?q=%s"_string, "kagi"_string },
+    { "Mojeek"_string, "https://www.mojeek.com/search?q=%s"_string, "mojeek"_string },
+    { "Startpage"_string, "https://startpage.com/search?q=%s"_string, "startpage"_string },
+    { "Yahoo"_string, "https://search.yahoo.com/search?p=%s"_string, "y"_string },
+    { "Yandex"_string, "https://yandex.com/search/?text=%s"_string, "ya"_string },
+    { "YouTube"_string, "https://www.youtube.com/results?search_query=%s"_string, "yt"_string },
 });
 
 ReadonlySpan<SearchEngine> builtin_search_engines()
 {
     return s_builtin_search_engines;
+}
+
+Optional<SearchEngine const&> find_search_engine_by_bang(String bang)
+{
+    bang = MUST(bang.substring_from_byte_offset(1));
+    if (bang.length_in_code_units() == 0)
+        return {};
+
+    auto it = AK::find_if(s_builtin_search_engines.begin(), s_builtin_search_engines.end(),
+        [&](auto const& engine) {
+            return engine.bang == bang;
+        });
+
+    if (it == s_builtin_search_engines.end())
+        return {};
+
+    return *it;
 }
 
 String SearchEngine::format_search_query_for_display(StringView query) const

--- a/Libraries/LibWebView/SearchEngine.h
+++ b/Libraries/LibWebView/SearchEngine.h
@@ -19,8 +19,10 @@ struct SearchEngine {
 
     String name;
     String query_url;
+    Optional<String> bang;
 };
 
 WEBVIEW_API ReadonlySpan<SearchEngine> builtin_search_engines();
+WEBVIEW_API Optional<SearchEngine const&> find_search_engine_by_bang(String bang);
 
 }

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -33,6 +33,7 @@ static constexpr auto search_engine_key = "searchEngine"sv;
 static constexpr auto search_engine_custom_key = "custom"sv;
 static constexpr auto search_engine_name_key = "name"sv;
 static constexpr auto search_engine_url_key = "url"sv;
+static constexpr auto search_engine_bang_key = "bang"sv;
 
 static constexpr auto autocomplete_engine_key = "autocompleteEngine"sv;
 static constexpr auto autocomplete_engine_name_key = "name"sv;
@@ -336,6 +337,7 @@ Optional<SearchEngine> Settings::parse_custom_search_engine(JsonValue const& sea
 
     auto name = search_engine.as_object().get_string(search_engine_name_key);
     auto url = search_engine.as_object().get_string(search_engine_url_key);
+    auto bang = search_engine.as_object().get_string(search_engine_bang_key);
     if (!name.has_value() || !url.has_value())
         return {};
 
@@ -343,7 +345,9 @@ Optional<SearchEngine> Settings::parse_custom_search_engine(JsonValue const& sea
     if (!parsed_url.has_value())
         return {};
 
-    return SearchEngine { .name = name.release_value(), .query_url = url.release_value() };
+    auto bangVal = bang.has_value() ? bang.release_value() : Optional<String> {}; // this doesnt feel like the best way
+
+    return SearchEngine { .name = name.release_value(), .query_url = url.release_value(), .bang = bangVal };
 }
 
 void Settings::add_custom_search_engine(SearchEngine search_engine)

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -11,7 +11,8 @@
 
 static WebView::SearchEngine s_test_engine {
     .name = "Test"_string,
-    .query_url = "https://ecosia.org/search?q=%s"_string
+    .query_url = "https://ecosia.org/search?q=%s"_string,
+    .bang = "ec"_string,
 };
 
 static void compare_url_parts(StringView url, WebView::URLParts const& expected)


### PR DESCRIPTION
Allow "Bangs" in the URL bar to select a search engine directly through the browser. 

* Redo https://github.com/LadybirdBrowser/ladybird/pull/2375
* prioritize first bang over last bang https://github.com/LadybirdBrowser/ladybird/pull/2375#discussion_r1845698317


Notes: 
* existing database from ddg: https://duckduckgo.com/bang.js
* Additional Reference: https://duckduckgo.com/bangs

## TODO
* use an external list instead of hard coding it on the array. 
  * Currently just a PoC