### PR TITLE
Docs: add libtool as linux void build dependency

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -137,7 +137,7 @@ This virtual environment can be created once and reused in future shell sessions
 
 ```
 sudo xbps-install -Su # (optional) ensure packages are up to date to avoid "Transaction aborted due to unresolved dependencies."
-sudo xbps-install -S git bash gcc python3 curl cmake zip unzip linux-headers make pkg-config autoconf automake autoconf-archive nasm MesaLib-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel
+sudo xbps-install -S git bash gcc python3 curl cmake libtool zip unzip linux-headers make pkg-config autoconf automake autoconf-archive nasm MesaLib-devel ninja qt6-base-devel qt6-tools-devel qt6-wayland-devel
 ```
 
 ### NixOS or with Nix:


### PR DESCRIPTION
This fixes an issue I encountered when trying to build on linux void using `./Meta/ladybird.py run`.

`Build/release/vcpkg-manifest-install.log`:

```
-- Using cached gperf-3.3.tar.gz
-- Cleaning sources at /home/void/code/ladybird/Build/vcpkg/buildtrees/gperf/src/gperf-3-b814f52c10.clean.
   Use --editable to skip cleaning for the packages you specify.
-- Extracting source /home/void/code/ladybird/Build/vcpkg/downloads/gperf-3.3.tar.gz
-- Using source at /home/void/code/ladybird/Build/vcpkg/buildtrees/gperf/src/gperf-3-b814f52c10.clean
-- Found external ninja('1.13.2').
-- Getting CMake variables for x64-linux-dynamic
-- Loading CMake variables from
   /home/void/code/ladybird/Build/vcpkg/buildtrees/gperf/cmake-get-vars_C_CXX-x64-linux-dynamic.cmake.log

CMake Error at
  /home/void/code/ladybird/Build/release/vcpkg_installed/x64-linux-dynamic/share/vcpkg-make/vcpkg_make.cmake:83 (message):

  gperf currently requires the following programs from the system package manager:

      autoconf
      autoconf-archive
      automake
      libtoolize

  On Debian and Ubuntu derivatives:
      sudo apt-get install autoconf autoconf-archive automake libtool

  On recent Red Hat and Fedora derivatives:
      sudo dnf install autoconf autoconf-archive automake libtool

  On Arch Linux and derivatives:
      sudo pacman -S autoconf autoconf-archive automake libtool

  On Alpine:
      apk add autoconf autoconf-archive automake libtool

  On macOS:
      brew install autoconf autoconf-archive automake libtool

Call Stack (most recent call first):
  /home/void/code/ladybird/Build/release/vcpkg_installed/x64-linux-dynamic/share/vcpkg-make/vcpkg_make_configure.cmake:62 (vcpkg_run_autoreconf)
  buildtrees/versioning_/versions/gperf/d5c53333d7745d56f06cb3e014c7c424a66ef4a7/portfile.cmake:17 (vcpkg_make_configure)
  scripts/ports.cmake:206 (include)

error: building gperf:x64-linux-dynamic failed with: BUILD_FAILED

See https://learn.microsoft.com/vcpkg/troubleshoot/build-failures?WT.mc_id=vcpkg_inproduct_cli for more information.

Elapsed time to handle gperf:x64-linux-dynamic: 1 s

Please ensure you're using the latest port files with `git pull` and `vcpkg update`.

Then check for known issues at:
  https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+gperf

You can submit a new issue at:
  https://github.com/microsoft/vcpkg/issues/new?title=%5Bgperf%5D%20build%20error%20on%20x64-linux-dynamic&body=Copy%20issue%20body%20from%20%2Fhome%2Fvoid%2Fcode%2Fladybird%2FBuild%2Frelease%2Fvcpkg_installed%2Fvcpkg%2Fissue_body.md

```

After running `xbps-install libtool` the issue was solved. I saw that other distros also include the `libtool` package as a pre-requisite so I assume someone must have forgotten it for void, as it is not that popular of a distro.

I did stumble upon common issues during build in the Documentation, with the one I encountered being first, though I did not find it that helpful.

edit: accidentally pressed enter while in the process of opening this PR, edited a few times