### PR TITLE
LibMedia: Delete from_file() and from_mapped_file() in MatroskaDemuxer

### DIFF
--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
@@ -15,16 +15,6 @@
 
 namespace Media::Matroska {
 
-DecoderErrorOr<NonnullRefPtr<MatroskaDemuxer>> MatroskaDemuxer::from_file(StringView filename)
-{
-    return make_ref_counted<MatroskaDemuxer>(TRY(Reader::from_file(filename)));
-}
-
-DecoderErrorOr<NonnullRefPtr<MatroskaDemuxer>> MatroskaDemuxer::from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file)
-{
-    return make_ref_counted<MatroskaDemuxer>(TRY(Reader::from_mapped_file(move(mapped_file))));
-}
-
 DecoderErrorOr<NonnullRefPtr<MatroskaDemuxer>> MatroskaDemuxer::from_data(ReadonlyBytes data)
 {
     return make_ref_counted<MatroskaDemuxer>(TRY(Reader::from_data(data)));

--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
@@ -16,11 +16,6 @@ namespace Media::Matroska {
 
 class MEDIA_API MatroskaDemuxer final : public Demuxer {
 public:
-    // FIXME: We should instead accept some abstract data streaming type so that the demuxer
-    //        can work with non-contiguous data.
-    static DecoderErrorOr<NonnullRefPtr<MatroskaDemuxer>> from_file(StringView filename);
-    static DecoderErrorOr<NonnullRefPtr<MatroskaDemuxer>> from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file);
-
     static DecoderErrorOr<NonnullRefPtr<MatroskaDemuxer>> from_data(ReadonlyBytes data);
 
     MatroskaDemuxer(Reader&& reader)

--- a/Libraries/LibMedia/Containers/Matroska/Reader.cpp
+++ b/Libraries/LibMedia/Containers/Matroska/Reader.cpp
@@ -96,19 +96,6 @@ constexpr u32 CUE_RELATIVE_POSITION_ID = 0xF0;
 constexpr u32 CUE_CODEC_STATE_ID = 0xEA;
 constexpr u32 CUE_REFERENCE_ID = 0xDB;
 
-DecoderErrorOr<Reader> Reader::from_file(StringView path)
-{
-    auto mapped_file = DECODER_TRY(DecoderErrorCategory::IO, Core::MappedFile::map(path));
-    return from_mapped_file(move(mapped_file));
-}
-
-DecoderErrorOr<Reader> Reader::from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file)
-{
-    auto reader = TRY(from_data(mapped_file->bytes()));
-    reader.m_mapped_file = make_ref_counted<Core::SharedMappedFile>(move(mapped_file));
-    return reader;
-}
-
 DecoderErrorOr<Reader> Reader::from_data(ReadonlyBytes data)
 {
     Reader reader(data);
@@ -895,7 +882,7 @@ DecoderErrorOr<SampleIterator> Reader::create_sample_iterator(u64 track_number)
     auto position = optional_position.value() - get_element_id_size(CLUSTER_ELEMENT_ID) - m_segment_contents_position;
 
     dbgln_if(MATROSKA_DEBUG, "Creating sample iterator starting at {} relative to segment at {}", position, m_segment_contents_position);
-    return SampleIterator(this->m_mapped_file, segment_view, TRY(track_for_track_number(track_number)), TRY(segment_information()).timestamp_scale(), position);
+    return SampleIterator(segment_view, TRY(track_for_track_number(track_number)), TRY(segment_information()).timestamp_scale(), position);
 }
 
 static DecoderErrorOr<CueTrackPosition> parse_cue_track_position(Streamer& streamer)

--- a/Libraries/LibMedia/Containers/Matroska/Reader.h
+++ b/Libraries/LibMedia/Containers/Matroska/Reader.h
@@ -25,9 +25,6 @@ class MEDIA_API Reader {
 public:
     typedef Function<DecoderErrorOr<IterationDecision>(TrackEntry const&)> TrackEntryCallback;
 
-    static DecoderErrorOr<Reader> from_file(StringView path);
-    static DecoderErrorOr<Reader> from_mapped_file(NonnullOwnPtr<Core::MappedFile> mapped_file);
-
     static DecoderErrorOr<Reader> from_data(ReadonlyBytes data);
 
     EBMLHeader const& header() const { return m_header.value(); }
@@ -63,7 +60,6 @@ private:
     DecoderErrorOr<void> ensure_cues_are_parsed();
     DecoderErrorOr<void> seek_to_cue_for_timestamp(SampleIterator&, AK::Duration const&);
 
-    RefPtr<Core::SharedMappedFile> m_mapped_file;
     ReadonlyBytes m_data;
 
     Optional<EBMLHeader> m_header;
@@ -93,9 +89,8 @@ public:
 private:
     friend class Reader;
 
-    SampleIterator(RefPtr<Core::SharedMappedFile> file, ReadonlyBytes data, TrackEntry& track, u64 timestamp_scale, size_t position)
-        : m_file(move(file))
-        , m_data(data)
+    SampleIterator(ReadonlyBytes data, TrackEntry& track, u64 timestamp_scale, size_t position)
+        : m_data(data)
         , m_track(track)
         , m_segment_timestamp_scale(timestamp_scale)
         , m_position(position)
@@ -104,7 +99,6 @@ private:
 
     DecoderErrorOr<void> seek_to_cue_point(CuePoint const& cue_point);
 
-    RefPtr<Core::SharedMappedFile> m_file;
     ReadonlyBytes m_data;
     NonnullRefPtr<TrackEntry> m_track;
     u64 m_segment_timestamp_scale { 0 };

--- a/Tests/LibMedia/TestMediaCommon.h
+++ b/Tests/LibMedia/TestMediaCommon.h
@@ -8,6 +8,7 @@
 
 #include <AK/Function.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/File.h>
 #include <LibMedia/Containers/Matroska/MatroskaDemuxer.h>
 #include <LibMedia/Containers/Matroska/Reader.h>
 #include <LibMedia/Demuxer.h>
@@ -21,7 +22,9 @@
 template<typename T>
 static inline void decode_video(StringView path, size_t expected_frame_count, T create_decoder)
 {
-    auto matroska_reader = MUST(Media::Matroska::Reader::from_file(path));
+    auto file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
+    auto file_data = MUST(file->read_until_eof());
+    auto matroska_reader = MUST(Media::Matroska::Reader::from_data(file_data));
     u64 video_track = 0;
     MUST(matroska_reader.for_each_track_of_type(Media::Matroska::TrackEntry::TrackType::Video, [&](Media::Matroska::TrackEntry const& track_entry) -> Media::DecoderErrorOr<IterationDecision> {
         video_track = track_entry.track_number();

--- a/Tests/LibMedia/TestParseMatroska.cpp
+++ b/Tests/LibMedia/TestParseMatroska.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/File.h>
 #include <LibMedia/Containers/Matroska/MatroskaDemuxer.h>
 #include <LibTest/TestCase.h>
 
@@ -11,7 +12,9 @@
 
 TEST_CASE(master_elements_containing_crc32)
 {
-    auto matroska_reader = MUST(Media::Matroska::Reader::from_file("master_elements_containing_crc32.mkv"sv));
+    auto file = MUST(Core::File::open("./master_elements_containing_crc32.mkv"sv, Core::File::OpenMode::Read));
+    auto file_data = MUST(file->read_until_eof());
+    auto matroska_reader = MUST(Media::Matroska::Reader::from_data(file_data));
     u64 video_track = 0;
     MUST(matroska_reader.for_each_track_of_type(Media::Matroska::TrackEntry::TrackType::Video, [&](Media::Matroska::TrackEntry const& track_entry) -> Media::DecoderErrorOr<IterationDecision> {
         video_track = track_entry.track_number();
@@ -27,7 +30,9 @@ TEST_CASE(master_elements_containing_crc32)
 
 TEST_CASE(seek_in_multi_frame_blocks)
 {
-    auto demuxer = MUST(Media::Matroska::MatroskaDemuxer::from_file("test-webm-xiph-lacing.mka"sv));
+    auto file = MUST(Core::File::open("./test-webm-xiph-lacing.mka"sv, Core::File::OpenMode::Read));
+    auto file_data = MUST(file->read_until_eof());
+    auto demuxer = MUST(Media::Matroska::MatroskaDemuxer::from_data(file_data));
     auto optional_track = MUST(demuxer->get_preferred_track_for_type(Media::TrackType::Audio));
     EXPECT(optional_track.has_value());
     auto track = optional_track.release_value();


### PR DESCRIPTION
These calls were only used in tests where we could read the whole file into memory and use `from_data()`.

This is a part of https://github.com/LadybirdBrowser/ladybird/pull/6921 that could be merged independently.