### PR TITLE
LibGC: Use Vector::grow_capacity() in MarkingVisitor

### DIFF
--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -498,7 +498,7 @@ public:
 
     virtual void visit_impl(ReadonlySpan<NanBoxedValue> values) override
     {
-        m_work_queue.ensure_capacity(m_work_queue.size() + values.size());
+        m_work_queue.grow_capacity(m_work_queue.size() + values.size());
 
         for (auto value : values) {
             if (!value.is_cell())


### PR DESCRIPTION
Using ensure_capacity() was a mistake, as that API is for specifying an exact needed capacity, while grow_capacity() is for growing at a reasonable rate.

Amusingly, we ended up with very different behavior on macOS and Linux here, since ensure_capacity() calls kmalloc_good_size() which quantizes to malloc bucket sizes on macOS, but is effectively a no-op on Linux.

Extreme slowdown on Linux caught by GarBench/marking-stress.js