### PR TITLE
LibJS: Always use GetGlobal for `undefined` in global scope

### DIFF
--- a/Libraries/LibJS/Tests/reassigning-undefined-should-have-no-effect.js
+++ b/Libraries/LibJS/Tests/reassigning-undefined-should-have-no-effect.js
@@ -1,0 +1,15 @@
+test("reassigning undefined should have no effect", () => {
+    function attemptToChangeGlobalUndefined() {
+        undefined = 42;
+        eval("undefined = 42");
+    }
+
+    function modifyUndefinedInFunctionScope() {
+        var undefined = 42;
+        expect(undefined).toBe(42);
+    }
+
+    attemptToChangeGlobalUndefined();
+    modifyUndefinedInFunctionScope();
+    expect(undefined).toBeUndefined();
+});


### PR DESCRIPTION
It's safe because `undefined` in global scope isn't allowed to be redefined.