### PR TITLE
LibWeb: Add `--headless=manual` option to run until explicit exit

### DIFF
--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -19,6 +19,7 @@ enum class HeadlessMode {
     Screenshot,
     LayoutTree,
     Text,
+    Manual,
     Test,
 };
 


### PR DESCRIPTION
This headless mode will stay open until it is closed by manually or by calling `window.close()`.

I'm using this to run Speedometer headlessly.