### PR TITLE
LibWeb: Add StyleScope to keep style caches per Document/ShadowRoot

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -215,6 +215,7 @@ set(SOURCES
     CSS/StyleProperty.cpp
     CSS/StylePropertyMapReadOnly.cpp
     CSS/StylePropertyMap.cpp
+    CSS/StyleScope.cpp
     CSS/StyleSheet.cpp
     CSS/StyleSheetIdentifier.cpp
     CSS/StyleSheetList.cpp

--- a/Libraries/LibWeb/CSS/CSSLayerBlockRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSLayerBlockRule.cpp
@@ -69,7 +69,7 @@ String CSSLayerBlockRule::serialized() const
     return builder.to_string_without_validation();
 }
 
-FlyString CSSLayerBlockRule::internal_qualified_name(Badge<StyleComputer>) const
+FlyString CSSLayerBlockRule::internal_qualified_name(Badge<StyleScope>) const
 {
     auto const& parent_name = parent_layer_internal_qualified_name();
     if (parent_name.is_empty())

--- a/Libraries/LibWeb/CSS/CSSLayerBlockRule.h
+++ b/Libraries/LibWeb/CSS/CSSLayerBlockRule.h
@@ -24,7 +24,7 @@ public:
 
     FlyString const& name() const { return m_name; }
     FlyString const& internal_name() const { return m_name_internal; }
-    FlyString internal_qualified_name(Badge<StyleComputer>) const;
+    FlyString internal_qualified_name(Badge<StyleScope>) const;
 
 private:
     CSSLayerBlockRule(JS::Realm&, FlyString name, CSSRuleList&);

--- a/Libraries/LibWeb/CSS/CSSLayerStatementRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSLayerStatementRule.cpp
@@ -40,7 +40,7 @@ String CSSLayerStatementRule::serialized() const
     return builder.to_string_without_validation();
 }
 
