### PR TITLE
LibRequests+LibWeb: Don't copy data sent over WebSockets

### DIFF
--- a/Libraries/LibRequests/WebSocket.cpp
+++ b/Libraries/LibRequests/WebSocket.cpp
@@ -35,14 +35,14 @@ void WebSocket::set_subprotocol_in_use(ByteString subprotocol)
     m_subprotocol = move(subprotocol);
 }
 
-void WebSocket::send(ByteBuffer binary_or_text_message, bool is_text)
+void WebSocket::send(ReadonlyBytes binary_or_text_message, bool is_text)
 {
     m_client->async_websocket_send(m_websocket_id, is_text, binary_or_text_message);
 }
 
 void WebSocket::send(StringView text_message)
 {
-    send(ByteBuffer::copy(text_message.bytes()).release_value_but_fixme_should_propagate_errors(), true);
+    send(text_message.bytes(), true);
 }
 
 void WebSocket::close(u16 code, ByteString reason)

--- a/Libraries/LibRequests/WebSocket.h
+++ b/Libraries/LibRequests/WebSocket.h
@@ -55,7 +55,7 @@ public:
     ByteString subprotocol_in_use();
     void set_subprotocol_in_use(ByteString);
 
-    void send(ByteBuffer binary_or_text_message, bool is_text);
+    void send(ReadonlyBytes binary_or_text_message, bool is_text);
     void send(StringView text_message);
     void close(u16 code = 1005, ByteString reason = {});
 


### PR DESCRIPTION
We used to need an allocated `ByteBuffer` to send over IPC. Our IPC now accepts spans for types like `String` and `ByteBuffer` though, so we don't need to allocate buffers at the caller.