### PR TITLE
LibWeb: Prevent default on pointerdown/mousedown should skip focus steps

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -667,8 +667,10 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
         auto offset = compute_mouse_event_offset(page_offset, *layout_node->first_paintable());
         auto pointer_event = UIEvents::PointerEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::pointerdown, screen_position, page_offset, viewport_position, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors();
         light_dismiss_activities(pointer_event, node);
-        node->dispatch_event(pointer_event);
-        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::mousedown, screen_position, page_offset, viewport_position, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors());
+        if (!node->dispatch_event(pointer_event))
+            return EventResult::Cancelled;
+        if (!node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::mousedown, screen_position, page_offset, viewport_position, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors()))
+            return EventResult::Cancelled;
     }
 
     // NOTE: Dispatching an event may have disturbed the world.

--- a/Tests/LibWeb/Text/expected/cancel-of-pointerdown-or-mousedown-should-skip-focus-steps.txt
+++ b/Tests/LibWeb/Text/expected/cancel-of-pointerdown-or-mousedown-should-skip-focus-steps.txt
@@ -1,0 +1,4 @@
+pointerdown
+pointerup
+mouseup
+click

--- a/Tests/LibWeb/Text/input/cancel-of-pointerdown-or-mousedown-should-skip-focus-steps.html
+++ b/Tests/LibWeb/Text/input/cancel-of-pointerdown-or-mousedown-should-skip-focus-steps.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<button id="test-button" style="width: 100px; height: 100px">Test button</button>
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        const button = document.getElementById("test-button");
+
+        const eventsToLog = [
+            "mousedown",
+            "mouseup",
+            "click",
+            "dblclick",
+            "pointerdown",
+            "pointerup",
+            "focus",
+            "blur",
+            "focusin",
+            "focusout",
+        ];
+
+        eventsToLog.forEach(type => {
+            button.addEventListener(type, event => {
+                if (type === "pointerdown" || type === "mousedown") event.preventDefault();
+                println(`${type}`, {
+                    key: event.key,
+                    code: event.code,
+                    button: event.button,
+                    pointerType: event.pointerType,
+                    eventPhase: event.eventPhase,
+                    timeStamp: event.timeStamp,
+                });
+                if (type === "click") done();
+            });
+        });
+
+        internals.click(50, 50);
+    });
+</script>


### PR DESCRIPTION
Fixes a bug in the ChatGPT model dropdown where clicking it immediately closes the menu because focus is being stolen.

Before:

https://github.com/user-attachments/assets/c4e81be5-b9a5-45b4-95a4-b9e510023c38

After:

https://github.com/user-attachments/assets/2ae71908-e1dd-43db-b515-7f597ca3ca52

