### PR TITLE
LibWeb: Avoid intermediate string allocations in typed om  serialization

### DIFF
--- a/Libraries/LibWeb/CSS/CSSKeywordValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSKeywordValue.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "CSSKeywordValue.h"
+#include <AK/StringBuilder.h>
 #include <LibWeb/Bindings/CSSKeywordValuePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Keyword.h>
@@ -59,12 +60,19 @@ WebIDL::ExceptionOr<void> CSSKeywordValue::set_value(FlyString value)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#keywordvalue-serialization
-WebIDL::ExceptionOr<String> CSSKeywordValue::to_string() const
+void CSSKeywordValue::serialize(StringBuilder& builder) const
 {
     // To serialize a CSSKeywordValue this:
     // 1. Return this’s value internal slot.
     // AD-HOC: Serialize it as an identifier. Spec issue: https://github.com/w3c/csswg-drafts/issues/12545
-    return serialize_an_identifier(m_value);
+    serialize_an_identifier(builder, m_value);
+}
+
+WebIDL::ExceptionOr<String> CSSKeywordValue::to_string() const
+{
+    StringBuilder builder;
+    serialize(builder);
+    return builder.to_string_without_validation();
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#create-an-internal-representation

--- a/Libraries/LibWeb/CSS/CSSKeywordValue.h
+++ b/Libraries/LibWeb/CSS/CSSKeywordValue.h
@@ -28,6 +28,7 @@ public:
     FlyString const& value() const { return m_value; }
     WebIDL::ExceptionOr<void> set_value(FlyString value);
 
+    void serialize(StringBuilder&) const;
     virtual WebIDL::ExceptionOr<String> to_string() const override;
     virtual WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> create_an_internal_representation(PropertyNameAndID const&, PerformTypeCheck) const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathClamp.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathClamp.cpp
@@ -68,18 +68,16 @@ void CSSMathClamp::visit_edges(Visitor& visitor)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#serialize-a-cssmathvalue
-String CSSMathClamp::serialize_math_value(Nested, Parens) const
+void CSSMathClamp::serialize_math_value(StringBuilder& s, Nested, Parens) const
 {
     // AD-HOC: The spec is missing serialization rules for CSSMathClamp: https://github.com/w3c/css-houdini-drafts/issues/1152
-    StringBuilder s;
     s.append("clamp("sv);
-    s.append(m_lower->to_string({ .nested = true, .parenless = true }));
+    m_lower->serialize(s, { .nested = true, .parenless = true });
     s.append(", "sv);
-    s.append(m_value->to_string({ .nested = true, .parenless = true }));
+    m_value->serialize(s, { .nested = true, .parenless = true });
     s.append(", "sv);
-    s.append(m_upper->to_string({ .nested = true, .parenless = true }));
-    s.append(")"sv);
-    return s.to_string_without_validation();
+    m_upper->serialize(s, { .nested = true, .parenless = true });
+    s.append(')');
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-lower

--- a/Libraries/LibWeb/CSS/CSSMathClamp.h
+++ b/Libraries/LibWeb/CSS/CSSMathClamp.h
@@ -28,7 +28,7 @@ public:
     GC::Ref<CSSNumericValue> value() const;
     GC::Ref<CSSNumericValue> upper() const;
 
-    virtual String serialize_math_value(Nested, Parens) const override;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const override;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const override;
     virtual Optional<SumValue> create_a_sum_value() const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathInvert.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathInvert.cpp
@@ -54,11 +54,10 @@ void CSSMathInvert::visit_edges(Visitor& visitor)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#serialize-a-cssmathvalue
-String CSSMathInvert::serialize_math_value(Nested nested, Parens parens) const
+void CSSMathInvert::serialize_math_value(StringBuilder& s, Nested nested, Parens parens) const
 {
     // NB: Only steps 1 and 6 apply here.
     // 1. Let s initially be the empty string.
-    StringBuilder s;
 
     // 6. Otherwise, if this is a CSSMathInvert:
     {
@@ -66,7 +65,7 @@ String CSSMathInvert::serialize_math_value(Nested nested, Parens parens) const
         //    otherwise, append "calc(" to s.
         if (parens == Parens::With) {
             if (nested == Nested::Yes) {
-                s.append("("sv);
+                s.append('(');
             } else {
                 s.append("calc("sv);
             }
@@ -76,14 +75,13 @@ String CSSMathInvert::serialize_math_value(Nested nested, Parens parens) const
         s.append("1 / "sv);
 
         // 3. Serialize this’s value internal slot with nested set to true, and append the result to s.
-        s.append(m_value->to_string({ .nested = true }));
+        m_value->serialize(s, { .nested = true });
 
         // 4. If paren-less is false, append ")" to s,
         if (parens == Parens::With)
-            s.append(")"sv);
+            s.append(')');
 
         // 5. Return s.
-        return s.to_string_without_validation();
     }
 }
 

--- a/Libraries/LibWeb/CSS/CSSMathInvert.h
+++ b/Libraries/LibWeb/CSS/CSSMathInvert.h
@@ -26,7 +26,7 @@ public:
 
     GC::Ref<CSSNumericValue> value() const;
 
-    virtual String serialize_math_value(Nested, Parens) const override;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const override;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const override;
     virtual Optional<SumValue> create_a_sum_value() const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathMax.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathMax.cpp
@@ -81,11 +81,10 @@ void CSSMathMax::visit_edges(Visitor& visitor)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#serialize-a-cssmathvalue
-String CSSMathMax::serialize_math_value(Nested, Parens) const
+void CSSMathMax::serialize_math_value(StringBuilder& s, Nested, Parens) const
 {
     // NB: Only steps 1 and 2 apply here.
     // 1. Let s initially be the empty string.
-    StringBuilder s;
 
     // 2. If this is a CSSMathMin or CSSMathMax:
     {
@@ -101,12 +100,11 @@ String CSSMathMax::serialize_math_value(Nested, Parens) const
             } else {
                 s.append(", "sv);
             }
-            s.append(arg->to_string({ .nested = true, .parenless = true }));
+            arg->serialize(s, { .nested = true, .parenless = true });
         }
 
         // 3. Append ")" to s and return s.
-        s.append(")"sv);
-        return s.to_string_without_validation();
+        s.append(')');
     }
 }
 

--- a/Libraries/LibWeb/CSS/CSSMathMax.h
+++ b/Libraries/LibWeb/CSS/CSSMathMax.h
@@ -26,7 +26,7 @@ public:
 
     GC::Ref<CSSNumericArray> values() const;
 
-    virtual String serialize_math_value(Nested, Parens) const override;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const override;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const override;
     virtual Optional<SumValue> create_a_sum_value() const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathMin.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathMin.cpp
@@ -82,11 +82,10 @@ void CSSMathMin::visit_edges(Visitor& visitor)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#serialize-a-cssmathvalue
-String CSSMathMin::serialize_math_value(Nested, Parens) const
+void CSSMathMin::serialize_math_value(StringBuilder& s, Nested, Parens) const
 {
     // NB: Only steps 1 and 2 apply here.
     // 1. Let s initially be the empty string.
-    StringBuilder s;
 
     // 2. If this is a CSSMathMin or CSSMathMax:
     {
@@ -102,12 +101,11 @@ String CSSMathMin::serialize_math_value(Nested, Parens) const
             } else {
                 s.append(", "sv);
             }
-            s.append(arg->to_string({ .nested = true, .parenless = true }));
+            arg->serialize(s, { .nested = true, .parenless = true });
         }
 
         // 3. Append ")" to s and return s.
-        s.append(")"sv);
-        return s.to_string_without_validation();
+        s.append(')');
     }
 }
 

