### PR TITLE
RequestServer: Allow caching of HTTP responses with "Expires" header

### DIFF
--- a/Services/RequestServer/Cache/Utilities.cpp
+++ b/Services/RequestServer/Cache/Utilities.cpp
@@ -89,14 +89,14 @@ bool is_cacheable(u32 status_code, HTTP::HeaderMap const& headers)
         return false;
 
     auto cache_control = headers.get("Cache-Control"sv);
-    if (!cache_control.has_value())
+    if (!cache_control.has_value() && !headers.contains("Expires"sv))
         return false;
 
     // * if the response status code is 206 or 304, or the must-understand cache directive (see Section 5.2.2.3) is
     //   present: the cache understands the response status code;
 
     // * the no-store cache directive is not present in the response (see Section 5.2.2.5);
-    if (cache_control->contains("no-store"sv, CaseSensitivity::CaseInsensitive))
+    if (cache_control.has_value() && cache_control->contains("no-store"sv, CaseSensitivity::CaseInsensitive))
         return false;
 
     // * if the cache is shared: the private response directive is either not present or allows a shared cache to store


### PR DESCRIPTION
Per RFC 9111, we're allowed to cache HTTP responses that don't have a "Cache-Control" header, provided they do have an "Expires" header.

This lets us cache JavaScript resources on https://x.com/ and makes it load much faster when cached.