### PR TITLE
LibWeb: Don't crash when clicking on display: contents element

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -452,7 +452,8 @@ EventResult EventHandler::handle_mousewheel(CSSPixelPoint visual_viewport_positi
                 return EventResult::Dropped;
 
             auto page_offset = compute_mouse_event_page_offset(viewport_position);
-            auto offset = compute_mouse_event_offset(page_offset, *layout_node->first_paintable());
+            auto const& offset_paintable = layout_node->first_paintable() ? layout_node->first_paintable() : paintable.ptr();
+            auto offset = compute_mouse_event_offset(page_offset, *offset_paintable);
             if (node->dispatch_event(UIEvents::WheelEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::wheel, screen_position, page_offset, viewport_position, offset, wheel_delta_x, wheel_delta_y, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors())) {
                 m_navigable->scroll_viewport_by_delta({ wheel_delta_x, wheel_delta_y });
             }
@@ -526,7 +527,8 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
             }
 
             auto page_offset = compute_mouse_event_page_offset(viewport_position);
-            auto offset = compute_mouse_event_offset(page_offset, *layout_node->first_paintable());
+            auto const& offset_paintable = layout_node->first_paintable() ? layout_node->first_paintable() : paintable.ptr();
+            auto offset = compute_mouse_event_offset(page_offset, *offset_paintable);
             auto pointer_event = UIEvents::PointerEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::pointerup, screen_position, page_offset, viewport_position, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors();
             light_dismiss_activities(pointer_event, node);
             node->dispatch_event(pointer_event);
@@ -681,7 +683,8 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
 
         m_mousedown_target = node.ptr();
         auto page_offset = compute_mouse_event_page_offset(viewport_position);
-        auto offset = compute_mouse_event_offset(page_offset, *layout_node->first_paintable());
+        auto const& offset_paintable = layout_node->first_paintable() ? layout_node->first_paintable() : paintable.ptr();
+        auto offset = compute_mouse_event_offset(page_offset, *offset_paintable);
         auto pointer_event = UIEvents::PointerEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::pointerdown, screen_position, page_offset, viewport_position, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors();
         light_dismiss_activities(pointer_event, node);
         if (!node->dispatch_event(pointer_event))
@@ -881,7 +884,8 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
             }
 
             auto page_offset = compute_mouse_event_page_offset(viewport_position);
-            auto offset = compute_mouse_event_offset(page_offset, *layout_node->first_paintable());
+            auto const& offset_paintable = layout_node->first_paintable() ? layout_node->first_paintable() : paintable.ptr();
+            auto offset = compute_mouse_event_offset(page_offset, *offset_paintable);
             auto movement = compute_mouse_event_movement(screen_position);
 
             m_mousemove_previous_screen_position = screen_position;
@@ -1013,7 +1017,8 @@ EventResult EventHandler::handle_doubleclick(CSSPixelPoint visual_viewport_posit
         return EventResult::Dropped;
 
     auto page_offset = compute_mouse_event_page_offset(viewport_position);
-    auto offset = compute_mouse_event_offset(page_offset, *layout_node->first_paintable());
+    auto const& offset_paintable = layout_node->first_paintable() ? layout_node->first_paintable() : paintable.ptr();
+    auto offset = compute_mouse_event_offset(page_offset, *offset_paintable);
     node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), m_navigable->active_window_proxy(), UIEvents::EventNames::dblclick, screen_position, page_offset, viewport_position, offset, {}, button, buttons, modifiers).release_value_but_fixme_should_propagate_errors());
 
     // NOTE: Dispatching an event may have disturbed the world.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-display/display-contents-pseudo-click-target.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-display/display-contents-pseudo-click-target.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Clicking a display: contents pseudo-element targets that element

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-display/display-contents-pseudo-click-target.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-display/display-contents-pseudo-click-target.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<title>Clicking a display: contents pseudo-element targets that element</title>
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1959364">
+<link rel="help" href="https://drafts.csswg.org/css-display-4/#valdef-display-contents">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/testdriver.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+<script src="../../resources/testdriver-actions.js"></script>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    position: relative;
+  }
+  a {
+    display: contents;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+    }
+  }
+</style>
+<div>
+  <a href="#"></a>
+</div>
+<script>
+promise_test(async function() {
+  let target = document.querySelector("a");
+  let hitLink = false;
+  target.addEventListener("click", function(e) {
+    hitLink = true;
+    e.preventDefault();
+  });
+  await test_driver.click(target.parentElement);
+  assert_true(hitLink, "Link should've been clicked");
+});
+</script>


### PR DESCRIPTION
Fixes https://wpt.live/css/css-display/display-contents-pseudo-click-target.html