### PR TITLE
LibJS+LibWeb: Add missing visits for cached cross-origin properties

### DIFF
--- a/Libraries/LibJS/Runtime/PropertyDescriptor.cpp
+++ b/Libraries/LibJS/Runtime/PropertyDescriptor.cpp
@@ -224,4 +224,14 @@ PropertyAttributes PropertyDescriptor::attributes() const
     return { attributes };
 }
 
+void PropertyDescriptor::visit_edges(GC::Cell::Visitor& visitor)
+{
+    if (value.has_value())
+        visitor.visit(value.value());
+    if (get.has_value())
+        visitor.visit(get.value());
+    if (set.has_value())
+        visitor.visit(set.value());
+}
+
 }

--- a/Libraries/LibJS/Runtime/PropertyDescriptor.h
+++ b/Libraries/LibJS/Runtime/PropertyDescriptor.h
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <AK/String.h>
+#include <LibGC/Cell.h>
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Value.h>
@@ -34,6 +35,8 @@ public:
     {
         return !value.has_value() && !get.has_value() && !set.has_value() && !writable.has_value() && !enumerable.has_value() && !configurable.has_value() && !unimplemented.has_value();
     }
+
+    void visit_edges(GC::Cell::Visitor&);
 
     Optional<Value> value {};
     Optional<GC::Ptr<FunctionObject>> get {};

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -38,6 +38,8 @@ void Location::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_default_properties);
+    for (auto& descriptor : m_cross_origin_property_descriptor_map)
+        descriptor.value.visit_edges(visitor);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -138,6 +138,8 @@ void Window::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_scrollbars);
     visitor.visit(m_statusbar);
     visitor.visit(m_toolbar);
+    for (auto& descriptor : m_cross_origin_property_descriptor_map)
+        descriptor.value.visit_edges(visitor);
 }
 
 void Window::finalize()


### PR DESCRIPTION
This was causing GC-related crashes on various websites, most prominently on any site that contains embedded YouTube videos. The issue can be reproduced by going to any YouTube video, using the _Share_ button below it and pasting the embed code into an empty HTML file and loading it through localhost.

This is technically a regression from 89dbdd3411a3037ec31dcd96c15a47f062c7f48f (#7275) in that the problem became visible with that commit. However, there is nothing wrong with the commit by itself. It just happens that `Origin::is_same_origin_domain()` prior to that commit was completely bogus and would mistakenly return true in almost all cases, so the cross-origin code paths were not exercised.

I am uncertain how to make a automatic test case for this problem, given the nature of it being GC- and cross-origin-related. So there is no regression test included in this commit.