### PR TITLE
LibWeb: Use element's accent-color property for AccentColor keyword

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
@@ -149,8 +149,12 @@ Optional<Color> KeywordStyleValue::to_color(ColorResolutionContext color_resolut
     // https://www.w3.org/TR/css-color-4/#deprecated-system-colors
     switch (keyword()) {
     case Keyword::Accentcolor:
+        if (color_resolution_context.accent_color.has_value())
+            return color_resolution_context.accent_color.value();
         return SystemColor::accent_color(scheme);
     case Keyword::Accentcolortext:
+        if (color_resolution_context.accent_color.has_value())
+            return color_resolution_context.accent_color->suggested_foreground_color();
         return SystemColor::accent_color_text(scheme);
     case Keyword::Buttonborder:
     case Keyword::Activeborder:

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -90,9 +90,14 @@ ColorResolutionContext ColorResolutionContext::for_element(DOM::AbstractElement 
 
     CalculationResolutionContext calculation_resolution_context { .length_resolution_context = Length::ResolutionContext::for_element(element) };
 
+    Optional<Color> accent_color;
+    if (auto layout_node = element.layout_node())
+        accent_color = layout_node->computed_values().accent_color();
+
     return {
         .color_scheme = color_scheme,
-        .current_color = element.computed_properties()->color_or_fallback(PropertyID::Color, { color_scheme, CSS::InitialValues::color(), element.document(), calculation_resolution_context }, CSS::InitialValues::color()),
+        .current_color = element.computed_properties()->color_or_fallback(PropertyID::Color, { .color_scheme = color_scheme, .current_color = CSS::InitialValues::color(), .accent_color = {}, .document = element.document(), .calculation_resolution_context = calculation_resolution_context }, CSS::InitialValues::color()),
+        .accent_color = accent_color,
         .document = element.document(),
         .calculation_resolution_context = calculation_resolution_context
     };
@@ -103,6 +108,7 @@ ColorResolutionContext ColorResolutionContext::for_layout_node_with_style(Layout
     return {
         .color_scheme = layout_node.computed_values().color_scheme(),
         .current_color = layout_node.computed_values().color(),
+        .accent_color = layout_node.computed_values().accent_color(),
         .document = layout_node.document(),
         .calculation_resolution_context = { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) },
     };

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -154,6 +154,7 @@ using StyleValueVector = Vector<ValueComparingNonnullRefPtr<StyleValue const>>;
 struct ColorResolutionContext {
     Optional<PreferredColorScheme> color_scheme;
     Optional<Color> current_color;
+    Optional<Color> accent_color;
     GC::Ptr<DOM::Document const> document;
     CalculationResolutionContext calculation_resolution_context;
 


### PR DESCRIPTION
When resolving the AccentColor and AccentColorText CSS keywords, check the element's accent-color property first before falling back to the system color. This matches the CSS Color 4 specification.

Added `accent_color` to `ColorResolutionContext` and populated it from the element's computed values when available.

Fixes #7141.