### PR TITLE
LibWeb: Guard currentScript around module execution

### DIFF
--- a/Tests/LibWeb/Crash/HTML/module-script-exec-after-classic.html
+++ b/Tests/LibWeb/Crash/HTML/module-script-exec-after-classic.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<script>
+    let module_script = document.createElement("script");
+    module_script.type = "module";
+    module_script.src = "data:text/javascript,export%20default%201;";
+    document.head.appendChild(module_script);
+</script>


### PR DESCRIPTION
  - Ensure document.currentScript is null while running module scripts, matching spec semantics and avoiding reentrant assertion failures.
 - Restore the previous currentScript after module execution using a scope guard.
 - Add a crash test covering module script insertion from a classic script.
 - Fixes https://github.com/LadybirdBrowser/ladybird/issues/7245