### PR TITLE
Everywhere: Remove LibCore/System.h includes from header files

### DIFF
--- a/Libraries/LibIPC/AutoCloseFileDescriptor.cpp
+++ b/Libraries/LibIPC/AutoCloseFileDescriptor.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/System.h>
+#include <LibIPC/AutoCloseFileDescriptor.h>
+
+namespace IPC {
+
+AutoCloseFileDescriptor::AutoCloseFileDescriptor(int fd)
+    : m_fd(fd)
+{
+}
+
+AutoCloseFileDescriptor::~AutoCloseFileDescriptor()
+{
+    if (m_fd != -1)
+        (void)Core::System::close(m_fd);
+}
+
+}

--- a/Libraries/LibIPC/AutoCloseFileDescriptor.h
+++ b/Libraries/LibIPC/AutoCloseFileDescriptor.h
@@ -7,34 +7,19 @@
 #pragma once
 
 #include <AK/RefCounted.h>
-#include <LibCore/System.h>
 
 namespace IPC {
 
 class AutoCloseFileDescriptor : public RefCounted<AutoCloseFileDescriptor> {
 public:
-    AutoCloseFileDescriptor(int fd)
-        : m_fd(fd)
-    {
-    }
-
-    ~AutoCloseFileDescriptor()
-    {
-        if (m_fd != -1)
-            (void)Core::System::close(m_fd);
-    }
+    explicit AutoCloseFileDescriptor(int fd);
+    ~AutoCloseFileDescriptor();
 
     int value() const { return m_fd; }
-
-    int take_fd()
-    {
-        int fd = m_fd;
-        m_fd = -1;
-        return fd;
-    }
+    int take_fd() { return exchange(m_fd, -1); }
 
 private:
-    int m_fd;
+    int m_fd { -1 };
 };
 
 }

--- a/Libraries/LibIPC/CMakeLists.txt
+++ b/Libraries/LibIPC/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    AutoCloseFileDescriptor.cpp
     Connection.cpp
     Decoder.cpp
     Encoder.cpp

