### PR TITLE
fix: Break lines on non-whitespace items

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -344,6 +344,8 @@ void InlineFormattingContext::generate_line_boxes()
                 // If whitespace caused us to break, we swallow the whitespace instead of putting it on the next line.
                 if (is_whitespace && next_width > 0 && line_builder.break_if_needed(item.border_box_width() + next_width))
                     break;
+                if (!is_whitespace)
+                    line_builder.break_if_needed(item.border_box_width());
             } else if (text_node.computed_values().text_overflow() == CSS::TextOverflow::Ellipsis
                 && text_node.computed_values().overflow_x() != CSS::Overflow::Visible) {
                 // We may need to do an ellipsis if the text is too long for the container

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -181,8 +181,6 @@ bool LineBuilder::should_break(CSSPixels next_item_width)
         // at this Y coordinate, we don't need to break before inserting anything.
         if (!m_context.any_floats_intrude_at_block_offset(m_current_block_offset))
             return false;
-        if (!m_context.any_floats_intrude_at_block_offset(m_current_block_offset + m_context.containing_block().computed_values().line_height()))
-            return false;
     }
     auto current_line_width = ensure_last_line_box().width();
     return (current_line_width + next_item_width) > m_available_width_for_current_line;


### PR DESCRIPTION
## Description

This PR fixes the layout bug where text following a `float: left; width: 100%` element is pushed outside the visible page area.

Example from the issue:
```html
<div style="float: left; width: 100%;">Text</div>
<h2>First Second Third</h2>
```
Ladybird incorrectly placed “First” beyond the page boundary because the line breaker only checked `whitespace` when deciding whether text fits, and an extra float-intrusion check incorrectly treated the 100% float as non-blocking.

This patch:
- Applies break_if_needed() to all inline fragments, not just whitespace, ensuring text never gets placed when it doesn’t fit.
- Removes an overly permissive float-intrusion check so floats correctly reduce available line width.

As a result, text after full-width floats now renders in the correct position.

## Result

- Before changes:
<img width="306" height="123" alt="image" src="https://github.com/user-attachments/assets/18c3b088-5608-4a62-ab22-7b2e6f46cfb5" />

- After changes:
<img width="242" height="131" alt="image" src="https://github.com/user-attachments/assets/c0b50b22-a941-4151-81b5-6b2135c24da5" />

## Related Issue

Closes #6266 