--- a/Libraries/LibWeb/CSS/CSSMathMin.h
+++ b/Libraries/LibWeb/CSS/CSSMathMin.h
@@ -26,7 +26,7 @@ public:
 
     GC::Ref<CSSNumericArray> values() const;
 
-    virtual String serialize_math_value(Nested, Parens) const override;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const override;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const override;
     virtual Optional<SumValue> create_a_sum_value() const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathNegate.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathNegate.cpp
@@ -51,11 +51,10 @@ void CSSMathNegate::visit_edges(Visitor& visitor)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#serialize-a-cssmathvalue
-String CSSMathNegate::serialize_math_value(Nested nested, Parens parens) const
+void CSSMathNegate::serialize_math_value(StringBuilder& s, Nested nested, Parens parens) const
 {
     // NB: Only steps 1 and 4 apply here.
     // 1. Let s initially be the empty string.
-    StringBuilder s;
 
     // 4. Otherwise, if this is a CSSMathNegate:
     {
@@ -63,24 +62,23 @@ String CSSMathNegate::serialize_math_value(Nested nested, Parens parens) const
         //    otherwise, append "calc(" to s.
         if (parens == Parens::With) {
             if (nested == Nested::Yes) {
-                s.append("("sv);
+                s.append('(');
             } else {
                 s.append("calc("sv);
             }
         }
 
         // 2. Append "-" to s.
-        s.append("-"sv);
+        s.append('-');
 
         // 3. Serialize this’s value internal slot with nested set to true, and append the result to s.
-        s.append(m_value->to_string({ .nested = true }));
+        m_value->serialize(s, { .nested = true });
 
         // 4. If paren-less is false, append ")" to s,
         if (parens == Parens::With)
-            s.append(")"sv);
+            s.append(')');
 
         // 5. Return s.
-        return s.to_string_without_validation();
     }
 }
 

