### PR TITLE
LibJS: Demote VERIFY in `ThrowCompletionOr()` to ASSERT

### DIFF
--- a/Libraries/LibJS/Runtime/Completion.h
+++ b/Libraries/LibJS/Runtime/Completion.h
@@ -245,8 +245,9 @@ public:
     ALWAYS_INLINE ThrowCompletionOr(ValueType value)
         : m_value_or_error(move(value))
     {
-        if constexpr (IsSame<ValueType, Value>)
-            VERIFY(!m_value_or_error.template get<ValueType>().is_special_empty_value());
+        if constexpr (IsSame<ValueType, Value>) {
+            ASSERT(!m_value_or_error.template get<ValueType>().is_special_empty_value());
+        }
     }
 
     ALWAYS_INLINE ThrowCompletionOr(ThrowCompletionOr const&) = default;


### PR DESCRIPTION
This VERIFY was particularly expensive and removing it gives a significant speedup on multiple benchmarks on my machine.
```
Suite       Test                                   Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                              1.036  1.224 ± 1.223 … 1.225              1.181 ± 1.179 … 1.184
Kraken      audio-beat-detection.js                  1.124  1.014 ± 1.011 … 1.017              0.902 ± 0.901 … 0.903
Kraken      audio-dft.js                             1.083  0.648 ± 0.646 … 0.651              0.598 ± 0.596 … 0.601
Kraken      audio-fft.js                             1.131  0.885 ± 0.883 … 0.887              0.783 ± 0.780 … 0.786
Kraken      audio-oscillator.js                      1.086  0.760 ± 0.743 … 0.776              0.699 ± 0.685 … 0.713
Kraken      imaging-darkroom.js                      1.108  1.000 ± 0.992 … 1.008              0.903 ± 0.893 … 0.913
Kraken      imaging-desaturate.js                    1.156  1.569 ± 1.568 … 1.570              1.357 ± 1.345 … 1.368
Kraken      imaging-gaussian-blur.js                 1.16   5.968 ± 5.967 … 5.969              5.145 ± 5.145 … 5.145
Kraken      json-parse-financial.js                  0.994  0.072 ± 0.072 … 0.072              0.072 ± 0.070 … 0.075
Kraken      json-stringify-tinderbox.js              1.041  0.103 ± 0.103 … 0.104              0.099 ± 0.099 … 0.099
Kraken      stanford-crypto-aes.js                   1.104  0.370 ± 0.368 … 0.372              0.335 ± 0.330 … 0.340
Kraken      stanford-crypto-ccm.js                   1.084  0.365 ± 0.363 … 0.368              0.337 ± 0.337 … 0.337
Kraken      stanford-crypto-pbkdf2.js                1.073  0.621 ± 0.606 … 0.635              0.579 ± 0.576 … 0.581
Kraken      stanford-crypto-sha256-iterative.js      1.01   0.233 ± 0.232 … 0.235              0.231 ± 0.231 … 0.232
Octane      box2d.js                                 1.034  4681.000 ± 4679.000 … 4683.000     4839.000 ± 4813.000 … 4865.000
Octane      code-load.js                             1.02   9965.500 ± 9957.000 … 9974.000     10164.000 ± 10153.000 … 10175.000
Octane      crypto.js                                1.05   1739.000 ± 1736.000 … 1742.000     1826.500 ± 1821.000 … 1832.000
Octane      deltablue.js                             1.013  973.000 ± 964.000 … 982.000        985.500 ± 957.000 … 1014.000
Octane      earley-boyer.js                          1.047  2262.500 ± 2244.000 … 2281.000     2369.000 ± 2348.000 … 2390.000
Octane      gbemu.js                                 1.024  8591.500 ± 8528.000 … 8655.000     8796.500 ± 8712.000 … 8881.000
Octane      mandreel.js                              1.025  7474.500 ± 7452.000 … 7497.000     7664.000 ± 7611.000 … 7717.000
Octane      navier-stokes.js                         1.201  2570.000 ± 2549.000 … 2591.000     3086.000 ± 3086.000 … 3086.000
Octane      pdfjs.js                                 1.047  3647.000 ± 3629.000 … 3665.000     3819.500 ± 3789.000 … 3850.000
Octane      raytrace.js                              1.059  1534.000 ± 1528.000 … 1540.000     1624.500 ± 1621.000 … 1628.000
Octane      regexp.js                                1.033  119.500 ± 117.000 … 122.000        123.500 ± 123.000 … 124.000
Octane      richards.js                              1.006  1073.000 ± 1071.000 … 1075.000     1079.500 ± 1075.000 … 1084.000
Octane      splay.js                                 1.015  1863.000 ± 1862.000 … 1864.000     1891.000 ± 1886.000 … 1896.000
Octane      typescript.js                            1.032  10693.500 ± 10686.000 … 10701.000  11031.000 ± 11027.000 … 11035.000
Octane      zlib.js                                  1.123  2668.500 ± 2644.000 … 2693.000     2996.000 ± 2995.000 … 2997.000
JetStream   bigfib.cpp.js                            1.111  9.723 ± 9.710 … 9.737              8.754 ± 8.744 … 8.764
JetStream   cdjs.js                                  1.023  3.965 ± 3.964 … 3.966              3.874 ± 3.847 … 3.901
JetStream   container.cpp.js                         1.092  39.344 ± 39.216 … 39.471           36.036 ± 35.948 … 36.125
JetStream   dry.c.js                                 1.143  23.943 ± 23.924 … 23.962           20.952 ± 20.931 … 20.974
JetStream   float-mm.c.js                            1.168  23.060 ± 22.894 … 23.226           19.741 ± 19.456 … 20.026
JetStream   gcc-loops.cpp.js                         1.222  143.575 ± 143.533 … 143.617        117.495 ± 117.476 … 117.513
JetStream   hash-map.js                              1.025  1.655 ± 1.641 … 1.668              1.614 ± 1.593 … 1.636
JetStream   n-body.c.js                              1.124  35.449 ± 35.345 … 35.553           31.528 ± 31.226 … 31.830
JetStream   quicksort.c.js                           1.096  5.260 ± 5.252 … 5.267              4.800 ± 4.782 … 4.819
JetStream   towers.c.js                              1.115  8.127 ± 8.124 … 8.130              7.286 ± 7.278 … 7.294
Kraken      Total                                    1.122  14.833                             13.222
Octane      Total                                    1.041  59855.500                          62295.500
JetStream   Total                                    1.167  294.100                            252.081
All Suites  Total                                    1.138  429.159                            377.206
```

These results were generated on Linux using Clang-20.