### PR TITLE
LibJS: Optimize double boolean not (`!!`) operation

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -1209,6 +1209,9 @@ public:
     {
     }
 
+    auto const& lhs() const { return m_lhs; }
+    auto const& op() const { return m_op; }
+
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 

--- a/Libraries/LibJS/Tests/builtins/Boolean/Boolean.js
+++ b/Libraries/LibJS/Tests/builtins/Boolean/Boolean.js
@@ -30,3 +30,20 @@ test("basic functionality", () => {
     expect(Boolean([])).toBeTrue();
     expect(Boolean(1)).toBeTrue();
 });
+
+test("double negate", () => {
+    expect(!true).toBeFalse();
+    expect(!!true).toBeTrue();
+    expect(!false).toBeTrue();
+    expect(!!false).toBeFalse();
+    expect(!!null).toBeFalse();
+    expect(!!undefined).toBeFalse();
+    expect(!!NaN).toBeFalse();
+    expect(!!"").toBeFalse();
+    expect(!!0.0).toBeFalse();
+    expect(!!-0.0).toBeFalse();
+    expect(!!"0").toBeTrue();
+    expect(!!{}).toBeTrue();
+    expect(!![]).toBeTrue();
+    expect(!!1).toBeTrue();
+});


### PR DESCRIPTION
This is a common way to convert a value to a boolean. Instead of doing a boolean conversion and 2 negate operations, we replace this with a single `ToBoolean` op code.