### PR TITLE
LibMedia+Tests: Clear the current block when seeking in MatroskaDemuxer

### DIFF
--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
@@ -192,6 +192,8 @@ DecoderErrorOr<DemuxerSeekResult> MatroskaDemuxer::seek_to_most_recent_keyframe(
     }
 
     track_status.iterator = move(seeked_iterator);
+    track_status.block = {};
+    track_status.frame_index = 0;
     return DemuxerSeekResult::MovedPosition;
 }
 

--- a/Tests/LibMedia/TestParseMatroska.cpp
+++ b/Tests/LibMedia/TestParseMatroska.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibMedia/Containers/Matroska/MatroskaDemuxer.h>
 #include <LibTest/TestCase.h>
 
 #include <LibMedia/Containers/Matroska/Reader.h>
@@ -22,4 +23,27 @@ TEST_CASE(master_elements_containing_crc32)
     MUST(iterator.next_block());
     MUST(matroska_reader.seek_to_random_access_point(iterator, AK::Duration::from_seconds(7)));
     MUST(iterator.next_block());
+}
+
+TEST_CASE(seek_in_multi_frame_blocks)
+{
+    auto demuxer = MUST(Media::Matroska::MatroskaDemuxer::from_file("test-webm-xiph-lacing.mka"sv));
+    auto optional_track = MUST(demuxer->get_preferred_track_for_type(Media::TrackType::Audio));
+    EXPECT(optional_track.has_value());
+    auto track = optional_track.release_value();
+
+    auto initial_coded_frame = MUST(demuxer->get_next_sample_for_track(track));
+    EXPECT(initial_coded_frame.timestamp() <= AK::Duration::zero());
+
+    auto forward_seek_time = AK::Duration::from_seconds(5);
+    MUST(demuxer->seek_to_most_recent_keyframe(track, forward_seek_time, Media::DemuxerSeekOptions::None));
+    auto coded_frame_after_forward_seek = MUST(demuxer->get_next_sample_for_track(track));
+    EXPECT(coded_frame_after_forward_seek.timestamp() > AK::Duration::zero());
+    EXPECT(coded_frame_after_forward_seek.timestamp() <= forward_seek_time);
+
+    auto backward_seek_time = AK::Duration::from_seconds(2);
+    MUST(demuxer->seek_to_most_recent_keyframe(track, backward_seek_time, Media::DemuxerSeekOptions::None));
+    auto coded_frame_after_backward_seek = MUST(demuxer->get_next_sample_for_track(track));
+    EXPECT(coded_frame_after_backward_seek.timestamp() > AK::Duration::zero());
+    EXPECT(coded_frame_after_backward_seek.timestamp() <= backward_seek_time);
 }


### PR DESCRIPTION
Otherwise, if the sample iterator resides in a block with multiple frames before the seek, the demuxer will output all the remaining frames from that block before moving on to the block at the seeked position.