### PR TITLE
LibWeb: Resolve cursor to i-beam over contenteditable container

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -809,7 +809,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
             if (hovered_link_element)
                 is_hovering_link = true;
 
-            if (paintable->layout_node().is_text_node()) {
+            if (paintable->layout_node().is_text_node() || node->is_editing_host()) {
                 hovered_node_cursor = resolve_cursor(*paintable->layout_node().parent(), cursor_data, Gfx::StandardCursor::IBeam);
             } else if (node->is_element()) {
                 hovered_node_cursor = resolve_cursor(static_cast<Layout::NodeWithStyle&>(*layout_node), cursor_data, Gfx::StandardCursor::Arrow);


### PR DESCRIPTION
This PR aims to show the I-beam (indicating a click will result in caret insertion) when hovering within an editing host but outside of a textNode.