### PR TITLE
LibWeb: Save weak pointer to document in DocumentLoadEventDelayer

### DIFF
--- a/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.cpp
@@ -10,7 +10,7 @@
 namespace Web::DOM {
 
 DocumentLoadEventDelayer::DocumentLoadEventDelayer(Document& document)
-    : m_document(GC::make_root(document))
+    : m_document(document)
 {
     m_document->increment_number_of_things_delaying_the_load_event({});
 }

--- a/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.h
+++ b/Libraries/LibWeb/DOM/DocumentLoadEventDelayer.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/Noncopyable.h>
-#include <LibGC/Root.h>
+#include <LibGC/Weak.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::DOM {
@@ -24,7 +24,7 @@ public:
     ~DocumentLoadEventDelayer();
 
 private:
-    GC::Root<Document> m_document;
+    GC::Weak<Document> m_document;
 };
 
 }


### PR DESCRIPTION
This prevents GC leaks caused by a DocumentLoadEventDelayer that is never destroyed (for example, when its Document becomes inactive) from holding a strong reference to the Document and keeping it alive.