### PR TITLE
LibWeb: Implement Clear-Site-Data HTTP response header

### DIFF
--- a/Libraries/LibHTTP/Header.cpp
+++ b/Libraries/LibHTTP/Header.cpp
@@ -62,6 +62,20 @@ Optional<Vector<ByteString>> Header::extract_header_values() const
         return extract_token_headers(value);
     }
 
+    // Clear-Site-Data = 1#( quoted-string )
+    if (name.equals_ignoring_ascii_case("Clear-Site-Data"sv)) {
+        if (value.is_empty())
+            return {};
+
+        Vector<ByteString> trimmed_values;
+
+        value.view().for_each_split_view(',', SplitBehavior::Nothing, [&](auto value) {
+            trimmed_values.append(value.trim(" \t"sv));
+        });
+
+        return trimmed_values;
+    }
+
     // Access-Control-Request-Headers = 1#field-name      (field-name = token)
     // Accept-Ranges                  = acceptable-ranges (acceptable-ranges = 1#range-unit, range-unit = token)
     if (name.is_one_of_ignoring_ascii_case(

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -27,6 +27,9 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
+#include <LibWeb/SecureContexts/AbstractOperations.h>
+#include <LibWeb/StorageAPI/StorageEndpoint.h>
+#include <LibWeb/StorageAPI/StorageKey.h>
 
 namespace Web {
 
@@ -120,6 +123,121 @@ static void store_response_cookies(Page& page, URL::URL const& url, StringView s
         return;
 
     page.client().page_did_set_cookie(url, cookie.value(), HTTP::Cookie::Source::Http);
+}
+
+enum class ClearSiteDataType : u8 {
+    None = 0,
+    Cache = 1 << 0,
+    ClientHints = 1 << 1,
+    Cookies = 1 << 2,
+    ExecutionContexts = 1 << 3,
+    Storage = 1 << 4,
+};
+
+AK_ENUM_BITWISE_OPERATORS(ClearSiteDataType);
+
+// https://w3c.github.io/webappsec-clear-site-data/#parsing
+static ClearSiteDataType parse_clear_site_data_header(HTTP::HeaderList const& response_headers)
+{
+    // 1. Let types be an empty list.
+    auto types = ClearSiteDataType::None;
+
+    // 2. Let header be the result of extracting header list values given Clear-Site-Data and response's header list.
+    auto header = response_headers.extract_header_list_values("Clear-Site-Data"sv);
+
+    // 3. If header is null or failure, return an empty list.
+    if (header.has<Empty>() || header.has<HTTP::HeaderList::ExtractHeaderParseFailure>())
+        return ClearSiteDataType::None;
+
+    // 4. For each type in header, execute the first matching statement, if any, switching on type:
+    for (auto const& type : header.get<Vector<ByteString>>()) {
+        // `"cache"`
+        if (type == "\"cache\"") {
+            // Append "cache" and "clientHints" to types.
+            types |= ClearSiteDataType::Cache;
+            types |= ClearSiteDataType::ClientHints;
+        }
+        // `"cookies"`
+        else if (type == "\"cookies\"") {
+            // Append "cookies" and "clientHints" to types.
+            types |= ClearSiteDataType::Cookies;
+            types |= ClearSiteDataType::ClientHints;
+        }
+        // `"storage"`
+        else if (type == "\"storage\"") {
+            // Append "storage" to types.
+            types |= ClearSiteDataType::Storage;
+        }
+        // `"executionContexts"`
+        else if (type == "\"executionContexts\"") {
+            // Append "executionContexts" to types.
+            types |= ClearSiteDataType::ExecutionContexts;
+        }
+        // `"clientHints"`
+        else if (type == "\"clientHints\"") {
+            // Append "clientHints" to types.
+            types |= ClearSiteDataType::ClientHints;
+        }
+        // `"*"`
+        else if (type == "\"*\"") {
+            // Append "cache", "cookies", "storage", "clientHints", and "executionContexts" to types.
+            types |= ClearSiteDataType::Cache;
+            types |= ClearSiteDataType::Cookies;
+            types |= ClearSiteDataType::Storage;
+            types |= ClearSiteDataType::ClientHints;
+            types |= ClearSiteDataType::ExecutionContexts;
+        }
+    }
+
+    // 5. Return types.
+    return types;
+}
+
+// https://w3c.github.io/webappsec-clear-site-data/#clear-response
+static void handle_clear_site_data(Page& page, URL::URL const& url, HTTP::HeaderList const& response_headers)
+{
+    // 1. If response's url is not an a priori authenticated URL, then break.
+    if (SecureContexts::is_url_potentially_trustworthy(url) == SecureContexts::Trustworthiness::NotTrustworthy)
+        return;
+
+    // 2. Let types be the result of parsing response's Clear-Site-Data header.
+    auto types = parse_clear_site_data_header(response_headers);
+    if (types == ClearSiteDataType::None)
+        return;
+
+    // 3. Let origin be response's url's origin.
+    auto origin = url.origin();
+
+    // FIXME: 4. Let browsing contexts be the result of preparing to clear data for origin and types.
+
+    // 5. For each type in types:
+    //     1. Execute the first matching statement, if any, switching on type:
+
+    // "cache"
+    if (has_flag(types, ClearSiteDataType::Cache)) {
+        // FIXME: Clear cache for origin.
+    }
+    // "cookies"
+    if (has_flag(types, ClearSiteDataType::Cookies)) {
+        // Clear cookies for origin.
+        page.client().page_did_clear_cookies_for_origin(origin);
+    }
+    // "storage"
+    if (has_flag(types, ClearSiteDataType::Storage)) {
+        // Clear DOM-accessible storage for origin.
+        auto storage_key = StorageAPI::StorageKey { url.origin() }.to_string();
+        page.client().page_did_clear_storage(StorageAPI::StorageEndpointType::LocalStorage, storage_key);
+        page.client().page_did_clear_storage(StorageAPI::StorageEndpointType::SessionStorage, storage_key);
+        page.client().page_did_clear_storage(StorageAPI::StorageEndpointType::IndexedDB, storage_key);
+        page.client().page_did_clear_storage(StorageAPI::StorageEndpointType::ServiceWorkerRegistrations, storage_key);
+        page.client().page_did_clear_storage(StorageAPI::StorageEndpointType::Caches, storage_key);
+    }
+    // "clientHints"
+    if (has_flag(types, ClearSiteDataType::ClientHints)) {
+        // FIXME: Empty Accept-CH cache[origin].
+    }
+
+    // FIXME: 6. If types contains "executionContexts", then reload browsing contexts.
 }
 
 static NonnullRefPtr<HTTP::HeaderList> response_headers_for_file(StringView path, Optional<time_t> const& modified_time)
@@ -510,11 +628,13 @@ void ResourceLoader::handle_network_response_headers(LoadRequest const& request,
         // From https://fetch.spec.whatwg.org/#concept-http-network-fetch:
         // 15. If includeCredentials is true, then the user agent should parse and store response
         //     `Set-Cookie` headers given request and response.
-        for (auto const& [header, value] : response_headers) {
+        for (auto const& [header, value] : response_headers.headers()) {
             if (header.equals_ignoring_ascii_case("Set-Cookie"sv)) {
                 store_response_cookies(*request.page(), request.url().value(), value);
             }
         }
+
+        handle_clear_site_data(*request.page(), request.url().value(), response_headers);
     }
 }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -427,6 +427,7 @@ public:
     virtual void page_did_set_cookie(URL::URL const&, HTTP::Cookie::ParsedCookie const&, HTTP::Cookie::Source) { }
     virtual void page_did_update_cookie(HTTP::Cookie::Cookie const&) { }
     virtual void page_did_expire_cookies_with_time_offset(AK::Duration) { }
+    virtual void page_did_clear_cookies_for_origin([[maybe_unused]] URL::Origin const&) { }
     virtual Optional<String> page_did_request_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key) { return {}; }
     virtual WebView::StorageSetResult page_did_set_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key, [[maybe_unused]] String const& value) { return WebView::StorageOperationError::QuotaExceededError; }
     virtual void page_did_remove_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] String const& bottle_key) { }

