### PR TITLE
LibWeb: Make WebGLRenderingContextBase derive from PlatformObject

### DIFF
--- a/Libraries/LibWeb/WebGL/Extensions/EXTTextureFilterAnisotropic.cpp
+++ b/Libraries/LibWeb/WebGL/Extensions/EXTTextureFilterAnisotropic.cpp
@@ -14,12 +14,12 @@ namespace Web::WebGL::Extensions {
 
 GC_DEFINE_ALLOCATOR(EXTTextureFilterAnisotropic);
 
-JS::ThrowCompletionOr<GC::Ptr<EXTTextureFilterAnisotropic>> EXTTextureFilterAnisotropic::create(JS::Realm& realm, WebGLRenderingContextBase* context)
+JS::ThrowCompletionOr<GC::Ptr<EXTTextureFilterAnisotropic>> EXTTextureFilterAnisotropic::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context)
 {
     return realm.create<EXTTextureFilterAnisotropic>(realm, context);
 }
 
-EXTTextureFilterAnisotropic::EXTTextureFilterAnisotropic(JS::Realm& realm, WebGLRenderingContextBase* context)
+EXTTextureFilterAnisotropic::EXTTextureFilterAnisotropic(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context)
     : PlatformObject(realm)
     , m_context(context)
 {
@@ -35,7 +35,7 @@ void EXTTextureFilterAnisotropic::initialize(JS::Realm& realm)
 void EXTTextureFilterAnisotropic::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_context->gc_cell());
+    visitor.visit(m_context);
 }
 
 }

--- a/Libraries/LibWeb/WebGL/Extensions/EXTTextureFilterAnisotropic.h
+++ b/Libraries/LibWeb/WebGL/Extensions/EXTTextureFilterAnisotropic.h
@@ -17,17 +17,16 @@ class EXTTextureFilterAnisotropic : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(EXTTextureFilterAnisotropic);
 
 public:
-    static JS::ThrowCompletionOr<GC::Ptr<EXTTextureFilterAnisotropic>> create(JS::Realm&, WebGLRenderingContextBase*);
+    static JS::ThrowCompletionOr<GC::Ptr<EXTTextureFilterAnisotropic>> create(JS::Realm&, GC::Ref<WebGLRenderingContextBase>);
 
 protected:
     void initialize(JS::Realm&) override;
     void visit_edges(Visitor&) override;
 
 private:
-    EXTTextureFilterAnisotropic(JS::Realm&, WebGLRenderingContextBase*);
+    EXTTextureFilterAnisotropic(JS::Realm&, GC::Ref<WebGLRenderingContextBase>);
 
-    // FIXME: It should be GC::Ptr instead of raw pointer, but we need to make WebGLRenderingContextBase inherit from PlatformObject first.
-    WebGLRenderingContextBase* m_context;
+    GC::Ref<WebGLRenderingContextBase> m_context;
 };
 
 }

--- a/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tc.cpp
+++ b/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tc.cpp
@@ -14,12 +14,12 @@ namespace Web::WebGL::Extensions {
 
 GC_DEFINE_ALLOCATOR(WebGLCompressedTextureS3tc);
 
-JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tc>> WebGLCompressedTextureS3tc::create(JS::Realm& realm, WebGLRenderingContextBase* context)
+JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tc>> WebGLCompressedTextureS3tc::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context)
 {
     return realm.create<WebGLCompressedTextureS3tc>(realm, context);
 }
 
-WebGLCompressedTextureS3tc::WebGLCompressedTextureS3tc(JS::Realm& realm, WebGLRenderingContextBase* context)
+WebGLCompressedTextureS3tc::WebGLCompressedTextureS3tc(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context)
     : PlatformObject(realm)
     , m_context(context)
 {
@@ -37,7 +37,7 @@ void WebGLCompressedTextureS3tc::initialize(JS::Realm& realm)
 void WebGLCompressedTextureS3tc::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_context->gc_cell());
+    visitor.visit(m_context);
 }
 
 }

--- a/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tc.h
+++ b/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tc.h
@@ -17,17 +17,16 @@ class WebGLCompressedTextureS3tc : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(WebGLCompressedTextureS3tc);
 
 public:
-    static JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tc>> create(JS::Realm&, WebGLRenderingContextBase*);
+    static JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tc>> create(JS::Realm&, GC::Ref<WebGLRenderingContextBase>);
 
 protected:
     void initialize(JS::Realm&) override;
     void visit_edges(Visitor&) override;
 
 private:
-    WebGLCompressedTextureS3tc(JS::Realm&, WebGLRenderingContextBase*);
+    WebGLCompressedTextureS3tc(JS::Realm&, GC::Ref<WebGLRenderingContextBase>);
 
-    // FIXME: It should be GC::Ptr instead of raw pointer, but we need to make WebGLRenderingContextBase inherit from PlatformObject first.
-    WebGLRenderingContextBase* m_context;
+    GC::Ref<WebGLRenderingContextBase> m_context;
 };
 
 }

--- a/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tcSrgb.cpp
+++ b/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tcSrgb.cpp
@@ -14,12 +14,12 @@ namespace Web::WebGL::Extensions {
 
 GC_DEFINE_ALLOCATOR(WebGLCompressedTextureS3tcSrgb);
 
-JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tcSrgb>> WebGLCompressedTextureS3tcSrgb::create(JS::Realm& realm, WebGLRenderingContextBase* context)
+JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tcSrgb>> WebGLCompressedTextureS3tcSrgb::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context)
 {
     return realm.create<WebGLCompressedTextureS3tcSrgb>(realm, context);
 }
 
-WebGLCompressedTextureS3tcSrgb::WebGLCompressedTextureS3tcSrgb(JS::Realm& realm, WebGLRenderingContextBase* context)
+WebGLCompressedTextureS3tcSrgb::WebGLCompressedTextureS3tcSrgb(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context)
     : PlatformObject(realm)
     , m_context(context)
 {
@@ -35,7 +35,7 @@ void WebGLCompressedTextureS3tcSrgb::initialize(JS::Realm& realm)
 void WebGLCompressedTextureS3tcSrgb::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_context->gc_cell());
+    visitor.visit(m_context);
 }
 
 }

