### PR TITLE
AppKit: Prevent autocomplete popover from stealing focus

### DIFF
--- a/UI/AppKit/Interface/Autocomplete.mm
+++ b/UI/AppKit/Interface/Autocomplete.mm
@@ -151,9 +151,15 @@ static constexpr auto POPOVER_PADDING = 6uz;
 
     [self showRelativeToToolbarItem:self.toolbar_item];
 
+    auto* window = [self.toolbar_item.view window];
+    auto* first_responder = [window firstResponder];
+
     [self showRelativeToRect:self.toolbar_item.view.frame
                       ofView:self.toolbar_item.view
                preferredEdge:NSRectEdgeMaxY];
+
+    if (first_responder)
+        [window makeFirstResponder:first_responder];
 }
 
 - (void)selectRow:(NSInteger)row


### PR DESCRIPTION
The autocomplete popover on macOS was stealing focus from the location bar when suggestions were displayed. This change saves the current first responder before showing the popover and restores it immediately after, ensuring the user can continue typing without interruption.