### PR TITLE
Request: Fix typo in error message comment in Request.h

### DIFF
--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -74,7 +74,7 @@ private:
         Connect,      // Issue a network request to connect to the URL.
         Fetch,        // Issue a network request to fetch the URL.
         Complete,     // Finalize the request with the client.
-        Error,        // Any error occured during the request's lifetime.
+        Error,        // Any error occurred during the request's lifetime.
     };
 
     enum class CacheStatus : u8 {


### PR DESCRIPTION
File: Services/RequestServer/Request.h (Line 77):
"Error: // Any error occured during the request's lifetime."
Issue: "occured" should be "occurred" (missing one 'r').