### PR TITLE
LibMedia: Set Matroska "complex" tracks' types based on the codec

### DIFF
--- a/Libraries/LibMedia/CodecID.h
+++ b/Libraries/LibMedia/CodecID.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Format.h>
+#include <LibMedia/TrackType.h>
 
 namespace Media {
 
@@ -32,6 +33,32 @@ enum class CodecID : u32 {
     Opus,
     FLAC,
 };
+
+inline TrackType track_type_from_codec_id(CodecID codec)
+{
+    switch (codec) {
+    case CodecID::VP8:
+    case CodecID::VP9:
+    case CodecID::H261:
+    case CodecID::MPEG1:
+    case CodecID::H262:
+    case CodecID::H263:
+    case CodecID::H264:
+    case CodecID::H265:
+    case CodecID::AV1:
+        return TrackType::Video;
+    case CodecID::MP3:
+    case CodecID::AAC:
+    case CodecID::Theora:
+    case CodecID::Vorbis:
+    case CodecID::Opus:
+    case CodecID::FLAC:
+        return TrackType::Audio;
+    case CodecID::Unknown:
+        break;
+    }
+    return TrackType::Unknown;
+}
 
 }
 

--- a/Libraries/LibMedia/Track.h
+++ b/Libraries/LibMedia/Track.h
@@ -13,15 +13,9 @@
 #include <AK/Utf16String.h>
 #include <AK/Variant.h>
 #include <LibMedia/Color/CodingIndependentCodePoints.h>
+#include <LibMedia/TrackType.h>
 
 namespace Media {
-
-enum class TrackType : u32 {
-    Video,
-    Audio,
-    Subtitles,
-    Unknown,
-};
 
 class Track {
     struct VideoData {

--- a/Libraries/LibMedia/TrackType.h
+++ b/Libraries/LibMedia/TrackType.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, Gregory Bertilson <gregory@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Media {
+
+enum class TrackType : u8 {
+    Video,
+    Audio,
+    Subtitles,
+    Unknown,
+};
+
+}


### PR DESCRIPTION
The spec indicates that the codec defines how to interpret the data, so use our CodecIDs to determine the track type.