### PR TITLE
LibWeb: Avoid unnecessary sorting work when getting animations

### DIFF
--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -73,10 +73,10 @@ WebIDL::ExceptionOr<GC::Ref<Animation>> Animatable::animate(Optional<GC::Root<JS
 WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> Animatable::get_animations(Optional<GetAnimationsOptions> options)
 {
     as<DOM::Element>(*this).document().update_style();
-    return get_animations_internal(options);
+    return get_animations_internal(GetAnimationsSorted::Yes, options);
 }
 
-WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> Animatable::get_animations_internal(Optional<GetAnimationsOptions> options)
+WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> Animatable::get_animations_internal(GetAnimationsSorted sorted, Optional<GetAnimationsOptions> options)
 {
     // 1. Let object be the object on which this method was called.
 
@@ -108,18 +108,20 @@ WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> Animatable::get_animations_inter
     if (options.has_value() && options->subtree) {
         Optional<WebIDL::Exception> exception;
         TRY(target->for_each_child_of_type_fallible<DOM::Element>([&](auto& child) -> WebIDL::ExceptionOr<IterationDecision> {
-            relevant_animations.extend(TRY(child.get_animations(options)));
+            relevant_animations.extend(TRY(child.get_animations_internal(GetAnimationsSorted::No, options)));
             return IterationDecision::Continue;
         }));
     }
 
     // The returned list is sorted using the composite order described for the associated animations of effects in
     // §5.4.2 The effect stack.
-    quick_sort(relevant_animations, [](GC::Ref<Animation>& a, GC::Ref<Animation>& b) {
-        auto& a_effect = as<KeyframeEffect>(*a->effect());
-        auto& b_effect = as<KeyframeEffect>(*b->effect());
-        return KeyframeEffect::composite_order(a_effect, b_effect) < 0;
-    });
+    if (sorted == GetAnimationsSorted::Yes) {
+        quick_sort(relevant_animations, [](GC::Ref<Animation>& a, GC::Ref<Animation>& b) {
+            auto& a_effect = as<KeyframeEffect>(*a->effect());
+            auto& b_effect = as<KeyframeEffect>(*b->effect());
+            return KeyframeEffect::composite_order(a_effect, b_effect) < 0;
+        });
+    }
 
     return relevant_animations;
 }

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -45,9 +45,14 @@ public:
 
     virtual ~Animatable() = default;
 
+    enum class GetAnimationsSorted {
+        No,
+        Yes
+    };
+
     WebIDL::ExceptionOr<GC::Ref<Animation>> animate(Optional<GC::Root<JS::Object>> keyframes, Variant<Empty, double, KeyframeAnimationOptions> options = {});
     WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations(Optional<GetAnimationsOptions> options = {});
-    WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations_internal(Optional<GetAnimationsOptions> options = {});
+    WebIDL::ExceptionOr<Vector<GC::Ref<Animation>>> get_animations_internal(GetAnimationsSorted sorted, Optional<GetAnimationsOptions> options = {});
 
     void associate_with_animation(GC::Ref<Animation>);
     void disassociate_with_animation(GC::Ref<Animation>);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -23,6 +23,7 @@
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/WOFF/Loader.h>
 #include <LibGfx/Font/WOFF2/Loader.h>
+#include <LibWeb/Animations/Animatable.h>
 #include <LibWeb/Animations/AnimationEffect.h>
 #include <LibWeb/Animations/DocumentTimeline.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
@@ -2562,7 +2563,9 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
     // 5. Add or modify CSS-defined animations
     process_animation_definitions(computed_style, abstract_element);
 
-    auto animations = abstract_element.element().get_animations_internal(Animations::GetAnimationsOptions { .subtree = false });
+    auto animations = abstract_element.element().get_animations_internal(
+        Animations::Animatable::GetAnimationsSorted::Yes,
+        Animations::GetAnimationsOptions { .subtree = false });
     if (animations.is_exception()) {
         dbgln("Error getting animations for element {}", abstract_element.debug_description());
     } else {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5449,6 +5449,7 @@ void Document::remove_replaced_animations()
 
 WebIDL::ExceptionOr<Vector<GC::Ref<Animations::Animation>>> Document::get_animations()
 {
+    update_style();
     return calculate_get_animations(*this);
 }
 

--- a/Libraries/LibWeb/DOM/DocumentOrShadowRoot.h
+++ b/Libraries/LibWeb/DOM/DocumentOrShadowRoot.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibWeb/Animations/Animatable.h>
 #include <LibWeb/Animations/Animation.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Utils.h>
@@ -56,7 +57,9 @@ WebIDL::ExceptionOr<Vector<GC::Ref<Animations::Animation>>> calculate_get_animat
     // method is called.
     Vector<GC::Ref<Animations::Animation>> relevant_animations;
     TRY(self.template for_each_child_of_type_fallible<Element>([&](auto& child) -> WebIDL::ExceptionOr<IterationDecision> {
-        relevant_animations.extend(TRY(child.get_animations(Animations::GetAnimationsOptions { .subtree = true })));
+        relevant_animations.extend(TRY(child.get_animations_internal(
+            Animations::Animatable::GetAnimationsSorted::No,
+            Animations::GetAnimationsOptions { .subtree = true })));
         return IterationDecision::Continue;
     }));
 

--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -215,6 +215,7 @@ void ShadowRoot::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleShee
 
 WebIDL::ExceptionOr<Vector<GC::Ref<Animations::Animation>>> ShadowRoot::get_animations()
 {
+    document().update_style();
     return calculate_get_animations(*this);
 }
 


### PR DESCRIPTION
This way, the list is not re-sorted on every recursive call.

No new test since this isn't about correctness, but rather just a performance thing.