### PR TITLE
LibWeb: Address edge case on async module load

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -654,7 +654,7 @@ void fetch_single_module_script(JS::Realm& realm,
 
     // 6. If moduleMap[(url, moduleType)] exists, run onComplete given moduleMap[(url, moduleType)], and return.
     auto entry = module_map.get(url, module_type.to_byte_string());
-    if (entry.has_value() && entry->type == ModuleMap::EntryType::ModuleScript) {
+    if (entry.has_value()) {
         on_complete->function()(entry->module_script);
         return;
     }

--- a/Tests/LibWeb/Text/expected/HTML/ModuleLoading/multiple-failed-imports.txt
+++ b/Tests/LibWeb/Text/expected/HTML/ModuleLoading/multiple-failed-imports.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/expected/error-stack-must-contain-full-url.txt
+++ b/Tests/LibWeb/Text/expected/error-stack-must-contain-full-url.txt
@@ -6,6 +6,4 @@ module: Error
     at Error
     at blob:file:///[flaky-uuid-replaced]:3:36
     at <unknown>
-    at <unknown>
-    at <unknown>
 

--- a/Tests/LibWeb/Text/input/HTML/ModuleLoading/multiple-failed-imports.html
+++ b/Tests/LibWeb/Text/input/HTML/ModuleLoading/multiple-failed-imports.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!--
+    Adapted from https://github.com/LadybirdBrowser/ladybird/issues/6294 
+    Regression test for a crash when target JS modules fail to load
+-->
+<script src="../../include.js"></script>
+
+<script defer="defer" async type="module" src="file///doesnotexist1.file"></script>
+<script defer="defer" async type="module" src="file///doesnotexist1.file"></script>
+
+<script src="file///doesnotexist1.file"></script>
+
+<script defer="defer" async type="module" src="file///doesnotexist1.file"></script>
+
+<script defer="defer">
+    test(() => println("PASS! (Didn't crash)"));
+</script>


### PR DESCRIPTION
Attempting to address #6294 

This is an edge case when the same module is loaded three times in a document, but all fail.

Failure scenario:
1. Module load 1 set the state to "Fetching"
2. Module load 2 registers a callback to `on_complete` since the current state is "Fetching"
3. Module load 1 finish with a failure, invoking the callback for load 2
4. Module load 3 cause a crash. The state is neither "Fetching" or "ModuleScript", so we'll reset the state to "Fetching". This invokes the callback for module load 2 again, now with an unexpected state which will cause an assert violation.

Proposed fix is to remove the condition that invokes `on_complete` callback immediately for successfully loaded modules only, the callback should be invoked regardless of whether the fetch succeeded or failed. 

This reveals a separate bug in HTMLScriptElement, where `mark_as_ready()` can be invoked before `m_steps_to_run_when_the_result_is_ready` is assigned. 
To mitigate that, add a new method `set_steps_to_run_when_the_result_is_ready()` instead of assigning `m_steps_to_run_when_the_result_is_ready` directly.