### PR TITLE
Base: Align text properly next to icon in version page

### DIFF
--- a/Base/res/ladybird/templates/version.html
+++ b/Base/res/ladybird/templates/version.html
@@ -7,6 +7,10 @@
             html {
                 color-scheme: light dark;
             }
+            header {
+                display: flex;
+                align-items: center;
+            }
             img {
                 float: left;
                 margin-right: 10px;


### PR DESCRIPTION
Before:
<img width="832" height="593" alt="Screenshot 2025-11-03 215744" src="https://github.com/user-attachments/assets/87bd9a75-0d56-4095-b3cc-c5f262d84c8e" />

After:
<img width="824" height="584" alt="Screenshot 2025-11-03 215721" src="https://github.com/user-attachments/assets/abade729-4054-41ac-91fe-f4b0eb72fce8" />
