### PR TITLE
LibWeb/CSS: Implement and use ValueType::DashedIdent

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -379,6 +379,7 @@ private:
     Optional<FlyString> parse_custom_ident(TokenStream<ComponentValue>&, ReadonlySpan<StringView> blacklist);
     RefPtr<CustomIdentStyleValue const> parse_custom_ident_value(TokenStream<ComponentValue>&, ReadonlySpan<StringView> blacklist);
     Optional<FlyString> parse_dashed_ident(TokenStream<ComponentValue>&);
+    RefPtr<CustomIdentStyleValue const> parse_dashed_ident_value(TokenStream<ComponentValue>&);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)
     RefPtr<CalculationNode const> parse_math_function(Function const&, CalculationContext const&);
     RefPtr<CalculationNode const> parse_a_calc_function_node(Function const&, CalculationContext const&);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -224,6 +224,8 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
         return parsed.release_value();
     if (auto parsed = parse_for_type(ValueType::Counter); parsed.has_value())
         return parsed.release_value();
+    if (auto parsed = parse_for_type(ValueType::DashedIdent); parsed.has_value())
+        return parsed.release_value();
     if (auto parsed = parse_for_type(ValueType::EasingFunction); parsed.has_value())
         return parsed.release_value();
     if (auto parsed = parse_for_type(ValueType::Image); parsed.has_value())
@@ -1269,10 +1271,7 @@ RefPtr<StyleValue const> Parser::parse_anchor_name_value(TokenStream<ComponentVa
         return none;
 
     return parse_comma_separated_value_list(tokens, [this](TokenStream<ComponentValue>& inner_tokens) -> RefPtr<StyleValue const> {
-        auto dashed_ident = parse_dashed_ident(inner_tokens);
-        if (!dashed_ident.has_value())
-            return nullptr;
-        return CustomIdentStyleValue::create(*dashed_ident);
+        return parse_dashed_ident_value(inner_tokens);
     });
 }
 
@@ -1287,10 +1286,7 @@ RefPtr<StyleValue const> Parser::parse_anchor_scope_value(TokenStream<ComponentV
         return all;
 
     return parse_comma_separated_value_list(tokens, [this](TokenStream<ComponentValue>& inner_tokens) -> RefPtr<StyleValue const> {
-        auto dashed_ident = parse_dashed_ident(inner_tokens);
-        if (!dashed_ident.has_value())
-            return {};
-        return CustomIdentStyleValue::create(*dashed_ident);
+        return parse_dashed_ident_value(inner_tokens);
     });
 }
 
@@ -4238,10 +4234,7 @@ RefPtr<StyleValue const> Parser::parse_position_anchor_value(TokenStream<Compone
         return auto_keyword;
 
     // <anchor-name> = <dashed-ident>
-    auto dashed_ident = parse_dashed_ident(tokens);
-    if (!dashed_ident.has_value())
-        return nullptr;
-    return CustomIdentStyleValue::create(*dashed_ident);
+    return parse_dashed_ident_value(tokens);
 }
 
 // https://drafts.csswg.org/css-anchor-position/#position-try-fallbacks
@@ -4268,17 +4261,17 @@ RefPtr<StyleValue const> Parser::parse_single_position_try_fallbacks_value(Token
         return position_area;
     }
 
