### PR TITLE
Documentation: Fix typos in build instructions

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -25,7 +25,7 @@ There are some optional features that can be enabled during compilation that are
 - `ENABLE_FUZZERS_OSSFUZZ`: builds OSS-Fuzz compatible [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
 - `ENABLE_ALL_THE_DEBUG_MACROS`: used for checking whether debug code compiles on CI. This should not be set normally, as it clutters the console output and makes the system run very slowly. Instead, enable only the needed debug macros, as described below.
 - `ENABLE_COMPILETIME_FORMAT_CHECK`: checks for the validity of `std::format`-style format string during compilation. Enabled by default.
-- `LAGOM_TOOLS_ONLY`: Skips building libraries, utiltis and tests for [Lagom](../Meta/Lagom/ReadMe.md). Mostly only useful for cross-compilation.
+- `LAGOM_TOOLS_ONLY`: Skips building libraries, utilities and tests for [Lagom](../Meta/Lagom/ReadMe.md). Mostly only useful for cross-compilation.
 - `INCLUDE_WASM_SPEC_TESTS`: downloads and includes the WebAssembly spec testsuite tests. In order to use this option, you will need to install `prettier` and `wasm-tools`.
 - `INCLUDE_FLAC_SPEC_TESTS`: downloads and includes the xiph.org FLAC test suite.
 - `LADYBIRD_CACHE_DIR`: sets the location of a shared cache of downloaded files. Should not need to be set manually unless managing a distribution package.

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -238,7 +238,7 @@ BUILD_PRESET=Debug ./Meta/ladybird.py run
 
 Note that debug symbols are available in both Release and Debug builds.
 
-If you want to run other applications, such as the the JS REPL or the WebAssembly REPL, specify an executable with
+If you want to run other applications, such as the JS REPL or the WebAssembly REPL, specify an executable with
 `./Meta/ladybird.py run <executable_name>`.
 
 ### The User Interfaces


### PR DESCRIPTION
Couple of typos that caught my eye.