### PR TITLE
UI: Add `Close tab` tooltip

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -448,6 +448,7 @@ void BrowserWindow::create_close_button_for_tab(Tab* tab)
     m_tabs_container->setTabIcon(index, tab->favicon());
 
     auto* button = new TabBarButton(create_tvg_icon_with_theme_colors("close", palette()));
+    button->setToolTip("Close tab");
     auto position = audio_button_position_for_tab(index) == QTabBar::LeftSide ? QTabBar::RightSide : QTabBar::LeftSide;
 
     connect(button, &QPushButton::clicked, this, [this, tab]() {


### PR DESCRIPTION
This adds a tooltip for close tab button on Qt UI.

<img width="230" height="124" alt="image" src="https://github.com/user-attachments/assets/e78f159c-eba3-4e28-92cc-a5ccb284aff0" />
