### PR TITLE
LibRegex: Add support for regex modifiers

### DIFF
--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
@@ -376,3 +376,61 @@ test("RegExp string literal", () => {
         expect(() => new RegExp(pattern, "v")).toThrow(SyntaxError);
     });
 });
+
+// https://github.com/tc39/test262/tree/main/test/built-ins/RegExp/regexp-modifiers
+test("RegExp modifiers", () => {
+    const testModifiers = (pattern, flags, tests) => {
+        const re = new RegExp(pattern, flags);
+        tests.forEach(([input, expected]) => expect(re.test(input)).toBe(expected));
+    };
+
+    testModifiers("(^a$)|(?:^b$)|(?m:^c$)|(?:^d$)|(^e$)", "", [
+        ["\na\n", false],
+        ["\nb\n", false],
+        ["\nc\n", true],
+        ["\nd\n", false],
+        ["\ne\n", false],
+    ]);
+
+    testModifiers("(?m-:es$|(?-m:js$))", "", [
+        ["es\ns", true],
+        ["js", true],
+        ["js\ns", false],
+    ]);
+
+    testModifiers("(a)|(?:b)|(?-i:c)|(?:d)|(e)", "i", [
+        ["A", true],
+        ["B", true],
+        ["C", false],
+        ["D", true],
+        ["E", true],
+    ]);
+
+    testModifiers("(?m:es.$)", "", [
+        ["esz\n", true],
+        ["es\n\n", false],
+    ]);
+
+    testModifiers("(?m-:es.$)", "s", [
+        ["esz\n", true],
+        ["es\n\n", true],
+    ]);
+
+    testModifiers("(?-i:\\u{0061})b", "iu", [
+        ["ab", true],
+        ["aB", true],
+        ["Ab", false],
+    ]);
+
+    testModifiers("(?-i:\\p{Lu})", "iu", [
+        ["A", true],
+        ["a", false],
+        ["Z", true],
+        ["z", false],
+    ]);
+
+    testModifiers("(?-m:^es)$", "m", [
+        ["e\nes\n", false],
+        ["es\n", true],
+    ]);
+});

--- a/Libraries/LibRegex/RegexDefs.h
+++ b/Libraries/LibRegex/RegexDefs.h
@@ -29,6 +29,8 @@ enum __Regex_Error {
     __Regex_DuplicateNamedCapture,        // Duplicate named capture group
     __Regex_InvalidCharacterClassEscape,  // Invalid escaped entity in character class.
     __Regex_NegatedCharacterClassStrings, // Negated character class cannot contain strings.
+    __Regex_InvalidModifierGroup,         // Invalid modifier group.
+    __Regex_RepeatedModifierFlag,         // Repeated flag in modifier group.
 };
 
 enum __RegexAllFlags {

--- a/Libraries/LibRegex/RegexError.h
+++ b/Libraries/LibRegex/RegexError.h
@@ -34,6 +34,8 @@ enum class Error : u8 {
     DuplicateNamedCapture = __Regex_DuplicateNamedCapture,               // Name of property is invalid.
     InvalidCharacterClassEscape = __Regex_InvalidCharacterClassEscape,   // Invalid escaped entity in character class.
     NegatedCharacterClassStrings = __Regex_NegatedCharacterClassStrings, // Negated character class may contain strings.
+    InvalidModifierGroup = __Regex_InvalidModifierGroup,                 // Invalid modifier group.
+    RepeatedModifierFlag = __Regex_RepeatedModifierFlag,                 // Repeated flag in modifier group.
 };
 
 inline StringView get_error_string(Error error)
@@ -80,7 +82,11 @@ inline StringView get_error_string(Error error)
     case Error::InvalidCharacterClassEscape:
         return "Invalid escaped entity in character class."sv;
     case Error::NegatedCharacterClassStrings:
-        return "Negated character class cannot contain strings"sv;
+        return "Negated character class cannot contain strings."sv;
+    case Error::InvalidModifierGroup:
+        return "Invalid modifier group."sv;
+    case Error::RepeatedModifierFlag:
+        return "Repeated flag in modifier group."sv;
     }
     return "Undefined error."sv;
 }