-Vector<FlyString> CSSLayerStatementRule::internal_qualified_name_list(Badge<StyleComputer>) const
+Vector<FlyString> CSSLayerStatementRule::internal_qualified_name_list(Badge<StyleScope>) const
 {
     Vector<FlyString> qualified_layer_names;
 

--- a/Libraries/LibWeb/CSS/CSSLayerStatementRule.h
+++ b/Libraries/LibWeb/CSS/CSSLayerStatementRule.h
@@ -22,7 +22,7 @@ public:
 
     // FIXME: Should be FrozenArray
     ReadonlySpan<FlyString> name_list() const { return m_name_list; }
-    Vector<FlyString> internal_qualified_name_list(Badge<StyleComputer>) const;
+    Vector<FlyString> internal_qualified_name_list(Badge<StyleScope>) const;
 
 private:
     CSSLayerStatementRule(JS::Realm&, Vector<FlyString> name_list);

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -353,7 +353,8 @@ void CSSStyleSheet::invalidate_owners(DOM::StyleInvalidationReason reason)
     m_did_match = {};
     for (auto& document_or_shadow_root : m_owning_documents_or_shadow_roots) {
         document_or_shadow_root->invalidate_style(reason);
-        document_or_shadow_root->document().style_computer().invalidate_rule_cache();
+        auto& style_scope = document_or_shadow_root->is_shadow_root() ? as<DOM::ShadowRoot>(*document_or_shadow_root).style_scope() : document_or_shadow_root->document().style_scope();
+        style_scope.invalidate_rule_cache();
     }
 }
 

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2022-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ReportTime.h>
+#include <LibWeb/CSS/CSSKeyframesRule.h>
+#include <LibWeb/CSS/CSSLayerBlockRule.h>
+#include <LibWeb/CSS/CSSLayerStatementRule.h>
+#include <LibWeb/CSS/CSSNestedDeclarations.h>
+#include <LibWeb/CSS/CSSStyleRule.h>
+#include <LibWeb/CSS/CSSStyleSheet.h>
+#include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleScope.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/Page/Page.h>
+
+namespace Web::CSS {
+
+void StyleScope::visit_edges(GC::Cell::Visitor& visitor)
+{
+    visitor.visit(m_user_style_sheet);
+}
+
+StyleScope::StyleScope(GC::Ref<DOM::Node> node)
+    : m_node(node)
+{
+    m_qualified_layer_names_in_order.append({});
+}
+
+void StyleScope::build_rule_cache()
+{
+    m_author_rule_cache = make<RuleCaches>();
+    m_user_rule_cache = make<RuleCaches>();
+    m_user_agent_rule_cache = make<RuleCaches>();
+
+    m_selector_insights = make<SelectorInsights>();
+    m_style_invalidation_data = make<StyleInvalidationData>();
+
+    if (auto user_style_source = document().page().user_style(); user_style_source.has_value()) {
+        m_user_style_sheet = GC::make_root(parse_css_stylesheet(CSS::Parser::ParsingParams(document()), user_style_source.value()));
+    }
+
+    build_qualified_layer_names_cache();
+
+    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Hover)] = make<RuleCache>();
+    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Active)] = make<RuleCache>();
+    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Focus)] = make<RuleCache>();
+    m_pseudo_class_rule_cache[to_underlying(PseudoClass::FocusWithin)] = make<RuleCache>();
+    m_pseudo_class_rule_cache[to_underlying(PseudoClass::FocusVisible)] = make<RuleCache>();
+    m_pseudo_class_rule_cache[to_underlying(PseudoClass::Target)] = make<RuleCache>();
+
+    make_rule_cache_for_cascade_origin(CascadeOrigin::Author, *m_selector_insights);
+    make_rule_cache_for_cascade_origin(CascadeOrigin::User, *m_selector_insights);
+    make_rule_cache_for_cascade_origin(CascadeOrigin::UserAgent, *m_selector_insights);
+}
+
+void StyleScope::invalidate_rule_cache()
+{
+    m_author_rule_cache = nullptr;
+
+    // NOTE: We could be smarter about keeping the user rule cache, and style sheet.
+    //       Currently we are re-parsing the user style sheet every time we build the caches,
+    //       as it may have changed.
+    m_user_rule_cache = nullptr;
+    m_user_style_sheet = nullptr;
+
+    // NOTE: It might not be necessary to throw away the UA rule cache.
+    //       If we are sure that it's safe, we could keep it as an optimization.
+    m_user_agent_rule_cache = nullptr;
+
+    m_pseudo_class_rule_cache = {};
+    m_style_invalidation_data = nullptr;
+}
+
+void StyleScope::build_rule_cache_if_needed() const
+{
+    if (has_valid_rule_cache())
+        return;
+    const_cast<StyleScope&>(*this).build_rule_cache();
+}
+
+static CSSStyleSheet& default_stylesheet()
+{
+    static GC::Root<CSSStyleSheet> sheet;
+    if (!sheet.cell()) {
+        extern String default_stylesheet_source;
+        sheet = GC::make_root(parse_css_stylesheet(CSS::Parser::ParsingParams(internal_css_realm()), default_stylesheet_source));
+    }
+    return *sheet;
+}
+
+static CSSStyleSheet& quirks_mode_stylesheet()
+{
+    static GC::Root<CSSStyleSheet> sheet;
+    if (!sheet.cell()) {
+        extern String quirks_mode_stylesheet_source;
+        sheet = GC::make_root(parse_css_stylesheet(CSS::Parser::ParsingParams(internal_css_realm()), quirks_mode_stylesheet_source));
+    }
+    return *sheet;
+}
+
+static CSSStyleSheet& mathml_stylesheet()
+{
+    static GC::Root<CSSStyleSheet> sheet;
+    if (!sheet.cell()) {
+        extern String mathml_stylesheet_source;
+        sheet = GC::make_root(parse_css_stylesheet(CSS::Parser::ParsingParams(internal_css_realm()), mathml_stylesheet_source));
+    }
+    return *sheet;
+}
+
+static CSSStyleSheet& svg_stylesheet()
+{
+    static GC::Root<CSSStyleSheet> sheet;
+    if (!sheet.cell()) {
+        extern String svg_stylesheet_source;
+        sheet = GC::make_root(parse_css_stylesheet(CSS::Parser::ParsingParams(internal_css_realm()), svg_stylesheet_source));
+    }
+    return *sheet;
+}
+
+template<typename Callback>
+void StyleScope::for_each_stylesheet(CascadeOrigin cascade_origin, Callback callback) const
+{
+    if (cascade_origin == CascadeOrigin::UserAgent) {
+        callback(default_stylesheet());
+        if (document().in_quirks_mode())
+            callback(quirks_mode_stylesheet());
+        callback(mathml_stylesheet());
+        callback(svg_stylesheet());
+    }
+    if (cascade_origin == CascadeOrigin::User) {
+        if (m_user_style_sheet)
+            callback(*m_user_style_sheet);
+    }
+    if (cascade_origin == CascadeOrigin::Author) {
+        for_each_active_css_style_sheet(move(callback));
+    }
+}
+
+void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin, SelectorInsights& insights)
+{
+    GC::Ptr<DOM::ShadowRoot const> scope_shadow_root;
+    if (m_node->is_shadow_root())
+        scope_shadow_root = as<DOM::ShadowRoot>(*m_node);
+
+    Vector<MatchingRule> matching_rules;
+    size_t style_sheet_index = 0;
+    for_each_stylesheet(cascade_origin, [&](auto& sheet) {
+        auto& rule_caches = [&] -> RuleCaches& {
+            switch (cascade_origin) {
+            case CascadeOrigin::Author:
+                return *m_author_rule_cache;
+            case CascadeOrigin::User:
+                return *m_user_rule_cache;
+            case CascadeOrigin::UserAgent:
+                return *m_user_agent_rule_cache;
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        }();
+
+        size_t rule_index = 0;
+        sheet.for_each_effective_style_producing_rule([&](auto const& rule) {
+            SelectorList const& absolutized_selectors = [&]() {
+                if (rule.type() == CSSRule::Type::Style)
+                    return static_cast<CSSStyleRule const&>(rule).absolutized_selectors();
+                if (rule.type() == CSSRule::Type::NestedDeclarations)
+                    return static_cast<CSSNestedDeclarations const&>(rule).parent_style_rule().absolutized_selectors();
+                VERIFY_NOT_REACHED();
+            }();
+
+            for (auto const& selector : absolutized_selectors) {
+                m_style_invalidation_data->build_invalidation_sets_for_selector(selector);
+            }
+
+            for (CSS::Selector const& selector : absolutized_selectors) {
+                MatchingRule matching_rule {
+                    scope_shadow_root,
+                    &rule,
+                    sheet,
+                    sheet.default_namespace(),
+                    selector,
+                    style_sheet_index,
+                    rule_index,
+                    selector.specificity(),
+                    cascade_origin,
+                    false,
+                };
+
+                auto const& qualified_layer_name = matching_rule.qualified_layer_name();
+                auto& rule_cache = qualified_layer_name.is_empty() ? rule_caches.main : *rule_caches.by_layer.ensure(qualified_layer_name, [] { return make<RuleCache>(); });
+
+                bool contains_root_pseudo_class = false;
+                Optional<CSS::PseudoElement> pseudo_element;
+
+                collect_selector_insights(selector, insights);
+
+                for (auto const& simple_selector : selector.compound_selectors().last().simple_selectors) {
+                    if (!matching_rule.contains_pseudo_element) {
+                        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoElement) {
+                            matching_rule.contains_pseudo_element = true;
+                            pseudo_element = simple_selector.pseudo_element().type();
+                            matching_rule.slotted = pseudo_element == PseudoElement::Slotted;
+                        }
+                    }
+                    if (!contains_root_pseudo_class) {
+                        if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass
+                            && simple_selector.pseudo_class().type == CSS::PseudoClass::Root) {
+                            contains_root_pseudo_class = true;
+                        }
+                    }
+                }
+
+                for (size_t i = 0; i < to_underlying(PseudoClass::__Count); ++i) {
+                    auto pseudo_class = static_cast<PseudoClass>(i);
+                    // If we're not building a rule cache for this pseudo class, just ignore it.
+                    if (!m_pseudo_class_rule_cache[i])
+                        continue;
+                    if (selector.contains_pseudo_class(pseudo_class)) {
+                        // For pseudo class rule caches we intentionally pass no pseudo-element, because we don't want to bucket pseudo class rules by pseudo-element type.
+                        m_pseudo_class_rule_cache[i]->add_rule(matching_rule, {}, contains_root_pseudo_class);
+                    }
+                }
+
+                rule_cache.add_rule(matching_rule, pseudo_element, contains_root_pseudo_class);
+            }
+            ++rule_index;
+        });
+
+        // Loosely based on https://drafts.csswg.org/css-animations-2/#keyframe-processing
+        sheet.for_each_effective_keyframes_at_rule([&](CSSKeyframesRule const& rule) {
+            auto keyframe_set = adopt_ref(*new Animations::KeyframeEffect::KeyFrameSet);
+            HashTable<PropertyID> animated_properties;
+
+            // Forwards pass, resolve all the user-specified keyframe properties.
+            for (auto const& keyframe_rule : *rule.css_rules()) {
+                auto const& keyframe = as<CSSKeyframeRule>(*keyframe_rule);
+                Animations::KeyframeEffect::KeyFrameSet::ResolvedKeyFrame resolved_keyframe;
+
+                auto key = static_cast<u64>(keyframe.key().value() * Animations::KeyframeEffect::AnimationKeyFrameKeyScaleFactor);
+                auto const& keyframe_style = *keyframe.style();
+                for (auto const& it : keyframe_style.properties()) {
+                    if (!is_animatable_property(it.property_id))
+                        continue;
+
+                    // Unresolved properties will be resolved in collect_animation_into()
+                    StyleComputer::for_each_property_expanding_shorthands(it.property_id, it.value, [&](PropertyID shorthand_id, StyleValue const& shorthand_value) {
+                        animated_properties.set(shorthand_id);
+                        resolved_keyframe.properties.set(shorthand_id, NonnullRefPtr<StyleValue const> { shorthand_value });
+                    });
+                }
+
+                keyframe_set->keyframes_by_key.insert(key, resolved_keyframe);
+            }
+
+            Animations::KeyframeEffect::generate_initial_and_final_frames(keyframe_set, animated_properties);
+
+            if constexpr (LIBWEB_CSS_DEBUG) {
+                dbgln("Resolved keyframe set '{}' into {} keyframes:", rule.name(), keyframe_set->keyframes_by_key.size());
+                for (auto it = keyframe_set->keyframes_by_key.begin(); it != keyframe_set->keyframes_by_key.end(); ++it)
+                    dbgln("    - keyframe {}: {} properties", it.key(), it->properties.size());
+            }
+
+            rule_caches.main.rules_by_animation_keyframes.set(rule.name(), move(keyframe_set));
+        });
+        ++style_sheet_index;
+    });
+}
+
+void StyleScope::collect_selector_insights(Selector const& selector, SelectorInsights& insights)
+{
+    for (auto const& compound_selector : selector.compound_selectors()) {
+        for (auto const& simple_selector : compound_selector.simple_selectors) {
+            if (simple_selector.type == Selector::SimpleSelector::Type::PseudoClass) {
+                if (simple_selector.pseudo_class().type == PseudoClass::Has) {
+                    insights.has_has_selectors = true;
+                }
+                for (auto const& argument_selector : simple_selector.pseudo_class().argument_selector_list) {
+                    collect_selector_insights(*argument_selector, insights);
+                }
+            }
+        }
+    }
+}
+
+struct LayerNode {
+    OrderedHashMap<FlyString, LayerNode> children {};
+};
+
+static void flatten_layer_names_tree(Vector<FlyString>& layer_names, StringView const& parent_qualified_name, FlyString const& name, LayerNode const& node)
+{
+    FlyString qualified_name = parent_qualified_name.is_empty() ? name : MUST(String::formatted("{}.{}", parent_qualified_name, name));
+
+    for (auto const& item : node.children)
+        flatten_layer_names_tree(layer_names, qualified_name, item.key, item.value);
+
+    layer_names.append(qualified_name);
+}
+
+void StyleScope::build_qualified_layer_names_cache()
+{
+    LayerNode root;
+
+    auto insert_layer_name = [&](FlyString const& internal_qualified_name) {
+        auto* node = &root;
+        internal_qualified_name.bytes_as_string_view()
+            .for_each_split_view('.', SplitBehavior::Nothing, [&](StringView part) {
+                auto local_name = MUST(FlyString::from_utf8(part));
+                node = &node->children.ensure(local_name);
+            });
+    };
+
+    // Walk all style sheets, identifying when we first see a @layer name, and add its qualified name to the list.
+    // TODO: Separate the light and shadow-dom layers.
+    for_each_stylesheet(CascadeOrigin::Author, [&](auto& sheet) {
+        // NOTE: Postorder so that a @layer block is iterated after its children,
+        // because we want those children to occur before it in the list.
+        sheet.for_each_effective_rule(TraversalOrder::Postorder, [&](auto& rule) {
+            switch (rule.type()) {
+            case CSSRule::Type::Import:
+                // TODO: Handle `layer(foo)` in import rules once we implement that.
+                break;
+            case CSSRule::Type::LayerBlock: {
+                auto& layer_block = static_cast<CSSLayerBlockRule const&>(rule);
+                insert_layer_name(layer_block.internal_qualified_name({}));
+                break;
+            }
+            case CSSRule::Type::LayerStatement: {
+                auto& layer_statement = static_cast<CSSLayerStatementRule const&>(rule);
+                auto qualified_names = layer_statement.internal_qualified_name_list({});
+                for (auto& name : qualified_names)
+                    insert_layer_name(name);
+                break;
+            }
+
+                // Ignore everything else
+            case CSSRule::Type::Style:
+            case CSSRule::Type::Media:
+            case CSSRule::Type::FontFace:
+            case CSSRule::Type::Keyframes:
+            case CSSRule::Type::Keyframe:
+            case CSSRule::Type::Margin:
+            case CSSRule::Type::Namespace:
+            case CSSRule::Type::NestedDeclarations:
+            case CSSRule::Type::Page:
+            case CSSRule::Type::Property:
+            case CSSRule::Type::Supports:
+                break;
+            }
+        });
+    });
+
+    // Now, produce a flat list of qualified names to use later
+    m_qualified_layer_names_in_order.clear();
+    flatten_layer_names_tree(m_qualified_layer_names_in_order, ""sv, {}, root);
+}
+
+bool StyleScope::may_have_has_selectors() const
+{
+    if (!has_valid_rule_cache())
+        return true;
+
+    build_rule_cache_if_needed();
+    return m_selector_insights->has_has_selectors;
+}
+
+bool StyleScope::have_has_selectors() const
+{
+    build_rule_cache_if_needed();
+    return m_selector_insights->has_has_selectors;
+}
+
+DOM::Document& StyleScope::document() const
+{
+    return m_node->document();
+}
+
+RuleCache const& StyleScope::get_pseudo_class_rule_cache(PseudoClass pseudo_class) const
+{
+    build_rule_cache_if_needed();
+    return *m_pseudo_class_rule_cache[to_underlying(pseudo_class)];
+}
+
+void StyleScope::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const
+{
+    if (auto* shadow_root = as_if<DOM::ShadowRoot>(*m_node)) {
+        shadow_root->for_each_active_css_style_sheet(move(callback));
+    } else {
+        m_node->document().for_each_active_css_style_sheet(move(callback));
+    }
+}
+
+void StyleScope::invalidate_style_of_elements_affected_by_has()
+{
+    if (m_pending_nodes_for_style_invalidation_due_to_presence_of_has.is_empty()) {
+        return;
+    }
+
+    ScopeGuard clear_pending_nodes_guard = [&] {
+        m_pending_nodes_for_style_invalidation_due_to_presence_of_has.clear();
+    };
+
+    // It's ok to call have_has_selectors() instead of may_have_has_selectors() here and force
+    // rule cache build, because it's going to be built soon anyway, since we could get here
+    // only from update_style().
+    if (!have_has_selectors()) {
+        return;
+    }
+
+    auto nodes = move(m_pending_nodes_for_style_invalidation_due_to_presence_of_has);
+    for (auto const& node : nodes) {
+        if (!node)
+            continue;
+        for (auto ancestor = node.ptr(); ancestor; ancestor = ancestor->parent_or_shadow_host()) {
+            if (!ancestor->is_element())
+                continue;
+            auto& element = static_cast<DOM::Element&>(*ancestor);
+            element.invalidate_style_if_affected_by_has();
+
+            auto* parent = ancestor->parent_or_shadow_host();
+            if (!parent)
+                return;
+
+            // If any ancestor's sibling was tested against selectors like ".a:has(+ .b)" or ".a:has(~ .b)"
+            // its style might be affected by the change in descendant node.
+            parent->for_each_child_of_type<DOM::Element>([&](auto& ancestor_sibling_element) {
+                if (ancestor_sibling_element.affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator())
+                    ancestor_sibling_element.invalidate_style_if_affected_by_has();
+                return IterationDecision::Continue;
+            });
+        }
+    }
+}
+
+}

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <AK/HashMap.h>
+#include <AK/Optional.h>
+#include <AK/Vector.h>
+#include <LibGC/Ptr.h>
+#include <LibWeb/Animations/KeyframeEffect.h>
+#include <LibWeb/CSS/CascadeOrigin.h>
+#include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleInvalidationData.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::CSS {
+
+struct MatchingRule {
+    GC::Ptr<DOM::ShadowRoot const> shadow_root;
+    GC::Ptr<CSSRule const> rule; // Either CSSStyleRule or CSSNestedDeclarations
+    GC::Ptr<CSSStyleSheet const> sheet;
+    Optional<FlyString> default_namespace;
+    Selector const& selector;
+    size_t style_sheet_index { 0 };
+    size_t rule_index { 0 };
+
+    u32 specificity { 0 };
+    CascadeOrigin cascade_origin;
+    bool contains_pseudo_element { false };
+    bool slotted { false };
+
+    // Helpers to deal with the fact that `rule` might be a CSSStyleRule or a CSSNestedDeclarations
+    CSSStyleProperties const& declaration() const;
+    SelectorList const& absolutized_selectors() const;
+    FlyString const& qualified_layer_name() const;
+};
+
+struct RuleCache {
+    HashMap<FlyString, Vector<MatchingRule>> rules_by_id;
+    HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
+    HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
+    HashMap<FlyString, Vector<MatchingRule>, AK::ASCIICaseInsensitiveFlyStringTraits> rules_by_attribute_name;
+    Array<Vector<MatchingRule>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount)> rules_by_pseudo_element;
+    Vector<MatchingRule> root_rules;
+    Vector<MatchingRule> slotted_rules;
+    Vector<MatchingRule> other_rules;
+
+    HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;
+
+    void add_rule(MatchingRule const&, Optional<PseudoElement>, bool contains_root_pseudo_class);
+    void for_each_matching_rules(DOM::AbstractElement, Function<IterationDecision(Vector<MatchingRule> const&)> callback) const;
+};
+
+struct RuleCaches {
+    RuleCache main;
+    HashMap<FlyString, NonnullOwnPtr<RuleCache>> by_layer;
+};
+
+struct SelectorInsights {
+    bool has_has_selectors { false };
+};
+
+class StyleScope {
+public:
+    explicit StyleScope(GC::Ref<DOM::Node>);
+
+    DOM::Node& node() const { return m_node; }
+    DOM::Document& document() const;
+
+    RuleCaches const& author_rule_cache() const { return *m_author_rule_cache; }
+    RuleCaches const& user_rule_cache() const { return *m_user_rule_cache; }
+    RuleCaches const& user_agent_rule_cache() const { return *m_user_agent_rule_cache; }
+
+    [[nodiscard]] bool has_valid_rule_cache() const { return m_author_rule_cache; }
+    void invalidate_rule_cache();
+
+    [[nodiscard]] RuleCache const& get_pseudo_class_rule_cache(PseudoClass) const;
+
+    template<typename Callback>
+    void for_each_stylesheet(CascadeOrigin, Callback) const;
+
+    void make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&);
+
+    void build_rule_cache();
+    void build_rule_cache_if_needed() const;
+
+    static void collect_selector_insights(Selector const&, SelectorInsights&);
+
+    void build_qualified_layer_names_cache();
+
+    [[nodiscard]] bool may_have_has_selectors() const;
+    [[nodiscard]] bool have_has_selectors() const;
+
+    void for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
+
+    void invalidate_style_of_elements_affected_by_has();
+
+    void schedule_ancestors_style_invalidation_due_to_presence_of_has(DOM::Node& node) { m_pending_nodes_for_style_invalidation_due_to_presence_of_has.set(node); }
+
+    void visit_edges(GC::Cell::Visitor&);
+
+    Vector<FlyString> m_qualified_layer_names_in_order;
+    OwnPtr<SelectorInsights> m_selector_insights;
+    Array<OwnPtr<RuleCache>, to_underlying(PseudoClass::__Count)> m_pseudo_class_rule_cache;
+    OwnPtr<StyleInvalidationData> m_style_invalidation_data;
+    OwnPtr<RuleCaches> m_author_rule_cache;
+    OwnPtr<RuleCaches> m_user_rule_cache;
+    OwnPtr<RuleCaches> m_user_agent_rule_cache;
+
+    GC::Ptr<CSSStyleSheet> m_user_style_sheet;
+
+    HashTable<GC::Weak<DOM::Node>> m_pending_nodes_for_style_invalidation_due_to_presence_of_has;
+
+    GC::Ref<DOM::Node> m_node;
+};
+
+}

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -116,8 +116,15 @@ void StyleSheetList::add_sheet(CSSStyleSheet& sheet)
         return;
     }
 