--- a/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tcSrgb.h
+++ b/Libraries/LibWeb/WebGL/Extensions/WebGLCompressedTextureS3tcSrgb.h
@@ -17,17 +17,16 @@ class WebGLCompressedTextureS3tcSrgb : public Bindings::PlatformObject {
     GC_DECLARE_ALLOCATOR(WebGLCompressedTextureS3tcSrgb);
 
 public:
-    static JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tcSrgb>> create(JS::Realm&, WebGLRenderingContextBase*);
+    static JS::ThrowCompletionOr<GC::Ptr<WebGLCompressedTextureS3tcSrgb>> create(JS::Realm&, GC::Ref<WebGLRenderingContextBase>);
 
 protected:
     void initialize(JS::Realm&) override;
     void visit_edges(Visitor&) override;
 
 private:
-    WebGLCompressedTextureS3tcSrgb(JS::Realm&, WebGLRenderingContextBase*);
+    WebGLCompressedTextureS3tcSrgb(JS::Realm&, GC::Ref<WebGLRenderingContextBase>);
 
-    // FIXME: It should be GC::Ptr instead of raw pointer, but we need to make WebGLRenderingContextBase inherit from PlatformObject first.
-    WebGLRenderingContextBase* m_context;
+    GC::Ref<WebGLRenderingContextBase> m_context;
 };
 
 }

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
@@ -57,8 +57,7 @@ JS::ThrowCompletionOr<GC::Ptr<WebGL2RenderingContext>> WebGL2RenderingContext::c
 }
 
 WebGL2RenderingContext::WebGL2RenderingContext(JS::Realm& realm, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<OpenGLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)
-    : PlatformObject(realm)
-    , WebGL2RenderingContextOverloads(realm, move(context))
+    : WebGL2RenderingContextOverloads(realm, move(context))
     , m_canvas_element(canvas_element)
     , m_context_creation_parameters(context_creation_parameters)
     , m_actual_context_parameters(actual_context_parameters)
@@ -165,7 +164,7 @@ JS::Object* WebGL2RenderingContext::get_extension(String const& name)
 
     if (name.equals_ignoring_ascii_case("WEBGL_compressed_texture_s3tc"sv)) {
         if (!m_webgl_compressed_texture_s3tc_extension) {
-            m_webgl_compressed_texture_s3tc_extension = MUST(Extensions::WebGLCompressedTextureS3tc::create(realm(), this));
+            m_webgl_compressed_texture_s3tc_extension = MUST(Extensions::WebGLCompressedTextureS3tc::create(realm(), *this));
 
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_RGB_S3TC_DXT1_EXT);
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_RGBA_S3TC_DXT1_EXT);
@@ -179,7 +178,7 @@ JS::Object* WebGL2RenderingContext::get_extension(String const& name)
 
     if (name.equals_ignoring_ascii_case("WEBGL_compressed_texture_s3tc_srgb"sv)) {
         if (!m_webgl_compressed_texture_s3tc_srgb_extension) {
-            m_webgl_compressed_texture_s3tc_srgb_extension = MUST(Extensions::WebGLCompressedTextureS3tcSrgb::create(realm(), this));
+            m_webgl_compressed_texture_s3tc_srgb_extension = MUST(Extensions::WebGLCompressedTextureS3tcSrgb::create(realm(), *this));
 
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_SRGB_S3TC_DXT1_EXT);
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT);
@@ -211,7 +210,7 @@ JS::Object* WebGL2RenderingContext::get_extension(String const& name)
 
     if (name.equals_ignoring_ascii_case("EXT_texture_filter_anisotropic"sv)) {
         if (!m_ext_texture_filter_anisotropic) {
-            m_ext_texture_filter_anisotropic = MUST(Extensions::EXTTextureFilterAnisotropic::create(realm(), this));
+            m_ext_texture_filter_anisotropic = MUST(Extensions::EXTTextureFilterAnisotropic::create(realm(), *this));
         }
 
         VERIFY(m_ext_texture_filter_anisotropic);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.h
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.h
@@ -17,19 +17,14 @@
 
 namespace Web::WebGL {
 
-class WebGL2RenderingContext final : public Bindings::PlatformObject
-    , public WebGL2RenderingContextOverloads {
-    WEB_PLATFORM_OBJECT(WebGL2RenderingContext, Bindings::PlatformObject);
+class WebGL2RenderingContext final : public WebGL2RenderingContextOverloads {
+    WEB_PLATFORM_OBJECT(WebGL2RenderingContext, WebGL2RenderingContextOverloads);
     GC_DECLARE_ALLOCATOR(WebGL2RenderingContext);
 
 public:
     static JS::ThrowCompletionOr<GC::Ptr<WebGL2RenderingContext>> create(JS::Realm&, HTML::HTMLCanvasElement& canvas_element, JS::Value options);
 
     virtual ~WebGL2RenderingContext() override;
-
-    // FIXME: This is a hack required to visit context from WebGLObject.
-    //        It should be gone once WebGLRenderingContextBase inherits from PlatformObject.
-    GC::Cell const* gc_cell() const override { return this; }
 
     void present() override;
     void needs_to_present() override;

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
@@ -161,8 +161,8 @@ JS::Value WebGL2RenderingContextImpl::get_internalformat_parameter(WebIDL::Unsig
         size_t buffer_size = num_sample_counts * sizeof(GLint);
         auto samples_buffer = MUST(ByteBuffer::create_zeroed(buffer_size));
         glGetInternalformativRobustANGLE(target, internalformat, GL_SAMPLES, buffer_size, nullptr, reinterpret_cast<GLint*>(samples_buffer.data()));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(samples_buffer));
-        return JS::Int32Array::create(m_realm, num_sample_counts, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(samples_buffer));
+        return JS::Int32Array::create(realm(), num_sample_counts, array_buffer);
     }
     default:
         dbgln("Unknown WebGL internal format parameter name: {:x}", pname);
@@ -627,7 +627,7 @@ GC::Root<WebGLQuery> WebGL2RenderingContextImpl::create_query()
 
     GLuint handle = 0;
     glGenQueries(1, &handle);
-    return WebGLQuery::create(m_realm, *this, handle);
+    return WebGLQuery::create(realm(), *this, handle);
 }
 
 void WebGL2RenderingContextImpl::delete_query(GC::Root<WebGLQuery> query)
@@ -703,7 +703,7 @@ GC::Root<WebGLSampler> WebGL2RenderingContextImpl::create_sampler()
 
     GLuint handle = 0;
     glGenSamplers(1, &handle);
-    return WebGLSampler::create(m_realm, *this, handle);
+    return WebGLSampler::create(realm(), *this, handle);
 }
 
 void WebGL2RenderingContextImpl::delete_sampler(GC::Root<WebGLSampler> sampler)
@@ -824,7 +824,7 @@ GC::Root<WebGLSync> WebGL2RenderingContextImpl::fence_sync(WebIDL::UnsignedLong 
     m_context->make_current();
 
     GLsync handle = glFenceSync(condition, flags);
-    return WebGLSync::create(m_realm, *this, handle);
+    return WebGLSync::create(realm(), *this, handle);
 }
 
 void WebGL2RenderingContextImpl::delete_sync(GC::Root<WebGLSync> sync)
@@ -903,7 +903,7 @@ GC::Root<WebGLTransformFeedback> WebGL2RenderingContextImpl::create_transform_fe
 
     GLuint handle = 0;
     glGenTransformFeedbacks(1, &handle);
-    return WebGLTransformFeedback::create(m_realm, *this, handle);
+    return WebGLTransformFeedback::create(realm(), *this, handle);
 }
 
 void WebGL2RenderingContextImpl::delete_transform_feedback(GC::Root<WebGLTransformFeedback> transform_feedback)
