### PR TITLE
Meta+LibGfx: Remove fontconfig dependency on Windows

### DIFF
--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -12,10 +12,12 @@
 #include <core/SkFontMgr.h>
 #include <core/SkStream.h>
 #include <core/SkTypeface.h>
-#ifndef AK_OS_ANDROID
-#    include <ports/SkFontMgr_fontconfig.h>
-#else
+#if defined(AK_OS_ANDROID)
 #    include <ports/SkFontMgr_android.h>
+#elif defined(AK_OS_WINDOWS)
+#    include <ports/SkTypeface_win.h>
+#else
+#    include <ports/SkFontMgr_fontconfig.h>
 #endif
 
 #ifdef AK_OS_MACOS
@@ -38,12 +40,14 @@ ErrorOr<NonnullRefPtr<TypefaceSkia>> TypefaceSkia::load_from_buffer(AK::Readonly
             s_font_manager = SkFontMgr_New_CoreText(nullptr);
         }
 #endif
-#ifndef AK_OS_ANDROID
+#if defined(AK_OS_ANDROID)
+        s_font_manager = SkFontMgr_New_Android(nullptr);
+#elif defined(AK_OS_WINDOWS)
+        s_font_manager = SkFontMgr_New_DirectWrite();
+#else
         if (!s_font_manager) {
             s_font_manager = SkFontMgr_New_FontConfig(nullptr);
         }
-#else
-        s_font_manager = SkFontMgr_New_Android(nullptr);
 #endif
     }
 

--- a/Meta/CMake/fontconfig.cmake
+++ b/Meta/CMake/fontconfig.cmake
@@ -1,6 +1,6 @@
 include_guard()
 
-if (NOT APPLE AND NOT ANDROID)
+if (NOT APPLE AND NOT ANDROID AND NOT WIN32)
     find_package(Fontconfig REQUIRED)
     set(HAS_FONTCONFIG ON CACHE BOOL "" FORCE)
     add_cxx_compile_definitions(USE_FONTCONFIG=1)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -56,7 +56,7 @@
     },
     {
       "name": "fontconfig",
-      "platform": "linux | freebsd | openbsd | osx | windows"
+      "platform": "linux | freebsd | openbsd | osx"
     },
     {
       "name": "harfbuzz",
@@ -175,7 +175,17 @@
     },
     {
       "name": "skia",
-      "platform": "linux | freebsd | openbsd | windows",
+      "platform": "windows",
+      "features": [
+        "freetype",
+        "harfbuzz",
+        "icu",
+        "vulkan"
+      ]
+    },
+    {
+      "name": "skia",
+      "platform": "linux | freebsd | openbsd",
       "features": [
         "freetype",
         "fontconfig",


### PR DESCRIPTION
This change is inspired by [Tims discovery](https://discord.com/channels/1247070541085671459/1306918361732616212/1435017908039188490 ) in `#ui-windows` about fontconfig on Windows 

### Before (With Fontconfig)

https://github.com/user-attachments/assets/fb269c1c-b8d4-42f8-ac8f-1ba4ca62c74c

### After (Without Fontconfig)

https://github.com/user-attachments/assets/a6c3091d-3086-4eb5-9d09-819845532fdf


