### PR TITLE
LibWeb: Propagate <body>'s `image-rendering` to root element

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1159,6 +1159,19 @@ Vector<CSS::BackgroundLayerData> const* Document::background_layers() const
     return &body_layout_node->background_layers();
 }
 
+CSS::ImageRendering Document::background_image_rendering() const
+{
+    auto* body_element = body();
+    if (!body_element)
+        return CSS::ImageRendering::Auto;
+
+    auto body_layout_node = body_element->layout_node();
+    if (!body_layout_node)
+        return CSS::ImageRendering::Auto;
+
+    return body_layout_node->computed_values().image_rendering();
+}
+
 void Document::update_base_element(Badge<HTML::HTMLBaseElement>)
 {
     GC::Ptr<HTML::HTMLBaseElement> base_element_with_href = nullptr;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -347,6 +347,7 @@ public:
 
     Color background_color() const;
     Vector<CSS::BackgroundLayerData> const* background_layers() const;
+    CSS::ImageRendering background_image_rendering() const;
 
     Optional<Color> normal_link_color() const;
     void set_normal_link_color(Color);

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -609,11 +609,19 @@ void PaintableBox::paint_backdrop_filter(DisplayListRecordingContext& context) c
 
 void PaintableBox::paint_background(DisplayListRecordingContext& context) const
 {
-    // If the body's background properties were propagated to the root element, do no re-paint the body's background.
+    // If the body's background properties were propagated to the root element, do not re-paint the body's background.
     if (layout_node_with_style_and_box_metrics().is_body() && document().html_element()->should_use_body_background_properties())
         return;
 
-    Painting::paint_background(context, *this, computed_values().image_rendering(), m_resolved_background, normalized_border_radii_data());
+    // If the body's background was propagated to the root element, use the body's image-rendering value.
+    auto image_rendering = computed_values().image_rendering();
+    if (layout_node().is_root_element()
+        && document().html_element()
+        && document().html_element()->should_use_body_background_properties()) {
+        image_rendering = document().background_image_rendering();
+    }
+
+    Painting::paint_background(context, *this, image_rendering, m_resolved_background, normalized_border_radii_data());
 }
 
 void PaintableBox::paint_box_shadow(DisplayListRecordingContext& context) const

--- a/Tests/LibWeb/Ref/expected/body-background-image-rendering-propagation-ref.html
+++ b/Tests/LibWeb/Ref/expected/body-background-image-rendering-propagation-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+html {
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAE0lEQVR4nGNgYGD4//8/GDMwAAAp5AX71ZPZmwAAAABJRU5ErkJggg==') no-repeat;
+    background-size: 100px 100px;
+    image-rendering: pixelated;
+}
+</style>

--- a/Tests/LibWeb/Ref/input/body-background-image-rendering-propagation.html
+++ b/Tests/LibWeb/Ref/input/body-background-image-rendering-propagation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/body-background-image-rendering-propagation-ref.html">
+<style>
+body {
+    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAE0lEQVR4nGNgYGD4//8/GDMwAAAp5AX71ZPZmwAAAABJRU5ErkJggg==') no-repeat;
+    background-size: 100px 100px;
+    image-rendering: pixelated;
+}
+</style>


### PR DESCRIPTION
Whenever we propagated a \<body\>'s background image to the root element, we ignored any `image-rendering` property present.

Fixes the background image rendering on https://sninkygle.ink/