### PR TITLE
AK: Ignore `-Wfree-nonheap-object` on `RefCounted::unref`

### DIFF
--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -8,6 +8,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/Checked.h>
+#include <AK/Diagnostics.h>
 #include <AK/Noncopyable.h>
 #include <AK/Platform.h>
 
@@ -62,7 +63,9 @@ public:
         if (new_ref_count == 0) {
             if constexpr (requires { that->will_be_destroyed(); })
                 that->will_be_destroyed();
-            delete static_cast<T const*>(this);
+            // FIXME: GCC 15.1.0 seems to think this is reachable with non-heap objects
+            //        in some possibly Variant related cases.
+            AK_IGNORE_DIAGNOSTIC("-Wfree-nonheap-object", delete static_cast<T const*>(this);)
             return true;
         }
         return false;


### PR DESCRIPTION
(cherry picked from serenity)
GCC 15 seems to raise a false positive here in some cases

(cherry picked from commit 129c3ec0df061930e58f6d15d2ee4ad3e7599aad)