### PR TITLE
LibWeb: Include "url(" in the original source text of URL tokens

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -410,7 +410,7 @@ Token Tokenizer::consume_an_ident_like_token()
         }
 
         // Otherwise, consume a url token, and return it.
-        return consume_a_url_token();
+        return consume_a_url_token(start_byte_offset);
     }
 
     // Otherwise, if the next input code point is U+0028 LEFT PARENTHESIS ((), consume it.
@@ -576,7 +576,7 @@ FlyString Tokenizer::consume_an_ident_sequence()
 }
 
 // https://www.w3.org/TR/css-syntax-3/#consume-url-token
-Token Tokenizer::consume_a_url_token()
+Token Tokenizer::consume_a_url_token(size_t start_byte_offset)
 {
     // This section describes how to consume a url token from a stream of code points.
     // It returns either a <url-token> or a <bad-url-token>.
@@ -588,7 +588,6 @@ Token Tokenizer::consume_a_url_token()
     // shouldn’t be called directly otherwise.
 
     // 1. Initially create a <url-token> with its value set to the empty string.
-    auto start_byte_offset = current_byte_offset();
     StringBuilder builder;
 
     // 2. Consume as much whitespace as possible.

--- a/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -88,7 +88,7 @@ private:
     [[nodiscard]] double convert_a_string_to_a_number(StringView);
     [[nodiscard]] FlyString consume_an_ident_sequence();
     [[nodiscard]] u32 consume_escaped_code_point();
-    [[nodiscard]] Token consume_a_url_token();
+    [[nodiscard]] Token consume_a_url_token(size_t start_byte_offset);
     void consume_the_remnants_of_a_bad_url();
     void consume_comments();
     void consume_as_much_whitespace_as_possible();

--- a/Tests/LibWeb/Text/expected/css/url-style-property-value.txt
+++ b/Tests/LibWeb/Text/expected/css/url-style-property-value.txt
@@ -1,0 +1,2 @@
+url("image.svg")
+url(image.svg)

--- a/Tests/LibWeb/Text/input/css/url-style-property-value.html
+++ b/Tests/LibWeb/Text/input/css/url-style-property-value.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        --style-1: url("image.svg");
+        --style-2: url(image.svg);
+    }
+</style>
+<body></body>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const style = window.getComputedStyle(document.body);
+        println(style.getPropertyValue("--style-1"));
+        println(style.getPropertyValue("--style-2"));
+    });
+</script>


### PR DESCRIPTION
When we invoke `Tokenizer::consume_a_url_token`, we have already consumed the `url(` text from the source. Thus we would set the original source text to the text starting just after those consumed code points. Let's instead pass in the known starting position from the caller.

This fixes a bug seen on https://lichess.org, where they perform a `substring(4)` on the property value to remove the `url(` text. This would strip away the `http` part of the URL, and we would try to load `s://lichess.org/image.svg`. With this fixed, we can play chess games on this site.

<img width="1419" height="1120" alt="lichess" src="https://github.com/user-attachments/assets/49011e9c-f218-4d2b-b700-600c35a56606" />
