### PR TITLE
LibJS: Add shape caching for object literal instantiation

### DIFF
--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -706,6 +706,7 @@ endop
 op NewObject < Instruction
     @nothrow
     m_dst: Operand
+    m_cache_index: u32
 endop
 
 op NewObjectWithNoPrototype < Instruction
@@ -1061,5 +1062,20 @@ op Yield < Instruction
     @nothrow
     m_continuation_label: Optional<Label>
     m_value: Operand
+endop
+
+op CacheObjectShape < Instruction
+    @nothrow
+    m_object: Operand
+    m_cache_index: u32
+endop
+
+op InitObjectLiteralProperty < Instruction
+    @nothrow
+    m_object: Operand
+    m_property: PropertyKeyTableIndex
+    m_src: Operand
+    m_shape_cache_index: u32
+    m_property_slot: u32
 endop
 

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -27,6 +27,7 @@ Executable::Executable(
     size_t number_of_property_lookup_caches,
     size_t number_of_global_variable_caches,
     size_t number_of_template_object_caches,
+    size_t number_of_object_shape_caches,
     size_t number_of_registers,
     Strict strict)
     : bytecode(move(bytecode))
@@ -42,6 +43,7 @@ Executable::Executable(
     property_lookup_caches.resize(number_of_property_lookup_caches);
     global_variable_caches.resize(number_of_global_variable_caches);
     template_object_caches.resize(number_of_template_object_caches);
+    object_shape_caches.resize(number_of_object_shape_caches);
 }
 
 Executable::~Executable() = default;

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -76,6 +76,17 @@ struct TemplateObjectCache {
     GC::Ptr<Array> cached_template_object;
 };
 
+// Cache for object literal shapes.
+// When an object literal like {a: 1, b: 2} is instantiated, we cache the final shape
+// so that subsequent instantiations can allocate the object with the correct shape directly,
+// avoiding repeated shape transitions.
+// We also cache the property offsets so that subsequent property writes can bypass
+// shape lookups and write directly to the correct storage slot.
+struct ObjectShapeCache {
+    GC::Weak<Shape> shape;
+    Vector<u32> property_offsets;
+};
+
 struct SourceRecord {
     u32 source_start_offset {};
     u32 source_end_offset {};
@@ -97,6 +108,7 @@ public:
         size_t number_of_property_lookup_caches,
         size_t number_of_global_variable_caches,
         size_t number_of_template_object_caches,
+        size_t number_of_object_shape_caches,
         size_t number_of_registers,
         Strict);
 
@@ -107,6 +119,7 @@ public:
     Vector<PropertyLookupCache> property_lookup_caches;
     Vector<GlobalVariableCache> global_variable_caches;
     Vector<TemplateObjectCache> template_object_caches;
+    Vector<ObjectShapeCache> object_shape_caches;
     NonnullOwnPtr<StringTable> string_table;
     NonnullOwnPtr<IdentifierTable> identifier_table;
     NonnullOwnPtr<PropertyKeyTable> property_key_table;

--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -456,6 +456,7 @@ CodeGenerationErrorOr<GC::Ref<Executable>> Generator::compile(VM& vm, ASTNode co
         generator.m_next_property_lookup_cache,
         generator.m_next_global_variable_cache,
         generator.m_next_template_object_cache,
+        generator.m_next_object_shape_cache,
         generator.m_next_register,
         generator.m_strict);
 

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -349,6 +349,7 @@ public:
     [[nodiscard]] size_t next_global_variable_cache() { return m_next_global_variable_cache++; }
     [[nodiscard]] size_t next_property_lookup_cache() { return m_next_property_lookup_cache++; }
     [[nodiscard]] size_t next_template_object_cache() { return m_next_template_object_cache++; }
