### PR TITLE
AK: Increase MonotonicTime precision on Windows

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -248,17 +248,16 @@ Duration now_time_from_filetime()
 Duration now_time_from_query_performance_counter()
 {
     static LARGE_INTEGER ticks_per_second;
-    // FIXME: Limit to microseconds for now, but could probably use nanos?
-    static float ticks_per_microsecond;
+    static f64 ticks_per_nanosecond;
     if (ticks_per_second.QuadPart == 0) {
         QueryPerformanceFrequency(&ticks_per_second);
         VERIFY(ticks_per_second.QuadPart != 0);
-        ticks_per_microsecond = static_cast<float>(ticks_per_second.QuadPart) / 1'000'000.0F;
+        ticks_per_nanosecond = static_cast<f64>(ticks_per_second.QuadPart) / 1'000'000'000.0;
     }
 
     LARGE_INTEGER now_time {};
     QueryPerformanceCounter(&now_time);
-    return Duration::from_microseconds(static_cast<i64>(now_time.QuadPart / ticks_per_microsecond));
+    return Duration::from_nanoseconds(static_cast<i64>(now_time.QuadPart / ticks_per_nanosecond));
 }
 
 Duration now_time_from_clock(int clock_id)


### PR DESCRIPTION
MonotonicTime was using 32 bit floats for operations on the values converted from an i64 returned by the performance counter. This caused to either precision losses or complete losses of the data for timing even things as long as hundreds of miliseconds, which should never be a problem with the resolution of the performance counter. This change fixes that behavior.