### PR TITLE
LibWeb: Define SVGImageElement destructor for Core::Timer forward decl

### DIFF
--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -27,6 +27,8 @@ SVGImageElement::SVGImageElement(DOM::Document& document, DOM::QualifiedName qua
     m_animation_timer->on_timeout = [this] { animate(); };
 }
 
+SVGImageElement::~SVGImageElement() = default;
+
 void SVGImageElement::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGImageElement);

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -20,6 +20,8 @@ class SVGImageElement final
     WEB_PLATFORM_OBJECT(SVGImageElement, SVGGraphicsElement);
 
 public:
+    ~SVGImageElement();
+
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     GC::Ref<SVG::SVGAnimatedLength> x();


### PR DESCRIPTION
<details>

<summary>On master the Windows build is currently failing with the following build error:</summary>

```
[19/476] Building CXX object Lagom\Libraries\LibWeb\CMak...b.dir\Bindings\CanvasRenderingContext2DPrototype.cpp.obj
FAILED: Lagom/Libraries/LibWeb/CMakeFiles/LibWeb.dir/Bindings/CanvasRenderingContext2DPrototype.cpp.obj
C:\ProgramData\chocolatey\bin\ccache.exe C:\PROGRA~1\LLVM\bin\clang-cl.exe  /nologo -TP -DENABLE_COMPILETIME_FORMAT_CHECK -DLibWeb_EXPORTS -DNAME_MAX=255 -DNOMINMAX -DSKCMS_API=__declspec(dllimport) -DSK_CODEC_DECODES_BMP -DSK_CODEC_DECODES_GIF -DSK_CODEC_DECODES_ICO -DSK_CODEC_DECODES_JPEG -DSK_CODEC_DECODES_PNG -DSK_CODEC_DECODES_WBMP -DSK_CODEC_DECODES_WEBP -DSK_DISABLE_TRACING -DSK_ENABLE_AVX512_OPTS -DSK_ENABLE_PRECOMPILE -DSK_FONTMGR_ANDROID_AVAILABLE -DSK_FONTMGR_DIRECTWRITE_AVAILABLE -DSK_FONTMGR_FONTCONFIG_AVAILABLE -DSK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE -DSK_FONTMGR_FREETYPE_EMBEDDED_AVAILABLE -DSK_FONTMGR_FREETYPE_EMPTY_AVAILABLE -DSK_FONTMGR_GDI_AVAILABLE -DSK_GAMMA_APPLY_TO_A8 -DSK_GANESH -DSK_GL -DSK_HAS_WUFFS_LIBRARY -DSK_SUPPORT_PDF -DSK_SUPPORT_XPS -DSK_TYPEFACE_FACTORY_DIRECTWRITE -DSK_TYPEFACE_FACTORY_FREETYPE -DSK_USE_VMA -DSK_VULKAN -DSK_XML -DUSE_FONTCONFIG=1 -DUSE_VULKAN=1 -DWIN32_LEAN_AND_MEAN -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES -D_WIN32_WINNT=0x0A00 -IC:\Users\ayeteadoe\Development\ladybird -IC:\Users\ayeteadoe\Development\ladybird\Services -IC:\Users\ayeteadoe\Development\ladybird\Libraries -IC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\Lagom -IC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\Lagom\Services -IC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\Lagom\Libraries -IC:\Users\ayeteadoe\Development\ladybird\Meta\Lagom\..\.. -IC:\Users\ayeteadoe\Development\ladybird\Meta\Lagom\..\..\Libraries -IC:\Users\ayeteadoe\Development\ladybird\Meta\Lagom\..\..\Services -IC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers -IC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\vcpkg_installed\x64-windows\include\mman -imsvcC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\vcpkg_installed\x64-windows\include -imsvcC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\vcpkg_installed\x64-windows\include\skia -imsvcC:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\vcpkg_installed\x64-windows\include\libxml2 /DWIN32 /D_WINDOWS /EHsc /O2 /Ob1 /DNDEBUG -clang:-std=c++23 -MD -Zi /arch:AVX2 -Wno-reinterpret-base-class -Wno-microsoft-unqualified-friend -Wno-deprecated-declarations /W4 /EHs- /fp:precise /Zc:inline /Zc:dllexportInlines- -fstrict-aliasing /Gw -gcodeview-ghash -Wcast-qual -Wformat=2 -Wimplicit-fallthrough -Wlogical-op -Wmissing-declarations -Wmissing-field-initializers -Wsuggest-override -Wno-invalid-offsetof -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wpadded-bitfield -Werror -Wno-implicit-const-int-float-conversion -Wno-reserved-identifier -Wno-user-defined-literals -Wno-unqualified-std-cast-call -fsanitize=address /clang:-fno-omit-frame-pointer -fsanitize=undefined -Wno-maybe-uninitialized -Wno-shorten-64-to-32 /Z7 -O2 /showIncludes /FoLagom\Libraries\LibWeb\CMakeFiles\LibWeb.dir\Bindings\CanvasRenderingContext2DPrototype.cpp.obj /FdLagom\Libraries\LibWeb\CMakeFiles\LibWeb.dir\ -c -- C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\Lagom\Libraries\LibWeb\Bindings\CanvasRenderingContext2DPrototype.cpp
In file included from C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\Lagom\Libraries\LibWeb\Bindings\CanvasRenderingContext2DPrototype.cpp:3:
In file included from C:\Users\ayeteadoe\Development\ladybird\Libraries\LibIDL/Types.h:13:
In file included from C:\Users\ayeteadoe\Development\ladybird\AK/ByteString.h:9:
In file included from C:\Users\ayeteadoe\Development\ladybird\AK/ByteStringImpl.h:10:
C:\Users\ayeteadoe\Development\ladybird\AK/NonnullRefPtr.h(32,12): error: member access into incomplete type 'Core::Timer'
   32 |         ptr->unref();
      |            ^
C:\Users\ayeteadoe\Development\ladybird\AK/RefPtr.h(223,9): note: in instantiation of function template specialization 'AK::unref_if_not_null<Core::Timer>' requested here
  223 |         unref_if_not_null(ptr);
      |         ^
C:\Users\ayeteadoe\Development\ladybird\AK/RefPtr.h(103,9): note: in instantiation of member function 'AK::RefPtr<Core::Timer>::clear' requested here
  103 |         clear();
      |         ^
C:\Users\ayeteadoe\Development\ladybird\Libraries\LibWeb/SVG/SVGImageElement.h(16,7): note: in instantiation of member function 'AK::RefPtr<Core::Timer>::~RefPtr' requested here
   16 | class SVGImageElement final
      |       ^
C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\Lagom\Libraries\LibWeb\Bindings\CanvasRenderingContext2DPrototype.cpp(2653,21): note: in instantiation of function template specialization 'AK::is<Web::SVG::SVGImageElement, JS::Object>' requested here
 2653 |                 if (is<SVGImageElement>(arg0_object))
      |                     ^
C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore/Forward.h(45,7): note: forward declaration of 'Core::Timer'
   45 | class Timer;
      |       ^
1 error generated.
[50/476] Building CXX object Lagom\Libraries\LibWeb\CMak...s\LibWeb.dir\Bindings\HTMLOutputElementPrototype.cpp.obj
ninja: build stopped: interrupted by user.
```

</details>

I bisected the failure to https://github.com/LadybirdBrowser/ladybird/commit/cebd4cc10d1f5051dd54609dc8262fba3b8a2f35