### PR TITLE
LibHTTP+RequestServer: Implement the stale-while-revalidate directive

### DIFF
--- a/Libraries/LibHTTP/Cache/CacheEntry.cpp
+++ b/Libraries/LibHTTP/Cache/CacheEntry.cpp
@@ -270,6 +270,9 @@ void CacheEntryReader::revalidation_succeeded(HeaderList const& response_headers
 
     update_header_fields(m_response_headers, response_headers);
     m_index.update_response_headers(m_cache_key, m_response_headers);
+
+    if (m_revalidation_type != RevalidationType::MustRevalidate)
+        close_and_destroy_cache_entry();
 }
 
 void CacheEntryReader::revalidation_failed()

--- a/Libraries/LibHTTP/Cache/CacheEntry.h
+++ b/Libraries/LibHTTP/Cache/CacheEntry.h
@@ -108,8 +108,13 @@ public:
     static ErrorOr<NonnullOwnPtr<CacheEntryReader>> create(DiskCache&, CacheIndex&, u64 cache_key, NonnullRefPtr<HeaderList>, u64 data_size);
     virtual ~CacheEntryReader() override = default;
 
-    bool must_revalidate() const { return m_must_revalidate; }
-    void set_must_revalidate() { m_must_revalidate = true; }
+    enum class RevalidationType {
+        None,
+        MustRevalidate,
+        StaleWhileRevalidate,
+    };
+    RevalidationType revalidation_type() const { return m_revalidation_type; }
+    void set_revalidation_type(RevalidationType revalidation_type) { m_revalidation_type = revalidation_type; }
 
     void revalidation_succeeded(HeaderList const&);
     void revalidation_failed();
@@ -143,7 +148,7 @@ private:
     Optional<String> m_reason_phrase;
     NonnullRefPtr<HeaderList> m_response_headers;
 
-    bool m_must_revalidate { false };
+    RevalidationType m_revalidation_type { RevalidationType::None };
 
     u64 const m_data_offset { 0 };
     u64 const m_data_size { 0 };

--- a/Libraries/LibHTTP/Cache/CacheRequest.h
+++ b/Libraries/LibHTTP/Cache/CacheRequest.h
@@ -17,6 +17,8 @@ class CacheRequest : public Weakable<CacheRequest> {
 public:
     virtual ~CacheRequest() = default;
 
+    virtual bool is_revalidation_request() const = 0;
+
     virtual void notify_request_unblocked(Badge<DiskCache>) = 0;
 
 protected:

--- a/Libraries/LibHTTP/Cache/Utilities.h
+++ b/Libraries/LibHTTP/Cache/Utilities.h
@@ -18,6 +18,7 @@ namespace HTTP {
 
 constexpr inline auto TEST_CACHE_ENABLED_HEADER = "X-Ladybird-Enable-Disk-Cache"sv;
 constexpr inline auto TEST_CACHE_STATUS_HEADER = "X-Ladybird-Disk-Cache-Status"sv;
+constexpr inline auto TEST_CACHE_REVALIDATION_STATUS_HEADER = "X-Ladybird-Revalidation-Status"sv;
 constexpr inline auto TEST_CACHE_REQUEST_TIME_OFFSET = "X-Ladybird-Request-Time-Offset"sv;
 
 String serialize_url_for_cache_storage(URL::URL const&);
@@ -35,6 +36,7 @@ enum class CacheLifetimeStatus {
     Fresh,
     Expired,
     MustRevalidate,
+    StaleWhileRevalidate,
 };
 CacheLifetimeStatus cache_lifetime_status(HeaderList const&, AK::Duration freshness_lifetime, AK::Duration current_age);
 

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -25,7 +25,8 @@ public:
 
     virtual void die() override;
 
-    void request_complete(Badge<Request>, u64 request_id);
+    void start_revalidation_request(Badge<Request>, ByteString method, URL::URL, NonnullRefPtr<HTTP::HeaderList> request_headers, ByteBuffer request_body, Core::ProxyData proxy_data);
+    void request_complete(Badge<Request>, Request const&);
 
 private:
     explicit ConnectionFromClient(NonnullOwnPtr<IPC::Transport>);
@@ -59,6 +60,7 @@ private:
     void* m_curl_multi { nullptr };
 
     HashMap<u64, NonnullOwnPtr<Request>> m_active_requests;
+    HashMap<u64, NonnullOwnPtr<Request>> m_active_revalidation_requests;
     HashMap<u64, RefPtr<WebSocket::WebSocket>> m_websockets;
 
     RefPtr<Core::Timer> m_timer;
@@ -67,6 +69,8 @@ private:
 
     NonnullRefPtr<Resolver> m_resolver;
     ByteString m_alt_svc_cache_path;
+
+    u64 m_next_revalidation_request_id { 0 };
 };
 
 constexpr inline uintptr_t websocket_private_tag = 0x1;

--- a/Tests/LibWeb/Text/input/Cache/http-disk-cache.html
+++ b/Tests/LibWeb/Text/input/Cache/http-disk-cache.html
@@ -3,6 +3,7 @@
 <script>
     const TEST_CACHE_ENABLED_HEADER = "X-Ladybird-Enable-Disk-Cache";
     const TEST_CACHE_STATUS_HEADER = "X-Ladybird-Disk-Cache-Status";
+    const TEST_CACHE_REVALIDATION_STATUS_HEADER = "X-Ladybird-Revalidation-Status";
     const TEST_CACHE_REQUEST_TIME_OFFSET = "X-Ladybird-Request-Time-Offset";
     const TEST_CACHE_RESPOND_WITH_NOT_MODIFIED = "X-Ladybird-Respond-With-Not-Modified";
 
@@ -37,7 +38,8 @@
         });
 
         options.headers["Access-Control-Allow-Origin"] = location.origin;
