### PR TITLE
RequestServer: Immediately attempt HTTP/3 connection 

### DIFF
--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -348,6 +348,7 @@ void Request::handle_fetch_state()
     set_option(CURLOPT_ALTSVC, m_alt_svc_cache_path.characters());
     // FIXME: This ignores h3 in the alt-svc header, as downgrading to HTTP/2 on failure is not yet supported.
     set_option(CURLOPT_ALTSVC_CTRL, CURLALTSVC_H1 | CURLALTSVC_H2);
+    set_option(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_NONE);
 
     set_option(CURLOPT_CUSTOMREQUEST, m_method.characters());
     set_option(CURLOPT_FOLLOWLOCATION, 0);


### PR DESCRIPTION
We now attempt a HTTP/3 connection immediately and fall back to earlier HTTP versions if it isn't available, we also ignore `h3` if present in the `alt-svc` header, as this breaks sites that advertise HTTP/3 support with this header, but don't actually support it.

Related to #5679, in that this fixes http://grafana.app.ladybird.org and similarly configured sites. The proper fix for this issue is to support graceful downgrading from HTTP/3 to HTTP/2.