### PR TITLE
LibWebView+UI: Move the UI event loops to the UI folder

### DIFF
--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -80,30 +80,6 @@ if (HAS_FONTCONFIG)
     target_link_libraries(LibWebView PRIVATE Fontconfig::Fontconfig)
 endif()
 
-add_library(LibWebViewPlatform INTERFACE)
-if (ENABLE_QT)
-    add_library(LibWebViewQt STATIC
-        EventLoop/EventLoopImplementationQt.cpp
-        EventLoop/EventLoopImplementationQtEventTarget.cpp
-    )
-
-    set_target_properties(LibWebViewQt PROPERTIES AUTOMOC ON AUTORCC OFF AUTOUIC OFF)
-    find_package(Qt6 REQUIRED COMPONENTS Core)
-    target_link_libraries(LibWebViewQt PRIVATE LibCore)
-    target_link_libraries(LibWebViewQt PUBLIC Qt::Core)
-    if (WIN32)
-        find_package(pthread REQUIRED)
-        target_include_directories(LibWebViewQt PRIVATE $<BUILD_INTERFACE:${PTHREAD_INCLUDE_DIR}>)
-    endif()
-    target_link_libraries(LibWebViewPlatform INTERFACE LibWebViewQt)
-elseif (APPLE)
-    add_library(LibWebViewCocoa STATIC
-        EventLoop/EventLoopImplementationMacOS.mm
-    )
-    target_link_libraries(LibWebViewCocoa PUBLIC "-framework Cocoa")
-    target_link_libraries(LibWebViewPlatform INTERFACE LibWebViewCocoa)
-endif()
-
 if (ENABLE_INSTALL_HEADERS)
     foreach(header ${GENERATED_SOURCES})
         get_filename_component(extension ${header} EXT)

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Application/EventLoopImplementationMacOS.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/ThreadEventQueue.h>
-#include <LibWebView/EventLoop/EventLoopImplementationMacOS.h>
 #include <Utilities/Conversions.h>
 
 #import <Application/Application.h>
