### PR TITLE
LibJS: Remove "era" from Temporal's DateTimeFormat formatting options

### DIFF
--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -364,8 +364,8 @@ Optional<Unicode::CalendarPattern> get_date_time_format(Unicode::CalendarPattern
     // 13. Let anyPresent be false.
     auto any_present = false;
 
-    // 14. For each property name prop of « "weekday", "year", "month", "day", "era", "dayPeriod", "hour", "minute", "second", "fractionalSecondDigits" », do
-    static constexpr auto all_fields = AK::Array { Weekday, Year, Month, Day, Era, DayPeriod, Hour, Minute, Second, FractionalSecondDigits };
+    // 14. For each property name prop of « "weekday", "year", "month", "day", "dayPeriod", "hour", "minute", "second", "fractionalSecondDigits" », do
+    static constexpr auto all_fields = AK::Array { Weekday, Year, Month, Day, DayPeriod, Hour, Minute, Second, FractionalSecondDigits };
 
     options.for_each_calendar_field_zipped_with(format_options, all_fields, [&](auto const& option, auto&) {
         // a. If options.[[<prop>]] is not undefined, set anyPresent to true.

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -672,4 +672,11 @@ describe("Temporal objects", () => {
         const instant = new Temporal.Instant(1732740069000000000n);
         expect(formatter.format(instant)).toBe("2024-11-27, 8:41:09 PM");
     });
+
+    test("Formatting with only an era format option", () => {
+        const formatter = new Intl.DateTimeFormat("en", { era: "narrow", timeZone: "UTC" });
+
+        const plainDate = new Temporal.PlainDate(1989, 1, 23);
+        expect(formatter.format(plainDate)).toBe("1/23/1989 A");
+    });
 });


### PR DESCRIPTION
This fixes a bug I opened last year: `https://github.com/tc39/proposal-temporal/issues/3049`

test262 diff:
```
test/intl402/Temporal/PlainDate/prototype/toLocaleString/options-conflict.js      ❌ -> ✅
test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/options-conflict.js  💥 -> ✅
test/intl402/Temporal/PlainYearMonth/prototype/toLocaleString/options-conflict.js ❌ -> ✅
```