### PR TITLE
LibWeb/IDB: Handle off-by-one error in IDBIndex::getAll

### DIFF
--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -2266,8 +2266,13 @@ GC::Ref<JS::Array> retrieve_multiple_items_from_an_index(JS::Realm& target_realm
         // 3. Let i be 0.
         size_t i = 0;
 
+        // x. Append |range records[0]| to records.
+        // FIXME: https://github.com/w3c/IndexedDB/issues/480
+        if (range_records_length > 0)
+            records.append(range_records[0]);
+
         // 4. While i is less than range records length, then:
-        while (i < range_records_length) {
+        while (i < range_records_length - 1) {
             // 1. Increase i by 1.
             i++;
 
@@ -2302,8 +2307,13 @@ GC::Ref<JS::Array> retrieve_multiple_items_from_an_index(JS::Realm& target_realm
         // 3. Let i be 0.
         size_t i = 0;
 
+        // x. Append |range records[0]| to records.
+        // FIXME: https://github.com/w3c/IndexedDB/issues/480
+        if (range_records_length > 0)
+            records.append(range_records[0]);
+
         // 4. While i is less than range records length, then:
-        while (i < range_records_length) {
+        while (i < range_records_length - 1) {
             // 1. Increase i by 1.
             i++;
 
@@ -2312,7 +2322,7 @@ GC::Ref<JS::Array> retrieve_multiple_items_from_an_index(JS::Realm& target_realm
                 break;
 
             // 3. If the result of comparing two keys using the keys from |range records[i]| and |range records[i-1]| is equal, then continue.
-            if (i > 0 && Key::equals(range_records[i].key, range_records[i - 1].key))
+            if (Key::equals(range_records[i].key, range_records[i - 1].key))
                 continue;
 
             // 4. Else prepend |range records[i]| to records.


### PR DESCRIPTION
Also removes an unneeded check in the `prevunique` case

Fixes 25+ wpt tests

Relates to https://github.com/w3c/IndexedDB/issues/480