### PR TITLE
LibWeb/WebGL: Don't set uniform if it's null or not from current context

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
@@ -248,89 +248,195 @@ void WebGL2RenderingContextImpl::tex_sub_image3d(WebIDL::UnsignedLong target, We
 void WebGL2RenderingContextImpl::uniform1ui(GC::Root<WebGLUniformLocation> location, WebIDL::UnsignedLong v0)
 {
     m_context->make_current();
-    glUniform1ui(location ? location->handle() : 0, v0);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform1ui(location_handle, v0);
 }
 
 void WebGL2RenderingContextImpl::uniform2ui(GC::Root<WebGLUniformLocation> location, WebIDL::UnsignedLong v0, WebIDL::UnsignedLong v1)
 {
     m_context->make_current();
-    glUniform2ui(location ? location->handle() : 0, v0, v1);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform2ui(location_handle, v0, v1);
 }
 
 void WebGL2RenderingContextImpl::uniform3ui(GC::Root<WebGLUniformLocation> location, WebIDL::UnsignedLong v0, WebIDL::UnsignedLong v1, WebIDL::UnsignedLong v2)
 {
     m_context->make_current();
-    glUniform3ui(location ? location->handle() : 0, v0, v1, v2);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform3ui(location_handle, v0, v1, v2);
 }
 
 void WebGL2RenderingContextImpl::uniform4ui(GC::Root<WebGLUniformLocation> location, WebIDL::UnsignedLong v0, WebIDL::UnsignedLong v1, WebIDL::UnsignedLong v2, WebIDL::UnsignedLong v3)
 {
     m_context->make_current();
-    glUniform4ui(location ? location->handle() : 0, v0, v1, v2, v3);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform4ui(location_handle, v0, v1, v2, v3);
 }
 
 void WebGL2RenderingContextImpl::uniform1uiv(GC::Root<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
 
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_uint32_list(values, src_offset, src_length), GL_INVALID_VALUE);
-    glUniform1uiv(location->handle(), span.size(), span.data());
+    glUniform1uiv(location_handle, span.size(), span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform2uiv(GC::Root<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_uint32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 2 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2uiv(location->handle(), span.size() / 2, span.data());
+    glUniform2uiv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform3uiv(GC::Root<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_uint32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 3 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3uiv(location->handle(), span.size() / 3, span.data());
+    glUniform3uiv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform4uiv(GC::Root<WebGLUniformLocation> location, Uint32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_uint32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 4 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4uiv(location->handle(), span.size() / 4, span.data());
+    glUniform4uiv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix3x2fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 3 * 2;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -338,15 +444,25 @@ void WebGL2RenderingContextImpl::uniform_matrix3x2fv(GC::Root<WebGLUniformLocati
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3x2fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix3x2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix4x2fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 4 * 2;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -354,15 +470,25 @@ void WebGL2RenderingContextImpl::uniform_matrix4x2fv(GC::Root<WebGLUniformLocati
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4x2fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix4x2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix2x3fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 2 * 3;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -370,15 +496,25 @@ void WebGL2RenderingContextImpl::uniform_matrix2x3fv(GC::Root<WebGLUniformLocati
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2x3fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix2x3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix4x3fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 4 * 3;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -386,15 +522,25 @@ void WebGL2RenderingContextImpl::uniform_matrix4x3fv(GC::Root<WebGLUniformLocati
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4x3fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix4x3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix2x4fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 2 * 4;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -402,15 +548,25 @@ void WebGL2RenderingContextImpl::uniform_matrix2x4fv(GC::Root<WebGLUniformLocati
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2x4fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix2x4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix3x4fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 3 * 4;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -418,7 +574,7 @@ void WebGL2RenderingContextImpl::uniform_matrix3x4fv(GC::Root<WebGLUniformLocati
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3x4fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix3x4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::vertex_attrib_i4i(WebIDL::UnsignedLong index, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z, WebIDL::Long w)
@@ -1380,120 +1536,210 @@ void WebGL2RenderingContextImpl::uniform1fv(GC::Root<WebGLUniformLocation> locat
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
 
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(values, src_offset, src_length), GL_INVALID_VALUE);
-    glUniform1fv(location->handle(), span.size(), span.data());
+    glUniform1fv(location_handle, span.size(), span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform2fv(GC::Root<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 2 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2fv(location->handle(), span.size() / 2, span.data());
+    glUniform2fv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform3fv(GC::Root<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 3 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3fv(location->handle(), span.size() / 3, span.data());
+    glUniform3fv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform4fv(GC::Root<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 4 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4fv(location->handle(), span.size() / 4, span.data());
+    glUniform4fv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform1iv(GC::Root<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
 
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_int32_list(values, src_offset, src_length), GL_INVALID_VALUE);
-    glUniform1iv(location->handle(), span.size(), span.data());
+    glUniform1iv(location_handle, span.size(), span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform2iv(GC::Root<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_int32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 2 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2iv(location->handle(), span.size() / 2, span.data());
+    glUniform2iv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform3iv(GC::Root<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_int32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 3 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3iv(location->handle(), span.size() / 3, span.data());
+    glUniform3iv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform4iv(GC::Root<WebGLUniformLocation> location, Int32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_int32_list(values, src_offset, src_length), GL_INVALID_VALUE);
     if (span.size() % 4 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4iv(location->handle(), span.size() / 4, span.data());
+    glUniform4iv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix2fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 2 * 2;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -1501,15 +1747,25 @@ void WebGL2RenderingContextImpl::uniform_matrix2fv(GC::Root<WebGLUniformLocation
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix3fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 3 * 3;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -1517,15 +1773,25 @@ void WebGL2RenderingContextImpl::uniform_matrix3fv(GC::Root<WebGLUniformLocation
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::uniform_matrix4fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
 
     constexpr auto matrix_size = 4 * 4;
     auto span = SET_ERROR_VALUE_IF_ERROR(span_from_float32_list(data, src_offset, src_length), GL_INVALID_VALUE);
@@ -1533,7 +1799,7 @@ void WebGL2RenderingContextImpl::uniform_matrix4fv(GC::Root<WebGLUniformLocation
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGL2RenderingContextImpl::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, GC::Root<WebIDL::ArrayBufferView> pixels)
@@ -3186,7 +3452,7 @@ GC::Root<WebGLUniformLocation> WebGL2RenderingContextImpl::get_uniform_location(
     if (location == -1)
         return nullptr;
 
-    return WebGLUniformLocation::create(m_realm, location);
+    return WebGLUniformLocation::create(m_realm, *this, location);
 }
 
 JS::Value WebGL2RenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong index, WebIDL::UnsignedLong pname)
@@ -3504,49 +3770,161 @@ void WebGL2RenderingContextImpl::tex_parameteri(WebIDL::UnsignedLong target, Web
 void WebGL2RenderingContextImpl::uniform1f(GC::Root<WebGLUniformLocation> location, float x)
 {
     m_context->make_current();
-    glUniform1f(location ? location->handle() : 0, x);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform1f(location_handle, x);
 }
 
 void WebGL2RenderingContextImpl::uniform2f(GC::Root<WebGLUniformLocation> location, float x, float y)
 {
     m_context->make_current();
-    glUniform2f(location ? location->handle() : 0, x, y);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform2f(location_handle, x, y);
 }
 
 void WebGL2RenderingContextImpl::uniform3f(GC::Root<WebGLUniformLocation> location, float x, float y, float z)
 {
     m_context->make_current();
-    glUniform3f(location ? location->handle() : 0, x, y, z);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform3f(location_handle, x, y, z);
 }
 
 void WebGL2RenderingContextImpl::uniform4f(GC::Root<WebGLUniformLocation> location, float x, float y, float z, float w)
 {
     m_context->make_current();
-    glUniform4f(location ? location->handle() : 0, x, y, z, w);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform4f(location_handle, x, y, z, w);
 }
 
 void WebGL2RenderingContextImpl::uniform1i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x)
 {
     m_context->make_current();
-    glUniform1i(location ? location->handle() : 0, x);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform1i(location_handle, x);
 }
 
 void WebGL2RenderingContextImpl::uniform2i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y)
 {
     m_context->make_current();
-    glUniform2i(location ? location->handle() : 0, x, y);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform2i(location_handle, x, y);
 }
 
 void WebGL2RenderingContextImpl::uniform3i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z)
 {
     m_context->make_current();
-    glUniform3i(location ? location->handle() : 0, x, y, z);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform3i(location_handle, x, y, z);
 }
 
 void WebGL2RenderingContextImpl::uniform4i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z, WebIDL::Long w)
 {
     m_context->make_current();
-    glUniform4i(location ? location->handle() : 0, x, y, z, w);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform4i(location_handle, x, y, z, w);
 }
 
 void WebGL2RenderingContextImpl::use_program(GC::Root<WebGLProgram> program)

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -202,149 +202,270 @@ void WebGLRenderingContextImpl::uniform1fv(GC::Root<WebGLUniformLocation> locati
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_float32_list(v, /* src_offset= */ 0));
-    glUniform1fv(location->handle(), span.size(), span.data());
+    glUniform1fv(location_handle, span.size(), span.data());
 }
 
 void WebGLRenderingContextImpl::uniform2fv(GC::Root<WebGLUniformLocation> location, Float32List v)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_float32_list(v, /* src_offset= */ 0));
     if (span.size() % 2 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2fv(location->handle(), span.size() / 2, span.data());
+    glUniform2fv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform3fv(GC::Root<WebGLUniformLocation> location, Float32List v)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_float32_list(v, /* src_offset= */ 0));
     if (span.size() % 3 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3fv(location->handle(), span.size() / 3, span.data());
+    glUniform3fv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform4fv(GC::Root<WebGLUniformLocation> location, Float32List v)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_float32_list(v, /* src_offset= */ 0));
     if (span.size() % 4 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4fv(location->handle(), span.size() / 4, span.data());
+    glUniform4fv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform1iv(GC::Root<WebGLUniformLocation> location, Int32List v)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_int32_list(v, /* src_offset= */ 0));
-    glUniform1iv(location->handle(), span.size(), span.data());
+    glUniform1iv(location_handle, span.size(), span.data());
 }
 
 void WebGLRenderingContextImpl::uniform2iv(GC::Root<WebGLUniformLocation> location, Int32List v)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_int32_list(v, /* src_offset= */ 0));
     if (span.size() % 2 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform2iv(location->handle(), span.size() / 2, span.data());
+    glUniform2iv(location_handle, span.size() / 2, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform3iv(GC::Root<WebGLUniformLocation> location, Int32List v)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_int32_list(v, /* src_offset= */ 0));
     if (span.size() % 3 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform3iv(location->handle(), span.size() / 3, span.data());
+    glUniform3iv(location_handle, span.size() / 3, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform4iv(GC::Root<WebGLUniformLocation> location, Int32List v)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     auto span = MUST(span_from_int32_list(v, /* src_offset= */ 0));
     if (span.size() % 4 != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniform4iv(location->handle(), span.size() / 4, span.data());
+    glUniform4iv(location_handle, span.size() / 4, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform_matrix2fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List value)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     constexpr auto matrix_size = 2 * 2;
     auto span = MUST(span_from_float32_list(value, /* src_offset= */ 0));
     if (span.size() % matrix_size != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix2fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix2fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform_matrix3fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List value)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     constexpr auto matrix_size = 3 * 3;
     auto span = MUST(span_from_float32_list(value, /* src_offset= */ 0));
     if (span.size() % matrix_size != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix3fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix3fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGLRenderingContextImpl::uniform_matrix4fv(GC::Root<WebGLUniformLocation> location, bool transpose, Float32List value)
 {
     m_context->make_current();
 
-    if (!location)
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
         return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
     constexpr auto matrix_size = 4 * 4;
     auto span = MUST(span_from_float32_list(value, /* src_offset= */ 0));
     if (span.size() % matrix_size != 0) [[unlikely]] {
         set_error(GL_INVALID_VALUE);
         return;
     }
-    glUniformMatrix4fv(location->handle(), span.size() / matrix_size, transpose, span.data());
+    glUniformMatrix4fv(location_handle, span.size() / matrix_size, transpose, span.data());
 }
 
 void WebGLRenderingContextImpl::active_texture(WebIDL::UnsignedLong texture)
@@ -1695,7 +1816,7 @@ GC::Root<WebGLUniformLocation> WebGLRenderingContextImpl::get_uniform_location(G
     if (location == -1)
         return nullptr;
 
-    return WebGLUniformLocation::create(m_realm, location);
+    return WebGLUniformLocation::create(m_realm, *this, location);
 }
 
 JS::Value WebGLRenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong index, WebIDL::UnsignedLong pname)
@@ -2019,49 +2140,161 @@ void WebGLRenderingContextImpl::tex_parameteri(WebIDL::UnsignedLong target, WebI
 void WebGLRenderingContextImpl::uniform1f(GC::Root<WebGLUniformLocation> location, float x)
 {
     m_context->make_current();
-    glUniform1f(location ? location->handle() : 0, x);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform1f(location_handle, x);
 }
 
 void WebGLRenderingContextImpl::uniform2f(GC::Root<WebGLUniformLocation> location, float x, float y)
 {
     m_context->make_current();
-    glUniform2f(location ? location->handle() : 0, x, y);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform2f(location_handle, x, y);
 }
 
 void WebGLRenderingContextImpl::uniform3f(GC::Root<WebGLUniformLocation> location, float x, float y, float z)
 {
     m_context->make_current();
-    glUniform3f(location ? location->handle() : 0, x, y, z);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform3f(location_handle, x, y, z);
 }
 
 void WebGLRenderingContextImpl::uniform4f(GC::Root<WebGLUniformLocation> location, float x, float y, float z, float w)
 {
     m_context->make_current();
-    glUniform4f(location ? location->handle() : 0, x, y, z, w);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform4f(location_handle, x, y, z, w);
 }
 
 void WebGLRenderingContextImpl::uniform1i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x)
 {
     m_context->make_current();
-    glUniform1i(location ? location->handle() : 0, x);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform1i(location_handle, x);
 }
 
 void WebGLRenderingContextImpl::uniform2i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y)
 {
     m_context->make_current();
-    glUniform2i(location ? location->handle() : 0, x, y);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform2i(location_handle, x, y);
 }
 
 void WebGLRenderingContextImpl::uniform3i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z)
 {
     m_context->make_current();
-    glUniform3i(location ? location->handle() : 0, x, y, z);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform3i(location_handle, x, y, z);
 }
 
 void WebGLRenderingContextImpl::uniform4i(GC::Root<WebGLUniformLocation> location, WebIDL::Long x, WebIDL::Long y, WebIDL::Long z, WebIDL::Long w)
 {
     m_context->make_current();
-    glUniform4i(location ? location->handle() : 0, x, y, z, w);
+
+    // "If the passed location is not null and was not obtained from the currently used program via an earlier call to
+    //  getUniformLocation, an INVALID_OPERATION error will be generated. If the passed location is null, the data
+    //  passed in will be silently ignored and no uniform variables will be changed."
+    if (!location) [[unlikely]]
+        return;
+
+    auto handle_or_error = location->handle(this);
+    if (handle_or_error.is_error()) [[unlikely]] {
+        set_error(GL_INVALID_OPERATION);
+        return;
+    }
+    auto location_handle = handle_or_error.release_value();
+
+    glUniform4i(location_handle, x, y, z, w);
 }
 
 void WebGLRenderingContextImpl::use_program(GC::Root<WebGLProgram> program)

--- a/Libraries/LibWeb/WebGL/WebGLUniformLocation.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLUniformLocation.cpp
@@ -11,17 +11,20 @@
 #include <LibWeb/Bindings/WebGLUniformLocationPrototype.h>
 #include <LibWeb/WebGL/WebGLUniformLocation.h>
 
+#include <GLES2/gl2.h>
+
 namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLUniformLocation);
 
-GC::Ref<WebGLUniformLocation> WebGLUniformLocation::create(JS::Realm& realm, GLuint handle)
+GC::Ref<WebGLUniformLocation> WebGLUniformLocation::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
 {
-    return realm.create<WebGLUniformLocation>(realm, handle);
+    return realm.create<WebGLUniformLocation>(realm, context, handle);
 }
 
-WebGLUniformLocation::WebGLUniformLocation(JS::Realm& realm, GLuint handle)
+WebGLUniformLocation::WebGLUniformLocation(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
     : Bindings::PlatformObject(realm)
+    , m_context(&context)
     , m_handle(handle)
 {
 }
@@ -32,6 +35,19 @@ void WebGLUniformLocation::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(WebGLUniformLocation);
     Base::initialize(realm);
+}
+
+void WebGLUniformLocation::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_context->gc_cell());
+}
+
+ErrorOr<GLint> WebGLUniformLocation::handle(WebGLRenderingContextBase const* context) const
+{
+    if (context == m_context) [[likely]]
+        return m_handle;
+    return Error::from_errno(GL_INVALID_OPERATION);
 }
 
 }

--- a/Libraries/LibWeb/WebGL/WebGLUniformLocation.h
+++ b/Libraries/LibWeb/WebGL/WebGLUniformLocation.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/WebGL/Types.h>
+#include <LibWeb/WebGL/WebGLRenderingContextBase.h>
 
 namespace Web::WebGL {
 
@@ -17,18 +18,22 @@ class WebGLUniformLocation final : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(WebGLUniformLocation);
 
 public:
-    static GC::Ref<WebGLUniformLocation> create(JS::Realm& realm, GLuint handle);
+    static GC::Ref<WebGLUniformLocation> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
 
     virtual ~WebGLUniformLocation();
 
-    GLuint handle() const { return m_handle; }
+    ErrorOr<GLint> handle(WebGLRenderingContextBase const* context) const;
 
 protected:
-    explicit WebGLUniformLocation(JS::Realm&, GLuint handle);
+    explicit WebGLUniformLocation(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Visitor&) override;
 
-    GLuint m_handle { 0 };
+    // FIXME: It should be GC::Ptr instead of raw pointer, but we need to make WebGLRenderingContextBase inherit from PlatformObject first.
+    WebGLRenderingContextBase* m_context;
+
+    GLint m_handle { 0 };
 };
 
 }


### PR DESCRIPTION
Fixes regression on noclip.website where most of the textures were blank, since we overrided anything in uniform location 0 if the location was null, which is a valid location.