--- a/Libraries/LibWebView/CookieJar.h
+++ b/Libraries/LibWebView/CookieJar.h
@@ -47,6 +47,7 @@ public:
     Optional<HTTP::Cookie::Cookie> get_named_cookie(URL::URL const& url, StringView name);
     void expire_cookies_with_time_offset(AK::Duration);
     void expire_cookies_accessed_since(UnixDateTime since);
+    void clear_cookies_for_origin(URL::Origin const& origin);
     Requests::CacheSizes estimate_storage_size_accessed_since(UnixDateTime since) const;
 
 private:

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -578,6 +578,11 @@ void WebContentClient::did_expire_cookies_with_time_offset(AK::Duration offset)
     Application::cookie_jar().expire_cookies_with_time_offset(offset);
 }
 
+void WebContentClient::did_clear_cookies_for_origin(URL::Origin origin)
+{
+    Application::cookie_jar().clear_cookies_for_origin(origin);
+}
+
 Messages::WebContentClient::DidRequestStorageItemResponse WebContentClient::did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key)
 {
     return Application::storage_jar().get_item(storage_endpoint, storage_key, bottle_key);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -114,6 +114,7 @@ private:
     virtual void did_set_cookie(URL::URL, HTTP::Cookie::ParsedCookie, HTTP::Cookie::Source) override;
     virtual void did_update_cookie(HTTP::Cookie::Cookie) override;
     virtual void did_expire_cookies_with_time_offset(AK::Duration) override;
+    virtual void did_clear_cookies_for_origin(URL::Origin) override;
     virtual Messages::WebContentClient::DidRequestStorageItemResponse did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) override;
     virtual Messages::WebContentClient::DidSetStorageItemResponse did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value) override;
     virtual void did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -592,6 +592,11 @@ void PageClient::page_did_expire_cookies_with_time_offset(AK::Duration offset)
         document->reset_cookie_version();
 }
 
