### PR TITLE
LibWeb: Implement HTMLImageElement x() and y() getters

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -119,6 +119,8 @@ enum class InvalidateLayoutTreeReason {
     X(HTMLEventLoopRenderingUpdate)           \
     X(HTMLImageElementHeight)                 \
     X(HTMLImageElementWidth)                  \
+    X(HTMLImageElementX)                      \
+    X(HTMLImageElementY)                      \
     X(HTMLInputElementHeight)                 \
     X(HTMLInputElementWidth)                  \
     X(InternalsHitTest)                       \

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -305,6 +305,44 @@ unsigned HTMLImageElement::natural_height() const
     return 0;
 }
 
+// https://drafts.csswg.org/cssom-view/#dom-htmlimageelement-x
+int HTMLImageElement::x() const
+{
+    // The x attribute, on getting, must return the scaled x-coordinate of the left border edge of the first box
+    // associated with the element, relative to the initial containing block origin, ignoring any transforms that apply
+    // to the element and its ancestors, or zero if there is no box.
+    const_cast<DOM::Document&>(document()).update_layout(DOM::UpdateLayoutReason::HTMLImageElementX);
+
+    auto const* paintable_box = this->paintable_box();
+    if (!paintable_box)
+        return 0;
+
+    CSSPixels scroll_offset_x = 0;
+    if (auto enclosing_scroll = paintable_box->enclosing_scroll_frame(); enclosing_scroll)
+        scroll_offset_x = enclosing_scroll->cumulative_offset().x();
+
+    return (paintable_box->absolute_border_box_rect().x() - scroll_offset_x).to_int();
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-htmlimageelement-y
+int HTMLImageElement::y() const
+{
+    // The y attribute, on getting, must return the scaled y-coordinate of the top border edge of the first box
+    // associated with the element, relative to the initial containing block origin, ignoring any transforms that apply
+    // to the element and its ancestors, or zero if there is no box.
+    const_cast<DOM::Document&>(document()).update_layout(DOM::UpdateLayoutReason::HTMLImageElementY);
+
+    auto const* paintable_box = this->paintable_box();
+    if (!paintable_box)
+        return 0;
+
+    CSSPixels scroll_offset_y = 0;
+    if (auto enclosing_scroll = paintable_box->enclosing_scroll_frame(); enclosing_scroll)
+        scroll_offset_y = enclosing_scroll->cumulative_offset().y();
+
+    return (paintable_box->absolute_border_box_rect().y() - scroll_offset_y).to_int();
+}
+
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-complete
 bool HTMLImageElement::complete() const
 {

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -62,6 +62,9 @@ public:
     unsigned natural_width() const;
     unsigned natural_height() const;
 
+    int x() const;
+    int y() const;
+
     // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-complete
     bool complete() const;
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.idl
@@ -47,7 +47,7 @@ interface HTMLImageElement : HTMLElement {
     [CEReactions, LegacyNullToEmptyString, Reflect] attribute DOMString border;
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlimageelement-interface
-    [FIXME] readonly attribute long x;
-    [FIXME] readonly attribute long y;
+    readonly attribute long x;
+    readonly attribute long y;
 
 };

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/HTMLImageElement-x-and-y-ignore-transforms.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/HTMLImageElement-x-and-y-ignore-transforms.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	HTMLImageElement's 'x' and 'y' property values ignore transforms

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/cssom-view-img-attributes-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/cssom-view-img-attributes-001.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	test x with display false
+Pass	test y with display false
+Pass	test x with display true
+Pass	test y with display true

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/idlharness.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/idlharness.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 415 tests
 
-338 Pass
-77 Fail
+342 Pass
+73 Fail
 Pass	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Window: original interface defined
@@ -214,10 +214,10 @@ Fail	Element interface: document.createElement("div") must inherit property "con
 Fail	Element interface: calling convertRectFromNode(DOMRectReadOnly, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError
 Fail	Element interface: document.createElement("div") must inherit property "convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions)" with the proper type
 Fail	Element interface: calling convertPointFromNode(DOMPointInit, GeometryNode, optional ConvertCoordinateOptions) on document.createElement("div") with too few arguments must throw TypeError
-Fail	HTMLImageElement interface: attribute x
-Fail	HTMLImageElement interface: attribute y
-Fail	HTMLImageElement interface: document.createElement("img") must inherit property "x" with the proper type
-Fail	HTMLImageElement interface: document.createElement("img") must inherit property "y" with the proper type
+Pass	HTMLImageElement interface: attribute x
+Pass	HTMLImageElement interface: attribute y
+Pass	HTMLImageElement interface: document.createElement("img") must inherit property "x" with the proper type
+Pass	HTMLImageElement interface: document.createElement("img") must inherit property "y" with the proper type
 Pass	HTMLElement interface: document.createElement("img") must inherit property "scrollParent" with the proper type
 Pass	HTMLElement interface: document.createElement("img") must inherit property "offsetParent" with the proper type
 Pass	HTMLElement interface: document.createElement("img") must inherit property "offsetTop" with the proper type

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/HTMLImageElement-x-and-y-ignore-transforms.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/HTMLImageElement-x-and-y-ignore-transforms.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="author" href="mailto:mrobinson@igalia.com.org">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlimageelement-interface">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1676952">
+<title>CSS OM View Test: HTMLImageElement's 'x' and 'y' property values should ignore transforms</title>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+.transformed {
+    transform: translate(40px, 40px);
+}
+</style>
+
+<div id="container">
+    <img id="image" src="../../images/green.png">
+</div>
+
+<script>
+  test(() => {
+    const unTransformedX = image.x;
+    const unTransformedY = image.y;
+
+    container.classList.add("transformed");
+
+    assert_equals(unTransformedX, image.x);
+    assert_equals(unTransformedY, image.y);
+  }, `HTMLImageElement's 'x' and 'y' property values ignore transforms`);
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/cssom-view-img-attributes-001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/cssom-view-img-attributes-001.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>CSS Test: HTMLImageElement x and y attributes</title>
+        <link rel="author" title="Adobe" href="http://html.adobe.com/">
+        <link rel="author" title="Alan Stearns" href="mailto:stearns@adobe.com">
+        <link rel="reviewer" title="" href="">
+        <link rel="help" href="https://drafts.csswg.org/cssom-view/#excensions-to-the-htmlimageelement-interface">
+        <meta name="assert" content="HTMLImageElement attributes give x and y position of CSS layout box">
+        <meta name="flags" content="dom">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script type="text/javascript">
+
+        function testIMGAttributes(attribute_name, display_none) {
+            var element = document.createElement("img");
+            document.body.appendChild(element);
+            element.style.setProperty("position", "absolute");
+            element.style.setProperty("left", "10px");
+            element.style.setProperty("top", "10px");
+            if (display_none) {
+                element.style.setProperty("display", "none");
+            }
+            var attributeValue = element[attribute_name];
+            document.body.removeChild(element);
+            return attributeValue;
+        }
+
+        var imgAttributes = [
+            ["x", false, 10],
+            ["y", false, 10],
+            ["x", true, 0],
+            ["y", true, 0],
+        ];
+
+        imgAttributes.forEach(function(test_data) {
+            test (function() { assert_equals(testIMGAttributes(test_data[0], test_data[1]), test_data[2])},
+                "test " + test_data[0] + " with display " + test_data[1])
+            }
+        );
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
These attributes get the image's top left border edge  relative to the root element's origin.

These methods ignore any transforms.