### PR TITLE
ImageDecoder+LibWeb: Perform initial alpha conversion in ImageDecoder

### DIFF
--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -160,7 +160,7 @@ void SharedResourceRequest::handle_successful_fetch(URL::URL const& url_string, 
         Vector<AnimatedBitmapDecodedImageData::Frame> frames;
         for (auto& frame : result.frames) {
             frames.append(AnimatedBitmapDecodedImageData::Frame {
-                .bitmap = Gfx::ImmutableBitmap::create(*frame.bitmap, Gfx::AlphaType::Premultiplied, result.color_space),
+                .bitmap = Gfx::ImmutableBitmap::create(*frame.bitmap, result.color_space),
                 .duration = static_cast<int>(frame.duration),
             });
         }

--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -95,6 +95,7 @@ static void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder
             durations.unchecked_append(0);
         } else {
             auto frame = frame_or_error.release_value();
+            frame.image->set_alpha_type_destructive(Gfx::AlphaType::Premultiplied);
             bitmaps.unchecked_append(frame.image);
             durations.unchecked_append(frame.duration);
         }


### PR DESCRIPTION
This change moves the initial alpha premultiplication step for all decoded images from WebContent to the ImageDecoder process. This doesn't reduce the overall amount of work, but it can make sites with a lot of images more responsive.