### PR TITLE
Two HTTP cache improvements

### DIFF
--- a/Services/RequestServer/Cache/CacheEntry.cpp
+++ b/Services/RequestServer/Cache/CacheEntry.cpp
@@ -116,7 +116,7 @@ ErrorOr<void> CacheEntryWriter::write_status_and_reason(u32 status_code, Optiona
         if (!is_cacheable(status_code, response_headers))
             return Error::from_string_literal("Response is not cacheable");
 
-        auto freshness_lifetime = calculate_freshness_lifetime(response_headers);
+        auto freshness_lifetime = calculate_freshness_lifetime(status_code, response_headers);
         auto current_age = calculate_age(response_headers, m_request_time, m_response_time);
 
         // We can cache already-expired responses if there are other cache directives that allow us to revalidate the

--- a/Services/RequestServer/Cache/DiskCache.cpp
+++ b/Services/RequestServer/Cache/DiskCache.cpp
@@ -83,7 +83,7 @@ Variant<Optional<CacheEntryReader&>, DiskCache::CacheHasOpenEntry> DiskCache::op
     }
 
     auto const& response_headers = cache_entry.value()->response_headers();
-    auto freshness_lifetime = calculate_freshness_lifetime(response_headers);
+    auto freshness_lifetime = calculate_freshness_lifetime(cache_entry.value()->status_code(), response_headers);
     auto current_age = calculate_age(response_headers, index_entry->request_time, index_entry->response_time);
 
     switch (cache_lifetime_status(response_headers, freshness_lifetime, current_age)) {

--- a/Services/RequestServer/Cache/Utilities.h
+++ b/Services/RequestServer/Cache/Utilities.h
@@ -23,7 +23,7 @@ bool is_cacheable(StringView method);
 bool is_cacheable(u32 status_code, HTTP::HeaderMap const&);
 bool is_header_exempted_from_storage(StringView name);
 
-AK::Duration calculate_freshness_lifetime(HTTP::HeaderMap const&);
+AK::Duration calculate_freshness_lifetime(u32 status_code, HTTP::HeaderMap const&);
 AK::Duration calculate_age(HTTP::HeaderMap const&, UnixDateTime request_time, UnixDateTime response_time);
 
 enum class CacheLifetimeStatus {


### PR DESCRIPTION
Two things here:

- Stop incorrectly overwriting Content-Length when revalidating.
- Implement a (pretty conservative) heuristic for freshness if there's no explicit expiration information present.

Net result: we cache more resources on many, many websites! Examples: github.com, archive.org