### PR TITLE
Meta: Fix Clang plugins build on macOS

### DIFF
--- a/Meta/Lagom/ClangPlugins/CMakeLists.txt
+++ b/Meta/Lagom/ClangPlugins/CMakeLists.txt
@@ -14,13 +14,15 @@ function(clang_plugin target_name)
 
     add_custom_target(${target_name}Target DEPENDS ${target_name})
 
-    set_property(GLOBAL APPEND PROPERTY CLANG_PLUGINS_COMPILE_OPTIONS_FOR_TESTS -fplugin=${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${target_name}.so)
+    set_property(GLOBAL APPEND PROPERTY CLANG_PLUGINS_COMPILE_OPTIONS_FOR_TESTS -fplugin=${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${target_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
 
     add_lagom_library_install_rules(${target_name})
 
     if (NOT WIN32 AND NOT APPLE)
         target_link_options(${target_name} PRIVATE LINKER:-z,undefs)
         target_link_options(${target_name} PRIVATE LINKER:--allow-shlib-undefined)
+    elseif (APPLE)
+        target_link_options(${target_name} PRIVATE -undefined dynamic_lookup)
     endif()
 endfunction()
 


### PR DESCRIPTION
Two issues prevented building Clang plugins on macOS:

1. The plugin path used hardcoded `.so` extension, but macOS uses `.dylib`. Use CMAKE_SHARED_LIBRARY_SUFFIX instead.

2. The linker flags for allowing undefined symbols (resolved when the plugin is loaded by Clang) were only set for Linux. Add the equivalent `-undefined dynamic_lookup` flag for macOS.

Note: Building Clang plugins requires LLVM from Homebrew (e.g. `brew install llvm@20`) as Apple Clang does not ship with the required development headers.