--- a/Libraries/LibRegex/RegexMatch.h
+++ b/Libraries/LibRegex/RegexMatch.h
@@ -424,9 +424,12 @@ struct MatchState {
     COWVector<u64> repetition_marks;
     Vector<u64, 64> checkpoints;
     Vector<i64> step_backs;
+    Vector<FlagsUnderlyingType, 1> modifier_stack;
+    AllOptions current_options;
 
-    explicit MatchState(size_t capture_group_count)
+    explicit MatchState(size_t capture_group_count, AllOptions options = {})
         : capture_group_count(capture_group_count)
+        , current_options(options)
     {
     }
 

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -177,13 +177,13 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
     size_t match_count { 0 };
 
     MatchInput input;
-    MatchState state { m_pattern->parser_result.capture_groups_count };
     size_t operations = 0;
 
     input.pattern = m_pattern->pattern_value;
 
     input.regex_options = m_regex_options | regex_options.value_or({}).value();
     input.start_offset = m_pattern->start_offset;
+    MatchState state(m_pattern->parser_result.capture_groups_count, input.regex_options);
     size_t lines_to_skip = 0;
 
     bool unicode = input.regex_options.has_flag_set(AllFlags::Unicode) || input.regex_options.has_flag_set(AllFlags::UnicodeSets);
@@ -276,6 +276,8 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
 
             state.instruction_position = 0;
             state.repetition_marks.clear();
+            state.modifier_stack.clear();
+            state.current_options = input.regex_options;
 
             auto result = execute(input, state, temp_operations);
             // This success is acceptable only if it doesn't read anything from the input (input length is 0).
@@ -336,6 +338,8 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             }
             state.instruction_position = 0;
             state.repetition_marks.clear();
+            state.modifier_stack.clear();
+            state.current_options = input.regex_options;
 
             if (auto const result = execute(input, state, operations); result == ExecuteResult::Matched) {
                 succeeded = true;


### PR DESCRIPTION
This PR adds support for regex modifiers. The big three already support them, so we shouldn’t fall behind :)

Also finally fixes #4284.

We now pass 64/70 tests in [regexp-modifiers 262](https://ladybirdbrowser.github.io/libjs-website/test262/per-file/?path=test/built-ins/RegExp/regexp-modifiers). The remaining six still fail because we have issues with Unicode case-insensitive matching. I’m hoping to fix that in a different PR.

Summary:
+64 ✅    -64 ❌   

```
test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-alternatives-outside.js                       ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-dotAll-property.js                            ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-ignoreCase-flag.js                            ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-multiline-flag.js                             ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-dotAll.js                                                            ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-backreferences.js                                 ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-characterClasses.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-characterEscapes.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-alternatives-outside.js                   ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-dotAll-flag.js                            ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-ignoreCase-property.js                    ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-multiline-flag.js                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-ignoreCase.js                                                        ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-alternatives-outside.js                    ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-dotAll-flag.js                             ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-ignoreCase-flag.js                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-multiline-property.js                      ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-multiline.js                                                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/add-remove-modifiers.js                                                  ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js                  ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/changing-ignoreCase-flag-does-not-affect-ignoreCase-modifier.js          ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/changing-multiline-flag-does-not-affect-multiline-modifier.js            ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nested-add-remove-modifiers.js                                           ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-add-ignoreCase-within-remove-ignoreCase.js                       ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-add-multiline-within-remove-multiline.js                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-dotAll-does-not-affect-alternatives-outside.js                   ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-ignoreCase-does-not-affect-alternatives-outside.js               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-multiline-does-not-affect-alternatives-outside.js                ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-remove-dotAll-within-add-dotAll.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-remove-ignoreCase-within-add-ignoreCase.js                       ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/nesting-remove-multiline-within-add-multiline.js                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-alternatives-outside.js                    ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-dotAll-property.js                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-ignoreCase-flag.js                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-multiline-flag.js                          ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-dotAll.js                                                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-backreferences.js                              ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-characterClasses.js                            ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-characterEscapes.js                            ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-lower-b.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-lower-p.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-lower-w.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-upper-b.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-upper-p.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-upper-w.js                               ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-alternatives-outside.js                ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-dotAll-flag.js                         ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-ignoreCase-property.js                 ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-multiline-flag.js                      ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase.js                                                     ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-alternatives-outside.js                 ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-dotAll-flag.js                          ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-ignoreCase-flag.js                      ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-multiline-property.js                   ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/remove-multiline.js                                                      ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-and-remove-modifiers-can-have-empty-remove-modifiers.js ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-and-remove-modifiers.js                                 ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-modifiers-when-nested.js                                ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-modifiers-when-not-set-as-flags.js                      ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-modifiers-when-set-as-flags.js                          ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/remove-modifiers-when-nested.js                             ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/remove-modifiers-when-not-set-as-flags.js                   ❌ -> ✅
test/built-ins/RegExp/regexp-modifiers/syntax/valid/remove-modifiers-when-set-as-flags.js                       ❌ -> ✅ 
```