### PR TITLE
LibWeb: Fix dialog cleanup when disconnected from DOM

### DIFF
--- a/Tests/LibWeb/Text/expected/dialog-disconnected-cleanup.txt
+++ b/Tests/LibWeb/Text/expected/dialog-disconnected-cleanup.txt
@@ -1,0 +1,5 @@
+Before removal - d1.matches(':modal'): true
+Before removal - d2.matches(':modal'): true
+After removal - d1.matches(':modal'): true
+After removal - d2.matches(':modal'): false
+d2.open: true

--- a/Tests/LibWeb/Text/input/dialog-disconnected-cleanup.html
+++ b/Tests/LibWeb/Text/input/dialog-disconnected-cleanup.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="./include.js"></script>
+<body>
+<dialog id="d1">
+  <dialog id="d2">d2</dialog>
+</dialog>
+<script>
+    // Test for https://wpt.live/close-watcher/user-activation/y-dialog-disconnected.html
+    // Verify that when a modal dialog is removed from the DOM, it's properly cleaned up
+    // and no longer matches :modal.
+    
+    test(() => {
+        const d1 = document.getElementById('d1');
+        const d2 = document.getElementById('d2');
+        
+        // Open both dialogs as modal
+        d1.showModal();
+        d2.showModal();
+        
+        println(`Before removal - d1.matches(':modal'): ${d1.matches(':modal')}`);
+        println(`Before removal - d2.matches(':modal'): ${d2.matches(':modal')}`);
+        
+        // Remove d2 from the DOM
+        d2.remove();
+        
+        println(`After removal - d1.matches(':modal'): ${d1.matches(':modal')}`);
+        println(`After removal - d2.matches(':modal'): ${d2.matches(':modal')}`);
+        
+        // d2 should no longer match :modal after being removed
+        println(`d2.open: ${d2.open}`);
+    });
+</script>
+</body>


### PR DESCRIPTION
When a dialog element is removed from the DOM via element.remove(), properly clean up its state to prevent interference with subsequent close requests.
+1 WPT