### PR TITLE
LibWeb/DOM: Use a single scroll queue for all events

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -633,8 +633,12 @@ public:
     String domain() const;
     WebIDL::ExceptionOr<void> set_domain(String const&);
 
-    auto& pending_scroll_event_targets() { return m_pending_scroll_event_targets; }
-    auto& pending_scrollend_event_targets() { return m_pending_scrollend_event_targets; }
+    struct PendingScrollEvent {
+        GC::Ref<EventTarget> event_target;
+        FlyString event_type;
+        bool operator==(PendingScrollEvent const&) const = default;
+    };
+    Vector<PendingScrollEvent>& pending_scroll_events() { return m_pending_scroll_events; }
 
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#completely-loaded
     bool is_completely_loaded() const;
@@ -1129,11 +1133,9 @@ private:
 
     HashTable<ViewportClient*> m_viewport_clients;
 
-    // https://w3c.github.io/csswg-drafts/cssom-view-1/#document-pending-scroll-event-targets
-    Vector<GC::Ref<EventTarget>> m_pending_scroll_event_targets;
-
-    // https://w3c.github.io/csswg-drafts/cssom-view-1/#document-pending-scrollend-event-targets
-    Vector<GC::Ref<EventTarget>> m_pending_scrollend_event_targets;
+    // https://drafts.csswg.org/cssom-view-1/#document-pending-scroll-events
+    // Each Document has an associated list of pending scroll events, which stores pairs of (EventTarget, DOMString), initially empty.
+    Vector<PendingScrollEvent> m_pending_scroll_events;
 
     // Used by evaluate_media_queries_and_report_changes().
     bool m_needs_media_query_evaluation { false };

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2442,20 +2442,23 @@ void perform_url_and_history_update_steps(DOM::Document& document, URL::URL new_
 void Navigable::scroll_offset_did_change()
 {
     // https://w3c.github.io/csswg-drafts/cssom-view-1/#scrolling-events
-    // Whenever a viewport gets scrolled (whether in response to user interaction or by an API), the user agent must run these steps:
+    // Whenever a viewport gets scrolled (whether in response to user interaction or by an API), the user agent must
+    // run these steps:
 
     // 1. Let doc be the viewport’s associated Document.
     auto doc = active_document();
     VERIFY(doc);
 
-    // 2. If doc is already in doc’s pending scroll event targets, abort these steps.
-    for (auto& target : doc->pending_scroll_event_targets()) {
-        if (target.ptr() == doc)
-            return;
-    }
+    // FIXME: 2. If doc is a snap container, run the steps to update scrollsnapchanging targets for doc with doc’s eventual
+    //    snap target in the block axis as newBlockTarget and doc’s eventual snap target in the inline axis as
+    //    newInlineTarget.
 
-    // 3. Append doc to doc’s pending scroll event targets.
-    doc->pending_scroll_event_targets().append(*doc);
+    // 3. If (doc, "scroll") is already in doc’s pending scroll events, abort these steps.
+    if (doc->pending_scroll_events().contains_slow(DOM::Document::PendingScrollEvent { *doc, EventNames::scroll }))
+        return;
+
+    // 4. Append (doc, "scroll") to doc’s pending scroll events.
+    doc->pending_scroll_events().append({ *doc, EventNames::scroll });
 }
 
 CSSPixelRect Navigable::to_top_level_rect(CSSPixelRect const& a_rect)

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -153,12 +153,12 @@ PaintableBox::ScrollHandled PaintableBox::set_scroll_offset(CSSPixelPoint offset
 
     GC::Ref<DOM::EventTarget> const event_target = *dom_node();
 
-    // 3. If the element is already in doc’s pending scroll event targets, abort these steps.
-    if (document.pending_scroll_event_targets().contains_slow(event_target))
+    // 3. If (element, "scroll") is already in doc’s pending scroll events, abort these steps.
+    if (document.pending_scroll_events().contains_slow(DOM::Document::PendingScrollEvent { event_target, HTML::EventNames::scroll }))
         return ScrollHandled::Yes;
 
-    // 4. Append the element to doc’s pending scroll event targets.
-    document.pending_scroll_event_targets().append(*dom_node());
+    // 4. Append (element, "scroll") to doc’s pending scroll events.
+    document.pending_scroll_events().append({ event_target, HTML::EventNames::scroll });
 
     set_needs_display(InvalidateDisplayList::No);
     return ScrollHandled::Yes;


### PR DESCRIPTION
Corresponds to:
https://github.com/w3c/csswg-drafts/commit/36f05864a6dfa6b9d87673a9c7a68abe4f3c8886 https://github.com/w3c/csswg-drafts/commit/302490c80c294d826dd678032c19f9d47af226dc https://github.com/w3c/csswg-drafts/pull/13238
https://github.com/w3c/csswg-drafts/pull/13239

The latter two are my own corrections which haven't been merged yet.