### PR TITLE
LibGfx: A few Vulkan bug fixes found using validation layers

### DIFF
--- a/Libraries/LibGfx/VulkanContext.cpp
+++ b/Libraries/LibGfx/VulkanContext.cpp
@@ -333,7 +333,7 @@ ErrorOr<NonnullRefPtr<VulkanImage>> create_shared_vulkan_image(VulkanContext con
         .samples = VK_SAMPLE_COUNT_1_BIT,
         .tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT,
         .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-        .sharingMode = VK_SHARING_MODE_CONCURRENT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
         .queueFamilyIndexCount = queue_families.size(),
         .pQueueFamilyIndices = queue_families.data(),
         .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,


### PR DESCRIPTION
This is an another split off from #6976. This includes a few fixes that are useful by themselves.