### PR TITLE
UI/AppKit: Auto-focus location bar when opening new tabs on macOS

### DIFF
--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -189,6 +189,7 @@
 
     if (activate_tab == Web::HTML::ActivateTab::Yes) {
         [[controller window] orderFrontRegardless];
+        [controller focusLocationToolbarItem];
     }
 
     [self.managed_tabs addObject:controller];

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -145,7 +145,11 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 - (void)onURLChange:(URL::URL const&)url
 {
     [self setLocationFieldText:url.serialize()];
-    [self.window makeFirstResponder:[self tab].web_view];
+
+    // Don't steal focus from the location bar when loading the new tab page
+    if (url != WebView::Application::settings().new_tab_page_url()) {
+        [self.window makeFirstResponder:[self tab].web_view];
+    }
 }
 
 - (void)clearHistory


### PR DESCRIPTION
When a new tab is created, the location bar should automatically receive keyboard focus so users can immediately start typing a URL. However, the onURLChange callback was stealing focus back to the web view when loading the new tab page.

This fix:
1. Calls focusLocationToolbarItem when activating a new tab
2. Prevents onURLChange from stealing focus when loading the new tab page URL

Fixes #1512