### PR TITLE
Meta/CMake: Do not use -march=native when cross-compiling

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -63,7 +63,7 @@ elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
     # ISA or target string. Unfortunately hardware probing is also neither easy nor reliable at the moment.
     # For the time being use the defaults for the best compatibility with existing hardware and toolchains.
     # FIXME: Remove this branch once -march=native is supported.
-else()
+elseif (NOT CMAKE_CROSSCOMPILING)
     # In all other cases, compile for the native architecture of the host system.
     add_cxx_compile_options(-march=native)
 endif()


### PR DESCRIPTION
The introduction of ENABLE_CI_BASELINE_CPU made -march=native the default for non-CI builds. This breaks cross-compilation with Clang, where native CPU detection is explicitly unsupported when a target triple is set.

Guard the use of -march=native behind NOT CMAKE_CROSSCOMPILING so native tuning is only applied for true host builds, while cross builds continue to use the toolchain defaults.