### PR TITLE
LibWeb: Register shutdown-on-close handler once in ReadableStreamPipeTo

### DIFF
--- a/Libraries/LibWeb/Streams/ReadableStreamPipeTo.h
+++ b/Libraries/LibWeb/Streams/ReadableStreamPipeTo.h
@@ -71,6 +71,8 @@ private:
     GC::Ptr<WebIDL::Promise> m_last_write_promise;
     Vector<JS::Value, 1> m_unwritten_chunks;
 
+    GC::Ref<WebIDL::ReactionSteps> m_on_shutdown;
+
     bool m_prevent_close { false };
     bool m_prevent_abort { false };
     bool m_prevent_cancel { false };


### PR DESCRIPTION
Previously, we added a `reader.closed()` promise reaction during every `ReadableStreamPipeTo::process()` call, which meant allocating a new reaction objects for every processed chunk and retaining all of them until the stream closed. The same issue existed for `writer.closed()` inside `ReadableStreamPipeTo::read_chunk()`.

This change registers a single shutdown handler for both the reader and the writer in the ReadableStreamPipeTo constructor.