### PR TITLE
LibWeb: Block rendering while waiting for CSS @import downloads

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -546,6 +546,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     m_style_scope.visit_edges(visitor);
+    visitor.visit(m_pending_css_import_rules);
     visitor.visit(m_page);
     visitor.visit(m_window);
     visitor.visit(m_layout_root);
@@ -6284,6 +6285,10 @@ bool Document::is_render_blocked() const
     if (now > max_time_to_block_rendering_in_ms)
         return false;
 
+    // AD-HOC: Consider pending CSS @import rules as render-blocking
+    if (!m_pending_css_import_rules.is_empty())
+        return true;
+
     return !m_render_blocking_elements.is_empty() || allows_adding_render_blocking_elements();
 }
 
@@ -6898,6 +6903,16 @@ StringView to_string(UpdateLayoutReason reason)
 #undef ENUMERATE_UPDATE_LAYOUT_REASON
     }
     VERIFY_NOT_REACHED();
+}
+
+void Document::add_pending_css_import_rule(Badge<CSS::CSSImportRule>, GC::Ref<CSS::CSSImportRule> rule)
+{
+    m_pending_css_import_rules.set(rule);
+}
+
+void Document::remove_pending_css_import_rule(Badge<CSS::CSSImportRule>, GC::Ref<CSS::CSSImportRule> rule)
+{
+    m_pending_css_import_rules.remove(rule);
 }
 
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -541,6 +541,9 @@ public:
     void increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);
     void decrement_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);
 
+    void add_pending_css_import_rule(Badge<CSS::CSSImportRule>, GC::Ref<CSS::CSSImportRule>);
+    void remove_pending_css_import_rule(Badge<CSS::CSSImportRule>, GC::Ref<CSS::CSSImportRule>);
+
     bool page_showing() const { return m_page_showing; }
     void set_page_showing(bool);
 
@@ -1093,6 +1096,8 @@ private:
 
     // https://html.spec.whatwg.org/multipage/semantics.html#script-blocking-style-sheet-set
     HashTable<GC::Ref<DOM::Element>> m_script_blocking_style_sheet_set;
+
+    HashTable<GC::Ref<CSS::CSSImportRule>> m_pending_css_import_rules;
 
     GC::Ptr<HTML::History> m_history;
 


### PR DESCRIPTION
The implementation here is a ad-hoc, but there's no clear spec for exactly how to handle "critical subresources" blocking rendering.

For now, this is overly conservative but fixes ugly FOUC on some websites like https://hey.com/

Before/after demo where you can see the FOUCs:
https://github.com/user-attachments/assets/61ead705-c3ab-4bfa-ac2c-54c17814fee5

