### PR TITLE
LibWeb: Handle non-absolute lengths when resolving gradient data

### DIFF
--- a/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -122,11 +122,13 @@ LinearGradientData resolve_linear_gradient_data(Layout::NodeWithStyle const& nod
 
     CSS::CalculationResolutionContext context {
         .percentage_basis = CSS::Length::make_px(gradient_length_px),
+        .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(node),
     };
+
     auto resolved_color_stops = resolve_color_stop_positions(
         node, linear_gradient.color_stop_list(), [&](auto const& position) -> float {
             if (position.is_length())
-                return position.as_length().length().absolute_length_to_px_without_rounding() / gradient_length_px;
+                return position.as_length().length().to_px_without_rounding(*context.length_resolution_context) / gradient_length_px;
             if (position.is_percentage())
                 return position.as_percentage().percentage().as_fraction();
             return position.as_calculated().resolve_length(context)->absolute_length_to_px_without_rounding() / gradient_length_px;
@@ -151,13 +153,14 @@ RadialGradientData resolve_radial_gradient_data(Layout::NodeWithStyle const& nod
 {
     CSS::CalculationResolutionContext context {
         .percentage_basis = CSS::Length::make_px(gradient_size.width()),
+        .length_resolution_context = CSS::Length::ResolutionContext::for_layout_node(node),
     };
 
     // Start center, goes right to ending point, where the gradient line intersects the ending shape
     auto resolved_color_stops = resolve_color_stop_positions(
         node, radial_gradient.color_stop_list(), [&](auto const& position) -> float {
             if (position.is_length())
-                return position.as_length().length().absolute_length_to_px_without_rounding() / gradient_size.width().to_float();
+                return position.as_length().length().to_px_without_rounding(*context.length_resolution_context) / gradient_size.width().to_float();
             if (position.is_percentage())
                 return position.as_percentage().percentage().as_fraction();
             return position.as_calculated().resolve_length(context)->absolute_length_to_px_without_rounding() / gradient_size.width().to_float();

--- a/Tests/LibWeb/Crash/Layout/non-absolute-gradient-length.html
+++ b/Tests/LibWeb/Crash/Layout/non-absolute-gradient-length.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<div style="position: absolute; background: repeating-linear-gradient(to bottom, red, 10rem, transparent 10rem); width:1rem; top:1rem; height: 20rem"></div>


### PR DESCRIPTION
This fixes a crash on the major Dutch news site nos.nl. The crash was shrunk to the following case:
```html
<!doctype html>
<div style="position: absolute; background: repeating-linear-gradient(to bottom, red, 10rem, transparent 10rem); width:1rem; top:1rem; height: 20rem"></div>
```
In this case, the problem was caused by the usage of a font-relative size in the gradient section size. (10rem). Where the code expected this to be an absolute length.

The change swaps out calling a function that only handles absolute lengths to one that also handles non-absolute lengths. This function uses the same underlying functions for the already-working code paths, whilst the crashing case now also works.

I have looked through the spec for this length value, and nothing appears to me to imply that the length should be absolute. Chromium and Firefox also do not crash here.
See: https://drafts.csswg.org/css-images/#typedef-color-stop-list

I also added a test that crashes before the change, and does not crash after the change.