### PR TITLE
LibWeb: Make setInterval() reuse the timer to reduce drift

### DIFF
--- a/Libraries/LibWeb/HTML/Timer.h
+++ b/Libraries/LibWeb/HTML/Timer.h
@@ -22,20 +22,26 @@ class Timer final : public JS::Cell {
     GC_DECLARE_ALLOCATOR(Timer);
 
 public:
-    static GC::Ref<Timer> create(JS::Object&, i32 milliseconds, Function<void()> callback, i32 id);
+    enum class Repeating {
+        No,
+        Yes,
+    };
+
+    static GC::Ref<Timer> create(JS::Object&, i32 milliseconds, Function<void()> callback, i32 id, Repeating);
     virtual ~Timer() override;
 
     void start();
     void stop();
 
+    void set_callback(Function<void()>);
+
 private:
-    Timer(JS::Object& window, i32 milliseconds, GC::Ref<GC::Function<void()>> callback, i32 id);
+    Timer(JS::Object& window, i32 milliseconds, Function<void()> callback, i32 id, Repeating);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
     RefPtr<Core::Timer> m_timer;
     GC::Ref<JS::Object> m_window_or_worker_global_scope;
-    GC::Ref<GC::Function<void()>> m_callback;
     i32 m_id { 0 };
 };
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -117,7 +117,7 @@ private:
         No,
     };
     i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, GC::RootVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {});
-    void run_steps_after_a_timeout_impl(i32 timeout, Function<void()> completion_step, Optional<i32> timer_key = {});
+    void run_steps_after_a_timeout_impl(i32 timeout, Function<void()> completion_step, Optional<i32> timer_key, Repeat);
 
     GC::Ref<WebIDL::Promise> create_image_bitmap_impl(ImageBitmapSource& image, Optional<WebIDL::Long> sx, Optional<WebIDL::Long> sy, Optional<WebIDL::Long> sw, Optional<WebIDL::Long> sh, Optional<ImageBitmapOptions>& options) const;
 


### PR DESCRIPTION
Instead of creating a new single-shot timer every time a setInterval timer reschedules itself, we now use a repeating Core::Timer internally.

This dramatically reduces timer drift, since the next timeout is now based on when the timer fired, rather than when the timer callback completed (which could take arbitrarily long since we run JS).

It's not perfect, but it's a huge improvement and allows us to play DiabloWeb at full framerate (20 fps).

BEFORE (~13 fps):

https://github.com/user-attachments/assets/6697973a-b00d-40c7-a901-5b65b69e3f66

AFTER (20 fps):

https://github.com/user-attachments/assets/11ad8072-cb05-45b9-a439-53bacd4096f7