-    document().style_computer().invalidate_rule_cache();
-    document_or_shadow_root().invalidate_style(DOM::StyleInvalidationReason::StyleSheetListAddSheet);
+    if (auto* shadow_root = as_if<DOM::ShadowRoot>(document_or_shadow_root())) {
+        if (auto* host = shadow_root->host()) {
+            host->invalidate_style(DOM::StyleInvalidationReason::StyleSheetListAddSheet);
+        }
+        shadow_root->style_scope().invalidate_rule_cache();
+    } else {
+        document_or_shadow_root().invalidate_style(DOM::StyleInvalidationReason::StyleSheetListAddSheet);
+        document_or_shadow_root().document().style_scope().invalidate_rule_cache();
+    }
 }
 
 void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
@@ -131,8 +138,15 @@ void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
         return;
     }
 
-    m_document_or_shadow_root->document().style_computer().invalidate_rule_cache();
-    document_or_shadow_root().invalidate_style(DOM::StyleInvalidationReason::StyleSheetListRemoveSheet);
+    if (auto* shadow_root = as_if<DOM::ShadowRoot>(document_or_shadow_root())) {
+        if (auto* host = shadow_root->host()) {
+            host->invalidate_style(DOM::StyleInvalidationReason::StyleSheetListRemoveSheet);
+        }
+        shadow_root->style_scope().invalidate_rule_cache();
+    } else {
+        document_or_shadow_root().invalidate_style(DOM::StyleInvalidationReason::StyleSheetListRemoveSheet);
+        document_or_shadow_root().document().style_scope().invalidate_rule_cache();
+    }
 }
 
 GC::Ref<StyleSheetList> StyleSheetList::create(GC::Ref<DOM::Node> document_or_shadow_root)

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -209,4 +209,12 @@ String AbstractElement::debug_description() const
     return m_element->debug_description();
 }
 
