### PR TITLE
Tests: Recycle WebContent processes to prevent memory exhaustion

### DIFF
--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -60,4 +60,10 @@ void TestWebView::on_test_complete(TestCompletion completion)
     m_test_promise->resolve(move(completion));
 }
 
+void TestWebView::restart_web_content_process()
+{
+    initialize_client(CreateNewClient::Yes);
+    m_run_count = 0;
+}
+
 }

--- a/Tests/LibWeb/test-web/TestWebView.h
+++ b/Tests/LibWeb/test-web/TestWebView.h
@@ -29,6 +29,10 @@ public:
     TestPromise& test_promise() { return *m_test_promise; }
     void on_test_complete(TestCompletion);
 
+    void restart_web_content_process();
+    size_t run_count() const { return m_run_count; }
+    void increment_run_count() { ++m_run_count; }
+
 private:
     TestWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewport_size);
 
@@ -37,6 +41,8 @@ private:
     RefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> m_pending_screenshot;
 
     NonnullRefPtr<TestPromise> m_test_promise;
+
+    size_t m_run_count { 0 };
 };
 
 }

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -704,6 +704,11 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             if (result.result != TestResult::Pass)
                 non_passing_tests.append(move(result));
 
+            view->increment_run_count();
+            if (view->run_count() >= 50) {
+                view->restart_web_content_process();
+            }
+
             if (--tests_remaining == 0)
                 s_all_tests_complete->resolve({});
             else


### PR DESCRIPTION
Long-running test sessions currently accumulate significant memory usage in the WebContent process due to caching and fragmentation, eventually causing OOM even when concurrency is limited. This patch implements a recycling mechanism in TestWebView:

- Tracks the number of tests executed by the current process.

- Automatically restarts the WebContent process after a fixed threshold (e.g., 50 tests).

- This ensures memory usage follows a stable "sawtooth-like" pattern rather than growing linearly, enabling the full suite to pass on machines with 8GB RAM.

Fixes #7217 