### PR TITLE
LibCore: Use weak ownership in EventReceiver::deferred_invoke

### DIFF
--- a/Libraries/LibCore/EventReceiver.cpp
+++ b/Libraries/LibCore/EventReceiver.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/Badge.h>
 #include <AK/JsonObject.h>
+#include <AK/WeakPtr.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/EventReceiver.h>
@@ -60,7 +61,12 @@ void EventReceiver::stop_timer()
 
 void EventReceiver::deferred_invoke(Function<void()> invokee)
 {
-    Core::deferred_invoke([invokee = move(invokee), strong_this = NonnullRefPtr(*this)] { invokee(); });
+    Core::deferred_invoke([invokee = move(invokee), weak_this = make_weak_ptr()] {
+        auto strong_this = weak_this.strong_ref();
+        if (!strong_this)
+            return;
+        invokee();
+    });
 }
 
 void EventReceiver::dispatch_event(Core::Event& e)


### PR DESCRIPTION
With https://github.com/LadybirdBrowser/ladybird/pull/6661, it will be possible to run the `Text/input/test-http-test-server.html` test on Windows; however, when running from the Sanitizer preset, there is 1 UBSAN (fix already merged) and 1 ASAN error being reported which blocks us from running `test-web` in CI on Windows. This PR addresses the ASAN error.

<details>

<summary>Before & After Demo</summary>