--- a/Libraries/LibWeb/CSS/CSSMathNegate.h
+++ b/Libraries/LibWeb/CSS/CSSMathNegate.h
@@ -26,7 +26,7 @@ public:
 
     GC::Ref<CSSNumericValue> value() const;
 
-    virtual String serialize_math_value(Nested, Parens) const override;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const override;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const override;
     virtual Optional<SumValue> create_a_sum_value() const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathProduct.cpp
+++ b/Libraries/LibWeb/CSS/CSSMathProduct.cpp
@@ -81,11 +81,10 @@ void CSSMathProduct::visit_edges(Visitor& visitor)
 }
 
 // https://drafts.css-houdini.org/css-typed-om-1/#serialize-a-cssmathvalue
-String CSSMathProduct::serialize_math_value(Nested nested, Parens parens) const
+void CSSMathProduct::serialize_math_value(StringBuilder& s, Nested nested, Parens parens) const
 {
     // NB: Only steps 1 and 5 apply here.
     // 1. Let s initially be the empty string.
-    StringBuilder s;
 
     // 5. Otherwise, if this is a CSSMathProduct:
     {
@@ -93,14 +92,14 @@ String CSSMathProduct::serialize_math_value(Nested nested, Parens parens) const
         //    otherwise, append "calc(" to s.
         if (parens == Parens::With) {
             if (nested == Nested::Yes) {
-                s.append("("sv);
+                s.append('(');
             } else {
                 s.append("calc("sv);
             }
         }
 
         // 2. Serialize the first item in this’s values internal slot with nested set to true, and append the result to s.
-        s.append(m_values->values().first()->to_string({ .nested = true }));
+        m_values->values().first()->serialize(s, { .nested = true });
 
         // 3. For each arg in this’s values internal slot beyond the first:
         bool first = true;
@@ -114,22 +113,21 @@ String CSSMathProduct::serialize_math_value(Nested nested, Parens parens) const
             //    set to true, and append the result to s.
             if (auto* invert = as_if<CSSMathInvert>(*arg)) {
                 s.append(" / "sv);
-                s.append(invert->value()->to_string({ .nested = true }));
+                invert->value()->serialize(s, { .nested = true });
             }
 
             // 2. Otherwise, append " * " to s, then serialize arg with nested set to true, and append the result to s.
             else {
                 s.append(" * "sv);
-                s.append(arg->to_string({ .nested = true }));
+                arg->serialize(s, { .nested = true });
             }
         }
 
         // 4. If paren-less is false, append ")" to s,
         if (parens == Parens::With)
-            s.append(")"sv);
+            s.append(')');
 
         // 5. Return s.
-        return s.to_string_without_validation();
     }
 }
 

--- a/Libraries/LibWeb/CSS/CSSMathProduct.h
+++ b/Libraries/LibWeb/CSS/CSSMathProduct.h
@@ -26,7 +26,7 @@ public:
 
     GC::Ref<CSSNumericArray> values() const;
 
-    virtual String serialize_math_value(Nested, Parens) const override;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const override;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const override;
     virtual Optional<SumValue> create_a_sum_value() const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathSum.h
+++ b/Libraries/LibWeb/CSS/CSSMathSum.h
@@ -26,7 +26,7 @@ public:
 
     GC::Ref<CSSNumericArray> values() const;
 
-    virtual String serialize_math_value(Nested, Parens) const override;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const override;
     virtual bool is_equal_numeric_value(GC::Ref<CSSNumericValue> other) const override;
     virtual Optional<SumValue> create_a_sum_value() const override;
 

--- a/Libraries/LibWeb/CSS/CSSMathValue.h
+++ b/Libraries/LibWeb/CSS/CSSMathValue.h
@@ -30,7 +30,7 @@ public:
         With,
         Without,
     };
