### PR TITLE
Meta: Build All_Debug macros in release mode

### DIFF
--- a/Meta/CMake/presets/CMakeBasePresets.json
+++ b/Meta/CMake/presets/CMakeBasePresets.json
@@ -65,8 +65,8 @@
       "description": "All Debug build",
       "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/alldebug",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/debug-triplets",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/release-triplets",
         "ENABLE_ALL_THE_DEBUG_MACROS": "ON"
       }
     },


### PR DESCRIPTION
Originally was building All_Debug macros in debug, but that is not ideal as debug build will build both the release and debug builds, taking longer and using a lot of disk space.

Building in release as that is enough to find the issues with all the debug macros.


See the following for discussion about 'debug' build problems

https://github.com/microsoft/vcpkg/issues/38224

I found that link inside Ladybird's own debug.cmake file:

https://github.com/LadybirdBrowser/ladybird/blob/master/Meta/CMake/vcpkg/debug-triplets/debug.cmake
