### PR TITLE
LibWeb: Honor LegacyNullToEmptyString in union string conversion

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1636,7 +1636,7 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
             // NOTE: Currently all string types are converted to String.
 
             IDL::Parameter parameter { .type = *string_type, .name = ByteString::empty(), .optional_default_value = {}, .extended_attributes = {} };
-            generate_to_cpp(union_generator, parameter, js_name, js_suffix, ByteString::formatted("{}{}_string", js_name, js_suffix), interface, false, false, {}, false, recursion_depth + 1);
+            generate_to_cpp(union_generator, parameter, js_name, js_suffix, ByteString::formatted("{}{}_string", js_name, js_suffix), interface, legacy_null_to_empty_string, false, {}, false, recursion_depth + 1);
 
             union_generator.append(R"~~~(
         return { @js_name@@js_suffix@_string };

--- a/Tests/LibWeb/Text/expected/wpt-import/domparsing/outerhtml-02.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domparsing/outerhtml-02.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	outerHTML and string conversion: null.
+Pass	outerHTML and string conversion: undefined.
+Pass	outerHTML and string conversion: number.
+Pass	outerHTML and string conversion: toString.
+Pass	outerHTML and string conversion: valueOf.

--- a/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-Element-outerHTML.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-Element-outerHTML.txt
@@ -2,12 +2,11 @@ Harness status: OK
 
 Found 7 tests
 
-6 Pass
-1 Fail
+7 Pass
 Pass	outerHTML with html assigned via policy (successful HTML transformation).
 Pass	`outerHTML = TrustedHTML` throws NoModificationAllowedError when parent is a document.
 Pass	`outerHTML = string` throws.
 Pass	`outerHTML = string` throws TypeError even when parent is a document.
 Pass	`outerHTML = null` throws.
 Pass	`outerHTML = string` assigned via default policy (successful HTML transformation).
-Fail	`outerHTML = null` assigned via default policy does not throw
+Pass	`outerHTML = null` assigned via default policy does not throw

--- a/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-HTMLElement-generic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-HTMLElement-generic.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 9 tests
 
-8 Pass
-1 Fail
+9 Pass
 Pass	script.src accepts only TrustedScriptURL
 Pass	div.innerHTML accepts only TrustedHTML
 Pass	iframe.srcdoc accepts only TrustedHTML
 Pass	script.src accepts string and null after default policy was created
-Fail	div.innerHTML accepts string and null after default policy was created
+Pass	div.innerHTML accepts string and null after default policy was created
 Pass	iframe.srcdoc accepts string and null after default policy was created
 Pass	script.text accepts only TrustedScript
 Pass	script.innerText accepts only TrustedScript

--- a/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-ShadowRoot-innerHTML.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/trusted-types/block-string-assignment-to-ShadowRoot-innerHTML.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-4 Pass
-1 Fail
+5 Pass
 Pass	shadowRoot.innerHTML = html assigned via policy (successful HTML transformation).
 Pass	`shadowRoot.innerHTML = string` throws.
 Pass	`shadowRoot.innerHTML = null` throws.
 Pass	`shadowRoot.innerHTML = string` assigned via default policy (successful HTML transformation).
-Fail	`shadowRoot.innerHTML = string` assigned via default policy does not throw
+Pass	`shadowRoot.innerHTML = string` assigned via default policy does not throw

--- a/Tests/LibWeb/Text/input/wpt-import/domparsing/outerhtml-02.html
+++ b/Tests/LibWeb/Text/input/wpt-import/domparsing/outerhtml-02.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<title>outerHTML and string conversion</title>
+<link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
+<link rel="help" href="https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  var div = document.createElement("div");
+  var p = div.appendChild(document.createElement("p"));
+  p.outerHTML = null;
+  assert_equals(div.innerHTML, "");
+  assert_equals(div.textContent, "");
+}, "outerHTML and string conversion: null.")
+
+test(function() {
+  var div = document.createElement("div");
+  var p = div.appendChild(document.createElement("p"));
+  p.outerHTML = undefined;
+  assert_equals(div.innerHTML, "undefined");
+  assert_equals(div.textContent, "undefined");
+}, "outerHTML and string conversion: undefined.")
+
+test(function() {
+  var div = document.createElement("div");
+  var p = div.appendChild(document.createElement("p"));
+  p.outerHTML = 42;
+  assert_equals(div.innerHTML, "42");
+  assert_equals(div.textContent, "42");
+}, "outerHTML and string conversion: number.")
+
+test(function() {
+  var div = document.createElement("div");
+  var p = div.appendChild(document.createElement("p"));
+  p.outerHTML = {
+    toString: function() { return "pass"; },
+    valueOf: function() { return "fail"; }
+  };
+  assert_equals(div.innerHTML, "pass");
+  assert_equals(div.textContent, "pass");
+}, "outerHTML and string conversion: toString.")
+
+test(function() {
+  var div = document.createElement("div");
+  var p = div.appendChild(document.createElement("p"));
+  p.outerHTML = {
+    toString: undefined,
+    valueOf: function() { return "pass"; }
+  };
+  assert_equals(div.innerHTML, "pass");
+  assert_equals(div.textContent, "pass");
+}, "outerHTML and string conversion: valueOf.")
+</script>


### PR DESCRIPTION
The IDL generator was passing 'false' to generate_to_cpp when converting a union containing a string type.
This broke WebIDL's LegacyNullToEmptyString behavior.

Pass the actual legacy_null_to_empty_string flag instead. Fixes some WPTs:

domparsing/outerhtml-02.html
trusted-types/block-string-assignment-to-Element-outerHTML trusted-types/block-string-assignment-to-HTMLElement-generic trusted-types/block-string-assignment-to-ShadowRoot-innerHTML