### PR TITLE
LibWeb: More efficiently pack `ComputedValues` struct

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -694,85 +694,86 @@ public:
 protected:
     struct {
         Color caret_color { InitialValues::caret_color() };
-        RefPtr<Gfx::FontCascadeList const> font_list {};
         CSSPixels font_size { InitialValues::font_size() };
+        RefPtr<Gfx::FontCascadeList const> font_list {};
         double font_weight { InitialValues::font_weight() };
         Gfx::ShapeFeatures font_features { InitialValues::font_features() };
         Optional<FlyString> font_language_override;
         HashMap<FlyString, double> font_variation_settings;
         CSSPixels line_height { InitialValues::line_height() };
         BorderCollapse border_collapse { InitialValues::border_collapse() };
+        CaptionSide caption_side { InitialValues::caption_side() };
         EmptyCells empty_cells { InitialValues::empty_cells() };
+        ContentVisibility content_visibility { InitialValues::content_visibility() };
         Length border_spacing_horizontal { InitialValues::border_spacing() };
         Length border_spacing_vertical { InitialValues::border_spacing() };
-        CaptionSide caption_side { InitialValues::caption_side() };
         Color color { InitialValues::color() };
         ColorInterpolation color_interpolation { InitialValues::color_interpolation() };
+
         PreferredColorScheme color_scheme { InitialValues::color_scheme() };
         Optional<Color> accent_color {};
         Color webkit_text_fill_color { InitialValues::color() };
-        ContentVisibility content_visibility { InitialValues::content_visibility() };
         Vector<CursorData> cursor { InitialValues::cursor() };
         ImageRendering image_rendering { InitialValues::image_rendering() };
         PointerEvents pointer_events { InitialValues::pointer_events() };
-        Variant<Length, double> tab_size { InitialValues::tab_size() };
         TextAlign text_align { InitialValues::text_align() };
         TextJustify text_justify { InitialValues::text_justify() };
         TextTransform text_transform { InitialValues::text_transform() };
-        TextIndentData text_indent { InitialValues::text_indent() };
         TextWrapMode text_wrap_mode { InitialValues::text_wrap_mode() };
-        CSSPixels text_underline_offset { InitialValues::text_underline_offset() };
         TextUnderlinePosition text_underline_position { InitialValues::text_underline_position() };
+        Variant<Length, double> tab_size { InitialValues::tab_size() };
+        TextIndentData text_indent { InitialValues::text_indent() };
+        CSSPixels text_underline_offset { InitialValues::text_underline_offset() };
         WhiteSpaceCollapse white_space_collapse { InitialValues::white_space_collapse() };
         WordBreak word_break { InitialValues::word_break() };
+        ListStylePosition list_style_position { InitialValues::list_style_position() };
+        Visibility visibility { InitialValues::visibility() };
         CSSPixels word_spacing { InitialValues::word_spacing() };
         CSSPixels letter_spacing { InitialValues::letter_spacing() };
         ListStyleType list_style_type { InitialValues::list_style_type() };
-        ListStylePosition list_style_position { InitialValues::list_style_position() };
-        Visibility visibility { InitialValues::visibility() };
         QuotesData quotes { InitialValues::quotes() };
         Direction direction { InitialValues::direction() };
         WritingMode writing_mode { InitialValues::writing_mode() };
-
-        Optional<SVGPaint> fill;
         FillRule fill_rule { InitialValues::fill_rule() };
-        Optional<SVGPaint> stroke;
-        float fill_opacity { InitialValues::fill_opacity() };
-        PaintOrderList paint_order { InitialValues::paint_order() };
-        Vector<Variant<LengthPercentage, NumberOrCalculated>> stroke_dasharray;
-        LengthPercentage stroke_dashoffset { InitialValues::stroke_dashoffset() };
         StrokeLinecap stroke_linecap { InitialValues::stroke_linecap() };
+        float fill_opacity { InitialValues::fill_opacity() };
+        Optional<SVGPaint> fill;
+        Optional<SVGPaint> stroke;
+        PaintOrderList paint_order { InitialValues::paint_order() };
         StrokeLinejoin stroke_linejoin { InitialValues::stroke_linejoin() };
-        double stroke_miterlimit { InitialValues::stroke_miterlimit() };
-        float stroke_opacity { InitialValues::stroke_opacity() };
-        LengthPercentage stroke_width { InitialValues::stroke_width() };
         TextAnchor text_anchor { InitialValues::text_anchor() };
         ClipRule clip_rule { InitialValues::clip_rule() };
-
-        Vector<ShadowData> text_shadow;
-
         MathShift math_shift { InitialValues::math_shift() };
         MathStyle math_style { InitialValues::math_style() };
+        Vector<Variant<LengthPercentage, NumberOrCalculated>> stroke_dasharray;
+        LengthPercentage stroke_dashoffset { InitialValues::stroke_dashoffset() };
+        double stroke_miterlimit { InitialValues::stroke_miterlimit() };
+        LengthPercentage stroke_width { InitialValues::stroke_width() };
+        Vector<ShadowData> text_shadow;
         int math_depth { InitialValues::math_depth() };
-
         ScrollbarColorData scrollbar_color { InitialValues::scrollbar_color() };
+        float stroke_opacity { InitialValues::stroke_opacity() };
     } m_inherited;
 
     struct {
         AspectRatio aspect_ratio { InitialValues::aspect_ratio() };
         Float float_ { InitialValues::float_() };
         Clear clear { InitialValues::clear() };
+        TextOverflow text_overflow { InitialValues::text_overflow() };
+        Positioning position { InitialValues::position() };
+        Optional<int> z_index;
+        Display display_before_box_type_transformation { InitialValues::display() };
         Clip clip { InitialValues::clip() };
         Display display { InitialValues::display() };
-        Display display_before_box_type_transformation { InitialValues::display() };
-        Optional<int> z_index;
+        float opacity { InitialValues::opacity() };
         // FIXME: Store this as flags in a u8.
         Vector<TextDecorationLine> text_decoration_line { InitialValues::text_decoration_line() };
         TextDecorationThickness text_decoration_thickness { TextDecorationThickness::Auto {} };
         TextDecorationStyle text_decoration_style { InitialValues::text_decoration_style() };
+        bool has_noninitial_border_radii { false };
+        FlexWrap flex_wrap { InitialValues::flex_wrap() };
+        AlignContent align_content { InitialValues::align_content() };
         Color text_decoration_color { InitialValues::color() };
-        TextOverflow text_overflow { InitialValues::text_overflow() };
-        Positioning position { InitialValues::position() };
         Size width { InitialValues::width() };
         Size min_width { InitialValues::min_width() };
         Size max_width { InitialValues::max_width() };
@@ -788,21 +789,21 @@ protected:
         BorderData border_top;
         BorderData border_right;
         BorderData border_bottom;
-        bool has_noninitial_border_radii { false };
         BorderRadiusData border_bottom_left_radius;
         BorderRadiusData border_bottom_right_radius;
         BorderRadiusData border_top_left_radius;
         BorderRadiusData border_top_right_radius;
         Color background_color { InitialValues::background_color() };
-        BackgroundBox background_color_clip { InitialValues::background_color_clip() };
+        int order { InitialValues::order() };
         Vector<BackgroundLayerData> background_layers;
         FlexDirection flex_direction { InitialValues::flex_direction() };
-        FlexWrap flex_wrap { InitialValues::flex_wrap() };
+        ColumnSpan column_span { InitialValues::column_span() };
+        BackgroundBox background_color_clip { InitialValues::background_color_clip() };
+
+        Color flood_color { InitialValues::flood_color() };
         FlexBasis flex_basis { InitialValues::flex_basis() };
         float flex_grow { InitialValues::flex_grow() };
         float flex_shrink { InitialValues::flex_shrink() };
-        int order { InitialValues::order() };
-        AlignContent align_content { InitialValues::align_content() };
         AlignItems align_items { InitialValues::align_items() };
         AlignSelf align_self { InitialValues::align_self() };
         Appearance appearance { InitialValues::appearance() };
@@ -811,13 +812,12 @@ protected:
         JustifySelf justify_self { InitialValues::justify_self() };
         Overflow overflow_x { InitialValues::overflow() };
         Overflow overflow_y { InitialValues::overflow() };
-        float opacity { InitialValues::opacity() };
-        Vector<ShadowData> box_shadow {};
-        Vector<NonnullRefPtr<TransformationStyleValue const>> transformations {};
         TransformBox transform_box { InitialValues::transform_box() };
-        TransformOrigin transform_origin {};
         TransformStyle transform_style { InitialValues::transform_style() };
         BoxSizing box_sizing { InitialValues::box_sizing() };
+        Vector<ShadowData> box_shadow {};
+        Vector<NonnullRefPtr<TransformationStyleValue const>> transformations {};
+        TransformOrigin transform_origin {};
         ContentData content;
         Variant<VerticalAlign, LengthPercentage> vertical_align { InitialValues::vertical_align() };
         GridTrackSizeList grid_auto_columns;
@@ -825,13 +825,14 @@ protected:
         GridTrackSizeList grid_template_columns;
         GridTrackSizeList grid_template_rows;
         GridAutoFlow grid_auto_flow { InitialValues::grid_auto_flow() };
+        OutlineStyle outline_style { InitialValues::outline_style() };
+        ObjectFit object_fit { InitialValues::object_fit() };
+        ColumnCount column_count { InitialValues::column_count() };
         GridTrackPlacement grid_column_end { InitialValues::grid_column_end() };
         GridTrackPlacement grid_column_start { InitialValues::grid_column_start() };
         GridTrackPlacement grid_row_end { InitialValues::grid_row_end() };
         GridTrackPlacement grid_row_start { InitialValues::grid_row_start() };
-        ColumnCount column_count { InitialValues::column_count() };
         Variant<LengthPercentage, NormalGap> column_gap { InitialValues::column_gap() };
-        ColumnSpan column_span { InitialValues::column_span() };
         Size column_width { InitialValues::column_width() };
         Size column_height { InitialValues::column_height() };
         Variant<LengthPercentage, NormalGap> row_gap { InitialValues::row_gap() };
@@ -840,12 +841,9 @@ protected:
         float stop_opacity { InitialValues::stop_opacity() };
         Time transition_delay { InitialValues::transition_delay() };
         Color outline_color { InitialValues::outline_color() };
-        Length outline_offset { InitialValues::outline_offset() };
-        OutlineStyle outline_style { InitialValues::outline_style() };
         CSSPixels outline_width { InitialValues::outline_width() };
+        Length outline_offset { InitialValues::outline_offset() };
         TableLayout table_layout { InitialValues::table_layout() };
-        ObjectFit object_fit { InitialValues::object_fit() };
-        Position object_position { InitialValues::object_position() };
         UnicodeBidi unicode_bidi { InitialValues::unicode_bidi() };
         UserSelect user_select { InitialValues::user_select() };
         Isolation isolation { InitialValues::isolation() };
@@ -853,20 +851,21 @@ protected:
         ContainerType container_type { InitialValues::container_type() };
         MixBlendMode mix_blend_mode { InitialValues::mix_blend_mode() };
         WhiteSpaceTrimData white_space_trim;
+        Position object_position { InitialValues::object_position() };
         Optional<FlyString> view_transition_name;
         TouchActionData touch_action;
-
+        MaskType mask_type { InitialValues::mask_type() };
+        ScrollbarWidth scrollbar_width { InitialValues::scrollbar_width() };
+        ShapeRendering shape_rendering { InitialValues::shape_rendering() };
+        float flood_opacity { InitialValues::flood_opacity() };
         RefPtr<TransformationStyleValue const> rotate;
         RefPtr<TransformationStyleValue const> translate;
         RefPtr<TransformationStyleValue const> scale;
         Optional<CSSPixels> perspective;
         Position perspective_origin;
-
         Optional<MaskReference> mask;
-        MaskType mask_type { InitialValues::mask_type() };
         Optional<ClipPathReference> clip_path;
         RefPtr<AbstractImageStyleValue const> mask_image;
-
         LengthPercentage cx { InitialValues::cx() };
         LengthPercentage cy { InitialValues::cy() };
         LengthPercentage r { InitialValues::r() };
@@ -874,18 +873,10 @@ protected:
         LengthPercentageOrAuto ry { InitialValues::ry() };
         LengthPercentage x { InitialValues::x() };
         LengthPercentage y { InitialValues::x() };
-
-        ScrollbarWidth scrollbar_width { InitialValues::scrollbar_width() };
         Vector<CounterData, 0> counter_increment;
         Vector<CounterData, 0> counter_reset;
         Vector<CounterData, 0> counter_set;
-
         WillChange will_change { InitialValues::will_change() };
-
-        Color flood_color { InitialValues::flood_color() };
-        float flood_opacity { InitialValues::flood_opacity() };
-
-        ShapeRendering shape_rendering { InitialValues::shape_rendering() };
     } m_noninherited;
 };
 


### PR DESCRIPTION
This reduces the size of `ComputedValues` from 3240 bytes to 3064 bytes