### PR TITLE
Tests: Disable `naturalWidth-naturalHeight-width-height.tentative.html`

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -351,3 +351,6 @@ Text/input/wpt-import/html/semantics/popovers/popover-toggle-source.tentative.ht
 
 ; Flaky: https://github.com/LadybirdBrowser/ladybird/issues/5257
 Text/input/selection-over-multiple-code-units.html
+
+; Flaky: https://github.com/LadybirdBrowser/ladybird/issues/6846
+Text/input/wpt-import/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.tentative.html


### PR DESCRIPTION
This test is currently failing fairly frequently on CI.

I'm currently looking into a fix for this, but in the meantime lets disable it to unblock CI.