### PR TITLE
LibWeb: Show the network error if request failed

### DIFF
--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -433,8 +433,11 @@ void ResourceLoader::load(LoadRequest& request, GC::Root<OnHeadersReceived> on_h
             log_success(request);
             on_complete->function()(true, timing_info, {});
         } else {
-            log_failure(request, "Request finished with error"sv);
-            on_complete->function()(false, timing_info, "Request finished with error"sv);
+            auto error_description = MUST(String::formatted(
+                "Request finished with error: {}",
+                network_error_to_string(*network_error)));
+            log_failure(request, error_description);
+            on_complete->function()(false, timing_info, error_description);
         }
     };
 


### PR DESCRIPTION
We were dropping the actual network error on the floor when reporting that something had failed.