+CSS::StyleScope const& AbstractElement::style_scope() const
+{
+    auto& root = m_element->root();
+    if (root.is_shadow_root())
+        return as<DOM::ShadowRoot>(root).style_scope();
+    return root.document().style_scope();
+}
+
 }

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -60,6 +60,8 @@ public:
     String debug_description() const;
     bool operator==(AbstractElement const&) const = default;
 
+    CSS::StyleScope const& style_scope() const;
+
 private:
     enum class WalkMethod : u8 {
         Previous,

--- a/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
+++ b/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
@@ -31,7 +31,8 @@ GC::Ref<WebIDL::ObservableArray> create_adopted_style_sheets_list(Node& document
             return WebIDL::NotAllowedError::create(document_or_shadow_root.realm(), "Sharing a StyleSheet between documents is not allowed."_utf16);
 
         style_sheet.add_owning_document_or_shadow_root(document_or_shadow_root);
-        document_or_shadow_root.document().style_computer().invalidate_rule_cache();
+        auto& style_scope = document_or_shadow_root.is_shadow_root() ? as<DOM::ShadowRoot>(document_or_shadow_root).style_scope() : document_or_shadow_root.document().style_scope();
+        style_scope.invalidate_rule_cache();
         document_or_shadow_root.invalidate_style(DOM::StyleInvalidationReason::AdoptedStyleSheetsList);
         return {};
     });
