### PR TITLE
AK: Rename CaseInsensitiveStringTraits to CaseInsensitiveASCIIStringTraits

### DIFF
--- a/AK/ByteString.h
+++ b/AK/ByteString.h
@@ -317,8 +317,7 @@ struct Traits<ByteString> : public DefaultTraits<ByteString> {
     static unsigned hash(ByteString const& s) { return s.impl()->hash(); }
 };
 
-// FIXME: Rename this to indicate that it's about ASCII-only case insensitivity.
-struct CaseInsensitiveStringTraits : public Traits<ByteString> {
+struct CaseInsensitiveASCIIStringTraits : public Traits<ByteString> {
     static unsigned hash(ByteString const& s) { return s.impl()->case_insensitive_hash(); }
     static bool equals(ByteString const& a, ByteString const& b) { return a.equals_ignoring_ascii_case(b); }
 };
@@ -328,6 +327,6 @@ ByteString escape_html_entities(StringView html);
 }
 
 #if USING_AK_GLOBALLY
-using AK::CaseInsensitiveStringTraits;
+using AK::CaseInsensitiveASCIIStringTraits;
 using AK::escape_html_entities;
 #endif

--- a/Libraries/LibHTTP/Header.cpp
+++ b/Libraries/LibHTTP/Header.cpp
@@ -216,7 +216,7 @@ Vector<String> get_decode_and_split_header_value(StringView value)
 Vector<ByteString> convert_header_names_to_a_sorted_lowercase_set(ReadonlySpan<ByteString> header_names)
 {
     // 1. Let headerNamesSet be a new ordered set.
-    HashTable<StringView, CaseInsensitiveStringTraits> header_names_seen;
+    HashTable<StringView, CaseInsensitiveASCIIStringTraits> header_names_seen;
     Vector<ByteString> header_names_set;
 
     // 2. For each name of headerNames, append the result of byte-lowercasing name to headerNamesSet.

--- a/Libraries/LibHTTP/HeaderList.cpp
+++ b/Libraries/LibHTTP/HeaderList.cpp
@@ -259,7 +259,7 @@ Variant<Empty, u64, HeaderList::ExtractLengthFailure> HeaderList::extract_length
 // Non-standard
 Vector<ByteString> HeaderList::unique_names() const
 {
-    HashTable<StringView, CaseInsensitiveStringTraits> header_names_seen;
+    HashTable<StringView, CaseInsensitiveASCIIStringTraits> header_names_seen;
     Vector<ByteString> header_names;
 
     for (auto const& header : m_headers) {

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -142,7 +142,7 @@ TEST_CASE(take_all_matching)
 
 TEST_CASE(case_insensitive)
 {
-    HashMap<ByteString, int, CaseInsensitiveStringTraits> casemap;
+    HashMap<ByteString, int, CaseInsensitiveASCIIStringTraits> casemap;
     EXPECT_EQ(ByteString("nickserv").to_lowercase(), ByteString("NickServ").to_lowercase());
     EXPECT_EQ(casemap.set("nickserv", 3), AK::HashSetResult::InsertedNewEntry);
     EXPECT_EQ(casemap.set("NickServ", 3), AK::HashSetResult::ReplacedExistingEntry);

--- a/Tests/AK/TestHashTable.cpp
+++ b/Tests/AK/TestHashTable.cpp
@@ -165,7 +165,7 @@ TEST_CASE(take_all_matching)
 
 TEST_CASE(case_insensitive)
 {
-    HashTable<ByteString, CaseInsensitiveStringTraits> casetable;
+    HashTable<ByteString, CaseInsensitiveASCIIStringTraits> casetable;
     EXPECT_EQ(ByteString("nickserv").to_lowercase(), ByteString("NickServ").to_lowercase());
     EXPECT_EQ(casetable.set("nickserv"), AK::HashSetResult::InsertedNewEntry);
     EXPECT_EQ(casetable.set("NickServ"), AK::HashSetResult::ReplacedExistingEntry);


### PR DESCRIPTION
This change indicates that these traits are about ASCII-only insensitivity.