### PR TITLE
LibGfx+LibWeb: Fix compile errors in clang-cl from recent header cleanup

### DIFF
--- a/Libraries/LibGfx/Painter.cpp
+++ b/Libraries/LibGfx/Painter.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/PainterSkia.h>
 #include <LibGfx/PaintingSurface.h>

--- a/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -40,6 +40,8 @@ CSSImportRule::CSSImportRule(JS::Realm& realm, URL url, GC::Ptr<DOM::Document> d
 {
 }
 
+CSSImportRule::~CSSImportRule() = default;
+
 void CSSImportRule::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(CSSImportRule);

--- a/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -13,6 +13,7 @@
 #include <LibWeb/CSS/URL.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::CSS {
 
@@ -24,7 +25,7 @@ class WEB_API CSSImportRule final
 public:
     [[nodiscard]] static GC::Ref<CSSImportRule> create(JS::Realm&, URL, GC::Ptr<DOM::Document>, RefPtr<Supports>, Vector<NonnullRefPtr<MediaQuery>>);
 
-    virtual ~CSSImportRule() = default;
+    virtual ~CSSImportRule();
 
     URL const& url() const { return m_url; }
     String href() const { return m_url.url(); }

--- a/Libraries/LibWeb/HTML/ImageBitmap.cpp
+++ b/Libraries/LibWeb/HTML/ImageBitmap.cpp
@@ -58,6 +58,8 @@ ImageBitmap::ImageBitmap(JS::Realm& realm)
 {
 }
 
+ImageBitmap::~ImageBitmap() = default;
+
 void ImageBitmap::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(ImageBitmap);

--- a/Libraries/LibWeb/HTML/ImageBitmap.h
+++ b/Libraries/LibWeb/HTML/ImageBitmap.h
@@ -35,7 +35,7 @@ class ImageBitmap final : public Bindings::PlatformObject
 
 public:
     static GC::Ref<ImageBitmap> create(JS::Realm&);
-    virtual ~ImageBitmap() override = default;
+    virtual ~ImageBitmap() override;
 
     // ^Web::Bindings::Serializable
     virtual HTML::SerializeType serialize_type() const override { return HTML::SerializeType::ImageBitmap; }


### PR DESCRIPTION
The recent commits 28ba610f325aaed5d20daebdd3cf732a04e62eaf and 70c4ed261fb446fe25396164400d09e0c0df8bc6 adjusted some include directives to avoid excessive recompilation when changing some header files. This has broken compilation with clang-cl on Windows without getting noticed before the PRs were merged.