### PR TITLE
LibHTTP+LibWeb: Use LibHTTP to calculate stale-while-revalidate values

### DIFF
--- a/Libraries/LibHTTP/Cache/Utilities.h
+++ b/Libraries/LibHTTP/Cache/Utilities.h
@@ -31,6 +31,7 @@ bool is_header_exempted_from_storage(StringView name);
 
 AK::Duration calculate_freshness_lifetime(u32 status_code, HeaderList const&, AK::Duration current_time_offset_for_testing = {});
 AK::Duration calculate_age(HeaderList const&, UnixDateTime request_time, UnixDateTime response_time, AK::Duration current_time_offset_for_testing = {});
+AK::Duration calculate_stale_while_revalidate_lifetime(HeaderList const&, AK::Duration freshness_lifetime);
 
 enum class CacheLifetimeStatus {
     Fresh,


### PR DESCRIPTION
No need to duplicate this in LibWeb.

In doing so, this also fixes an apparent bug for SWR handling in LibWeb. We were previously deciding if we were in the SWR lifetime with:

    stale_while_revalidate > current_age

However, the SWR lifetime is meant to be an additional time on top of the freshness lifetime:

    freshness_lifetime + stale_while_revalidate > current_age