-        options.headers["Access-Control-Expose-Headers"] = TEST_CACHE_STATUS_HEADER;
+        options.headers["Access-Control-Expose-Headers"] =
+            `${TEST_CACHE_STATUS_HEADER}, ${TEST_CACHE_REVALIDATION_STATUS_HEADER}`;
 
         return server.createEcho(options.method, path, {
             status: options.status,
@@ -71,6 +73,15 @@
 
         if (result !== status) {
             println(`Expected ${url} to contain a cache status of '${status}': received: '${result}'`);
+            anyTestFailed = true;
+        }
+    }
+
+    function expectRevalidationStatus(url, response, status) {
+        const result = response.headers.get(TEST_CACHE_REVALIDATION_STATUS_HEADER);
+
+        if (result !== status) {
+            println(`Expected ${url} to contain a revalidation status of '${status}': received: '${result}'`);
             anyTestFailed = true;
         }
     }
@@ -307,6 +318,94 @@
             response = await cacheFetch(url, {
                 headers: {
                     [TEST_CACHE_REQUEST_TIME_OFFSET]: 90 * 60,
+                },
+            });
+            expectCacheStatus(url, response, "written-to-cache");
+        })();
+
+        // Expired responses are cached until their max-age and stale-while-revalidate directives are reached. The
+        // response is successfully revalidated in the background.
+        await (async () => {
+            url = await createRequest("/cache-test/stale-while-revalidate-fresh", {
+                headers: {
+                    "Cache-Control": "max-age=10,stale-while-revalidate=10",
+                    "Last-Modified": new Date().toUTCString(),
+                },
+            });
+
+            response = await cacheFetch(url);
+            expectCacheStatus(url, response, "written-to-cache");
+
+            response = await cacheFetch(url);
+            expectCacheStatus(url, response, "read-from-cache");
+
+            response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 12,
+                    [TEST_CACHE_RESPOND_WITH_NOT_MODIFIED]: "1",
+                },
+            });
+            expectCacheStatus(url, response, "read-from-cache");
+            expectRevalidationStatus(url, response, null);
+
+            // We must issue another request to inspect the status of the background revalidation request triggered by
+            // the previous request.
+            response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 15,
+                    [TEST_CACHE_RESPOND_WITH_NOT_MODIFIED]: "1",
+                },
+            });
+            expectCacheStatus(url, response, "read-from-cache");
+            expectRevalidationStatus(url, response, "fresh");
+
+            response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 60,
+                },
+            });
+            expectCacheStatus(url, response, "written-to-cache");
+        })();
+
+        // Expired responses are cached until their max-age and stale-while-revalidate directives are reached. The
+        // response is unsuccessfully revalidated in the background.
+        await (async () => {
+            url = await createRequest("/cache-test/stale-while-revalidate-expired", {
+                headers: {
+                    "Cache-Control": "max-age=10,stale-while-revalidate=10",
+                    "Last-Modified": new Date().toUTCString(),
+                },
+            });
+
+            response = await cacheFetch(url);
+            expectCacheStatus(url, response, "written-to-cache");
+
+            response = await cacheFetch(url);
+            expectCacheStatus(url, response, "read-from-cache");
+
+            // By not attaching a TEST_CACHE_RESPOND_WITH_NOT_MODIFIED header, we tell http-test-server to respond to
+            // revalidation requests with an HTTP 200 (i.e. revalidation fails).
+            response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 12,
+                },
+            });
+            expectCacheStatus(url, response, "read-from-cache");
+
+            // We must issue another request to inspect the status of the background revalidation request triggered by
+            // the previous request. Even though revalidation failed, the revalidation request itself will have written
+            // a fresh response to disk, thus this request is served from cache.
+            response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 15,
+                },
+            });
+            expectCacheStatus(url, response, "read-from-cache");
+            expectRevalidationStatus(url, response, "expired");
+
+            response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: 60,
                 },
             });
             expectCacheStatus(url, response, "written-to-cache");


### PR DESCRIPTION
This directive allows our disk cache to serve stale responses for a time indicated by the directive itself, while we revalidate the response in the background.

Issuing requests that weren't initiated by a client is a new thing for RequestServer. In this implementation, we associate the request with the client that initiated the request to the stale cache entry. This adds a "background request" mode to the Request object, to prevent us from trying to send any of the revalidation response over IPC.