### PR TITLE
LibJS: Reduce number of op codes needed for template literals

### DIFF
--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -17,6 +17,7 @@
 #include <LibJS/Bytecode/StringTable.h>
 #include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/ErrorTypes.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
@@ -2559,10 +2560,40 @@ Bytecode::CodeGenerationErrorOr<Optional<ScopedOperand>> TemplateLiteral::genera
 
     auto dst = choose_dst(generator, preferred_dst);
 
-    for (size_t i = 0; i < m_expressions.size(); i++) {
-        auto value = TRY(m_expressions[i]->generate_bytecode(generator)).value();
+    Vector segments(m_expressions);
+
+    segments.remove_all_matching([&](auto expr) {
+        return expr->is_string_literal() && static_cast<StringLiteral const&>(*expr).value().is_empty();
+    });
+
+    // OPTIMIZATION: Empty template literal (``) can be turned into empty string literal ("")
+    if (segments.size() == 0)
+        return generator.add_constant(Value { GC::Ref { generator.vm().empty_string() } });
+
+    if (segments.size() == 1) {
+        auto value = TRY(segments[0]->generate_bytecode(generator)).value();
+
+        // OPTIMIZATION: String literal template (`xyz`) can be returned directly
+        if (value.operand().is_constant())
+            return value;
+
+        // OPTIMIZATION: `${x}` can be turned into ToString(x) op
+        generator.emit<Bytecode::Op::ToString>(dst, value);
+
+        return dst;
+    }
+
+    for (size_t i = 0; i < segments.size(); i++) {
+        auto expr = segments[i];
+
+        auto value = TRY(expr->generate_bytecode(generator)).value();
+
         if (i == 0) {
-            generator.emit_mov(dst, value);
+            if (expr->is_string_literal()) {
+                generator.emit_mov(dst, value);
+            } else {
+                generator.emit<Bytecode::Op::ToString>(dst, value);
+            }
         } else {
             generator.emit<Bytecode::Op::ConcatString>(dst, value);
         }

--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -57,6 +57,11 @@ op ToInt32 < Instruction
     m_value: Operand
 endop
 
+op ToString < Instruction
+    m_dst: Operand
+    m_value: Operand
+endop
+
 op BitwiseXor < Instruction
     m_dst: Operand
     m_lhs: Operand

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -474,6 +474,7 @@ void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(BitwiseNot);
             HANDLE_INSTRUCTION(BitwiseOr);
             HANDLE_INSTRUCTION(ToInt32);
+            HANDLE_INSTRUCTION(ToString);
             HANDLE_INSTRUCTION(BitwiseXor);
             HANDLE_INSTRUCTION(Call);
             HANDLE_INSTRUCTION(CallBuiltin);
@@ -1674,6 +1675,13 @@ ThrowCompletionOr<void> ToInt32::execute_impl(Bytecode::Interpreter& interpreter
         return {};
     }
     interpreter.set(m_dst, Value(TRY(value.to_i32(vm))));
+    return {};
+}
+
+ThrowCompletionOr<void> ToString::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& vm = interpreter.vm();
+    interpreter.set(m_dst, Value { TRY(interpreter.get(m_value).to_primitive_string(vm)) });
     return {};
 }
 

--- a/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
@@ -1,0 +1,55 @@
+JS bytecode executable ""
+[   0]    0: InitializeLexicalBinding identifier:a, src:String("abcxyz")
+[  18]       InitializeLexicalBinding identifier:b, src:String("abcxyz")
+[  30]       InitializeLexicalBinding identifier:c, src:String("abcxyz")
+[  48]       InitializeLexicalBinding identifier:d, src:String("abcxyz")
+[  60]       InitializeLexicalBinding identifier:e, src:String("abcxyz")
+[  78]       InitializeLexicalBinding identifier:f, src:String("abcxyz")
+[  90]       Mov dst:reg5, src:String("abc")
+[  a0]       ConcatString dst:reg5, src:String("xyz")
+[  b0]       InitializeLexicalBinding identifier:g, src:reg5
+[  c8]       GetGlobal dst:reg6, identifier:prefix
+[  d8]       Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
+[ 100]       InitializeLexicalBinding identifier:_prefix, src:reg5
+[ 118]       GetGlobal dst:reg6, identifier:suffix
+[ 128]       Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
+[ 150]       InitializeLexicalBinding identifier:_suffix, src:reg5
+[ 168]       GetGlobal dst:reg6, identifier:tostring
+[ 178]       Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
+[ 1a0]       InitializeLexicalBinding identifier:_tostring, src:reg5
+[ 1b8]       GetGlobal dst:reg6, identifier:multi
+[ 1c8]       Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
+[ 1f8]       InitializeLexicalBinding identifier:_multi, src:reg5
+[ 210]       GetGlobal dst:reg6, identifier:literal
+[ 220]       Call dst:reg5, callee:reg6, this_value:Undefined, literal
+[ 240]       InitializeLexicalBinding identifier:_literal, src:reg5
+[ 258]       GetGlobal dst:reg6, identifier:empty
+[ 268]       Call dst:reg5, callee:reg6, this_value:Undefined, empty
+[ 288]       InitializeLexicalBinding identifier:_empty, src:reg5
+[ 2a0]       End value:Undefined
+
+JS bytecode executable "prefix"
+[   0]    0: Mov dst:reg5, src:String("prefix-")
+[  10]       ConcatString dst:reg5, src:arg0
+[  20]       Return value:reg5
+
+JS bytecode executable "suffix"
+[   0]    0: ToString dst:reg5, value:arg0
+[  10]       ConcatString dst:reg5, src:String("-suffix")
+[  20]       Return value:reg5
+
+JS bytecode executable "tostring"
+[   0]    0: ToString dst:reg5, value:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "multi"
+[   0]    0: ToString dst:reg5, value:arg0
+[  10]       ConcatString dst:reg5, src:arg1
+[  20]       ConcatString dst:reg5, src:arg2
+[  30]       Return value:reg5
+
+JS bytecode executable "literal"
+[   0]    0: Return value:String("hello world")
+
+JS bytecode executable "empty"
+[   0]    0: Return value:String("")

