### PR TITLE
LibWeb: Add stub implementation for Navigator.getBattery()

### DIFF
--- a/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Libraries/LibWeb/HTML/Navigator.cpp
@@ -76,6 +76,7 @@ void Navigator::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_service_worker_container);
     visitor.visit(m_media_capabilities);
     visitor.visit(m_credentials);
+    visitor.visit(m_battery_promise);
 }
 
 GC::Ref<MimeTypeArray> Navigator::mime_types()
@@ -146,6 +147,33 @@ GC::Ref<MediaCapabilitiesAPI::MediaCapabilities> Navigator::media_capabilities()
     if (!m_media_capabilities)
         m_media_capabilities = realm().create<MediaCapabilitiesAPI::MediaCapabilities>(realm());
     return *m_media_capabilities;
+}
+
+// https://w3c.github.io/battery/#the-getbattery-method
+GC::Ref<WebIDL::Promise> Navigator::get_battery()
+{
+    auto& realm = this->realm();
+
+    // FIXME: 1. If this.[[BatteryPromise]] is null, then set it to a new promise in this's relevant realm.
+    if (!m_battery_promise) {
+        WebIDL::SimpleException exception {
+            WebIDL::SimpleExceptionType::TypeError,
+            "Battery Status API is not yet implemented"sv
+        };
+        m_battery_promise = WebIDL::create_rejected_promise_from_exception(realm, move(exception));
+    }
+
+    // FIXME: 2. If this's relevant global object's associated Document is not allowed to use the "battery"
+    // policy-controlled feature, then reject this.[[BatteryPromise]] with a "NotAllowedError" DOMException.
+
+    // FIXME: 3. Otherwise:
+    //    1. If this.[[BatteryManager]] is null, then set it to the result of creating a new BatteryManager
+    //       in this's relevant realm.
+
+    //    2. Resolve this.[[BatteryPromise]] with this.[[BatteryManager]].
+
+    // 4. Return this.[[BatteryPromise]].
+    return *m_battery_promise;
 }
 
 }

--- a/Libraries/LibWeb/HTML/Navigator.h
+++ b/Libraries/LibWeb/HTML/Navigator.h
@@ -65,6 +65,7 @@ public:
     [[nodiscard]] GC::Ref<Serial::Serial> serial();
     [[nodiscard]] GC::Ref<UserActivation> user_activation();
     [[nodiscard]] GC::Ref<CredentialManagement::CredentialsContainer> credentials();
+    [[nodiscard]] GC::Ref<WebIDL::Promise> get_battery();
 
     GC::Ref<ServiceWorker::ServiceWorkerContainer> service_worker();
 
@@ -108,6 +109,9 @@ private:
 
     // https://w3c.github.io/webappsec-credential-management/#framework-credential-management
     GC::Ptr<CredentialManagement::CredentialsContainer> m_credentials;
+
+    // https://w3c.github.io/battery/
+    GC::Ptr<WebIDL::Promise> m_battery_promise;
 };
 
 }

--- a/Libraries/LibWeb/HTML/Navigator.idl
+++ b/Libraries/LibWeb/HTML/Navigator.idl
@@ -46,6 +46,9 @@ interface Navigator {
 
     // https://w3c.github.io/webappsec-credential-management/#framework-credential-management
     [SecureContext, SameObject] readonly attribute CredentialsContainer credentials;
+
+    // https://w3c.github.io/battery/
+    [SecureContext] Promise<BatteryManager> getBattery();
 };
 
 // NOTE: As NavigatorContentUtils, NavigatorCookies, NavigatorPlugins, and NavigatorAutomationInformation

--- a/Tests/LibWeb/Text/expected/wpt-import/battery-status/battery-promise-window.https.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/battery-status/battery-promise-window.https.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	window.open() makes a different Navigator object thus getting another battery promise

--- a/Tests/LibWeb/Text/input/wpt-import/battery-status/battery-promise-window.https.html
+++ b/Tests/LibWeb/Text/input/wpt-import/battery-status/battery-promise-window.https.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Battery Test: window.open() makes a different Navigator object</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="https://www.w3.org/TR/battery-status/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+  #note {
+    background-color: #fef1b5;
+    border: solid 1px #cdab2d;
+    padding: 5px;
+    margin: 15px;
+    display: block;
+  }
+</style>
+<div id="note">
+  Allow pop-up windows before running the tests.
+</div>
+<div id="log"></div>
+<script>
+async_test(function (t) {
+  var win = window.open('resources/support-window-open.html');
+  window.onmessage = t.step_func(function(e) {
+    assert_array_equals(e.data, [false, false, true]);
+    win.close();
+    t.done();
+  });
+}, 'window.open() makes a different Navigator object thus getting another battery promise');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/battery-status/resources/support-window-open.html
+++ b/Tests/LibWeb/Text/input/wpt-import/battery-status/resources/support-window-open.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<script>
+var data = [
+    navigator === window.opener.navigator,
+    navigator.getBattery() === window.opener.navigator.getBattery(),
+    navigator.getBattery() === navigator.getBattery()
+];
+window.opener.postMessage(data, '*');
+</script>


### PR DESCRIPTION
Adds a stub that returns a cached rejected promise with a not yet implemented error. This converts
battery-status/battery-promise-window.https.html from timeout to pass. Full implementation still needed.