### PR TITLE
LibWebView: Make GNU Release build work again with LibCore

### DIFF
--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -89,6 +89,7 @@ if (ENABLE_QT)
 
     set_target_properties(LibWebViewQt PROPERTIES AUTOMOC ON AUTORCC OFF AUTOUIC OFF)
     find_package(Qt6 REQUIRED COMPONENTS Core)
+    target_link_libraries(LibWebViewQt PRIVATE LibCore)
     target_link_libraries(LibWebViewQt PUBLIC Qt::Core)
     if (WIN32)
         find_package(pthread REQUIRED)


### PR DESCRIPTION
GNU Release build on Ubuntu 25.04 and Ubuntu 25.10 not working with this error
```
/usr/bin/ld: lib/liblagom-webview.so.0.0.0: undefined reference to symbol '_ZN4Core6System10socketpairEiiiPi'
/usr/bin/ld: lib/liblagom-coreminimal.so.0.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

Changed `Meta/CMake/lagom_compile_options.cmake:79` to
```
add_link_options(LINKER:--allow-shlib-undefined)
```

which gave:

```
/usr/bin/ld: lib/libLibWebViewQt.a(EventLoopImplementationQt.cpp.o): in function `WebView::EventLoopManagerQt::set_main_loop_signal_notifiers(AK::Badge<WebView::EventLoopImplementationQt>)':
/home/bobo/projects/ladybird/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.cpp:400:(.text+0x10b9): undefined reference to `Core::System::socketpair(int, int, int, int*)'
```

Looking into `Libraries/LibWebView/CMakeLists.txt:84` we have

```if (ENABLE_QT)
    add_library(LibWebViewQt STATIC
        EventLoop/EventLoopImplementationQt.cpp
        EventLoop/EventLoopImplementationQtEventTarget.cpp
    )
```

LibCore missing from LibWebViewQt, put between lines 91 and 92

```
target_link_libraries(LibWebViewQt PRIVATE LibCore)
```

Problem resolved.