### PR TITLE
LibWeb: Remove spin_until from HTMLImageElement::decode

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -68,7 +68,7 @@ public:
     String current_src() const;
 
     // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode
-    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> decode() const;
+    [[nodiscard]] WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> decode();
 
     virtual Optional<ARIA::Role> default_role() const override;
 

--- a/Libraries/LibWeb/HTML/ImageRequest.cpp
+++ b/Libraries/LibWeb/HTML/ImageRequest.cpp
@@ -44,6 +44,7 @@ void ImageRequest::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_shared_resource_request);
     visitor.visit(m_page);
     visitor.visit(m_image_data);
+    visitor.visit(m_state_change_callback);
 }
 
 // https://html.spec.whatwg.org/multipage/images.html#img-available
@@ -66,6 +67,9 @@ ImageRequest::State ImageRequest::state() const
 void ImageRequest::set_state(State state)
 {
     m_state = state;
+
+    if (m_state_change_callback)
+        m_state_change_callback->function()();
 }
 
 void ImageRequest::set_current_url(JS::Realm& realm, String url)
@@ -132,6 +136,11 @@ void ImageRequest::add_callbacks(Function<void()> on_finish, Function<void()> on
 {
     VERIFY(m_shared_resource_request);
     m_shared_resource_request->add_callbacks(move(on_finish), move(on_fail));
+}
+
+void ImageRequest::set_state_changed_callback(GC::Ptr<GC::Function<void()>> callback)
+{
+    m_state_change_callback = callback;
 }
 
 }

--- a/Libraries/LibWeb/HTML/ImageRequest.h
+++ b/Libraries/LibWeb/HTML/ImageRequest.h
@@ -56,6 +56,7 @@ public:
 
     void fetch_image(JS::Realm&, GC::Ref<Fetch::Infrastructure::Request>);
     void add_callbacks(Function<void()> on_finish, Function<void()> on_fail);
+    void set_state_changed_callback(GC::Ptr<GC::Function<void()>> callback);
 
     GC::Ptr<SharedResourceRequest const> shared_resource_request() const { return m_shared_resource_request; }
 
@@ -87,6 +88,8 @@ private:
     Optional<Gfx::FloatSize> m_preferred_density_corrected_dimensions;
 
     GC::Ptr<SharedResourceRequest> m_shared_resource_request;
+
+    GC::Ptr<GC::Function<void()>> m_state_change_callback;
 };
 
 // https://html.spec.whatwg.org/multipage/images.html#abort-the-image-request


### PR DESCRIPTION
The main issue with this currently is the setting of callbacks instead of adding to a list.