### PR TITLE
LibWeb/HTML: Rename popover "invoker"

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -604,7 +604,7 @@ set(SOURCES
     HTML/Plugin.cpp
     HTML/PluginArray.cpp
     HTML/PolicyContainers.cpp
-    HTML/PopoverInvokerElement.cpp
+    HTML/PopoverTargetAttributes.cpp
     HTML/PopStateEvent.cpp
     HTML/PotentialCORSRequest.cpp
     HTML/PromiseRejectionEvent.cpp

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -735,7 +735,7 @@ class PageTransitionEvent;
 class Path2D;
 class Plugin;
 class PluginArray;
-class PopoverInvokerElement;
+class PopoverTargetAttributes;
 class PromiseRejectionEvent;
 class RadioNodeList;
 class SelectedFile;

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -101,13 +101,13 @@ void HTMLButtonElement::set_type_for_bindings(String const& type)
 
 void HTMLButtonElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    PopoverInvokerElement::associated_attribute_changed(name, value, namespace_);
+    PopoverTargetAttributes::associated_attribute_changed(name, value, namespace_);
 }
 
 void HTMLButtonElement::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    PopoverInvokerElement::visit_edges(visitor);
+    PopoverTargetAttributes::visit_edges(visitor);
     visitor.visit(m_command_for_element);
 }
 
@@ -217,9 +217,9 @@ void HTMLButtonElement::activation_behavior(DOM::Event const& event)
             // 1. Assert: target's namespace is the HTML namespace.
             VERIFY(target->namespace_uri() == Namespace::HTML);
 
-            // 2. If this standard does not define is valid invoker command steps for target's local name, then return.
-            // 3. Otherwise, if the result of running target's corresponding is valid invoker command steps given command is false, then return.
-            if (!target->is_valid_invoker_command(command))
+            // 2. If this standard does not define is valid command steps for target's local name, then return.
+            // 3. Otherwise, if the result of running target's corresponding is valid command steps given command is false, then return.
+            if (!target->is_valid_command(command))
                 return;
         }
 
@@ -284,16 +284,16 @@ void HTMLButtonElement::activation_behavior(DOM::Event const& event)
             }
         }
 
-        // 12. Otherwise, if this standard defines invoker command steps for target's local name,
-        //     then run the corresponding invoker command steps given target, element, and command.
+        // 12. Otherwise, if this standard defines command steps for target's local name,
+        //     then run the corresponding command steps given target, element, and command.
         else {
-            target->invoker_command_steps(*this, command);
+            target->command_steps(*this, command);
         }
     }
 
     // 6. Otherwise, run the popover target attribute activation behavior given element and event's target.
     else if (event.target() && event.target()->is_dom_node())