@@ -41,8 +42,9 @@ GC::Ref<WebIDL::ObservableArray> create_adopted_style_sheets_list(Node& document
         VERIFY(is<CSS::CSSStyleSheet>(object));
         auto& style_sheet = static_cast<CSS::CSSStyleSheet&>(object);
 
+        auto& style_scope = document_or_shadow_root.is_shadow_root() ? as<DOM::ShadowRoot>(document_or_shadow_root).style_scope() : document_or_shadow_root.document().style_scope();
         style_sheet.remove_owning_document_or_shadow_root(document_or_shadow_root);
-        document_or_shadow_root.document().style_computer().invalidate_rule_cache();
+        style_scope.invalidate_rule_cache();
         document_or_shadow_root.invalidate_style(DOM::StyleInvalidationReason::AdoptedStyleSheetsList);
         return {};
     });

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -24,6 +24,7 @@
 #include <LibWeb/CSS/CSSPropertyRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/EnvironmentVariable.h>
+#include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/CSS/StyleSheetList.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/DOM/ParentNode.h>
@@ -262,7 +263,7 @@ public:
     CSS::StyleSheetList& style_sheets();
     CSS::StyleSheetList const& style_sheets() const;
 
-    void for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&, GC::Ptr<DOM::ShadowRoot>)>&& callback) const;
+    void for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
 
     CSS::StyleSheetList* style_sheets_for_bindings() { return &style_sheets(); }
 
