### PR TITLE
Meta: Compile for the native architecture of the host system on Windows

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -49,10 +49,7 @@ macro(add_swift_link_options)
     add_link_options($<$<LINK_LANGUAGE:Swift>:${args}>)
 endmacro()
 
-if (MSVC)
-    # On Windows, we always target the same architecture since there is no -march=native equivalent.
-    add_cxx_compile_options(/arch:AVX2)
-elseif (ENABLE_CI_BASELINE_CPU)
+if (ENABLE_CI_BASELINE_CPU)
     # In CI, we want to target a common architecture so different runners can share ccache caches effectively.
     if (APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
         add_cxx_compile_options(-mcpu=apple-m1)


### PR DESCRIPTION
PR #6210 broke my local Windows build: IPCCompiler.exe crashes with error 0xc0000142 because of illegal instruction in lagom-ak.dll. This is the fix. Note that clang-cl accepts many clang options, including -march=native.

This PR needs the windows label.