### PR TITLE
LibWeb: Account for box-sizing in max-content contribution [GFC]

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2508,8 +2508,17 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
         return min(result, maximum_size);
     }
 
-    auto containing_block_size = containing_block_size_for_item(item, dimension);
-    auto result = item.add_margin_box_sizes(preferred_size.to_px(grid_container(), containing_block_size), dimension);
+    auto resolve_size = [&] {
+        auto available_width = AvailableSize::make_definite(containing_block_size_for_item(item, GridDimension::Column));
+        if (dimension == GridDimension::Row) {
+            auto available_height = AvailableSize::make_definite(containing_block_size_for_item(item, GridDimension::Row));
+            AvailableSpace item_available_space { available_width, available_height };
+            return calculate_inner_height(item.box, item_available_space, preferred_size);
+        }
+        return calculate_inner_width(item.box, available_width, preferred_size);
+    };
+
+    auto result = item.add_margin_box_sizes(resolve_size(), dimension);
     return min(result, maximum_size);
 }
 

--- a/Tests/LibWeb/Layout/expected/grid/account-for-box-sizing-in-max-content-contribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid/account-for-box-sizing-in-max-content-contribution.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 66 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 50 0+0+8] children: not-inline
+      Box <div.container> at [8,8] [0+0+0 784 0+0+0] [0+0+0 50 0+0+0] [GFC] children: not-inline
+        BlockContainer <div.item> at [18,18] [0+0+10 764 10+0+0] [0+0+10 30 10+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 31, rect: [18,18 255.71875x18] baseline: 13.796875
+              "There should be no red visible."
+          TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableBox (Box<DIV>.container) [8,8 784x50]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 784x50]
+          TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x66] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/account-for-box-sizing-in-max-content-contribution.html
+++ b/Tests/LibWeb/Layout/input/grid/account-for-box-sizing-in-max-content-contribution.html
@@ -1,0 +1,12 @@
+<!doctype html><style>
+.container {
+    display: grid;
+    background: red;
+}
+.item {
+    box-sizing: border-box;
+    height: 50px;
+    padding: 10px;
+    background: lime;
+}
+</style><div class="container"><div class="item">There should be no red visible.</div></div>


### PR DESCRIPTION
Use `calculate_inner_height()` and `calculate_inner_width()`, which account for box-sizing, to resolve the item's size in max-content contribution calculations.