### PR TITLE
LibJS: Add dedicated bytecode instruction for x|0 (ToInt32)

### DIFF
--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -268,6 +268,11 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> BinaryExpression::gener
         generator.emit<Bytecode::Op::BitwiseAnd>(dst, lhs, rhs);
         break;
     case BinaryOp::BitwiseOr:
+        if (rhs.operand().is_constant() && generator.get_constant(rhs).is_int32() && generator.get_constant(rhs).as_i32() == 0) {
+            // OPTIMIZATION: x | 0 == ToInt32(x)
+            generator.emit<Bytecode::Op::ToInt32>(dst, lhs);
+            break;
+        }
         generator.emit<Bytecode::Op::BitwiseOr>(dst, lhs, rhs);
         break;
     case BinaryOp::BitwiseXor:

--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -52,6 +52,11 @@ op BitwiseOr < Instruction
     m_rhs: Operand
 endop
 
+op ToInt32 < Instruction
+    m_dst: Operand
+    m_value: Operand
+endop
+
 op BitwiseXor < Instruction
     m_dst: Operand
     m_lhs: Operand

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -470,6 +470,7 @@ void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(BitwiseAnd);
             HANDLE_INSTRUCTION(BitwiseNot);
             HANDLE_INSTRUCTION(BitwiseOr);
+            HANDLE_INSTRUCTION(ToInt32);
             HANDLE_INSTRUCTION(BitwiseXor);
             HANDLE_INSTRUCTION(Call);
             HANDLE_INSTRUCTION(CallBuiltin);
@@ -1615,6 +1616,18 @@ ThrowCompletionOr<void> BitwiseAnd::execute_impl(Bytecode::Interpreter& interpre
         return {};
     }
     interpreter.set(m_dst, TRY(bitwise_and(vm, lhs, rhs)));
+    return {};
+}
+
+ThrowCompletionOr<void> ToInt32::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& vm = interpreter.vm();
+    auto const value = interpreter.get(m_value);
+    if (value.is_int32()) [[likely]] {
+        interpreter.set(m_dst, value);
+        return {};
+    }
+    interpreter.set(m_dst, Value(TRY(value.to_i32(vm))));
     return {};
 }
 


### PR DESCRIPTION
This operation is a very common technique to force a value to become a 32-bit integer.

JetStream has quite a lot of this. Linux results look good:

