### PR TITLE
Tests/LibMedia: Avoid assertions that assume a valid PlaybackStream

### DIFF
--- a/Tests/LibMedia/TestPlaybackStream.cpp
+++ b/Tests/LibMedia/TestPlaybackStream.cpp
@@ -28,7 +28,8 @@ TEST_CASE(create_and_destroy_playback_stream)
     {
         auto stream_result = Audio::PlaybackStream::create(Audio::OutputState::Playing, 100, [](Audio::SampleSpecification) {}, [](Span<float> buffer) -> ReadonlySpan<float> { return buffer.trim(0); });
         EXPECT_EQ(!stream_result.is_error(), has_implementation);
-        EXPECT_EQ(stream_result.value()->total_time_played(), AK::Duration::zero());
+        if (has_implementation)
+            EXPECT_EQ(stream_result.value()->total_time_played(), AK::Duration::zero());
     }
 
 #if defined(HAVE_PULSEAUDIO)


### PR DESCRIPTION
Running `ladybird.py test` on Windows currently fails with:

```
        Start 151: TestPlaybackStream
151/167 Test #151: TestPlaybackStream .............................***Exception: Illegal  2.98 sec
Running test 'create_and_destroy_playback_stream'.
VERIFICATION FAILED: has<T>() at D:\a\ladybird\ladybird\AK/Variant.h:370
Stack trace (most recent call first):
#0 0x00007ff6e6c81acf in __test_create_and_destroy_playback_stream() at D:\a\ladybird\ladybird\Tests\LibMedia\TestPlaybackStream.cpp:31
```

https://github.com/LadybirdBrowser/ladybird/pull/7095/commits/abfa0e9a0ac464b33c0b64545176b3db03ab1599 updated TestPlaybackStream with an assertion that assumes Audio::PlaybackStream::create() always succeeds, so this guards that new assertion behind an audio backend implementation existing.