### PR TITLE
LibXML: Prevent auto-detection of UTF-32 encoding by `libxml2`

### DIFF
--- a/Libraries/LibXML/Parser/Parser.cpp
+++ b/Libraries/LibXML/Parser/Parser.cpp
@@ -7,6 +7,7 @@
 #include <AK/StringBuilder.h>
 #include <LibXML/Parser/Parser.h>
 
+#include <libxml/encoding.h>
 #include <libxml/parser.h>
 #include <libxml/parserInternals.h>
 #include <libxml/xmlerror.h>
@@ -360,6 +361,8 @@ ErrorOr<void, ParseError> Parser::parse_with_listener(Listener& listener)
     parser_ctx->_private = &context;
     xmlCtxtUseOptions(parser_ctx, options);
 
+    xmlSwitchEncoding(parser_ctx, XML_CHAR_ENCODING_UTF8);
+
     auto result = xmlParseChunk(parser_ctx, m_source.characters_without_null_termination(), static_cast<int>(m_source.length()), 1);
 
     bool well_formed = parser_ctx->wellFormed;
@@ -398,6 +401,8 @@ ErrorOr<Document, ParseError> Parser::parse()
 
     parser_ctx->_private = &context;
     xmlCtxtUseOptions(parser_ctx, options);
+
+    xmlSwitchEncoding(parser_ctx, XML_CHAR_ENCODING_UTF8);
 
     auto result = xmlParseChunk(parser_ctx, m_source.characters_without_null_termination(), static_cast<int>(m_source.length()), 1);
 

--- a/Tests/LibWeb/Text/expected/XML/xml-utf32-encoding-ignored.txt
+++ b/Tests/LibWeb/Text/expected/XML/xml-utf32-encoding-ignored.txt
@@ -1,0 +1,4 @@
+Normal XML: characterSet=UTF-8, element=root
+UTF-32 declared: characterSet=UTF-8, element=root
+UTF-32BE declared: characterSet=UTF-8, element=root
+UTF-32LE declared: characterSet=UTF-8, element=root

--- a/Tests/LibWeb/Text/input/XML/xml-utf32-encoding-ignored.html
+++ b/Tests/LibWeb/Text/input/XML/xml-utf32-encoding-ignored.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+test(() => {
+    const parser = new DOMParser();
+
+    const doc1 = parser.parseFromString("<root/>", "application/xml");
+    println(`Normal XML: characterSet=${doc1.characterSet}, element=${doc1.documentElement.localName}`);
+
+    const doc2 = parser.parseFromString('<?xml version="1.0" encoding="UTF-32"?><root/>', "application/xml");
+    println(`UTF-32 declared: characterSet=${doc2.characterSet}, element=${doc2.documentElement.localName}`);
+
+    const doc3 = parser.parseFromString('<?xml version="1.0" encoding="UTF-32BE"?><root/>', "application/xml");
+    println(`UTF-32BE declared: characterSet=${doc3.characterSet}, element=${doc3.documentElement.localName}`);
+
+    const doc4 = parser.parseFromString('<?xml version="1.0" encoding="UTF-32LE"?><root/>', "application/xml");
+    println(`UTF-32LE declared: characterSet=${doc4.characterSet}, element=${doc4.documentElement.localName}`);
+});
+</script>


### PR DESCRIPTION
This fixes a regression in https://wpt.live/encoding/utf-32.html that was introduced when we started using `libxml2` for parsing. I've included my own test since this test doesn't work correctly when imported.