### PR TITLE
Tests: Re-enable WebSocket echo test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -252,10 +252,6 @@ Text/input/wpt-import/css/mediaqueries/media-query-matches-in-iframe.html
 ; https://github.com/LadybirdBrowser/ladybird/issues/4191
 Ref/input/scroll-iframe.html
 
-; Inconsistently times out because the echo server doesn't respond in time.
-; https://github.com/LadybirdBrowser/ladybird/issues/4192
-Text/input/WebSocket/echo.html
-
 ; Times out due to us not implementing auto-commit the correct way.
 Text/input/wpt-import/IndexedDB/idbfactory_open.any.html
 


### PR DESCRIPTION
The apparent cause of the timeouts was resolved back in August so let's try this again.

I guess it'll depend on CI's network infrastructure, but running it locally, it's very snappy.

Closes #4192.