### PR TITLE
LibWeb: Explicitly accept AVIF and WebP for images

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -262,7 +262,9 @@ GC::Ref<Infrastructure::FetchController> fetch(JS::Realm& realm, Infrastructure:
             // -> "image"
             case Infrastructure::Request::Destination::Image:
                 // `image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5`
-                value = "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"sv;
+                // Spec issue: Websites depend on there being modern image formats in the Accept header for re-encoding software, especially WebP to preserve transparency.
+                //             https://github.com/whatwg/fetch/issues/1905
+                value = "image/avif,image/webp,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"sv;
                 break;
             // -> "json"
             case Infrastructure::Request::Destination::JSON:


### PR DESCRIPTION
Websites depend on there being modern image formats in the Accept header for server side re-encoding software, especially WebP to preserve transparency.

For example, https://tvtropes.org/ for pages about pixel art games where there's typically transparency around the edges of the sprite.

Before:
<img width="823" height="220" alt="Screenshot 2026-01-07 at 13 41 22" src="https://github.com/user-attachments/assets/c8f4e9e0-996e-4769-92a2-f0afaf9c1abe" />

After:
<img width="808" height="214" alt="Screenshot 2026-01-07 at 13 42 41" src="https://github.com/user-attachments/assets/00ca0174-72d8-4965-87e8-50e8e65e2a85" />

Spec issue: https://github.com/whatwg/fetch/issues/1905