+    [[nodiscard]] u32 next_object_shape_cache() { return m_next_object_shape_cache++; }
 
     enum class DeduplicateConstant {
         Yes,
@@ -428,6 +429,7 @@ private:
     u32 m_next_property_lookup_cache { 0 };
     u32 m_next_global_variable_cache { 0 };
     u32 m_next_template_object_cache { 0 };
+    u32 m_next_object_shape_cache { 0 };
     FunctionKind m_enclosing_function_kind { FunctionKind::Normal };
     Vector<LabelableScope> m_continuable_scopes;
     Vector<LabelableScope> m_breakable_scopes;


### PR DESCRIPTION
When a function creates object literals with simple property names, we now cache the resulting shape after the first instantiation. On subsequent calls, we create the object with the cached shape directly and write property values at their known offsets.

This avoids repeated shape transitions and property offset lookups for a common JavaScript pattern.

The optimization uses two new bytecode instructions:
- CacheObjectShape: Captures the final shape after object construction
- InitObjectLiteralProperty: Writes properties using cached offsets

Only "simple" object literals are optimized (string literal keys with simple value expressions). Complex cases like computed properties, getters/setters, and spread elements use the existing slow path.

3.4x speedup on a microbenchmark that repeatedly instantiates an object literal with 26 properties. Small progressions on various benchmarks.

```
Suite       Test                                      Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  --------------------------------------  ---------  ---------------------------------  ---------------------------------
Kraken      ai-astar.js                                 1.036  0.928 ± 0.895 … 0.962              0.896 ± 0.894 … 0.898
Kraken      audio-beat-detection.js                     0.989  0.724 ± 0.720 … 0.729              0.732 ± 0.731 … 0.733
Kraken      audio-dft.js                                0.982  0.473 ± 0.469 … 0.478              0.482 ± 0.477 … 0.487
Kraken      audio-fft.js                                1.104  0.695 ± 0.623 … 0.767              0.630 ± 0.629 … 0.630
Kraken      audio-oscillator.js                         0.975  0.491 ± 0.490 … 0.491              0.503 ± 0.502 … 0.505
Kraken      imaging-darkroom.js                         0.988  0.943 ± 0.942 … 0.943              0.954 ± 0.946 … 0.962
Kraken      imaging-desaturate.js                       1.029  1.152 ± 1.141 … 1.163              1.119 ± 1.107 … 1.132
Kraken      imaging-gaussian-blur.js                    0.981  4.032 ± 4.028 … 4.035              4.110 ± 4.110 … 4.111
Kraken      json-parse-financial.js                     0.974  0.071 ± 0.070 … 0.072              0.073 ± 0.073 … 0.073
Kraken      json-stringify-tinderbox.js                 0.973  0.068 ± 0.068 … 0.068              0.070 ± 0.070 … 0.070
Kraken      stanford-crypto-aes.js                      0.988  0.276 ± 0.276 … 0.276              0.279 ± 0.279 … 0.279
Kraken      stanford-crypto-ccm.js                      0.993  0.261 ± 0.260 … 0.262              0.263 ± 0.263 … 0.263
Kraken      stanford-crypto-pbkdf2.js                   0.997  0.486 ± 0.486 … 0.487              0.488 ± 0.486 … 0.490
Kraken      stanford-crypto-sha256-iterative.js         0.994  0.180 ± 0.179 … 0.180              0.181 ± 0.181 … 0.181
Octane      box2d.js                                    0.977  6053.500 ± 6031.000 … 6076.000     5917.000 ± 5911.000 … 5923.000
Octane      code-load.js                                0.983  15946.000 ± 15917.000 … 15975.000  15672.000 ± 15658.000 … 15686.000
Octane      crypto.js                                   0.983  2274.000 ± 2274.000 … 2274.000     2234.500 ± 2233.000 … 2236.000
Octane      deltablue.js                                0.966  1159.500 ± 1151.000 … 1168.000     1120.000 ± 1116.000 … 1124.000
Octane      earley-boyer.js                             0.957  3490.500 ± 3479.000 … 3502.000     3339.500 ± 3339.000 … 3340.000
Octane      gbemu.js                                    0.993  11906.000 ± 11884.000 … 11928.000  11826.000 ± 11810.000 … 11842.000
Octane      mandreel.js                                 0.989  9624.000 ± 9605.000 … 9643.000     9514.000 ± 9514.000 … 9514.000
Octane      navier-stokes.js                            0.98   2534.500 ± 2532.000 … 2537.000     2484.500 ± 2483.000 … 2486.000
Octane      pdfjs.js                                    0.992  6128.500 ± 6094.000 … 6163.000     6082.000 ± 6075.000 … 6089.000
Octane      raytrace.js                                 0.962  2458.000 ± 2442.000 … 2474.000     2365.000 ± 2359.000 … 2371.000
Octane      regexp.js                                   0.987  231.500 ± 231.000 … 232.000        228.500 ± 227.000 … 230.000
Octane      richards.js                                 0.985  1387.500 ± 1384.000 … 1391.000     1366.500 ± 1366.000 … 1367.000
Octane      splay.js                                    0.964  6326.000 ± 6187.000 … 6465.000     6096.000 ± 6020.000 … 6172.000
Octane      typescript.js                               0.966  15458.500 ± 15451.000 … 15466.000  14930.000 ± 14875.000 … 14985.000
Octane      zlib.js                                     0.987  3509.000 ± 3508.000 … 3510.000     3462.500 ± 3445.000 … 3480.000
JetStream   bigfib.cpp.js                               0.992  7.525 ± 7.519 … 7.530              7.583 ± 7.582 … 7.584
JetStream   cdjs.js                                     0.995  2.934 ± 2.934 … 2.934              2.950 ± 2.950 … 2.951
JetStream   container.cpp.js                            1      30.262 ± 30.232 … 30.291           30.255 ± 30.030 … 30.479
JetStream   dry.c.js                                    1.018  18.984 ± 18.912 … 19.056           18.644 ± 18.644 … 18.645
JetStream   float-mm.c.js                               1.021  20.173 ± 20.133 … 20.214           19.757 ± 19.729 … 19.784
JetStream   gcc-loops.cpp.js                            1.035  114.454 ± 114.256 … 114.653        110.547 ± 110.431 … 110.663
JetStream   hash-map.js                                 1.01   1.267 ± 1.262 … 1.273              1.254 ± 1.252 … 1.256
JetStream   n-body.c.js                                 0.989  28.968 ± 28.923 … 29.014           29.279 ± 29.279 … 29.280
JetStream   quicksort.c.js                              1.022  4.408 ± 4.404 … 4.413              4.312 ± 4.299 … 4.325
JetStream   towers.c.js                                 1.03   5.424 ± 5.415 … 5.432              5.264 ± 5.255 … 5.273
JetStream3  js-tokens.js                                1.023  0.614 ± 0.608 … 0.620              0.600 ± 0.598 … 0.603
JetStream3  lazy-collections.js                         1.032  1.026 ± 1.025 … 1.026              0.994 ± 0.992 … 0.995
JetStream3  raytrace-private-class-fields.js            1.016  4.137 ± 4.111 … 4.163              4.072 ± 4.065 … 4.079
JetStream3  raytrace-public-class-fields.js             1.01   3.163 ± 3.152 … 3.175              3.131 ± 3.128 … 3.134
JetStream3  sync-file-system.js                         1.007  1.711 ± 1.691 … 1.732              1.699 ± 1.666 … 1.733
GarBench    array-of-objects.js                         1.268  0.749 ± 0.744 … 0.753              0.590 ± 0.589 … 0.592
GarBench    closures.js                                 1.012  0.879 ± 0.875 … 0.884              0.868 ± 0.864 … 0.873
GarBench    cyclic-graph.js                             1.018  2.350 ± 2.232 … 2.468              2.308 ± 2.197 … 2.419
GarBench    deep-linked-list.js                         1.09   0.582 ± 0.580 … 0.583              0.534 ± 0.532 … 0.535
GarBench    finalization.js                             1.01   0.968 ± 0.959 … 0.978              0.959 ± 0.957 … 0.961
GarBench    many-properties.js                          1.021  2.210 ± 2.207 … 2.212              2.164 ± 2.150 … 2.178
GarBench    marking-stress.js                           1.01   2.155 ± 2.148 … 2.162              2.133 ± 2.119 … 2.147
GarBench    mixed-sizes.js                              1.065  0.969 ± 0.964 … 0.975              0.910 ± 0.896 … 0.924
GarBench    sparse-arrays.js                            1.011  1.690 ± 1.689 … 1.691              1.671 ± 1.665 … 1.677
GarBench    string-heavy.js                             1.012  1.299 ± 1.297 … 1.301              1.284 ± 1.284 … 1.285
GarBench    wide-tree.js                                1.015  1.218 ± 1.207 … 1.229              1.201 ± 1.194 … 1.208
MicroBench  array-destructuring-assignment-rest.js      1.022  0.416 ± 0.403 … 0.429              0.407 ± 0.394 … 0.420
MicroBench  array-destructuring-assignment.js           1.09   2.351 ± 2.164 … 2.538              2.156 ± 2.152 … 2.161
MicroBench  array-prototype-map.js                      1.021  1.110 ± 1.103 … 1.117              1.087 ± 1.086 … 1.089
MicroBench  array-prototype-shift.js                    1.028  0.010 ± 0.010 … 0.011              0.010 ± 0.010 … 0.011
MicroBench  base64-from.js                              1.004  0.247 ± 0.246 … 0.249              0.247 ± 0.243 … 0.250
MicroBench  base64-to.js                                0.996  0.218 ± 0.215 … 0.221              0.219 ± 0.218 … 0.221
MicroBench  bound-call-00-args.js                       1.006  1.191 ± 1.187 … 1.195              1.183 ± 1.167 … 1.200
MicroBench  bound-call-04-args.js                       1.01   1.249 ± 1.244 … 1.253              1.237 ± 1.225 … 1.248
MicroBench  bound-call-16-args.js                       1.046  1.561 ± 1.528 … 1.594              1.492 ± 1.464 … 1.520
MicroBench  call-00-args.js                             0.926  1.254 ± 1.254 … 1.255              1.355 ± 1.255 … 1.455
MicroBench  call-01-args.js                             1.095  1.409 ± 1.319 … 1.499              1.287 ± 1.286 … 1.288
MicroBench  call-02-args.js                             1.029  1.282 ± 1.274 … 1.289              1.246 ± 1.245 … 1.246
MicroBench  call-03-args.js                             1.002  1.188 ± 1.188 … 1.189              1.186 ± 1.175 … 1.196
MicroBench  call-04-args.js                             0.999  1.175 ± 1.167 … 1.182              1.176 ± 1.169 … 1.183
MicroBench  call-16-args.js                             1.013  1.313 ± 1.311 … 1.316              1.296 ± 1.293 … 1.299
MicroBench  call-32-args.js                             1.013  1.492 ± 1.484 … 1.499              1.473 ± 1.466 … 1.479
MicroBench  call-native.js                              1.022  0.632 ± 0.631 … 0.632              0.618 ± 0.614 … 0.622
MicroBench  construct-00-args.js                        1.004  0.810 ± 0.806 … 0.814              0.806 ± 0.794 … 0.819
MicroBench  construct-04-args.js                        0.963  0.822 ± 0.822 … 0.823              0.854 ± 0.823 … 0.885
MicroBench  deep-call-stack.js                          1.018  0.986 ± 0.940 … 1.032              0.969 ± 0.962 … 0.976
MicroBench  for-in-indexed-properties.js                1.016  0.930 ± 0.927 … 0.933              0.915 ± 0.913 … 0.917
MicroBench  for-in-named-properties.js                  1.01   1.386 ± 1.381 … 1.390              1.371 ± 1.362 … 1.381
MicroBench  for-of.js                                   1.024  0.402 ± 0.399 … 0.405              0.393 ± 0.393 … 0.393
MicroBench  lots-alloc.js                               1.02   2.585 ± 2.583 … 2.587              2.533 ± 2.522 … 2.545
MicroBench  object-keys.js                              1.021  1.819 ± 1.818 … 1.820              1.782 ± 1.782 … 1.782
MicroBench  object-literal.js                           3.397  3.790 ± 3.773 … 3.808              1.116 ± 1.107 … 1.125
MicroBench  object-set-with-rope-strings.js             1.004  0.608 ± 0.608 … 0.608              0.605 ± 0.603 … 0.607
MicroBench  pic-add-own.js                              0.982  0.728 ± 0.728 … 0.729              0.742 ± 0.731 … 0.753
MicroBench  pic-get-own.js                              0.999  1.097 ± 1.089 … 1.106              1.098 ± 1.095 … 1.102
MicroBench  pic-get-pchain.js                           1.028  1.162 ± 1.132 … 1.192              1.130 ± 1.115 … 1.146
MicroBench  pic-put-own.js                              0.974  1.206 ± 1.205 … 1.207              1.238 ± 1.214 … 1.262
MicroBench  pic-put-pchain.js                           0.991  2.381 ± 2.338 … 2.425              2.402 ± 2.372 … 2.433
MicroBench  setter-in-prototype-chain.js                0.952  1.713 ± 1.711 … 1.716              1.800 ± 1.714 … 1.886
MicroBench  strictly-equals-object.js                   1.015  1.030 ± 1.030 … 1.031              1.016 ± 1.014 … 1.017
Kraken      Total                                       1      10.780                             10.780
Octane      Total                                       0.979  88487.000                          86638.000
JetStream   Total                                       1.02   234.400                            229.845
JetStream3  Total                                       1.015  10.652                             10.496
GarBench    Total                                       1.031  15.069                             14.621
MicroBench  Total                                       1.081  41.555                             38.446
All Suites  Total                                       1.018  405.693                            398.451
```