### PR TITLE
Two more things to slim down the JS interpreter

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -3125,7 +3125,7 @@ ThrowCompletionOr<void> GetMethod::execute_impl(Bytecode::Interpreter& interpret
     return {};
 }
 
-ThrowCompletionOr<void> GetObjectPropertyIterator::execute_impl(Bytecode::Interpreter& interpreter) const
+NEVER_INLINE ThrowCompletionOr<void> GetObjectPropertyIterator::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto iterator_record = TRY(get_object_property_iterator(interpreter, interpreter.get(m_object)));
     interpreter.set(m_dst_iterator_object, iterator_record.iterator);
@@ -3193,7 +3193,7 @@ ThrowCompletionOr<void> IteratorNextUnpack::execute_impl(Bytecode::Interpreter& 
     return {};
 }
 
-ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interpreter) const
+NEVER_INLINE ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     Value super_class;
     if (m_super_class.has_value())


### PR DESCRIPTION
Just making some things `COLD` and `NEVER_INLINE`.

These were enough to finally push the interpreter code size below the magic threshold where things start going brr:

Linux summary:
```
Kraken      Total                                       1.093  13.784                             12.609
Octane      Total                                       1.053  63353.500                          66701.000
JetStream   Total                                       1.17   286.862                            245.139
JetStream3  Total                                       1.012  13.374                             13.217
MicroBench  Total                                       1.016  38.918                             38.294
```

macOS summary:
```
Kraken      Total                                       1.15   12.263                             10.661
Octane      Total                                       1.055  78038.000                          82315.000
JetStream   Total                                       1.291  285.238                            220.993
JetStream3  Total                                       1.016  10.993                             10.816
MicroBench  Total                                       1.025  36.517                             35.624
```

