### PR TITLE
LibJS: Avoid `IteratorRecord` GC-allocation in `GetIterator` instruction

### DIFF
--- a/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Libraries/LibJS/Bytecode/Instruction.h
@@ -68,8 +68,6 @@
     O(GetLengthWithThis)               \
     O(GetMethod)                       \
     O(GetNewTarget)                    \
-    O(GetNextMethodFromIteratorRecord) \
-    O(GetObjectFromIteratorRecord)     \
     O(GetObjectPropertyIterator)       \
     O(GetPrivateById)                  \
     O(GetBinding)                      \

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -596,8 +596,6 @@ FLATTEN_ON_CLANG void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(GetLengthWithThis);
             HANDLE_INSTRUCTION(GetMethod);
             HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetNewTarget);
-            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetNextMethodFromIteratorRecord);
-            HANDLE_INSTRUCTION_WITHOUT_EXCEPTION_CHECK(GetObjectFromIteratorRecord);
             HANDLE_INSTRUCTION(GetObjectPropertyIterator);
             HANDLE_INSTRUCTION(GetPrivateById);
             HANDLE_INSTRUCTION(GetBinding);
@@ -1697,7 +1695,7 @@ class JS_API PropertyNameIterator final
 public:
     virtual ~PropertyNameIterator() override = default;
 
-    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const&) override { return this; }
+    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(Value) override { return this; }
     ThrowCompletionOr<void> next(VM& vm, bool& done, Value& value) override
     {
         while (true) {
@@ -1742,7 +1740,7 @@ private:
 GC_DEFINE_ALLOCATOR(PropertyNameIterator);
 
 // 14.7.5.9 EnumerateObjectProperties ( O ), https://tc39.es/ecma262/#sec-enumerate-object-properties
-inline ThrowCompletionOr<Value> get_object_property_iterator(Interpreter& interpreter, Value value)
+inline ThrowCompletionOr<IteratorRecordImpl> get_object_property_iterator(Interpreter& interpreter, Value value)
 {
     // While the spec does provide an algorithm, it allows us to implement it ourselves so long as we meet the following invariants:
     //    1- Returned property keys do not include keys that are Symbols
@@ -1809,8 +1807,7 @@ inline ThrowCompletionOr<Value> get_object_property_iterator(Interpreter& interp
     }
 
     auto iterator = interpreter.realm().create<PropertyNameIterator>(interpreter.realm(), object, move(properties));
-
-    return vm.heap().allocate<IteratorRecord>(iterator, js_undefined(), false);
+    return IteratorRecordImpl { .done = false, .iterator = iterator, .next_method = js_undefined() };
 }
 
 ByteString Instruction::to_byte_string(Bytecode::Executable const& executable) const
@@ -2180,7 +2177,25 @@ ThrowCompletionOr<void> ImportCall::execute_impl(Bytecode::Interpreter& interpre
 
 ThrowCompletionOr<void> IteratorToArray::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    interpreter.set(dst(), TRY(iterator_to_array(interpreter.vm(), interpreter.get(iterator()))));
+    auto& vm = interpreter.vm();
+    auto& iterator_object = interpreter.get(m_iterator_object).as_object();
+    auto iterator_next_method = interpreter.get(m_iterator_next_method);
+    auto iterator_done_property = interpreter.get(m_iterator_done_property).as_bool();
+    IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
+
+    auto array = MUST(Array::create(*vm.current_realm(), 0));
+    size_t index = 0;
+
+    while (true) {
+        auto value = TRY(iterator_step_value(vm, iterator_record));
+        if (!value.has_value())
+            break;
+
+        MUST(array->create_data_property_or_throw(index, value.release_value()));
+        index++;
+    }
+
+    interpreter.set(dst(), array);
     return {};
 }
 
@@ -3298,20 +3313,11 @@ ThrowCompletionOr<void> DeleteByValueWithThis::execute_impl(Bytecode::Interprete
 ThrowCompletionOr<void> GetIterator::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    interpreter.set(dst(), TRY(get_iterator(vm, interpreter.get(iterable()), m_hint)));
+    auto iterator_record = TRY(get_iterator_impl(vm, interpreter.get(iterable()), m_hint));
+    interpreter.set(m_dst_iterator_object, iterator_record.iterator);
+    interpreter.set(m_dst_iterator_next, iterator_record.next_method);
+    interpreter.set(m_dst_iterator_done, Value(iterator_record.done));
     return {};
-}
-
-void GetObjectFromIteratorRecord::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    auto& iterator_record = static_cast<IteratorRecord&>(interpreter.get(m_iterator_record).as_cell());
-    interpreter.set(m_object, iterator_record.iterator);
-}
-
-void GetNextMethodFromIteratorRecord::execute_impl(Bytecode::Interpreter& interpreter) const
-{
-    auto& iterator_record = static_cast<IteratorRecord&>(interpreter.get(m_iterator_record).as_cell());
-    interpreter.set(m_next_method, iterator_record.next_method);
 }
 
 ThrowCompletionOr<void> GetMethod::execute_impl(Bytecode::Interpreter& interpreter) const
@@ -3325,51 +3331,69 @@ ThrowCompletionOr<void> GetMethod::execute_impl(Bytecode::Interpreter& interpret
 
 ThrowCompletionOr<void> GetObjectPropertyIterator::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    auto iterator_record = TRY(get_object_property_iterator(interpreter, interpreter.get(object())));
-    interpreter.set(dst(), iterator_record);
+    auto iterator_record = TRY(get_object_property_iterator(interpreter, interpreter.get(m_object)));
+    interpreter.set(m_dst_iterator_object, iterator_record.iterator);
+    interpreter.set(m_dst_iterator_next, iterator_record.next_method);
+    interpreter.set(m_dst_iterator_done, Value(iterator_record.done));
     return {};
 }
 
 ThrowCompletionOr<void> IteratorClose::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    auto& iterator = static_cast<IteratorRecord&>(interpreter.get(m_iterator_record).as_cell());
+    auto& iterator_object = interpreter.get(m_iterator_object).as_object();
+    auto iterator_next_method = interpreter.get(m_iterator_next);
+    auto iterator_done_property = interpreter.get(m_iterator_done).as_bool();
+    IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
 
     // FIXME: Return the value of the resulting completion. (Note that m_completion_value can be empty!)
-    TRY(iterator_close(vm, iterator, Completion { m_completion_type, m_completion_value.value_or(js_undefined()) }));
+    TRY(iterator_close(vm, iterator_record, Completion { m_completion_type, m_completion_value.value_or(js_undefined()) }));
     return {};
 }
 
 ThrowCompletionOr<void> AsyncIteratorClose::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    auto& iterator = static_cast<IteratorRecord&>(interpreter.get(m_iterator_record).as_cell());
