### PR TITLE
LibWeb: Add synthetic height for contenteditable elements

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -710,6 +710,12 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
             return marker_line_height;
     }
 
+    // AD-HOC: Contenteditable elements must have a minimum height (line-height) when empty, to remain clickable and
+    //         usable for text input, even though this is not specified.
+    //         See: https://github.com/w3c/editing/issues/70.
+    if (auto const* element = as_if<DOM::Element>(box.dom_node()); element && element->is_editing_host())
+        return box.computed_values().line_height();
+
     // 4. zero, otherwise
     return 0;
 }

--- a/Tests/LibWeb/Layout/expected/empty-editable-shows-cursor.txt
+++ b/Tests/LibWeb/Layout/expected/empty-editable-shows-cursor.txt
@@ -1,86 +1,86 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 56 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 74 0+0+0] [BFC] children: not-inline
     BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
       TextNode <#text> (not painted)
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 40 0+0+8] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 58 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
-      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 40 0+0+0] children: inline
-        frag 0 from TextInputBox start: 0, length: 0, rect: [9,25 200x20] baseline: 20
-        frag 1 from TextNode start: 0, length: 1, rect: [210,30 8x18] baseline: 13.796875
+      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 40 0+0+0] children: inline
+        frag 0 from TextInputBox start: 0, length: 0, rect: [9,43 200x20] baseline: 20
+        frag 1 from TextNode start: 0, length: 1, rect: [210,48 8x18] baseline: 13.796875
             " "
-        frag 2 from TextAreaBox start: 0, length: 0, rect: [221,11 160x30] baseline: 36
-        frag 3 from TextNode start: 0, length: 1, rect: [384,30 8x18] baseline: 13.796875
+        frag 2 from TextAreaBox start: 0, length: 0, rect: [221,29 160x30] baseline: 36
+        frag 3 from TextNode start: 0, length: 1, rect: [384,48 8x18] baseline: 13.796875
             " "
-        frag 4 from TextInputBox start: 0, length: 0, rect: [393,25 200x20] baseline: 20
-        frag 5 from TextNode start: 0, length: 1, rect: [594,30 8x18] baseline: 13.796875
+        frag 4 from TextInputBox start: 0, length: 0, rect: [393,43 200x20] baseline: 20
+        frag 5 from TextNode start: 0, length: 1, rect: [594,48 8x18] baseline: 13.796875
             " "
-        frag 6 from TextAreaBox start: 0, length: 0, rect: [605,11 160x30] baseline: 36
+        frag 6 from TextAreaBox start: 0, length: 0, rect: [605,29 160x30] baseline: 36
         TextNode <#text> (not painted)
-        TextInputBox <input> at [9,25] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
-          Box <div> at [11,26] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
-            BlockContainer <div> at [11,26] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 0, rect: [11,26 0x18] baseline: 13.796875
+        TextInputBox <input> at [9,43] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
+          Box <div> at [11,44] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [11,44] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 0, rect: [11,44 0x18] baseline: 13.796875
               TextNode <#text> (not painted)
-            BlockContainer <div> at [11,26] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 5, rect: [11,26 36.84375x18] baseline: 13.796875
+            BlockContainer <div> at [11,44] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [11,44 36.84375x18] baseline: 13.796875
                   "hello"
               TextNode <#text> (not painted)
         TextNode <#text> (not painted)
-        TextAreaBox <textarea> at [221,11] inline-block [0+1+2 160 2+1+0] [0+1+2 30 2+1+0] [BFC] children: not-inline
-          BlockContainer <div> at [221,11] [0+0+0 160 0+0+0] [0+0+0 15 0+0+0] children: inline
-            InlineNode <div> at [221,11] [0+0+0 0 0+0+0] [0+0+0 15 0+0+0]
-              frag 0 from TextNode start: 0, length: 0, rect: [221,11 0x15] baseline: 11.390625
+        TextAreaBox <textarea> at [221,29] inline-block [0+1+2 160 2+1+0] [0+1+2 30 2+1+0] [BFC] children: not-inline
+          BlockContainer <div> at [221,29] [0+0+0 160 0+0+0] [0+0+0 15 0+0+0] children: inline
+            InlineNode <div> at [221,29] [0+0+0 0 0+0+0] [0+0+0 15 0+0+0]
+              frag 0 from TextNode start: 0, length: 0, rect: [221,29 0x15] baseline: 11.390625
               TextNode <#text> (not painted)
-            InlineNode <div> at [221,11] [0+0+0 29.921875 0+0+0] [0+0+0 15 0+0+0]
-              frag 0 from TextNode start: 0, length: 5, rect: [221,11 29.921875x15] baseline: 11.390625
+            InlineNode <div> at [221,29] [0+0+0 29.921875 0+0+0] [0+0+0 15 0+0+0]
+              frag 0 from TextNode start: 0, length: 5, rect: [221,29 29.921875x15] baseline: 11.390625
                   "hello"
               TextNode <#text> (not painted)
         TextNode <#text> (not painted)
