### PR TITLE
AK+LibRegex: Only set node metadata on Trie::ensure_child if missing

### DIFF
--- a/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Libraries/LibRegex/RegexOptimizer.cpp
@@ -1467,7 +1467,7 @@ void Optimizer::append_alternation(ByteCode& target, Span<ByteCode> alternatives
                     node_key_bytes.append(edge.jump_insn);
             }
 
-            active_node = static_cast<decltype(active_node)>(MUST(active_node->ensure_child(DisjointSpans<ByteCodeValueType const> { move(node_key_bytes) }, Vector<NodeMetadataEntry> {})));
+            active_node = static_cast<decltype(active_node)>(MUST(active_node->ensure_child(DisjointSpans<ByteCodeValueType const> { move(node_key_bytes) }, [] -> Vector<NodeMetadataEntry> { return {}; })));
 
             auto next_compare = [&alternative, &state](StaticallyInterpretedCompares& compares) {
                 TemporaryChange state_change { state.instruction_position, state.instruction_position };


### PR DESCRIPTION
a290034a8164dcfe83b3679ab848592a97e0e2b1 passed an empty vector to this, which caused nodes that appeared multiple times to reset the trie metadata...which broke the optimisation.

This patchset makes the function take a 'provide missing metadata' function instead, and only invokes it when the node is missing rather than unconditionally setting the metadata on all nodes.

cc @gmta - your bug report.