### PR TITLE
LibHTTP+LibWeb: Store the in-memory HTTP cache without JS realms 

### DIFF
--- a/Libraries/LibHTTP/CMakeLists.txt
+++ b/Libraries/LibHTTP/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     Cache/CacheEntry.cpp
     Cache/CacheIndex.cpp
     Cache/DiskCache.cpp
+    Cache/MemoryCache.cpp
     Cache/Utilities.cpp
     Header.cpp
     HeaderList.cpp

--- a/Libraries/LibHTTP/Cache/MemoryCache.cpp
+++ b/Libraries/LibHTTP/Cache/MemoryCache.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <LibHTTP/Cache/MemoryCache.h>
+#include <LibHTTP/Cache/Utilities.h>
+
+namespace HTTP {
+
+NonnullRefPtr<MemoryCache> MemoryCache::create()
+{
+    return adopt_ref(*new MemoryCache());
+}
+
+// https://httpwg.org/specs/rfc9111.html#constructing.responses.from.caches
+Optional<MemoryCache::Entry const&> MemoryCache::open_entry(URL::URL const& url, StringView method, HeaderList const& request_headers) const
+{
+    // When presented with a request, a cache MUST NOT reuse a stored response unless:
+    // - the presented target URI (Section 7.1 of [HTTP]) and that of the stored response match, and
+    // - the request method associated with the stored response allows it to be used for the presented request, and
+    auto serialized_url = serialize_url_for_cache_storage(url);
+    auto cache_key = create_cache_key(serialized_url, method);
+
+    auto cache_entry = m_complete_entries.get(cache_key);
+    if (!cache_entry.has_value()) {
+        dbgln_if(HTTP_MEMORY_CACHE_DEBUG, "\033[31;1mHTTP CACHE MISS!\033[0m {}", url);
+        return {};
+    }
+
+    // FIXME: - request header fields nominated by the stored response (if any) match those presented (see Section 4.1), and
+    (void)request_headers;
+
+    // FIXME: - the stored response does not contain the no-cache directive (Section 5.2.2.4), unless it is successfully validated (Section 4.3), and
+
+    // FIXME: - the stored response is one of the following:
+    //          + fresh (see Section 4.2), or
+    //          + allowed to be served stale (see Section 4.2.4), or
+    //          + successfully validated (see Section 4.3).
+
+    dbgln_if(HTTP_MEMORY_CACHE_DEBUG, "\033[32;1mHTTP CACHE HIT!\033[0m {}", url);
+    return cache_entry;
+}
+
+void MemoryCache::create_entry(URL::URL const& url, StringView method, u32 status_code, ByteString reason_phrase, HeaderList const& response_headers)
+{
+    if (!is_cacheable(method))
+        return;
+    if (!is_cacheable(status_code, response_headers))
+        return;
+
+    auto serialized_url = serialize_url_for_cache_storage(url);
+    auto cache_key = create_cache_key(serialized_url, method);
+
+    auto response_headers_copy = HeaderList::create();
+    store_header_and_trailer_fields(response_headers_copy, response_headers);
+
+    Entry cache_entry {
+        .status_code = status_code,
+        .reason_phrase = move(reason_phrase),
+        .response_headers = move(response_headers_copy),
+        .response_body = {},
+    };
+
+    m_pending_entries.set(cache_key, move(cache_entry));
+}
+
+void MemoryCache::finalize_entry(URL::URL const& url, StringView method, ByteBuffer response_body)
+{
+    auto serialized_url = serialize_url_for_cache_storage(url);
+    auto cache_key = create_cache_key(serialized_url, method);
+
+    if (auto cache_entry = m_pending_entries.take(cache_key); cache_entry.has_value()) {
+        cache_entry->response_body = move(response_body);
+        m_complete_entries.set(cache_key, cache_entry.release_value());
+    }
+}
+
+}

