### PR TITLE
LibJS: Use TypedTransfer<T>::copy() when possible in CopyDataBlockBytes

### DIFF
--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -112,6 +112,12 @@ void copy_data_block_bytes(ByteBuffer& to_block, u64 to_index, ByteBuffer const&
     // 5. Assert: toIndex + count ≤ toSize.
     VERIFY(to_index + count <= to_size);
 
+    // OPTIMIZATION: If neither block is a Shared Data Block, we can copy the whole range at once.
+    if (true) {
+        AK::TypedTransfer<u8>::copy(to_block.data() + to_index, from_block.data() + from_index, count);
+        return;
+    }
+
     // 6. Repeat, while count > 0,
     while (count > 0) {
         // FIXME: a. If fromBlock is a Shared Data Block, then


### PR DESCRIPTION
If neither block is a Shared Data Block we can use memcpy rather than copying one byte at a time. Currently, we are using `memcpy` unconditionally, as Shared Data Blocks are not yet supported in this method.

This showed up in a profile of https://cloudflare.com and took 0.77% of total time. After this change it completely disappears from the profile.