### PR TITLE
Implement 'decoding' attribute on HTMLImageElement

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -163,6 +163,15 @@ private:
     SourceSet m_source_set;
 
     CSSPixelSize m_last_seen_viewport_size;
+
+    // https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-decoding
+    enum class DecodingMode {
+        Auto,
+        Sync,
+        Async,
+    };
+
+    DecodingMode m_decoding_mode { DecodingMode::Auto };
 };
 
 }

--- a/Libraries/LibWeb/HTML/SharedResourceRequest.h
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.h
@@ -24,6 +24,7 @@ public:
     virtual ~SharedResourceRequest() override;
 
     URL::URL const& url() const { return m_url; }
+    ReadonlyBytes encoded_data() const;
 
     [[nodiscard]] GC::Ptr<DecodedImageData> image_data() const;
 
@@ -65,6 +66,7 @@ private:
     Vector<Callbacks> m_callbacks;
 
     URL::URL m_url;
+    ByteBuffer m_encoded_data;
     GC::Ptr<DecodedImageData> m_image_data;
     GC::Ptr<Fetch::Infrastructure::FetchController> m_fetch_controller;
 


### PR DESCRIPTION
sync Mode

   * The Spec: "Image decoding is said to be synchronous if it prevents presentation of other content until it is finished. Typically, this has an effect of atomically presenting
     the image and any other content at the same time. However, this presentation is delayed by the amount of time it takes to perform the decode."
   * The Implementation: The code path for decoding="sync" uses Core::EventLoop::current().spin_until([...]). This call effectively blocks the main thread, halting further script
     execution and rendering updates. It waits in a tight loop until the image decoding process, running on a separate thread, completes (either successfully or with a failure).
     This blocking behavior directly matches the specification's requirement to "prevent presentation of other content until it is finished," thereby achieving an atomic
     presentation.

  async Mode

   * The Spec: "Image decoding is said to be asynchronous if it does not prevent presentation of other content. This has an effect of presenting non-image content faster. However,
     the image content is missing on screen until the decode finishes."
   * The Implementation: The code path for decoding="async" queues a microtask to perform the work. The actual decoding is initiated via
     Web::Platform::ImageCodecPlugin::the().decode_image(), which is an asynchronous operation. Callbacks are attached to this operation to resolve or reject the promise when the
     decoding is complete. This entire process does not block the main thread, allowing the browser's rendering engine to continue processing and displaying other content on the
     page. This aligns perfectly with the spec's definition of asynchronous decoding.

  auto Mode

   * The Spec: "Indicates no preference in decoding mode (the default)." The user agent is free to choose the most appropriate decoding strategy.
   * The Implementation: The implementation treats the auto mode identically to the async mode. This is a valid and common interpretation of the spec. By defaulting to asynchronous
      decoding, the implementation prioritizes a non-blocking user experience, which is generally preferred for web performance.