@@ -930,11 +931,6 @@ public:
     void add_render_blocking_element(GC::Ref<Element>);
     void remove_render_blocking_element(GC::Ref<Element>);
 
-    void schedule_ancestors_style_invalidation_due_to_presence_of_has(Node& node)
-    {
-        m_pending_nodes_for_style_invalidation_due_to_presence_of_has.set(node);
-    }
-
     ElementByIdMap& element_by_id() const;
 
     auto& script_blocking_style_sheet_set() { return m_script_blocking_style_sheet_set; }
@@ -950,6 +946,9 @@ public:
     HashMap<FlyString, GC::Ref<Web::CSS::CSSPropertyRule>>& registered_custom_properties();
 
     NonnullRefPtr<CSS::StyleValue const> custom_property_initial_value(FlyString const& name) const;
+
+    CSS::StyleScope const& style_scope() const { return m_style_scope; }
+    CSS::StyleScope& style_scope() { return m_style_scope; }
 
 protected:
     virtual void initialize(JS::Realm&) override;
@@ -1341,12 +1340,12 @@ private:
     // https://drafts.csswg.org/css-view-transitions-1/#document-update-callback-queue
     Vector<GC::Ptr<ViewTransition::ViewTransition>> m_update_callback_queue = {};
 
-    HashTable<GC::Weak<Node>> m_pending_nodes_for_style_invalidation_due_to_presence_of_has;
-
     GC::Ref<StyleInvalidator> m_style_invalidator;
 
     // https://www.w3.org/TR/css-properties-values-api-1/#dom-window-registeredpropertyset-slot
     HashMap<FlyString, GC::Ref<Web::CSS::CSSPropertyRule>> m_registered_custom_properties;
