### PR TITLE
LibWeb: Prevent view transition crashes due to lack of execution context

### DIFF
--- a/Tests/LibWeb/Crash/CSS/view-transition-crash.html
+++ b/Tests/LibWeb/Crash/CSS/view-transition-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+    document.startViewTransition(() => {});
+    document.startViewTransition(() => {});
+</script>


### PR DESCRIPTION
Fixes the crash on https://angular.dev/