--- a/Libraries/LibIPC/File.cpp
+++ b/Libraries/LibIPC/File.cpp
@@ -1,15 +1,64 @@
 /*
  * Copyright (c) 2020, Sergey Bugaev <bugaevc@serenityos.org>
  * Copyright (c) 2021, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/File.h>
 
 namespace IPC {
+
+File File::adopt_file(NonnullOwnPtr<Core::File> file)
+{
+    return File(file->leak_fd());
+}
+
+File File::adopt_fd(int fd)
+{
+    return File(fd);
+}
+
+ErrorOr<File> File::clone_fd(int fd)
+{
+    int new_fd = TRY(Core::System::dup(fd));
+    return File(new_fd);
+}
+
+File::File(int fd)
+    : m_fd(fd)
+{
+}
+
+File::File(File&& other)
+    : m_fd(exchange(other.m_fd, -1))
+{
+}
+
+File& File::operator=(File&& other)
+{
+    if (this != &other) {
+        m_fd = exchange(other.m_fd, -1);
+    }
+    return *this;
+}
+
+File::~File()
+{
+    if (m_fd != -1)
+        (void)Core::System::close(m_fd);
+}
+
+// FIXME: IPC::Files transferred over the wire always set O_CLOEXEC during decoding. Perhaps we should add an option to
+//        allow the receiver to decide whether to make it O_CLOEXEC or not. Or an attribute in the .ipc file?
+ErrorOr<void> File::clear_close_on_exec()
+{
+    return Core::System::set_close_on_exec(m_fd, false);
+}
 
 template<>
 ErrorOr<File> decode(Decoder& decoder)

--- a/Libraries/LibIPC/SingleServer.h
+++ b/Libraries/LibIPC/SingleServer.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <LibCore/System.h>
 #include <LibCore/SystemServerTakeover.h>
 #include <LibIPC/ConnectionFromClient.h>
 

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/File.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
 

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -592,6 +592,8 @@ set(SOURCES
     HTML/NavigationTransition.cpp
     HTML/Navigator.cpp
     HTML/NavigatorBeacon.cpp
+    HTML/NavigatorConcurrentHardware.cpp
+    HTML/NavigatorDeviceMemory.cpp
     HTML/NavigatorID.cpp
     HTML/Numbers.cpp
     HTML/OffscreenCanvas.cpp

--- a/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.cpp
+++ b/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/System.h>
+#include <LibWeb/HTML/NavigatorConcurrentHardware.h>
+
+namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/workers.html#dom-navigator-hardwareconcurrency
+WebIDL::UnsignedLongLong NavigatorConcurrentHardwareMixin::hardware_concurrency()
+{
+    return Core::System::hardware_concurrency();
+}
+
+}

--- a/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.h
+++ b/Libraries/LibWeb/HTML/NavigatorConcurrentHardware.h
@@ -7,15 +7,13 @@
 
 #pragma once
 
-#include <LibCore/System.h>
 #include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
 class NavigatorConcurrentHardwareMixin {
 public:
-    // https://html.spec.whatwg.org/multipage/workers.html#dom-navigator-hardwareconcurrency
-    static WebIDL::UnsignedLongLong hardware_concurrency() { return Core::System::hardware_concurrency(); }
+    static WebIDL::UnsignedLongLong hardware_concurrency();
 };
 
 }

--- a/Libraries/LibWeb/HTML/NavigatorDeviceMemory.cpp
+++ b/Libraries/LibWeb/HTML/NavigatorDeviceMemory.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/BuiltinWrappers.h>
+#include <LibCore/System.h>
+#include <LibWeb/HTML/NavigatorDeviceMemory.h>
+
+namespace Web::HTML {
+
+// https://www.w3.org/TR/device-memory/#computing-device-memory-value
+WebIDL::Double NavigatorDeviceMemoryMixin::device_memory() const
+{
+    // The value is calculated by using the actual device memory in MiB then rounding it to the nearest number where
+    // only the most significant bit can be set and the rest are zeros (nearest power of two).
+    auto memory_in_bytes = Core::System::physical_memory_bytes();
+    auto memory_in_mib = memory_in_bytes / MiB;
+    auto required_bits = AK::count_required_bits(memory_in_mib);
+    auto lower_memory_in_mib = static_cast<u64>(1) << (required_bits - 1);
+    auto upper_memory_in_mib = static_cast<u64>(1) << required_bits;
+    auto rounded_memory_in_mib = upper_memory_in_mib - memory_in_mib <= memory_in_mib - lower_memory_in_mib
+        ? upper_memory_in_mib
+        : lower_memory_in_mib;
+
+    // Then dividing that number by 1024.0 to get the value in GiB.
+    auto memory_in_gib = static_cast<WebIDL::Double>(rounded_memory_in_mib) / 1024.0;
+
+    // An upper bound and a lower bound should be set on the list of values.
+    return AK::clamp(memory_in_gib, 1.0, 4.0);
+}
+
+}

--- a/Libraries/LibWeb/HTML/NavigatorDeviceMemory.h
+++ b/Libraries/LibWeb/HTML/NavigatorDeviceMemory.h
@@ -6,35 +6,13 @@
 
 #pragma once
 
-#include <AK/BuiltinWrappers.h>
-#include <LibCore/System.h>
 #include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
 class NavigatorDeviceMemoryMixin {
 public:
-    // https://www.w3.org/TR/device-memory/#computing-device-memory-value
-    WebIDL::Double device_memory() const
-    {
-        // The value is calculated by using the actual device memory in MiB then rounding it to the
-        // nearest number where only the most significant bit can be set and the rest are zeros
-        // (nearest power of two).
-        auto memory_in_bytes = Core::System::physical_memory_bytes();
-        auto memory_in_mib = memory_in_bytes / MiB;
-        auto required_bits = AK::count_required_bits(memory_in_mib);
-        auto lower_memory_in_mib = static_cast<u64>(1) << (required_bits - 1);
-        auto upper_memory_in_mib = static_cast<u64>(1) << required_bits;
-        auto rounded_memory_in_mib = upper_memory_in_mib - memory_in_mib <= memory_in_mib - lower_memory_in_mib
-            ? upper_memory_in_mib
-            : lower_memory_in_mib;
-
-        // Then dividing that number by 1024.0 to get the value in GiB.
-        auto memory_in_gib = static_cast<WebIDL::Double>(rounded_memory_in_mib) / 1024.0;
-
-        // An upper bound and a lower bound should be set on the list of values.
-        return AK::clamp(memory_in_gib, 1.0, 4.0);
-    }
+    WebIDL::Double device_memory() const;
 };
 
 }

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -9,6 +9,7 @@
 #include <LibCore/Directory.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/Resource.h>
+#include <LibCore/System.h>
 #include <LibGC/Function.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Enumerate.h>
 #include <LibCore/Process.h>
+#include <LibCore/System.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/Utilities.h>

--- a/Libraries/LibWebView/Process.cpp
+++ b/Libraries/LibWebView/Process.cpp
@@ -8,7 +8,9 @@
 #include <LibCore/Process.h>
 #include <LibCore/Socket.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
 #include <LibWebView/Process.h>
+
 #if defined(AK_OS_WINDOWS)
 #    include <AK/ScopeGuard.h>
 #    include <AK/Windows.h>

--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -8,6 +8,7 @@
 #include <AK/IDAllocator.h>
 #include <ImageDecoder/ConnectionFromClient.h>
 #include <ImageDecoder/ImageDecoderClientEndpoint.h>
+#include <LibCore/System.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 #include <LibGfx/ImageFormats/TIFFMetadata.h>

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/Proxy.h>
 #include <LibCore/Socket.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
 #include <LibHTTP/Cache/DiskCache.h>
 #include <LibRequests/WebSocket.h>
 #include <LibWebSocket/ConnectionInfo.h>

--- a/Tests/LibWeb/test-web/Fixture.cpp
+++ b/Tests/LibWeb/test-web/Fixture.cpp
@@ -11,6 +11,7 @@
 #include <AK/LexicalPath.h>
 #include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
 
 namespace TestWeb {
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -23,6 +23,7 @@
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <LibCore/Timer.h>
 #include <LibDiff/Format.h>
 #include <LibDiff/Generator.h>


### PR DESCRIPTION
This reduces the number of compilation jobs when System.h changes from about 750 to 60. (There are still a large number of linker jobs.)