### PR TITLE
Meta+Tests: Enforce test concurrency limit via environment variable

### DIFF
--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -147,7 +147,7 @@ def main():
     elif args.command == "test":
         build_dir = configure_main(platform, args.preset, args.cc, args.cxx)
         build_main(build_dir, args.jobs)
-        test_main(build_dir, args.preset, args.pattern)
+        test_main(build_dir, args.preset, args.jobs, args.pattern)
     elif args.command == "run":
         if args.preset == "Sanitizer":
             # FIXME: Find some way to centralize these b/w CMakePresets.json, CI files, Documentation and here.
@@ -352,7 +352,7 @@ def build_main(build_dir: Path, jobs: Optional[str], target: Optional[str] = Non
     run_command(build_args, exit_on_failure=True)
 
 
-def test_main(build_dir: Path, preset: str, pattern: Optional[str]):
+def test_main(build_dir: Path, preset: str, jobs: Optional[str], pattern: Optional[str]):
     test_args = [
         "ctest",
         "--preset",
@@ -361,6 +361,12 @@ def test_main(build_dir: Path, preset: str, pattern: Optional[str]):
         "--test-dir",
         str(build_dir),
     ]
+
+    if not jobs:
+        jobs = os.environ.get("MAKEJOBS", None)
+    if jobs:
+        test_args.extend(["-j", jobs])
+        os.environ["LADYBIRD_TEST_CONCURRENCY"] = jobs
 
     if pattern:
         test_args.extend(["-R", pattern])

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -595,6 +595,15 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         return Error::from_string_literal("No tests found matching filter");
     }
 
+    // CTest cannot forward the -j flag, so look for the bridge variable set by ladybird.py
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
+    if (char* env_concurrency = getenv("LADYBIRD_TEST_CONCURRENCY")) {
+        if (auto val = StringView { env_concurrency, strlen(env_concurrency) }.to_number<size_t>(); val.has_value()) {
+            app.test_concurrency = val.value();
+            outln("Forcing concurrency to {} via LADYBIRD_TEST_CONCURRENCY", app.test_concurrency);
+        }
+    }
+
     auto concurrency = min(app.test_concurrency, tests.size());
     size_t loaded_web_views = 0;
 


### PR DESCRIPTION
Currently, running `./Meta/ladybird.py test` defaults to spawning WebContent processes equal to the system core count. On systems with 8GB RAM, this leads to immediate OOM/freezing as 4-8 processes launch simultaneously, even if the job flag is specified. 

This PR updates the runner to propagate the `-j` argument to the underlying `test-web` binary (via environment variable), allowing users to limit concurrency (e.g., `-j 1`) and run the suite safely on constrained hardware. 

Fixes #7216 