### PR TITLE
LibWeb/CSS: Update syntax comments for a couple of properties

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1050,7 +1050,7 @@ RefPtr<StyleValue const> Parser::parse_counter_set_value(TokenStream<ComponentVa
 // https://drafts.csswg.org/css-ui-4/#cursor
 RefPtr<StyleValue const> Parser::parse_cursor_value(TokenStream<ComponentValue>& tokens)
 {
-    // <cursor-image>#? <cursor-predefined>
+    // [<cursor-image>,]* <cursor-predefined>
     // <cursor-image> = <url> <number>{2}?
     // So, any number of custom cursor definitions, and then a mandatory cursor name keyword, all comma-separated.
 

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2282,6 +2282,7 @@ RefPtr<StyleValue const> Parser::parse_color_mix_function(TokenStream<ComponentV
 
     // color-mix() = color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#)
     // FIXME: Update color-mix to accept 1+ colors instead of exactly 2.
+    // FIXME: <color-interpolation-method> is optional in the current spec.
     auto transaction = tokens.begin_transaction();
     tokens.discard_whitespace();
 
@@ -2529,7 +2530,7 @@ RefPtr<StyleValue const> Parser::parse_corner_shape_value(TokenStream<ComponentV
     }
 
     if (token.is_function("superellipse"sv)) {
-        // superellipse() = superellipse(<number [-∞,∞]> | infinity | -infinity)
+        // superellipse() = superellipse(<number> | infinity | -infinity)
         auto const& function = token.function();
 
         auto context_guard = push_temporary_value_parsing_context(FunctionContext { function.name });


### PR DESCRIPTION
Corresponds to:
https://github.com/w3c/csswg-drafts/commit/3a2ac8d75c3a852eb234aabceaf9164301d73ff9
https://github.com/w3c/csswg-drafts/commit/fdc08f79a22f0b6cda2ac823b1c7a2f8b1004445

No code changes.