### PR TITLE
LibJS: Introduce VM::the() and use it instead of caching VM pointer

### DIFF
--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -183,8 +183,6 @@ public:
 protected:
     Cell() = default;
 
-    ALWAYS_INLINE void* private_data() const { return bit_cast<HeapBase*>(&heap())->private_data(); }
-
     void set_overrides_must_survive_garbage_collection(bool b) { m_overrides_must_survive_garbage_collection = b; }
 
 private:

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -37,9 +37,8 @@ Heap& Heap::the()
     return *s_the;
 }
 
-Heap::Heap(void* private_data, AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> gather_embedder_roots)
-    : HeapBase(private_data)
-    , m_gather_embedder_roots(move(gather_embedder_roots))
+Heap::Heap(AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> gather_embedder_roots)
+    : m_gather_embedder_roots(move(gather_embedder_roots))
 {
     s_the = this;
     static_assert(HeapBlock::min_possible_cell_size <= 32, "Heap Cell tracking uses too much data!");

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -30,12 +30,12 @@
 
 namespace GC {
 
-class GC_API Heap : public HeapBase {
+class GC_API Heap {
     AK_MAKE_NONCOPYABLE(Heap);
     AK_MAKE_NONMOVABLE(Heap);
 
 public:
-    explicit Heap(void* private_data, AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> gather_embedder_roots);
+    explicit Heap(AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> gather_embedder_roots);
     ~Heap();
 
     static Heap& the();

--- a/Libraries/LibGC/Internals.h
+++ b/Libraries/LibGC/Internals.h
@@ -13,22 +13,6 @@
 
 namespace GC {
 
-class GC_API HeapBase {
-    AK_MAKE_NONCOPYABLE(HeapBase);
-    AK_MAKE_NONMOVABLE(HeapBase);
-
-public:
-    void* private_data() { return m_private_data; }
-
-protected:
-    explicit HeapBase(void* private_data)
-        : m_private_data(private_data)
-    {
-    }
-
-    void* m_private_data;
-};
-
 class GC_API HeapBlockBase {
     AK_MAKE_NONMOVABLE(HeapBlockBase);
     AK_MAKE_NONCOPYABLE(HeapBlockBase);

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -86,14 +86,9 @@ ALWAYS_INLINE static ThrowCompletionOr<bool> strict_equals(VM&, Value src1, Valu
     return is_strictly_equal(src1, src2);
 }
 
-Interpreter::Interpreter(VM& vm)
-    : m_vm(vm)
-{
-}
+Interpreter::Interpreter() = default;
 
-Interpreter::~Interpreter()
-{
-}
+Interpreter::~Interpreter() = default;
 
 ALWAYS_INLINE Value Interpreter::get(Operand op) const
 {

--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -23,14 +23,13 @@ class InstructionStreamIterator;
 
 class JS_API Interpreter {
 public:
-    explicit Interpreter(VM&);
+    Interpreter();
     ~Interpreter();
 
     [[nodiscard]] Realm& realm() { return *m_running_execution_context->realm; }
     [[nodiscard]] Object& global_object() { return *m_running_execution_context->global_object; }
     [[nodiscard]] DeclarativeEnvironment& global_declarative_environment() { return *m_running_execution_context->global_declarative_environment; }
-    VM& vm() { return m_vm; }
-    VM const& vm() const { return m_vm; }
+    static VM& vm() { return VM::the(); }
 
     ThrowCompletionOr<Value> run(Script&, GC::Ptr<Environment> lexical_environment_override = nullptr);
     ThrowCompletionOr<Value> run(SourceTextModule&);
@@ -96,7 +95,6 @@ private:
     };
     [[nodiscard]] HandleExceptionResponse handle_exception(u32& program_counter, Value exception);
 
-    VM& m_vm;
     ExecutionContext* m_running_execution_context { nullptr };
 };
 

--- a/Libraries/LibJS/Heap/Cell.h
+++ b/Libraries/LibJS/Heap/Cell.h
@@ -20,7 +20,7 @@ public:
 
     virtual bool is_generator_result() const { return false; }
 
-    ALWAYS_INLINE VM& vm() const { return *reinterpret_cast<VM*>(private_data()); }
+    ALWAYS_INLINE VM& vm() const;
 };
 
 }

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -58,6 +58,8 @@ public:
     static NonnullRefPtr<VM> create();
     ~VM();
 
+    static VM& the();
+
     GC::Heap& heap() const { return const_cast<GC::Heap&>(m_heap); }
 
     Bytecode::Interpreter& bytecode_interpreter() { return *m_bytecode_interpreter; }
@@ -315,6 +317,8 @@ private:
 
     void run_queued_promise_jobs_impl();
 
+    static VM* s_the;
+
     HashMap<String, GC::Ptr<PrimitiveString>> m_string_cache;
     HashMap<Utf16String, GC::Ptr<PrimitiveString>> m_utf16_string_cache;
 
@@ -374,5 +378,7 @@ template<typename GlobalObjectType, typename... Args>
         nullptr));
     return root_execution_context;
 }
+
+ALWAYS_INLINE VM& Cell::vm() const { return VM::the(); }
 
 }

