### PR TITLE
LibURL: Add domain concept to URL::Origin to fix same-origin-domain

### DIFF
--- a/Libraries/LibIPC/Decoder.cpp
+++ b/Libraries/LibIPC/Decoder.cpp
@@ -119,8 +119,9 @@ ErrorOr<URL::Origin> decode(Decoder& decoder)
     auto scheme = TRY(decoder.decode<Optional<String>>());
     auto host = TRY(decoder.decode<URL::Host>());
     auto port = TRY(decoder.decode<Optional<u16>>());
+    auto domain = TRY(decoder.decode<Optional<String>>());
 
-    return URL::Origin { move(scheme), move(host), port };
+    return URL::Origin { move(scheme), move(host), port, move(domain) };
 }
 
 template<>

--- a/Libraries/LibIPC/Encoder.cpp
+++ b/Libraries/LibIPC/Encoder.cpp
@@ -140,6 +140,7 @@ ErrorOr<void> encode(Encoder& encoder, URL::Origin const& origin)
         TRY(encoder.encode(origin.scheme()));
         TRY(encoder.encode(origin.host()));
         TRY(encoder.encode(origin.port()));
+        TRY(encoder.encode(origin.domain()));
     }
 
     return {};

--- a/Libraries/LibURL/Origin.cpp
+++ b/Libraries/LibURL/Origin.cpp
@@ -82,6 +82,9 @@ unsigned Traits<URL::Origin>::hash(URL::Origin const& origin)
 
     hash = pair_int_hash(hash, origin.host().serialize().hash());
 
+    if (origin.domain().has_value())
+        hash = pair_int_hash(hash, origin.domain()->hash());
+
     return hash;
 }
 


### PR DESCRIPTION
The same-origin domain check always returned true if only the scheme matched. This was because of missing steps to check for the origin's domain, which didn't exist. Add this concept to URL::Origin, even though we do not use it at this stage in document.domain setter.

Ressurects https://github.com/LadybirdBrowser/ladybird/pull/5488 but with changes of:

- Does not implement the document.domain setter
- Adds tests
- Fixes the type of the domain member in URL::Origin::Tuple