### PR TITLE
UI: Add `Close Tab` tooltip

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -448,6 +448,7 @@ void BrowserWindow::create_close_button_for_tab(Tab* tab)
     m_tabs_container->setTabIcon(index, tab->favicon());
 
     auto* button = new TabBarButton(create_tvg_icon_with_theme_colors("close", palette()));
+    button->setToolTip("Close Tab");
     auto position = audio_button_position_for_tab(index) == QTabBar::LeftSide ? QTabBar::RightSide : QTabBar::LeftSide;
 
     connect(button, &QPushButton::clicked, this, [this, tab]() {


### PR DESCRIPTION
This PR adds a "Close Tab" tooltip to tab close button on Qt ui.

<img width="230" height="124" alt="image" src="https://github.com/user-attachments/assets/7d8bd0b5-d59e-4c99-83f6-7ddd09cfcc0b" />