+void PageClient::page_did_clear_cookies_for_origin(URL::Origin const& origin)
+{
+    client().async_did_clear_cookies_for_origin(origin);
+}
+
 Optional<String> PageClient::page_did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key)
 {
     auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestStorageItem>(storage_endpoint, storage_key, bottle_key);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -164,6 +164,7 @@ private:
     virtual void page_did_set_cookie(URL::URL const&, HTTP::Cookie::ParsedCookie const&, HTTP::Cookie::Source) override;
     virtual void page_did_update_cookie(HTTP::Cookie::Cookie const&) override;
     virtual void page_did_expire_cookies_with_time_offset(AK::Duration) override;
+    virtual void page_did_clear_cookies_for_origin(URL::Origin const&) override;
     virtual Optional<String> page_did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key) override;
     virtual WebView::StorageSetResult page_did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key, String const& value) override;
     virtual void page_did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, String const& bottle_key) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -8,6 +8,7 @@
 #include <LibHTTP/Header.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
+#include <LibURL/Origin.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Clipboard/SystemClipboard.h>
@@ -86,6 +87,7 @@ endpoint WebContentClient
     did_set_cookie(URL::URL url, HTTP::Cookie::ParsedCookie cookie, HTTP::Cookie::Source source) => ()
     did_update_cookie(HTTP::Cookie::Cookie cookie) =|
     did_expire_cookies_with_time_offset(AK::Duration offset) =|
+    did_clear_cookies_for_origin(URL::Origin origin) =|
 
     did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key) => (Optional<String> value)
     did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, String bottle_key, String value) => (WebView::StorageSetResult result)


### PR DESCRIPTION
Add support for parsing and processing the Clear-Site-Data HTTP response header per W3C specification. This causes the navigation.https.html WPT test to go from timeout to pass.

Implemented:
- Storage clearing (origin-scoped): LocalStorage, SessionStorage, IndexedDB, ServiceWorkers, Caches
- Cookie clearing (global - CookieJar lacks domain-scoped API)
- Header parsing for `"cache"`, `"cookies"`, `"storage"`, `"*"` directives

Not implemented:
- Cache clearing (no API available)
- ExecutionContexts/reload

Testing:
WPT test `clear-site-data/navigation.https.html` passes via browser runner (./Meta/ladybird.py).
