### PR TITLE
Documentation: State wasm requirements in build instructions

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -7,6 +7,9 @@ Qt6 development packages, nasm, additional build tools, and a C++23 capable comp
 We currently use gcc-14 and clang-20 in our CI pipeline. If these versions are not available on your system, see
 [`Meta/find_compiler.py`](../Meta/find_compiler.py) for the minimum compatible version.
 
+> [!NOTE]
+> For wasm usage gcc-14 is supported, but gcc-14 lacks the musttail attribute which is very important when executing larger wasm files (for example, full games, OSes, complex apps). For those planning on validating Ladybird using larger wasm applications the recommendation is to use a supported clang version or gcc-15 (or later).
+
 CMake 3.25 or newer must be available in $PATH.
 
 ---


### PR DESCRIPTION
Related to #7009, #7025, #7032, #7038

Following discord question was put in the wasm channel

-------------

Got a few reports of WebContent crashing (#7038, #7032, #7025 #7009) and bottom line is that GNU 14 is being used and it lacks the musttail attribute support, that is only introduced in GNU 15. Without musttail large wasm files will create a huge stack size (I've seen >200K frames).  These large wasm files are usually complex games or OSes.

What should be done in this case of lacking musttail and large wasm? Just document it in installation instructions that GNU 14 and wasm don't play well together or after we know the size of the wasm file not execute it to avoid the crash and display a message saying "wasm too big, won't execute".

This issue has most of the information in

https://github.com/LadybirdBrowser/ladybird/issues/7009

What should be done to deal with this?