### PR TITLE
LibWeb: Update UA styles for form controls

### DIFF
--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -29,7 +29,6 @@ input:not([type=submit], input[type=button], input[type=image], input[type=reset
     border: 1px solid ButtonBorder;
     min-height: 16px;
     cursor: text;
-    overflow: hidden;
 
     background-color: Field;
     color: FieldText;
@@ -659,8 +658,17 @@ input, select, button, textarea {
     appearance: auto;
 }
 
+input:not([type=image i], [type=range i], [type=checkbox i], [type=radio i]) {
+    overflow: clip !important;
+    overflow-clip-margin: 0 !important;
+}
+
 input, select, textarea {
     text-align: initial;
+}
+
+:autofill {
+    field-sizing: fixed !important;
 }
 
 input:is([type=reset i], [type=button i], [type=submit i]), button {
@@ -680,9 +688,7 @@ input:is([type=radio i], [type=checkbox i], [type=reset i], [type=button i],
     box-sizing: border-box;
 }
 
-textarea {
-    white-space: pre-wrap;
-}
+textarea { white-space: pre-wrap; }
 
 /* 15.3.11 The hr element
  * https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2

--- a/Tests/LibWeb/Layout/expected/css-line-height-zero.txt
+++ b/Tests/LibWeb/Layout/expected/css-line-height-zero.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 84 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 68 0+0+8] children: not-inline
-      BlockContainer <input#a> at [9,9] [0+1+0 200 0+1+582] [0+1+0 20 0+1+0] [BFC] children: not-inline
+      BlockContainer <input#a> at [9,9] [0+1+0 200 0+1+582] [0+1+0 20 0+1+0] children: not-inline
         Box <div> at [11,10] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,10] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 11, rect: [11,10 91.953125x18] baseline: 13.796875
@@ -9,7 +9,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-
             TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,30] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      BlockContainer <input#b> at [9,31] [0+1+0 200 0+1+582] [0+1+0 16 0+1+0] [BFC] children: not-inline
+      BlockContainer <input#b> at [9,31] [0+1+0 200 0+1+582] [0+1+0 16 0+1+0] children: not-inline
         Box <div> at [11,32] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 16 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,40] flex-item [0+0+0 196 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 11, rect: [11,40 91.953125x0] baseline: 4.796875
@@ -17,7 +17,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-
             TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,48] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      BlockContainer <input#c> at [9,49] [0+1+0 200 0+1+582] [0+1+0 26 0+1+0] [BFC] children: not-inline
+      BlockContainer <input#c> at [9,49] [0+1+0 200 0+1+582] [0+1+0 26 0+1+0] children: not-inline
         Box <div> at [11,50] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 24 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,50] flex-item [0+0+0 196 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 11, rect: [11,50 91.953125x24] baseline: 16.796875


### PR DESCRIPTION
This specifically includes a `!important` for `overflow: clip`, which makes sure an `<input>`'s contents cannot easily be made to overflow its boundaries.

Especially visible on the Roundcube login form:

| Before | After |
|--|--|
| <img width="512" height="168" alt="image" src="https://github.com/user-attachments/assets/8e1e9716-9071-4478-bd15-9deec2637d3b" /> | <img width="336" height="163" alt="image" src="https://github.com/user-attachments/assets/9ee9fb8c-03cc-407c-9164-0dc90b706011" /> |
