### PR TITLE
LibWeb/HTML: Fix Origin.from(value) for Window objects

### DIFF
--- a/Libraries/LibWeb/DOMURL/Origin.cpp
+++ b/Libraries/LibWeb/DOMURL/Origin.cpp
@@ -8,6 +8,8 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/OriginPrototype.h>
 #include <LibWeb/DOMURL/Origin.h>
+#include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/WindowProxy.h>
 
 namespace Web::DOMURL {
 
@@ -38,6 +40,10 @@ GC::Ref<Origin> Origin::construct_impl(JS::Realm& realm)
 WebIDL::ExceptionOr<GC::Ref<Origin>> Origin::from(JS::VM& vm, JS::Value value)
 {
     auto& realm = *vm.current_realm();
+
+    // NB: IDL only ever sees HTML::WindowProxy but we want to use HTML::Window.
+    if (auto* window_proxy = value.as_if<HTML::WindowProxy>())
+        value = window_proxy->window();
 
     // 1. If value is a platform object:
     if (auto* object = value.as_if<Bindings::PlatformObject>()) {

--- a/Tests/LibWeb/Text/expected/HTML/origin-from-window.txt
+++ b/Tests/LibWeb/Text/expected/HTML/origin-from-window.txt
@@ -1,0 +1,2 @@
+[object Origin]
+true

--- a/Tests/LibWeb/Text/input/HTML/origin-from-window.html
+++ b/Tests/LibWeb/Text/input/HTML/origin-from-window.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+          const origin = Origin.from(window);
+          println(origin);
+          println(origin.isSameOrigin(Origin.from(window)));
+    });
+</script>


### PR DESCRIPTION
I had completely managed to forget about the special case of Window where a WindowProxy is what is received over IDL. This was caught by the origin-from-window WPT test, but unfortunately this cannot be imported as it relies on a web server running and other surroundsing WPT infrastructure.