### PR TITLE
LibWeb: Stop returning the value in HTMLMediaElement::set_current_time

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -267,7 +267,7 @@ double HTMLMediaElement::current_time() const
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime
-double HTMLMediaElement::set_current_time(double current_time)
+void HTMLMediaElement::set_current_time(double current_time)
 {
     // On setting, if the media element's readyState is HAVE_NOTHING, then it must set the media element's default playback start
     // position to the new value; otherwise, it must set the official playback position to the new value and then seek to the new
@@ -283,7 +283,6 @@ double HTMLMediaElement::set_current_time(double current_time)
 
         seek_element(current_time);
     }
-    return current_time;
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -95,7 +95,7 @@ public:
     WebIDL::ExceptionOr<void> load();
 
     double current_time() const;
-    double set_current_time(double);
+    void set_current_time(double);
     void fast_seek(double);
 
     double current_playback_position() const { return m_current_playback_position; }


### PR DESCRIPTION
This wasn't actually affecting the result in a script assigning a variable to the result of an expression assigning to currentTime.