### PR TITLE
LibWeb/IDB: Handle cursor iteration more correctly

### DIFF
--- a/Libraries/LibWeb/IndexedDB/Internal/Key.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Key.h
@@ -69,6 +69,8 @@ public:
     [[nodiscard]] static bool equals(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) == 0; }
     [[nodiscard]] static bool less_than(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) < 0; }
     [[nodiscard]] static bool greater_than(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) > 0; }
+    [[nodiscard]] static bool less_than_or_equal(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) <= 0; }
+    [[nodiscard]] static bool greater_than_or_equal(GC::Ref<Key> a, GC::Ref<Key> b) { return compare_two_keys(a, b) >= 0; }
 
     AK::String dump() const;
 

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-advance-invalid.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-advance-invalid.any.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-4 Pass
-2 Fail
-Fail	IDBCursor.advance() - invalid - attempt to call advance twice
+6 Pass
+Pass	IDBCursor.advance() - invalid - attempt to call advance twice
 Pass	IDBCursor.advance() - invalid - pass something other than number
 Pass	IDBCursor.advance() - invalid - pass null/undefined
 Pass	IDBCursor.advance() - invalid - missing argument
 Pass	IDBCursor.advance() - invalid - pass negative numbers
-Fail	IDBCursor.advance() - invalid - got value not set on exception
+Pass	IDBCursor.advance() - invalid - got value not set on exception

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-advance.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-advance.any.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-2 Pass
-4 Fail
-Fail	IDBCursor.advance() - advances
-Fail	IDBCursor.advance() - advances backwards
+6 Pass
+Pass	IDBCursor.advance() - advances
+Pass	IDBCursor.advance() - advances backwards
 Pass	IDBCursor.advance() - skip far forward
-Fail	IDBCursor.advance() - within range
+Pass	IDBCursor.advance() - within range
 Pass	IDBCursor.advance() - within single key range
-Fail	IDBCursor.advance() - within single key range, with several results
+Pass	IDBCursor.advance() - within single key range, with several results

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-continue.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-continue.any.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-2 Pass
-4 Fail
-Fail	IDBCursor.continue() - continues
-Fail	IDBCursor.continue() - with given key
+6 Pass
+Pass	IDBCursor.continue() - continues
+Pass	IDBCursor.continue() - with given key
 Pass	IDBCursor.continue() - skip far forward
-Fail	IDBCursor.continue() - within range
+Pass	IDBCursor.continue() - within range
 Pass	IDBCursor.continue() - within single key range
-Fail	IDBCursor.continue() - within single key range, with several results
+Pass	IDBCursor.continue() - within single key range, with several results

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-direction-index-keyrange.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-direction-index-keyrange.any.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	IDBCursor direction - index with keyrange - next
+Pass	IDBCursor direction - index with keyrange - prev
+Pass	IDBCursor direction - index with keyrange - nextunique
+Pass	IDBCursor direction - index with keyrange - prevunique

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-request-source.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbcursor-request-source.any.txt
@@ -2,12 +2,11 @@ Harness status: OK
 
 Found 8 tests
 
-6 Pass
-2 Fail
+8 Pass
 Pass	IDBObjectStore::openCursor's request source must be the IDBObjectStore instance that opened the cursor
 Pass	IDBObjectStore::openKeyCursor's request source must be the IDBObjectStore instance that opened the cursor
-Fail	IDBIndex::openCursor's request source must be the IDBIndex instance that opened the cursor
-Fail	IDBIndex::openKeyCursor's request source must be the IDBIndex instance that opened the cursor
+Pass	IDBIndex::openCursor's request source must be the IDBIndex instance that opened the cursor
+Pass	IDBIndex::openKeyCursor's request source must be the IDBIndex instance that opened the cursor
 Pass	The source of the request from IDBObjectStore::update() is the cursor itself
 Pass	The source of the request from IDBObjectStore::delete() is the cursor itself
 Pass	The source of the request from IDBIndex::update() is the cursor itself

--- a/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbcursor-direction-index-keyrange.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbcursor-direction-index-keyrange.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IDBCursor direction - index with keyrange</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/support.js"></script>
+<div id=log></div>
+<script src="../IndexedDB/idbcursor-direction-index-keyrange.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbcursor-direction-index-keyrange.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbcursor-direction-index-keyrange.any.js
@@ -1,0 +1,55 @@
+// META: global=window,worker
+// META: title=IDBCursor direction - index with keyrange
+// META: script=resources/support.js
+
+// Spec: https://w3c.github.io/IndexedDB/#cursor-iteration-operation
+
+'use strict';
+
+let records = [1337, 'Alice', 'Bob', 'Bob', 'Greg', 'Åke', ['Anne']];
+let cases = [
+  {dir: 'next', expect: ['Alice:1', 'Bob:2', 'Bob:3', 'Greg:4']},
+  {dir: 'prev', expect: ['Greg:4', 'Bob:3', 'Bob:2', 'Alice:1']},
+  {dir: 'nextunique', expect: ['Alice:1', 'Bob:2', 'Greg:4']},
+  {dir: 'prevunique', expect: ['Greg:4', 'Bob:2', 'Alice:1']}
+];
+
+cases.forEach(function(testcase) {
+  let dir = testcase.dir;
+  let expect = testcase.expect;
+  indexeddb_test(
+      function(t, db, tx) {
+        let objStore = db.createObjectStore('test');
+        objStore.createIndex('idx', 'name');
+
+        for (let i = 0; i < records.length; i++) {
+          objStore.add({name: records[i]}, i);
+        }
+      },
+      function(t, db) {
+        let count = 0;
+        let rq = db.transaction('test', 'readonly')
+                     .objectStore('test')
+                     .index('idx')
+                     .openCursor(IDBKeyRange.bound('AA', 'ZZ'), dir);
+        rq.onsuccess = t.step_func(function(e) {
+          let cursor = e.target.result;
+          if (!cursor) {
+            assert_equals(count, expect.length, 'cursor runs');
+            t.done();
+            return;
+          }
+          assert_equals(
+              cursor.value.name + ':' + cursor.primaryKey, expect[count],
+              'cursor.value');
+          count++;
+          cursor.continue();
+        });
+        rq.onerror = t.step_func(function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          assert_unreached('rq.onerror - ' + e.message);
+        });
+      },
+      'IDBCursor direction - index with keyrange - ' + dir);
+});


### PR DESCRIPTION
Gives a few more WPT passes

Related spec bug: https://github.com/w3c/IndexedDB/pull/481/