### PR TITLE
LibWeb: Create containing blocks for non-initial filter values

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -114,6 +114,20 @@ bool Node::establishes_an_absolute_positioning_containing_block() const
     if (computed_values.perspective().has_value() || will_change_property(CSS::PropertyID::Perspective))
         return true;
 
+    // https://drafts.csswg.org/filter-effects-1/#FilterProperty
+    // A value other than none for the filter property results in the creation of a containing block for absolute and
+    // fixed positioned descendants, unless the element it applies to is a document root element in the current
+    // browsing context.
+    if ((computed_values.filter().has_filters() || will_change_property(CSS::PropertyID::Filter)) && !is_root_element())
+        return true;
+
+    // https://drafts.csswg.org/filter-effects-2/#BackdropFilterProperty
+    // A computed value of other than none results in the creation of both a stacking context and a containing block
+    // for absolute and fixed position descendants, unless the element it applies to is a document root element in the
+    // current browsing context.
+    if ((computed_values.backdrop_filter().has_filters() || will_change_property(CSS::PropertyID::BackdropFilter)) && !is_root_element())
+        return true;
+
     // https://drafts.csswg.org/css-contain-2/#containment-types
     // 4. The layout containment box establishes an absolute positioning containing block and a fixed positioning
     //    containing block.
@@ -167,6 +181,20 @@ bool Node::establishes_a_fixed_positioning_containing_block() const
     // The use of this property with any value other than 'none' establishes a stacking context. It also establishes
     // a containing block for all descendants, just like the 'transform' property does.
     if (computed_values.perspective().has_value() || will_change_property(CSS::PropertyID::Perspective))
+        return true;
+
+    // https://drafts.csswg.org/filter-effects-1/#FilterProperty
+    // A value other than none for the filter property results in the creation of a containing block for absolute and
+    // fixed positioned descendants, unless the element it applies to is a document root element in the current
+    // browsing context.
+    if ((computed_values.filter().has_filters() || will_change_property(CSS::PropertyID::Filter)) && !is_root_element())
+        return true;
+
+    // https://drafts.csswg.org/filter-effects-2/#BackdropFilterProperty
+    // A computed value of other than none results in the creation of both a stacking context and a containing block
+    // for absolute and fixed position descendants, unless the element it applies to is a document root element in the
+    // current browsing context.
+    if ((computed_values.backdrop_filter().has_filters() || will_change_property(CSS::PropertyID::BackdropFilter)) && !is_root_element())
         return true;
 
     // https://drafts.csswg.org/css-contain-2/#containment-types

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-abspos-cb-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-abspos-cb-002-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+  div {
+    border: 1px solid green;
+    background: green;
+    margin-top: 100px;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-abspos-cb-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-abspos-cb-003-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+  div {
+    border: 1px solid green;
+    background: green;
+    margin-top: 100px;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-fixedpos-cb-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-fixedpos-cb-001-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+  div {
+    border: 1px solid green;
+    background: green;
+    margin-top: 100px;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-fixedpos-cb-004-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-will-change/will-change-fixedpos-cb-004-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+  div {
+    border: 1px solid green;
+    background: green;
+    margin-top: 100px;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-abspos-cb-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-abspos-cb-002.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: will-change: filter should generate a containing block for absolute positioned elements.</title>
+<link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=960953">
+<link rel="help" href="https://drafts.csswg.org/css-will-change/#will-change">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#FilterProperty">
+<link rel="match" href="../../../../expected/wpt-import/css/css-will-change/will-change-abspos-cb-002-ref.html">
+<style>
+  .container {
+    border: 1px solid green;
+    background: red;
+    width: 100px;
+    height: 100px;
+    margin-top: 100px;
+    will-change: filter;
+  }
+  .abspos {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: green;
+    height: 100px;
+    width: 100px;
+  }
+</style>
+<div class="container">
+  <div class="abspos"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-abspos-cb-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-abspos-cb-003.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: will-change: backdrop-filter should generate a containing block for absolute positioned elements.</title>
+<link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=960953">
+<link rel="help" href="https://drafts.csswg.org/css-will-change/#will-change">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match" href="../../../../expected/wpt-import/css/css-will-change/will-change-abspos-cb-003-ref.html">
+<style>
+  .container {
+    border: 1px solid green;
+    background: red;
+    width: 100px;
+    height: 100px;
+    margin-top: 100px;
+    will-change: backdrop-filter;
+  }
+  .abspos {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: green;
+    height: 100px;
+    width: 100px;
+  }
+</style>
+<div class="container">
+  <div class="abspos"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-fixedpos-cb-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-fixedpos-cb-001.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: will-change: filter should generate a containing block for fixed positioned elements.</title>
+<link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=960953">
+<link rel="help" href="https://drafts.csswg.org/css-will-change/#will-change">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#FilterProperty">
+<link rel="match" href="../../../../expected/wpt-import/css/css-will-change/will-change-fixedpos-cb-001-ref.html">
+<style>
+  .container {
+    border: 1px solid green;
+    background: red;
+    width: 100px;
+    height: 100px;
+    margin-top: 100px;
+    will-change: filter;
+  }
+  .fixedpos {
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: green;
+    height: 100px;
+    width: 100px;
+  }
+</style>
+<div class="container">
+  <div class="fixedpos"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-fixedpos-cb-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-will-change/will-change-fixedpos-cb-004.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: will-change: backdrop-filter should generate a containing block for fixed positioned elements.</title>
+<link rel="author" title="Philip Rogers" href="mailto:pdr@chromium.org">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=960953">
+<link rel="help" href="https://drafts.csswg.org/css-will-change/#will-change">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match" href="../../../../expected/wpt-import/css/css-will-change/will-change-fixedpos-cb-004-ref.html">
+<style>
+  .container {
+    border: 1px solid green;
+    background: red;
+    width: 100px;
+    height: 100px;
+    margin-top: 100px;
+    will-change: backdrop-filter;
+  }
+  .fixedpos {
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: green;
+    height: 100px;
+    width: 100px;
+  }
+</style>
+<div class="container">
+  <div class="fixedpos"></div>
+</div>


### PR DESCRIPTION
This fixes:
http://wpt.live/css/css-will-change/will-change-abspos-cb-002.html 
http://wpt.live/css/css-will-change/will-change-abspos-cb-003.html
http://wpt.live/css/css-will-change/will-change-fixedpos-cb-001.html
http://wpt.live/css/css-will-change/will-change-fixedpos-cb-004.html
