### PR TITLE
AK: Use NumericLimits instead of hardcoded limits in Duration methods

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -115,7 +115,7 @@ i64 Duration::to_truncated_milliseconds() const
     }
     if (!milliseconds.has_overflow())
         return milliseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
+    return m_seconds < 0 ? NumericLimits<i64>::min() : NumericLimits<i64>::max();
 }
 
 i64 Duration::to_truncated_microseconds() const
@@ -134,7 +134,7 @@ i64 Duration::to_truncated_microseconds() const
     }
     if (!microseconds.has_overflow())
         return microseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
+    return m_seconds < 0 ? NumericLimits<i64>::min() : NumericLimits<i64>::max();
 }
 
 i64 Duration::to_seconds() const
@@ -143,7 +143,7 @@ i64 Duration::to_seconds() const
     if (m_seconds >= 0 && m_nanoseconds) {
         Checked<i64> seconds(m_seconds);
         seconds++;
-        return seconds.has_overflow() ? 0x7fff'ffff'ffff'ffffLL : seconds.value();
+        return seconds.has_overflow() ? NumericLimits<i64>::max() : seconds.value();
     }
     return m_seconds;
 }
@@ -168,7 +168,7 @@ i64 Duration::to_milliseconds() const
     }
     if (!milliseconds.has_overflow())
         return milliseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
+    return m_seconds < 0 ? NumericLimits<i64>::min() : NumericLimits<i64>::max();
 }
 
 i64 Duration::to_microseconds() const
@@ -185,7 +185,7 @@ i64 Duration::to_microseconds() const
     }
     if (!microseconds.has_overflow())
         return microseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
+    return m_seconds < 0 ? NumericLimits<i64>::min() : NumericLimits<i64>::max();
 }
 
 i64 Duration::to_nanoseconds() const
@@ -200,7 +200,7 @@ i64 Duration::to_nanoseconds() const
     }
     if (!nanoseconds.has_overflow())
         return nanoseconds.value();
-    return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
+    return m_seconds < 0 ? NumericLimits<i64>::min() : NumericLimits<i64>::max();
 }
 
 timespec Duration::to_timespec() const


### PR DESCRIPTION
With https://github.com/LadybirdBrowser/ladybird/pull/6661, it will be possible to run the `Text/input/test-http-test-server.html` test on Windows; however, when running from the Sanitizer preset, there is 1 UBSAN and 1 ASAN error being reported which blocks us from running `test-web` in CI on Windows. This PR addresses the UBSAN error.

<details>

<summary>Before & After Demo</summary>

**NOTE:** I have a local fix for the ASAN error so you don't see it being reported in the demos below

### Before
```
>python Meta\ladybird.py run --preset Windows_Sanitizer_CI test-web -f Text\\input\\test-http-test-server.html
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers'
C:\Users\ayeteadoe\Development\ladybird\AK\Time.cpp:171:28: runtime error: negation of -9223372036854775808 cannot be represented in type 'long long'; cast to an unsigned type to negate this value to itself
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior C:\Users\ayeteadoe\Development\ladybird\AK\Time.cpp:171:28
Running 1 tests...
Done!
==========================================================
Pass: 1, Fail: 0, Skipped: 0, Timeout: 0, Crashed: 0
==========================================================
```

### After
```
>python Meta\ladybird.py run --preset Windows_Sanitizer_CI test-web -f Text\\input\\test-http-test-server.html
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers'
Running 1 tests...
Done!
==========================================================
Pass: 1, Fail: 0, Skipped: 0, Timeout: 0, Crashed: 0
==========================================================
```

</details>