### PR TITLE
LibWeb: Skip intrinsic sizing for stretched grid items

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/auto-margins-prevent-stretch-fr-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/auto-margins-prevent-stretch-fr-tracks.txt
@@ -1,0 +1,49 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 220 0+1+0] [BFC] children: not-inline
+    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 202 0+1+8] children: not-inline
+      Box <div.grid> at [11,11] [0+1+0 200 0+1+578] [0+1+0 200 0+1+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,12] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [12,12 58.796875x18] baseline: 13.796875
+              "stretch"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [149.234375,12] [37.234375+1+0 60.765625 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [149.234375,12 60.765625x18] baseline: 13.796875
+              "ml auto"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,192] [0+1+0 98 0+1+0] [80+1+0 18 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [12,192 63.390625x18] baseline: 13.796875
+              "mt auto"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [132.734375,152] [20.734375+1+0 56.53125 0+1+20.734375] [40+1+0 18 0+1+40] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 6, rect: [132.734375,152 56.53125x18] baseline: 13.796875
+              "m auto"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [10,212] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.grid) [10,10 202x202]
+        PaintableWithLines (BlockContainer<DIV>.item) [11,11 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [148.234375,11 62.765625x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [11,191 100x20]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [131.734375,151 58.53125x20]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,212 780x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/mixed-alignment-fr-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/mixed-alignment-fr-tracks.txt
@@ -1,0 +1,65 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 220 0+1+0] [BFC] children: not-inline
+    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 202 0+1+8] children: not-inline
+      Box <div.grid> at [11,11] [0+1+0 300 0+1+478] [0+1+0 200 0+1+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,12] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [12,12 58.796875x18] baseline: 13.796875
+              "stretch"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [112,12] [0+1+0 98 0+1+0] [0+1+0 18 0+1+80] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [112,12 41.234375x18] baseline: 13.796875
+              "start"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [212,52] [0+1+0 98 0+1+0] [40+1+0 18 0+1+40] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 6, rect: [212,52 51.625x18] baseline: 13.796875
+              "center"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,192] [0+1+0 98 0+1+0] [80+1+0 18 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [12,192 26.1875x18] baseline: 13.796875
+              "end"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [112,112] [0+1+0 54.171875 0+1+43.828125] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [112,112 54.171875x18] baseline: 13.796875
+              "j-start"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [228.71875,112] [16.71875+1+0 64.5625 0+1+16.71875] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 8, rect: [228.71875,112 64.5625x18] baseline: 13.796875
+              "j-center"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [10,212] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.grid) [10,10 302x202]
+        PaintableWithLines (BlockContainer<DIV>.item) [11,11 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [111,11 100x20]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [211,51 100x20]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [11,191 100x20]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [111,111 56.171875x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [227.71875,111 66.5625x100]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,212 780x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/nested-grid-stretch-fr-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/nested-grid-stretch-fr-tracks.txt
@@ -1,0 +1,63 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 220 0+1+0] [BFC] children: not-inline
+    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 202 0+1+8] children: not-inline
+      Box <div.outer-grid> at [11,11] [0+1+0 400 0+1+378] [0+1+0 200 0+1+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.inner-grid> at [12,12] [0+1+0 198 0+1+0] [0+1+0 198 0+1+0] [GFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.item> at [13,13] [0+1+0 97 0+1+0] [0+1+0 97 0+1+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x18] baseline: 13.796875
+                "A"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.item> at [112,13] [0+1+0 97 0+1+0] [0+1+0 97 0+1+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [112,13 9.34375x18] baseline: 13.796875
+                "B"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.item> at [13,112] [0+1+0 97 0+1+0] [0+1+0 97 0+1+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [13,112 10.3125x18] baseline: 13.796875
+                "C"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.item> at [112,112] [0+1+0 97 0+1+0] [0+1+0 97 0+1+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [112,112 11.140625x18] baseline: 13.796875
+                "D"
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [212,12] [0+1+0 198 0+1+0] [0+1+0 198 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [212,12 11.859375x18] baseline: 13.796875
+              "E"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [10,212] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.outer-grid) [10,10 402x202]
+        PaintableBox (Box<DIV>.inner-grid) [11,11 200x200]
+          PaintableWithLines (BlockContainer<DIV>.item) [12,12 99x99]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.item) [111,12 99x99]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.item) [12,111 99x99]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.item) [111,111 99x99]
+            TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [211,11 200x200]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,212 780x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/stretch-explicit-alignment-fr-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/stretch-explicit-alignment-fr-tracks.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 120 0+1+0] [BFC] children: not-inline
+    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 102 0+1+8] children: not-inline
+      Box <div.grid> at [11,11] [0+1+0 300 0+1+478] [0+1+0 100 0+1+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,12] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [12,12 58.796875x18] baseline: 13.796875
+              "stretch"
+          frag 1 from TextNode start: 8, length: 4, rect: [12,30 35.984375x18] baseline: 13.796875
+              "both"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [112,12] [0+1+0 198 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 16, rect: [112,12 123.75x18] baseline: 13.796875
+              "explicit stretch"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [10,112] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x122]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x104]
+      PaintableBox (Box<DIV>.grid) [10,10 302x102]
+        PaintableWithLines (BlockContainer<DIV>.item) [11,11 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [111,11 200x100]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,112 780x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x120] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/stretch-in-fr-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/stretch-in-fr-tracks.txt
@@ -1,0 +1,49 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 220 0+1+0] [BFC] children: not-inline
+    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 202 0+1+8] children: not-inline
+      Box <div.grid> at [11,11] [0+1+0 200 0+1+578] [0+1+0 200 0+1+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,12] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [12,12 6.34375x18] baseline: 13.796875
+              "1"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [112,12] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [112,12 8.8125x18] baseline: 13.796875
+              "2"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,112] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [12,112 9.09375x18] baseline: 13.796875
+              "3"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [112,112] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [112,112 7.75x18] baseline: 13.796875
+              "4"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [10,212] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.grid) [10,10 202x202]
+        PaintableWithLines (BlockContainer<DIV>.item) [11,11 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [111,11 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [11,111 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item) [111,111 100x100]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,212 780x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/stretch-with-fixed-margins-fr-tracks.txt
+++ b/Tests/LibWeb/Layout/expected/grid/stretch-with-fixed-margins-fr-tracks.txt
@@ -1,0 +1,53 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 220 0+1+0] [BFC] children: not-inline
+    BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 202 0+1+8] children: not-inline
+      Box <div.grid> at [11,11] [0+1+0 200 0+1+578] [0+1+0 200 0+1+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [12,12] [0+1+0 98 0+1+0] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 9, rect: [12,12 80.078125x18] baseline: 13.796875
+              "no margin"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item.with-margin> at [122,22] [10+1+0 78 0+1+10] [10+1+0 78 0+1+10] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [122,22 35.0625x18] baseline: 13.796875
+              "10px"
+          frag 1 from TextNode start: 5, length: 6, rect: [122,40 52.109375x18] baseline: 13.796875
+              "margin"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item.with-horizontal-margin> at [17,112] [5+1+0 78 0+1+15] [0+1+0 98 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [17,112 9.296875x18] baseline: 13.796875
+              "h"
+          frag 1 from TextNode start: 2, length: 7, rect: [17,130 61.453125x18] baseline: 13.796875
+              "margins"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item.with-vertical-margin> at [112,120] [0+1+0 98 0+1+0] [8+1+0 78 0+1+12] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 9, rect: [112,120 77.65625x18] baseline: 13.796875
+              "v margins"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [10,212] [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.grid) [10,10 202x202]
+        PaintableWithLines (BlockContainer<DIV>.item) [11,11 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item.with-margin) [121,21 80x80]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item.with-horizontal-margin) [16,111 80x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.item.with-vertical-margin) [111,119 100x80]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [10,212 780x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [1,1 798x220] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/auto-margins-prevent-stretch-fr-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/auto-margins-prevent-stretch-fr-tracks.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    * {
+        border: 1px solid black;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        width: 200px;
+        height: 200px;
+    }
+    .item {
+        background: lavender;
+    }
+</style>
+<div class="grid">
+    <div class="item">stretch</div>
+    <div class="item" style="margin-left: auto;">ml auto</div>
+    <div class="item" style="margin-top: auto;">mt auto</div>
+    <div class="item" style="margin: auto;">m auto</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/mixed-alignment-fr-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/mixed-alignment-fr-tracks.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+    * {
+        border: 1px solid black;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        width: 300px;
+        height: 200px;
+    }
+    .item {
+        background: lightcoral;
+    }
+</style>
+<div class="grid">
+    <div class="item">stretch</div>
+    <div class="item" style="align-self: start;">start</div>
+    <div class="item" style="align-self: center;">center</div>
+    <div class="item" style="align-self: end;">end</div>
+    <div class="item" style="justify-self: start;">j-start</div>
+    <div class="item" style="justify-self: center;">j-center</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/nested-grid-stretch-fr-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/nested-grid-stretch-fr-tracks.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+    * {
+        border: 1px solid black;
+    }
+    .outer-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr;
+        width: 400px;
+        height: 200px;
+    }
+    .inner-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        background: lightpink;
+    }
+    .item {
+        background: lightblue;
+    }
+</style>
+<div class="outer-grid">
+    <div class="inner-grid">
+        <div class="item">A</div>
+        <div class="item">B</div>
+        <div class="item">C</div>
+        <div class="item">D</div>
+    </div>
+    <div class="item">E</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/stretch-explicit-alignment-fr-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/stretch-explicit-alignment-fr-tracks.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    * {
+        border: 1px solid black;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        grid-template-rows: 1fr;
+        width: 300px;
+        height: 100px;
+        align-items: stretch;
+        justify-items: stretch;
+    }
+    .item {
+        background: lightgreen;
+    }
+</style>
+<div class="grid">
+    <div class="item">stretch both</div>
+    <div class="item" style="align-self: stretch; justify-self: stretch;">explicit stretch</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/stretch-in-fr-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/stretch-in-fr-tracks.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    * {
+        border: 1px solid black;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        width: 200px;
+        height: 200px;
+    }
+    .item {
+        background: lightblue;
+    }
+</style>
+<div class="grid">
+    <div class="item">1</div>
+    <div class="item">2</div>
+    <div class="item">3</div>
+    <div class="item">4</div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/stretch-with-fixed-margins-fr-tracks.html
+++ b/Tests/LibWeb/Layout/input/grid/stretch-with-fixed-margins-fr-tracks.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+    * {
+        border: 1px solid black;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr;
+        width: 200px;
+        height: 200px;
+    }
+    .item {
+        background: lightyellow;
+    }
+    .with-margin {
+        margin: 10px;
+    }
+    .with-horizontal-margin {
+        margin-left: 5px;
+        margin-right: 15px;
+    }
+    .with-vertical-margin {
+        margin-top: 8px;
+        margin-bottom: 12px;
+    }
+</style>
+<div class="grid">
+    <div class="item">no margin</div>
+    <div class="item with-margin">10px margin</div>
+    <div class="item with-horizontal-margin">h margins</div>
+    <div class="item with-vertical-margin">v margins</div>
+</div>


### PR DESCRIPTION
For grid items with auto preferred size, stretch/normal alignment, and no auto margins, the final size is simply the containing block size minus margin box sizes. We can compute this directly without calling `calculate_fit_content_width/height`, which triggers expensive intrinsic sizing layout passes.