### PR TITLE
LibWeb/WebGL: Implement getRenderbufferParameter()

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
@@ -118,7 +118,7 @@ interface mixin WebGLRenderingContextBase {
     [FIXME] any getFramebufferAttachmentParameter(GLenum target, GLenum attachment, GLenum pname);
     any getProgramParameter(WebGLProgram program, GLenum pname);
     DOMString? getProgramInfoLog(WebGLProgram program);
-    [FIXME] any getRenderbufferParameter(GLenum target, GLenum pname);
+    any getRenderbufferParameter(GLenum target, GLenum pname);
     any getShaderParameter(WebGLShader shader, GLenum pname);
     WebGLShaderPrecisionFormat? getShaderPrecisionFormat(GLenum shadertype, GLenum precisiontype);
     DOMString? getShaderInfoLog(WebGLShader shader);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -1604,6 +1604,32 @@ Optional<String> WebGLRenderingContextImpl::get_program_info_log(GC::Root<WebGLP
     return String::from_utf8_without_validation(ReadonlyBytes { info_log.data(), static_cast<size_t>(info_log_length - 1) });
 }
 
+JS::Value WebGLRenderingContextImpl::get_renderbuffer_parameter(WebIDL::UnsignedLong target, WebIDL::UnsignedLong pname)
+{
+    m_context->make_current();
+
+    switch (pname) {
+    case GL_RENDERBUFFER_WIDTH:
+    case GL_RENDERBUFFER_HEIGHT:
+    case GL_RENDERBUFFER_INTERNAL_FORMAT:
+    case GL_RENDERBUFFER_RED_SIZE:
+    case GL_RENDERBUFFER_GREEN_SIZE:
+    case GL_RENDERBUFFER_BLUE_SIZE:
+    case GL_RENDERBUFFER_ALPHA_SIZE:
+    case GL_RENDERBUFFER_DEPTH_SIZE:
+    case GL_RENDERBUFFER_SAMPLES:
+    case GL_RENDERBUFFER_STENCIL_SIZE: {
+        GLint result = 0;
+        glGetRenderbufferParameteriv(target, pname, &result);
+        return JS::Value(result);
+    }
+    default:
+        // If pname is not in the table above, generates an INVALID_ENUM error.
+        set_error(GL_INVALID_ENUM);
+        return JS::js_null();
+    }
+}
+
 JS::Value WebGLRenderingContextImpl::get_shader_parameter(GC::Root<WebGLShader> shader, WebIDL::UnsignedLong pname)
 {
     m_context->make_current();

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
@@ -88,6 +88,7 @@ public:
     WebIDL::UnsignedLong get_error();
     JS::Value get_program_parameter(GC::Root<WebGLProgram> program, WebIDL::UnsignedLong pname);
     Optional<String> get_program_info_log(GC::Root<WebGLProgram> program);
+    JS::Value get_renderbuffer_parameter(WebIDL::UnsignedLong target, WebIDL::UnsignedLong pname);
     JS::Value get_shader_parameter(GC::Root<WebGLShader> shader, WebIDL::UnsignedLong pname);
     GC::Root<WebGLShaderPrecisionFormat> get_shader_precision_format(WebIDL::UnsignedLong shadertype, WebIDL::UnsignedLong precisiontype);
     Optional<String> get_shader_info_log(GC::Root<WebGLShader> shader);


### PR DESCRIPTION
Makes the animations on https://blog.frost.kiwi/analytical-anti-aliasing/ work:

<img width="701" height="523" alt="Screenshot 2025-11-26 at 14 33 11" src="https://github.com/user-attachments/assets/bdf3d35e-35b0-4974-9d4f-0a1ca2199e2a" />
