### PR TITLE
LibWeb: Make CSSPerspective correctly clamp its input for toMatrix()

### DIFF
--- a/Libraries/LibWeb/CSS/CSSPerspective.cpp
+++ b/Libraries/LibWeb/CSS/CSSPerspective.cpp
@@ -121,7 +121,7 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMMatrix>> CSSPerspective::to_matrix() co
         [&matrix](GC::Ref<CSSNumericValue> const& numeric_value) -> WebIDL::ExceptionOr<void> {
             // NB: to() throws a TypeError if the conversion can't be done.
             auto distance = TRY(numeric_value->to("px"_fly_string))->value();
-            matrix->set_m34(-1 / (distance <= 0 ? 1 : distance));
+            matrix->set_m34(-1 / max(distance, 1));
             return {};
         },
         [](GC::Ref<CSSKeywordValue> const&) -> WebIDL::ExceptionOr<void> {

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix.html
@@ -66,14 +66,15 @@ test(() => {
 }, 'CSSSkewY.toMatrix() returns correct matrix');
 
 test(() => {
-  const length = 10;
-  const component = new CSSPerspective(new CSSUnitValue(length, 'px'));
-  const expectedMatrix = new DOMMatrixReadOnly(
-        [1, 0, 0, 0,
-         0, 1, 0, 0,
-         0, 0, 1, -1/length,
-         0, 0, 0, 1]);
-  assert_matrix_approx_equals(component.toMatrix(), expectedMatrix, gEpsilon);
+  for (const length of [10, 1, 0.5, 0, -10]) {
+    const component = new CSSPerspective(new CSSUnitValue(length, 'px'));
+    const expectedMatrix = new DOMMatrixReadOnly(
+          [1, 0, 0, 0,
+           0, 1, 0, 0,
+           0, 0, 1, -1/Math.max(1, length),
+           0, 0, 0, 1]);
+    assert_matrix_approx_equals(component.toMatrix(), expectedMatrix, gEpsilon);
+  }
 }, 'CSSPerspective.toMatrix() returns correct matrix');
 
 test(() => {


### PR DESCRIPTION
The WPT test change is currently being reviewed here: https://github.com/web-platform-tests/wpt/pull/56008
The behavior is to spec though, so I'd expect it to be accepted.