### PR TITLE
LibWeb: Move min-height handling for independent FCs to parent context

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2037,8 +2037,6 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
 
     build_grid_areas();
 
-    auto const& grid_computed_values = grid_container().computed_values();
-
     // NOTE: We store explicit grid sizes to later use in determining the position of items with negative index.
     m_explicit_columns_line_count = m_column_lines.size();
     m_explicit_rows_line_count = m_row_lines.size();
@@ -2099,26 +2097,6 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
     resolve_track_spacing(GridDimension::Column);
 
     resolve_track_spacing(GridDimension::Row);
-
-    CSSPixels min_height = 0;
-    if (!grid_computed_values.min_height().is_auto())
-        min_height = calculate_inner_height(grid_container(), available_space, grid_computed_values.min_height());
-
-    // If automatic grid container height is less than min-height, we need to re-run the track sizing algorithm
-    if (m_automatic_content_height < min_height) {
-        resolve_items_box_metrics(GridDimension::Row);
-
-        AvailableSize width(available_space.width);
-        AvailableSize height(AvailableSize::make_definite(min_height));
-        m_available_space = AvailableSpace(width, height);
-        run_track_sizing(GridDimension::Row);
-
-        resolve_items_box_metrics(GridDimension::Row);
-
-        resolve_grid_item_sizes(GridDimension::Row);
-
-        determine_grid_container_height();
-    }
 
     if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         determine_intrinsic_size_of_grid_container(available_space);

--- a/Tests/LibWeb/Layout/expected/grid-min-height-definite.txt
+++ b/Tests/LibWeb/Layout/expected/grid-min-height-definite.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 216 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 200 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 100 0+0+684] [0+0+0 200 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [8,8 32.375x18] baseline: 13.796875
+              "Item"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableBox (Box<DIV>.grid) [8,8 100x200]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x50]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x216] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid-min-height-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid-min-height-fit-content.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
+      Box <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] [GFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid-min-height-max-content-with-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid-min-height-max-content-with-content.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 66 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 50 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 100 0+0+684] [0+0+0 50 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [8,8 32.375x18] baseline: 13.796875
+              "Item"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,58] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableBox (Box<DIV>.grid) [8,8 100x50]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x50]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,58 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x66] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid-min-height-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid-min-height-max-content.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
+      Box <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] [GFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid-min-height-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid-min-height-min-content.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
+      Box <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] [GFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid-min-height-definite.html
+++ b/Tests/LibWeb/Layout/input/grid-min-height-definite.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+    .grid {
+        display: grid;
+        min-height: 200px;
+        width: 100px;
+        background: lightblue;
+    }
+    .item {
+        height: 50px;
+        background: pink;
+    }
+</style>
+<div class="grid">
+    <div class="item">Item</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid-min-height-fit-content.html
+++ b/Tests/LibWeb/Layout/input/grid-min-height-fit-content.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<style>
+    div { display: grid; min-height: fit-content; }
+</style>
+<div></div>

--- a/Tests/LibWeb/Layout/input/grid-min-height-max-content-with-content.html
+++ b/Tests/LibWeb/Layout/input/grid-min-height-max-content-with-content.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+    .grid {
+        display: grid;
+        min-height: max-content;
+        width: 100px;
+        background: lightblue;
+    }
+    .item {
+        height: 50px;
+        background: pink;
+    }
+</style>
+<div class="grid">
+    <div class="item">Item</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid-min-height-max-content.html
+++ b/Tests/LibWeb/Layout/input/grid-min-height-max-content.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<style>
+    div { display: grid; min-height: max-content; }
+</style>
+<div></div>

--- a/Tests/LibWeb/Layout/input/grid-min-height-min-content.html
+++ b/Tests/LibWeb/Layout/input/grid-min-height-min-content.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<style>
+    div { display: grid; min-height: min-content; }
+</style>
+<div></div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-template-rows-computed-withcontent.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-template-rows-computed-withcontent.txt
@@ -2,26 +2,26 @@ Harness status: OK
 
 Found 27 tests
 
-21 Pass
-6 Fail
+25 Pass
+2 Fail
 Pass	Property grid-template-rows value 'none'
-Fail	Property grid-template-rows value '20%'
+Pass	Property grid-template-rows value '20%'
 Pass	Property grid-template-rows value 'calc(-0.5em + 10px)'
 Pass	Property grid-template-rows value 'calc(0.5em + 10px)'
-Fail	Property grid-template-rows value 'calc(30% + 40px)'
+Pass	Property grid-template-rows value 'calc(30% + 40px)'
 Pass	Property grid-template-rows value '5fr'
 Pass	Property grid-template-rows value 'min-content'
 Pass	Property grid-template-rows value 'max-content'
 Pass	Property grid-template-rows value 'auto'
 Pass	Property grid-template-rows value 'minmax(10px, auto)'
-Fail	Property grid-template-rows value 'minmax(20%, max-content)'
+Pass	Property grid-template-rows value 'minmax(20%, max-content)'
 Pass	Property grid-template-rows value 'minmax(min-content, calc(-0.5em + 10px))'
 Pass	Property grid-template-rows value 'minmax(auto, 0)'
 Pass	Property grid-template-rows value 'fit-content(70px)'
 Pass	Property grid-template-rows value 'fit-content(20%)'
 Pass	Property grid-template-rows value 'fit-content(calc(-0.5em + 10px))'
 Pass	Property grid-template-rows value 'repeat(1, 10px)'
-Fail	Property grid-template-rows value 'repeat(1, [one two] 20%)'
+Pass	Property grid-template-rows value 'repeat(1, [one two] 20%)'
 Pass	Property grid-template-rows value 'repeat(2, minmax(10px, auto))'
 Pass	Property grid-template-rows value 'repeat(2, fit-content(20%) [three four] 30px 40px [five six])'
 Pass	Property grid-template-rows value 'min-content repeat(5, minmax(10px, auto))'


### PR DESCRIPTION
Previously, GridFormattingContext handled its own min-height constraints internally, which caused infinite recursion when min-height was an intrinsic sizing keyword (e.g., min-height: max-content).

This change moves the responsibility to the parent formatting context (BFC). When any box establishing an independent formatting context has auto height but non-auto min-height:
1. BFC measures content height using a throwaway LayoutState
2. If content height < min-height, BFC passes min-height as definite available height to the child formatting context
3. Child FC runs once with correct constraints, unaware of min-height

Fixes https://github.com/LadybirdBrowser/ladybird/issues/4261 which is corresponding to stack overflow on https://claude.ai/