### PR TITLE
Tests: Re-enable scroll-iframe test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -248,10 +248,6 @@ Text/input/wpt-import/html/rendering/replaced-elements/svg-inline-sizing/svg-inl
 ; https://github.com/LadybirdBrowser/ladybird/issues/4190
 Text/input/wpt-import/css/mediaqueries/media-query-matches-in-iframe.html
 
-; Inconsistently fails on CI.
-; https://github.com/LadybirdBrowser/ladybird/issues/4191
-Ref/input/scroll-iframe.html
-
 ; Times out due to us not implementing auto-commit the correct way.
 Text/input/wpt-import/IndexedDB/idbfactory_open.any.html
 


### PR DESCRIPTION
I couldn't reproduce the flake when running it 100 times locally, so I suspect something we did since this was disabled 9 months ago has fixed the issue.

Closes #4191.

I had this patch I was considering as a fix, before realising that I couldn't reproduce the issue on master. So I'll leave it here in case this does turn out to be flaky and needs a further look.

```diff
diff --git a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
index d49da7541ff..695225dbe51 100644
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -511,8 +511,11 @@ void EventLoop::update_the_rendering()
         auto navigable = document->navigable();
         if (!navigable->is_traversable())
             continue;
-        auto traversable = navigable->traversable_navigable();
-        traversable->process_screenshot_requests();
+        // AD-HOC: Take screenshots, but only once all scroll events have completed.
+        if (document->pending_scroll_events().is_empty()) {
+            auto traversable = navigable->traversable_navigable();
+            traversable->process_screenshot_requests();
+        }
         if (!navigable->needs_repaint())
             continue;
         navigable->paint_next_frame();
```