-        TextInputBox <input> at [393,25] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
-          Box <div> at [395,26] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
-            BlockContainer <div> at [395,26] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 0, rect: [395,26 0x18] baseline: 13.796875
+        TextInputBox <input> at [393,43] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
+          Box <div> at [395,44] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [395,44] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 0, rect: [395,44 0x18] baseline: 13.796875
               TextNode <#text> (not painted)
         TextNode <#text> (not painted)
-        TextAreaBox <textarea> at [605,11] inline-block [0+1+2 160 2+1+0] [0+1+2 30 2+1+0] [BFC] children: not-inline
-          BlockContainer <div> at [605,11] [0+0+0 160 0+0+0] [0+0+0 15 0+0+0] children: not-inline
-            BlockContainer <div> at [605,11] [0+0+0 160 0+0+0] [0+0+0 15 0+0+0] children: inline
-              frag 0 from TextNode start: 0, length: 0, rect: [605,11 0x15] baseline: 11.390625
+        TextAreaBox <textarea> at [605,29] inline-block [0+1+2 160 2+1+0] [0+1+2 30 2+1+0] [BFC] children: not-inline
+          BlockContainer <div> at [605,29] [0+0+0 160 0+0+0] [0+0+0 15 0+0+0] children: not-inline
+            BlockContainer <div> at [605,29] [0+0+0 160 0+0+0] [0+0+0 15 0+0+0] children: inline
+              frag 0 from TextNode start: 0, length: 0, rect: [605,29 0x15] baseline: 11.390625
               TextNode <#text> (not painted)
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x56]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x74]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x40]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x58]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
-      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x40]
-        PaintableWithLines (TextInputBox<INPUT>) [8,24 202x22]
-          PaintableBox (Box<DIV>) [9,25 200x20]
-            PaintableWithLines (BlockContainer<DIV>) [11,26 0x18]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x18]
+      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x40]
+        PaintableWithLines (TextInputBox<INPUT>) [8,42 202x22]
+          PaintableBox (Box<DIV>) [9,43 200x20]
+            PaintableWithLines (BlockContainer<DIV>) [11,44 0x18]
               TextPaintable (TextNode<#text>)
-            PaintableWithLines (BlockContainer<DIV>) [11,26 196x18]
-              TextPaintable (TextNode<#text>)
-        TextPaintable (TextNode<#text>)
-        PaintableWithLines (TextAreaBox<TEXTAREA>) [218,8 166x36]
-          PaintableWithLines (BlockContainer<DIV>) [221,11 160x15]
-            PaintableWithLines (InlineNode<DIV>) [221,11 0x15]
-              TextPaintable (TextNode<#text>)
-            PaintableWithLines (InlineNode<DIV>) [221,11 29.921875x15]
+            PaintableWithLines (BlockContainer<DIV>) [11,44 196x18]
               TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
-        PaintableWithLines (TextInputBox<INPUT>) [392,24 202x22]
-          PaintableBox (Box<DIV>) [393,25 200x20]
-            PaintableWithLines (BlockContainer<DIV>) [395,26 196x18]
+        PaintableWithLines (TextAreaBox<TEXTAREA>) [218,26 166x36]
+          PaintableWithLines (BlockContainer<DIV>) [221,29 160x15]
+            PaintableWithLines (InlineNode<DIV>) [221,29 0x15]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (InlineNode<DIV>) [221,29 29.921875x15]
               TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
-        PaintableWithLines (TextAreaBox<TEXTAREA>) [602,8 166x36]
-          PaintableWithLines (BlockContainer<DIV>) [605,11 160x15]
-            PaintableWithLines (BlockContainer<DIV>) [605,11 160x15]
+        PaintableWithLines (TextInputBox<INPUT>) [392,42 202x22]
+          PaintableBox (Box<DIV>) [393,43 200x20]
+            PaintableWithLines (BlockContainer<DIV>) [395,44 196x18]
+              TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (TextAreaBox<TEXTAREA>) [602,26 166x36]
+          PaintableWithLines (BlockContainer<DIV>) [605,29 160x15]
+            PaintableWithLines (BlockContainer<DIV>) [605,29 160x15]
               TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x56] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x74] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Ref/expected/wpt-import/contenteditable/synthetic-height-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/contenteditable/synthetic-height-ref.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<title>CSS test reference</title>
+<style>
+  div { background: green; border: 1px solid; }
+</style>
+<div><br></div>
+<div><br></div>
+<div><br></div>
+<div><br></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/contenteditable/synthetic-height.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/contenteditable/synthetic-height.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>contenteditable causes blocks to have a synthesized height</title>
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1098151">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1634543">
+<link rel="help" href="https://github.com/w3c/editing/issues/70">
+<link rel="match" href="../../../expected/wpt-import/contenteditable/synthetic-height-ref.html">
+<style>
+  div { background: green; border: 1px solid; }
+  .pseudo::before {
+    content: "";
+  }
+  .abspos-pseudo::before {
+    position: absolute;
+  }
+</style>
+<div contenteditable></div>
+<div contenteditable><span style="position: absolute"></span></div>
+<div contenteditable class="pseudo"></div>
+<div contenteditable class="pseudo abspos-pseudo"></div>


### PR DESCRIPTION
Contenteditable elements that would otherwise have zero height now get a minimum height equal to their line-height. This ensures they remain clickable and usable for text editing.

This fixes the WPT test:
contenteditable/synthetic-height.html