### PR TITLE
LibWeb: Handle empty string namespaces in selector matching

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -1085,6 +1085,13 @@ static ALWAYS_INLINE bool matches_namespace(
             return false;
 
         auto selector_namespace = style_sheet_for_rule->namespace_uri(qualified_name.namespace_);
+
+        // https://www.w3.org/TR/css-namespaces-3/#terminology
+        // In CSS Namespaces a namespace name consisting of the empty string is taken to represent the null namespace
+        // or lack of a namespace.
+        if (selector_namespace.has_value() && selector_namespace.value().is_empty())
+            return !element.namespace_uri().has_value();
+
         return selector_namespace.has_value() && selector_namespace.value() == element.namespace_uri();
     }
     VERIFY_NOT_REACHED();

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-1-generic.xml
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-1-generic.xml
@@ -1,0 +1,11 @@
+<root>
+ <head xmlns="http://www.w3.org/1999/xhtml">
+  <link rel="author" title="L. David Baron" href="https://dbaron.org/"/>
+  <link rel="author" title="Mozilla" href="http://mozilla.org/"/>
+  <title>CSS Namespaces Test Suite reference</title>
+  <style>
+   t { background:lime }
+  </style>
+ </head>
+ <t>This sentence should have a green background.</t>
+</root>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-002.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-002.xml
@@ -1,0 +1,17 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#prefixes"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <title>CSS Namespaces Test Suite: empty string prefix (Explicit element namespace)</title>
+  <style>
+   @namespace foo "";
+   t { background:red }
+   foo|t { background:lime }
+  </style>
+ </head>
+ <body>
+  <p><t xmlns="">This sentence should have a green background.</t></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-003.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-003.xml
@@ -1,0 +1,15 @@
+<root>
+ <head xmlns="http://www.w3.org/1999/xhtml">
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#prefixes"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1-generic.xml"/>
+  <title>CSS Namespaces Test Suite: empty string prefix (Implied element namespace)</title>
+  <style>
+   @namespace foo "";
+   t { background:red }
+   foo|t { background:lime }
+  </style>
+ </head>
+ <t>This sentence should have a green background.</t>
+</root>


### PR DESCRIPTION
Per the CSS Namespaces spec, an empty string declared in an @namespace rule represents no namespace.

Fixes WPT:
- css/css-namespaces/prefix-002.xml
- css/css-namespaces/prefix-003.xml