### PR TITLE
LibWeb/CSS: Handle whitespace better in font-language-override strings

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-language-override-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-language-override-computed.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-1 Pass
-4 Fail
+5 Pass
 Pass	Property font-language-override value 'normal'
-Fail	Property font-language-override value '"KSW"'
-Fail	Property font-language-override value '"ENG "'
-Fail	Property font-language-override value '"en  "'
-Fail	Property font-language-override value '" en "'
+Pass	Property font-language-override value '"KSW"'
+Pass	Property font-language-override value '"ENG "'
+Pass	Property font-language-override value '"en  "'
+Pass	Property font-language-override value '" en "'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-language-override-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/parsing/font-language-override-valid.txt
@@ -2,14 +2,13 @@ Harness status: OK
 
 Found 9 tests
 
-2 Pass
-7 Fail
+9 Pass
 Pass	e.style['font-language-override'] = "normal" should set the property value
-Fail	e.style['font-language-override'] = "\"KSW\"" should set the property value
+Pass	e.style['font-language-override'] = "\"KSW\"" should set the property value
 Pass	e.style['font-language-override'] = "\"APPH\"" should set the property value
-Fail	e.style['font-language-override'] = "\"ENG \"" should set the property value
-Fail	e.style['font-language-override'] = "\"ksw\"" should set the property value
-Fail	e.style['font-language-override'] = "\"tr\"" should set the property value
-Fail	e.style['font-language-override'] = "\"en  \"" should set the property value
-Fail	e.style['font-language-override'] = "\" en \"" should set the property value
-Fail	e.style['font-language-override'] = "\"1 %\"" should set the property value
+Pass	e.style['font-language-override'] = "\"ENG \"" should set the property value
+Pass	e.style['font-language-override'] = "\"ksw\"" should set the property value
+Pass	e.style['font-language-override'] = "\"tr\"" should set the property value
+Pass	e.style['font-language-override'] = "\"en  \"" should set the property value
+Pass	e.style['font-language-override'] = "\" en \"" should set the property value
+Pass	e.style['font-language-override'] = "\"1 %\"" should set the property value


### PR DESCRIPTION
The rules for strings here are:
- 4 ASCII characters long
- Shorter ones are right-padded with spaces before use
- Trailing whitespace is always removed when serializing

We previously always padded them during parsing, which was incorrect. This commit flips it around so we trim trailing whitespace when parsing.

We don't yet actually use this property's value for anything. Once we do so, maybe we'll care more about them being stored as 4 characters always, but for now this avoids us needing a special step during computation.