### PR TITLE
LibWeb: Clamp any values less than 1 in perspective() transform function

### DIFF
--- a/Libraries/LibWeb/CSS/Transformation.cpp
+++ b/Libraries/LibWeb/CSS/Transformation.cpp
@@ -75,15 +75,20 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
 
     switch (m_function) {
     case CSS::TransformFunction::Perspective:
-        // https://drafts.csswg.org/css-transforms-2/#perspective
+        // https://drafts.csswg.org/css-transforms-2/#funcdef-perspective
         // Count is zero when null parameter
         if (count == 1) {
-            // FIXME: Add support for the 'perspective-origin' CSS property.
             auto distance = TRY(value(0));
+            // If the depth value is less than '1px', it must be treated as '1px' for the purpose of rendering, for
+            // computing the resolved value of 'transform', and when used as the endpoint of interpolation.
+            // Note: The intent of the above rules on values less than '1px' is that they cover the cases where
+            // the 'perspective()' function needs to be converted into a matrix.
+            if (distance < 1)
+                distance = 1;
             return Gfx::FloatMatrix4x4(1, 0, 0, 0,
                 0, 1, 0, 0,
                 0, 0, 1, 0,
-                0, 0, -1 / (distance <= 0 ? 1 : distance), 1);
+                0, 0, -1 / distance, 1);
         }
         return Gfx::FloatMatrix4x4(1, 0, 0, 0,
             0, 1, 0, 0,

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/reference/green.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/reference/green.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: A green box</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<p>Pass if there is NO red below:</p>
+<div id="ref" style="width: 100px; height: 100px; background: green"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-zero-point-five.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-zero-point-five.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: transform: perspective(0)</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#funcdef-perspective">
+<meta name="assert" content="perspective(0.5px) should be clamped to 1px">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/reference/green.html">
+<style>
+#cover-me {
+  width: 100px;
+  height: 100px;
+  background: red;
+  position: relative;
+  margin-bottom: -100px;
+}
+#test {
+  background: green;
+  transform-origin: top left;
+  width: 50px;
+  height: 50px;
+  /* perspective(0.5px) should be treated as perspective(1px), which should
+   * cause this box to be much larger. */
+  transform: perspective(0.5px) translateZ(0.5px);
+}
+</style>
+<p>Pass if there is NO red below:</p>
+<div id="cover-me"></div><div id="test"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-zero.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-zero.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: transform: perspective(0)</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#funcdef-perspective">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/413">
+<meta name="assert" content="perspective(0) should be clamped to 1px">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/reference/green.html">
+<style>
+#cover-me {
+  width: 100px;
+  height: 100px;
+  background: red;
+  position: relative;
+  margin-bottom: -100px;
+}
+#test {
+  background: green;
+  transform-origin: top left;
+  width: 50px;
+  height: 50px;
+  /* perspective(0) should be treated as perspective(1px), which should
+   * cause this box to be much larger. */
+  transform: perspective(0) translateZ(0.5px);
+}
+</style>
+<p>Pass if there is NO red below:</p>
+<div id="cover-me"></div><div id="test"></div>


### PR DESCRIPTION
Anything less than 1px should be clamped up to 1px, not just 0.
I've also fixed the spec link while here and removed the FIXME about `perspective-origin`. That property only interacts with the `perspective` property, not with the `perspective()` function.
I wrote the `perspective-zero-point-five.html` test myself, and it is currently under review here: https://github.com/web-platform-tests/wpt/pull/55998 (I manually hand-imported it for now, should be identical to an actual import)