### PR TITLE
LibJS: Store full realized SourceRange with each AST node

### DIFF
--- a/Libraries/LibJS/AST.cpp
+++ b/Libraries/LibJS/AST.cpp
@@ -41,15 +41,8 @@
 namespace JS {
 
 ASTNode::ASTNode(SourceRange source_range)
-    : m_start_offset(source_range.start.offset)
-    , m_source_code(source_range.code)
-    , m_end_offset(source_range.end.offset)
+    : m_source_range(move(source_range))
 {
-}
-
-SourceRange ASTNode::source_range() const
-{
-    return m_source_code->range_from_offsets(m_start_offset, m_end_offset);
 }
 
 ByteString ASTNode::class_name() const

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -64,17 +64,13 @@ public:
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const;
     virtual void dump(int indent) const;
 
-    [[nodiscard]] SourceRange source_range() const;
-    UnrealizedSourceRange unrealized_source_range() const
-    {
-        return { m_source_code, m_start_offset, m_end_offset };
-    }
-    u32 start_offset() const { return m_start_offset; }
-    u32 end_offset() const { return m_end_offset; }
+    [[nodiscard]] SourceRange const& source_range() const { return m_source_range; }
+    u32 start_offset() const { return m_source_range.start.offset; }
+    u32 end_offset() const { return m_source_range.end.offset; }
 
-    SourceCode const& source_code() const { return *m_source_code; }
+    SourceCode const& source_code() const { return *m_source_range.code; }
 
-    void set_end_offset(Badge<Parser>, u32 end_offset) { m_end_offset = end_offset; }
+    void set_end_offset(Badge<Parser>, u32 end_offset) { m_source_range.end.offset = end_offset; }
 
     ByteString class_name() const;
 
@@ -116,11 +112,7 @@ protected:
     explicit ASTNode(SourceRange);
 
 private:
-    // NOTE: These members are carefully ordered so that `m_start_offset` is packed with the padding after RefCounted::m_ref_count.
-    //       This creates a 4-byte padding hole after `m_end_offset` which is used to pack subclasses better.
-    u32 m_start_offset { 0 };
-    RefPtr<SourceCode const> m_source_code;
-    u32 m_end_offset { 0 };
+    SourceRange m_source_range;
 };
 
 // This is a helper class that packs an array of T after the AST node, all in the same allocation.

--- a/Libraries/LibJS/Position.h
+++ b/Libraries/LibJS/Position.h
@@ -11,9 +11,9 @@
 namespace JS {
 
 struct Position {
-    size_t line { 0 };
-    size_t column { 0 };
-    size_t offset { 0 };
+    u32 line { 0 };
+    u32 column { 0 };
+    u32 offset { 0 };
 };
 
 }

--- a/Libraries/LibJS/SourceCode.cpp
+++ b/Libraries/LibJS/SourceCode.cpp
@@ -35,9 +35,9 @@ void SourceCode::fill_position_cache() const
         return;
 
     u32 previous_code_point = 0;
-    size_t line = 1;
-    size_t column = 1;
-    size_t offset_of_last_starting_point = 0;
+    u32 line = 1;
+    u32 column = 1;
+    u32 offset_of_last_starting_point = 0;
 
     m_cached_positions.ensure_capacity(predicted_minimum_cached_positions + (m_code.length_in_code_units() / maximum_distance_between_cached_positions));
     m_cached_positions.append({ .line = 1, .column = 1, .offset = 0 });
@@ -49,12 +49,13 @@ void SourceCode::fill_position_cache() const
         bool is_line_terminator = code_point == '\r' || (code_point == '\n' && previous_code_point != '\r') || code_point == LINE_SEPARATOR || code_point == PARAGRAPH_SEPARATOR;
 
         auto offset = view.iterator_offset(it);
+        VERIFY(offset <= NumericLimits<u32>::max());
 
         bool is_nonempty_line = is_line_terminator && previous_code_point != '\n' && previous_code_point != LINE_SEPARATOR && previous_code_point != PARAGRAPH_SEPARATOR && (code_point == '\n' || previous_code_point != '\r');
         auto distance_between_cached_position = offset - offset_of_last_starting_point;
 
         if ((distance_between_cached_position >= minimum_distance_between_cached_positions && is_nonempty_line) || distance_between_cached_position >= maximum_distance_between_cached_positions) {
-            m_cached_positions.append({ .line = line, .column = column, .offset = offset });
+            m_cached_positions.append({ .line = line, .column = column, .offset = static_cast<u32>(offset) });
             offset_of_last_starting_point = offset;
         }
 

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -224,9 +224,9 @@ public:
             [](Empty) -> Utf16FlyString { VERIFY_NOT_REACHED(); });
     }
 
-    size_t line_number() const { return m_line_number; }
-    size_t line_column() const { return m_line_column; }
-    size_t offset() const { return m_offset; }
+    u32 line_number() const { return m_line_number; }
+    u32 line_column() const { return m_line_column; }
+    u32 offset() const { return m_offset; }
     double double_value() const;
     bool bool_value() const;
 
@@ -254,9 +254,9 @@ private:
     Utf16View m_trivia;
     Utf16View m_original_value;
     Variant<Empty, Utf16View, Utf16FlyString> m_value;
-    size_t m_line_number { 0 };
-    size_t m_line_column { 0 };
-    size_t m_offset { 0 };
+    u32 m_line_number { 0 };
+    u32 m_line_column { 0 };
+    u32 m_offset { 0 };
 };
 
 }


### PR DESCRIPTION
We were spending way too much time converting unrealized source ranges into line/column pairs on real web content.

This improves JS parsing speed on x.com by 1.13x (at the cost of 8 bytes per AST node, but we eventually want to discard most of the AST after compiling bytecode from it!)