### PR TITLE
LibWeb: Use weak pointer for cache in HTMLCollection

### DIFF
--- a/Libraries/LibWeb/DOM/HTMLCollection.h
+++ b/Libraries/LibWeb/DOM/HTMLCollection.h
@@ -60,8 +60,8 @@ private:
     void update_name_to_element_mappings_if_needed() const;
 
     mutable u64 m_cached_dom_tree_version { 0 };
-    mutable Vector<GC::Ref<Element>> m_cached_elements;
-    mutable OwnPtr<OrderedHashMap<FlyString, GC::Ref<Element>>> m_cached_name_to_element_mappings;
+    mutable Vector<GC::Weak<Element>> m_cached_elements;
+    mutable OwnPtr<OrderedHashMap<FlyString, GC::Weak<Element>>> m_cached_name_to_element_mappings;
 
     GC::Ref<ParentNode> m_root;
     Function<bool(Element const&)> m_filter;


### PR DESCRIPTION
This avoids keeping elements cached in an HTMLCollection alive longer than necessary in the following scenario:
1. The HTMLCollection cache is populated by querying it.
2. Elements that were included in the cache are removed from the DOM.
3. The cached elements are kept alive by strong references in the cache until it is updated, which might never happen.