### PR TITLE
LibWeb: Correct the early exit condition in AudioPaintable::paint()

### DIFF
--- a/Libraries/LibWeb/Painting/AudioPaintable.cpp
+++ b/Libraries/LibWeb/Painting/AudioPaintable.cpp
@@ -35,7 +35,7 @@ void AudioPaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
         return;
 
     auto const& audio_element = as<HTML::HTMLAudioElement const>(*dom_node());
-    if (audio_element.should_paint())
+    if (!audio_element.should_paint())
         return;
 
     Base::paint(context, phase);


### PR DESCRIPTION
We're not painting controls for audio elements that are supposed to have them!