### PR TITLE
LibWeb: Skip scroll promise allocation in mouse event handling

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2784,7 +2784,7 @@ RefPtr<Gfx::SkiaBackendContext> Navigable::skia_backend_context() const
 }
 
 // https://drafts.csswg.org/cssom-view/#viewport-perform-a-scroll
-GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta)
+void Navigable::scroll_viewport_by_delta_without_promise(CSSPixelPoint delta)
 {
     // 1. Let doc be the viewport’s associated Document.
     auto doc = active_document();
@@ -2834,7 +2834,7 @@ GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta
     // FIXME: Get a Promise from this.
     // AD-HOC: Skip scrolling unscrollable boxes.
     if (!doc->paintable_box()->could_be_scrolled_by_wheel_event())
-        return WebIDL::create_resolved_promise(doc->realm(), JS::js_undefined());
+        return;
     auto scrolling_area = doc->paintable_box()->scrollable_overflow_rect()->to_type<float>();
     auto new_viewport_scroll_offset = m_viewport_scroll_offset.to_type<double>() + Gfx::Point(layout_dx, layout_dy);
     // NOTE: Clamp to the scrolling area.
@@ -2848,6 +2848,14 @@ GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta
     // FIXME: Get a Promise from this.
     vv->scroll_by({ visual_dx, visual_dy });
     doc->set_needs_display(InvalidateDisplayList::No);
+}
+
+// https://drafts.csswg.org/cssom-view/#viewport-perform-a-scroll
+GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta)
+{
+    auto doc = active_document();
+
+    scroll_viewport_by_delta_without_promise(delta);
 
     // 16. Let scrollPromise be a new Promise.
     auto scroll_promise = WebIDL::create_promise(doc->realm());

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -219,6 +219,7 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
+    void scroll_viewport_by_delta_without_promise(CSSPixelPoint delta);
     GC::Ref<WebIDL::Promise> scroll_viewport_by_delta(CSSPixelPoint delta);
     void reset_zoom();
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -445,7 +445,7 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
             auto page_offset = compute_mouse_event_page_offset(viewport_position);
             auto offset = compute_mouse_event_offset(page_offset, *layout_node->first_paintable());
             if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::wheel, screen_position, page_offset, viewport_position, offset, wheel_delta_x, wheel_delta_y, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors())) {
-                m_navigable->scroll_viewport_by_delta({ wheel_delta_x, wheel_delta_y });
+                m_navigable->scroll_viewport_by_delta_without_promise({ wheel_delta_x, wheel_delta_y });
             }
 
             handled_event = EventResult::Handled;


### PR DESCRIPTION
Fixes crashing introduced in a610639 when `scroll_viewport_by_delta()` is called from `EventHandler::handle_mousewheel()` and there's no running execution context to grab current realm from to allocate a promise.