### PR TITLE
LibWeb: Prevent race condition when setting up parent window listeners

### DIFF
--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-iframe.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-iframe.html
@@ -30,13 +30,21 @@
 
         const sendMessageAndWait = (message) => {
             return new Promise((resolve) => {
-                window.onmessage = ({ data }) => {
+                const listener = ({ data }) => {
+                    window.removeEventListener('message', listener);
                     resolve(data);
                 };
-
+                window.addEventListener('message', listener);
                 testIframe.contentWindow.postMessage(message, "*");
             });
         };
+
+        // wait for the iframe to be ready
+        await new Promise((resolve) => {
+            testIframe.addEventListener('load', resolve);
+            if (testIframe.contentDocument.readyState === 'complete')
+                resolve();
+        });
 
         const gamepad = internals.connectVirtualGamepad();
         await handleSDLInputEvents();


### PR DESCRIPTION
This fixes the sporadic timeouts of the gamepad-iframe test. 

I ran this test 300 times locally and got 9 timeouts before this fix and 0 after. 