### PR TITLE
LibJS: Avoid cast to out-of-range value in `MathObject::abs()` fast path

### DIFF
--- a/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Libraries/LibJS/Runtime/MathObject.cpp
@@ -89,8 +89,11 @@ void MathObject::initialize(Realm& realm)
 ThrowCompletionOr<Value> MathObject::abs_impl(VM& vm, Value x)
 {
     // OPTIMIZATION: Fast path for Int32 values.
-    if (x.is_int32())
-        return Value(AK::abs(x.as_i32()));
+    if (x.is_int32()) {
+        if (auto x_int32 = x.as_i32(); x_int32 != NumericLimits<i32>::min()) [[likely]]
+            return Value(AK::abs(x_int32));
+        return Value(static_cast<u32>(NumericLimits<i32>::max()) + 1);
+    }
 
     // Let n be ? ToNumber(x).
     auto number = TRY(x.to_number(vm));

--- a/Libraries/LibJS/Tests/builtins/Math/Math.abs.js
+++ b/Libraries/LibJS/Tests/builtins/Math/Math.abs.js
@@ -12,3 +12,7 @@ test("basic functionality", () => {
     expect(Math.abs("string")).toBeNaN();
     expect(Math.abs()).toBeNaN();
 });
+
+test("i32 min value", () => {
+    expect(Math.abs(-2_147_483_648)).toBe(2_147_483_648);
+});


### PR DESCRIPTION
I hit this when running `JetStream/gcc-loops.cpp.js` with GCC-15. The included test case fails on `master` when sanitizers are enabled. 