--- a/Tests/LibJS/Bytecode/input/const-fold-template-literals.js
+++ b/Tests/LibJS/Bytecode/input/const-fold-template-literals.js
@@ -1,0 +1,33 @@
+function prefix(x) {
+    return `prefix-${x}`;
+}
+function suffix(x) {
+    return `${x}-suffix`;
+}
+function tostring(x) {
+    return `${x}`;
+}
+function multi(a, b, c) {
+    return `${a}${b}${c}`;
+}
+function literal() {
+    return `hello world`;
+}
+function empty() {
+    return ``;
+}
+
+const a = `abc` + "xyz";
+const b = `abc` + `xyz`;
+const c = "abc" + `xyz`;
+const d = "abc" + "xyz";
+const e = `abc` + `` + `xyz`;
+const f = `abc` + "" + `xyz`;
+const g = `${"abc"}${"xyz"}`;
+
+const _prefix = prefix("abc");
+const _suffix = suffix("abc");
+const _tostring = tostring("abc");
+const _multi = multi(1, 2, 3);
+const _literal = literal();
+const _empty = empty();

--- a/Tests/LibJS/Runtime/template-literals.js
+++ b/Tests/LibJS/Runtime/template-literals.js
@@ -72,3 +72,19 @@ test("invalid escapes should give syntax error", () => {
     expect("`\\01`").not.toEval();
     expect("`\\u{10FFFFF}`").not.toEval();
 });
+
+test("empty template literal", () => {
+    expect(``).toBe("");
+});
+
+test("const fold template literal concatenation", () => {
+    expect(`abc` + "xyz").toBe("abcxyz");
+    expect(`abc` + `xyz`).toBe("abcxyz");
+    expect("abc" + `xyz`).toBe("abcxyz");
+    expect("abc" + "xyz").toBe("abcxyz");
+    expect(`abc` + `` + `xyz`).toBe("abcxyz");
+    expect(`abc` + "" + `xyz`).toBe("abcxyz");
+    expect(`${"abcxyz"}`).toBe("abcxyz");
+    // TODO: not const fold-able (yet)
+    expect(`${"abc"}${"xyz"}`).toBe("abcxyz");
+});


### PR DESCRIPTION
There is no need to concat empty string literals when building template literals. Now strings will only be concatenated if they need to be.

To handle the edge case where the first segment is not a string literal, a new `ToString` op code has been added to ensure the value is a string concatenating more strings.

Given the following JS program:

```js
function prefix(x) {
    return `prefix-${x}`;
}
function suffix(x) {
    return `${x}-suffix`;
}
function tostring(x) {
    return `${x}`;
}
function multi(a, b, c) {
    return `${a}${b}${c}`;
}
function literal() {
    return `hello world`;
}
function empty() {
    return ``;
}

console.log(prefix("abc"));
console.log(suffix("abc"));
console.log(tostring("abc"));
console.log(multi(1, 2, 3));
console.log(literal());
console.log(empty());
```

The the following bytecode is emitted, shown as a diff between the old/new version:

```diff
 JS bytecode executable "prefix"
 0: Mov dst:reg5, src:String("prefix-")
    ConcatString dst:reg5, src:arg0
-   ConcatString dst:reg5, src:String("")
    Return value:reg5

 JS bytecode executable "suffix"
-0: Mov dst:reg5, src:String("")
-   ConcatString dst:reg5, src:arg0
+0: ToString dst:reg5, value:arg0
    ConcatString dst:reg5, src:String("-suffix")
    Return value:reg5

 JS bytecode executable "tostring"
-0: Mov dst:reg5, src:String("")
-   ConcatString dst:reg5, src:arg0
-   ConcatString dst:reg5, src:String("")
+0: ToString dst:reg5, value:arg0
    Return value:reg5

 JS bytecode executable "multi"
-0: Mov dst:reg5, src:String("")
-   ConcatString dst:reg5, src:arg0
-   ConcatString dst:reg5, src:String("")
+0: ToString dst:reg5, value:arg0
    ConcatString dst:reg5, src:arg1
-   ConcatString dst:reg5, src:String("")
    ConcatString dst:reg5, src:arg2
-   ConcatString dst:reg5, src:String("")
    Return value:reg5

 JS bytecode executable "literal"
 0: Mov dst:reg5, src:String("hello world")
    Return value:reg5
 
 JS bytecode executable "empty"
 0: Mov dst:reg5, src:String("")
    Return value:reg5
```

~~In the future this could be expanded to const fold string literals in template literals, but considering how niche that is I didn't invest much time into looking into it for this PR.~~

I added basic support for this via https://github.com/LadybirdBrowser/ladybird/pull/7389#issuecomment-3733554004, but did not support edge cases like `` `${"abc"}${"xyz"}` ``. In the future we could de-sugar this to `"abc" + "xyz"`, but that may be more effort than it's worth.