### PR TITLE
LibWeb: Various encoding detection improvements

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,9 +15,9 @@
 namespace Web::HTML {
 
 Optional<StringView> extract_character_encoding_from_meta_element(ByteString const&);
-GC::Ptr<DOM::Attr> prescan_get_attribute(DOM::Document&, ByteBuffer const& input, size_t& position);
-Optional<ByteString> run_prescan_byte_stream_algorithm(DOM::Document&, ByteBuffer const& input);
-Optional<ByteString> run_bom_sniff(ByteBuffer const& input);
-ByteString run_encoding_sniffing_algorithm(DOM::Document&, ByteBuffer const& input, Optional<MimeSniff::MimeType> maybe_mime_type = {});
+GC::Ptr<DOM::Attr> prescan_get_attribute(DOM::Document&, ReadonlyBytes input, size_t& position);
+Optional<ByteString> run_prescan_byte_stream_algorithm(DOM::Document&, ReadonlyBytes input);
+Optional<ByteString> run_bom_sniff(ReadonlyBytes input);
+ByteString run_encoding_sniffing_algorithm(DOM::Document&, ReadonlyBytes input, Optional<MimeSniff::MimeType> maybe_mime_type = {});
 
 }


### PR DESCRIPTION
I was seeing a lot of `Attr` instances with a local_name of `"` - now fixed.