### PR TITLE
LibJS: Demote VERIFY to ASSERT in JS value casting functions

### DIFF
--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -257,7 +257,7 @@ ThrowCompletionOr<bool> Value::is_array(VM& vm) const
 
 Array& Value::as_array()
 {
-    VERIFY(is_object() && is<Array>(as_object()));
+    ASSERT(is_object() && is<Array>(as_object()));
     return static_cast<Array&>(as_object());
 }
 
@@ -272,13 +272,13 @@ bool Value::is_function() const
 
 FunctionObject& Value::as_function()
 {
-    VERIFY(is_function());
+    ASSERT(is_function());
     return static_cast<FunctionObject&>(as_object());
 }
 
 FunctionObject const& Value::as_function() const
 {
-    VERIFY(is_function());
+    ASSERT(is_function());
     return static_cast<FunctionObject const&>(as_object());
 }
 

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -271,19 +271,19 @@ public:
 
     Cell& as_cell()
     {
-        VERIFY(is_cell());
+        ASSERT(is_cell());
         return *extract_pointer<Cell>();
     }
 
     Cell& as_cell() const
     {
-        VERIFY(is_cell());
+        ASSERT(is_cell());
         return *extract_pointer<Cell>();
     }
 
     double as_double() const
     {
-        VERIFY(is_number());
+        ASSERT(is_number());
         if (is_int32())
             return as_i32();
         return m_value.as_double;
@@ -291,61 +291,61 @@ public:
 
     bool as_bool() const
     {
-        VERIFY(is_boolean());
+        ASSERT(is_boolean());
         return static_cast<bool>(m_value.encoded & 0x1);
     }
 
     Object& as_object()
     {
-        VERIFY(is_object());
+        ASSERT(is_object());
         return *extract_pointer<Object>();
     }
 
     Object const& as_object() const
     {
-        VERIFY(is_object());
+        ASSERT(is_object());
         return *extract_pointer<Object>();
     }
 
     PrimitiveString& as_string()
     {
-        VERIFY(is_string());
+        ASSERT(is_string());
         return *extract_pointer<PrimitiveString>();
     }
 
     PrimitiveString const& as_string() const
     {
-        VERIFY(is_string());
+        ASSERT(is_string());
         return *extract_pointer<PrimitiveString>();
     }
 
     Symbol& as_symbol()
     {
-        VERIFY(is_symbol());
+        ASSERT(is_symbol());
         return *extract_pointer<Symbol>();
     }
 
     Symbol const& as_symbol() const
     {
-        VERIFY(is_symbol());
+        ASSERT(is_symbol());
         return *extract_pointer<Symbol>();
     }
 
     Accessor& as_accessor()
     {
-        VERIFY(is_accessor());
+        ASSERT(is_accessor());
         return *extract_pointer<Accessor>();
     }
 
     BigInt const& as_bigint() const
     {
-        VERIFY(is_bigint());
+        ASSERT(is_bigint());
         return *extract_pointer<BigInt>();
     }
 
     BigInt& as_bigint()
     {
-        VERIFY(is_bigint());
+        ASSERT(is_bigint());
         return *extract_pointer<BigInt>();
     }
 
@@ -404,13 +404,13 @@ public:
 
     i32 as_i32() const
     {
-        VERIFY(is_int32());
+        ASSERT(is_int32());
         return static_cast<i32>(m_value.encoded & 0xFFFFFFFF);
     }
 
     i32 as_i32_clamped_integral_number() const
     {
-        VERIFY(is_int32() || is_finite_number());
+        ASSERT(is_int32() || is_finite_number());
         if (is_int32())
             return as_i32();
         double value = trunc(as_double());


### PR DESCRIPTION
This yields a ~3% performance increase across the board in JS benchmarks.

```
Suite       Test                                   Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                              1.027  1.202 ± 1.202 … 1.202              1.170 ± 1.165 … 1.176
Kraken      audio-beat-detection.js                  1.029  0.907 ± 0.903 … 0.911              0.881 ± 0.857 … 0.905
Kraken      audio-dft.js                             1.058  0.610 ± 0.605 … 0.615              0.576 ± 0.561 … 0.592
Kraken      audio-fft.js                             1.065  0.787 ± 0.786 … 0.787              0.738 ± 0.736 … 0.741
Kraken      audio-oscillator.js                      1.036  0.692 ± 0.689 … 0.694              0.667 ± 0.665 … 0.670
Kraken      imaging-darkroom.js                      1.082  0.908 ± 0.907 … 0.909              0.839 ± 0.837 … 0.842
Kraken      imaging-desaturate.js                    1.046  1.350 ± 1.349 … 1.352              1.291 ± 1.291 … 1.292
Kraken      imaging-gaussian-blur.js                 1.037  5.177 ± 5.176 … 5.177              4.992 ± 4.921 … 5.064
Kraken      json-parse-financial.js                  1.027  0.072 ± 0.072 … 0.072              0.070 ± 0.069 … 0.071
Kraken      json-stringify-tinderbox.js              0.986  0.101 ± 0.100 … 0.101              0.102 ± 0.102 … 0.103
Kraken      stanford-crypto-aes.js                   1.018  0.328 ± 0.327 … 0.329              0.322 ± 0.321 … 0.323
Kraken      stanford-crypto-ccm.js                   1.038  0.338 ± 0.335 … 0.341              0.326 ± 0.325 … 0.326
Kraken      stanford-crypto-pbkdf2.js                1.036  0.583 ± 0.582 … 0.584              0.563 ± 0.560 … 0.565
Kraken      stanford-crypto-sha256-iterative.js      1.036  0.224 ± 0.223 … 0.225              0.216 ± 0.215 … 0.217
Octane      box2d.js                                 1.061  4754.500 ± 4715.000 … 4794.000     5044.000 ± 5030.000 … 5058.000
Octane      code-load.js                             1.032  9964.000 ± 9928.000 … 10000.000    10278.500 ± 10271.000 … 10286.000
Octane      crypto.js                                1.02   1874.000 ± 1873.000 … 1875.000     1912.000 ± 1862.000 … 1962.000
Octane      deltablue.js                             1.026  989.500 ± 980.000 … 999.000        1015.000 ± 1014.000 … 1016.000
Octane      earley-boyer.js                          1.051  2317.500 ± 2301.000 … 2334.000     2435.500 ± 2434.000 … 2437.000
Octane      gbemu.js                                 1.013  8814.000 ± 8792.000 … 8836.000     8931.000 ± 8734.000 … 9128.000
Octane      mandreel.js                              1.027  7593.500 ± 7553.000 … 7634.000     7801.500 ± 7777.000 … 7826.000
Octane      navier-stokes.js                         1.064  3053.500 ± 3049.000 … 3058.000     3249.000 ± 3229.000 … 3269.000
Octane      pdfjs.js                                 1.042  3772.500 ± 3760.000 … 3785.000     3930.000 ± 3909.000 … 3951.000
Octane      raytrace.js                              1.036  1593.000 ± 1578.000 … 1608.000     1650.000 ± 1648.000 … 1652.000
Octane      regexp.js                                1.042  118.500 ± 118.000 … 119.000        123.500 ± 123.000 … 124.000
Octane      richards.js                              1.052  1053.500 ± 1030.000 … 1077.000     1108.500 ± 1103.000 … 1114.000
Octane      splay.js                                 1.059  1858.000 ± 1848.000 … 1868.000     1967.000 ± 1955.000 … 1979.000
Octane      typescript.js                            1.037  10805.500 ± 10782.000 … 10829.000  11203.000 ± 11183.000 … 11223.000
Octane      zlib.js                                  1.037  2999.500 ± 2988.000 … 3011.000     3109.500 ± 3105.000 … 3114.000
JetStream   bigfib.cpp.js                            1.045  8.884 ± 8.832 … 8.937              8.499 ± 8.482 … 8.516
JetStream   cdjs.js                                  1.031  3.867 ± 3.842 … 3.892              3.750 ± 3.735 … 3.766
JetStream   container.cpp.js                         1.035  36.080 ± 36.003 … 36.157           34.865 ± 34.786 … 34.945
JetStream   dry.c.js                                 1.031  20.990 ± 20.983 … 20.996           20.355 ± 20.333 … 20.377
JetStream   float-mm.c.js                            1.029  19.299 ± 19.296 … 19.302           18.756 ± 18.641 … 18.871
JetStream   gcc-loops.cpp.js                         1.03   117.225 ± 117.141 … 117.309        113.834 ± 113.403 … 114.265
JetStream   hash-map.js                              1.03   1.625 ± 1.608 … 1.642              1.578 ± 1.572 … 1.584
JetStream   n-body.c.js                              1.046  31.685 ± 31.459 … 31.910           30.296 ± 30.250 … 30.342
JetStream   quicksort.c.js                           0.986  4.847 ± 4.816 … 4.878              4.915 ± 4.708 … 5.121
JetStream   towers.c.js                              0.998  7.373 ± 7.360 … 7.386              7.388 ± 7.323 … 7.452
Kraken      Total                                    1.041  13.277                             12.755
Octane      Total                                    1.036  61561.000                          63758.000
JetStream   Total                                    1.031  251.875                            244.236
All Suites  Total                                    1.028  378.061                            367.586
```

I did also have a go at creating some `as_if_<type>()` methods to avoid repeated checks, but this turned out to be slower.