```
Suite       Test                                      Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                                 0.995  1.135 ± 1.132 … 1.138              1.140 ± 1.139 … 1.142
Kraken      audio-beat-detection.js                     0.988  0.775 ± 0.775 … 0.776              0.785 ± 0.769 … 0.801
Kraken      audio-dft.js                                0.999  0.515 ± 0.512 … 0.518              0.516 ± 0.514 … 0.517
Kraken      audio-fft.js                                0.998  0.668 ± 0.667 … 0.669              0.670 ± 0.664 … 0.675
Kraken      audio-oscillator.js                         1.001  0.627 ± 0.627 … 0.628              0.627 ± 0.625 … 0.629
Kraken      imaging-darkroom.js                         1.002  0.863 ± 0.862 … 0.865              0.861 ± 0.861 … 0.862
Kraken      imaging-desaturate.js                       0.998  1.140 ± 1.139 … 1.141              1.142 ± 1.133 … 1.151
Kraken      imaging-gaussian-blur.js                    1.004  4.128 ± 4.121 … 4.134              4.109 ± 4.101 … 4.118
Kraken      json-parse-financial.js                     0.976  0.066 ± 0.066 … 0.066              0.067 ± 0.067 … 0.068
Kraken      json-stringify-tinderbox.js                 1.018  0.075 ± 0.074 … 0.075              0.073 ± 0.073 … 0.074
Kraken      stanford-crypto-aes.js                      1.008  0.281 ± 0.281 … 0.282              0.279 ± 0.278 … 0.280
Kraken      stanford-crypto-ccm.js                      1.011  0.305 ± 0.301 … 0.309              0.301 ± 0.298 … 0.305
Kraken      stanford-crypto-pbkdf2.js                   1.001  0.516 ± 0.510 … 0.522              0.515 ± 0.510 … 0.520
Kraken      stanford-crypto-sha256-iterative.js         0.987  0.193 ± 0.191 … 0.196              0.196 ± 0.196 … 0.196
Octane      box2d.js                                    0.998  5371.000 ± 5363.000 … 5379.000     5358.000 ± 5326.000 … 5390.000
Octane      code-load.js                                1.003  11268.500 ± 11237.000 … 11300.000  11299.500 ± 11276.000 … 11323.000
Octane      crypto.js                                   1.043  2141.000 ± 2124.000 … 2158.000     2232.000 ± 2218.000 … 2246.000
Octane      deltablue.js                                0.98   1059.500 ± 1059.000 … 1060.000     1038.000 ± 1019.000 … 1057.000
Octane      earley-boyer.js                             1.001  2523.500 ± 2510.000 … 2537.000     2526.000 ± 2513.000 … 2539.000
Octane      gbemu.js                                    0.979  10291.000 ± 10160.000 … 10422.000  10079.500 ± 9809.000 … 10350.000
Octane      mandreel.js                                 1.016  8815.500 ± 8808.000 … 8823.000     8958.500 ± 8918.000 … 8999.000
Octane      navier-stokes.js                            1.01   3485.500 ± 3465.000 … 3506.000     3521.000 ± 3519.000 … 3523.000
Octane      pdfjs.js                                    1.015  4260.000 ± 4212.000 … 4308.000     4325.000 ± 4301.000 … 4349.000
Octane      raytrace.js                                 1.006  1963.500 ± 1957.000 … 1970.000     1974.500 ± 1973.000 … 1976.000
Octane      regexp.js                                   1      154.000 ± 154.000 … 154.000        154.000 ± 154.000 … 154.000
Octane      richards.js                                 1.008  1181.500 ± 1165.000 … 1198.000     1190.500 ± 1178.000 … 1203.000
Octane      splay.js                                    0.998  1718.500 ± 1709.000 … 1728.000     1714.500 ± 1711.000 … 1718.000
Octane      typescript.js                               1.013  11536.000 ± 11440.000 … 11632.000  11684.000 ± 11653.000 … 11715.000
Octane      zlib.js                                     1.065  3425.500 ± 3350.000 … 3501.000     3648.000 ± 3631.000 … 3665.000
JetStream   bigfib.cpp.js                               1.231  9.698 ± 8.231 … 11.165             7.879 ± 7.757 … 8.001
JetStream   cdjs.js                                     1.008  3.548 ± 3.546 … 3.550              3.520 ± 3.512 … 3.527
JetStream   container.cpp.js                            1.108  33.805 ± 33.787 … 33.823           30.498 ± 30.468 … 30.528
JetStream   dry.c.js                                    1.008  18.335 ± 18.239 … 18.430           18.188 ± 17.815 … 18.560
JetStream   float-mm.c.js                               0.99   17.630 ± 17.566 … 17.695           17.806 ± 17.781 … 17.830
JetStream   gcc-loops.cpp.js                            1.074  112.503 ± 111.407 … 113.599        104.712 ± 102.598 … 106.826
JetStream   hash-map.js                                 1.018  1.488 ± 1.481 … 1.496              1.463 ± 1.459 … 1.466
JetStream   n-body.c.js                                 1.017  28.886 ± 28.722 … 29.051           28.393 ± 28.000 … 28.785
JetStream   quicksort.c.js                              1.072  4.793 ± 4.744 … 4.842              4.472 ± 4.436 … 4.509
JetStream   towers.c.js                                 1.088  6.686 ± 6.560 … 6.811              6.143 ± 6.045 … 6.241
JetStream3  js-tokens.js                                1.013  0.734 ± 0.728 … 0.741              0.725 ± 0.724 … 0.726
JetStream3  lazy-collections.js                         1.011  1.481 ± 1.481 … 1.482              1.465 ± 1.465 … 1.466
JetStream3  raytrace-private-class-fields.js            0.993  4.832 ± 4.828 … 4.835              4.867 ± 4.851 … 4.882
JetStream3  raytrace-public-class-fields.js             0.995  3.941 ± 3.915 … 3.966              3.960 ± 3.953 … 3.968
JetStream3  sync-file-system.js                         0.998  1.872 ± 1.871 … 1.873              1.876 ± 1.872 … 1.880
MicroBench  array-destructuring-assignment-rest.js      1.023  0.434 ± 0.429 … 0.439              0.424 ± 0.423 … 0.425
MicroBench  array-destructuring-assignment.js           0.987  4.727 ± 4.715 … 4.738              4.788 ± 4.764 … 4.812
MicroBench  array-prototype-map.js                      0.969  1.397 ± 1.390 … 1.405              1.442 ± 1.430 … 1.455
MicroBench  array-prototype-shift.js                    1.074  0.007 ± 0.007 … 0.007              0.007 ± 0.007 … 0.007
MicroBench  bound-call-00-args.js                       1.016  1.555 ± 1.503 … 1.608              1.530 ± 1.524 … 1.536
MicroBench  bound-call-04-args.js                       0.996  1.607 ± 1.595 … 1.619              1.614 ± 1.610 … 1.617
MicroBench  bound-call-16-args.js                       0.944  1.800 ± 1.788 … 1.813              1.908 ± 1.824 … 1.992
MicroBench  call-00-args.js                             0.966  1.216 ± 1.209 … 1.223              1.259 ± 1.226 … 1.292
MicroBench  call-01-args.js                             0.977  1.244 ± 1.236 … 1.252              1.273 ± 1.254 … 1.292
MicroBench  call-02-args.js                             0.973  1.238 ± 1.235 … 1.241              1.273 ± 1.269 … 1.277
MicroBench  call-03-args.js                             1.007  1.253 ± 1.252 … 1.254              1.244 ± 1.243 … 1.245
MicroBench  call-04-args.js                             1.005  1.257 ± 1.255 … 1.258              1.250 ± 1.249 … 1.251
MicroBench  call-16-args.js                             1.016  1.389 ± 1.378 … 1.400              1.368 ± 1.364 … 1.372
MicroBench  call-32-args.js                             0.996  1.623 ± 1.617 … 1.628              1.629 ± 1.624 … 1.633
MicroBench  deep-call-stack.js                          0.917  0.890 ± 0.817 … 0.963              0.970 ± 0.861 … 1.079
MicroBench  for-in-indexed-properties.js                1.007  1.145 ± 1.141 … 1.149              1.137 ± 1.136 … 1.138
MicroBench  for-in-named-properties.js                  0.955  1.263 ± 1.261 … 1.265              1.323 ± 1.251 … 1.394
MicroBench  for-of.js                                   1.057  0.476 ± 0.449 … 0.502              0.450 ± 0.447 … 0.453
MicroBench  object-keys.js                              0.99   1.379 ± 1.374 … 1.384              1.393 ± 1.388 … 1.397
MicroBench  object-set-with-rope-strings.js             0.979  0.750 ± 0.749 … 0.752              0.766 ± 0.745 … 0.788
MicroBench  pic-add-own.js                              0.998  0.931 ± 0.931 … 0.931              0.933 ± 0.927 … 0.939
MicroBench  pic-get-own.js                              1.041  1.290 ± 1.273 … 1.306              1.239 ± 1.234 … 1.244
MicroBench  pic-get-pchain.js                           0.986  1.274 ± 1.267 … 1.281              1.292 ± 1.267 … 1.318
MicroBench  pic-put-own.js                              0.985  1.386 ± 1.385 … 1.386              1.407 ± 1.401 … 1.413
MicroBench  pic-put-pchain.js                           0.991  2.507 ± 2.501 … 2.512              2.529 ± 2.517 … 2.540
MicroBench  setter-in-prototype-chain.js                0.946  1.894 ± 1.878 … 1.910              2.001 ± 1.941 … 2.062
MicroBench  strictly-equals-object.js                   1.005  1.243 ± 1.238 … 1.248              1.236 ± 1.233 … 1.240
Kraken      Total                                       1      11.287                             11.282
Octane      Total                                       1.007  69194.500                          69703.000
JetStream   Total                                       1.064  237.372                            223.072
JetStream3  Total                                       0.997  12.860                             12.893
MicroBench  Total                                       0.986  37.174                             37.685
All Suites  Total                                       1.044  400.145                            383.171
```