### PR TITLE
LibWeb: Use element's accent-color property for AccentColor keyword

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/KeywordStyleValue.cpp
@@ -149,8 +149,10 @@ Optional<Color> KeywordStyleValue::to_color(ColorResolutionContext color_resolut
     // https://www.w3.org/TR/css-color-4/#deprecated-system-colors
     switch (keyword()) {
     case Keyword::Accentcolor:
-        return SystemColor::accent_color(scheme);
+        return color_resolution_context.accent_color.value_or(SystemColor::accent_color(scheme));
     case Keyword::Accentcolortext:
+        if (color_resolution_context.accent_color.has_value())
+            return color_resolution_context.accent_color->suggested_foreground_color();
         return SystemColor::accent_color_text(scheme);
     case Keyword::Buttonborder:
     case Keyword::Activeborder:

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -91,9 +91,14 @@ ColorResolutionContext ColorResolutionContext::for_element(DOM::AbstractElement 
 
     CalculationResolutionContext calculation_resolution_context { .length_resolution_context = Length::ResolutionContext::for_element(element) };
 
+    Optional<Color> accent_color;
+    if (auto layout_node = element.layout_node())
+        accent_color = layout_node->computed_values().accent_color();
+
     return {
         .color_scheme = color_scheme,
-        .current_color = element.computed_properties()->color_or_fallback(PropertyID::Color, { color_scheme, CSS::InitialValues::color(), element.document(), calculation_resolution_context }, CSS::InitialValues::color()),
+        .current_color = element.computed_properties()->color_or_fallback(PropertyID::Color, { .color_scheme = color_scheme, .current_color = CSS::InitialValues::color(), .accent_color = accent_color, .document = element.document(), .calculation_resolution_context = calculation_resolution_context }, CSS::InitialValues::color()),
+        .accent_color = accent_color,
         .document = element.document(),
         .calculation_resolution_context = calculation_resolution_context
     };
@@ -104,6 +109,7 @@ ColorResolutionContext ColorResolutionContext::for_layout_node_with_style(Layout
     return {
         .color_scheme = layout_node.computed_values().color_scheme(),
         .current_color = layout_node.computed_values().color(),
+        .accent_color = layout_node.computed_values().accent_color(),
         .document = layout_node.document(),
         .calculation_resolution_context = { .length_resolution_context = Length::ResolutionContext::for_layout_node(layout_node) },
     };

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -153,6 +153,7 @@ private:
 struct ColorResolutionContext {
     Optional<PreferredColorScheme> color_scheme;
     Optional<Color> current_color;
+    Optional<Color> accent_color;
     GC::Ptr<DOM::Document const> document;
     CalculationResolutionContext calculation_resolution_context;
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -500,7 +500,12 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     // NOTE: color must be set after font_size as `CalculatedStyleValue`s can rely on it being set for resolving lengths.
     computed_values.set_color(computed_style.color_or_fallback(CSS::PropertyID::Color, CSS::ColorResolutionContext::for_layout_node_with_style(*this), CSS::InitialValues::color()));
 
-    // NOTE: This color resolution context must be created after we set color above so that currentColor resolves correctly
+    // NOTE: accent_color must be set before we create the color resolution context so that AccentColor keyword resolves correctly.
+    auto accent_color = computed_style.accent_color(*this);
+    if (accent_color.has_value())
+        computed_values.set_accent_color(accent_color.value());
+
+    // NOTE: This color resolution context must be created after we set color and accent_color above so that currentColor and AccentColor resolve correctly
     // FIXME: We should resolve colors to their absolute forms at compute time (i.e. by implementing the relevant absolutized methods)
     auto color_resolution_context = CSS::ColorResolutionContext::for_layout_node_with_style(*this);
 
@@ -573,10 +578,6 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     computed_values.set_justify_content(computed_style.justify_content());
     computed_values.set_justify_items(computed_style.justify_items());
     computed_values.set_justify_self(computed_style.justify_self());
-
-    auto accent_color = computed_style.accent_color(*this);
-    if (accent_color.has_value())
-        computed_values.set_accent_color(accent_color.value());
 
     computed_values.set_align_content(computed_style.align_content());
     computed_values.set_align_items(computed_style.align_items());

--- a/Tests/LibWeb/Text/expected/css/accent-color-keyword.txt
+++ b/Tests/LibWeb/Text/expected/css/accent-color-keyword.txt
@@ -1,0 +1,2 @@
+AccentColor with custom accent-color: rgb(255, 0, 0)
+PASS: AccentColor respects element's accent-color property

--- a/Tests/LibWeb/Text/input/css/accent-color-keyword.html
+++ b/Tests/LibWeb/Text/input/css/accent-color-keyword.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #target {
+        accent-color: rgb(255, 0, 0);
+        background-color: AccentColor;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="target"></div>
+<script>
+test(() => {
+    const target = document.getElementById("target");
+    const computedBg = getComputedStyle(target).backgroundColor;
+    println(`AccentColor with custom accent-color: ${computedBg}`);
+
+    // Verify it's the custom red, not the system default
+    if (computedBg === "rgb(255, 0, 0)") {
+        println("PASS: AccentColor respects element's accent-color property");
+    } else {
+        println(`FAIL: Expected rgb(255, 0, 0), got ${computedBg}`);
+    }
+});
+</script>


### PR DESCRIPTION
## Summary
- When resolving the `AccentColor` and `AccentColorText` CSS keywords, check the element's `accent-color` property first before falling back to the system color
- This aligns with the CSS Color 4 specification which states that `AccentColor` takes its value from `accent-color`
- Added `accent_color` field to `ColorResolutionContext` and populated it from the element's computed values when available

Fixes #7141

## Test plan
- [x] All LibWeb tests pass (5519 pass, 0 fail)
- [x] Existing `color-scheme.html` screenshot test continues to pass
- [x] Manual verification that `AccentColor` respects custom `accent-color` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)