### PR TITLE
CI: Give the test262 runner write permissions

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -15,6 +15,9 @@ jobs:
 
     concurrency: libjs-test262
 
+    permissions:
+      contents: write
+
     steps:
       - name: Cleanup
         run: |


### PR DESCRIPTION
Shot in the dark to fix our ability to push changes to the libjs-data repo.