### PR TITLE
LibWeb: Avoid intermediate string allocations in `calc()` serialization

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -274,6 +274,7 @@ public:
 
     virtual Vector<NonnullRefPtr<CalculationNode const>> children() const override { return {}; }
     NumericValue const& value() const { return m_value; }
+    void serialize_value(StringBuilder&) const;
     String value_to_string() const;
 
     Optional<NonFiniteValue> infinite_or_nan_value() const;
@@ -753,6 +754,7 @@ public:
     // NOTE: We don't return children here as serialization is handled ad-hoc
     virtual Vector<NonnullRefPtr<CalculationNode const>> children() const override { return {}; }
 
+    void serialize(StringBuilder&, CalculationContext const&, SerializationMode) const;
     String to_string(CalculationContext const&, SerializationMode serialization_mode) const;
 
     virtual void dump(StringBuilder&, int indent) const override;


### PR DESCRIPTION
To test the performance improvement I used this test:
```html
<!DOCTYPE html>
<html>
<style>
    #results {
        font-family: monospace;
        white-space: pre;
    }
    .target {
        position: absolute;
        visibility: hidden;
    }
</style>

<div id="results"></div>
<script>
    const results = document.getElementById('results');
    const iterations = 10000;

    function log(msg) {
        results.textContent += msg + '\n';
        console.log(msg);
    }

    function createTarget(calcExpr) {
        const el = document.createElement('div');
        el.className = 'target';
        el.style.width = calcExpr;
        document.body.appendChild(el);
        return el;
    }

    function testSpecifiedValue(name, calcExpr) {
        const el = createTarget(calcExpr);
        const start = performance.now();
        for (let i = 0; i < iterations; i++) {
            const _ = el.style.width;
        }
        const time = performance.now() - start;
        el.remove();
        return time;
    }

    const expressions = [
        ['Simple calc', 'calc(100px + 50px)'],
        ['Nested calc', 'calc(calc(50px + 25px) + calc(25px * 2))'],
        ['Complex calc', 'calc(100px + 50% - 25px * 2 / 4 + 10em)'],
        ['clamp()', 'clamp(100px, calc(50% + 20px), 500px)'],
        ['Nested min/max', 'max(min(calc(100px + 50px), 200px), min(50px, calc(25px * 3)))'],
        ['min() many children', 'min(100px, 200px, 150px, 80px, 250px, 120px)'],
        ['Trig functions', 'calc(sin(45deg) * 100px + cos(30deg) * 50px)'],
        ['round()', 'round(nearest, calc(100px + 33px), 10px)'],
        ['Very long calc', 'calc(10px + 20px + 30px + 40px + 50px + 60px + 70px + 80px + 90px + 100px - 50px - 40px - 30px - 20px - 10px)'],
    ];

    function runAllTests() {
        log('Calc Serialization Stress Test');
        log('==============================');
        log(`Iterations per test: ${iterations}\n`);

        let total = 0;
        for (const [name, expr] of expressions) {
            const time = testSpecifiedValue(name, expr);
            total += time;
            log(`${name.padEnd(25)} ${time.toFixed(2).padStart(8)} ms`);
        }

        log('');
        log(`${'Total'.padEnd(25)} ${total.toFixed(2).padStart(8)} ms`);
        log(`${'Average per test'.padEnd(25)} ${(total / expressions.length).toFixed(2).padStart(8)} ms`);
    }

    window.onload = () => {
        setTimeout(runAllTests, 100);
    };
</script>
</html>
```

Which gave  the following results:

Before
```
Calc Serialization Stress Test
==============================
Iterations per test: 10000

Simple calc                   4.20 ms
Nested calc                   4.50 ms
Complex calc                  9.10 ms
clamp()                      11.40 ms
Nested min/max                4.20 ms
min() many children           4.00 ms
Trig functions                4.40 ms
round()                       4.00 ms
Very long calc                3.90 ms

Total                        49.70 ms
Average per test              5.52 ms
```

After
```
Calc Serialization Stress Test
==============================
Iterations per test: 10000

Simple calc                   3.30 ms
Nested calc                   3.40 ms
Complex calc                  6.90 ms
clamp()                       8.20 ms
Nested min/max                3.10 ms
min() many children           3.00 ms
Trig functions                3.30 ms
round()                       3.60 ms
Very long calc                3.00 ms

Total                        37.80 ms
Average per test              4.20 ms
```