+
+    CSS::StyleScope m_style_scope;
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -420,10 +420,12 @@ void Node::invalidate_style(StyleInvalidationReason reason)
     if (is_character_data())
         return;
 
-    if (document().style_computer().may_have_has_selectors()) {
+    auto& style_scope = root().is_shadow_root() ? static_cast<ShadowRoot&>(root()).style_scope() : document().style_scope();
+
+    if (style_scope.may_have_has_selectors()) {
         if (reason == StyleInvalidationReason::NodeRemove) {
             if (auto* parent = parent_or_shadow_host(); parent) {
-                document().schedule_ancestors_style_invalidation_due_to_presence_of_has(*parent);
+                style_scope.schedule_ancestors_style_invalidation_due_to_presence_of_has(*parent);
                 parent->for_each_child_of_type<Element>([&](auto& element) {
                     if (element.affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator())
                         element.invalidate_style_if_affected_by_has();
@@ -431,7 +433,7 @@ void Node::invalidate_style(StyleInvalidationReason reason)
                 });
             }
         } else {
-            document().schedule_ancestors_style_invalidation_due_to_presence_of_has(*this);
+            style_scope.schedule_ancestors_style_invalidation_due_to_presence_of_has(*this);
         }
     }
 
@@ -499,29 +501,48 @@ void Node::invalidate_style(StyleInvalidationReason reason, Vector<CSS::Invalida
     if (is_character_data())
         return;
 
+    auto& root = this->root();
+    auto& style_scope = root.is_shadow_root() ? static_cast<ShadowRoot&>(root).style_scope() : document().style_scope();
+    CSS::StyleScope* shadow_style_scope = nullptr;
+    if (auto* element = as_if<Element>(this); element && element->is_shadow_host()) {
+        if (auto element_shadow_root = element->shadow_root())
+            shadow_style_scope = &element_shadow_root->style_scope();
+    }
+
     bool properties_used_in_has_selectors = false;
     for (auto const& property : properties) {
-        properties_used_in_has_selectors |= document().style_computer().invalidation_property_used_in_has_selector(property);
+        properties_used_in_has_selectors |= document().style_computer().invalidation_property_used_in_has_selector(property, style_scope);
+        if (shadow_style_scope)
+            properties_used_in_has_selectors |= document().style_computer().invalidation_property_used_in_has_selector(property, *shadow_style_scope);
     }
     if (properties_used_in_has_selectors) {
-        document().schedule_ancestors_style_invalidation_due_to_presence_of_has(*this);
+        style_scope.schedule_ancestors_style_invalidation_due_to_presence_of_has(*this);
+        if (shadow_style_scope)
+            shadow_style_scope->schedule_ancestors_style_invalidation_due_to_presence_of_has(*this);
     }
 
-    auto invalidation_set = document().style_computer().invalidation_set_for_properties(properties);
-    if (invalidation_set.needs_invalidate_whole_subtree()) {
-        invalidate_style(reason);
-        return;
-    }
+    auto invalidate_for_style_scope = [this, reason, &properties, &options](CSS::StyleScope& style_scope) {
+        auto invalidation_set = document().style_computer().invalidation_set_for_properties(properties, style_scope);
 
-    if (options.invalidate_self || invalidation_set.needs_invalidate_self()) {
-        set_needs_style_update(true);
-    }
+        if (invalidation_set.needs_invalidate_whole_subtree()) {
+            invalidate_style(reason);
+            return;
+        }
 
-    if (!invalidation_set.has_properties()) {
-        return;
-    }
+        if (options.invalidate_self || invalidation_set.needs_invalidate_self()) {
+            set_needs_style_update(true);
+        }
 
-    document().style_invalidator().add_pending_invalidation(*this, move(invalidation_set));
+        if (!invalidation_set.has_properties()) {
+            return;
+        }
+
+        document().style_invalidator().add_pending_invalidation(*this, move(invalidation_set));
+    };
+
+    invalidate_for_style_scope(style_scope);
+    if (shadow_style_scope)
+        invalidate_for_style_scope(*shadow_style_scope);
 }
 
 Utf16String Node::child_text_content() const

--- a/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
+#include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/ElementByIdMap.h>
 #include <LibWeb/Export.h>
@@ -63,10 +64,14 @@ public:
     WebIDL::ExceptionOr<void> set_adopted_style_sheets(JS::Value);
 
     void for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
+    void for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
 
     WebIDL::ExceptionOr<Vector<GC::Ref<Animations::Animation>>> get_animations();
 
     ElementByIdMap& element_by_id() const;
+
+    CSS::StyleScope const& style_scope() const { return m_style_scope; }
+    CSS::StyleScope& style_scope() { return m_style_scope; }
 
     virtual void finalize() override;
 
@@ -102,6 +107,8 @@ private:
     mutable GC::Ptr<WebIDL::ObservableArray> m_adopted_style_sheets;
 
     IntrusiveListNode<ShadowRoot> m_list_node;
+
+    CSS::StyleScope m_style_scope;
 
 public:
     using DocumentShadowRootList = IntrusiveList<&ShadowRoot::m_list_node>;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -370,6 +370,7 @@ class StringStyleValue;
 class StyleComputer;
 class StylePropertyMap;
 class StylePropertyMapReadOnly;
+class StyleScope;
 class StyleSheet;
 class StyleSheetList;
 class StyleValue;

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -599,7 +599,11 @@ void Page::set_user_style(String source)
 {
     m_user_style_sheet_source = source;
     if (top_level_traversable_is_initialized() && top_level_traversable()->active_document()) {
-        top_level_traversable()->active_document()->style_computer().invalidate_rule_cache();
+        auto& document = *top_level_traversable()->active_document();
+        document.style_scope().invalidate_rule_cache();
+        document.for_each_shadow_root([](auto& shadow_root) {
+            shadow_root.style_scope().invalidate_rule_cache();
+        });
     }
 }
 


### PR DESCRIPTION
Before this change, we've been maintaining various StyleComputer caches at the document level.

This made sense for old-school documents without shadow trees, since all the style information was document-wide anyway. However, documents with many shadow trees ended up suffering since any time you mutated a style sheet inside a shadow tree, *all* style caches for the entire document would get invalidated.

This was particularly expensive on Reddit, which has tons of shadow trees with their own style elements. Every time we'd create one of their custom elements, we'd invalidate the document-level "rule cache" and have to rebuild it, taking about ~60ms each time (ouch).

This commit introduces a new object called StyleScope.

Every Document and ShadowRoot has its own StyleScope. Rule caches etc are moved from StyleComputer to StyleScope.

Rule cache invalidation now happens at StyleScope level. As an example, rule cache rebuilds now take ~1ms on Reddit instead of ~60ms.

This is largely a mechanical change, moving things around, but there's one key detail to be aware of: due to the :host selector, which works across the shadow DOM boundary and reaches from inside a shadow tree out into the light tree, there are various places where we have to check both the shadow tree's StyleScope *and* the document-level StyleScope in order to get all rules that may apply.