Full Linux results:
```
Suite       Test                                      Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                                 1.004  1.140 ± 1.133 … 1.146              1.135 ± 1.125 … 1.145
Kraken      audio-beat-detection.js                     1.126  0.933 ± 0.929 … 0.937              0.829 ± 0.827 … 0.831
Kraken      audio-dft.js                                1.061  0.554 ± 0.553 … 0.554              0.522 ± 0.520 … 0.525
Kraken      audio-fft.js                                1.111  0.818 ± 0.816 … 0.821              0.737 ± 0.734 … 0.740
Kraken      audio-oscillator.js                         1.126  0.700 ± 0.699 … 0.701              0.622 ± 0.614 … 0.630
Kraken      imaging-darkroom.js                         1.058  0.956 ± 0.952 … 0.959              0.903 ± 0.898 … 0.908
Kraken      imaging-desaturate.js                       0.964  1.384 ± 1.381 … 1.387              1.436 ± 1.434 … 1.437
Kraken      imaging-gaussian-blur.js                    1.132  5.580 ± 5.465 … 5.695              4.930 ± 4.777 … 5.083
Kraken      json-parse-financial.js                     0.987  0.065 ± 0.065 … 0.065              0.066 ± 0.065 … 0.067
Kraken      json-stringify-tinderbox.js                 1.03   0.077 ± 0.076 … 0.079              0.075 ± 0.075 … 0.075
Kraken      stanford-crypto-aes.js                      1.194  0.345 ± 0.345 … 0.346              0.289 ± 0.289 … 0.290
Kraken      stanford-crypto-ccm.js                      1.084  0.345 ± 0.344 … 0.345              0.318 ± 0.315 … 0.321
Kraken      stanford-crypto-pbkdf2.js                   1.194  0.649 ± 0.649 … 0.649              0.544 ± 0.537 … 0.550
Kraken      stanford-crypto-sha256-iterative.js         1.168  0.238 ± 0.238 … 0.238              0.204 ± 0.202 … 0.205
Octane      box2d.js                                    1.035  4912.000 ± 4903.000 … 4921.000     5082.000 ± 5082.000 … 5082.000
Octane      code-load.js                                1.014  10792.500 ± 10760.000 … 10825.000  10942.500 ± 10933.000 … 10952.000
Octane      crypto.js                                   1.176  1705.000 ± 1699.000 … 1711.000     2005.500 ± 2003.000 … 2008.000
Octane      deltablue.js                                0.999  1036.500 ± 1029.000 … 1044.000     1035.000 ± 1017.000 … 1053.000
Octane      earley-boyer.js                             1.025  2354.000 ± 2347.000 … 2361.000     2413.500 ± 2394.000 … 2433.000
Octane      gbemu.js                                    1.063  9184.000 ± 9184.000 … 9184.000     9764.000 ± 9701.000 … 9827.000
Octane      mandreel.js                                 1.047  8308.500 ± 8281.000 … 8336.000     8700.000 ± 8685.000 … 8715.000
Octane      navier-stokes.js                            1.18   2783.500 ± 2775.000 … 2792.000     3284.500 ± 3249.000 … 3320.000
Octane      pdfjs.js                                    1.044  4033.500 ± 4014.000 … 4053.000     4210.000 ± 4201.000 … 4219.000
Octane      raytrace.js                                 1.009  1697.000 ± 1697.000 … 1697.000     1713.000 ± 1705.000 … 1721.000
Octane      regexp.js                                   1      125.000 ± 125.000 … 125.000        125.000 ± 124.000 … 126.000
Octane      richards.js                                 1.052  1112.500 ± 1105.000 … 1120.000     1170.500 ± 1161.000 … 1180.000
Octane      splay.js                                    1.007  1702.000 ± 1701.000 … 1703.000     1714.500 ± 1708.000 … 1721.000
Octane      typescript.js                               1.036  10771.000 ± 10742.000 … 10800.000  11162.500 ± 11150.000 … 11175.000
Octane      zlib.js                                     1.191  2836.500 ± 2832.000 … 2841.000     3378.500 ± 3365.000 … 3392.000
JetStream   bigfib.cpp.js                               1.177  9.579 ± 9.567 … 9.592              8.136 ± 8.064 … 8.208
JetStream   cdjs.js                                     1.013  3.728 ± 3.718 … 3.739              3.680 ± 3.667 … 3.692
JetStream   container.cpp.js                            1.203  39.578 ± 39.395 … 39.760           32.904 ± 32.506 … 33.302
JetStream   dry.c.js                                    1.16   23.498 ± 23.474 … 23.523           20.251 ± 20.135 … 20.367
JetStream   float-mm.c.js                               1.157  24.624 ± 24.556 … 24.692           21.281 ± 21.237 … 21.325
JetStream   gcc-loops.cpp.js                            1.177  135.107 ± 134.320 … 135.894        114.761 ± 113.897 … 115.625
JetStream   hash-map.js                                 1.04   1.601 ± 1.588 … 1.614              1.539 ± 1.534 … 1.544
JetStream   n-body.c.js                                 1.127  35.393 ± 35.239 … 35.548           31.399 ± 31.393 … 31.405
JetStream   quicksort.c.js                              1.295  5.932 ± 5.923 … 5.941              4.581 ± 4.546 … 4.616
JetStream   towers.c.js                                 1.184  7.822 ± 7.774 … 7.870              6.608 ± 6.415 … 6.801
JetStream3  js-tokens.js                                0.993  0.819 ± 0.814 … 0.825              0.825 ± 0.823 … 0.827
JetStream3  lazy-collections.js                         1.041  1.559 ± 1.558 … 1.559              1.497 ± 1.477 … 1.517
JetStream3  raytrace-private-class-fields.js            1.013  4.955 ± 4.955 … 4.956              4.894 ± 4.865 … 4.923
JetStream3  raytrace-public-class-fields.js             1.015  4.073 ± 4.056 … 4.090              4.011 ± 3.999 … 4.023
JetStream3  sync-file-system.js                         0.989  1.968 ± 1.966 … 1.970              1.990 ± 1.918 … 2.061
MicroBench  array-destructuring-assignment-rest.js      1.032  0.433 ± 0.433 … 0.434              0.420 ± 0.417 … 0.423
MicroBench  array-destructuring-assignment.js           0.998  4.846 ± 4.840 … 4.853              4.857 ± 4.763 … 4.951
MicroBench  array-prototype-map.js                      1.019  1.400 ± 1.387 … 1.412              1.374 ± 1.359 … 1.388
MicroBench  array-prototype-shift.js                    1.079  0.007 ± 0.007 … 0.008              0.007 ± 0.007 … 0.007
MicroBench  bound-call-00-args.js                       0.99   1.681 ± 1.680 … 1.681              1.697 ± 1.687 … 1.708
MicroBench  bound-call-04-args.js                       0.974  1.761 ± 1.760 … 1.762              1.808 ± 1.748 … 1.869
MicroBench  bound-call-16-args.js                       0.992  1.988 ± 1.955 … 2.021              2.004 ± 2.000 … 2.008
MicroBench  call-00-args.js                             1.05   1.322 ± 1.313 … 1.331              1.260 ± 1.246 … 1.273
MicroBench  call-01-args.js                             1.051  1.361 ± 1.358 … 1.363              1.294 ± 1.286 … 1.303
MicroBench  call-02-args.js                             1.027  1.393 ± 1.391 … 1.395              1.356 ± 1.295 … 1.418
MicroBench  call-03-args.js                             1.054  1.370 ± 1.365 … 1.374              1.300 ± 1.287 … 1.312
MicroBench  call-04-args.js                             0.754  1.362 ± 1.359 … 1.366              1.806 ± 1.326 … 2.286
MicroBench  call-16-args.js                             1.046  1.419 ± 1.395 … 1.443              1.356 ± 1.355 … 1.356
MicroBench  call-32-args.js                             1.022  1.656 ± 1.642 … 1.671              1.620 ± 1.617 … 1.623
MicroBench  for-in-indexed-properties.js                1.04   1.180 ± 1.178 … 1.182              1.135 ± 1.134 … 1.135
MicroBench  for-in-named-properties.js                  1.133  1.395 ± 1.389 … 1.401              1.232 ± 1.229 … 1.234
MicroBench  for-of.js                                   1.145  0.492 ± 0.490 … 0.493              0.429 ± 0.428 … 0.430
MicroBench  object-keys.js                              0.982  1.405 ± 1.405 … 1.406              1.431 ± 1.412 … 1.451
MicroBench  object-set-with-rope-strings.js             1.036  0.767 ± 0.764 … 0.769              0.740 ± 0.729 … 0.750
MicroBench  pic-add-own.js                              1.003  0.972 ± 0.967 … 0.977              0.969 ± 0.968 … 0.971
MicroBench  pic-get-own.js                              1.021  1.382 ± 1.376 … 1.389              1.354 ± 1.346 … 1.361
MicroBench  pic-get-pchain.js                           1.089  1.490 ± 1.391 … 1.588              1.368 ± 1.368 … 1.368
MicroBench  pic-put-own.js                              1.045  1.580 ± 1.566 … 1.593              1.512 ± 1.508 … 1.516
MicroBench  pic-put-pchain.js                           1.007  2.642 ± 2.639 … 2.644              2.622 ± 2.619 … 2.625
MicroBench  setter-in-prototype-chain.js                1.076  2.260 ± 2.252 … 2.268              2.100 ± 2.070 … 2.131
MicroBench  strictly-equals-object.js                   1.091  1.355 ± 1.355 … 1.356              1.242 ± 1.241 … 1.243
Kraken      Total                                       1.093  13.784                             12.609
Octane      Total                                       1.053  63353.500                          66701.000
JetStream   Total                                       1.17   286.862                            245.139
JetStream3  Total                                       1.012  13.374                             13.217
MicroBench  Total                                       1.016  38.918                             38.294
All Suites  Total                                       1.131  469.228                            414.975
```

