### PR TITLE
LibRegex: Add missing StringSet cases

### DIFF
--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -1239,7 +1239,8 @@ Vector<CompareTypeAndValuePair> OpCode_Compare::flat_compares() const
         } else if (compare_type == CharacterCompareType::GeneralCategory
             || compare_type == CharacterCompareType::Property
             || compare_type == CharacterCompareType::Script
-            || compare_type == CharacterCompareType::ScriptExtension) {
+            || compare_type == CharacterCompareType::ScriptExtension
+            || compare_type == CharacterCompareType::StringSet) {
             auto value = m_bytecode->at(offset++);
             result.append({ compare_type, value });
         } else {
@@ -1366,8 +1367,8 @@ Vector<ByteString> OpCode_Compare::variable_arguments_to_byte_string(Optional<Ma
         } else if (compare_type == CharacterCompareType::GeneralCategory
             || compare_type == CharacterCompareType::Property
             || compare_type == CharacterCompareType::Script
-            || compare_type == CharacterCompareType::ScriptExtension) {
-
+            || compare_type == CharacterCompareType::ScriptExtension
+            || compare_type == CharacterCompareType::StringSet) {
             auto value = m_bytecode->at(offset++);
             result.empend(ByteString::formatted(" value={}", value));
         }


### PR DESCRIPTION
Fixes #6948.

I previously missed the case in `OpCode_Compare::variable_arguments_to_byte_string()` since it's only used with REGEX_DEBUG enabled. Also added the same case to `OpCode_Compare::flat_compares()`.

These are the only places I could find that were missing StringSet, so it should be good now. Checked that test-js doesn't crash anymore, but I'm unable to run the full test suite with debug flags - my 16GB of RAM is not nearly enough to handle it :cry: 