### PR TITLE
LibWeb: Make User-Agent updates apply to HTTP requests on reload

### DIFF
--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP.cpp
@@ -10,11 +10,10 @@
 namespace Web::Fetch::Infrastructure {
 
 // https://fetch.spec.whatwg.org/#default-user-agent-value
-ByteString const& default_user_agent_value()
+ByteString default_user_agent_value()
 {
     // A default `User-Agent` value is an implementation-defined header value for the `User-Agent` header.
-    static auto user_agent = ResourceLoader::the().user_agent().to_byte_string();
-    return user_agent;
+    return ResourceLoader::the().user_agent().to_byte_string();
 }
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP.h
@@ -17,6 +17,6 @@ enum class RedirectTaint {
     CrossSite,
 };
 
-[[nodiscard]] ByteString const& default_user_agent_value();
+[[nodiscard]] ByteString default_user_agent_value();
 
 }


### PR DESCRIPTION
Runtime User-Agent changes would appear in navigator.userAgent but HTTP requests would still send the old User-Agent after reloads or navigating back/forward, causing inconsistent behavior.  

Updated default_user_agent_value() to return the current User-Agent by value instead of caching it in a static variable. 

Introduced in 9375660b. 