### PR TITLE
LibRegex: Track local compares in nested classes

### DIFF
--- a/Libraries/LibRegex/RegexParser.cpp
+++ b/Libraries/LibRegex/RegexParser.cpp
@@ -2418,6 +2418,7 @@ bool ECMA262Parser::parse_nested_class(Vector<regex::CompareTypeAndValuePair>& c
     if (match(TokenType::LeftBracket)) {
         consume();
 
+        auto initial_compares_size = compares.size();
         compares.append(CompareTypeAndValuePair { CharacterCompareType::Or, 0 });
 
         if (match(TokenType::Circumflex)) {
@@ -2429,12 +2430,13 @@ bool ECMA262Parser::parse_nested_class(Vector<regex::CompareTypeAndValuePair>& c
         // ClassContents :: [empty]
         if (match(TokenType::RightBracket)) {
             consume();
+            auto added_compares = compares.size() - initial_compares_size;
             // Should only have at most an 'Inverse' (after an 'Or')
             if (m_parser_state.regex_options.has_flag_set(regex::AllFlags::UnicodeSets)) {
                 // In unicode sets mode, we can have an additional 'And'/'Or' before the 'Inverse'.
-                VERIFY(compares.size() <= 3);
+                VERIFY(added_compares <= 3);
             } else {
-                VERIFY(compares.size() <= 2);
+                VERIFY(added_compares <= 2);
             }
             compares.append(CompareTypeAndValuePair { CharacterCompareType::EndAndOr, 0 });
             return true;

--- a/Tests/LibRegex/TestRegex.cpp
+++ b/Tests/LibRegex/TestRegex.cpp
@@ -891,6 +891,7 @@ TEST_CASE(ECMA262_unicode_sets_match)
         { "[\\w&&\\d]"sv, "a"sv, false },
         { "[\\w&&\\d]"sv, "4"sv, true },
         { "([^\\:]+?)"sv, "a"sv, true },
+        { "[[a][]]"sv, "a"sv, true }, // ladybird#6647
     };
 
     for (auto& test : tests) {


### PR DESCRIPTION
This prevents verification failures when parsing nested empty character classes. We now only count compares added by the current parse_nested_class invocation.

Fixes one crash in #6647,  but I don’t dare touch the optimizer, so hopefully @alimpfard can take a look at the second crash there. :sweat_smile: 