### PR TITLE
CI: Use self-hosted macOS runners for nightly builds

### DIFF
--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -38,7 +38,7 @@ jobs:
             build_preset: 'Distribution'
             toolchain: 'Clang'
             clang_plugins: false
-            runner_labels: '["macos-15"]'
+            runner_labels: '["macos-15", "self-hosted"]'
 
           - os_name: 'Linux'
             arch: 'arm64'
@@ -59,7 +59,7 @@ jobs:
             build_preset: 'Sanitizer'
             toolchain: 'Swift'
             clang_plugins: false
-            runner_labels: '["macos-15"]'
+            runner_labels: '["macos-15", "self-hosted"]'
 
           - os_name: 'Windows'
             arch: 'x86_64'


### PR DESCRIPTION
These have been broken for a while now. Add the `self-hosted` tag so we at least use the same runners we already use for PR checks.