### PR TITLE
RequestServer: Move the Alt-Svc cache to the cache directory

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -34,7 +34,7 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transpo
 {
     s_connections.set(client_id(), *this);
 
-    m_alt_svc_cache_path = ByteString::formatted("{}/Ladybird/alt-svc-cache.txt", Core::StandardPaths::user_data_directory());
+    m_alt_svc_cache_path = ByteString::formatted("{}/Ladybird/alt-svc-cache.txt", Core::StandardPaths::cache_directory());
 
     m_curl_multi = curl_multi_init();
 


### PR DESCRIPTION
We did not have a `StandardPaths::cache_directory` when this cache was added. Now that we do, let's make use of it.