-    virtual String serialize_math_value(Nested, Parens) const = 0;
+    virtual void serialize_math_value(StringBuilder&, Nested, Parens) const = 0;
 
     virtual WebIDL::ExceptionOr<NonnullRefPtr<StyleValue const>> create_an_internal_representation(PropertyNameAndID const&, PerformTypeCheck) const final override;
 

--- a/Libraries/LibWeb/CSS/CSSNumericValue.h
+++ b/Libraries/LibWeb/CSS/CSSNumericValue.h
@@ -58,6 +58,7 @@ public:
     NumericType const& type() const { return m_type; }
 
     virtual WebIDL::ExceptionOr<String> to_string() const final override { return to_string({}); }
+    void serialize(StringBuilder&, SerializationParams const&) const;
     String to_string(SerializationParams const&) const;
 
     static WebIDL::ExceptionOr<GC::Ref<CSSNumericValue>> parse(JS::VM&, String const& css_text);

--- a/Libraries/LibWeb/CSS/CSSRotate.cpp
+++ b/Libraries/LibWeb/CSS/CSSRotate.cpp
@@ -106,25 +106,25 @@ WebIDL::ExceptionOr<Utf16String> CSSRotate::to_string() const
         builder.append("rotate3d("sv);
 
         // 2. Serialize this’s x internal slot, and append it to s.
-        builder.append(TRY(m_x->to_string()));
+        m_x->serialize(builder, {});
 
         // 3. Append ", " to s.
         builder.append(", "sv);
 
         // 4. Serialize this’s y internal slot, and append it to s.
-        builder.append(TRY(m_y->to_string()));
+        m_y->serialize(builder, {});
 
         // 5. Append ", " to s.
         builder.append(", "sv);
 
         // 6. Serialize this’s z internal slot, and append it to s.
-        builder.append(TRY(m_z->to_string()));
+        m_z->serialize(builder, {});
 
         // 7. Append "," to s.
         builder.append(", "sv);
 
         // 8. Serialize this’s angle internal slot, and append it to s.
-        builder.append(TRY(m_angle->to_string()));
+        m_angle->serialize(builder, {});
 
         // 9. Append ")" to s, and return s.
         builder.append(")"sv);
@@ -136,7 +136,7 @@ WebIDL::ExceptionOr<Utf16String> CSSRotate::to_string() const
         builder.append("rotate("sv);
 
         // 2. Serialize this’s angle internal slot, and append it to s.
-        builder.append(TRY(m_angle->to_string()));
+        m_angle->serialize(builder, {});
 
         // 3. Append ")" to s, and return s.
         builder.append(")"sv);

--- a/Libraries/LibWeb/CSS/CSSScale.cpp
+++ b/Libraries/LibWeb/CSS/CSSScale.cpp
@@ -91,19 +91,19 @@ WebIDL::ExceptionOr<Utf16String> CSSScale::to_string() const
         builder.append("scale3d("sv);
 
         // 2. Serialize this’s x internal slot, and append it to s.
-        builder.append(TRY(m_x->to_string()));
+        m_x->serialize(builder, {});
 
         // 3. Append ", " to s.
         builder.append(", "sv);
 
         // 4. Serialize this’s y internal slot, and append it to s.
-        builder.append(TRY(m_y->to_string()));
+        m_y->serialize(builder, {});
 
         // 5. Append ", " to s.
         builder.append(", "sv);
 
         // 6. Serialize this’s z internal slot, and append it to s.
-        builder.append(TRY(m_z->to_string()));
+        m_z->serialize(builder, {});
 
         // 7. Append ")" to s, and return s.
         builder.append(")"sv);
@@ -116,7 +116,7 @@ WebIDL::ExceptionOr<Utf16String> CSSScale::to_string() const
         builder.append("scale("sv);
 
         // 2. Serialize this’s x internal slot, and append it to s.
-        builder.append(TRY(m_x->to_string()));
+        m_x->serialize(builder, {});
 
         // 3. If this’s x and y internal slots are equal numeric values, append ")" to s and return s.
         // AD-HOC: Don't do this - neither Chrome nor Safari show this behavior.
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<Utf16String> CSSScale::to_string() const
         builder.append(", "sv);
 
         // 5. Serialize this’s y internal slot, and append it to s.
-        builder.append(TRY(m_y->to_string()));
+        m_y->serialize(builder, {});
 
         // 6. Append ")" to s, and return s.
         builder.append(")"sv);