-    Optional<FlyString> dashed_ident;
+    RefPtr<StyleValue const> dashed_ident;
     RefPtr<StyleValue const> try_tactic;
     while (tokens.has_next_token()) {
         if (auto try_tactic_value = parse_try_tactic_value(tokens)) {
             if (try_tactic)
                 return {};
             try_tactic = try_tactic_value.release_nonnull();
-        } else if (auto maybe_dashed_ident = parse_dashed_ident(tokens); maybe_dashed_ident.has_value()) {
-            if (dashed_ident.has_value())
+        } else if (auto maybe_dashed_ident = parse_dashed_ident_value(tokens)) {
+            if (dashed_ident)
                 return {};
-            dashed_ident = maybe_dashed_ident.release_value();
+            dashed_ident = maybe_dashed_ident.release_nonnull();
         } else {
             break;
         }
@@ -4286,8 +4279,8 @@ RefPtr<StyleValue const> Parser::parse_single_position_try_fallbacks_value(Token
     }
 
     StyleValueVector values;
-    if (dashed_ident.has_value())
-        values.append(CustomIdentStyleValue::create(dashed_ident.release_value()));
+    if (dashed_ident)
+        values.append(dashed_ident.release_nonnull());
     if (try_tactic)
         values.append(try_tactic.release_nonnull());
 

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -3593,6 +3593,17 @@ Optional<FlyString> Parser::parse_dashed_ident(TokenStream<ComponentValue>& toke
     return custom_ident;
 }
 
+RefPtr<CustomIdentStyleValue const> Parser::parse_dashed_ident_value(TokenStream<ComponentValue>& tokens)
+{
+    auto transaction = tokens.begin_transaction();
+    tokens.discard_whitespace();
+    if (auto dashed_ident = parse_dashed_ident(tokens); dashed_ident.has_value()) {
+        transaction.commit();
+        return CustomIdentStyleValue::create(*dashed_ident);
+    }
+    return nullptr;
+}
+
 // https://www.w3.org/TR/css-grid-2/#typedef-track-breadth
 Optional<GridSize> Parser::parse_grid_track_breadth(TokenStream<ComponentValue>& tokens)
 {
@@ -4908,6 +4919,8 @@ RefPtr<StyleValue const> Parser::parse_value(ValueType value_type, TokenStream<C
     case ValueType::CustomIdent:
         // FIXME: Figure out how to pass the blacklist here
         return parse_custom_ident_value(tokens, {});
+    case ValueType::DashedIdent:
+        return parse_dashed_ident_value(tokens);
     case ValueType::EasingFunction:
         return parse_easing_value(tokens);
     case ValueType::FilterValueList:

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -198,11 +198,11 @@
     "animation-type": "discrete",
     "inherited": false,
     "initial": "none",
+    "valid-types": [
+      "dashed-ident"
+    ],
     "valid-identifiers": [
       "none"
-    ],
-    "valid-types": [
-      "custom-ident ![none]"
     ]
   },
   "anchor-scope": {
@@ -210,6 +210,9 @@
     "animation-type": "discrete",
     "inherited": false,
     "initial": "none",
+    "valid-types": [
+      "dashed-ident"
+    ],
     "valid-identifiers": [
       "none",
       "all"
@@ -3259,7 +3262,7 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
-      "custom-ident ![auto]"
+      "dashed-ident"
     ],
     "valid-identifiers": [
       "auto"
@@ -3282,7 +3285,7 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
-      "custom-ident ![none]",
+      "dashed-ident",
       "try-tactic"
     ],
     "valid-identifiers": [

--- a/Libraries/LibWeb/CSS/ValueType.cpp
+++ b/Libraries/LibWeb/CSS/ValueType.cpp
@@ -27,6 +27,8 @@ Optional<ValueType> value_type_from_string(StringView string)
         return ValueType::Counter;
     if (string.equals_ignoring_ascii_case("custom-ident"sv))
         return ValueType::CustomIdent;
+    if (string.equals_ignoring_ascii_case("dashed-ident"sv))
+        return ValueType::DashedIdent;
     if (string.equals_ignoring_ascii_case("easing-function"sv))
         return ValueType::EasingFunction;
     if (string.equals_ignoring_ascii_case("filter-value-list"sv))
@@ -103,6 +105,8 @@ StringView value_type_to_string(ValueType value_type)
         return "Counter"sv;
     case Web::CSS::ValueType::CustomIdent:
         return "CustomIdent"sv;
+    case Web::CSS::ValueType::DashedIdent:
+        return "DashedIdent"sv;
     case Web::CSS::ValueType::EasingFunction:
         return "EasingFunction"sv;
     case Web::CSS::ValueType::FilterValueList:

--- a/Libraries/LibWeb/CSS/ValueType.h
+++ b/Libraries/LibWeb/CSS/ValueType.h
@@ -23,6 +23,7 @@ enum class ValueType : u8 {
     CornerShape,
     Counter,
     CustomIdent,
+    DashedIdent,
     EasingFunction,
     FilterValueList,
     FitContent,


### PR DESCRIPTION
Reduces the repeated code for parsing these, and makes them available to the generic value parser.