### PR TITLE
LibGfx: Make Nvidia 10 series GPU work with Dedicated Memory Allocation

### DIFF
--- a/Libraries/LibGfx/VulkanContext.cpp
+++ b/Libraries/LibGfx/VulkanContext.cpp
@@ -358,9 +358,18 @@ ErrorOr<NonnullRefPtr<VulkanImage>> create_shared_vulkan_image(VulkanContext con
         return Error::from_string_literal("unable to find suitable image memory type");
     }
 
+    // Set up dedicated memory allocation; required for NVIDIA 10 series GPUs.
+    // https://docs.vulkan.org/refpages/latest/refpages/source/VkMemoryAllocateInfo.html#VUID-VkMemoryAllocateInfo-pNext-00639
+    VkMemoryDedicatedAllocateInfo mem_dedicated_alloc_info = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .image = image->image,
+        .buffer = VK_NULL_HANDLE,
+    };
+
     VkExportMemoryAllocateInfo export_mem_alloc_info = {
         .sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO,
-        .pNext = nullptr,
+        .pNext = &mem_dedicated_alloc_info,
         .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
     };
     VkMemoryAllocateInfo mem_alloc_info = {


### PR DESCRIPTION
Vulkan validation layers reports that in `Gfx::create_shared_vulkan_image()` the image's external memory needed a dedicated allocation.

Also on Nvidia GTX 1060 and 1070 (Pascal micro-architecture) encountered problems with WebGL and WebGL2. Only one context could be created and on the second context glCheckFramebufferStatus would not report GL_FRAMEBUFFER_COMPLETE, see #7207

Fixes following Vulkan validation layers error, which is only visible when checking on an Nvidia device:
```
Validation Error: [ VUID-VkMemoryAllocateInfo-pNext-00639 ] Object 0: handle = 0x3c000000003c, type = VK_OBJECT_TYPE_IMAGE; Object 1: handle = 0x3d000000003d, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0xfd0fdaf4 | vkBindImageMemory(): memory (VkDeviceMemory 0x3d000000003d[]) has VkExportMemoryAllocateInfo::handleTypes with the VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT flag set, which requires dedicated allocation for the image created with format (VK_FORMAT_B8G8R8A8_UNORM), type (VK_IMAGE_TYPE_2D), tiling (VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT), usage (VK_IMAGE_USAGE_TRANSFER_SRC_BIT|VK_IMAGE_USAGE_TRANSFER_DST_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT), flags (VkImageCreateFlags(0)), but the memory is allocated without dedicated allocation support.
The Vulkan spec states: If the pNext chain includes a VkExportMemoryAllocateInfo structure, and any of the handle types specified in VkExportMemoryAllocateInfo::handleTypes require a dedicated allocation, as reported by vkGetPhysicalDeviceImageFormatProperties2 in VkExternalImageFormatProperties::externalMemoryProperties.externalMemoryFeatures, or by vkGetPhysicalDeviceExternalBufferProperties in VkExternalBufferProperties::externalMemoryProperties.externalMemoryFeatures, the pNext chain must include a VkMemoryDedicatedAllocateInfo or VkDedicatedAllocationMemoryAllocateInfoNV structure with either its image or buffer member set to a value other than VK_NULL_HANDLE (https://docs.vulkan.org/spec/latest/chapters/memory.html#VUID-VkMemoryAllocateInfo-pNext-00639)
```


fixes: #7207

Fix tested on following GPUs: Nvidia GTX 1060, Nvidia RTX 3060, AMD RX 9060 XT, and IGDs: Intel UHD Graphics 630

With this fix in place, no Vulkan validation layers errors remain.