### Before
```
>python Meta\ladybird.py run --preset Windows_Sanitizer_CI test-web -f Text\\input\\test-http-test-server.html
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers'
Running 1 tests...
Done!
==========================================================
Pass: 1, Fail: 0, Skipped: 0, Timeout: 0, Crashed: 0
==========================================================
=================================================================
==26972==ERROR: AddressSanitizer: heap-use-after-free on address 0x1204e6b0ca40 at pc 0x7ff9dba94149 bp 0x0007ec5ff170 sp 0x0007ec5ff1b8
READ of size 1 at 0x1204e6b0ca40 thread T0
    #0 0x7ff9dba94148 in AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>::lookup_with_hash<class `public: class AK::HashTableIterator<class AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>, class WebView::WebContentClient *, struct AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>::Bucket> __cdecl AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>::find(class WebView::WebContentClient *const &)'::`1'::<lambda_1>>(unsigned int, class `public: class AK::HashTableIterator<class AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>, class WebView::WebContentClient *, struct AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>::Bucket> __cdecl AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>::find(class WebView::WebContentClient *const &)'::`1'::<lambda_1>) const C:\Users\ayeteadoe\Development\ladybird\AK\HashTable.h:639
    #1 0x7ff9dba93c04 in AK::HashTable<WebView::WebContentClient *,AK::Traits<WebView::WebContentClient *>,0>::find C:\Users\ayeteadoe\Development\ladybird\AK\HashTable.h:426
    #2 0x7ff9dba93c04 in AK::HashTable<class WebView::WebContentClient *, struct AK::Traits<class WebView::WebContentClient *>, 0>::find(class WebView::WebContentClient *const &) C:\Users\ayeteadoe\Development\ladybird\AK\HashTable.h:433
    #3 0x7ff9dba5f95d in AK::HashTable<WebView::WebContentClient *,AK::Traits<WebView::WebContentClient *>,0>::remove C:\Users\ayeteadoe\Development\ladybird\AK\HashTable.h:484
    #4 0x7ff9dba5f95d in WebView::WebContentClient::~WebContentClient(void) C:\Users\ayeteadoe\Development\ladybird\Libraries\LibWebView\WebContentClient.cpp:44
    #5 0x7ff9dba7d735 in WebView::WebContentClient::`scalar deleting dtor'(unsigned int) C:\Users\ayeteadoe\Development\ladybird\Libraries\LibWebView\WebContentClient.cpp:43
    #6 0x7ffa3edf2a68 in AK::AtomicRefCounted<Core::EventReceiver>::unref C:\Users\ayeteadoe\Development\ladybird\AK\AtomicRefCounted.h:76
    #7 0x7ffa3edf2a68 in AK::unref_if_not_null C:\Users\ayeteadoe\Development\ladybird\AK\NonnullRefPtr.h:32
    #8 0x7ffa3edf2a68 in AK::NonnullRefPtr<Core::EventReceiver>::~NonnullRefPtr C:\Users\ayeteadoe\Development\ladybird\AK\NonnullRefPtr.h:97
    #9 0x7ffa3edf2a68 in Core::EventReceiver::deferred_invoke::<lambda_0>::~`lambda at C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\EventReceiver.cpp:63:27' C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\EventReceiver.cpp:63
    #10 0x7ffa3edf3019 in AK::Function<void ()>::CallableWrapper<`lambda at C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\EventReceiver.cpp:63:27'>::~CallableWrapper C:\Users\ayeteadoe\Development\ladybird\AK\Function.h:236
    #11 0x7ffa3edf3019 in AK::Function<void ()>::CallableWrapper<`lambda at C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\EventReceiver.cpp:63:27'>::~CallableWrapper C:\Users\ayeteadoe\Development\ladybird\AK\Function.h:229
    #12 0x7ffa3edf13a8 in AK::Function<(void)>::clear(bool) C:\Users\ayeteadoe\Development\ladybird\AK\Function.h:301
    #13 0x7ffa3ee27c95 in AK::Function<void ()>::~Function C:\Users\ayeteadoe\Development\ladybird\AK\Function.h:100
    #14 0x7ffa3ee27c95 in Core::ThreadEventQueue::Private::QueuedEvent::~QueuedEvent C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\ThreadEventQueue.cpp:36
    #15 0x7ffa3ee27c95 in AK::Vector<struct Core::ThreadEventQueue::Private::QueuedEvent, 0, 0>::clear_with_capacity(void) C:\Users\ayeteadoe\Development\ladybird\AK\Vector.h:485
    #16 0x7ffa3ee23fdc in AK::Vector<Core::ThreadEventQueue::Private::QueuedEvent,0,0>::clear C:\Users\ayeteadoe\Development\ladybird\AK\Vector.h:474
    #17 0x7ffa3ee23fdc in AK::Vector<Core::ThreadEventQueue::Private::QueuedEvent,0,0>::~Vector C:\Users\ayeteadoe\Development\ladybird\AK\Vector.h:134
    #18 0x7ffa3ee23fdc in Core::ThreadEventQueue::Private::~Private C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\ThreadEventQueue.cpp:18
    #19 0x7ffa3ee23fdc in AK::DefaultDelete<struct Core::ThreadEventQueue::Private>::operator()(struct Core::ThreadEventQueue::Private *) C:\Users\ayeteadoe\Development\ladybird\AK\DefaultDelete.h:17
    #20 0x7ffa3ee2127e in AK::OwnPtr<Core::ThreadEventQueue::Private,AK::DefaultDelete<Core::ThreadEventQueue::Private> >::clear C:\Users\ayeteadoe\Development\ladybird\AK\OwnPtr.h:110
    #21 0x7ffa3ee2127e in AK::OwnPtr<Core::ThreadEventQueue::Private,AK::DefaultDelete<Core::ThreadEventQueue::Private> >::~OwnPtr C:\Users\ayeteadoe\Development\ladybird\AK\OwnPtr.h:45
    #22 0x7ffa3ee2127e in Core::ThreadEventQueue::~ThreadEventQueue(void) C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\ThreadEventQueue.cpp:73
    #23 0x7ffa3ee23c94 in Core::ThreadEventQueue::current::<lambda_0>::operator()::<lambda_1>::operator() C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\ThreadEventQueue.cpp:56
    #24 0x7ffa3ee23c94 in Core::ThreadEventQueue::current::<lambda_0>::operator()::<lambda_1>::__invoke C:\Users\ayeteadoe\Development\ladybird\Libraries\LibCore\ThreadEventQueue.cpp:54
    #25 0x7ffa87ea13f1  (C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\bin\pthreadVC3.dll+0x1800013f1)
    #26 0x7ffa87ea8ca2  (C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\bin\pthreadVC3.dll+0x180008ca2)
    #27 0x7ffa87ea1037  (C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\bin\pthreadVC3.dll+0x180001037)
    #28 0x7ffa87ea9ef5  (C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers\bin\pthreadVC3.dll+0x180009ef5)
    #29 0x7ffabd81f86d  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18015f86d)
    #30 0x7ffabd6cbcad  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000bcad)
    #31 0x7ffabd74d4ae  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008d4ae)
    #32 0x7ffabd74c67d  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c67d)
    #33 0x7ffabc7318aa  (C:\WINDOWS\System32\KERNEL32.DLL+0x1800418aa)
    #34 0x7ffabb030092  (C:\WINDOWS\System32\ucrtbase.dll+0x1800a0092)
    #35 0x7ff7d1416c0a in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:295
    #36 0x7ffabc71e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #37 0x7ffabd74c53b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c53b)
```

### After
```
>python Meta\ladybird.py run --preset Windows_Sanitizer_CI test-web -f Text\\input\\test-http-test-server.html
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\sanitizers'
Running 1 tests...
Done!
==========================================================
Pass: 1, Fail: 0, Skipped: 0, Timeout: 0, Crashed: 0
==========================================================
```

</details>