### PR TITLE
LibWeb/HTML: Invalidate HTMLCollection caches when selectedness of options changes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -732,6 +732,8 @@ void HTMLSelectElement::update_inner_text_element()
 // https://whatpr.org/html/11890/form-elements.html#selectedness-setting-algorithm
 void HTMLSelectElement::update_selectedness()
 {
+    ScopeGuard invalidate_dom_tree = [&] { document().bump_dom_tree_version(); };
+
     // The selectedness setting algorithm, given a select element element, is to run the following steps:
     update_cached_list_of_options();
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-selectedOptions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-selectedOptions.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 8 tests
 
-7 Pass
-1 Fail
+8 Pass
 Pass	.selectedOptions with no selected option
 Pass	.selectedOptions with one selected option
 Pass	.selectedOptions using the 'multiple' attribute with no selected options
@@ -11,4 +10,4 @@ Pass	.selectedOptions using the 'multiple' attribute with two selected options
 Pass	.selectedOptions without the 'multiple' attribute but more than one selected option should return the last one
 Pass	.selectedOptions should return `HTMLCollection` instance
 Pass	.selectedOptions should always return the same value - [SameObject]
-Fail	.selectedOptions should return the same object after selection changes - [SameObject]
+Pass	.selectedOptions should return the same object after selection changes - [SameObject]

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-validity.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-validity.tentative.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
-Fail	Validation for placeholder option
+2 Pass
+Pass	Validation for placeholder option
 Pass	Check form not submitted for invalid select

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-validity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-validity.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-4 Pass
-2 Fail
+6 Pass
 Pass	Placeholder label options within a select
 Pass	Placeholder label-like options within optgroup
-Fail	Validation on selects with display size set as more than one
-Fail	Validation on selects with multiple set
+Pass	Validation on selects with display size set as more than one
+Pass	Validation on selects with multiple set
 Pass	Validation on selects with non-empty disabled option
 Pass	Remove and add back the placeholder label option


### PR DESCRIPTION
This adds an invalidation step to the method for updating the selectedness of a select element. This is necessary for updating the html collections for the selected options.