### PR TITLE
LibWeb: Update Animations in InternalAnimationTimeline::setTime()

### DIFF
--- a/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
+++ b/Libraries/LibWeb/Internals/InternalAnimationTimeline.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Animations/Animation.h>
 #include <LibWeb/Bindings/InternalAnimationTimelinePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
@@ -22,6 +23,16 @@ void InternalAnimationTimeline::update_current_time(double)
 void InternalAnimationTimeline::set_time(Optional<double> time)
 {
     set_current_time(time.map([](double value) -> Animations::TimeValue { return { Animations::TimeValue::Type::Milliseconds, value }; }));
+
+    // https://drafts.csswg.org/web-animations-1/#animation-frame-loop
+    // Note: Due to the hierarchical nature of the timing model, updating the current time of a timeline also involves:
+    // - Updating the current time of any animations associated with the timeline.
+    // - Running the update an animation's finished state procedure for any animations whose current time has been
+    //   updated.
+    // - Queueing animation events for any such animations.
+    // NB: This mirrors what the event loop does for DocumentTimeline in Document::update_animations_and_send_events().
+    for (auto const& animation : associated_animations())
+        animation->update();
 }
 
 InternalAnimationTimeline::InternalAnimationTimeline(JS::Realm& realm)


### PR DESCRIPTION
## The Problem

This fixes a race condition that caused the flaky test failure in `Tests/LibWeb/Text/input/WebAnimations/misc/animation-single-iteration-no-repeat.html`.

When tests manually set the timeline's time via `setTime()`, the timeline's current time changes immediately, but `animation->update()` isn't called until the next event loop frame. This creates a race window where style recalculation can call `pause()` on an animation that's already finished (by time) but hasn't yet processed its finished state.

The sequence that causes the bug:

1. Test calls `timeline.setTime(1000)` — animation is now "finished" by time
2. `play_state()` returns "Finished" (computed from current time)
3. But `animation->update()` hasn't run yet, so `m_is_finished` is still false
4. Style recalculation triggers `apply_animation_properties()` in `StyleComputer.cpp`
5. This sees CSS says "paused" but animation's `play_state()` is "Finished", so it calls `Animation::pause()`
6. Inside `pause()`, the flag `m_pending_pause_task` is set to `Scheduled`
7. Now `play_state()` returns "Paused" instead of "Finished"
8. When `finish_notification_steps` runs, it checks `play_state()` — sees "Paused", exits early
9. The `onfinish` event is never dispatched

## The Solution

In `InternalAnimationTimeline::set_time()`, after setting the timeline's current time, also call `animation->update()` for all associated animations. This ensures the animation's finished state is processed immediately, eliminating the race window