### PR TITLE
Avoid shifting vector elements in get_session_history_entries()

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -665,7 +665,7 @@ Vector<GC::Ref<SessionHistoryEntry>>& Navigable::get_session_history_entries() c
         return traversable->session_history_entries();
 
     // 4. Let docStates be an empty ordered set of document states.
-    Vector<GC::Ptr<DocumentState>> doc_states;
+    GC::ConservativeVector<GC::Ptr<DocumentState>> doc_states { heap() };
 
     // 5. For each entry of traversable's session history entries, append entry's document state to docStates.
     for (auto& entry : traversable->session_history_entries())


### PR DESCRIPTION
This function essentially performs a BFS traversal over document states.
With this change, we let `doc_states` grow instead of removing traversed
states, avoiding shifting elements on every iteration.

This reduces `./test-web -j 1` from ~7m to ~5m on my machine.