### PR TITLE
LibWeb: Visit members of TrustedTypePolicy instead of using GC roots

### DIFF
--- a/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.cpp
+++ b/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.cpp
@@ -30,7 +30,9 @@ GC_DEFINE_ALLOCATOR(TrustedTypePolicy);
 TrustedTypePolicy::TrustedTypePolicy(JS::Realm& realm, Utf16String const& name, TrustedTypePolicyOptions const& options)
     : PlatformObject(realm)
     , m_name(name)
-    , m_options(options)
+    , m_create_html(options.create_html)
+    , m_create_script(options.create_script)
+    , m_create_script_url(options.create_script_url)
 {
 }
 
@@ -38,6 +40,14 @@ void TrustedTypePolicy::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(TrustedTypePolicy);
     Base::initialize(realm);
+}
+
+void TrustedTypePolicy::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_create_html);
+    visitor.visit(m_create_script);
+    visitor.visit(m_create_script_url);
 }
 
 Utf16String to_string(TrustedTypeName trusted_type_name)
@@ -153,13 +163,13 @@ WebIDL::ExceptionOr<JS::Value> TrustedTypePolicy::get_trusted_type_policy_value(
     GC::Ptr<WebIDL::CallbackType> function;
     switch (trusted_type_name) {
     case TrustedTypeName::TrustedHTML:
-        function = m_options.create_html;
+        function = m_create_html;
         break;
     case TrustedTypeName::TrustedScript:
-        function = m_options.create_script;
+        function = m_create_script;
         break;
     case TrustedTypeName::TrustedScriptURL:
-        function = m_options.create_script_url;
+        function = m_create_script_url;
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.h
+++ b/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.h
@@ -56,6 +56,8 @@ public:
 
     WebIDL::ExceptionOr<JS::Value> get_trusted_type_policy_value(TrustedTypeName, Utf16String const& value, GC::RootVector<JS::Value> const& values, ThrowIfCallbackMissing throw_if_missing);
 
+    virtual void visit_edges(Visitor&) override;
+
 private:
     explicit TrustedTypePolicy(JS::Realm&, Utf16String const&, TrustedTypePolicyOptions const&);
     virtual void initialize(JS::Realm&) override;
@@ -63,7 +65,9 @@ private:
     TrustedTypesVariants create_a_trusted_type(TrustedTypeName, Utf16String const&, GC::RootVector<JS::Value> const& values);
 
     Utf16String const m_name;
-    TrustedTypePolicyOptions const m_options;
+    GC::Ptr<WebIDL::CallbackType> const m_create_html;
+    GC::Ptr<WebIDL::CallbackType> const m_create_script;
+    GC::Ptr<WebIDL::CallbackType> const m_create_script_url;
 };
 
 WebIDL::ExceptionOr<Optional<TrustedType>> process_value_with_a_default_policy(TrustedTypeName, JS::Object&, Variant<GC::Root<TrustedHTML>, GC::Root<TrustedScript>, GC::Root<TrustedScriptURL>, Utf16String>, InjectionSink);


### PR DESCRIPTION
GC roots owned by GC-visited objects always result in leaks.