### PR TITLE
LibWeb: Implement ServiceWorkerContainer.ready attribute

### DIFF
--- a/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.h
+++ b/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.h
@@ -40,6 +40,8 @@ public:
 
     GC::Ref<WebIDL::Promise> get_registration(String const& client_url);
 
+    GC::Ref<WebIDL::Promise> ready();
+
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)       \
     void set_##attribute_name(WebIDL::CallbackType*); \
@@ -56,6 +58,7 @@ private:
     void start_register(Optional<URL::URL> scope_url, Optional<URL::URL> script_url, GC::Ref<WebIDL::Promise>, HTML::EnvironmentSettingsObject&, URL::URL referrer, Bindings::WorkerType, Bindings::ServiceWorkerUpdateViaCache);
 
     GC::Ref<HTML::EnvironmentSettingsObject> m_service_worker_client;
+    GC::Ptr<WebIDL::Promise> m_ready_promise;
 };
 
 }

--- a/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.idl
+++ b/Libraries/LibWeb/ServiceWorker/ServiceWorkerContainer.idl
@@ -8,7 +8,7 @@
 [SecureContext, Exposed=(Window,Worker)]
 interface ServiceWorkerContainer : EventTarget {
     [FIXME] readonly attribute ServiceWorker? controller;
-    [FIXME] readonly attribute Promise<ServiceWorkerRegistration> ready;
+    readonly attribute Promise<ServiceWorkerRegistration> ready;
 
     [NewObject, ImplementedAs=register_] Promise<ServiceWorkerRegistration> register((TrustedScriptURL or Utf16USVString) scriptURL, optional RegistrationOptions options = {});
 

--- a/Tests/LibWeb/Text/expected/ServiceWorker/service-worker-ready.txt
+++ b/Tests/LibWeb/Text/expected/ServiceWorker/service-worker-ready.txt
@@ -1,0 +1,2 @@
+ready is a Promise: true
+ready is the same object on second access: true

--- a/Tests/LibWeb/Text/input/ServiceWorker/service-worker-ready.html
+++ b/Tests/LibWeb/Text/input/ServiceWorker/service-worker-ready.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        setTimeout(() => {
+            // We need to do this spoofing later in the event loop so that we don't end up
+            // telling the test runner the wrong URL in page_did_finish_loading.
+            spoofCurrentURL("https://example.com/service-worker-ready.html");
+
+            const ready = navigator.serviceWorker.ready;
+
+            println(`ready is a Promise: ${ready instanceof Promise}`);
+            println(`ready is the same object on second access: ${ready === navigator.serviceWorker.ready}`);
+
+            done();
+        }, 0);
+    });
+</script>


### PR DESCRIPTION
This patch implements the `ready` attribute on `ServiceWorkerContainer`, a `Promise` that resolves when there's a `ServiceWorkerRegistration` with an active worker for the current page. The promise never rejects and stays pending if no active service worker exists.

This makes https://instagram.com/ load once again :^)

<img width="793" height="778" alt="image" src="https://github.com/user-attachments/assets/ac8a6149-6b8c-4cf5-a946-69629193a4c7" />
