### PR TITLE
LibWeb/CSS: Allow a slash in border-radius longhand properties

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1789,12 +1789,24 @@ RefPtr<StyleValue const> Parser::parse_border_image_slice_value(TokenStream<Comp
         fill);
 }
 
+// https://drafts.csswg.org/css-borders-4/#typedef-border-radius
 RefPtr<StyleValue const> Parser::parse_border_radius_value(TokenStream<ComponentValue>& tokens)
 {
+    // <border-radius> = <slash-separated-border-radius-syntax> | <legacy-border-radius-syntax>
+    // <slash-separated-border-radius-syntax> = <length-percentage [0,∞]> [ / <length-percentage [0,∞]> ]?
+    // <legacy-border-radius-syntax> = <length-percentage [0,∞]>{1,2}
+    // NB: So, 1 or 2 `<length-percentage>`s, optionally separated with a `/`.
+
     auto transaction = tokens.begin_transaction();
     tokens.discard_whitespace();
     auto horizontal = parse_length_percentage_value(tokens);
     tokens.discard_whitespace();
+
+    if (tokens.next_token().is_delim('/')) {
+        tokens.discard_a_token(); // '/'
+        tokens.discard_whitespace();
+    }
+
     auto vertical = parse_length_percentage_value(tokens);
     if (horizontal && vertical) {
         transaction.commit();

--- a/Tests/LibWeb/Ref/expected/css/border-radius-slash-syntax-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/border-radius-slash-syntax-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    #target {
+        width: 100px;
+        height: 100px;
+        background-color: black;
+        border-top-left-radius: 20px 40px;
+    }
+</style>
+<div id="target"></div>

--- a/Tests/LibWeb/Ref/input/css/border-radius-slash-syntax.html
+++ b/Tests/LibWeb/Ref/input/css/border-radius-slash-syntax.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/border-radius-slash-syntax-ref.html" />
+<style>
+    #target {
+        width: 100px;
+        height: 100px;
+        background-color: black;
+        border-top-left-radius: 20px / 40px;
+    }
+</style>
+<div id="target"></div>


### PR DESCRIPTION
`border-radius` requires a slash between the x/y components, but the longhands like `border-top-left-radius` don't allow it. This spec change allows authors to put a slash there for consistency.

Corresponds to:
https://github.com/w3c/csswg-drafts/commit/e938d7d705e7cead7b1d8cb12ba07dfa475bc71e