### PR TITLE
CI: Set the Ladybird token when checking out libjs-data

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           repository: LadybirdBrowser/libjs-data
           path: libjs-data
+          token: ${{ secrets.LADYBIRD_BOT_TOKEN }}
 
       - name: Checkout tc39/test262
         uses: actions/checkout@v6


### PR DESCRIPTION
According to:
https://github.com/orgs/community/discussions/26694#discussioncomment-3252933

We need to set the token when checking out the repo as well.