### PR TITLE
LibWeb/CSS: Apply easing function to segments of keyframes

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.h
+++ b/Libraries/LibWeb/Animations/AnimationEffect.h
@@ -151,10 +151,10 @@ public:
     AnimationDirection current_direction() const;
     Optional<double> simple_iteration_progress() const;
     Optional<double> current_iteration() const;
-    Optional<double> transformed_progress() const;
 
     HashTable<CSS::PropertyID> const& target_properties() const { return m_target_properties; }
 
+    virtual Optional<double> transformed_progress() const;
     virtual DOM::Element* target() const { return {}; }
     virtual bool is_keyframe_effect() const { return false; }
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.h
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.h
@@ -102,9 +102,10 @@ public:
     WebIDL::ExceptionOr<GC::RootVector<JS::Object*>> get_keyframes();
     WebIDL::ExceptionOr<void> set_keyframes(Optional<GC::Root<JS::Object>> const&);
 
-    KeyFrameSet const* key_frame_set() { return m_key_frame_set; }
+    KeyFrameSet const* key_frame_set() const { return m_key_frame_set; }
     void set_key_frame_set(RefPtr<KeyFrameSet const> key_frame_set) { m_key_frame_set = key_frame_set; }
 
+    virtual Optional<double> transformed_progress() const override;
     virtual bool is_keyframe_effect() const override { return true; }
 
     virtual void update_computed_properties(AnimationUpdateContext&) override;


### PR DESCRIPTION
Fixes [6549](https://github.com/LadybirdBrowser/ladybird/issues/6549).

Ladybird is applying easing functions for the whole duration of an animation, while other browser apply it to segments of it.