+    auto& iterator_object = interpreter.get(m_iterator_object).as_object();
+    auto iterator_next_method = interpreter.get(m_iterator_next);
+    auto iterator_done_property = interpreter.get(m_iterator_done).as_bool();
+    IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
 
     // FIXME: Return the value of the resulting completion. (Note that m_completion_value can be empty!)
-    TRY(async_iterator_close(vm, iterator, Completion { m_completion_type, m_completion_value.value_or(js_undefined()) }));
+    TRY(async_iterator_close(vm, iterator_record, Completion { m_completion_type, m_completion_value.value_or(js_undefined()) }));
     return {};
 }
 
 ThrowCompletionOr<void> IteratorNext::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    auto& iterator_record = static_cast<IteratorRecord&>(interpreter.get(m_iterator_record).as_cell());
-    interpreter.set(dst(), TRY(iterator_next(vm, iterator_record)));
+    auto& iterator_object = interpreter.get(m_iterator_object).as_object();
+    auto iterator_next_method = interpreter.get(m_iterator_next);
+    auto iterator_done_property = interpreter.get(m_iterator_done).as_bool();
+    IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
+    interpreter.set(m_dst, TRY(iterator_next(vm, iterator_record)));
+    if (iterator_done_property)
+        interpreter.set(m_iterator_done, Value(true));
     return {};
 }
 
 ThrowCompletionOr<void> IteratorNextUnpack::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    auto& iterator_record = static_cast<IteratorRecord&>(interpreter.get(m_iterator_record).as_cell());
+    auto& iterator_object = interpreter.get(m_iterator_object).as_object();
+    auto iterator_next_method = interpreter.get(m_iterator_next);
+    auto iterator_done_property = interpreter.get(m_iterator_done).as_bool();
+    IteratorRecordImpl iterator_record { .done = iterator_done_property, .iterator = iterator_object, .next_method = iterator_next_method };
     auto iteration_result_or_done = TRY(iterator_step(vm, iterator_record));
+    if (iterator_done_property)
+        interpreter.set(m_iterator_done, Value(true));
     if (iteration_result_or_done.has<IterationDone>()) {
-        interpreter.set(dst_done(), Value(true));
+        interpreter.set(m_dst_done, Value(true));
         return {};
     }
     auto& iteration_result = iteration_result_or_done.get<IterationResult>();
-    interpreter.set(dst_done(), TRY(iteration_result.done));
-    interpreter.set(dst_value(), TRY(iteration_result.value));
+    interpreter.set(m_dst_done, TRY(iteration_result.done));
+    interpreter.set(m_dst_value, TRY(iteration_result.value));
     return {};
 }
 
@@ -3467,9 +3491,11 @@ ByteString ArrayAppend::to_byte_string_impl(Bytecode::Executable const& executab
 
 ByteString IteratorToArray::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
-    return ByteString::formatted("IteratorToArray {}, {}",
+    return ByteString::formatted("IteratorToArray {}, {}, {}, {}",
         format_operand("dst"sv, dst(), executable),
-        format_operand("iterator"sv, iterator(), executable));
+        format_operand("iterator_object"sv, m_iterator_object, executable),
+        format_operand("iterator_next"sv, m_iterator_next_method, executable),
+        format_operand("iterator_done"sv, m_iterator_done_property, executable));
 }
 
 ByteString NewObject::to_byte_string_impl(Bytecode::Executable const& executable) const
