### PR TITLE
LibWeb: Do not assume hovered URLs are valid

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -874,8 +874,10 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         }
 
         if (is_hovering_link) {
-            page.set_is_hovering_link(true);
-            page.client().page_did_hover_link(*document.encoding_parse_url(hovered_link_element->href()));
+            if (auto link_url = document.encoding_parse_url(hovered_link_element->href()); link_url.has_value()) {
+                page.set_is_hovering_link(true);
+                page.client().page_did_hover_link(*link_url);
+            }
         } else if (page.is_hovering_link()) {
             page.set_is_hovering_link(false);
             page.client().page_did_unhover_link();

--- a/Tests/LibWeb/Crash/UIEvents/hover-invalid-url.html
+++ b/Tests/LibWeb/Crash/UIEvents/hover-invalid-url.html
@@ -1,0 +1,4 @@
+<a href="https://xn--a.com">Invalid URL</a>
+<script>
+    internals.movePointerTo(30, 20);
+</script>


### PR DESCRIPTION
Let's just not display any tooltip for invalid URLs. This matches how Firefox behaves.

Fixes #6601.