### PR TITLE
Meta: Remove unused function `check_program_version_at_least`

### DIFF
--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -17,24 +17,6 @@ exit_if_running_as_root() {
     fi
 }
 
-# Usage: check_program_version_at_least <Display Name> <Program Name> <Version String>
-check_program_version_at_least()
-{
-    echo -n "Checking for $1 version at least $3... "
-    if ! command -v "$2" > /dev/null 2>&1; then
-        echo "ERROR: Cannot find $2 ($1)"
-        return 1
-    fi
-    v=$("$2" --version 2>&1 | grep -E -o '[0-9]+\.[0-9\.]+[a-z]*' | head -n1)
-    if printf '%s\n' "$3" "$v" | sort -V -c &>/dev/null; then
-        echo "ok, found $v"
-        return 0;
-    else
-        echo "ERROR: found version $v, too old!"
-        return 1;
-    fi
-}
-
 get_number_of_processing_units() {
   number_of_processing_units="nproc"
   SYSTEM_NAME="$(uname -s)"


### PR DESCRIPTION
The function `check_program_version_at_least` was only used in `ladybird.sh`, which was removed in PR #4904.