### PR TITLE
Tests: Disconnect the virtual gamepad in the navigables gamepad test

### DIFF
--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-is-available-in-new-navigables.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-is-available-in-new-navigables.html
@@ -34,6 +34,7 @@
 
             println(`Gamepad is now exposed in the new navigable: ${await sendMessageAndWait("getGamepads")}`);
 
+            gamepad.disconnect();
             done();
         };
 


### PR DESCRIPTION
Failing to disconnect the gamepad would cause subsequent gamepad tests to fail if they ran in the same WebView.