### PR TITLE
LibJS: Add fast path for loosely comparing object and nullish values

### DIFF
--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -2395,12 +2395,22 @@ ThrowCompletionOr<bool> is_loosely_equal(VM& vm, Value lhs, Value rhs)
     // B.3.6.2 Changes to IsLooselyEqual, https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-aec
     // 4. Perform the following steps:
     // a. If Type(x) is Object and x has an [[IsHTMLDDA]] internal slot and y is either null or undefined, return true.
-    if (lhs.is_object() && lhs.as_object().is_htmldda() && rhs.is_nullish())
-        return true;
+    if (lhs.is_object() && rhs.is_nullish()) {
+        if (lhs.as_object().is_htmldda())
+            return true;
+
+        // OPTIMIZATION: We can return early here since non-HTMLDDA objects and nullish values are never equal.
+        return false;
+    }
 
     // b. If x is either null or undefined and Type(y) is Object and y has an [[IsHTMLDDA]] internal slot, return true.
-    if (lhs.is_nullish() && rhs.is_object() && rhs.as_object().is_htmldda())
-        return true;
+    if (lhs.is_nullish() && rhs.is_object()) {
+        if (rhs.as_object().is_htmldda())
+            return true;
+
+        // OPTIMIZATION: We can return early here since non-HTMLDDA objects and nullish values are never equal.
+        return false;
+    }
 
     // == End of B.3.6.2 ==
 


### PR DESCRIPTION
I noticed this when profiling `Octane/typescript.js`:

```
Suite       Test                                   Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                              0.992  1.202 ± 1.202 … 1.202              1.211 ± 1.196 … 1.226
Kraken      audio-beat-detection.js                  1.019  0.907 ± 0.903 … 0.911              0.890 ± 0.889 … 0.890
Kraken      audio-dft.js                             1.046  0.610 ± 0.605 … 0.615              0.583 ± 0.581 … 0.585
Kraken      audio-fft.js                             1      0.787 ± 0.786 … 0.787              0.787 ± 0.784 … 0.789
Kraken      audio-oscillator.js                      1.01   0.692 ± 0.689 … 0.694              0.685 ± 0.684 … 0.685
Kraken      imaging-darkroom.js                      0.997  0.908 ± 0.907 … 0.909              0.911 ± 0.905 … 0.917
Kraken      imaging-desaturate.js                    1.007  1.350 ± 1.349 … 1.352              1.341 ± 1.335 … 1.347
Kraken      imaging-gaussian-blur.js                 0.993  5.177 ± 5.176 … 5.177              5.214 ± 5.150 … 5.277
Kraken      json-parse-financial.js                  1.015  0.072 ± 0.072 … 0.072              0.071 ± 0.071 … 0.071
Kraken      json-stringify-tinderbox.js              0.993  0.101 ± 0.100 … 0.101              0.101 ± 0.100 … 0.103
Kraken      stanford-crypto-aes.js                   0.999  0.328 ± 0.327 … 0.329              0.329 ± 0.326 … 0.331
Kraken      stanford-crypto-ccm.js                   1.017  0.338 ± 0.335 … 0.341              0.332 ± 0.330 … 0.335
Kraken      stanford-crypto-pbkdf2.js                1.003  0.583 ± 0.582 … 0.584              0.581 ± 0.576 … 0.586
Kraken      stanford-crypto-sha256-iterative.js      1.01   0.224 ± 0.223 … 0.225              0.222 ± 0.221 … 0.223
Octane      box2d.js                                 1.03   4754.500 ± 4715.000 … 4794.000     4896.500 ± 4885.000 … 4908.000
Octane      code-load.js                             1.02   9964.000 ± 9928.000 … 10000.000    10166.000 ± 10137.000 … 10195.000
Octane      crypto.js                                1.012  1874.000 ± 1873.000 … 1875.000     1897.000 ± 1893.000 … 1901.000
Octane      deltablue.js                             1.009  989.500 ± 980.000 … 999.000        998.500 ± 989.000 … 1008.000
Octane      earley-boyer.js                          1.028  2317.500 ± 2301.000 … 2334.000     2381.500 ± 2380.000 … 2383.000
Octane      gbemu.js                                 1.01   8814.000 ± 8792.000 … 8836.000     8905.500 ± 8785.000 … 9026.000
Octane      mandreel.js                              1.004  7593.500 ± 7553.000 … 7634.000     7622.500 ± 7599.000 … 7646.000
Octane      navier-stokes.js                         0.992  3053.500 ± 3049.000 … 3058.000     3030.000 ± 2974.000 … 3086.000
Octane      pdfjs.js                                 0.96   3772.500 ± 3760.000 … 3785.000     3623.000 ± 3610.000 … 3636.000
Octane      raytrace.js                              1.012  1593.000 ± 1578.000 … 1608.000     1612.500 ± 1605.000 … 1620.000
Octane      regexp.js                                1.021  118.500 ± 118.000 … 119.000        121.000 ± 119.000 … 123.000
Octane      richards.js                              1.037  1053.500 ± 1030.000 … 1077.000     1092.500 ± 1085.000 … 1100.000
Octane      splay.js                                 1.038  1858.000 ± 1848.000 … 1868.000     1928.500 ± 1922.000 … 1935.000
Octane      typescript.js                            1.018  10805.500 ± 10782.000 … 10829.000  10995.500 ± 10981.000 … 11010.000
Octane      zlib.js                                  1.021  2999.500 ± 2988.000 … 3011.000     3063.500 ± 3056.000 … 3071.000
JetStream   bigfib.cpp.js                            1.019  8.884 ± 8.832 … 8.937              8.716 ± 8.711 … 8.722
JetStream   cdjs.js                                  1.002  3.867 ± 3.842 … 3.892              3.858 ± 3.827 … 3.890
JetStream   container.cpp.js                         1.018  36.080 ± 36.003 … 36.157           35.447 ± 35.349 … 35.545
JetStream   dry.c.js                                 0.986  20.990 ± 20.983 … 20.996           21.284 ± 20.957 … 21.611
JetStream   float-mm.c.js                            0.988  19.299 ± 19.296 … 19.302           19.529 ± 19.506 … 19.551
JetStream   gcc-loops.cpp.js                         0.996  117.225 ± 117.141 … 117.309        117.647 ± 117.150 … 118.144
JetStream   hash-map.js                              1.01   1.625 ± 1.608 … 1.642              1.608 ± 1.608 … 1.609
JetStream   n-body.c.js                              0.996  31.685 ± 31.459 … 31.910           31.798 ± 31.545 … 32.052
JetStream   quicksort.c.js                           1.014  4.847 ± 4.816 … 4.878              4.779 ± 4.775 … 4.784
JetStream   towers.c.js                              1.01   7.373 ± 7.360 … 7.386              7.298 ± 7.240 … 7.357
Kraken      Total                                    1.002  13.277                             13.256
Octane      Total                                    1.013  61561.000                          62334.000
JetStream   Total                                    1      251.875                            251.965
All Suites  Total                                    1.005  378.061                            376.333
```