### PR TITLE
LibWeb/HTML: Update worker construction spec steps

### DIFF
--- a/Libraries/LibWeb/HTML/SharedWorker.h
+++ b/Libraries/LibWeb/HTML/SharedWorker.h
@@ -27,7 +27,12 @@ public:
 
     virtual ~SharedWorker();
 
-    GC::Ref<MessagePort> port() { return m_port; }
+    // https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworker-port
+    GC::Ref<MessagePort> port()
+    {
+        // The port getter steps are to return this's port.
+        return m_port;
+    }
 
     void set_agent(WorkerAgentParent& agent) { m_agent = agent; }
 
@@ -42,7 +47,11 @@ private:
 
     URL::URL m_script_url;
     WorkerOptions m_options;
+
+    // Each SharedWorker has a port, a MessagePort set when the object is created.
+    // https://html.spec.whatwg.org/multipage/workers.html#concept-sharedworker-port
     GC::Ref<MessagePort> m_port;
+
     GC::Ptr<WorkerAgentParent> m_agent;
 };
 

--- a/Libraries/LibWeb/HTML/Worker.idl
+++ b/Libraries/LibWeb/HTML/Worker.idl
@@ -19,9 +19,9 @@ interface Worker : EventTarget {
 };
 
 dictionary WorkerOptions {
+    DOMString name = "";
     WorkerType type = "classic";
     RequestCredentials credentials = "same-origin";
-    DOMString name = "";
 };
 
 enum WorkerType { "classic", "module" };

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -15,9 +15,9 @@
 namespace Web::HTML {
 
 struct WorkerOptions {
+    String name { String {} };
     Bindings::WorkerType type { Bindings::WorkerType::Classic };
     Bindings::RequestCredentials credentials { Bindings::RequestCredentials::SameOrigin };
-    String name { String {} };
 };
 
 // FIXME: Figure out a better naming convention for this type of parent/child process pattern.


### PR DESCRIPTION
This is largely editorial. One behaviour change is that events are now sent from a global task on the DOMManipiulation task source.

Somewhat awkwardly, the spec refers to `this` before the Worker exists. As it's for getting the relevent global object / settings object, I've had to work around that.

Corresponds to:
https://github.com/whatwg/html/commit/917c2f6a7367aa36d347f11e65dd4503ff87ddce