### PR TITLE
Meta: Set SSL_CERT_DIR in Flatpak manifest

### DIFF
--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -15,7 +15,8 @@
     "--socket=wayland",
     "--socket=fallback-x11",
     "--socket=pulseaudio",
-    "--socket=session-bus"
+    "--socket=session-bus",
+    "--env=SSL_CERT_DIR=/etc/ssl/certs"
   ],
   "cleanup": [
     "/sbin",


### PR DESCRIPTION
In #6406 the Flatpak build is fixed and linting is added. As part of the changes the openssl dependency is now built from source, but at runtime the certificates cannot be found.

This PR sets the `SSL_CERT_DIR` environment variable in the Flatpak sandbox, solving the certificate issue.