### PR TITLE
LibWeb: Update svg type for root element checks when set/get title

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1034,7 +1034,7 @@ Utf16String Document::title() const
 
     // 1. If the document element is an SVG svg element, then let value be the child text content of the first SVG title
     //    element that is a child of the document element.
-    if (auto const* document_element = this->document_element(); is<SVG::SVGElement>(document_element)) {
+    if (auto const* document_element = this->document_element(); is<SVG::SVGSVGElement>(document_element)) {
         if (auto const* title_element = document_element->first_child_of_type<SVG::SVGTitleElement>())
             value = title_element->child_text_content();
     }
@@ -1058,7 +1058,7 @@ WebIDL::ExceptionOr<void> Document::set_title(Utf16String const& title)
     auto* document_element = this->document_element();
 
     // -> If the document element is an SVG svg element
-    if (is<SVG::SVGElement>(document_element)) {
+    if (is<SVG::SVGSVGElement>(document_element)) {
         GC::Ptr<Element> element;
 
         // 1. If there is an SVG title element that is a child of the document element, let element be the first such

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/documents/dom-tree-accessors/document.title-09.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/documents/dom-tree-accessors/document.title-09.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	No title element in SVG document
+Pass	Title element in SVG document
+Pass	Title element not child of SVG root
+Pass	Title element not in SVG namespace
+Pass	Root element not named "svg"

--- a/Tests/LibWeb/Text/input/wpt-import/html/dom/documents/dom-tree-accessors/document.title-09.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/dom/documents/dom-tree-accessors/document.title-09.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#document.title">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+var SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+var HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+
+function newSVGDocument() {
+  return document.implementation.createDocument(SVG_NAMESPACE, "svg", null);
+}
+
+function assertIsSVGTitle(element, expectedText) {
+  assert_equals(element.namespaceURI, SVG_NAMESPACE);
+  assert_equals(element.localName, "title");
+  assert_equals(element.textContent, expectedText);
+}
+
+test(function() {
+  var doc = newSVGDocument();
+  assert_equals(doc.title, "");
+  var child = doc.createElementNS(SVG_NAMESPACE, "x-child");
+  doc.documentElement.appendChild(child);
+  doc.title = "foo";
+  assertIsSVGTitle(doc.documentElement.firstChild, "foo");
+  assert_equals(doc.title, "foo");
+}, "No title element in SVG document");
+
+test(function() {
+  var doc = newSVGDocument();
+  var title = doc.createElementNS(SVG_NAMESPACE, "title");
+  title.textContent = "foo";
+  doc.documentElement.appendChild(title)
+  assert_equals(doc.title, "foo");
+  doc.title += "bar";
+  assert_equals(title.textContent, "foobar");
+  assert_equals(title.childNodes.length, 1);
+  assert_true(title.childNodes[0] instanceof Text);
+  assert_equals(doc.title, "foobar");
+  doc.title = "";
+  assert_equals(title.textContent, "");
+  assert_equals(doc.title, "");
+  assert_equals(title.childNodes.length, 0);
+}, "Title element in SVG document");
+
+test(function() {
+  var doc = newSVGDocument();
+  var title = doc.createElementNS(SVG_NAMESPACE, "title");
+  title.textContent = "foo";
+  var child = doc.createElementNS(SVG_NAMESPACE, "x-child");
+  child.appendChild(title);
+  doc.documentElement.appendChild(child);
+  assert_equals(doc.title, "");
+
+  // Now test that on setting, we create a new element and don't change the
+  // existing one
+  doc.title = "bar";
+  assert_equals(title.textContent, "foo");
+  assertIsSVGTitle(doc.documentElement.firstChild, "bar");
+  assert_equals(doc.title, "bar");
+}, "Title element not child of SVG root");
+
+test(function() {
+  var doc = newSVGDocument();
+  var title = doc.createElementNS(HTML_NAMESPACE, "title");
+  title.textContent = "foo";
+  doc.documentElement.appendChild(title);
+  assert_equals(doc.title, "");
+}, "Title element not in SVG namespace");
+
+test(function() {
+  // "SVG" != "svg"
+  var doc = document.implementation.createDocument(SVG_NAMESPACE, "SVG", null);
+
+  // Per spec, this does nothing
+  doc.title = "foo";
+  assert_equals(doc.documentElement.childNodes.length, 0);
+  assert_equals(doc.title, "");
+
+  // An SVG title is ignored by .title
+  doc.documentElement.appendChild(doc.createElementNS(SVG_NAMESPACE, "title"));
+  doc.documentElement.lastChild.textContent = "foo";
+  assert_equals(doc.title, "");
+
+  // But an HTML title is respected
+  doc.documentElement.appendChild(doc.createElementNS(HTML_NAMESPACE, "title"));
+  doc.documentElement.lastChild.textContent = "bar";
+  assert_equals(doc.title, "bar");
+
+  // Even if it's not a child of the root
+  var div = doc.createElementNS(HTML_NAMESPACE, "div");
+  div.appendChild(doc.documentElement.lastChild);
+  doc.documentElement.appendChild(div);
+  assert_equals(doc.title, "bar");
+}, 'Root element not named "svg"');
+</script>


### PR DESCRIPTION
Document::title() and Document::set_title() now only runs SVG-specific title logic when the document element is a lowercase svg. Fixing this [WPT](https://wpt.fyi/results/html/dom/documents/dom-tree-accessors/document.title-09.html?label=master&product=chrome)