### PR TITLE
LibWeb: Return custom validity error message in FormAssociatedElement::validation_message()

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -267,13 +267,18 @@ Utf16String FormAssociatedElement::validation_message() const
     if (!is_candidate_for_constraint_validation() || satisfies_its_constraints())
         return {};
 
-    // FIXME:
     // 2. Return a suitably localized message that the user agent would show the user if this were the only form
     //    control with a validity constraint problem. If the user agent would not actually show a textual message in
     //    such a situation (e.g., it would show a graphical cue instead), then return a suitably localized message that
-    //    expresses (one or more of) the validity constraint(s) that the control does not satisfy. If the element is a
-    //    candidate for constraint validation and is suffering from a custom error, then the custom validity error
-    //    message should be present in the return value.
+    //    expresses (one or more of) the validity constraint(s) that the control does not satisfy.
+
+    // If the element is a candidate for constraint validation and is suffering from a custom error, then
+    // the custom validity error message should be present in the return value.
+    if (suffering_from_a_custom_error()) {
+        return Utf16String::from_utf8(m_custom_validity_error_message);
+    }
+
+    // FIXME: Return more specific localized messages
     return "Invalid form"_utf16;
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	[input]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[input]  The validity.customError must be false if the custom validity error message is empty
+Pass	[button]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[button]  The validity.customError must be false if the custom validity error message is empty
+Pass	[select]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[select]  The validity.customError must be false if the custom validity error message is empty
+Pass	[textarea]  The validity.customError must be true if the custom validity error message is not empty
+Pass	[textarea]  The validity.customError must be false if the custom validity error message is empty

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/constraints/form-validation-validity-customError.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The constraint validation API Test: element.validity.customError</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-validitystate-customerror">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-constraint-validation-api">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<script src="support/validator.js"></script>
+<div id="log"></div>
+<script>
+var testElements = [
+    {
+      tag: "input",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    },
+    {
+      tag: "button",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    },
+    {
+      tag: "select",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    },
+    {
+      tag: "textarea",
+      types: [],
+      testData: [
+        {conditions: {message: "My custom error"}, expected: true, name: "[target] The validity.customError must be true if the custom validity error message is not empty"},
+        {conditions: {message: ""}, expected: false, name: "[target] The validity.customError must be false if the custom validity error message is empty"}
+      ]
+    }
+  ]
+
+  validator.run_test(testElements, "customError");
+</script>


### PR DESCRIPTION
Previously, validation_message() was always returning a hardcoded "Invalid form" string, now it correctly returns the custom validity error message when the element is suffering from a custom error. Other validation errors still return the "Invalid form" message.

Fixes remaining failing tests in: https://wpt.live/html/semantics/forms/constraints/form-validation-validity-customError.html