-        PopoverInvokerElement::popover_target_activation_behaviour(*this, as<DOM::Node>(*event.target()));
+        PopoverTargetAttributes::popover_target_activation_behaviour(*this, as<DOM::Node>(*event.target()));
 }
 
 bool HTMLButtonElement::is_focusable() const

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -9,7 +9,7 @@
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
-#include <LibWeb/HTML/PopoverInvokerElement.h>
+#include <LibWeb/HTML/PopoverTargetAttributes.h>
 
 namespace Web::HTML {
 
@@ -22,7 +22,7 @@ namespace Web::HTML {
 class HTMLButtonElement final
     : public HTMLElement
     , public FormAssociatedElement
-    , public PopoverInvokerElement {
+    , public PopoverTargetAttributes {
     WEB_PLATFORM_OBJECT(HTMLButtonElement, HTMLElement);
     GC_DECLARE_ALLOCATOR(HTMLButtonElement);
     FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLButtonElement)

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -1,6 +1,6 @@
 #import <HTML/HTMLElement.idl>
 #import <HTML/HTMLFormElement.idl>
-#import <HTML/PopoverInvokerElement.idl>
+#import <HTML/PopoverTargetAttributes.idl>
 #import <HTML/ValidityState.idl>
 
 [MissingValueDefault=submit, InvalidValueDefault=submit]
@@ -37,4 +37,4 @@ interface HTMLButtonElement : HTMLElement {
 
     readonly attribute NodeList labels;
 };
-HTMLButtonElement includes PopoverInvokerElement;
+HTMLButtonElement includes PopoverTargetAttributes;

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -484,8 +484,8 @@ void HTMLDialogElement::set_is_modal(bool is_modal)
     invalidate_style(DOM::StyleInvalidationReason::HTMLDialogElementSetIsModal);
 }
 
-// https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element:is-valid-invoker-command-steps
-bool HTMLDialogElement::is_valid_invoker_command(String& command)
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element:is-valid-command-steps
+bool HTMLDialogElement::is_valid_command(String& command)
 {
     // 1. If command is in the Close state, the Request Close state, or the Show Modal state, then return true.
     if (command == "close" || command == "request-close" || command == "show-modal")
@@ -495,8 +495,8 @@ bool HTMLDialogElement::is_valid_invoker_command(String& command)
     return false;
 }
 
-// https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element:invoker-command-steps
-void HTMLDialogElement::invoker_command_steps(DOM::Element& invoker, String& command)
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element:command-steps
+void HTMLDialogElement::command_steps(DOM::Element& source, String& command)
 {
     // 1. If element is in the popover showing state, then return.
     if (popover_visibility_state() == PopoverVisibilityState::Showing) {
@@ -504,22 +504,22 @@ void HTMLDialogElement::invoker_command_steps(DOM::Element& invoker, String& com
     }
 
     // 2. If command is in the Close state and element has an open attribute,
-    //    then close the dialog given element with invoker's optional value and invoker.
+    //    then close the dialog given element with source's optional value and source.
     if (command == "close" && has_attribute(AttributeNames::open)) {
-        auto const optional_value = as<FormAssociatedElement>(invoker).optional_value();
-        close_the_dialog(optional_value, invoker);
+        auto const optional_value = as<FormAssociatedElement>(source).optional_value();
+        close_the_dialog(optional_value, source);
     }
 
     // 3. If command is in the Request Close state and element has an open attribute,
-    //    then request to close the dialog element with invoker's optional value and invoker.
+    //    then request to close the dialog element with source's optional value and source.
     if (command == "request-close" && has_attribute(AttributeNames::open)) {
-        auto const optional_value = as<FormAssociatedElement>(invoker).optional_value();
-        request_close_the_dialog(optional_value, invoker);
+        auto const optional_value = as<FormAssociatedElement>(source).optional_value();
+        request_close_the_dialog(optional_value, source);
     }
 
-    // 4. If command is the Show Modal state and element does not have an open attribute, then show a modal dialog given element and invoker.
+    // 4. If command is the Show Modal state and element does not have an open attribute, then show a modal dialog given element and source.
     if (command == "show-modal" && !has_attribute(AttributeNames::open)) {
-        MUST(show_a_modal_dialog(*this, invoker));
+        MUST(show_a_modal_dialog(*this, source));
     }
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -47,8 +47,8 @@ public:
     bool is_modal() const { return m_is_modal; }
     void set_is_modal(bool);
 
-    bool is_valid_invoker_command(String&) override;
-    void invoker_command_steps(DOM::Element&, String&) override;
+    bool is_valid_command(String&) override;
+    void command_steps(DOM::Element&, String&) override;
 
 private:
     HTMLDialogElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -175,11 +175,11 @@ public:
     WebIDL::ExceptionOr<bool> toggle_popover(TogglePopoverOptionsOrForceBoolean const&);
 
     WebIDL::ExceptionOr<bool> check_popover_validity(ExpectedToBeShowing expected_to_be_showing, ThrowExceptions throw_exceptions, GC::Ptr<DOM::Document>, IgnoreDomState ignore_dom_state);
-    WebIDL::ExceptionOr<void> show_popover(ThrowExceptions throw_exceptions, GC::Ptr<HTMLElement> invoker);
+    WebIDL::ExceptionOr<void> show_popover(ThrowExceptions throw_exceptions, GC::Ptr<HTMLElement> source);
     WebIDL::ExceptionOr<void> hide_popover(FocusPreviousElement focus_previous_element, FireEvents fire_events, ThrowExceptions throw_exceptions, IgnoreDomState ignore_dom_state, GC::Ptr<HTMLElement> source);
 
     static void hide_all_popovers_until(Variant<GC::Ptr<HTMLElement>, GC::Ptr<DOM::Document>> endpoint, FocusPreviousElement focus_previous_element, FireEvents fire_events);
-    static GC::Ptr<HTMLElement> topmost_popover_ancestor(GC::Ptr<DOM::Node> new_popover_or_top_layer_element, Vector<GC::Ref<HTMLElement>> const& popover_list, GC::Ptr<HTMLElement> invoker, IsPopover is_popover);
+    static GC::Ptr<HTMLElement> topmost_popover_ancestor(GC::Ptr<DOM::Node> new_popover_or_top_layer_element, Vector<GC::Ref<HTMLElement>> const& popover_list, GC::Ptr<HTMLElement> source, IsPopover is_popover);
 
     static void light_dismiss_open_popovers(UIEvents::PointerEvent const&, GC::Ptr<DOM::Node>);
 
@@ -188,8 +188,8 @@ public:
     bool draggable() const;
     void set_draggable(bool draggable);
 
-    virtual bool is_valid_invoker_command(String&) { return false; }
-    virtual void invoker_command_steps(DOM::Element&, String&) { }
+    virtual bool is_valid_command(String&) { return false; }
+    virtual void command_steps(DOM::Element&, String&) { }
 
     bool is_form_associated_custom_element();
 
@@ -240,7 +240,7 @@ private:
     static Optional<String> popover_value_to_state(Optional<String> value);
     void hide_popover_stack_until(Vector<GC::Ref<HTMLElement>> const& popover_list, FocusPreviousElement focus_previous_element, FireEvents fire_events);
     GC::Ptr<HTMLElement> nearest_inclusive_open_popover();
-    GC::Ptr<HTMLElement> nearest_inclusive_target_popover_for_invoker();
+    GC::Ptr<HTMLElement> nearest_inclusive_target_popover();
     static void close_entire_popover_list(Vector<GC::Ref<HTMLElement>> const& popover_list, FocusPreviousElement focus_previous_element, FireEvents fire_events);
     static GC::Ptr<HTMLElement> topmost_clicked_popover(GC::Ptr<DOM::Node> node);
     size_t popover_stack_position();
@@ -264,8 +264,8 @@ private:
     // https://html.spec.whatwg.org/multipage/popover.html#popover-showing-or-hiding
     bool m_popover_showing_or_hiding { false };
 
-    // https://html.spec.whatwg.org/multipage/popover.html#popover-invoker
-    GC::Ptr<HTMLElement> m_popover_invoker;
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-trigger
+    GC::Ptr<HTMLElement> m_popover_trigger;
 
     // https://html.spec.whatwg.org/multipage/popover.html#the-popover-attribute:toggle-task-tracker
     Optional<ToggleTaskTracker> m_popover_toggle_task_tracker;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1414,7 +1414,7 @@ void HTMLInputElement::did_lose_focus()
 
 void HTMLInputElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    PopoverInvokerElement::associated_attribute_changed(name, value, namespace_);
+    PopoverTargetAttributes::associated_attribute_changed(name, value, namespace_);
 
     if (name == HTML::AttributeNames::checked) {
         // https://html.spec.whatwg.org/multipage/input.html#the-input-element:concept-input-checked-dirty-2
@@ -3094,7 +3094,7 @@ void HTMLInputElement::activation_behavior(DOM::Event const& event)
 
     // 4. Run the popover target attribute activation behavior given element and event's target.
     if (event.target() && event.target()->is_dom_node())
-        PopoverInvokerElement::popover_target_activation_behaviour(*this, as<DOM::Node>(*event.target()));
+        PopoverTargetAttributes::popover_target_activation_behaviour(*this, as<DOM::Node>(*event.target()));
 }
 
 bool HTMLInputElement::has_input_activation_behavior() const

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -19,7 +19,7 @@
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
-#include <LibWeb/HTML/PopoverInvokerElement.h>
+#include <LibWeb/HTML/PopoverTargetAttributes.h>
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/Types.h>
@@ -55,7 +55,7 @@ class WEB_API HTMLInputElement final
     : public HTMLElement
     , public FormAssociatedTextControlElement
     , public Layout::ImageProvider
-    , public PopoverInvokerElement
+    , public PopoverTargetAttributes
     , public AutocompleteElement {
     WEB_PLATFORM_OBJECT(HTMLInputElement, HTMLElement);
     GC_DECLARE_ALLOCATOR(HTMLInputElement);

--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -1,7 +1,7 @@
 #import <HTML/HTMLDataListElement.idl>
 #import <HTML/HTMLElement.idl>
 #import <HTML/HTMLFormElement.idl>
-#import <HTML/PopoverInvokerElement.idl>
+#import <HTML/PopoverTargetAttributes.idl>
 #import <HTML/ValidityState.idl>
 #import <FileAPI/FileList.idl>
 
@@ -75,4 +75,4 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString align;
     [CEReactions, Reflect=usemap] attribute DOMString useMap;
 };
-HTMLInputElement includes PopoverInvokerElement;
+HTMLInputElement includes PopoverTargetAttributes;

--- a/Libraries/LibWeb/HTML/PopoverTargetAttributes.cpp
+++ b/Libraries/LibWeb/HTML/PopoverTargetAttributes.cpp
@@ -10,11 +10,11 @@
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
-#include <LibWeb/HTML/PopoverInvokerElement.h>
+#include <LibWeb/HTML/PopoverTargetAttributes.h>
 
 namespace Web::HTML {
 
-void PopoverInvokerElement::associated_attribute_changed(FlyString const& name, Optional<String> const&, Optional<FlyString> const& namespace_)
+void PopoverTargetAttributes::associated_attribute_changed(FlyString const& name, Optional<String> const&, Optional<FlyString> const& namespace_)
 {
     // From: https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributess
     // For element reflected targets only: the following attribute change steps, given element, localName, oldValue, value, and namespace,
@@ -28,19 +28,19 @@ void PopoverInvokerElement::associated_attribute_changed(FlyString const& name, 
     m_popover_target_element = nullptr;
 }
 
-void PopoverInvokerElement::visit_edges(JS::Cell::Visitor& visitor)
+void PopoverTargetAttributes::visit_edges(JS::Cell::Visitor& visitor)
 {
     visitor.visit(m_popover_target_element);
 }
 
 // https://html.spec.whatwg.org/multipage/popover.html#popover-target-attribute-activation-behavior
 // https://whatpr.org/html/9457/popover.html#popover-target-attribute-activation-behavior
-void PopoverInvokerElement::popover_target_activation_behaviour(GC::Ref<DOM::Node> node, GC::Ref<DOM::Node> event_target)
+void PopoverTargetAttributes::popover_target_activation_behaviour(GC::Ref<DOM::Node> node, GC::Ref<DOM::Node> event_target)
 {
     // To run the popover target attribute activation behavior given a Node node and a Node eventTarget:
 
     // 1. Let popover be node's popover target element.
-    auto popover = PopoverInvokerElement::get_the_popover_target_element(node);
+    auto popover = PopoverTargetAttributes::get_the_popover_target_element(node);
 
     // 2. If popover is null, then return.
     if (!popover)
@@ -74,7 +74,7 @@ void PopoverInvokerElement::popover_target_activation_behaviour(GC::Ref<DOM::Nod
 }
 
 // https://html.spec.whatwg.org/multipage/popover.html#popover-target-element
-GC::Ptr<HTMLElement> PopoverInvokerElement::get_the_popover_target_element(GC::Ref<DOM::Node> node)
+GC::Ptr<HTMLElement> PopoverTargetAttributes::get_the_popover_target_element(GC::Ref<DOM::Node> node)
 {
     // To get the popover target element given a Node node, perform the following steps. They return an HTML element or null.
 
@@ -95,7 +95,7 @@ GC::Ptr<HTMLElement> PopoverInvokerElement::get_the_popover_target_element(GC::R
         return {};
 
     // 4. Let popoverElement be the result of running node's get the popovertarget-associated element.
-    auto const* popover_invoker_element = as_if<PopoverInvokerElement>(*node);
+    auto const* popover_invoker_element = as_if<PopoverTargetAttributes>(*node);
     GC::Ptr<HTMLElement> popover_element = as<HTMLElement>(popover_invoker_element->m_popover_target_element.ptr());
     if (!popover_element) {
         auto target_id = as<HTMLElement>(*node).attribute("popovertarget"_fly_string);

--- a/Libraries/LibWeb/HTML/PopoverTargetAttributes.h
+++ b/Libraries/LibWeb/HTML/PopoverTargetAttributes.h
@@ -12,10 +12,10 @@
 
 namespace Web::HTML {
 
-class PopoverInvokerElement {
+class PopoverTargetAttributes {
 
 public:
-    PopoverInvokerElement() { }
+    PopoverTargetAttributes() { }
 
     GC::Ptr<DOM::Element> popover_target_element() { return m_popover_target_element; }
 

--- a/Libraries/LibWeb/HTML/PopoverTargetAttributes.idl
+++ b/Libraries/LibWeb/HTML/PopoverTargetAttributes.idl
@@ -6,8 +6,8 @@ enum PopoverTargetActionAttribute {
     "hide"
 };
 
-// https://html.spec.whatwg.org/multipage/popover.html#popoverinvokerelement
-interface mixin PopoverInvokerElement {
+// https://html.spec.whatwg.org/multipage/popover.html#popovertargetattributes
+interface mixin PopoverTargetAttributes {
     [Reflect=popovertarget, CEReactions] attribute Element? popoverTargetElement;
     [Reflect=popovertargetaction, Enumerated=PopoverTargetActionAttribute, CEReactions] attribute DOMString popoverTargetAction;
 };

--- a/Tests/LibWeb/Text/input/wpt-import/interfaces/html.idl
+++ b/Tests/LibWeb/Text/input/wpt-import/interfaces/html.idl
@@ -951,7 +951,7 @@ interface HTMLInputElement : HTMLElement {
 
   // also has obsolete members
 };
-HTMLInputElement includes PopoverInvokerElement;
+HTMLInputElement includes PopoverTargetAttributes;
 
 [Exposed=Window]
 interface HTMLButtonElement : HTMLElement {
@@ -979,7 +979,7 @@ interface HTMLButtonElement : HTMLElement {
 
   readonly attribute NodeList labels;
 };
-HTMLButtonElement includes PopoverInvokerElement;
+HTMLButtonElement includes PopoverTargetAttributes;
 
 [Exposed=Window]
 interface HTMLSelectElement : HTMLElement {
@@ -1813,7 +1813,7 @@ dictionary DragEventInit : MouseEventInit {
   DataTransfer? dataTransfer = null;
 };
 
-interface mixin PopoverInvokerElement {
+interface mixin PopoverTargetAttributes {
   [CEReactions] attribute Element? popoverTargetElement;
   [CEReactions] attribute DOMString popoverTargetAction;
 };


### PR DESCRIPTION
Lots of renames, no behaviour differences. (Apart from the rename of the IDL type, which does of course affect JS.)

Corresponds to:
https://github.com/whatwg/html/commit/16cb7808da5f850ae26fe86ce25074cce0c0643e