### PR TITLE
LibWeb: Don't store custom name on StyleProperty

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -150,8 +150,7 @@ String CSSStyleProperties::item(size_t index) const
 
     if (index < custom_properties_count) {
         auto keys = m_custom_properties.keys();
-        auto custom_property = m_custom_properties.get(keys[index]);
-        return custom_property.ptr()->custom_name.to_string();
+        return keys[index].to_string();
     }
 
     return CSS::string_from_property_id(m_properties[index - custom_properties_count].property_id).to_string();
@@ -250,7 +249,6 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property_internal(PropertyName
                 .important = !priority.is_empty() ? Important::Yes : Important::No,
                 .property_id = property.id(),
                 .value = component_value_list.release_nonnull(),
-                .custom_name = property.name(),
             };
             m_custom_properties.set(property.name(), style_property);
             updated = true;
@@ -415,8 +413,7 @@ WebIDL::ExceptionOr<void> CSSStyleProperties::set_property_style_value(PropertyN
             StyleProperty {
                 Important::No,
                 PropertyID::Custom,
-                style_value,
-                property.name() });
+                style_value });
         return {};
     }
 
@@ -534,7 +531,6 @@ Optional<StyleProperty> CSSStyleProperties::get_direct_property(PropertyNameAndI
                 return StyleProperty {
                     .property_id = property_id,
                     .value = maybe_value.release_nonnull(),
-                    .custom_name = property_name_and_id.name(),
                 };
             }
             return {};

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1269,8 +1269,10 @@ Optional<StyleProperty> Parser::parse_as_supports_condition()
     m_rule_context.append(RuleContext::SupportsCondition);
     auto maybe_declaration = parse_a_declaration(m_token_stream);
     m_rule_context.take_last();
-    if (maybe_declaration.has_value())
-        return convert_to_style_property(maybe_declaration.release_value());
+    if (maybe_declaration.has_value()) {
+        if (auto maybe_property_and_name = convert_to_style_property(maybe_declaration.release_value()); maybe_property_and_name.has_value())
+            return maybe_property_and_name->property;
+    }
     return {};
 }
 
@@ -1596,10 +1598,10 @@ bool Parser::is_valid_in_the_current_context(QualifiedRule const&) const
 
 void Parser::extract_property(Declaration const& declaration, PropertiesAndCustomProperties& dest)
 {
-    if (auto maybe_property = convert_to_style_property(declaration); maybe_property.has_value()) {
-        auto property = maybe_property.release_value();
+    if (auto maybe_property_and_name = convert_to_style_property(declaration); maybe_property_and_name.has_value()) {
+        auto property = maybe_property_and_name->property;
         if (property.property_id == PropertyID::Custom) {
-            dest.custom_properties.set(property.custom_name, property);
+            dest.custom_properties.set(maybe_property_and_name->name, property);
         } else {
             dest.properties.append(move(property));
         }
@@ -1616,7 +1618,7 @@ GC::Ref<CSSStyleProperties> Parser::convert_to_style_declaration(Vector<Declarat
     return CSSStyleProperties::create(realm(), move(properties.properties), move(properties.custom_properties));
 }
 
-Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& declaration)
+Optional<StylePropertyAndName> Parser::convert_to_style_property(Declaration const& declaration)
 {
     auto property = PropertyNameAndID::from_name(declaration.name);
 
@@ -1642,9 +1644,14 @@ Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& dec
     }
 
     if (property->is_custom_property())
-        return StyleProperty { declaration.important, property->id(), value.release_value(), property->name() };
+        return StylePropertyAndName {
+            StyleProperty { declaration.important, property->id(), value.release_value() },
+            property->name()
+        };
 
-    return StyleProperty { declaration.important, property->id(), value.release_value(), {} };
+    return StylePropertyAndName {
+        StyleProperty { declaration.important, property->id(), value.release_value() }
+    };
 }
 
 Optional<LengthOrAutoOrCalculated> Parser::parse_source_size_value(TokenStream<ComponentValue>& tokens)

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -291,7 +291,7 @@ private:
     GC::Ptr<CSSSupportsRule> convert_to_supports_rule(AtRule const&, Nested);
 
     GC::Ref<CSSStyleProperties> convert_to_style_declaration(Vector<Declaration> const&);
-    Optional<StyleProperty> convert_to_style_property(Declaration const&);
+    Optional<StylePropertyAndName> convert_to_style_property(Declaration const&);
 
     Optional<Descriptor> convert_to_descriptor(AtRuleID, Declaration const&);
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3098,7 +3098,6 @@ void StyleComputer::compute_custom_properties(ComputedProperties&, DOM::Abstract
                 .important = style_property.important,
                 .property_id = style_property.property_id,
                 .value = compute_value_of_custom_property(abstract_element, name),
-                .custom_name = style_property.custom_name,
             });
     }
     abstract_element.set_custom_properties(move(resolved_custom_properties));

--- a/Libraries/LibWeb/CSS/StyleProperty.cpp
+++ b/Libraries/LibWeb/CSS/StyleProperty.cpp
@@ -13,7 +13,7 @@ StyleProperty::~StyleProperty() = default;
 
 bool StyleProperty::operator==(StyleProperty const& other) const
 {
-    if (important != other.important || property_id != other.property_id || custom_name != other.custom_name)
+    if (important != other.important || property_id != other.property_id)
         return false;
     return value->equals(*other.value);
 }

--- a/Libraries/LibWeb/CSS/StyleProperty.h
+++ b/Libraries/LibWeb/CSS/StyleProperty.h
@@ -22,9 +22,13 @@ struct WEB_API StyleProperty {
     Important important { Important::No };
     PropertyID property_id;
     NonnullRefPtr<StyleValue const> value;
-    FlyString custom_name {};
 
     bool operator==(StyleProperty const& other) const;
+};
+
+struct StylePropertyAndName {
+    StyleProperty property;
+    FlyString name {};
 };
 
 }


### PR DESCRIPTION
This reduces time spent in `~StyleProperty()` from 2.18% to 0.67% on https://cloudflare.com.