Full macOS results:

```
Suite       Test                                      Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                                 1.056  0.991 ± 0.971 … 1.011              0.938 ± 0.935 … 0.941
Kraken      audio-beat-detection.js                     1.146  0.797 ± 0.797 … 0.797              0.696 ± 0.694 … 0.697
Kraken      audio-dft.js                                1.135  0.519 ± 0.519 … 0.519              0.457 ± 0.455 … 0.460
Kraken      audio-fft.js                                1.164  0.698 ± 0.697 … 0.698              0.599 ± 0.599 … 0.599
Kraken      audio-oscillator.js                         1.044  0.695 ± 0.688 … 0.701              0.665 ± 0.659 … 0.672
Kraken      imaging-darkroom.js                         1.022  0.955 ± 0.954 … 0.955              0.934 ± 0.933 … 0.935
Kraken      imaging-desaturate.js                       1.139  1.257 ± 1.256 … 1.258              1.104 ± 1.092 … 1.115
Kraken      imaging-gaussian-blur.js                    1.229  4.857 ± 4.778 … 4.937              3.951 ± 3.824 … 4.079
Kraken      json-parse-financial.js                     0.985  0.069 ± 0.069 … 0.070              0.070 ± 0.070 … 0.071
Kraken      json-stringify-tinderbox.js                 0.979  0.067 ± 0.067 … 0.067              0.069 ± 0.068 … 0.069
Kraken      stanford-crypto-aes.js                      1.232  0.323 ± 0.322 … 0.324              0.262 ± 0.261 … 0.263
Kraken      stanford-crypto-ccm.js                      1.158  0.290 ± 0.289 … 0.291              0.251 ± 0.251 … 0.251
Kraken      stanford-crypto-pbkdf2.js                   1.129  0.547 ± 0.544 … 0.550              0.484 ± 0.484 … 0.485
Kraken      stanford-crypto-sha256-iterative.js         1.103  0.198 ± 0.198 … 0.198              0.180 ± 0.179 … 0.180
Octane      box2d.js                                    0.991  5585.000 ± 5580.000 … 5590.000     5533.500 ± 5528.000 … 5539.000
Octane      code-load.js                                0.997  14535.500 ± 14525.000 … 14546.000  14485.500 ± 14469.000 … 14502.000
Octane      crypto.js                                   1.258  1869.500 ± 1866.000 … 1873.000     2351.000 ± 2350.000 … 2352.000
Octane      deltablue.js                                0.976  1143.000 ± 1140.000 … 1146.000     1115.500 ± 1110.000 … 1121.000
Octane      earley-boyer.js                             1.017  3240.000 ± 3239.000 … 3241.000     3295.500 ± 3274.000 … 3317.000
Octane      gbemu.js                                    1.092  10029.000 ± 10024.000 … 10034.000  10953.500 ± 10908.000 … 10999.000
Octane      mandreel.js                                 1.181  8746.000 ± 8731.000 … 8761.000     10332.000 ± 10321.000 … 10343.000
Octane      navier-stokes.js                            1.001  2571.000 ± 2561.000 … 2581.000     2573.500 ± 2571.000 … 2576.000
Octane      pdfjs.js                                    1.055  5395.500 ± 5386.000 … 5405.000     5693.000 ± 5693.000 … 5693.000
Octane      raytrace.js                                 0.999  2110.500 ± 2084.000 … 2137.000     2107.500 ± 2091.000 … 2124.000
Octane      regexp.js                                   1.01   144.000 ± 144.000 … 144.000        145.500 ± 145.000 … 146.000
Octane      richards.js                                 1.012  1298.500 ± 1298.000 … 1299.000     1314.000 ± 1305.000 … 1323.000
Octane      splay.js                                    0.985  4965.000 ± 4904.000 … 5026.000     4889.500 ± 4863.000 … 4916.000
Octane      typescript.js                               1.007  13665.500 ± 13646.000 … 13685.000  13755.000 ± 13721.000 … 13789.000
Octane      zlib.js                                     1.376  2740.000 ± 2730.000 … 2750.000     3770.500 ± 3765.000 … 3776.000
JetStream   bigfib.cpp.js                               1.319  10.118 ± 10.027 … 10.208           7.671 ± 7.670 … 7.671
JetStream   cdjs.js                                     1.029  3.119 ± 3.095 … 3.143              3.030 ± 2.994 … 3.067
JetStream   container.cpp.js                            1.287  36.098 ± 35.941 … 36.256           28.050 ± 28.048 … 28.051
JetStream   dry.c.js                                    1.233  21.542 ± 21.530 … 21.554           17.471 ± 17.410 … 17.532
JetStream   float-mm.c.js                               1.18   24.177 ± 24.162 … 24.192           20.489 ± 20.401 … 20.576
JetStream   gcc-loops.cpp.js                            1.354  143.184 ± 142.465 … 143.904        105.741 ± 105.701 … 105.781
JetStream   hash-map.js                                 1.043  1.345 ± 1.344 … 1.346              1.290 ± 1.287 … 1.292
JetStream   n-body.c.js                                 1.2    33.556 ± 33.470 … 33.642           27.953 ± 27.950 … 27.957
JetStream   quicksort.c.js                              1.327  5.622 ± 5.621 … 5.622              4.237 ± 4.233 … 4.241
JetStream   towers.c.js                                 1.28   6.477 ± 6.470 … 6.484              5.062 ± 5.049 … 5.074
JetStream3  js-tokens.js                                0.995  0.675 ± 0.673 … 0.677              0.679 ± 0.676 … 0.682
JetStream3  lazy-collections.js                         1.005  1.136 ± 1.134 … 1.138              1.131 ± 1.113 … 1.148
JetStream3  raytrace-private-class-fields.js            1.002  4.177 ± 4.160 … 4.195              4.168 ± 4.168 … 4.169
JetStream3  raytrace-public-class-fields.js             0.999  3.187 ± 3.173 … 3.201              3.191 ± 3.175 … 3.208
JetStream3  sync-file-system.js                         1.103  1.818 ± 1.788 … 1.848              1.648 ± 1.645 … 1.650
MicroBench  array-destructuring-assignment-rest.js      1.071  0.402 ± 0.401 … 0.403              0.375 ± 0.369 … 0.381
MicroBench  array-destructuring-assignment.js           1.071  2.388 ± 2.373 … 2.403              2.230 ± 2.139 … 2.320
MicroBench  array-prototype-map.js                      1.005  1.038 ± 1.036 … 1.040              1.033 ± 1.031 … 1.035
MicroBench  array-prototype-shift.js                    0.996  0.010 ± 0.009 … 0.011              0.010 ± 0.009 … 0.011
MicroBench  base64-from.js                              0.997  0.237 ± 0.234 … 0.240              0.238 ± 0.237 … 0.238
MicroBench  base64-to.js                                0.977  0.213 ± 0.212 … 0.214              0.218 ± 0.213 … 0.223
MicroBench  bound-call-00-args.js                       0.981  1.222 ± 1.219 … 1.224              1.245 ± 1.245 … 1.245
MicroBench  bound-call-04-args.js                       1.037  1.313 ± 1.313 … 1.314              1.267 ± 1.225 … 1.308
MicroBench  bound-call-16-args.js                       1.036  1.515 ± 1.495 … 1.536              1.463 ± 1.446 … 1.481
MicroBench  call-00-args.js                             0.954  1.204 ± 1.200 … 1.209              1.262 ± 1.199 … 1.325
MicroBench  call-01-args.js                             0.965  1.221 ± 1.198 … 1.243              1.265 ± 1.250 … 1.280
MicroBench  call-02-args.js                             1.03   1.254 ± 1.236 … 1.272              1.218 ± 1.157 … 1.279
MicroBench  call-03-args.js                             0.994  1.176 ± 1.149 … 1.202              1.183 ± 1.165 … 1.201
MicroBench  call-04-args.js                             1.009  1.174 ± 1.171 … 1.178              1.164 ± 1.162 … 1.165
MicroBench  call-16-args.js                             1.009  1.279 ± 1.276 … 1.281              1.267 ± 1.258 … 1.276
MicroBench  call-32-args.js                             1.007  1.480 ± 1.478 … 1.483              1.470 ± 1.455 … 1.485
MicroBench  call-goofy.js                               0.954  1.183 ± 1.175 … 1.192              1.240 ± 1.172 … 1.308
MicroBench  call-native.js                              1.023  0.638 ± 0.638 … 0.639              0.624 ± 0.623 … 0.624
MicroBench  construct-00-args.js                        1.006  0.820 ± 0.815 … 0.825              0.815 ± 0.779 … 0.852
MicroBench  construct-04-args.js                        1.044  0.843 ± 0.841 … 0.845              0.807 ± 0.802 … 0.812
MicroBench  deep-call-stack.js                          1.033  1.034 ± 1.030 … 1.037              1.001 ± 0.996 … 1.005
MicroBench  for-in-indexed-properties.js                0.999  0.949 ± 0.946 … 0.951              0.949 ± 0.949 … 0.950
MicroBench  for-in-named-properties.js                  1.01   1.436 ± 1.430 … 1.441              1.421 ± 1.417 … 1.424
MicroBench  for-of.js                                   1.177  0.434 ± 0.431 … 0.436              0.368 ± 0.368 … 0.369
MicroBench  object-keys.js                              1.004  1.706 ± 1.699 … 1.714              1.699 ± 1.697 … 1.701
MicroBench  object-set-with-rope-strings.js             1.029  0.617 ± 0.615 … 0.618              0.599 ± 0.599 … 0.600
MicroBench  pic-add-own.js                              1.056  0.736 ± 0.735 … 0.737              0.697 ± 0.695 … 0.698
MicroBench  pic-get-own.js                              0.992  1.154 ± 1.146 … 1.161              1.163 ± 1.152 … 1.173
MicroBench  pic-get-pchain.js                           1.017  1.230 ± 1.196 … 1.265              1.210 ± 1.202 … 1.217
MicroBench  pic-put-own.js                              1.045  1.241 ± 1.225 … 1.257              1.187 ± 1.172 … 1.202
MicroBench  pic-put-pchain.js                           0.999  2.331 ± 2.306 … 2.355              2.332 ± 2.330 … 2.335
MicroBench  setter-in-prototype-chain.js                0.974  1.720 ± 1.711 … 1.730              1.766 ± 1.766 … 1.766
MicroBench  strictly-equals-object.js                   1.577  1.321 ± 1.321 … 1.322              0.838 ± 0.821 … 0.855
Kraken      Total                                       1.15   12.263                             10.661
Octane      Total                                       1.055  78038.000                          82315.000
JetStream   Total                                       1.291  285.238                            220.993
JetStream3  Total                                       1.016  10.993                             10.816
MicroBench  Total                                       1.025  36.517                             35.624
All Suites  Total                                       1.224  457.074                            373.422
```