### PR TITLE
CI: Remove `LADYBIRD_BOT_TOKEN` from the Ladybird checkout step

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -15,40 +15,37 @@ jobs:
 
     concurrency: libjs-test262
 
-    permissions:
-      contents: write
-
     steps:
       - name: Cleanup
         run: |
           echo "Cleaning up previous run"
           rm -rf "${{ github.workspace }}/*"
 
+      # FIXME: Update the checkout versions once JamesIves/github-pages-deploy-action has a more recent release than v4.7.4.
+
       - name: Checkout LadybirdBrowser/ladybird
-        uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.LADYBIRD_BOT_TOKEN }}
+        uses: actions/checkout@v6.0.0
 
       - name: Checkout LadybirdBrowser/libjs-test262
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.0
         with:
           repository: LadybirdBrowser/libjs-test262
           path: libjs-test262
 
       - name: Checkout LadybirdBrowser/libjs-data
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.0
         with:
           repository: LadybirdBrowser/libjs-data
           path: libjs-data
 
       - name: Checkout tc39/test262
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.0
         with:
           repository: tc39/test262
           path: test262
 
       - name: Checkout tc39/test262-parser-tests
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.0
         with:
           repository: tc39/test262-parser-tests
           path: test262-parser-tests


### PR DESCRIPTION
We discovered the issue with failed deployments was due to an update to the checkout action that did not interact well with the deploy action. There is a fix in the deploy action already. See:

https://github.com/JamesIves/github-pages-deploy-action/commit/1d137fdcc70752d4669a19f62ceb3ad44a6ebf5c

However, a tagged release for the deploy action is not yet available, and pulling the action at a specific commit hash does not work.

For now, let's pin the checkout action at a known-good version. We can update both actions when the deploy action has a tagged release. In the meantime, this just removes the token with write-permissions from the Ladybird checkout.