### PR TITLE
LibWeb/CSS: Reject selectors with multiple pseudo-elements

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-scoping/slotted-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-scoping/slotted-parsing.txt
@@ -13,9 +13,9 @@ Fail	"::slotted(*):host" should be an invalid selector
 Fail	"::slotted(*):host(div)" should be an invalid selector
 Fail	"::slotted(*):hover" should be an invalid selector
 Fail	"::slotted(*):read-only" should be an invalid selector
-Fail	"::slotted(*)::slotted(*)" should be an invalid selector
-Fail	"::slotted(*)::before::slotted(*)" should be an invalid selector
-Fail	"::slotted(*) span" should be an invalid selector
+Pass	"::slotted(*)::slotted(*)" should be an invalid selector
+Pass	"::slotted(*)::before::slotted(*)" should be an invalid selector
+Pass	"::slotted(*) span" should be an invalid selector
 Pass	"::slotted(*)" should be a valid selector
 Pass	"::slotted(div)" should be a valid selector
 Pass	"::slotted([attr]:hover)" should be a valid selector
@@ -27,12 +27,12 @@ Fail	"::slotted(*):where()" should be a valid selector
 Fail	"::slotted(*):where(:hover)" should be a valid selector
 Fail	"::slotted(*):where(#id)" should be a valid selector
 Fail	"::slotted(*):where(::before)" should be a valid selector
-Pass	"::slotted(*)::before" should be a valid selector
-Pass	"::slotted(*)::after" should be a valid selector
-Pass	"::slotted(*)::details-content" should be a valid selector
-Pass	"::slotted(*)::file-selector-button" should be a valid selector
-Pass	"::slotted(*)::placeholder" should be a valid selector
-Pass	"::slotted(*)::marker" should be a valid selector
-Fail	"::slotted(*)::first-line" should be an invalid selector
-Fail	"::slotted(*)::first-letter" should be an invalid selector
-Fail	"::slotted(*)::selection" should be an invalid selector
+Fail	"::slotted(*)::before" should be a valid selector
+Fail	"::slotted(*)::after" should be a valid selector
+Fail	"::slotted(*)::details-content" should be a valid selector
+Fail	"::slotted(*)::file-selector-button" should be a valid selector
+Fail	"::slotted(*)::placeholder" should be a valid selector
+Fail	"::slotted(*)::marker" should be a valid selector
+Pass	"::slotted(*)::first-line" should be an invalid selector
+Pass	"::slotted(*)::first-letter" should be an invalid selector
+Pass	"::slotted(*)::selection" should be an invalid selector


### PR DESCRIPTION
Our codebase assumes that a selector only contains a single pseudo-element, and that it's in the final compound selector. If there are multiple of them, or they're somewhere else in the selector, we just silently pretend the others aren't there, which is *not* what we want, and causes the selector to match things it shouldn't.

A proper fix is quite involved, so as a temporary fix, just reject any selector that doesn't fit our assumptions during parsing. That way we get false negatives instead of false positives.