### PR TITLE
LibWeb/CSS: Do not crash when parsing some multi-layer mask shorthands

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -3854,12 +3854,10 @@ RefPtr<StyleValue const> Parser::parse_mask_value(TokenStream<ComponentValue>& t
         mask_composites.append(mask_composite ? mask_composite.release_nonnull() : initial_mask_composite);
         mask_modes.append(mask_mode ? mask_mode.release_nonnull() : initial_mask_mode);
 
-        if (!mask_origin && !mask_clip) {
+        if (!mask_origin)
             mask_origin = initial_mask_origin;
-            mask_clip = initial_mask_clip;
-        } else if (!mask_clip) {
+        if (!mask_clip)
             mask_clip = mask_origin;
-        }
         mask_origins.append(mask_origin.release_nonnull());
         mask_clips.append(mask_clip.release_nonnull());
 

--- a/Tests/LibWeb/Crash/CSS/mask-parsing-shorthand-multi-layer-mask-clip.html
+++ b/Tests/LibWeb/Crash/CSS/mask-parsing-shorthand-multi-layer-mask-clip.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+body {
+  mask: url(foo.png), url(bar.png) no-clip;
+}
+</style>


### PR DESCRIPTION
This fixes a silly bug where we would crash when parsing a multi-layer mask shorthand property that contained the no-clip keyword but no value for mask-origin.

Fixes a crash when parsing the CSS of https://www.browserbase.com/. The site still has other, unrelated problems though.