### PR TITLE
LibWeb: Use ● instead of * for password masking

### DIFF
--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -308,7 +308,7 @@ Utf16String const& TextNode::text_for_rendering() const
 void TextNode::compute_text_for_rendering()
 {
     if (dom_node().is_password_input()) {
-        m_text_for_rendering = Utf16String::repeated('*', dom_node().data().length_in_code_points());
+        m_text_for_rendering = Utf16String::repeated(u'●', dom_node().data().length_in_code_points());
         return;
     }
 

--- a/Tests/LibWeb/Layout/expected/input-text-to-password.txt
+++ b/Tests/LibWeb/Layout/expected/input-text-to-password.txt
@@ -5,8 +5,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-
       BlockContainer <input> at [9,9] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
         Box <div> at [11,10] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,10] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 7, rect: [11,10 55.5625x18] baseline: 13.796875
-                "*******"
+            frag 0 from TextNode start: 0, length: 7, rect: [11,10 40.90625x18] baseline: 13.796875
+                "●●●●●●●"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
       TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/unicode-password-input.txt
+++ b/Tests/LibWeb/Layout/expected/unicode-password-input.txt
@@ -5,8 +5,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-
       BlockContainer <input> at [9,9] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
         Box <div> at [11,10] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,10] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 14, rect: [11,10 111.125x18] baseline: 13.796875
-                "**************"
+            frag 0 from TextNode start: 0, length: 14, rect: [11,10 81.8125x18] baseline: 13.796875
+                "●●●●●●●●●●●●●●"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
 


### PR DESCRIPTION
Looks slightly more modern.

| Before | After |
|--|--|
| <img width="336" height="166" alt="image" src="https://github.com/user-attachments/assets/d25b81c0-1304-45c8-bd8c-13ffe949fd33" /> | <img width="341" height="168" alt="image" src="https://github.com/user-attachments/assets/7b11d46e-a4dc-4748-a9d3-f48066a128ef" /> |
