### PR TITLE
UI/AppKit: Support dead keys on MacOS

### DIFF
--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -38,7 +38,7 @@
 
 @end
 
-@interface LadybirdWebView : NSView <NSMenuDelegate>
+@interface LadybirdWebView : NSView <NSMenuDelegate, NSTextInputClient>
 
 - (instancetype)init:(id<LadybirdWebViewObserver>)observer;
 - (instancetype)initAsChild:(id<LadybirdWebViewObserver>)observer


### PR DESCRIPTION
We now pass key press events to `interpretKeyEvents()`, which handles dead key composition for us.

This change brings gives us equivalent dead key functionality on MacOS and Linux. We don't currently support displaying the appropriate pre-edit text in either UI.

Please bear in mind that I have very little idea what I'm doing with MacOS stuff, so there may be a better way to do this.

Tested with a Spanish keyboard layout, as that's what I had set up on my Mac.

Fixes #6624