### PR TITLE
LibCore: Remove unused NotifierActivationEvent fd() and type() methods

### DIFF
--- a/Libraries/LibCore/Event.h
+++ b/Libraries/LibCore/Event.h
@@ -71,32 +71,14 @@ public:
     ~TimerEvent() = default;
 };
 
-enum class NotificationType : u8 {
-    None = 0,
-    Read = 1,
-    Write = 2,
-    HangUp = 4,
-    Error = 8,
-};
-
-AK_ENUM_BITWISE_OPERATORS(NotificationType);
-
 class NotifierActivationEvent final : public Event {
 public:
-    explicit NotifierActivationEvent(int fd, NotificationType type)
+    explicit NotifierActivationEvent()
         : Event(Event::NotifierActivation)
-        , m_fd(fd)
-        , m_type(type)
     {
     }
+
     ~NotifierActivationEvent() = default;
-
-    int fd() const { return m_fd; }
-    NotificationType type() const { return m_type; }
-
-private:
-    int m_fd;
-    NotificationType m_type;
 };
 
 }

--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -405,7 +405,7 @@ try_select_again:
 
 #ifdef AK_OS_ANDROID
             // FIXME: Make the check work under Android, perhaps use ALooper.
-            ThreadEventQueue::current().post_event(notifier, make<NotifierActivationEvent>(notifier.fd(), notifier.type()));
+            ThreadEventQueue::current().post_event(notifier, make<NotifierActivationEvent>());
 #else
             auto revents = thread_data.poll_fds[i].revents;
 
@@ -422,7 +422,7 @@ try_select_again:
             type &= notifier.type();
 
             if (type != NotificationType::None)
-                ThreadEventQueue::current().post_event(notifier, make<NotifierActivationEvent>(notifier.fd(), type));
+                ThreadEventQueue::current().post_event(notifier, make<NotifierActivationEvent>());
 #endif
         }
     }

--- a/Libraries/LibCore/Notifier.h
+++ b/Libraries/LibCore/Notifier.h
@@ -13,6 +13,16 @@
 
 namespace Core {
 
+enum class NotificationType : u8 {
+    None = 0,
+    Read = 1,
+    Write = 2,
+    HangUp = 4,
+    Error = 8,
+};
+
+AK_ENUM_BITWISE_OPERATORS(NotificationType);
+
 class Notifier final : public EventReceiver {
     C_OBJECT(Notifier);
 

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.mm
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.mm
@@ -331,7 +331,7 @@ static void socket_notifier(CFSocketRef socket, CFSocketCallBackType notificatio
     // before dispatching the event, which allows it to be triggered again.
     CFSocketEnableCallBacks(socket, notification_type);
 
-    Core::NotifierActivationEvent event(notifier.fd(), notifier.type());
+    Core::NotifierActivationEvent event;
     notifier.dispatch_event(event);
 
     // This manual process of enabling the callbacks also seems to require waking the event loop,

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.cpp
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.cpp
@@ -297,7 +297,7 @@ void EventLoopManagerQt::unregister_timer(intptr_t timer_id)
 
 static void qt_notifier_activated(Core::Notifier& notifier)
 {
-    Core::NotifierActivationEvent event(notifier.fd(), notifier.type());
+    Core::NotifierActivationEvent event;
     notifier.dispatch_event(event);
 }
 

--- a/UI/Android/src/main/cpp/ALooperEventLoopImplementation.cpp
+++ b/UI/Android/src/main/cpp/ALooperEventLoopImplementation.cpp
@@ -221,8 +221,10 @@ static int notifier_callback(int fd, int events, void* data)
     if (events & ALOOPER_EVENT_ERROR)
         type |= Core::NotificationType::Error;
 
-    Core::NotifierActivationEvent event(notifier.fd(), type);
-    notifier.dispatch_event(event);
+    if (type != Core::NotificationType::None) {
+        Core::NotifierActivationEvent event;
+        notifier.dispatch_event(event);
+    }
 
     // Wake up from ALooper_pollAll, and service this event on the event queue
     current_impl().wake();


### PR DESCRIPTION
See commit for details