### PR TITLE
LibWeb: Create an execution context before registering import map

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/Fetching.h>
 #include <LibWeb/HTML/Scripting/ImportMapParseResult.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Infra/Strings.h>
@@ -154,6 +155,8 @@ void HTMLScriptElement::execute_script()
     }
     // -> "importmap"
     else if (m_script_type == ScriptType::ImportMap) {
+        HTML::TemporaryExecutionContext execution_context { realm() };
+
         // 1. Register an import map given el's relevant global object and el's result.
         m_result.get<GC::Ref<ImportMapParseResult>>()->register_import_map(as<Window>(relevant_global_object(*this)));
     }

--- a/Tests/LibWeb/Text/input/HTML/import-maps-invalid.html
+++ b/Tests/LibWeb/Text/input/HTML/import-maps-invalid.html
@@ -3,6 +3,69 @@
 <script type="importmap">
     Invalid import map.
 </script>
+<script type="importmap">
+    null
+</script>
+<script type="importmap">
+    0
+</script>
+<script type="importmap">
+    ["invalid", "import", "map"]
+</script>
+<script type="importmap">
+    {
+        "imports": null
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": 0
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": []
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": { "application": "./import-maps-1.js" },
+        "scopes": null
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": { "application": "./import-maps-1.js" },
+        "scopes": 0
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": { "application": "./import-maps-1.js" },
+        "scopes": []
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": { "application": "./import-maps-1.js" },
+	"integrity": null
+
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": { "application": "./import-maps-1.js" },
+	"integrity": 0
+
+    }
+</script>
+<script type="importmap">
+    {
+        "imports": { "application": "./import-maps-1.js" },
+	"integrity": []
+
+    }
+</script>
 <script type="module">
     test(() => {
         println("PASS");


### PR DESCRIPTION
Fixes #6297


------

Note to reviewer: I just want to say that (a) I am new in this code base and (b) I found this fix more-or-less by trial and error.  I don't have a deep understanding of why this is fixing the issue, or if this is the best form for this fix.  It seems like an awkward fix to me.  I would be happy to iterate on it given some guidance.  I am not sure the tests are executing properly.

With this fix in place, loading the HTML in the bug report produces:

```
4405501.614 WebContent(13493): Unhandled JavaScript exception: [TypeError] The top-level value of an importmap needs to be a JSON object.
4405501.614 WebContent(13493):
```

And no extraneous output or crash.