### PR TITLE
CMake: Remove unnecessary dependencies from WebContent on Windows

### DIFF
--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -39,9 +39,6 @@ add_executable(WebContent main.cpp)
 target_link_libraries(WebContent PRIVATE webcontentservice LibURL)
 
 if(WIN32)
-    find_package(unofficial-angle REQUIRED CONFIG)
-    find_package(SQLite3 REQUIRED)
-    target_link_libraries(WebContent PRIVATE LibMedia LibTextCodec SQLite::SQLite3 unofficial::angle::libGLESv2)
     lagom_windows_bin(WebContent)
 endif()
 


### PR DESCRIPTION
Some CMake cleanup for Windows that was noticed after investigating [this question](https://discord.com/channels/1247070541085671459/1306918361732616212/1433498479858286652) in `ui-windows`