@@ -26,7 +26,7 @@ Application::Application() = default;
 NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
 {
     if (!browser_options().headless_mode.has_value()) {
-        Core::EventLoopManager::install(*new WebView::EventLoopManagerMacOS);
+        Core::EventLoopManager::install(*new EventLoopManagerMacOS);
         [::Application sharedApplication];
     }
 

--- a/UI/AppKit/Application/EventLoopImplementationMacOS.h
+++ b/UI/AppKit/Application/EventLoopImplementationMacOS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,11 +9,10 @@
 #include <AK/Function.h>
 #include <AK/NonnullOwnPtr.h>
 #include <LibCore/EventLoopImplementation.h>
-#include <LibWebView/Forward.h>
 
-namespace WebView {
+namespace Ladybird {
 
-class WEBVIEW_API EventLoopManagerMacOS final : public Core::EventLoopManager {
+class EventLoopManagerMacOS final : public Core::EventLoopManager {
 public:
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
@@ -29,7 +28,7 @@ public:
     virtual void unregister_signal(int) override;
 };
 
-class WEBVIEW_API EventLoopImplementationMacOS final : public Core::EventLoopImplementation {
+class EventLoopImplementationMacOS final : public Core::EventLoopImplementation {
 public:
     // FIXME: This currently only manages the main NSApp event loop, as that is all we currently
     //        interact with. When we need multiple event loops, or an event loop that isn't the

--- a/UI/AppKit/Application/EventLoopImplementationMacOS.mm
+++ b/UI/AppKit/Application/EventLoopImplementationMacOS.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,11 +9,11 @@
 #include <AK/IDAllocator.h>
 #include <AK/Singleton.h>
 #include <AK/TemporaryChange.h>
+#include <Application/EventLoopImplementationMacOS.h>
 #include <LibCore/Event.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/ThreadEventQueue.h>
 #include <LibThreading/RWLock.h>
-#include <LibWebView/EventLoop/EventLoopImplementationMacOS.h>
 
 #import <Cocoa/Cocoa.h>
 #import <CoreFoundation/CoreFoundation.h>
@@ -22,7 +22,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
-namespace WebView {
+namespace Ladybird {
 
 struct ThreadData;
 static thread_local OwnPtr<ThreadData> s_this_thread_data;

--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ladybird_impl STATIC
     Application/Application.mm
     Application/ApplicationDelegate.mm
+    Application/EventLoopImplementationMacOS.mm
     Interface/Autocomplete.mm
     Interface/Event.mm
     Interface/InfoBar.mm

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
     set(LADYBIRD_TARGET ladybird PRIVATE)
 endif()
 
-set(LADYBIRD_LIBS AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibWebViewPlatform LibRequests LibURL)
+set(LADYBIRD_LIBS AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibRequests LibURL)
 target_link_libraries(${LADYBIRD_TARGET} PRIVATE ${LADYBIRD_LIBS})
 target_link_libraries(${LADYBIRD_TARGET} PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -5,9 +5,9 @@
  */
 
 #include <LibCore/ArgsParser.h>
-#include <LibWebView/EventLoop/EventLoopImplementationQt.h>
 #include <LibWebView/URL.h>
 #include <UI/Qt/Application.h>
+#include <UI/Qt/EventLoopImplementationQt.h>
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
 
@@ -102,14 +102,14 @@ void Application::create_platform_options(WebView::BrowserOptions&, WebView::Req
 NonnullOwnPtr<Core::EventLoop> Application::create_platform_event_loop()
 {
     if (!browser_options().headless_mode.has_value()) {
-        Core::EventLoopManager::install(*new WebView::EventLoopManagerQt);
+        Core::EventLoopManager::install(*new EventLoopManagerQt);
         m_application = make<LadybirdQApplication>(arguments());
     }
 
     auto event_loop = WebView::Application::create_platform_event_loop();
 
     if (!browser_options().headless_mode.has_value())
-        static_cast<WebView::EventLoopImplementationQt&>(event_loop->impl()).set_main_loop();
+        static_cast<EventLoopImplementationQt&>(event_loop->impl()).set_main_loop();
 
     return event_loop;
 }

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -3,6 +3,8 @@ target_sources(ladybird PRIVATE
     Application.cpp
     Autocomplete.cpp
     BrowserWindow.cpp
+    EventLoopImplementationQt.cpp
+    EventLoopImplementationQtEventTarget.cpp
     FindInPageWidget.cpp
     Icon.cpp
     LocationEdit.cpp

--- a/UI/Qt/EventLoopImplementationQt.cpp
+++ b/UI/Qt/EventLoopImplementationQt.cpp
@@ -16,8 +16,8 @@
 #include <LibCore/ThreadEventQueue.h>
 #include <LibThreading/Mutex.h>
 #include <LibThreading/RWLock.h>
-#include <LibWebView/EventLoop/EventLoopImplementationQt.h>
-#include <LibWebView/EventLoop/EventLoopImplementationQtEventTarget.h>
+#include <UI/Qt/EventLoopImplementationQt.h>
+#include <UI/Qt/EventLoopImplementationQtEventTarget.h>
 
 #include <QCoreApplication>
 #include <QEvent>
@@ -26,7 +26,7 @@
 #include <QThread>
 #include <QTimer>
 
-namespace WebView {
+namespace Ladybird {
 
 struct ThreadData;
 static thread_local OwnPtr<ThreadData> s_this_thread_data;

--- a/UI/Qt/EventLoopImplementationQt.h
+++ b/UI/Qt/EventLoopImplementationQt.h
@@ -14,7 +14,7 @@ class QEvent;
 class QEventLoop;
 class QSocketNotifier;
 
-namespace WebView {
+namespace Ladybird {
 
 class EventLoopImplementationQt;
 class EventLoopImplementationQtEventTarget;

--- a/UI/Qt/EventLoopImplementationQtEventTarget.cpp
+++ b/UI/Qt/EventLoopImplementationQtEventTarget.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWebView/EventLoop/EventLoopImplementationQt.h>
-#include <LibWebView/EventLoop/EventLoopImplementationQtEventTarget.h>
+#include <UI/Qt/EventLoopImplementationQt.h>
+#include <UI/Qt/EventLoopImplementationQtEventTarget.h>
 
-namespace WebView {
+namespace Ladybird {
 
 bool EventLoopImplementationQtEventTarget::event(QEvent* event)
 {

--- a/UI/Qt/EventLoopImplementationQtEventTarget.h
+++ b/UI/Qt/EventLoopImplementationQtEventTarget.h
@@ -9,7 +9,7 @@
 #include <QEvent>
 #include <QObject>
 
-namespace WebView {
+namespace Ladybird {
 
 class EventLoopImplementationQtEventTarget final : public QObject {
     Q_OBJECT


### PR DESCRIPTION
Once upon a time, we needed the UI-specific event loops outside of the UI process. This is no longer the case. Let's move the event loops back to the UI folder to remove the awkward interface library we were left with.