### PR TITLE
LibWeb: Handle calc percentages when interpolating scale function

### DIFF
--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -773,9 +773,9 @@ RefPtr<StyleValue const> interpolate_transform(DOM::Element& element, StyleValue
                 auto& calculated = value->as_calculated();
                 if (calculated.resolves_to_angle()) {
                     values.append(AngleOrCalculated { calculated });
-                } else if (calculated.resolves_to_length_percentage()) {
+                } else if (calculated.resolves_to_length()) {
                     values.append(LengthPercentage { calculated });
-                } else if (calculated.resolves_to_number()) {
+                } else if (calculated.resolves_to_number() || calculated.resolves_to_percentage()) {
                     values.append(NumberPercentage { calculated });
                 } else {
                     dbgln("Calculation `{}` inside {} transform-function is not a recognized type", calculated.to_string(SerializationMode::Normal), to_string(transformation.transform_function()));

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
@@ -41,12 +41,9 @@ Transformation TransformationStyleValue::to_transformation() const
 
         if (transformation_value->is_calculated()) {
             auto& calculated = transformation_value->as_calculated();
-            if (function_type == TransformFunctionParameterType::NumberPercentage
-                && (calculated.resolves_to_number() || calculated.resolves_to_percentage())) {
-                values.append(NumberPercentage { calculated });
-            } else if (calculated.resolves_to_length_percentage()) {
+            if (calculated.resolves_to_length()) {
                 values.append(LengthPercentage { calculated });
-            } else if (calculated.resolves_to_number()) {
+            } else if (calculated.resolves_to_number() || calculated.resolves_to_percentage()) {
                 values.append(NumberPercentage { calculated });
             } else if (calculated.resolves_to_angle()) {
                 values.append(AngleOrCalculated { calculated });

--- a/Tests/LibWeb/Crash/CSS/transform-function-number-percentage-transition.html
+++ b/Tests/LibWeb/Crash/CSS/transform-function-number-percentage-transition.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <style>
+        #foo {
+            transition: transform 1s;
+            transform: scale(50%);
+        }
+    </style>
+    <div id="foo"></div>
+    <script>
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                foo.style.transform = "scale(calc(50% + 25%))";
+            });
+        });
+    </script>
+</html>


### PR DESCRIPTION
Also clean up the corresponding handling in `TransformationStyleValue::to_transformation`