@@ -1109,7 +1109,7 @@ JS::Value WebGL2RenderingContextImpl::get_active_uniforms(GC::Root<WebGLProgram>
         }
     }
 
-    return JS::Array::create_from(m_realm, params_as_values);
+    return JS::Array::create_from(realm(), params_as_values);
 }
 
 WebIDL::UnsignedLong WebGL2RenderingContextImpl::get_uniform_block_index(GC::Root<WebGLProgram> program, String uniform_block_name)
@@ -1158,8 +1158,8 @@ JS::Value WebGL2RenderingContextImpl::get_active_uniform_block_parameter(GC::Roo
         size_t buffer_size = num_active_uniforms * sizeof(GLint);
         auto active_uniform_indices_buffer = MUST(ByteBuffer::create_zeroed(buffer_size));
         glGetActiveUniformBlockivRobustANGLE(program_handle, uniform_block_index, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES, num_active_uniforms, nullptr, reinterpret_cast<GLint*>(active_uniform_indices_buffer.data()));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(active_uniform_indices_buffer));
-        return JS::Uint32Array::create(m_realm, num_active_uniforms, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(active_uniform_indices_buffer));
+        return JS::Uint32Array::create(realm(), num_active_uniforms, array_buffer);
     }
     case GL_UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER:
     case GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER: {
@@ -1220,7 +1220,7 @@ GC::Root<WebGLVertexArrayObject> WebGL2RenderingContextImpl::create_vertex_array
 
     GLuint handle = 0;
     glGenVertexArrays(1, &handle);
-    return WebGLVertexArrayObject::create(m_realm, *this, handle);
+    return WebGLVertexArrayObject::create(realm(), *this, handle);
 }
 
 void WebGL2RenderingContextImpl::delete_vertex_array(GC::Root<WebGLVertexArrayObject> vertex_array)

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.h
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.h
@@ -20,6 +20,8 @@ namespace Web::WebGL {
 using namespace Web::HTML;
 
 class WebGL2RenderingContextImpl : public WebGLRenderingContextImpl {
+    WEB_PLATFORM_OBJECT(WebGL2RenderingContextImpl, WebGLRenderingContextImpl);
+
 public:
     WebGL2RenderingContextImpl(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
@@ -18,6 +18,8 @@ namespace Web::WebGL {
 using namespace Web::HTML;
 
 class WebGL2RenderingContextOverloads : public WebGL2RenderingContextImpl {
+    WEB_PLATFORM_OBJECT(WebGL2RenderingContextOverloads, WebGL2RenderingContextImpl);
+
 public:
     WebGL2RenderingContextOverloads(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 

--- a/Libraries/LibWeb/WebGL/WebGLBuffer.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLBuffer.cpp
@@ -17,12 +17,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLBuffer);
 
-GC::Ref<WebGLBuffer> WebGLBuffer::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLBuffer> WebGLBuffer::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLBuffer>(realm, context, handle);
 }
 
-WebGLBuffer::WebGLBuffer(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLBuffer::WebGLBuffer(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLBuffer.h
+++ b/Libraries/LibWeb/WebGL/WebGLBuffer.h
@@ -19,14 +19,14 @@ class WebGLBuffer final : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLBuffer);
 
 public:
-    static GC::Ref<WebGLBuffer> create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle);
+    static GC::Ref<WebGLBuffer> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle);
 
     virtual ~WebGLBuffer();
 
     bool is_compatible_with(GLenum target);
 
 protected:
-    explicit WebGLBuffer(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLBuffer(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Libraries/LibWeb/WebGL/WebGLFramebuffer.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLFramebuffer.cpp
@@ -14,12 +14,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLFramebuffer);
 
-GC::Ref<WebGLFramebuffer> WebGLFramebuffer::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLFramebuffer> WebGLFramebuffer::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLFramebuffer>(realm, context, handle);
 }
 
-WebGLFramebuffer::WebGLFramebuffer(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLFramebuffer::WebGLFramebuffer(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLFramebuffer.h
+++ b/Libraries/LibWeb/WebGL/WebGLFramebuffer.h
@@ -16,12 +16,12 @@ class WebGLFramebuffer final : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLFramebuffer);
 
 public:
-    static GC::Ref<WebGLFramebuffer> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
+    static GC::Ref<WebGLFramebuffer> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLFramebuffer();
 
 protected:
-    explicit WebGLFramebuffer(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLFramebuffer(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/WebGL/WebGLObject.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLObject.cpp
@@ -14,9 +14,9 @@
 
 namespace Web::WebGL {
 
-WebGLObject::WebGLObject(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLObject::WebGLObject(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : Bindings::PlatformObject(realm)
-    , m_context(&context)
+    , m_context(context)
     , m_handle(handle)
 {
 }
@@ -32,7 +32,7 @@ void WebGLObject::initialize(JS::Realm& realm)
 void WebGLObject::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_context->gc_cell());
+    visitor.visit(m_context);
 }
 
 ErrorOr<GLuint> WebGLObject::handle(WebGLRenderingContextBase const* context) const

--- a/Libraries/LibWeb/WebGL/WebGLObject.h
+++ b/Libraries/LibWeb/WebGL/WebGLObject.h
@@ -27,15 +27,14 @@ public:
     ErrorOr<GLuint> handle(WebGLRenderingContextBase const* context) const;
 
 protected:
-    explicit WebGLObject(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLObject(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     void initialize(JS::Realm&) override;
     void visit_edges(Visitor&) override;
 
     bool invalidated() const { return m_invalidated; }
 
-    // FIXME: It should be GC::Ptr instead of raw pointer, but we need to make WebGLRenderingContextBase inherit from PlatformObject first.
-    WebGLRenderingContextBase* m_context;
+    GC::Ref<WebGLRenderingContextBase> m_context;
 
 private:
     GLuint m_handle { 0 };

--- a/Libraries/LibWeb/WebGL/WebGLProgram.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLProgram.cpp
@@ -16,12 +16,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLProgram);
 
-GC::Ref<WebGLProgram> WebGLProgram::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLProgram> WebGLProgram::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLProgram>(realm, context, handle);
 }
 
-WebGLProgram::WebGLProgram(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLProgram::WebGLProgram(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLProgram.h
+++ b/Libraries/LibWeb/WebGL/WebGLProgram.h
@@ -18,7 +18,7 @@ class WebGLProgram final : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLProgram);
 
 public:
-    static GC::Ref<WebGLProgram> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
+    static GC::Ref<WebGLProgram> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLProgram();
 
@@ -29,7 +29,7 @@ public:
     void set_attached_fragment_shader(GC::Ptr<WebGLShader> shader) { m_attached_fragment_shader = shader; }
 
 protected:
-    explicit WebGLProgram(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLProgram(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;

--- a/Libraries/LibWeb/WebGL/WebGLQuery.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLQuery.cpp
@@ -13,12 +13,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLQuery);
 
-GC::Ref<WebGLQuery> WebGLQuery::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLQuery> WebGLQuery::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLQuery>(realm, context, handle);
 }
 
-WebGLQuery::WebGLQuery(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLQuery::WebGLQuery(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLQuery.h
+++ b/Libraries/LibWeb/WebGL/WebGLQuery.h
@@ -16,12 +16,12 @@ class WebGLQuery : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLQuery);
 
 public:
-    static GC::Ref<WebGLQuery> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
+    static GC::Ref<WebGLQuery> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLQuery() override;
 
 protected:
-    explicit WebGLQuery(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLQuery(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/WebGL/WebGLRenderbuffer.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderbuffer.cpp
@@ -14,12 +14,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLRenderbuffer);
 
-GC::Ref<WebGLRenderbuffer> WebGLRenderbuffer::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLRenderbuffer> WebGLRenderbuffer::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLRenderbuffer>(realm, context, handle);
 }
 
-WebGLRenderbuffer::WebGLRenderbuffer(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLRenderbuffer::WebGLRenderbuffer(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLRenderbuffer.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderbuffer.h
@@ -16,12 +16,12 @@ class WebGLRenderbuffer final : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLRenderbuffer);
 
 public:
-    static GC::Ref<WebGLRenderbuffer> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
+    static GC::Ref<WebGLRenderbuffer> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLRenderbuffer();
 
 protected:
-    explicit WebGLRenderbuffer(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLRenderbuffer(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -75,8 +75,7 @@ JS::ThrowCompletionOr<GC::Ptr<WebGLRenderingContext>> WebGLRenderingContext::cre
 }
 
 WebGLRenderingContext::WebGLRenderingContext(JS::Realm& realm, HTML::HTMLCanvasElement& canvas_element, NonnullOwnPtr<OpenGLContext> context, WebGLContextAttributes context_creation_parameters, WebGLContextAttributes actual_context_parameters)
-    : PlatformObject(realm)
-    , WebGLRenderingContextOverloads(realm, move(context))
+    : WebGLRenderingContextOverloads(realm, move(context))
     , m_canvas_element(canvas_element)
     , m_context_creation_parameters(context_creation_parameters)
     , m_actual_context_parameters(actual_context_parameters)
@@ -203,7 +202,7 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
 
     if (name.equals_ignoring_ascii_case("EXT_texture_filter_anisotropic"sv)) {
         if (!m_ext_texture_filter_anisotropic) {
-            m_ext_texture_filter_anisotropic = MUST(Extensions::EXTTextureFilterAnisotropic::create(realm(), this));
+            m_ext_texture_filter_anisotropic = MUST(Extensions::EXTTextureFilterAnisotropic::create(realm(), *this));
         }
 
         VERIFY(m_ext_texture_filter_anisotropic);
@@ -230,7 +229,7 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
 
     if (name.equals_ignoring_ascii_case("WEBGL_compressed_texture_s3tc"sv)) {
         if (!m_webgl_compressed_texture_s3tc_extension) {
-            m_webgl_compressed_texture_s3tc_extension = MUST(Extensions::WebGLCompressedTextureS3tc::create(realm(), this));
+            m_webgl_compressed_texture_s3tc_extension = MUST(Extensions::WebGLCompressedTextureS3tc::create(realm(), *this));
 
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_RGB_S3TC_DXT1_EXT);
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_RGBA_S3TC_DXT1_EXT);
@@ -244,7 +243,7 @@ JS::Object* WebGLRenderingContext::get_extension(String const& name)
 
     if (name.equals_ignoring_ascii_case("WEBGL_compressed_texture_s3tc_srgb"sv)) {
         if (!m_webgl_compressed_texture_s3tc_srgb_extension) {
-            m_webgl_compressed_texture_s3tc_srgb_extension = MUST(Extensions::WebGLCompressedTextureS3tcSrgb::create(realm(), this));
+            m_webgl_compressed_texture_s3tc_srgb_extension = MUST(Extensions::WebGLCompressedTextureS3tcSrgb::create(realm(), *this));
 
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_SRGB_S3TC_DXT1_EXT);
             m_enabled_compressed_texture_formats.append(GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.h
@@ -16,19 +16,14 @@
 
 namespace Web::WebGL {
 
-class WebGLRenderingContext final : public Bindings::PlatformObject
-    , public WebGLRenderingContextOverloads {
-    WEB_PLATFORM_OBJECT(WebGLRenderingContext, Bindings::PlatformObject);
+class WebGLRenderingContext final : public WebGLRenderingContextOverloads {
+    WEB_PLATFORM_OBJECT(WebGLRenderingContext, WebGLRenderingContextOverloads);
     GC_DECLARE_ALLOCATOR(WebGLRenderingContext);
 
 public:
     static JS::ThrowCompletionOr<GC::Ptr<WebGLRenderingContext>> create(JS::Realm&, HTML::HTMLCanvasElement& canvas_element, JS::Value options);
 
     virtual ~WebGLRenderingContext() override;
-
-    // FIXME: This is a hack required to visit context from WebGLObject.
-    //        It should be gone once WebGLRenderingContextBase inherits from PlatformObject.
-    GC::Cell const* gc_cell() const override { return this; }
 
     void present() override;
     void needs_to_present() override;

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -82,6 +82,11 @@ static constexpr Optional<Gfx::ExportFormat> determine_export_format(WebIDL::Uns
     return {};
 }
 
+WebGLRenderingContextBase::WebGLRenderingContextBase(JS::Realm& realm)
+    : Bindings::PlatformObject(realm)
+{
+}
+
 Optional<Gfx::BitmapExportResult> WebGLRenderingContextBase::read_and_pixel_convert_texture_image_source(TexImageSource const& source, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, Optional<int> destination_width, Optional<int> destination_height)
 {
     // FIXME: If this function is called with an ImageData whose data attribute has been neutered,

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -34,19 +34,19 @@ static constexpr int MAX_CLIENT_WAIT_TIMEOUT_WEBGL = 0x9247;
 // NOTE: This is the Variant created by the IDL wrapper generator, and needs to be updated accordingly.
 using TexImageSource = Variant<GC::Root<HTML::ImageBitmap>, GC::Root<HTML::ImageData>, GC::Root<HTML::HTMLImageElement>, GC::Root<HTML::HTMLCanvasElement>, GC::Root<HTML::OffscreenCanvas>, GC::Root<HTML::HTMLVideoElement>>;
 
-// FIXME: This object should inherit from Bindings::PlatformObject and implement the WebGLRenderingContextBase IDL interface.
-//        We should make WebGL code generator to produce implementation for this interface.
-class WebGLRenderingContextBase {
+class WebGLRenderingContextBase : public Bindings::PlatformObject {
+    WEB_PLATFORM_OBJECT(WebGLRenderingContextBase, Bindings::PlatformObject);
+
 public:
     using Float32List = Variant<GC::Root<JS::Float32Array>, Vector<float>>;
     using Int32List = Variant<GC::Root<JS::Int32Array>, Vector<WebIDL::Long>>;
     using Uint32List = Variant<GC::Root<JS::Uint32Array>, Vector<WebIDL::UnsignedLong>>;
 
-    virtual GC::Cell const* gc_cell() const = 0;
-    virtual void visit_edges(JS::Cell::Visitor&) = 0;
     virtual OpenGLContext& context() = 0;
 
 protected:
+    WebGLRenderingContextBase(JS::Realm&);
+
     virtual bool ext_texture_filter_anisotropic_extension_enabled() const = 0;
     virtual bool angle_instanced_arrays_extension_enabled() const = 0;
     virtual bool oes_standard_derivatives_extension_enabled() const = 0;

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.cpp
@@ -37,7 +37,7 @@ extern "C" {
 namespace Web::WebGL {
 
 WebGLRenderingContextImpl::WebGLRenderingContextImpl(JS::Realm& realm, NonnullOwnPtr<OpenGLContext> context)
-    : m_realm(realm)
+    : WebGLRenderingContextBase(realm)
     , m_context(move(context))
 {
 }
@@ -375,7 +375,7 @@ GC::Root<WebGLBuffer> WebGLRenderingContextImpl::create_buffer()
 
     GLuint handle = 0;
     glGenBuffers(1, &handle);
-    return WebGLBuffer::create(m_realm, *this, handle);
+    return WebGLBuffer::create(realm(), *this, handle);
 }
 
 GC::Root<WebGLFramebuffer> WebGLRenderingContextImpl::create_framebuffer()
@@ -384,13 +384,13 @@ GC::Root<WebGLFramebuffer> WebGLRenderingContextImpl::create_framebuffer()
 
     GLuint handle = 0;
     glGenFramebuffers(1, &handle);
-    return WebGLFramebuffer::create(m_realm, *this, handle);
+    return WebGLFramebuffer::create(realm(), *this, handle);
 }
 
 GC::Root<WebGLProgram> WebGLRenderingContextImpl::create_program()
 {
     m_context->make_current();
-    return WebGLProgram::create(m_realm, *this, glCreateProgram());
+    return WebGLProgram::create(realm(), *this, glCreateProgram());
 }
 
 GC::Root<WebGLRenderbuffer> WebGLRenderingContextImpl::create_renderbuffer()
@@ -399,7 +399,7 @@ GC::Root<WebGLRenderbuffer> WebGLRenderingContextImpl::create_renderbuffer()
 
     GLuint handle = 0;
     glGenRenderbuffers(1, &handle);
-    return WebGLRenderbuffer::create(m_realm, *this, handle);
+    return WebGLRenderbuffer::create(realm(), *this, handle);
 }
 
 GC::Root<WebGLShader> WebGLRenderingContextImpl::create_shader(WebIDL::UnsignedLong type)
@@ -413,7 +413,7 @@ GC::Root<WebGLShader> WebGLRenderingContextImpl::create_shader(WebIDL::UnsignedL
     }
 
     GLuint handle = glCreateShader(type);
-    return WebGLShader::create(m_realm, *this, handle, type);
+    return WebGLShader::create(realm(), *this, handle, type);
 }
 
 GC::Root<WebGLTexture> WebGLRenderingContextImpl::create_texture()
@@ -422,7 +422,7 @@ GC::Root<WebGLTexture> WebGLRenderingContextImpl::create_texture()
 
     GLuint handle = 0;
     glGenTextures(1, &handle);
-    return WebGLTexture::create(m_realm, *this, handle);
+    return WebGLTexture::create(realm(), *this, handle);
 }
 
 void WebGLRenderingContextImpl::cull_face(WebIDL::UnsignedLong mode)
@@ -695,7 +695,7 @@ GC::Root<WebGLActiveInfo> WebGLRenderingContextImpl::get_active_attrib(GC::Root<
     GLchar name[256];
     glGetActiveAttrib(program_handle, index, buf_size, &length, &size, &type, name);
     auto readonly_bytes = ReadonlyBytes { name, static_cast<size_t>(length) };
-    return WebGLActiveInfo::create(m_realm, String::from_utf8_without_validation(readonly_bytes), type, size);
+    return WebGLActiveInfo::create(realm(), String::from_utf8_without_validation(readonly_bytes), type, size);
 }
 
 GC::Root<WebGLActiveInfo> WebGLRenderingContextImpl::get_active_uniform(GC::Root<WebGLProgram> program, WebIDL::UnsignedLong index)
@@ -719,7 +719,7 @@ GC::Root<WebGLActiveInfo> WebGLRenderingContextImpl::get_active_uniform(GC::Root
     GLchar name[256];
     glGetActiveUniform(program_handle, index, buf_size, &length, &size, &type, name);
     auto readonly_bytes = ReadonlyBytes { name, static_cast<size_t>(length) };
-    return WebGLActiveInfo::create(m_realm, String::from_utf8_without_validation(readonly_bytes), type, size);
+    return WebGLActiveInfo::create(realm(), String::from_utf8_without_validation(readonly_bytes), type, size);
 }
 
 Optional<Vector<GC::Root<WebGLShader>>> WebGLRenderingContextImpl::get_attached_shaders(GC::Root<WebGLProgram> program)
@@ -805,8 +805,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 2 * sizeof(GLfloat);
         glGetFloatvRobustANGLE(GL_ALIASED_LINE_WIDTH_RANGE, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Float32Array::create(m_realm, 2, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Float32Array::create(realm(), 2, array_buffer);
     }
     case GL_ALIASED_POINT_SIZE_RANGE: {
         Array<GLfloat, 2> result;
@@ -814,8 +814,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 2 * sizeof(GLfloat);
         glGetFloatvRobustANGLE(GL_ALIASED_POINT_SIZE_RANGE, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Float32Array::create(m_realm, 2, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Float32Array::create(realm(), 2, array_buffer);
     }
     case GL_ALPHA_BITS: {
         GLint result { 0 };
@@ -838,8 +838,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 4 * sizeof(GLfloat);
         glGetFloatvRobustANGLE(GL_BLEND_COLOR, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Float32Array::create(m_realm, 4, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Float32Array::create(realm(), 4, array_buffer);
     }
     case GL_BLEND_DST_ALPHA: {
         GLint result { 0 };
@@ -882,8 +882,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 4 * sizeof(GLfloat);
         glGetFloatvRobustANGLE(GL_COLOR_CLEAR_VALUE, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Float32Array::create(m_realm, 4, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Float32Array::create(realm(), 4, array_buffer);
     }
     case GL_CULL_FACE: {
         GLboolean result { GL_FALSE };
@@ -921,8 +921,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 2 * sizeof(GLfloat);
         glGetFloatvRobustANGLE(GL_DEPTH_RANGE, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Float32Array::create(m_realm, 2, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Float32Array::create(realm(), 2, array_buffer);
     }
     case GL_DEPTH_TEST: {
         GLboolean result { GL_FALSE };
@@ -1035,8 +1035,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 2 * sizeof(GLint);
         glGetIntegervRobustANGLE(GL_MAX_VIEWPORT_DIMS, 2, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Int32Array::create(m_realm, 2, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Int32Array::create(realm(), 2, array_buffer);
     }
     case GL_PACK_ALIGNMENT: {
         GLint result { 0 };
@@ -1070,7 +1070,7 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
     }
     case GL_RENDERER: {
         auto result = reinterpret_cast<char const*>(glGetString(GL_RENDERER));
-        return JS::PrimitiveString::create(m_realm->vm(), ByteString { result });
+        return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_SAMPLE_ALPHA_TO_COVERAGE: {
         GLboolean result { GL_FALSE };
@@ -1108,8 +1108,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 4 * sizeof(GLint);
         glGetIntegervRobustANGLE(GL_SCISSOR_BOX, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Int32Array::create(m_realm, 4, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Int32Array::create(realm(), 4, array_buffer);
     }
     case GL_SCISSOR_TEST: {
         GLboolean result { GL_FALSE };
@@ -1118,7 +1118,7 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
     }
     case GL_SHADING_LANGUAGE_VERSION: {
         auto result = reinterpret_cast<char const*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
-        return JS::PrimitiveString::create(m_realm->vm(), ByteString { result });
+        return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_STENCIL_BACK_FAIL: {
         GLint result { 0 };
@@ -1227,11 +1227,11 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
     }
     case GL_VENDOR: {
         auto result = reinterpret_cast<char const*>(glGetString(GL_VENDOR));
-        return JS::PrimitiveString::create(m_realm->vm(), ByteString { result });
+        return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_VERSION: {
         auto result = reinterpret_cast<char const*>(glGetString(GL_VERSION));
-        return JS::PrimitiveString::create(m_realm->vm(), ByteString { result });
+        return JS::PrimitiveString::create(realm().vm(), ByteString { result });
     }
     case GL_VIEWPORT: {
         Array<GLint, 4> result;
@@ -1239,8 +1239,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         constexpr size_t buffer_size = 4 * sizeof(GLint);
         glGetIntegervRobustANGLE(GL_VIEWPORT, 4, nullptr, result.data());
         auto byte_buffer = MUST(ByteBuffer::copy(result.data(), buffer_size));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Int32Array::create(m_realm, 4, array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Int32Array::create(realm(), 4, array_buffer);
     }
 
     case GL_FRAGMENT_SHADER_DERIVATIVE_HINT: { // NOTE: This has the same value as GL_FRAGMENT_SHADER_DERIVATIVE_HINT_OES
@@ -1287,8 +1287,8 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
     case COMPRESSED_TEXTURE_FORMATS: {
         auto formats = enabled_compressed_texture_formats();
         auto byte_buffer = MUST(ByteBuffer::copy(formats.data(), formats.reinterpret<u8 const>().size()));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Uint32Array::create(m_realm, formats.size(), array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Uint32Array::create(realm(), formats.size(), array_buffer);
     }
     case UNPACK_FLIP_Y_WEBGL:
         return JS::Value(m_unpack_flip_y);
@@ -1496,7 +1496,7 @@ JS::Value WebGLRenderingContextImpl::get_parameter(WebIDL::UnsignedLong pname)
         case GL_SAMPLER_BINDING: {
             GLint handle { 0 };
             glGetIntegervRobustANGLE(GL_SAMPLER_BINDING, 1, nullptr, &handle);
-            return WebGLSampler::create(m_realm, *this, handle);
+            return WebGLSampler::create(realm(), *this, handle);
         }
         case GL_UNIFORM_BUFFER_BINDING: {
             if (!m_uniform_buffer_binding)
@@ -1678,7 +1678,7 @@ GC::Root<WebGLShaderPrecisionFormat> WebGLRenderingContextImpl::get_shader_preci
     GLint range[2];
     GLint precision;
     glGetShaderPrecisionFormat(shadertype, precisiontype, range, &precision);
-    return WebGLShaderPrecisionFormat::create(m_realm, range[0], range[1], precision);
+    return WebGLShaderPrecisionFormat::create(realm(), range[0], range[1], precision);
 }
 
 Optional<String> WebGLRenderingContextImpl::get_shader_info_log(GC::Root<WebGLShader> shader)
@@ -1758,7 +1758,7 @@ GC::Root<WebGLUniformLocation> WebGLRenderingContextImpl::get_uniform_location(G
     if (location == -1)
         return nullptr;
 
-    return WebGLUniformLocation::create(m_realm, location, program.ptr());
+    return WebGLUniformLocation::create(realm(), location, program.ptr());
 }
 
 JS::Value WebGLRenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong index, WebIDL::UnsignedLong pname)
@@ -1770,13 +1770,13 @@ JS::Value WebGLRenderingContextImpl::get_vertex_attrib(WebIDL::UnsignedLong inde
         glGetVertexAttribfvRobustANGLE(index, GL_CURRENT_VERTEX_ATTRIB, result.size(), nullptr, result.data());
 
         auto byte_buffer = MUST(ByteBuffer::copy(result.span().reinterpret<u8>()));
-        auto array_buffer = JS::ArrayBuffer::create(m_realm, move(byte_buffer));
-        return JS::Float32Array::create(m_realm, result.size(), array_buffer);
+        auto array_buffer = JS::ArrayBuffer::create(realm(), move(byte_buffer));
+        return JS::Float32Array::create(realm(), result.size(), array_buffer);
     }
     case GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: {
         GLint handle { 0 };
         glGetVertexAttribivRobustANGLE(index, GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING, 1, nullptr, &handle);
-        return WebGLBuffer::create(m_realm, *this, handle);
+        return WebGLBuffer::create(realm(), *this, handle);
     }
     case GL_VERTEX_ATTRIB_ARRAY_DIVISOR: { // NOTE: This has the same value as GL_VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE
         if (angle_instanced_arrays_extension_enabled() || m_context->webgl_version() == OpenGLContext::WebGLVersion::WebGL2) {
@@ -2301,7 +2301,8 @@ void WebGLRenderingContextImpl::viewport(WebIDL::Long x, WebIDL::Long y, WebIDL:
 
 void WebGLRenderingContextImpl::visit_edges(JS::Cell::Visitor& visitor)
 {
-    visitor.visit(m_realm);
+    Base::visit_edges(visitor);
+
     visitor.visit(m_array_buffer_binding);
     visitor.visit(m_element_array_buffer_binding);
     visitor.visit(m_current_program);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextImpl.h
@@ -20,6 +20,8 @@ namespace Web::WebGL {
 using namespace Web::HTML;
 
 class WebGLRenderingContextImpl : public WebGLRenderingContextBase {
+    WEB_PLATFORM_OBJECT(WebGLRenderingContextImpl, WebGLRenderingContextBase);
+
 public:
     WebGLRenderingContextImpl(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 
@@ -144,7 +146,6 @@ public:
 protected:
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
-    GC::Ref<JS::Realm> m_realm;
     GC::Ptr<WebGLBuffer> m_array_buffer_binding;
     GC::Ptr<WebGLBuffer> m_element_array_buffer_binding;
     GC::Ptr<WebGLProgram> m_current_program;

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.h
@@ -18,6 +18,8 @@ namespace Web::WebGL {
 using namespace Web::HTML;
 
 class WebGLRenderingContextOverloads : public WebGLRenderingContextImpl {
+    WEB_PLATFORM_OBJECT(WebGLRenderingContextOverloads, WebGLRenderingContextImpl);
+
 public:
     WebGLRenderingContextOverloads(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 

--- a/Libraries/LibWeb/WebGL/WebGLSampler.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLSampler.cpp
@@ -13,12 +13,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLSampler);
 
-GC::Ref<WebGLSampler> WebGLSampler::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLSampler> WebGLSampler::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLSampler>(realm, context, handle);
 }
 
-WebGLSampler::WebGLSampler(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLSampler::WebGLSampler(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLSampler.h
+++ b/Libraries/LibWeb/WebGL/WebGLSampler.h
@@ -16,12 +16,12 @@ class WebGLSampler : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLSampler);
 
 public:
-    static GC::Ref<WebGLSampler> create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle);
+    static GC::Ref<WebGLSampler> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle);
 
     virtual ~WebGLSampler() override;
 
 protected:
-    explicit WebGLSampler(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLSampler(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/WebGL/WebGLShader.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLShader.cpp
@@ -15,12 +15,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLShader);
 
-GC::Ref<WebGLShader> WebGLShader::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle, GLenum type)
+GC::Ref<WebGLShader> WebGLShader::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle, GLenum type)
 {
     return realm.create<WebGLShader>(realm, context, handle, type);
 }
 
-WebGLShader::WebGLShader(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle, GLenum type)
+WebGLShader::WebGLShader(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle, GLenum type)
     : WebGLObject(realm, context, handle)
     , m_type(type)
 {

--- a/Libraries/LibWeb/WebGL/WebGLShader.h
+++ b/Libraries/LibWeb/WebGL/WebGLShader.h
@@ -18,14 +18,14 @@ class WebGLShader final : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLShader);
 
 public:
-    static GC::Ref<WebGLShader> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle, GLenum type);
+    static GC::Ref<WebGLShader> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle, GLenum type);
 
     virtual ~WebGLShader();
 
     GLenum type() const { return m_type; }
 
 protected:
-    explicit WebGLShader(JS::Realm&, WebGLRenderingContextBase&, GLuint handle, GLenum type);
+    explicit WebGLShader(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle, GLenum type);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Libraries/LibWeb/WebGL/WebGLSync.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLSync.cpp
@@ -15,12 +15,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLSync);
 
-GC::Ref<WebGLSync> WebGLSync::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLsyncInternal handle)
+GC::Ref<WebGLSync> WebGLSync::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLsyncInternal handle)
 {
     return realm.create<WebGLSync>(realm, context, handle);
 }
 
-WebGLSync::WebGLSync(JS::Realm& realm, WebGLRenderingContextBase& context, GLsyncInternal handle)
+WebGLSync::WebGLSync(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLsyncInternal handle)
     : WebGLObject(realm, context, 0)
     , m_sync_handle(handle)
 {

--- a/Libraries/LibWeb/WebGL/WebGLSync.h
+++ b/Libraries/LibWeb/WebGL/WebGLSync.h
@@ -16,14 +16,14 @@ class WebGLSync : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLSync);
 
 public:
-    static GC::Ref<WebGLSync> create(JS::Realm& realm, WebGLRenderingContextBase&, GLsyncInternal handle);
+    static GC::Ref<WebGLSync> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLsyncInternal handle);
 
     virtual ~WebGLSync() override;
 
     ErrorOr<GLsyncInternal> sync_handle(WebGLRenderingContextBase const* context) const;
 
 protected:
-    explicit WebGLSync(JS::Realm&, WebGLRenderingContextBase&, GLsyncInternal handle);
+    explicit WebGLSync(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLsyncInternal handle);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Libraries/LibWeb/WebGL/WebGLTexture.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLTexture.cpp
@@ -15,12 +15,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLTexture);
 
-GC::Ref<WebGLTexture> WebGLTexture::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLTexture> WebGLTexture::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLTexture>(realm, context, handle);
 }
 
-WebGLTexture::WebGLTexture(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLTexture::WebGLTexture(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLTexture.h
+++ b/Libraries/LibWeb/WebGL/WebGLTexture.h
@@ -18,12 +18,12 @@ class WebGLTexture final : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLTexture);
 
 public:
-    static GC::Ref<WebGLTexture> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
+    static GC::Ref<WebGLTexture> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLTexture();
 
 protected:
-    explicit WebGLTexture(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLTexture(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/WebGL/WebGLTransformFeedback.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLTransformFeedback.cpp
@@ -13,12 +13,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLTransformFeedback);
 
-GC::Ref<WebGLTransformFeedback> WebGLTransformFeedback::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLTransformFeedback> WebGLTransformFeedback::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLTransformFeedback>(realm, context, handle);
 }
 
-WebGLTransformFeedback::WebGLTransformFeedback(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLTransformFeedback::WebGLTransformFeedback(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLTransformFeedback.h
+++ b/Libraries/LibWeb/WebGL/WebGLTransformFeedback.h
@@ -16,12 +16,12 @@ class WebGLTransformFeedback : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLTransformFeedback);
 
 public:
-    static GC::Ref<WebGLTransformFeedback> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
+    static GC::Ref<WebGLTransformFeedback> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLTransformFeedback() override;
 
 protected:
-    explicit WebGLTransformFeedback(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLTransformFeedback(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Libraries/LibWeb/WebGL/WebGLVertexArrayObject.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLVertexArrayObject.cpp
@@ -13,12 +13,12 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLVertexArrayObject);
 
-GC::Ref<WebGLVertexArrayObject> WebGLVertexArrayObject::create(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+GC::Ref<WebGLVertexArrayObject> WebGLVertexArrayObject::create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
 {
     return realm.create<WebGLVertexArrayObject>(realm, context, handle);
 }
 
-WebGLVertexArrayObject::WebGLVertexArrayObject(JS::Realm& realm, WebGLRenderingContextBase& context, GLuint handle)
+WebGLVertexArrayObject::WebGLVertexArrayObject(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase> context, GLuint handle)
     : WebGLObject(realm, context, handle)
 {
 }

--- a/Libraries/LibWeb/WebGL/WebGLVertexArrayObject.h
+++ b/Libraries/LibWeb/WebGL/WebGLVertexArrayObject.h
@@ -16,12 +16,12 @@ class WebGLVertexArrayObject : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLVertexArrayObject);
 
 public:
-    static GC::Ref<WebGLVertexArrayObject> create(JS::Realm& realm, WebGLRenderingContextBase&, GLuint handle);
+    static GC::Ref<WebGLVertexArrayObject> create(JS::Realm& realm, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual ~WebGLVertexArrayObject() override;
 
 protected:
-    explicit WebGLVertexArrayObject(JS::Realm&, WebGLRenderingContextBase&, GLuint handle);
+    explicit WebGLVertexArrayObject(JS::Realm&, GC::Ref<WebGLRenderingContextBase>, GLuint handle);
 
     virtual void initialize(JS::Realm&) override;
 };


### PR DESCRIPTION
This resolves a bunch of FIXMEs, removes a bunch of raw pointers and sketchy hacks. There's quite a high chance I messed something up with the WEB_PLATFORM_OBJECT and GC_DECLARE_ALLOCATOR as I'm not sure if I understand them entirely correctly, so sorry in advance :^).