### PR TITLE
LibWeb: Store `ColorStopListElement::transition_hint` as a `RefPtr`

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -40,7 +40,7 @@ Optional<Vector<ColorStopListElement>> Parser::parse_color_stop_list(TokenStream
             tokens.discard_whitespace();
             // <T-percentage>
             if (!tokens.has_next_token() || tokens.next_token().is(Token::Type::Comma)) {
-                element.transition_hint = ColorStopListElement::ColorHint { *position };
+                element.transition_hint = position;
                 return ElementType::ColorHint;
             }
             // <T-percentage> <color>

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.cpp
@@ -25,9 +25,7 @@ ColorStopListElement ColorStopListElement::absolutized(ComputationContext const&
     };
 
     return {
-        .transition_hint = transition_hint.map([&context](ColorHint const& color_hint) {
-            return ColorHint { color_hint.value->absolutized(context) };
-        }),
+        .transition_hint = absolutize_if_nonnull(transition_hint),
         .color_stop = {
             .color = absolutize_if_nonnull(color_stop.color),
             .position = absolutize_if_nonnull(color_stop.position),
@@ -43,8 +41,8 @@ void serialize_color_stop_list(StringBuilder& builder, Vector<ColorStopListEleme
         if (!first)
             builder.append(", "sv);
 
-        if (element.transition_hint.has_value())
-            builder.appendff("{}, "sv, element.transition_hint->value->to_string(mode));
+        if (element.transition_hint)
+            builder.appendff("{}, "sv, element.transition_hint->to_string(mode));
 
         builder.append(element.color_stop.color->to_string(mode));
         if (element.color_stop.position)

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -158,12 +158,7 @@ struct InterpolationMethod {
 };
 
 struct ColorStopListElement {
-    struct ColorHint {
-        NonnullRefPtr<StyleValue const> value;
-        bool operator==(ColorHint const&) const = default;
-    };
-
-    Optional<ColorHint> transition_hint;
+    RefPtr<StyleValue const> transition_hint;
     struct ColorStop {
         RefPtr<StyleValue const> color;
         RefPtr<StyleValue const> position;

--- a/Libraries/LibWeb/Painting/GradientPainting.cpp
+++ b/Libraries/LibWeb/Painting/GradientPainting.cpp
@@ -58,8 +58,8 @@ static ColorStopData resolve_color_stop_positions(Layout::NodeWithStyle const& n
     };
     size_t resolved_index = 0;
     for (auto& stop : color_stop_list) {
-        if (stop.transition_hint.has_value())
-            resolved_color_stops[resolved_index].transition_hint = resolve_stop_position(*stop.transition_hint->value);
+        if (stop.transition_hint)
+            resolved_color_stops[resolved_index].transition_hint = resolve_stop_position(*stop.transition_hint);
         if (stop.color_stop.position)
             resolved_color_stops[resolved_index].position = resolve_stop_position(*stop.color_stop.position);
         if (stop.color_stop.second_position)


### PR DESCRIPTION
There's no need for us to wrap this in an optional struct.