### PR TITLE
LibWeb: Explicitly disallow skipping 0 characters in HTML tokenizer

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -220,6 +220,7 @@ Optional<u32> HTMLTokenizer::next_code_point(StopAtInsertionPoint stop_at_insert
 
 void HTMLTokenizer::skip(size_t count)
 {
+    VERIFY(count > 0);
     if (!m_source_positions.is_empty())
         m_source_positions.append(m_source_positions.last());
     for (size_t i = 0; i < count; ++i) {
@@ -1725,7 +1726,7 @@ _StartOfFunction:
                     auto num_consumed = m_temporary_buffer.size() - starting_consumed_count;
                     if (num_consumed == 0) {
                         DONT_CONSUME_NEXT_INPUT_CHARACTER;
-                    } else {
+                    } else if (num_consumed > 1) {
                         skip(num_consumed - 1);
                     }
                 }

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -266,3 +266,12 @@ TEST_CASE(regression)
     u32 hash = hash_tokens(tokens);
     EXPECT_EQ(hash, 3657343287u);
 }
+
+TEST_CASE(ambiguous_ampersand_offset)
+{
+    auto tokens = run_tokenizer("&a"sv);
+    auto& token = tokens.first();
+    EXPECT_EQ(token.type(), Token::Type::Character);
+    EXPECT_EQ(token.start_position().line, 0u);
+    EXPECT_EQ(token.start_position().column, 1u);
+}


### PR DESCRIPTION
Previously, this caused the source position of an ambiguous ampersand to be incorrect.

AFAICT, this doesn't affect any HTML parsing tests, but it did cause the HTML syntax highlighter to use the incorrect offset, which could cause a crash if the offset expected by the syntax highligher was outside the bounds of a given source string. 

Fixes #6211