### PR TITLE
LibMedia: Propagate errors from create_context_for_track

### DIFF
--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.cpp
@@ -83,10 +83,11 @@ static Track track_from_track_entry(TrackEntry const& track_entry)
     return track;
 }
 
-void MatroskaDemuxer::create_context_for_track(Track const& track, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const& stream_cursor)
+DecoderErrorOr<void> MatroskaDemuxer::create_context_for_track(Track const& track, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const& stream_cursor)
 {
-    auto iterator = MUST(m_reader.create_sample_iterator(stream_cursor, track.identifier()));
+    auto iterator = TRY(m_reader.create_sample_iterator(stream_cursor, track.identifier()));
     VERIFY(m_track_statuses.set(track, TrackStatus(move(iterator))) == HashSetResult::InsertedNewEntry);
+    return {};
 }
 
 DecoderErrorOr<Vector<Track>> MatroskaDemuxer::get_tracks_for_type(TrackType type)

--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
@@ -24,7 +24,7 @@ public:
     {
     }
 
-    virtual void create_context_for_track(Track const&, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const&) override;
+    virtual DecoderErrorOr<void> create_context_for_track(Track const&, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const&) override;
 
     DecoderErrorOr<Vector<Track>> get_tracks_for_type(TrackType) override;
     DecoderErrorOr<Optional<Track>> get_preferred_track_for_type(TrackType) override;

--- a/Libraries/LibMedia/Demuxer.h
+++ b/Libraries/LibMedia/Demuxer.h
@@ -35,7 +35,7 @@ class Demuxer : public AtomicRefCounted<Demuxer> {
 public:
     virtual ~Demuxer() = default;
 
-    virtual void create_context_for_track(Track const&, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const&) = 0;
+    virtual DecoderErrorOr<void> create_context_for_track(Track const&, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const&) = 0;
 
     virtual DecoderErrorOr<Vector<Track>> get_tracks_for_type(TrackType) = 0;
     // Returns the container's preferred track for a given track type. This must return a value if any track of the

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -55,7 +55,7 @@ DecoderErrorOr<NonnullRefPtr<FFmpegDemuxer>> FFmpegDemuxer::from_stream(NonnullR
     return demuxer;
 }
 
-void FFmpegDemuxer::create_context_for_track(Track const& track, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const& stream_cursor)
+DecoderErrorOr<void> FFmpegDemuxer::create_context_for_track(Track const& track, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const& stream_cursor)
 {
     auto io_context = MUST(Media::FFmpeg::FFmpegIOContext::create(stream_cursor));
 
@@ -68,6 +68,8 @@ void FFmpegDemuxer::create_context_for_track(Track const& track, NonnullRefPtr<I
     VERIFY(track_context->packet != nullptr);
 
     VERIFY(m_track_contexts.set(track, move(track_context)) == HashSetResult::InsertedNewEntry);
+
+    return {};
 }
 
 FFmpegDemuxer::TrackContext& FFmpegDemuxer::get_track_context(Track const& track)

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~FFmpegDemuxer() override;
 
-    virtual void create_context_for_track(Track const&, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const&) override;
+    virtual DecoderErrorOr<void> create_context_for_track(Track const&, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const&) override;
 
     virtual DecoderErrorOr<Vector<Track>> get_tracks_for_type(TrackType) override;
     virtual DecoderErrorOr<Optional<Track>> get_preferred_track_for_type(TrackType) override;

--- a/Libraries/LibMedia/MutexedDemuxer.h
+++ b/Libraries/LibMedia/MutexedDemuxer.h
@@ -28,10 +28,10 @@ public:
         });
     }
 
-    virtual void create_context_for_track(Track const& track, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const& stream_cursor) override
+    virtual DecoderErrorOr<void> create_context_for_track(Track const& track, NonnullRefPtr<IncrementallyPopulatedStream::Cursor> const& stream_cursor) override
     {
-        m_demuxer.with_locked([&](auto& demuxer) {
-            demuxer->create_context_for_track(track, stream_cursor);
+        return m_demuxer.with_locked([&](auto& demuxer) {
+            return demuxer->create_context_for_track(track, stream_cursor);
         });
     }
 

--- a/Libraries/LibMedia/Providers/AudioDataProvider.cpp
+++ b/Libraries/LibMedia/Providers/AudioDataProvider.cpp
@@ -27,7 +27,7 @@ DecoderErrorOr<NonnullRefPtr<AudioDataProvider>> AudioDataProvider::try_create(N
     auto converter = DECODER_TRY_ALLOC(FFmpeg::FFmpegAudioConverter::try_create());
 
     auto stream_cursor = stream->create_cursor();
-    demuxer->create_context_for_track(track, stream_cursor);
+    TRY(demuxer->create_context_for_track(track, stream_cursor));
     auto thread_data = DECODER_TRY_ALLOC(try_make_ref_counted<AudioDataProvider::ThreadData>(main_thread_event_loop, demuxer, stream_cursor, track, move(decoder), move(converter)));
     auto provider = DECODER_TRY_ALLOC(try_make_ref_counted<AudioDataProvider>(thread_data));
 

--- a/Libraries/LibMedia/Providers/VideoDataProvider.cpp
+++ b/Libraries/LibMedia/Providers/VideoDataProvider.cpp
@@ -24,7 +24,7 @@ DecoderErrorOr<NonnullRefPtr<VideoDataProvider>> VideoDataProvider::try_create(N
     auto decoder = DECODER_TRY_ALLOC(FFmpeg::FFmpegVideoDecoder::try_create(codec_id, codec_initialization_data));
 
     auto stream_cursor = stream->create_cursor();
-    demuxer->create_context_for_track(track, stream_cursor);
+    TRY(demuxer->create_context_for_track(track, stream_cursor));
 
     auto thread_data = DECODER_TRY_ALLOC(try_make_ref_counted<VideoDataProvider::ThreadData>(main_thread_event_loop, demuxer, stream_cursor, track, move(decoder), time_provider));
     auto provider = DECODER_TRY_ALLOC(try_make_ref_counted<VideoDataProvider>(thread_data));

--- a/Tests/LibMedia/TestParseMatroska.cpp
+++ b/Tests/LibMedia/TestParseMatroska.cpp
@@ -36,7 +36,7 @@ TEST_CASE(seek_in_multi_frame_blocks)
     auto optional_track = MUST(demuxer->get_preferred_track_for_type(Media::TrackType::Audio));
     EXPECT(optional_track.has_value());
     auto track = optional_track.release_value();
-    demuxer->create_context_for_track(track, stream->create_cursor());
+    MUST(demuxer->create_context_for_track(track, stream->create_cursor()));
 
     auto initial_coded_frame = MUST(demuxer->get_next_sample_for_track(track));
     EXPECT(initial_coded_frame.timestamp() <= AK::Duration::zero());


### PR DESCRIPTION
Fixes crash on https://wpt.live/html/semantics/embedded-content/the-video-element/resize-during-playback.html, test still fails though, but fail is better than crash