### PR TITLE
LibWeb: Implement Navigator.maxTouchPoints

### DIFF
--- a/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Libraries/LibWeb/HTML/Navigator.cpp
@@ -129,10 +129,22 @@ GC::Ref<CredentialManagement::CredentialsContainer> Navigator::credentials()
 }
 
 // https://w3c.github.io/pointerevents/#dom-navigator-maxtouchpoints
-WebIDL::Long Navigator::max_touch_points()
+WebIDL::Long Navigator::max_touch_points() const
 {
-    dbgln("FIXME: Unimplemented Navigator.maxTouchPoints");
-    return 0;
+    // 1. Let emulated maxTouchPoints be the result of WebDriver BiDi emulated max touch points.
+    // FIXME: WebDriver BiDi is not yet implemented.
+    //        https://www.w3.org/TR/webdriver-bidi/#webdriver-bidi-emulated-max-touch-points
+
+    // 2. If emulated maxTouchPoints is not null, return emulated maxTouchPoints.
+    // FIXME: Pseudo code for when WebDriver BiDi is implemented.
+    // if (auto emulated = get_webdriver_bidi_emulated_max_touch_points(); emulated.has_value())
+    //     return emulated.value();
+
+    // 3. Return the maximum number of simultaneous touch contacts supported by the device.
+    //    In the case of devices with multiple digitizers (e.g. multiple touchscreens), the value
+    //    must be the maximum of the set of maximum supported contacts by each individual digitizer.
+    auto& window = as<HTML::Window>(HTML::relevant_global_object(*this));
+    return window.page().client().max_touch_points();
 }
 
 GC::Ref<ServiceWorker::ServiceWorkerContainer> Navigator::service_worker()

--- a/Libraries/LibWeb/HTML/Navigator.h
+++ b/Libraries/LibWeb/HTML/Navigator.h
@@ -71,7 +71,7 @@ public:
 
     GC::Ref<MediaCapabilitiesAPI::MediaCapabilities> media_capabilities();
 
-    static WebIDL::Long max_touch_points();
+    WebIDL::Long max_touch_points() const;
 
     virtual ~Navigator() override;
 

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -116,6 +116,11 @@ public:
     Geolocation::EmulatedPositionData const& emulated_position_data() const;
     void set_emulated_position_data(Geolocation::EmulatedPositionData data);
 
+    // FIXME: Implement WebDriver BiDi emulated max_touch_points. The emulated value is stored
+    //        per BiDi session with mappings for default, user contexts, and navigables - not
+    //        on the traversable. Leaving this as a placeholder until BiDi is implemented.
+    //        https://www.w3.org/TR/webdriver-bidi/#webdriver-bidi-emulated-max-touch-points
+
     void process_screenshot_requests();
     void queue_screenshot_task(Optional<UniqueNodeID> node_id)
     {

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -41,6 +41,7 @@
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
 #include <LibWeb/UIEvents/KeyCode.h>
+#include <LibWeb/WebIDL/Types.h>
 #include <LibWebView/StorageOperationError.h>
 
 namespace Web {
@@ -426,6 +427,12 @@ public:
     virtual bool is_headless() const = 0;
 
     virtual bool is_svg_page_client() const { return false; }
+
+    // https://w3c.github.io/pointerevents/#dom-navigator-maxtouchpoints
+    // FIXME: Platform clients should override this to return the actual maximum touch points
+    //        supported by the device. For devices with multiple digitizers, this should be
+    //        the maximum across all digitizers.
+    virtual WebIDL::Long max_touch_points() const { return 0; }
 
 protected:
     virtual ~PageClient() = default;

--- a/Tests/LibWeb/Text/expected/navigator-max-touch-points.txt
+++ b/Tests/LibWeb/Text/expected/navigator-max-touch-points.txt
@@ -1,0 +1,4 @@
+maxTouchPoints in navigator: true
+typeof maxTouchPoints: number
+maxTouchPoints >= 0: true
+maxTouchPoints: 0

--- a/Tests/LibWeb/Text/input/navigator-max-touch-points.html
+++ b/Tests/LibWeb/Text/input/navigator-max-touch-points.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        // Test that maxTouchPoints exists on navigator
+        println(`maxTouchPoints in navigator: ${'maxTouchPoints' in navigator}`);
+        
+        // Test that it returns a number
+        println(`typeof maxTouchPoints: ${typeof navigator.maxTouchPoints}`);
+        
+        // Test that the value is >= 0 (spec requirement)
+        println(`maxTouchPoints >= 0: ${navigator.maxTouchPoints >= 0}`);
+        
+        // The default implementation returns 0 when no emulation is set
+        println(`maxTouchPoints: ${navigator.maxTouchPoints}`);
+    });
+</script>


### PR DESCRIPTION
Hello all, I am a frontend engineer trying to learn more about the browser + love the mission + want to learn more C++. I am using LLM, but hoping things are small enough so that I understand what I'm doing. Hopefully this is helpful first PR.

---

Implement the maxTouchPoints attribute on Navigator as specified in
the W3C Pointer Events specification. The implementation queries the
PageClient for the maximum number of simultaneous touch contacts
supported by the device.

Platform clients can override PageClient::max_touch_points() to return
the actual device capability. The default implementation returns 0.

Added a FIXME for future WebDriver BiDi emulated max touch points
support, which will allow overriding the value during automation.