### PR TITLE
LibWeb: Use parent's space for anonymous wrappers with inline contents

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -840,8 +840,9 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         independent_formatting_context->run(box_state.available_inner_space_or_constraints_from(available_space));
     } else {
         // This box participates in the current block container's flow.
+        auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
         if (box.children_are_inline()) {
-            layout_inline_children(as<BlockContainer>(box), box_state.available_inner_space_or_constraints_from(available_space));
+            layout_inline_children(as<BlockContainer>(box), space_available_for_children);
         } else {
             if (box_state.border_top > 0 || box_state.padding_top > 0) {
                 // margin-top of block container can't collapse with it's children if it has non zero border or padding
@@ -854,8 +855,6 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
                     }
                 });
             }
-
-            auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
             layout_block_level_children(as<BlockContainer>(box), space_available_for_children);
         }
     }

--- a/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/resolve-height-of-containing-block.txt
@@ -11,7 +11,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-
         BlockContainer <div> at [8,16] [0+0+0 1280 0+0+0] [0+0+0 400 0+0+0] children: not-inline
           BlockContainer <(anonymous)> at [8,16] [0+0+0 1280 0+0+0] [0+0+0 0 0+0+0] children: inline
             TextNode <#text> (not painted)
-            ImageBox <img> at [488,16] floating [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+            ImageBox <img> at [488,16] floating [0+0+0 800 0+0+0] [0+0+0 400 0+0+0] children: not-inline
             TextNode <#text> (not painted)
           BlockContainer <p> at [8,16] [0+0+0 1280 0+0+0] [16+0+0 18 0+0+16] children: inline
             frag 0 from TextNode start: 0, length: 4, rect: [8,16 37.21875x18] baseline: 13.796875
@@ -32,8 +32,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 1288x824]
       PaintableWithLines (BlockContainer<DIV>.foo) [8,16 1280x800]
         PaintableWithLines (BlockContainer(anonymous)) [8,16 1280x0]
         PaintableWithLines (BlockContainer<DIV>) [8,16 1280x400]
-          PaintableWithLines (BlockContainer(anonymous)) [8,16 1280x0]
-            ImagePaintable (ImageBox<IMG>) [488,16 800x0]
+          PaintableWithLines (BlockContainer(anonymous)) [8,16 1280x0] overflow: [488,16 800x400]
+            ImagePaintable (ImageBox<IMG>) [488,16 800x400]
           PaintableWithLines (BlockContainer<P>) [8,16 1280x18]
             TextPaintable (TextNode<#text>)
           PaintableWithLines (BlockContainer(anonymous)) [8,50 1280x0]

--- a/Tests/LibWeb/Ref/expected/img-height-inside-anonymous-wrapper-ref.html
+++ b/Tests/LibWeb/Ref/expected/img-height-inside-anonymous-wrapper-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+.a {
+    background-color: #0f0;
+    height: 300px;
+    width: 300px;
+}
+</style><div class="a">

--- a/Tests/LibWeb/Ref/input/img-height-inside-anonymous-wrapper.html
+++ b/Tests/LibWeb/Ref/input/img-height-inside-anonymous-wrapper.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/img-height-inside-anonymous-wrapper-ref.html" />
+<style>
+.a {
+    background-color: red;
+    height: 300px;
+    width: 300px;
+}
+img {
+    height: 100%;
+}
+</style>
+<div class="a"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEBgIApD5fRAAAAABJRU5ErkJggg=="><div>


### PR DESCRIPTION
We already dealt with this for block level children, but inline level children should also look at the anonymous wrapper's parent's available space to be able to properly resolve percentage values, for example.

Fixes the banner image size on LinkedIn posts such as [this one](https://www.linkedin.com/feed/update/urn:li:activity:7404844356228034560/) when not logged in (this is a great time to mention that you should follow [Ladybird on LinkedIn](https://www.linkedin.com/company/ladybird-browser-initiative/)!):

| Before | After |
|--|--|
| <img width="334" height="231" alt="image" src="https://github.com/user-attachments/assets/e0448804-c560-4211-97b4-cd3a46198817" /> | <img width="338" height="235" alt="Screenshot 2025-12-11 at 15 08 08" src="https://github.com/user-attachments/assets/43209480-d583-49f9-93d3-f91b8850ac6b" /> |