--- a/Utilities/wasm.cpp
+++ b/Utilities/wasm.cpp
@@ -418,7 +418,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
             }
 
             auto js_script = script.release_value();
-            JS::Bytecode::Interpreter interp(vm);
+            JS::Bytecode::Interpreter interp;
             auto maybe_function = interp.run(*js_script);
             if (maybe_function.is_error()) {
                 warnln("Failed to run JS export source '{}'", js_function);


### PR DESCRIPTION
In our process architecture, there's only ever one JS::VM per process. This allows us to have a VM::the() singleton getter that optimizes down to a single global access everywhere.

Seeing 1-2% speed-up on all JS benchmarks from this.

From Hetzner Linux box identical to our JS benchmark runner:

```
Suite       Test                                      Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                                 0.988  1.159 ± 1.153 … 1.164              1.172 ± 1.165 … 1.180
Kraken      audio-beat-detection.js                     1.031  0.814 ± 0.800 … 0.827              0.789 ± 0.783 … 0.796
Kraken      audio-dft.js                                1.051  0.544 ± 0.542 … 0.546              0.517 ± 0.515 … 0.519
Kraken      audio-fft.js                                1.014  0.684 ± 0.682 … 0.687              0.675 ± 0.674 … 0.677
Kraken      audio-oscillator.js                         1      0.661 ± 0.661 … 0.662              0.661 ± 0.654 … 0.669
Kraken      imaging-darkroom.js                         1.027  0.882 ± 0.882 … 0.883              0.859 ± 0.856 … 0.862
Kraken      imaging-desaturate.js                       1.004  1.158 ± 1.156 … 1.159              1.153 ± 1.149 … 1.157
Kraken      imaging-gaussian-blur.js                    1.048  4.479 ± 4.455 … 4.503              4.274 ± 4.270 … 4.277
Kraken      json-parse-financial.js                     0.991  0.066 ± 0.066 … 0.066              0.066 ± 0.066 … 0.067
Kraken      json-stringify-tinderbox.js                 0.943  0.074 ± 0.074 … 0.075              0.079 ± 0.079 … 0.079
Kraken      stanford-crypto-aes.js                      1.082  0.313 ± 0.307 … 0.318              0.289 ± 0.288 … 0.290
Kraken      stanford-crypto-ccm.js                      1.017  0.324 ± 0.321 … 0.327              0.319 ± 0.319 … 0.319
Kraken      stanford-crypto-pbkdf2.js                   1.03   0.549 ± 0.540 … 0.557              0.533 ± 0.530 … 0.535
Kraken      stanford-crypto-sha256-iterative.js         1.047  0.206 ± 0.206 … 0.206              0.197 ± 0.197 … 0.197
Octane      box2d.js                                    1.019  4908.000 ± 4908.000 … 4908.000     5000.000 ± 4984.000 … 5016.000
Octane      code-load.js                                1.006  10789.000 ± 10766.000 … 10812.000  10858.000 ± 10840.000 … 10876.000
Octane      crypto.js                                   1.012  2109.000 ± 2106.000 … 2112.000     2134.000 ± 2120.000 … 2148.000
Octane      deltablue.js                                1.03   1018.000 ± 1009.000 … 1027.000     1049.000 ± 1049.000 … 1049.000
Octane      earley-boyer.js                             1.017  2401.000 ± 2383.000 … 2419.000     2441.000 ± 2434.000 … 2448.000
Octane      gbemu.js                                    1.019  9307.000 ± 9208.000 … 9406.000     9486.000 ± 9482.000 … 9490.000
Octane      mandreel.js                                 1.032  8323.500 ± 8254.000 … 8393.000     8588.500 ± 8507.000 … 8670.000
Octane      navier-stokes.js                            0.998  3307.500 ± 3288.000 … 3327.000     3302.500 ± 3301.000 … 3304.000
Octane      pdfjs.js                                    1.059  4026.500 ± 3967.000 … 4086.000     4265.000 ± 4261.000 … 4269.000
Octane      raytrace.js                                 1.017  1681.000 ± 1678.000 … 1684.000     1710.000 ± 1702.000 … 1718.000
Octane      regexp.js                                   0.984  123.000 ± 123.000 … 123.000        121.000 ± 119.000 … 123.000
Octane      richards.js                                 0.983  1120.500 ± 1120.000 … 1121.000     1101.500 ± 1100.000 … 1103.000
Octane      splay.js                                    0.998  1707.500 ± 1704.000 … 1711.000     1704.000 ± 1701.000 … 1707.000
Octane      typescript.js                               1.016  11034.500 ± 11026.000 … 11043.000  11212.500 ± 11183.000 … 11242.000
Octane      zlib.js                                     1.035  3431.000 ± 3391.000 … 3471.000     3551.500 ± 3545.000 … 3558.000
JetStream   bigfib.cpp.js                               0.999  8.204 ± 8.002 … 8.407              8.213 ± 8.017 … 8.409
JetStream   cdjs.js                                     1.002  3.723 ± 3.703 … 3.743              3.716 ± 3.685 … 3.746
JetStream   container.cpp.js                            1.011  31.518 ± 31.403 … 31.633           31.170 ± 30.738 … 31.603
JetStream   dry.c.js                                    1.052  20.334 ± 19.855 … 20.814           19.331 ± 19.245 … 19.417
JetStream   float-mm.c.js                               0.971  17.247 ± 17.060 … 17.434           17.759 ± 17.634 … 17.885
JetStream   gcc-loops.cpp.js                            1.013  108.305 ± 108.033 … 108.577        106.916 ± 106.638 … 107.193
JetStream   hash-map.js                                 1.044  1.563 ± 1.517 … 1.610              1.498 ± 1.483 … 1.513
JetStream   n-body.c.js                                 0.996  27.866 ± 27.437 … 28.295           27.989 ± 27.681 … 28.298
JetStream   quicksort.c.js                              1.035  4.346 ± 4.250 … 4.442              4.199 ± 4.179 … 4.220
JetStream   towers.c.js                                 1.02   6.267 ± 6.120 … 6.414              6.142 ± 6.000 … 6.284
JetStream3  js-tokens.js                                0.994  0.826 ± 0.822 … 0.830              0.831 ± 0.822 … 0.840
JetStream3  lazy-collections.js                         1.03   1.535 ± 1.532 … 1.537              1.489 ± 1.488 … 1.490
JetStream3  raytrace-private-class-fields.js            1.011  4.996 ± 4.981 … 5.012              4.941 ± 4.919 … 4.963
JetStream3  raytrace-public-class-fields.js             1.008  4.111 ± 4.083 … 4.139              4.079 ± 4.070 … 4.088
JetStream3  sync-file-system.js                         1.048  1.988 ± 1.978 … 1.998              1.896 ± 1.895 … 1.897
MicroBench  array-destructuring-assignment-rest.js      1.01   0.418 ± 0.416 … 0.421              0.414 ± 0.413 … 0.415
MicroBench  array-destructuring-assignment.js           1.017  4.817 ± 4.814 … 4.820              4.734 ± 4.731 … 4.737
MicroBench  array-prototype-map.js                      1.007  1.446 ± 1.428 … 1.465              1.437 ± 1.371 … 1.503
MicroBench  array-prototype-shift.js                    0.97   0.007 ± 0.007 … 0.008              0.008 ± 0.007 … 0.008
MicroBench  bound-call-00-args.js                       1.022  1.664 ± 1.589 … 1.740              1.628 ± 1.576 … 1.681
MicroBench  bound-call-04-args.js                       1.014  1.682 ± 1.657 … 1.706              1.659 ± 1.658 … 1.660
MicroBench  bound-call-16-args.js                       0.956  1.915 ± 1.904 … 1.926              2.003 ± 1.904 … 2.101
MicroBench  call-00-args.js                             1.047  1.306 ± 1.294 … 1.319              1.247 ± 1.202 … 1.293
MicroBench  call-01-args.js                             0.887  1.379 ± 1.351 … 1.407              1.555 ± 1.266 … 1.844
MicroBench  call-02-args.js                             1.035  1.337 ± 1.326 … 1.347              1.291 ± 1.284 … 1.298
MicroBench  call-03-args.js                             1.031  1.350 ± 1.342 … 1.359              1.310 ± 1.309 … 1.310
MicroBench  call-04-args.js                             1.082  1.389 ± 1.387 … 1.391              1.284 ± 1.281 … 1.288
MicroBench  call-16-args.js                             1.055  1.431 ± 1.411 … 1.452              1.356 ± 1.354 … 1.358
MicroBench  call-32-args.js                             0.961  1.791 ± 1.687 … 1.896              1.865 ± 1.645 … 2.085
MicroBench  for-in-indexed-properties.js                1.013  1.161 ± 1.161 … 1.161              1.146 ± 1.141 … 1.151
MicroBench  for-in-named-properties.js                  0.986  1.290 ± 1.288 … 1.292              1.308 ± 1.251 … 1.364
MicroBench  for-of.js                                   1.016  0.455 ± 0.455 … 0.456              0.448 ± 0.444 … 0.452
MicroBench  object-keys.js                              1.003  1.397 ± 1.386 … 1.407              1.392 ± 1.385 … 1.399
MicroBench  object-set-with-rope-strings.js             0.993  0.752 ± 0.750 … 0.754              0.757 ± 0.757 … 0.758
MicroBench  pic-add-own.js                              1.002  0.973 ± 0.971 … 0.974              0.971 ± 0.965 … 0.976
MicroBench  pic-get-own.js                              0.999  1.260 ± 1.251 … 1.270              1.261 ± 1.259 … 1.263
MicroBench  pic-get-pchain.js                           0.998  1.271 ± 1.259 … 1.282              1.273 ± 1.272 … 1.274
MicroBench  pic-put-own.js                              1.028  1.435 ± 1.403 … 1.466              1.395 ± 1.394 … 1.397
MicroBench  pic-put-pchain.js                           0.982  2.530 ± 2.486 … 2.574              2.575 ± 2.573 … 2.577
MicroBench  setter-in-prototype-chain.js                0.961  2.046 ± 2.040 … 2.052              2.129 ± 2.090 … 2.169
MicroBench  strictly-equals-object.js                   1.054  1.102 ± 1.098 … 1.106              1.046 ± 1.046 … 1.047
Kraken      Total                                       1.028  11.913                             11.583
Octane      Total                                       1.019  65287.000                          66524.500
JetStream   Total                                       1.011  229.373                            226.934
JetStream3  Total                                       1.017  13.455                             13.236
MicroBench  Total                                       1.003  37.604                             37.494
All Suites  Total                                       1.012  397.534                            392.689
```