### PR TITLE
LibWeb: Dont try to transition custom properties

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1322,7 +1322,7 @@ static void compute_transitioned_properties(ComputedProperties const& style, DOM
         auto const append_property_mapping_logical_aliases = [&](PropertyID property_id) {
             if (property_is_logical_alias(property_id))
                 properties_for_this_transition.append(map_logical_alias_to_physical_property(property_id, LogicalAliasMappingContext { style.writing_mode(), style.direction() }));
-            else
+            else if (property_id != PropertyID::Custom)
                 properties_for_this_transition.append(property_id);
         };
 

--- a/Tests/LibWeb/Crash/CSS/transitioned-custom-property.html
+++ b/Tests/LibWeb/Crash/CSS/transitioned-custom-property.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <style>
+        #foo {
+            --bar: 10px;
+            transition: --bar 1s linear;
+        }
+    </style>
+    <div id="foo"></div>
+    <script>
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                foo.style = "--bar: 100px";
+            });
+        });
+    </script>
+</html>


### PR DESCRIPTION
Fixes a crash introduced in dd9d6d2

CC @tcl3 