### PR TITLE
LibWeb: Implement functionality for the map and area tags

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -9,6 +9,8 @@
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/PixelUnits.h>
+#include <LibWeb/UIEvents/MouseEvent.h>
 
 namespace Web::HTML {
 
@@ -83,6 +85,126 @@ Optional<ARIA::Role> HTMLAreaElement::default_role() const
         return ARIA::Role::link;
     // https://www.w3.org/TR/html-aria/#el-area
     return ARIA::Role::generic;
+}
+
+// https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements
+void HTMLAreaElement::activate(Web::DOM::Event const& event)
+{
+    // See implementation of activation_behavior of an anchor tag for reference.
+    // Step (3) has been omitted for a lack of observed relevance. Following from the EventHandler only HTMLImageElements with usemap will activate an area tag.
+
+    // The activation behavior of an a or area element element given an event event is:
+
+    // 1. If element has no href attribute, then return.
+    if (href().is_empty())
+        return;
+
+    // AD-HOC: Do not activate the element for clicks with the ctrl/cmd modifier present. This lets
+    //         the browser process open the link in a new tab.
+    if (is<UIEvents::MouseEvent>(event)) {
+        auto const& mouse_event = static_cast<UIEvents::MouseEvent const&>(event);
+        if (mouse_event.platform_ctrl_key())
+            return;
+    }
+
+    // 2. Let hyperlinkSuffix be null.
+    Optional<String> hyperlink_suffix {};
+
+    // 3. Let userInvolvement be event's user navigation involvement.
+    auto user_involvement = user_navigation_involvement(event);
+
+    // 4. If the user has expressed a preference to download the hyperlink, then set userInvolvement to "browser UI".
+    // NOTE: That is, if the user has expressed a specific preference for downloading, this no longer counts as merely "activation".
+    if (has_download_preference())
+        user_involvement = UserNavigationInvolvement::BrowserUI;
+
+    // FIXME: 5. If element has a download attribute, or if the user has expressed a preference to download the
+    //     hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
+    //     userInvolvement set to userInvolvement.
+
+    // 6. Otherwise, follow the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and userInvolvement set to userInvolvement.
+    follow_the_hyperlink(hyperlink_suffix, user_involvement);
+}
+
+bool HTMLAreaElement::has_download_preference() const
+{
+    return has_attribute(HTML::AttributeNames::download);
+}
+
+bool HTMLAreaElement::check_if_contains_point(Gfx::IntPoint point) const
+{
+    auto shape = attribute(HTML::AttributeNames::shape);
+
+    auto coords = attribute(HTML::AttributeNames::coords);
+    if (!coords.has_value() && shape.has_value())
+        return false;
+
+    // Parse coordinates for the area.
+    // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-a-list-of-floating-point-numbers
+    Vector<float> coords_list;
+    if (coords.has_value()) {
+        String coords_string = coords.release_value();
+        auto parts_or_error = coords_string.split(',');
+        if (parts_or_error.is_error())
+            return false;
+
+        auto const& parts = parts_or_error.value();
+        for (auto const& part : parts) {
+            coords_list.append(part.to_number<float>().value());
+        }
+    }
+
+    // https://html.spec.whatwg.org/multipage/image-maps.html#image-map-processing-model
+    // If the number of items in the coords list is less than the minimum number given for the area element's current state, as per the following table, then the shape is empty; return.
+    // For excess coordinates, see shape-by-shape behavior.
+    if (shape == "rect"sv) {
+        if (coords_list.size() < 4)
+            return false;
+
+        auto left = coords_list[0];
+        auto top = coords_list[1];
+        auto right = coords_list[2];
+        auto bottom = coords_list[3];
+
+        return point.x() >= left && point.x() <= right 
+            && point.y() >= top && point.y() <= bottom;
+    }
+    if (shape == "circle"sv) {
+        if (coords_list.size() < 3)
+            return false;
+
+        auto center_x_position_from_left = coords_list[0];
+        auto center_y_position_from_top = coords_list[1];
+        auto radius = coords_list[2];
+
+        float difference_in_x = point.x() - center_x_position_from_left;
+        float difference_in_y = point.y() - center_y_position_from_top;
+        return (difference_in_x * difference_in_x + difference_in_y * difference_in_y) <= (radius * radius);
+    }
+    if (shape == "poly"sv) {
+        if (coords_list.size() < 6)
+            return false;
+
+        Vector<Gfx::FloatPoint> polygon_coordinate_representation;
+        for (size_t i = 0; i < coords_list.size() - (coords_list.size() % 2); i += 2)
+            polygon_coordinate_representation.append({ coords_list[i], coords_list[i + 1] });
+
+        bool inside = false;
+        for (size_t i = 0, j = polygon_coordinate_representation.size() - 1; i < polygon_coordinate_representation.size(); j = i++) {
+            auto& coordinate_i = polygon_coordinate_representation[i];
+            auto& coordinate_j = polygon_coordinate_representation[j];
+
+            bool intersect = ((coordinate_i.y() > point.y()) != (coordinate_j.y() > point.y()))
+                && (point.x() < (coordinate_j.x() - coordinate_i.x()) * (point.y() - coordinate_i.y()) / (coordinate_j.y() - coordinate_i.y()) + coordinate_i.x());
+
+            if (intersect)
+                inside = !inside;
+        }
+        return inside;
+    }
+
+    // Default area is the image, thus always contains the clicked point.
+    return true;
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -22,10 +22,16 @@ public:
     virtual ~HTMLAreaElement() override;
     GC::Ref<DOM::DOMTokenList> rel_list();
 
+    void activate(Web::DOM::Event const&);
+
+    bool check_if_contains_point(Gfx::IntPoint) const;
+
 private:
     HTMLAreaElement(DOM::Document&, DOM::QualifiedName);
 
     virtual bool is_html_area_element() const override { return true; }
+
+    bool has_download_preference() const;
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/HTML/HTMLMapElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMapElement.cpp
@@ -44,4 +44,24 @@ GC::Ref<DOM::HTMLCollection> HTMLMapElement::areas()
     return *m_areas;
 }
 
+// Iterates through a maps associated areas, activating the first element seen in reverse tree order.
+void HTMLMapElement::activate_area_by_point(CSSPixels x, CSSPixels y, Web::DOM::Event const& event)
+{
+    Gfx::IntPoint point_coordinates { x.to_int(), y.to_int() };
+
+    auto area_collection = areas();
+    for (size_t i = 0; i < area_collection->length(); ++i) {
+        auto* element = area_collection->item(i);
+        if (!element || !is<HTMLAreaElement>(*element))
+            continue;
+
+        auto& area = static_cast<HTMLAreaElement&>(*element);
+
+        if (area.check_if_contains_point(point_coordinates)) {
+            area.activate(event);
+            return;
+        }
+    }
+}
+
 }

--- a/Libraries/LibWeb/HTML/HTMLMapElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMapElement.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/DOM/Event.h>
 
 namespace Web::HTML {
 
@@ -19,6 +20,8 @@ public:
     virtual ~HTMLMapElement() override;
 
     GC::Ref<DOM::HTMLCollection> areas();
+
+    void activate_area_by_point(CSSPixels x, CSSPixels y, Web::DOM::Event const&);
 
 private:
     HTMLMapElement(DOM::Document&, DOM::QualifiedName);


### PR DESCRIPTION
Previously, implementation of HTML spec for the map and area tags was 
limited, only associating area elements with a map element. These 
changes add methods for hit-testing a point inside of an image element 
with the usemap attribute set, and handle mouse-down events for an 
image to test for a hit and handle the area elements redirect.