### PR TITLE
LibGfx: Improve Vulkan device selection logic

### DIFF
--- a/Libraries/LibGfx/VulkanContext.cpp
+++ b/Libraries/LibGfx/VulkanContext.cpp
@@ -150,7 +150,9 @@ static ErrorOr<VkDevice> create_logical_device(VkPhysicalDevice physical_device,
     create_device_info.enabledExtensionCount = device_extension_count;
     create_device_info.ppEnabledExtensionNames = device_extensions;
 
-    if (vkCreateDevice(physical_device, &create_device_info, nullptr, &device) != VK_SUCCESS) {
+    VkResult result = vkCreateDevice(physical_device, &create_device_info, nullptr, &device);
+    if (result != VK_SUCCESS) {
+        dbgln("vkCreateDevice returned {}", to_underlying(result));
         return Error::from_string_literal("vkCreateDevice failed");
     }
 


### PR DESCRIPTION
(My first PR here, please tell me if I did anything wrong.)

Ladybird was unacceptably slow on my Linux machine, and I noticed that it was caused by vkCreateDevice failing due to missing extensions. I have 2 relatively modern AMD GPUs, so I figured that they should've had all of the extensions required. Turns out it was because Ladybird was picking the wrong device; I had both the open source and the proprietary drivers installed, Ladybird picked a Vulkan device that used the proprietary driver, which did not have `VK_EXT_image_drm_format_modifier`.

This aims to prevent that from happening. Instead of blindly selecting the first device or the last discrete GPU, give each device a score, based on the device type and the extensions they support, and pick the one with the highest score. Priority is given to discrete GPUs and integrated GPUs, with discrete GPUs being the most prioritized (leaving virtual GPUs and CPUs with a lower score).

The scores I gave to the 2 extensions required for Vulkan images are arbitrary. In case Ladybird depends on more extensions later on, these scores could be adjusted and new ones could be added for better device selection.