### PR TITLE
LibWebView: Add a bit of explicit handling for "localhost:port" URLs

### DIFF
--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -184,6 +184,7 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://example.def/"sv, "https://example.def"sv);
 
     expect_url_equals_sanitized_url("https://localhost/"sv, "localhost"sv); // Respect localhost.
+    expect_url_equals_sanitized_url("https://localhost:8000/"sv, "localhost:8000"sv);
     expect_url_equals_sanitized_url("https://localhost/hello"sv, "localhost/hello"sv);
     expect_url_equals_sanitized_url("https://localhost/hello.world"sv, "localhost/hello.world"sv);
     expect_url_equals_sanitized_url("https://localhost/hello.world?query=123"sv, "localhost/hello.world?query=123"sv);


### PR DESCRIPTION
LibURL parses "localhost:8000" as a URL with a scheme of "localhost" and basename of "8000". Similar to "mailto:" URLs.  We then drop the URL as having an invalid scheme.

Let's explicitly check for such localhost URLs here and prepend a valid scheme, as it is a bit of a special case.

Ref #6753