### PR TITLE
LibWeb: Use last promise to wait for pending writes ReadableStreamPipeTo

### DIFF
--- a/Libraries/LibWeb/Streams/ReadableStreamPipeTo.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamPipeTo.h
@@ -68,7 +68,7 @@ private:
     GC::Ptr<DOM::AbortSignal> m_signal;
     DOM::AbortSignal::AbortAlgorithmID m_signal_id { 0 };
 
-    Vector<GC::Ref<WebIDL::Promise>> m_pending_writes;
+    GC::Ptr<WebIDL::Promise> m_last_write_promise;
     Vector<JS::Value, 1> m_unwritten_chunks;
 
     bool m_prevent_close { false };


### PR DESCRIPTION
ReadableStreamPipeTo is used in fetching, and previously requests with large bodies could lead to tens of thousands of pending write promises being accumulated in `m_pending_writes`.

With this change, instead of accumulating all pending write promises up until pipe shutdown, we only keep track of the last one and use it to determine whether there are pending writes when we need to shut down the pipe.