### PR TITLE
LibWeb: Set attribute value directly in HTMLScriptElement::set_src

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -707,7 +707,7 @@ WebIDL::ExceptionOr<void> HTMLScriptElement::set_src(TrustedTypes::TrustedScript
         TrustedTypes::Script.to_string()));
 
     // 2. Set this’s src content attribute to value.
-    TRY(set_attribute(AttributeNames::src, value));
+    set_attribute_value(AttributeNames::src, value.to_utf8_but_should_be_ported_to_utf16());
     return {};
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-HTMLElement-generic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-HTMLElement-generic.txt
@@ -2,9 +2,9 @@ Harness status: OK
 
 Found 9 tests
 
-6 Pass
-3 Fail
-Fail	script.src accepts only TrustedScriptURL
+7 Pass
+2 Fail
+Pass	script.src accepts only TrustedScriptURL
 Pass	div.innerHTML accepts only TrustedHTML
 Fail	iframe.srcdoc accepts only TrustedHTML
 Pass	script.src accepts string and null after default policy was created

--- a/Tests/LibWeb/Text/expected/wpt-import/trusted-types/policy-without-return-value.sub.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/trusted-types/policy-without-return-value.sub.txt
@@ -2,9 +2,9 @@ Harness status: OK
 
 Found 4 tests
 
-1 Pass
-3 Fail
+2 Pass
+2 Fail
 Fail	createHTML with a policy that returns undefined DOMParser
 Fail	createHTML with a policy that returns undefined iframe.srcdoc
 Pass	createScript with a policy that returns undefined <div onload>
-Fail	createScriptURL with a policy that returns undefined script.src
+Pass	createScriptURL with a policy that returns undefined script.src


### PR DESCRIPTION
Otherwise we'll try to use the Utf16String that has already been through Trusted Types and put it through again. That can also fail if there's no default policy and there's a `require-trusted-types-for 'script'` directive.

Fixes Outlook failing to load.