### PR TITLE
LibWeb: Treat near-zero aspect-ratios as degenerate

### DIFF
--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -91,7 +91,12 @@ Optional<CSSPixelFraction> Box::preferred_aspect_ratio() const
     if (ratio.is_degenerate())
         return {};
 
-    return CSSPixelFraction(ratio.numerator(), ratio.denominator());
+    auto fraction = CSSPixelFraction(ratio.numerator(), ratio.denominator());
+    // ratio.is_degenerate() operates on doubles while CSSPixelFraction uses CSSPixels, so we need to check again here.
+    if (fraction == 0)
+        return {};
+
+    return fraction;
 }
 
 }

--- a/Tests/LibWeb/Crash/wpt-import/css/css-sizing/aspect-ratio/small-aspect-ratio-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/css/css-sizing/aspect-ratio/small-aspect-ratio-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: Doesn't crash with small but nonzero width/height in ratio</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<div style="aspect-ratio: 1/0.00000000000001"></div>
+<div style="aspect-ratio: 0.00000000000001/1"></div>


### PR DESCRIPTION
Prevents a crash in https://wpt.live/css/css-sizing/aspect-ratio/small-aspect-ratio-crash.html