### PR TITLE
LibWeb: Propagate style values in deep anonymous wrappers

### DIFF
--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -271,6 +271,7 @@ private:
     virtual bool is_node_with_style() const final { return true; }
 
     void reset_table_box_computed_values_used_by_wrapper_to_init_values();
+    void propagate_non_inherit_values(NodeWithStyle& target_node) const;
     void propagate_style_to_anonymous_wrappers();
 
     NonnullOwnPtr<CSS::ComputedValues> m_computed_values;

--- a/Tests/LibWeb/Ref/expected/button-hover-text-color-ref.html
+++ b/Tests/LibWeb/Ref/expected/button-hover-text-color-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+  .btn {
+    color: white;
+    background: black;
+  }
+</style>
+<button type="button" class="btn">BUTTON</button>

--- a/Tests/LibWeb/Ref/input/button-hover-text-color.html
+++ b/Tests/LibWeb/Ref/input/button-hover-text-color.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/button-hover-text-color-ref.html" />
+<style>
+    .btn {
+        background: black;
+        color: red;
+    }
+
+    .btn:hover {
+        color: white;
+    }
+</style>
+<button type="button" class="btn">BUTTON</button>
+<script>
+    requestAnimationFrame(() => internals.movePointerTo(15, 15));
+</script>


### PR DESCRIPTION
`wrap_in_button_layout_tree_if_needed` creates two nested anonymous wrapper. With this fix styles get propagated two the children.

fixes #4676 