### PR TITLE
LibWeb: Reset text-shadow if needed after paint-only properties update

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1644,8 +1644,8 @@ void PaintableWithLines::resolve_paint_properties()
         fragment.set_text_decoration_thickness(css_line_thickness);
 
         auto const& text_shadow = text_node.computed_values().text_shadow();
+        Vector<ShadowData> resolved_shadow_data;
         if (!text_shadow.is_empty()) {
-            Vector<ShadowData> resolved_shadow_data;
             resolved_shadow_data.ensure_capacity(text_shadow.size());
             for (auto const& layer : text_shadow) {
                 resolved_shadow_data.empend(
@@ -1656,8 +1656,8 @@ void PaintableWithLines::resolve_paint_properties()
                     layer.spread_distance.to_px(layout_node),
                     ShadowPlacement::Outer);
             }
-            fragment.set_shadows(move(resolved_shadow_data));
         }
+        fragment.set_shadows(move(resolved_shadow_data));
     }
 }
 

--- a/Tests/LibWeb/Text/expected/reset-text-shadow-after-unhover.txt
+++ b/Tests/LibWeb/Text/expected/reset-text-shadow-after-unhover.txt
@@ -1,0 +1,2 @@
+hovered text-shadow: rgb(88, 161, 230) 0px 0px 3px
+unhovered text-shadow: none

--- a/Tests/LibWeb/Text/input/reset-text-shadow-after-unhover.html
+++ b/Tests/LibWeb/Text/input/reset-text-shadow-after-unhover.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+    span:hover {
+        text-shadow: 0 0 3px #58a1e6;
+    }
+</style>
+<script src="./include.js"></script>
+<span>Hover over this span</span>
+<script>
+    test(() => {
+        // hover
+        internals.movePointerTo(10, 10);
+        println("hovered text-shadow: " + getComputedStyle(document.querySelector("span")).textShadow);
+
+        // unhover
+        internals.movePointerTo(0, 0);
+        println("unhovered text-shadow: " + getComputedStyle(document.querySelector("span")).textShadow);
+    });
+</script>


### PR DESCRIPTION
Previously we would not propagate text-shadow changes when it's changed from some value to none.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/6580