### PR TITLE
LibWeb: Absolutize transition hint in ColorStopListElement

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
@@ -25,7 +25,9 @@ ColorStopListElement ColorStopListElement::absolutized(ComputationContext const&
     };
 
     return {
-        .transition_hint = transition_hint,
+        .transition_hint = transition_hint.map([&context](ColorHint const& color_hint) {
+            return ColorHint { color_hint.value->absolutized(context) };
+        }),
         .color_stop = {
             .color = absolutize_if_nonnull(color_stop.color),
             .position = absolutize_if_nonnull(color_stop.position),

--- a/Tests/LibWeb/Crash/Layout/non-absolute-gradient-length.html
+++ b/Tests/LibWeb/Crash/Layout/non-absolute-gradient-length.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<div style="position: absolute; background: repeating-linear-gradient(to bottom, red, 10rem, transparent 10rem); width:1rem; top:1rem; height: 20rem"></div>


### PR DESCRIPTION
This fixes a crash on the major Dutch news site nos.nl. The crash was shrunk to the following case:
```html
<!doctype html>
<div style="position: absolute; background: repeating-linear-gradient(to bottom, red, 10rem, transparent 10rem); width:1rem; top:1rem; height: 20rem"></div>
```
In this case, the problem was caused by the usage of a font-relative size in the gradient section size. (10rem). This is then placed into the transition hint of a `ColorStopListElement`, which is not absolutized when the element is. I've added the absolutization of this member into the absolutize function for the `ColorStopListElement`, and the page now now no longer crashes.

I also added a test that crashes before the change, and does not crash after the change.

(This is a solution for the problem that was initially solved in a different way in #7290, which I've closed.)