### PR TITLE
LibWeb: Selection toString focused text control delegation

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -890,6 +890,18 @@ void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
     did_edit_text_node();
 }
 
+Optional<Utf16String> FormAssociatedTextControlElement::selected_text_for_stringifier() const
+{
+    // https://w3c.github.io/selection-api/#dom-selection-stringifier
+    // Used for clipboard copy and window.getSelection().toString() when this element is active.
+    size_t start = this->selection_start();
+    size_t end = this->selection_end();
+    if (start >= end)
+        return {};
+
+    return Utf16String::from_utf16(relevant_value().substring_view(start, end - start));
+}
+
 void FormAssociatedTextControlElement::collapse_selection_to_offset(size_t position)
 {
     m_selection_start = position;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -197,8 +197,9 @@ class WEB_API FormAssociatedTextControlElement
     , public InputEventsTarget {
 public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value
-    virtual Utf16String relevant_value() = 0;
+    virtual Utf16String relevant_value() const = 0;
     virtual WebIDL::ExceptionOr<void> set_relevant_value(Utf16String const&) = 0;
+    virtual Optional<Utf16String> selected_text_for_stringifier() const;
 
     virtual void set_dirty_value_flag(bool flag) = 0;
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -85,8 +85,9 @@ public:
     WebIDL::ExceptionOr<void> set_value(Utf16String const&);
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value
-    virtual Utf16String relevant_value() override { return value(); }
+    virtual Utf16String relevant_value() const override { return value(); }
     WebIDL::ExceptionOr<void> set_relevant_value(Utf16String const& value) override { return set_value(value); }
+    virtual Optional<Utf16String> selected_text_for_stringifier() const override;
 
     virtual void set_dirty_value_flag(bool flag) override { m_dirty_value = flag; }
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -81,6 +81,8 @@ void HTMLTextAreaElement::did_receive_focus()
 
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
+
+    document().get_selection()->remove_all_ranges();
 }
 
 void HTMLTextAreaElement::did_lose_focus()

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -88,7 +88,7 @@ public:
     Utf16String api_value() const;
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value
-    virtual Utf16String relevant_value() override { return api_value(); }
+    virtual Utf16String relevant_value() const override { return api_value(); }
     virtual WebIDL::ExceptionOr<void> set_relevant_value(Utf16String const& value) override;
 
     virtual void set_dirty_value_flag(bool flag) override { m_dirty_value = flag; }

--- a/Libraries/LibWeb/Selection/Selection.h
+++ b/Libraries/LibWeb/Selection/Selection.h
@@ -56,6 +56,7 @@ public:
 
     // Non-standard convenience accessor for the selection's range.
     GC::Ptr<DOM::Range> range() const;
+    Optional<Utf16String> try_form_control_selected_text_for_stringifier() const;
 
     // Non-standard accessor for the selection's document.
     GC::Ref<DOM::Document> document() const;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -763,7 +763,8 @@ void Application::initialize_actions()
 
     m_copy_selection_action = Action::create("Copy"sv, ActionID::CopySelection, [this]() {
         if (auto view = active_web_view(); view.has_value())
-            insert_clipboard_entry({ view->selected_text(), "text/plain"_string });
+            if (!view->selected_text().is_empty())
+                insert_clipboard_entry({ view->selected_text(), "text/plain"_string });
     });
     m_paste_action = Action::create("Paste"sv, ActionID::Paste, [this]() {
         if (auto view = active_web_view(); view.has_value())

--- a/Tests/LibWeb/Text/expected/selection-toString-focused-text-control-delegation.txt
+++ b/Tests/LibWeb/Text/expected/selection-toString-focused-text-control-delegation.txt
@@ -1,0 +1,6 @@
+initial, window.getSelection().toString() is ""
+after selecting foo, window.getSelection().toString() is "foo"
+after selecting bar, window.getSelection().toString() is "bar"
+after unselecting bar, window.getSelection().toString() is ""
+after selecting 'z' from normal text input, window.getSelection().toString() is "z"
+after selecting 'boo' from password input, window.getSelection().toString() is "•••"

--- a/Tests/LibWeb/Text/input/selection-toString-focused-text-control-delegation.html
+++ b/Tests/LibWeb/Text/input/selection-toString-focused-text-control-delegation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Selection reflects textarea selection</title>
+    <script src="./include.js"></script>
+    <script>
+        test(() => {
+            function verify(expected, label) {
+                let s = window.getSelection().toString();
+                println(`${label}, window.getSelection().toString() is "${s}"`);
+                if (s !== expected)
+                    throw new Error(`${label}: expected "${expected}", got "${s}"`);
+            }
+
+            verify("", "initial");
+
+            let foo = document.getElementById("foo");
+            let r = document.createRange();
+            r.selectNodeContents(foo);
+            let sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(r);
+            verify("foo", "after selecting foo");
+
+            let textarea = document.getElementById("bar");
+            textarea.focus();
+            textarea.select();
+            verify("bar", "after selecting bar");
+
+            textarea.setSelectionRange(0, 0);
+            verify("", "after unselecting bar");
+
+            let input = document.getElementById("baz");
+            input.focus();
+            input.setSelectionRange(2, 3);
+            verify("z", "after selecting 'z' from normal text input");
+            let password = document.getElementById("boo");
+            password.focus();
+            password.setSelectionRange(0, 3);
+            verify("•••", "after selecting 'boo' from password input");
+        });
+    </script>
+</head>
+<body>
+    <p id="foo">foo</p>
+    <textarea id="bar">bar</textarea>
+    <input id="baz" type="text" value="baz">
+    <input id="boo" type="password" value="boo!">
+</body>
+</html>


### PR DESCRIPTION
Allows selected text in form controls to be copied to clipboard and brings `window.getSelection().toString()` behavior closer to the [w3c selection api working draft](https://www.w3.org/TR/selection-api/#dom-selection-stringifier).

Fixes #7267