### PR TITLE
Ladybird: Register signal handlers for graceful shutdown

### DIFF
--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -12,6 +12,7 @@
 #include <UI/Qt/Application.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/Settings.h>
+#include <signal.h>
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #    include <QStyleHints>
@@ -37,6 +38,12 @@ bool is_using_dark_system_theme(QWidget& widget)
     return luma <= 0.5f;
 }
 
+static void handle_signal(int signal)
+{
+    VERIFY(signal == SIGINT || signal == SIGTERM);
+    Core::EventLoop::current().quit(0);
+}
+
 }
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
@@ -45,6 +52,9 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     auto app = TRY(Ladybird::Application::create(arguments));
     WebView::BrowserProcess browser_process;
+
+    Core::EventLoop::register_signal(SIGINT, Ladybird::handle_signal);
+    Core::EventLoop::register_signal(SIGTERM, Ladybird::handle_signal);
 
     WebView::copy_default_config_files(Ladybird::Settings::the()->directory());
 


### PR DESCRIPTION
I'm fed up of being hit with "Ladybird PID file '/run/user/1000/Ladybird.pid' exists with PID 12254, but process cannot be found" if i CTRL + C on the CLI to close the browser and then launch it back up, which I often do as the options to maximize/minimize/close the application in the top right does not show on Linux Mint if the application is maximized, and with the extension rid of titles of applications, so I think this is worthy of its own PR.