### PR TITLE
Base: Use the correct memory unit suffixes in `about::processes`

### DIFF
--- a/Base/res/ladybird/about-pages/processes.html
+++ b/Base/res/ladybird/about-pages/processes.html
@@ -76,18 +76,16 @@
             </thead>
             <tbody id="process-table"></tbody>
         </table>
-
-        <script type="text/javascript">
+        <script type="module">
+            import { getByteFormatter }  from "resource://ladybird/utils.js";
+            const memoryFormatter = getByteFormatter(() => {
+                return {
+                    unitDisplay: "narrow",
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                }
+            })
             const cpuFormatter = new Intl.NumberFormat([], {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-            });
-
-            const memoryFormatter = new Intl.NumberFormat([], {
-                style: "unit",
-                unit: "byte",
-                notation: "compact",
-                unitDisplay: "narrow",
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,
             });
@@ -141,7 +139,7 @@
                     insertColumn(row, process.name);
                     insertColumn(row, process.pid);
                     insertColumn(row, cpuFormatter.format(process.cpu));
-                    insertColumn(row, memoryFormatter.format(process.memory));
+                    insertColumn(row, memoryFormatter.formatBytes(process.memory));
                 });
 
                 oldTable.parentNode.replaceChild(newTable, oldTable);

--- a/Base/res/ladybird/about-pages/settings/privacy.js
+++ b/Base/res/ladybird/about-pages/settings/privacy.js
@@ -1,3 +1,11 @@
+import { getByteFormatter } from "../../utils.js";
+const byteFormatter = getByteFormatter(unit => {
+    return {
+        unitDisplay: unit === "byte" ? "long" : "short",
+        maximumFractionDigits: 1,
+    };
+});
+
 const clearBrowsingData = document.querySelector("#clear-browsing-data");
 const clearBrowsingDataCachedFiles = document.querySelector("#clear-browsing-data-cached-files");
 const clearBrowsingDataCachedFilesSize = document.querySelector("#clear-browsing-data-cached-files-size");
@@ -9,37 +17,6 @@ const clearBrowsingDataSiteDataSize = document.querySelector("#clear-browsing-da
 const clearBrowsingDataTimeRange = document.querySelector("#clear-browsing-data-time-range");
 const clearBrowsingDataTotalSize = document.querySelector("#clear-browsing-data-total-size");
 const globalPrivacyControlToggle = document.querySelector("#global-privacy-control-toggle");
-
-const BYTE_UNITS = ["byte", "kilobyte", "megabyte", "gigabyte", "terabyte"];
-
-const BYTE_FORMATTERS = {
-    byte: undefined,
-    kilobyte: undefined,
-    megabyte: undefined,
-    gigabyte: undefined,
-    terabyte: undefined,
-};
-
-function formatBytes(bytes) {
-    let index = 0;
-    while (bytes >= 1024 && index < BYTE_UNITS.length - 1) {
-        bytes /= 1024;
-        ++index;
-    }
-
-    const unit = BYTE_UNITS[index];
-
-    if (!BYTE_FORMATTERS[unit]) {
-        BYTE_FORMATTERS[unit] = new Intl.NumberFormat([], {
-            style: "unit",
-            unit: unit,
-            unitDisplay: unit === "byte" ? "long" : "short",
-            maximumFractionDigits: 1,
-        });
-    }
-
-    return BYTE_FORMATTERS[unit].format(bytes);
-}
 
 function loadSettings(settings) {
     globalPrivacyControlToggle.checked = settings.globalPrivacyControl;
@@ -74,10 +51,10 @@ function estimateBrowsingDataSizes() {
 function updateBrowsingDataSizes(sizes) {
     const totalSize = sizes.totalCacheSize + sizes.totalSiteDataSize;
 
-    clearBrowsingDataTotalSize.innerText = `Your browsing data is currently using ${formatBytes(totalSize)} of disk space`;
+    clearBrowsingDataTotalSize.innerText = `Your browsing data is currently using ${byteFormatter.formatBytes(totalSize)} of disk space`;
 
-    clearBrowsingDataCachedFilesSize.innerText = ` (remove ${formatBytes(sizes.cacheSizeSinceRequestedTime)})`;
-    clearBrowsingDataSiteDataSize.innerText = ` (remove ${formatBytes(sizes.siteDataSizeSinceRequestedTime)})`;
+    clearBrowsingDataCachedFilesSize.innerText = ` (remove ${byteFormatter.formatBytes(sizes.cacheSizeSinceRequestedTime)})`;
+    clearBrowsingDataSiteDataSize.innerText = ` (remove ${byteFormatter.formatBytes(sizes.siteDataSizeSinceRequestedTime)})`;
 }
 
 clearBrowsingData.addEventListener("click", () => {

--- a/Base/res/ladybird/utils.js
+++ b/Base/res/ladybird/utils.js
@@ -1,0 +1,32 @@
+export function getByteFormatter(optionsFunction) {
+    const BYTE_UNITS = ["byte", "kilobyte", "megabyte", "gigabyte", "terabyte"];
+    const BYTE_FORMATTERS = {
+        byte: undefined,
+        kilobyte: undefined,
+        megabyte: undefined,
+        gigabyte: undefined,
+        terabyte: undefined,
+        petabyte: undefined,
+    };
+    return {
+        formatBytes: bytes => {
+            let index = 0;
+            while (bytes >= 1024 && index < BYTE_UNITS.length - 1) {
+                bytes /= 1024;
+                ++index;
+            }
+
+            const unit = BYTE_UNITS[index];
+
+            if (!BYTE_FORMATTERS[unit]) {
+                let options = { style: "unit", unit: unit };
+                if (optionsFunction) {
+                    options = { ...options, ...optionsFunction(unit) };
+                }
+                BYTE_FORMATTERS[unit] = new Intl.NumberFormat([], options);
+            }
+
+            return BYTE_FORMATTERS[unit].format(bytes);
+        },
+    };
+}

--- a/UI/cmake/ResourceFiles.cmake
+++ b/UI/cmake/ResourceFiles.cmake
@@ -63,6 +63,7 @@ list(TRANSFORM BROWSER_ICONS PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/icons/brow
 
 set(INTERNAL_RESOURCES
     ladybird.css
+    utils.js
 )
 list(TRANSFORM INTERNAL_RESOURCES PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/ladybird/")
 


### PR DESCRIPTION
Previously the GB suffix was displayed as BB.

This seems to be a limitation of Intl.NumberFormat, as it also behaves this way in other browsers

Before:
<img width="795" height="261" alt="image" src="https://github.com/user-attachments/assets/c6bd9f4d-ed87-4e4a-a277-b5f1d077890b" />

After:
<img width="795" height="261" alt="image" src="https://github.com/user-attachments/assets/6db1ee44-6361-4ed9-b3d8-d3760500ee25" />

