### PR TITLE
CI: Set the PAT on the main test262 checkout step

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Checkout LadybirdBrowser/ladybird
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.LADYBIRD_BOT_TOKEN }}
 
       - name: Checkout LadybirdBrowser/libjs-test262
         uses: actions/checkout@v6
@@ -38,7 +40,6 @@ jobs:
         with:
           repository: LadybirdBrowser/libjs-data
           path: libjs-data
-          token: ${{ secrets.LADYBIRD_BOT_TOKEN }}
 
       - name: Checkout tc39/test262
         uses: actions/checkout@v6


### PR DESCRIPTION
In the deploy step, git commands are run from the main directory, so that is where the PAT must be set.

Managed to get this working on my fork:
https://github.com/trflynn89/ladybird/actions/runs/19900453147/job/57042493049