### PR TITLE
LibWeb: Handle indefinite width in block formatting context

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -290,7 +290,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
                     }
                 } else if (available_space.width.is_min_content()) {
                     width = CSS::Length::make_px(calculate_min_content_width(box));
-                } else if (available_space.width.is_max_content()) {
+                } else if (available_space.width.is_max_content() || available_space.width.is_indefinite()) {
                     width = CSS::Length::make_px(calculate_max_content_width(box));
                 } else {
                     VERIFY_NOT_REACHED();


### PR DESCRIPTION
## Summary
This fixes a crash when visiting Reddit (issue #7183 ) by handling the `indefinite` case for `available_space.width` in `BlockFormattingContext::compute_width()`.

## Changes
   - Modified `BlockFormattingContext.cpp:293` to treat `is_indefinite()` the same as `is_max_content()`, using `calculate_max_content_width(box)`