### PR TITLE
Meta: Fix typo in URL

### DIFF
--- a/Meta/CMake/freedesktop/org.ladybird.Ladybird.metainfo.xml.in
+++ b/Meta/CMake/freedesktop/org.ladybird.Ladybird.metainfo.xml.in
@@ -14,7 +14,7 @@
   <url type="bugtracker">https://github.com/LadybirdBrowser/ladybird/issues</url>
   <url type="faq">https://ladybird.org/#faq</url>
   <url type="donation">https://donorbox.org/ladybird</url>
-  <url type="contact">https://ladybird.org/organization/#intiative</url>
+  <url type="contact">https://ladybird.org/organization/#initiative</url>
   <url type="vcs-browser">https://github.com/LadybirdBrowser/ladybird</url>
   <url type="contribute">https://ladybird.org/#gi</url>
 


### PR DESCRIPTION
Corresponds with LadybirdBrowser/ladybird.org#204