### PR TITLE
LibCore: Rename the forward declaration of WeakEventLoopReference

### DIFF
--- a/Libraries/LibCore/Forward.h
+++ b/Libraries/LibCore/Forward.h
@@ -21,7 +21,6 @@ class DeferredInvocationContext;
 class ElapsedTimer;
 class Event;
 class EventLoop;
-class EventLoopWeak;
 class EventReceiver;
 class File;
 class LocalServer;
@@ -48,6 +47,7 @@ class TimerEvent;
 class TimeZoneWatcher;
 class UDPServer;
 class UDPSocket;
+class WeakEventLoopReference;
 
 struct ProxyData;
 


### PR DESCRIPTION
This was missed by the rename tool when changing EventLoopWeak to WeakEventLoopReference.