### PR TITLE
RequestServer: Support HTTP response write retries on Windows

### DIFF
--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Enumerate.h>
+#include <AK/GenericShorthands.h>
 #include <LibCore/Notifier.h>
 #include <LibTextCodec/Decoder.h>
 #include <RequestServer/CURL.h>
@@ -614,7 +615,7 @@ ErrorOr<void> Request::write_queued_bytes_without_blocking()
 
     auto result = m_client_request_pipe->write(bytes_to_send);
     if (result.is_error()) {
-        if (result.error().code() != EAGAIN)
+        if (!first_is_one_of(result.error().code(), EAGAIN, EWOULDBLOCK))
             return result.release_error();
 
         m_client_writer_notifier->set_enabled(true);

--- a/Services/RequestServer/RequestPipe.cpp
+++ b/Services/RequestServer/RequestPipe.cpp
@@ -59,8 +59,11 @@ ErrorOr<ssize_t> RequestPipe::write(ReadonlyBytes bytes)
 {
 #if defined(AK_OS_WINDOWS)
     auto sent = ::send(m_writer_fd, reinterpret_cast<char const*>(bytes.data()), bytes.size(), 0);
-    if (sent == SOCKET_ERROR)
+    if (sent == SOCKET_ERROR) {
+        if (WSAGetLastError() == WSAEWOULDBLOCK)
+            return Error::from_errno(EWOULDBLOCK);
         return Error::from_windows_error();
+    }
     return sent;
 #else
     return Core::System::write(m_writer_fd, bytes);


### PR DESCRIPTION
See [discussion](https://discord.com/channels/1247070541085671459/1306918361732616212/1440408549602889885) in `#ui-windows` and commit for details. 

### Before

https://github.com/user-attachments/assets/02ff0a4d-0043-41e4-aa9f-8892427ac4e7

### After

https://github.com/user-attachments/assets/22dedb72-7cf7-4af8-a793-06125e2cf317

