### PR TITLE
LibWeb: Do not attempt to access elements of empty list

### DIFF
--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -4201,7 +4201,9 @@ void toggle_lists(DOM::Document& document, FlyString const& tag_name)
 
             // 2. While either sublist is empty, or node list is not empty and its first member is the nextSibling of
             //    sublist's last member:
-            while (sublist.is_empty() || (!node_list.is_empty() && node_list.first().ptr() == sublist.last()->next_sibling())) {
+            // AD-HOC: This condition needs to be a bit different from what the spec describes, because node_list and
+            //         sublist can both be empty at the same time: https://github.com/w3c/editing/issues/521
+            while (!node_list.is_empty() && (sublist.is_empty() || node_list.first().ptr() == sublist.last()->next_sibling())) {
                 // 1. If node list's first member is a p or div, set the tag name of node list's first member to "li",
                 //    and append the result to sublist. Remove the first member from node list.
                 if (is<HTML::HTMLParagraphElement>(*node_list.first()) || is<HTML::HTMLDivElement>(*node_list.first())) {

--- a/Tests/LibWeb/Crash/HTML/execCommand-insertorderedlist-invisible-selection.html
+++ b/Tests/LibWeb/Crash/HTML/execCommand-insertorderedlist-invisible-selection.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<div contenteditable=""> </div>
+<script>
+const div = document.querySelector("[contenteditable]");
+const range = document.createRange();
+range.setStart(div, 0);
+range.setEnd(div, 1);
+document.getSelection().addRange(range);
+document.execCommand("insertorderedlist", false, "");
+</script>


### PR DESCRIPTION
This recovers 750+ WPT subtests that were lost when web-platform-tests/wpt#56913 was merged and added new testcases, two of which exposed this crash.

I have added my own testcase instead of importing the affected WPT tests since they are large and complex, which makes it hard to understand where the problem is coming from based on them alone. Also this is only a crash test (i.e. not a different kind) because the tested scenario doesn't actually behave correctly yet for seemingly unrelated reasons.

Fixes #7291.