### PR TITLE
LibWeb/WebGL: Respect UNPACK_PREMULTIPLY_ALPHA

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
@@ -2992,6 +2992,8 @@ JS::Value WebGL2RenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
     }
     case UNPACK_FLIP_Y_WEBGL:
         return JS::Value(m_unpack_flip_y);
+    case UNPACK_PREMULTIPLY_ALPHA_WEBGL:
+        return JS::Value(m_unpack_premultiply_alpha);
     case MAX_CLIENT_WAIT_TIMEOUT_WEBGL: {
         // FIXME: Make this an actual limit
         return JS::js_infinity();
@@ -3397,6 +3399,9 @@ void WebGL2RenderingContextImpl::pixel_storei(WebIDL::UnsignedLong pname, WebIDL
     switch (pname) {
     case UNPACK_FLIP_Y_WEBGL:
         m_unpack_flip_y = param != GL_FALSE;
+        return;
+    case UNPACK_PREMULTIPLY_ALPHA_WEBGL:
+        m_unpack_premultiply_alpha = param != GL_FALSE;
         return;
     }
 

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -166,11 +166,10 @@ Optional<WebGLRenderingContextBase::ConvertedTexture> WebGLRenderingContextBase:
     auto buffer = MUST(ByteBuffer::create_zeroed(buffer_pitch.value() * height));
 
     if (width > 0 && height > 0) {
-        // FIXME: Respect UNPACK_PREMULTIPLY_ALPHA_WEBGL
         // FIXME: Respect unpackColorSpace
         auto skia_format = opengl_format_and_type_to_skia_color_type(format, type);
         auto color_space = SkColorSpace::MakeSRGB();
-        auto image_info = SkImageInfo::Make(width, height, skia_format, SkAlphaType::kPremul_SkAlphaType, color_space);
+        auto image_info = SkImageInfo::Make(width, height, skia_format, m_unpack_premultiply_alpha ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType, color_space);
         auto surface = SkSurfaces::WrapPixels(image_info, buffer.data(), buffer_pitch.value());
         VERIFY(surface);
         auto surface_canvas = surface->getCanvas();

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -16,6 +16,7 @@ namespace Web::WebGL {
 
 static constexpr int COMPRESSED_TEXTURE_FORMATS = 0x86A3;
 static constexpr int UNPACK_FLIP_Y_WEBGL = 0x9240;
+static constexpr int UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241;
 static constexpr int MAX_CLIENT_WAIT_TIMEOUT_WEBGL = 0x9247;
 
 // NOTE: This is the Variant created by the IDL wrapper generator, and needs to be updated accordingly.
@@ -121,6 +122,12 @@ protected:
     //      the vertical axis, so that conceptually the last row is the first one transferred. The initial value is false.
     //      Any non-zero value is interpreted as true.
     bool m_unpack_flip_y { false };
+
+    // UNPACK_PREMULTIPLY_ALPHA_WEBGL of type boolean
+    //      If set, then during any subsequent calls to texImage2D or texSubImage2D, the alpha channel of the source data,
+    //      if present, is multiplied into the color channels during the data transfer. The initial value is false.
+    //      Any non-zero value is interpreted as true.
+    bool m_unpack_premultiply_alpha { false };
 };
 
 }

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -1509,6 +1509,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
     }
     case UNPACK_FLIP_Y_WEBGL:
         return JS::Value(m_unpack_flip_y);
+    case UNPACK_PREMULTIPLY_ALPHA_WEBGL:
+        return JS::Value(m_unpack_premultiply_alpha);
     default:
         dbgln("Unknown WebGL parameter name: {:x}", pname);
         set_error(GL_INVALID_ENUM);
@@ -1906,6 +1908,9 @@ void WebGLRenderingContextImpl::pixel_storei(WebIDL::UnsignedLong pname, WebIDL:
     switch (pname) {
     case UNPACK_FLIP_Y_WEBGL:
         m_unpack_flip_y = param != GL_FALSE;
+        return;
+    case UNPACK_PREMULTIPLY_ALPHA_WEBGL:
+        m_unpack_premultiply_alpha = param != GL_FALSE;
         return;
     }
 


### PR DESCRIPTION
Fixes splats on https://superspl.at having dark splotches, as they expect textures with unpremultiplied alpha.

Before:
<img width="1624" height="990" alt="Screenshot 2025-11-04 at 14 12 08" src="https://github.com/user-attachments/assets/d6a6d92f-5ec7-44b0-998f-cfdbd01b3e16" />

After:
<img width="1624" height="990" alt="Screenshot 2025-11-04 at 14 22 14" src="https://github.com/user-attachments/assets/9334373e-3f2d-4810-8c75-0aaa3c3d0056" />
