### PR TITLE
Tests: Correct CSS bug in WPT test harness

### DIFF
--- a/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
@@ -4977,7 +4977,7 @@ table#results.assertions > tbody > tr > td:last-child {\
     width:35%;\
 }\
 \
-table#results > thead > > tr > th {\
+table#results > thead > tr > th {\
     padding:0;\
     padding-bottom:0.5em;\
     border-bottom:medium solid black;\


### PR DESCRIPTION
Corresponds to:
https://github.com/web-platform-tests/wpt/commit/ef6fcf9d74f6ce25dcc7cd08676aadf908fc825a

This really doesn't do a lot, but having the parse error show up all the time was bothering me. :sweat_smile: 