--- a/Libraries/LibHTTP/Cache/MemoryCache.h
+++ b/Libraries/LibHTTP/Cache/MemoryCache.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <AK/HashMap.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <AK/String.h>
+#include <LibHTTP/Forward.h>
+#include <LibURL/URL.h>
+
+namespace HTTP {
+
+class MemoryCache : public RefCounted<MemoryCache> {
+public:
+    struct Entry {
+        u32 status_code { 0 };
+        ByteString reason_phrase;
+
+        NonnullRefPtr<HeaderList> response_headers;
+        ByteBuffer response_body;
+    };
+
+    static NonnullRefPtr<MemoryCache> create();
+
+    Optional<Entry const&> open_entry(URL::URL const&, StringView method, HeaderList const& request_headers) const;
+
+    void create_entry(URL::URL const&, StringView method, u32 status_code, ByteString reason_phrase, HeaderList const& response_headers);
+    void finalize_entry(URL::URL const&, StringView method, ByteBuffer response_body);
+
+private:
+    HashMap<u64, Entry> m_pending_entries;
+    HashMap<u64, Entry> m_complete_entries;
+};
+
+}

--- a/Libraries/LibHTTP/Forward.h
+++ b/Libraries/LibHTTP/Forward.h
@@ -17,6 +17,7 @@ class DiskCache;
 class HeaderList;
 class HttpRequest;
 class HttpResponse;
+class MemoryCache;
 
 struct Header;
 

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
@@ -9,6 +9,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <LibGC/CellAllocator.h>
+#include <LibHTTP/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Forward.h>
 
@@ -31,7 +32,7 @@ public:
     void handle_network_bytes(ReadonlyBytes, NetworkState);
 
 private:
-    FetchedDataReceiver(GC::Ref<Infrastructure::FetchParams const>, GC::Ref<Streams::ReadableStream>);
+    FetchedDataReceiver(GC::Ref<Infrastructure::FetchParams const>, GC::Ref<Streams::ReadableStream>, RefPtr<HTTP::MemoryCache>);
 
     virtual void visit_edges(Visitor& visitor) override;
 
@@ -44,6 +45,8 @@ private:
     GC::Ref<Infrastructure::FetchParams const> m_fetch_params;
     GC::Ref<Streams::ReadableStream> m_stream;
     GC::Ptr<WebIDL::Promise> m_pending_promise;
+
+    RefPtr<HTTP::MemoryCache> m_http_cache;
 
     ByteBuffer m_buffer;
     size_t m_pulled_bytes { 0 };

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -8,7 +8,9 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/RefPtr.h>
 #include <LibGC/Ptr.h>
+#include <LibHTTP/Forward.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -47,7 +49,7 @@ GC::Ref<PendingResponse> scheme_fetch(JS::Realm&, Infrastructure::FetchParams co
 GC::Ref<PendingResponse> http_fetch(JS::Realm&, Infrastructure::FetchParams const&, MakeCORSPreflight make_cors_preflight = MakeCORSPreflight::No);
 GC::Ptr<PendingResponse> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 GC::Ref<PendingResponse> http_network_or_cache_fetch(JS::Realm&, Infrastructure::FetchParams const&, IsAuthenticationFetch is_authentication_fetch = IsAuthenticationFetch::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
-GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
+GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, IncludeCredentials include_credentials = IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No, RefPtr<HTTP::MemoryCache> = {});
 GC::Ref<PendingResponse> cors_preflight_fetch(JS::Realm&, Infrastructure::Request&);
 void set_sec_fetch_dest_header(Infrastructure::Request&);
 void set_sec_fetch_mode_header(Infrastructure::Request&);


### PR DESCRIPTION
The in-memory HTTP Fetch cache currently keeps the realm which created each cache entry alive indefinitely. This patch migrates this cache to LibHTTP, to ensure it is completely unaware of any JS objects.

Now that we are not interacting with Fetch response objects, we can no longer use Streams infrastructure to pipe the response body into the Fetch response. Fetch also ultimately creates the cache response once the HTTP response headers have arrived. So the LibHTTP cache will hold entries in a pending list until we have received the entire response body. Then it is moved to a completed list and may be used thereafter.