@@ -4048,8 +4074,10 @@ ByteString DeleteByValueWithThis::to_byte_string_impl(Bytecode::Executable const
 ByteString GetIterator::to_byte_string_impl(Executable const& executable) const
 {
     auto hint = m_hint == IteratorHint::Sync ? "sync" : "async";
-    return ByteString::formatted("GetIterator {}, {}, hint:{}",
-        format_operand("dst"sv, m_dst, executable),
+    return ByteString::formatted("GetIterator {}, {}, {}, {}, hint:{}",
+        format_operand("dst_iterator_object"sv, m_dst_iterator_object, executable),
+        format_operand("dst_iterator_next"sv, m_dst_iterator_next, executable),
+        format_operand("dst_iterator_done"sv, m_dst_iterator_done, executable),
         format_operand("iterable"sv, m_iterable, executable),
         hint);
 }
@@ -4064,50 +4092,64 @@ ByteString GetMethod::to_byte_string_impl(Bytecode::Executable const& executable
 
 ByteString GetObjectPropertyIterator::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
-    return ByteString::formatted("GetObjectPropertyIterator {}, {}",
-        format_operand("dst"sv, dst(), executable),
-        format_operand("object"sv, object(), executable));
+    return ByteString::formatted("GetObjectPropertyIterator {}, {}, {}, {}",
+        format_operand("dst_iterator_object"sv, m_dst_iterator_object, executable),
+        format_operand("dst_iterator_next"sv, m_dst_iterator_next, executable),
+        format_operand("dst_iterator_done"sv, m_dst_iterator_done, executable),
+        format_operand("object"sv, m_object, executable));
 }
 
 ByteString IteratorClose::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
     if (!m_completion_value.has_value())
-        return ByteString::formatted("IteratorClose {}, completion_type={} completion_value=<empty>",
-            format_operand("iterator_record"sv, m_iterator_record, executable),
+        return ByteString::formatted("IteratorClose {}, {}, {}, completion_type={} completion_value=<empty>",
+            format_operand("iterator_object"sv, m_iterator_object, executable),
+            format_operand("iterator_next"sv, m_iterator_next, executable),
+            format_operand("iterator_done"sv, m_iterator_done, executable),
             to_underlying(m_completion_type));
 
     auto completion_value_string = m_completion_value->to_string_without_side_effects();
-    return ByteString::formatted("IteratorClose {}, completion_type={} completion_value={}",
-        format_operand("iterator_record"sv, m_iterator_record, executable),
+    return ByteString::formatted("IteratorClose {}, {}, {} completion_type={} completion_value={}",
+        format_operand("iterator_object"sv, m_iterator_object, executable),
+        format_operand("iterator_next"sv, m_iterator_next, executable),
+        format_operand("iterator_done"sv, m_iterator_done, executable),
         to_underlying(m_completion_type), completion_value_string);
 }
 
 ByteString AsyncIteratorClose::to_byte_string_impl(Bytecode::Executable const& executable) const
 {
     if (!m_completion_value.has_value()) {
-        return ByteString::formatted("AsyncIteratorClose {}, completion_type:{} completion_value:<empty>",
-            format_operand("iterator_record"sv, m_iterator_record, executable),
+        return ByteString::formatted("AsyncIteratorClose {}, {}, {}, completion_type:{} completion_value:<empty>",
+            format_operand("iterator_object"sv, m_iterator_object, executable),
+            format_operand("iterator_next"sv, m_iterator_next, executable),
+            format_operand("iterator_done"sv, m_iterator_done, executable),
             to_underlying(m_completion_type));
     }
 
-    return ByteString::formatted("AsyncIteratorClose {}, completion_type:{}, completion_value:{}",
-        format_operand("iterator_record"sv, m_iterator_record, executable),
+    return ByteString::formatted("AsyncIteratorClose {}, {}, {}, completion_type:{}, completion_value:{}",
+        format_operand("iterator_object"sv, m_iterator_object, executable),
+        format_operand("iterator_next"sv, m_iterator_next, executable),
+        format_operand("iterator_done"sv, m_iterator_done, executable),
         to_underlying(m_completion_type), m_completion_value);
 }
 
 ByteString IteratorNext::to_byte_string_impl(Executable const& executable) const
 {
-    return ByteString::formatted("IteratorNext {}, {}",
+    return ByteString::formatted("IteratorNext {}, {}, {}, {}",
         format_operand("dst"sv, m_dst, executable),
-        format_operand("iterator_record"sv, m_iterator_record, executable));
+        format_operand("iterator_object"sv, m_iterator_object, executable),
+        format_operand("iterator_next"sv, m_iterator_next, executable),
+        format_operand("iterator_done"sv, m_iterator_done, executable));
 }
 
 ByteString IteratorNextUnpack::to_byte_string_impl(Executable const& executable) const
 {
-    return ByteString::formatted("IteratorNextUnpack {}, {}, {}",
+    return ByteString::formatted("IteratorNextUnpack {}, {}, {}, {}, {}",
         format_operand("dst_value"sv, m_dst_value, executable),
         format_operand("dst_done"sv, m_dst_done, executable),
-        format_operand("iterator_record"sv, m_iterator_record, executable));
+        format_operand("iterator_object"sv, m_iterator_object, executable),
+        format_operand("iterator_next"sv, m_iterator_next, executable),
+        format_operand("iterator_done"sv, m_iterator_done, executable));
 }
 
 ByteString ResolveThisBinding::to_byte_string_impl(Bytecode::Executable const&) const
@@ -4160,20 +4202,6 @@ ByteString LeaveFinally::to_byte_string_impl(Bytecode::Executable const&) const
 ByteString RestoreScheduledJump::to_byte_string_impl(Bytecode::Executable const&) const
 {
     return ByteString::formatted("RestoreScheduledJump");
-}
-
-ByteString GetObjectFromIteratorRecord::to_byte_string_impl(Bytecode::Executable const& executable) const
-{
-    return ByteString::formatted("GetObjectFromIteratorRecord {}, {}",
-        format_operand("object"sv, m_object, executable),
-        format_operand("iterator_record"sv, m_iterator_record, executable));
-}
-
-ByteString GetNextMethodFromIteratorRecord::to_byte_string_impl(Bytecode::Executable const& executable) const
-{
-    return ByteString::formatted("GetNextMethodFromIteratorRecord {}, {}",
-        format_operand("next_method"sv, m_next_method, executable),
-        format_operand("iterator_record"sv, m_iterator_record, executable));
 }
 
 ByteString End::to_byte_string_impl(Bytecode::Executable const& executable) const

--- a/Libraries/LibJS/Bytecode/Op.h
+++ b/Libraries/LibJS/Bytecode/Op.h
@@ -484,10 +484,12 @@ private:
 
 class IteratorToArray final : public Instruction {
 public:
-    explicit IteratorToArray(Operand dst, Operand iterator)
+    explicit IteratorToArray(Operand dst, Operand iterator_object, Operand iterator_next_method, Operand iterator_done_property)
         : Instruction(Type::IteratorToArray)
         , m_dst(dst)
-        , m_iterator(iterator)
+        , m_iterator_object(iterator_object)
+        , m_iterator_next_method(iterator_next_method)
+        , m_iterator_done_property(iterator_done_property)
     {
     }
 
@@ -495,17 +497,20 @@ public:
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
 
     Operand dst() const { return m_dst; }
-    Operand iterator() const { return m_iterator; }
 
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
         visitor(m_dst);
-        visitor(m_iterator);
+        visitor(m_iterator_object);
+        visitor(m_iterator_next_method);
+        visitor(m_iterator_done_property);
     }
 
 private:
     Operand m_dst;
-    Operand m_iterator;
+    Operand m_iterator_object;
+    Operand m_iterator_next_method;
+    Operand m_iterator_done_property;
 };
 
 class ConcatString final : public Instruction {
@@ -2684,9 +2689,11 @@ private:
 
 class GetIterator final : public Instruction {
 public:
-    GetIterator(Operand dst, Operand iterable, IteratorHint hint = IteratorHint::Sync)
+    GetIterator(Operand dst_iterator_object, Operand dst_iterator_next_method, Operand dst_iterator_done_property, Operand iterable, IteratorHint hint = IteratorHint::Sync)
         : Instruction(Type::GetIterator)
-        , m_dst(dst)
+        , m_dst_iterator_object(dst_iterator_object)
+        , m_dst_iterator_next(dst_iterator_next_method)
+        , m_dst_iterator_done(dst_iterator_done_property)
         , m_iterable(iterable)
         , m_hint(hint)
     {
@@ -2696,68 +2703,21 @@ public:
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
-        visitor(m_dst);
+        visitor(m_dst_iterator_object);
+        visitor(m_dst_iterator_next);
+        visitor(m_dst_iterator_done);
         visitor(m_iterable);
     }
 
-    Operand dst() const { return m_dst; }
     Operand iterable() const { return m_iterable; }
     IteratorHint hint() const { return m_hint; }
 
 private:
-    Operand m_dst;
+    Operand m_dst_iterator_object;
+    Operand m_dst_iterator_next;
+    Operand m_dst_iterator_done;
     Operand m_iterable;
     IteratorHint m_hint { IteratorHint::Sync };
-};
-
-class GetObjectFromIteratorRecord final : public Instruction {
-public:
-    GetObjectFromIteratorRecord(Operand object, Operand iterator_record)
-        : Instruction(Type::GetObjectFromIteratorRecord)
-        , m_object(object)
-        , m_iterator_record(iterator_record)
-    {
-    }
-
-    void execute_impl(Bytecode::Interpreter&) const;
-    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-    void visit_operands_impl(Function<void(Operand&)> visitor)
-    {
-        visitor(m_object);
-        visitor(m_iterator_record);
-    }
-
-    Operand object() const { return m_object; }
-    Operand iterator_record() const { return m_iterator_record; }
-
-private:
-    Operand m_object;
-    Operand m_iterator_record;
-};
-
-class GetNextMethodFromIteratorRecord final : public Instruction {
-public:
-    GetNextMethodFromIteratorRecord(Operand next_method, Operand iterator_record)
-        : Instruction(Type::GetNextMethodFromIteratorRecord)
-        , m_next_method(next_method)
-        , m_iterator_record(iterator_record)
-    {
-    }
-
-    void execute_impl(Bytecode::Interpreter&) const;
-    ByteString to_byte_string_impl(Bytecode::Executable const&) const;
-    void visit_operands_impl(Function<void(Operand&)> visitor)
-    {
-        visitor(m_next_method);
-        visitor(m_iterator_record);
-    }
-
-    Operand next_method() const { return m_next_method; }
-    Operand iterator_record() const { return m_iterator_record; }
-
-private:
-    Operand m_next_method;
-    Operand m_iterator_record;
 };
 
 class GetMethod final : public Instruction {
@@ -2790,9 +2750,11 @@ private:
 
 class GetObjectPropertyIterator final : public Instruction {
 public:
-    GetObjectPropertyIterator(Operand dst, Operand object)
+    GetObjectPropertyIterator(Operand dst_iterator_object, Operand dst_iterator_next, Operand dst_iterator_done, Operand object)
         : Instruction(Type::GetObjectPropertyIterator)
-        , m_dst(dst)
+        , m_dst_iterator_object(dst_iterator_object)
+        , m_dst_iterator_next(dst_iterator_next)
+        , m_dst_iterator_done(dst_iterator_done)
         , m_object(object)
     {
     }
@@ -2801,23 +2763,26 @@ public:
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
-        visitor(m_dst);
+        visitor(m_dst_iterator_object);
+        visitor(m_dst_iterator_next);
+        visitor(m_dst_iterator_done);
         visitor(m_object);
     }
 
-    Operand dst() const { return m_dst; }
-    Operand object() const { return m_object; }
-
 private:
-    Operand m_dst;
+    Operand m_dst_iterator_object;
+    Operand m_dst_iterator_next;
+    Operand m_dst_iterator_done;
     Operand m_object;
 };
 
 class IteratorClose final : public Instruction {
 public:
-    IteratorClose(Operand iterator_record, Completion::Type completion_type, Optional<Value> completion_value)
+    IteratorClose(Operand iterator_object, Operand iterator_next, Operand iterator_done, Completion::Type completion_type, Optional<Value> completion_value)
         : Instruction(Type::IteratorClose)
-        , m_iterator_record(iterator_record)
+        , m_iterator_object(iterator_object)
+        , m_iterator_next(iterator_next)
+        , m_iterator_done(iterator_done)
         , m_completion_type(completion_type)
         , m_completion_value(completion_value)
     {
@@ -2827,24 +2792,29 @@ public:
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
-        visitor(m_iterator_record);
+        visitor(m_iterator_object);
+        visitor(m_iterator_next);
+        visitor(m_iterator_done);
     }
 
-    Operand iterator_record() const { return m_iterator_record; }
     Completion::Type completion_type() const { return m_completion_type; }
     Optional<Value> const& completion_value() const { return m_completion_value; }
 
 private:
-    Operand m_iterator_record;
+    Operand m_iterator_object;
+    Operand m_iterator_next;
+    Operand m_iterator_done;
     Completion::Type m_completion_type { Completion::Type::Normal };
     Optional<Value> m_completion_value;
 };
 
 class AsyncIteratorClose final : public Instruction {
 public:
-    AsyncIteratorClose(Operand iterator_record, Completion::Type completion_type, Optional<Value> completion_value)
+    AsyncIteratorClose(Operand iterator_object, Operand iterator_next, Operand iterator_done, Completion::Type completion_type, Optional<Value> completion_value)
         : Instruction(Type::AsyncIteratorClose)
-        , m_iterator_record(iterator_record)
+        , m_iterator_object(iterator_object)
+        , m_iterator_next(iterator_next)
+        , m_iterator_done(iterator_done)
         , m_completion_type(completion_type)
         , m_completion_value(completion_value)
     {
@@ -2854,25 +2824,30 @@ public:
     ByteString to_byte_string_impl(Bytecode::Executable const&) const;
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
-        visitor(m_iterator_record);
+        visitor(m_iterator_object);
+        visitor(m_iterator_next);
+        visitor(m_iterator_done);
     }
 
-    Operand iterator_record() const { return m_iterator_record; }
     Completion::Type completion_type() const { return m_completion_type; }
     Optional<Value> const& completion_value() const { return m_completion_value; }
 
 private:
-    Operand m_iterator_record;
+    Operand m_iterator_object;
+    Operand m_iterator_next;
+    Operand m_iterator_done;
     Completion::Type m_completion_type { Completion::Type::Normal };
     Optional<Value> m_completion_value;
 };
 
 class IteratorNext final : public Instruction {
 public:
-    IteratorNext(Operand dst, Operand iterator_record)
+    IteratorNext(Operand dst, Operand iterator_object, Operand iterator_next, Operand iterator_done)
         : Instruction(Type::IteratorNext)
         , m_dst(dst)
-        , m_iterator_record(iterator_record)
+        , m_iterator_object(iterator_object)
+        , m_iterator_next(iterator_next)
+        , m_iterator_done(iterator_done)
     {
     }
 
@@ -2881,24 +2856,27 @@ public:
     void visit_operands_impl(Function<void(Operand&)> visitor)
     {
         visitor(m_dst);
-        visitor(m_iterator_record);
+        visitor(m_iterator_object);
+        visitor(m_iterator_next);
+        visitor(m_iterator_done);
     }
-
-    Operand dst() const { return m_dst; }
-    Operand iterator_record() const { return m_iterator_record; }
 
 private:
     Operand m_dst;
-    Operand m_iterator_record;
+    Operand m_iterator_object;
+    Operand m_iterator_next;
+    Operand m_iterator_done;
 };
 
 class IteratorNextUnpack final : public Instruction {
 public:
-    IteratorNextUnpack(Operand dst_value, Operand dst_done, Operand iterator_record)
+    IteratorNextUnpack(Operand dst_value, Operand dst_done, Operand iterator_object, Operand iterator_next, Operand iterator_done)
         : Instruction(Type::IteratorNextUnpack)
         , m_dst_value(dst_value)
         , m_dst_done(dst_done)
-        , m_iterator_record(iterator_record)
+        , m_iterator_object(iterator_object)
+        , m_iterator_next(iterator_next)
+        , m_iterator_done(iterator_done)
     {
     }
 
@@ -2908,17 +2886,17 @@ public:
     {
         visitor(m_dst_value);
         visitor(m_dst_done);
-        visitor(m_iterator_record);
+        visitor(m_iterator_object);
+        visitor(m_iterator_next);
+        visitor(m_iterator_done);
     }
-
-    Operand dst_value() const { return m_dst_value; }
-    Operand dst_done() const { return m_dst_done; }
-    Operand iterator_record() const { return m_iterator_record; }
 
 private:
     Operand m_dst_value;
     Operand m_dst_done;
-    Operand m_iterator_record;
+    Operand m_iterator_object;
+    Operand m_iterator_next;
+    Operand m_iterator_done;
 };
 
 class ResolveThisBinding final : public Instruction {

--- a/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -341,7 +341,8 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayConstructor::from_async)
         else if (using_sync_iterator) {
             // i. Set iteratorRecord to ? CreateAsyncFromSyncIterator(GetIterator(asyncItems, sync, usingSyncIterator)).
             // FIXME: The Array.from proposal is out of date - it should be using GetIteratorFromMethod.
-            iterator_record = create_async_from_sync_iterator(vm, TRY(get_iterator_from_method(vm, async_items, *using_sync_iterator)));
+            auto iterator_record_impl = create_async_from_sync_iterator(vm, TRY(get_iterator_from_method(vm, async_items, *using_sync_iterator)));
+            iterator_record = vm.heap().allocate<IteratorRecord>(iterator_record_impl.iterator, iterator_record_impl.next_method, iterator_record_impl.done);
         }
 
         // h. If iteratorRecord is not undefined, then

--- a/Libraries/LibJS/Runtime/ArrayIterator.cpp
+++ b/Libraries/LibJS/Runtime/ArrayIterator.cpp
@@ -37,10 +37,10 @@ void ArrayIterator::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_array);
 }
 
-BuiltinIterator* ArrayIterator::as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const& iterator_record)
+BuiltinIterator* ArrayIterator::as_builtin_iterator_if_next_is_not_redefined(Value next_method)
 {
-    if (iterator_record.next_method.is_object()) {
-        auto const& next_function = iterator_record.next_method.as_object();
+    if (next_method.is_object()) {
+        auto const& next_function = next_method.as_object();
         if (next_function.is_native_function()) {
             auto const& native_function = static_cast<NativeFunction const&>(next_function);
             if (native_function.is_array_prototype_next_builtin())

--- a/Libraries/LibJS/Runtime/ArrayIterator.h
+++ b/Libraries/LibJS/Runtime/ArrayIterator.h
@@ -21,7 +21,7 @@ public:
 
     virtual ~ArrayIterator() override = default;
 
-    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const&) override;
+    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(Value next_method) override;
     ThrowCompletionOr<void> next(VM&, bool& done, Value& value) override;
 
 private:

--- a/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.cpp
@@ -261,7 +261,7 @@ JS_DEFINE_NATIVE_FUNCTION(AsyncFromSyncIteratorPrototype::throw_)
 }
 
 // 27.1.4.1 CreateAsyncFromSyncIterator ( syncIteratorRecord ), https://tc39.es/ecma262/#sec-createasyncfromsynciterator
-GC::Ref<IteratorRecord> create_async_from_sync_iterator(VM& vm, GC::Ref<IteratorRecord> sync_iterator_record)
+IteratorRecordImpl create_async_from_sync_iterator(VM& vm, GC::Ref<IteratorRecord> sync_iterator_record)
 {
     auto& realm = *vm.current_realm();
 
@@ -273,7 +273,7 @@ GC::Ref<IteratorRecord> create_async_from_sync_iterator(VM& vm, GC::Ref<Iterator
     auto next_method = MUST(async_iterator->get(vm.names.next));
 
     // 4. Let iteratorRecord be the Iterator Record { [[Iterator]]: asyncIterator, [[NextMethod]]: nextMethod, [[Done]]: false }.
-    auto iterator_record = vm.heap().allocate<IteratorRecord>(async_iterator, next_method, false);
+    IteratorRecordImpl iterator_record { .done = false, .iterator = async_iterator, .next_method = next_method };
 
     // 5. Return iteratorRecord.
     return iterator_record;

--- a/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
+++ b/Libraries/LibJS/Runtime/AsyncFromSyncIteratorPrototype.h
@@ -31,6 +31,6 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(throw_);
 };
 
-GC::Ref<IteratorRecord> create_async_from_sync_iterator(VM&, GC::Ref<IteratorRecord> sync_iterator);
+IteratorRecordImpl create_async_from_sync_iterator(VM&, GC::Ref<IteratorRecord> sync_iterator);
 
 }

--- a/Libraries/LibJS/Runtime/MapIterator.cpp
+++ b/Libraries/LibJS/Runtime/MapIterator.cpp
@@ -32,10 +32,10 @@ void MapIterator::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_map);
 }
 
-BuiltinIterator* MapIterator::as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const& iterator_record)
+BuiltinIterator* MapIterator::as_builtin_iterator_if_next_is_not_redefined(Value next_method)
 {
-    if (iterator_record.next_method.is_object()) {
-        auto& next_function = iterator_record.next_method.as_object();
+    if (next_method.is_object()) {
+        auto& next_function = next_method.as_object();
         if (next_function.is_native_function()) {
             auto const& native_function = static_cast<NativeFunction const&>(next_function);
             if (native_function.is_map_prototype_next_builtin())

--- a/Libraries/LibJS/Runtime/MapIterator.h
+++ b/Libraries/LibJS/Runtime/MapIterator.h
@@ -22,7 +22,7 @@ public:
 
     virtual ~MapIterator() override = default;
 
-    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const&) override;
+    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(Value next_method) override;
     ThrowCompletionOr<void> next(VM&, bool& done, Value& value) override;
 
 private:

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -233,7 +233,7 @@ public:
 
     virtual bool eligible_for_own_property_enumeration_fast_path() const { return true; }
 
-    virtual BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const&) { return nullptr; }
+    virtual BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined([[maybe_unused]] Value next_method) { return nullptr; }
 
     virtual bool is_array_iterator_prototype() const { return false; }
     virtual bool is_map_iterator_prototype() const { return false; }

--- a/Libraries/LibJS/Runtime/SetIterator.cpp
+++ b/Libraries/LibJS/Runtime/SetIterator.cpp
@@ -31,10 +31,10 @@ void SetIterator::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_set);
 }
 
-BuiltinIterator* SetIterator::as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const& iterator_record)
+BuiltinIterator* SetIterator::as_builtin_iterator_if_next_is_not_redefined(Value next_method)
 {
-    if (iterator_record.next_method.is_object()) {
-        auto const& next_function = iterator_record.next_method.as_object();
+    if (next_method.is_object()) {
+        auto const& next_function = next_method.as_object();
         if (next_function.is_native_function()) {
             auto const& native_function = static_cast<NativeFunction const&>(next_function);
             if (native_function.is_set_prototype_next_builtin())

--- a/Libraries/LibJS/Runtime/SetIterator.h
+++ b/Libraries/LibJS/Runtime/SetIterator.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~SetIterator() override = default;
 
-    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const&) override;
+    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(Value next_method) override;
     ThrowCompletionOr<void> next(VM&, bool& done, Value& value) override;
 
 private:

--- a/Libraries/LibJS/Runtime/StringIterator.cpp
+++ b/Libraries/LibJS/Runtime/StringIterator.cpp
@@ -25,10 +25,10 @@ StringIterator::StringIterator(String string, Object& prototype)
 {
 }
 
-BuiltinIterator* StringIterator::as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const& iterator_record)
+BuiltinIterator* StringIterator::as_builtin_iterator_if_next_is_not_redefined(Value next_method)
 {
-    if (iterator_record.next_method.is_object()) {
-        auto const& next_function = iterator_record.next_method.as_object();
+    if (next_method.is_object()) {
+        auto const& next_function = next_method.as_object();
         if (next_function.is_native_function()) {
             auto const& native_function = static_cast<NativeFunction const&>(next_function);
             if (native_function.is_string_prototype_next_builtin())

--- a/Libraries/LibJS/Runtime/StringIterator.h
+++ b/Libraries/LibJS/Runtime/StringIterator.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~StringIterator() override = default;
 
-    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(IteratorRecord const&) override;
+    BuiltinIterator* as_builtin_iterator_if_next_is_not_redefined(Value next_method) override;
     ThrowCompletionOr<void> next(VM&, bool& done, Value& value) override;
 
 private:


### PR DESCRIPTION
With this change, `GetIterator` no longer GC-allocates an `IteratorRecord`. Instead, it stores the iterator record fields in bytecode registers. This avoids per-iteration allocations in patterns like: `for (let [x] of array) {}`.

`IteratorRecord` now inherits from `IteratorRecordImpl`, which holds the iteration state. This allows the existing iteration helpers (`iterator_next()`, `iterator_step()`, etc.) operate on both the GC-allocated and the register-backed forms.

Microbenchmarks:
1.1x array-destructuring-assignment-rest.js
1.226x array-destructuring-assignment.js

```
Suite       Test                                      Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------  ---------------------
MicroBench  array-destructuring-assignment-rest.js      1.1    0.427 ± 0.425 … 0.428  0.388 ± 0.387 … 0.389
MicroBench  array-destructuring-assignment.js           1.226  2.943 ± 2.898 … 2.988  2.400 ± 2.391 … 2.410
MicroBench  array-prototype-map.js                      1.031  1.255 ± 1.253 … 1.256  1.217 ± 1.215 … 1.218
MicroBench  array-prototype-shift.js                    1.072  0.015 ± 0.014 … 0.015  0.014 ± 0.013 … 0.014
MicroBench  bound-call-00-args.js                       1.004  1.334 ± 1.332 … 1.336  1.329 ± 1.322 … 1.337
MicroBench  bound-call-04-args.js                       1.001  1.414 ± 1.403 … 1.425  1.413 ± 1.379 … 1.447
MicroBench  bound-call-16-args.js                       1.02   1.656 ± 1.635 … 1.677  1.624 ± 1.618 … 1.630
MicroBench  call-00-args.js                             1.008  1.254 ± 1.254 … 1.254  1.245 ± 1.239 … 1.250
MicroBench  call-01-args.js                             1.015  1.279 ± 1.275 … 1.283  1.260 ± 1.255 … 1.265
MicroBench  call-02-args.js                             1.004  1.288 ± 1.287 … 1.289  1.283 ± 1.278 … 1.287
MicroBench  call-03-args.js                             1.008  1.302 ± 1.296 … 1.308  1.291 ± 1.290 … 1.293
MicroBench  call-04-args.js                             1.011  1.321 ± 1.318 … 1.323  1.307 ± 1.305 … 1.309
MicroBench  call-16-args.js                             1.018  1.524 ± 1.514 … 1.535  1.498 ± 1.492 … 1.503
MicroBench  call-32-args.js                             1.007  1.849 ± 1.849 … 1.850  1.837 ± 1.836 … 1.838
MicroBench  for-in-indexed-properties.js                0.97   0.964 ± 0.963 … 0.965  0.994 ± 0.988 … 1.000
MicroBench  for-in-named-properties.js                  0.978  1.331 ± 1.324 … 1.338  1.361 ± 1.357 … 1.366
MicroBench  for-of.js                                   1      0.385 ± 0.384 … 0.387  0.385 ± 0.382 … 0.388
MicroBench  object-assign.js                            1.001  6.294 ± 6.292 … 6.297  6.288 ± 6.242 … 6.334
MicroBench  object-keys.js                              0.995  1.632 ± 1.628 … 1.637  1.640 ± 1.639 … 1.641
MicroBench  object-set-with-rope-strings.js             0.995  0.615 ± 0.613 … 0.617  0.618 ± 0.615 … 0.621
MicroBench  pic-add-own.js                              1.068  0.764 ± 0.748 … 0.781  0.715 ± 0.715 … 0.716
MicroBench  pic-get-own.js                              0.995  1.301 ± 1.293 … 1.310  1.308 ± 1.272 … 1.345
MicroBench  pic-get-pchain.js                           1.026  1.354 ± 1.353 … 1.356  1.320 ± 1.316 … 1.324
MicroBench  pic-put-own.js                              0.991  1.258 ± 1.257 … 1.260  1.270 ± 1.267 … 1.273
MicroBench  pic-put-pchain.js                           1.036  2.752 ± 2.752 … 2.752  2.655 ± 2.589 … 2.722
MicroBench  setter-in-prototype-chain.js                0.995  2.009 ± 1.972 … 2.046  2.019 ± 2.014 … 2.024
MicroBench  strictly-equals-object.js                   1.153  1.164 ± 1.143 … 1.186  1.010 ± 1.008 … 1.012
MicroBench  Total                                       1.025  40.687                 39.690
All Suites  Total                                       1.025  40.687                 39.690
```