--- a/Libraries/LibWeb/CSS/CSSSkew.cpp
+++ b/Libraries/LibWeb/CSS/CSSSkew.cpp
@@ -69,7 +69,7 @@ WebIDL::ExceptionOr<Utf16String> CSSSkew::to_string() const
     builder.append("skew("sv);
 
     // 2. Serialize this’s ax internal slot, and append it to s.
-    builder.append(TRY(m_ax->to_string()));
+    m_ax->serialize(builder, {});
 
     // 3. If this’s ay internal slot is a CSSUnitValue with a value of 0, then append ")" to s and return s.
     if (auto* ay_unit_value = as_if<CSSUnitValue>(*m_ay); ay_unit_value && ay_unit_value->value() == 0) {
@@ -81,7 +81,7 @@ WebIDL::ExceptionOr<Utf16String> CSSSkew::to_string() const
     builder.append(", "sv);
 
     // 5. Serialize this’s ay internal slot, and append it to s.
-    builder.append(TRY(m_ay->to_string()));
+    m_ay->serialize(builder, {});
 
     // 6. Append ")" to s, and return s.
     builder.append(")"sv);

--- a/Libraries/LibWeb/CSS/CSSSkewX.cpp
+++ b/Libraries/LibWeb/CSS/CSSSkewX.cpp
@@ -64,7 +64,7 @@ WebIDL::ExceptionOr<Utf16String> CSSSkewX::to_string() const
     builder.append("skewX("sv);
 
     // 2. Serialize this’s ax internal slot, and append it to s.
-    builder.append(TRY(m_ax->to_string()));
+    m_ax->serialize(builder, {});
 
     // 3. Append ")" to s, and return s.
     builder.append(")"sv);

--- a/Libraries/LibWeb/CSS/CSSSkewY.cpp
+++ b/Libraries/LibWeb/CSS/CSSSkewY.cpp
@@ -64,7 +64,7 @@ WebIDL::ExceptionOr<Utf16String> CSSSkewY::to_string() const
     builder.append("skewY("sv);
 
     // 2. Serialize this’s ay internal slot, and append it to s.
-    builder.append(TRY(m_ay->to_string()));
+    m_ay->serialize(builder, {});
 
     // 3. Append ")" to s, and return s.
     builder.append(")"sv);

--- a/Libraries/LibWeb/CSS/CSSTranslate.cpp
+++ b/Libraries/LibWeb/CSS/CSSTranslate.cpp
@@ -89,19 +89,19 @@ WebIDL::ExceptionOr<Utf16String> CSSTranslate::to_string() const
         builder.append("translate3d("sv);
 
         // 2. Serialize this’s x internal slot, and append it to s.
-        builder.append(TRY(m_x->to_string()));
+        m_x->serialize(builder, {});
 
         // 3. Append ", " to s.
         builder.append(", "sv);
 
         // 4. Serialize this’s y internal slot, and append it to s.
-        builder.append(TRY(m_y->to_string()));
+        m_y->serialize(builder, {});
 
         // 5. Append ", " to s.
         builder.append(", "sv);
 
         // 6. Serialize this’s z internal slot, and append it to s.
-        builder.append(TRY(m_z->to_string()));
+        m_z->serialize(builder, {});
 
         // 7. Append ")" to s, and return s.
         builder.append(")"sv);
@@ -113,13 +113,13 @@ WebIDL::ExceptionOr<Utf16String> CSSTranslate::to_string() const
         builder.append("translate("sv);
 
         // 2. Serialize this’s x internal slot, and append it to s.
-        builder.append(TRY(m_x->to_string()));
+        m_x->serialize(builder, {});
 
         // 3. Append ", " to s.
         builder.append(", "sv);
 
         // 4. Serialize this’s y internal slot, and append it to s.
-        builder.append(TRY(m_y->to_string()));
+        m_y->serialize(builder, {});
 
         // 5. Append ")" to s, and return s.
         builder.append(")"sv);

--- a/Libraries/LibWeb/CSS/CSSUnitValue.h
+++ b/Libraries/LibWeb/CSS/CSSUnitValue.h
@@ -28,7 +28,7 @@ public:
 
     FlyString const& unit() const { return m_unit; }
 
-    String serialize_unit_value(Optional<double> minimum, Optional<double> maximum) const;
+    void serialize_unit_value(StringBuilder&, Optional<double> minimum, Optional<double> maximum) const;
 
     GC::Ptr<CSSUnitValue> converted_to_unit(FlyString const& unit) const;
 


### PR DESCRIPTION
This increases the speed of typed-om object serialization by between 5-20% with the largest gains being in deeply nested math values.

No change to the WPT tests in `css/css-typed-om`.
