### PR TITLE
CI: Add Linux arm64 build to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
             runner_labels: '["macos-15", "self-hosted"]'
 
           - os_name: 'Linux'
+            arch: 'arm64'
+            build_preset: 'Sanitizer'
+            toolchain: 'Clang'
+            clang_plugins: false
+            runner_labels: '["blacksmith-16vcpu-ubuntu-2404-arm"]'
+
+          - os_name: 'Linux'
             arch: 'x86_64'
             build_preset: 'Fuzzers'
             toolchain: 'Clang'


### PR DESCRIPTION
Duplicate of Jelle's PR #7146, to test some possible solutions.

We already ran the distribution preset build in our nightly action, and this adds it to the jobs we run for PRs as well.