### PR TITLE
LibWeb: Fire click event when hitting Enter/space on focused element

### DIFF
--- a/Tests/LibWeb/Text/expected/keypress-on-focused-button-triggers-onclick.txt
+++ b/Tests/LibWeb/Text/expected/keypress-on-focused-button-triggers-onclick.txt
@@ -1,0 +1,8 @@
+<BUTTON id="button1">
+Clicked button 1
+Clicked button 1
+Clicked button 1
+Clicked button 1
+Clicked button 1
+Clicked button 1
+<BUTTON id="button2">

--- a/Tests/LibWeb/Text/input/keypress-on-focused-button-triggers-onclick.html
+++ b/Tests/LibWeb/Text/input/keypress-on-focused-button-triggers-onclick.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<button id="button1">Button 1</button>
+<button id="button2">Button 2</button>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        let button1 = document.getElementById("button1");
+        let button2 = document.getElementById("button2");
+
+        button1.addEventListener("click", e => {
+            println("Clicked button 1");
+        });
+        button2.addEventListener("click", e => {
+            println("Clicked button 2");
+        });
+
+        internals.sendKey(document.body, "Tab");
+        printElement(document.activeElement);
+        internals.sendKey(document.body, "Return");
+        internals.sendKey(document.body, "Return", internals.MOD_ALT);
+        internals.sendKey(document.body, "Return", internals.MOD_CTRL);
+        internals.sendKey(document.body, "Return", internals.MOD_SHIFT);
+        internals.sendKey(document.body, "Return", internals.MOD_SUPER);
+        internals.sendKey(document.body, "Return", internals.MOD_KEYPAD);
+
+        internals.sendKey(document.body, "Tab");
+        printElement(document.activeElement);
+        // FIXME: figure out a way to test keyup event
+        // document.activeElement.dispatchEvent(new KeyboardEvent("keyup", {key: "Space"}));
+        // internals.sendKey(document.body, "Space");
+    });
+</script>


### PR DESCRIPTION
Now when an element is focused, hitting the Enter/space key will fire a click event on that element. This behaviour is consistent with both Firefox and Chromium.

Closes #6703.

### Notes

One potential caveat is what to do with keyboard modifiers: On Linux, Firefox doesn't care if any modifier is used, but Chromium does not fire events for the Enter key when used with certain modifiers. I haven't tested any other browsers, or tested these browsers on MacOS/Windows.

Here is a list of the modifiers I tested, and how each browser handled it:

**Legend**

| Status | Meaning |
|--------|---------|
| (empty)| No click event fired |
| X      | Single click event fired |
| Each   | A click event is fired for Each key press/repeat |
| Up     | A click event is only fired on keyup |

| Browser  | Repeat? | Key + | None | NumPad | LeftCtrl | RightCtrl | LeftShift | RightShift | LeftAlt | RightAlt | Super |
|----------|---------|-------|------|--------|----------|-----------|-----------|------------|---------|----------|-------|
| Ladybird | No      | Enter | X    | X      | X        | X         | X         | X          | X       | X        | X     |
| Ladybird | No      | Space | X    | N/A    | X        | X         | X         | X          | X       | X        | X     |
| Ladybird | Yes     | Enter | Each | Each   | Each     | Each      | Each      | Each       | Each    | Each     | Each  |
| Ladybird | Yes     | Space | Up   | N/A    | Up       | Up        | Up        | Up         | Up      | Up       | Up    |
|          |         |       |      |        |          |           |           |            |         |          |       |
| Firefox  | No      | Enter | X    | X      | X        | X         | X         | X          | X       | X        | X     |
| Firefox  | No      | Space | X    | N/A    | X        | X         | X         | X          | X       | X        | X     |
| Firefox  | Yes     | Enter | Each | Each   | Each     | Each      | Each      | Each       | Each    | Each     | Each  |
| Firefox  | Yes     | Space | Up   | N/A    | Up       | Up        | Up        | Up         | Up      | Up       | Up    |
|          |         |       |      |        |          |           |           |            |         |          |       |
| Chromium | No      | Enter | X    | X      |          |           | X         | X          |         |          | X     |
| Chromium | No      | Space | X    | N/A    |          |           | X         | X          |         |          | X     | 
| Chromium | Yes     | Enter | Each | Each   |       |        | Each      | Each       |     |      | Each  |
| Chromium | Yes     | Space | Up   | N/A    | Up       | Up        | Up        | Up         | Up      | Up       | Up    |

~~I don't know what the procedure is for handling discrepancies between browsers, but for me, ignoring the modifier seems easiest.~~

I've opted to use Firefox's behavior since it is the most straightforward to implement.