### PR TITLE
LibWeb: Parse Referrer-Policy header when creating policy container

### DIFF
--- a/Libraries/LibWeb/HTML/PolicyContainers.cpp
+++ b/Libraries/LibWeb/HTML/PolicyContainers.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/Fetch/Infrastructure/URL.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/SerializedPolicyContainer.h>
+#include <LibWeb/ReferrerPolicy/AbstractOperations.h>
 
 namespace Web::HTML {
 
@@ -50,9 +51,11 @@ GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(GC::Hea
     // FIXME: 4. If environment is non-null, then set result's embedder policy to the result of obtaining an embedder
     //           policy given response and environment. Otherwise, set it to "unsafe-none".
 
-    // FIXME: 5. Set result's referrer policy to the result of parsing the `Referrer-Policy` header given response.
-    //           [REFERRERPOLICY]
-    //        Doing this currently makes Fetch fail the policy != ReferrerPolicy::EmptyString verification.
+    // 5. Set result's referrer policy to the result of parsing the `Referrer-Policy` header given response.
+    //    [REFERRERPOLICY]
+    auto parsed_referrer_policy = ReferrerPolicy::parse_a_referrer_policy_from_a_referrer_policy_header(response);
+    if (parsed_referrer_policy != ReferrerPolicy::ReferrerPolicy::EmptyString)
+        result->referrer_policy = parsed_referrer_policy;
 
     // FIXME: 6. Parse Integrity-Policy headers with response and result.
 

--- a/Tests/LibWeb/Text/expected/HTML/referrer-policy-http-header.txt
+++ b/Tests/LibWeb/Text/expected/HTML/referrer-policy-http-header.txt
@@ -1,0 +1,2 @@
+no-referrer policy: PASS (no Referer header sent)
+origin policy: PASS (only origin sent)

--- a/Tests/LibWeb/Text/input/HTML/referrer-policy-http-header.html
+++ b/Tests/LibWeb/Text/input/HTML/referrer-policy-http-header.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const httpServer = httpTestServer();
+
+        const reflectorUrl = await httpServer.createEcho("GET", "/referrer-policy-reflector", {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "application/json",
+            },
+            reflect_headers_in_body: true,
+        });
+
+        const noReferrerIframeUrl = await httpServer.createEcho("GET", "/no-referrer-iframe", {
+            status: 200,
+            headers: {
+                "Content-Type": "text/html",
+                "Referrer-Policy": "no-referrer",
+            },
+            body: `<!DOCTYPE html>
+                <script>
+                    (async () => {
+                        try {
+                            const response = await fetch("${reflectorUrl}");
+                            const headers = await response.json();
+                            const refererArray = headers["Referer"];
+                            const referer = refererArray ? refererArray[0] : null;
+                            parent.postMessage({ test: "no-referrer", referer: referer }, "*");
+                        } catch (e) {
+                            parent.postMessage({ test: "no-referrer", error: e.message }, "*");
+                        }
+                    })();
+                <\/script>`,
+        });
+
+        const originIframeUrl = await httpServer.createEcho("GET", "/origin-iframe", {
+            status: 200,
+            headers: {
+                "Content-Type": "text/html",
+                "Referrer-Policy": "origin",
+            },
+            body: `<!DOCTYPE html>
+                <script>
+                    (async () => {
+                        try {
+                            const response = await fetch("${reflectorUrl}");
+                            const headers = await response.json();
+                            const refererArray = headers["Referer"];
+                            const referer = refererArray ? refererArray[0] : null;
+                            parent.postMessage({ test: "origin", referer: referer }, "*");
+                        } catch (e) {
+                            parent.postMessage({ test: "origin", error: e.message }, "*");
+                        }
+                    })();
+                <\/script>`,
+        });
+
+        const results = {};
+        let expectedResults = 2;
+        addEventListener("message", (event) => {
+            const { test, referer, error } = event.data;
+            if (error) {
+                println(`${test}: ERROR - ${error}`);
+            } else {
+                results[test] = referer;
+            }
+
+            expectedResults--;
+            if (expectedResults === 0) {
+                if (results["no-referrer"] === null) {
+                    println("no-referrer policy: PASS (no Referer header sent)");
+                } else {
+                    println(`no-referrer policy: FAIL (Referer was "${results["no-referrer"]}")`);
+                }
+
+                // Verify origin policy: referer should be origin only (e.g., "http://127.0.0.1:PORT/")
+                const originReferer = results["origin"];
+                const isOriginOnly = originReferer &&
+                    originReferer.endsWith("/") &&
+                    !originReferer.includes("?") &&
+                    originReferer.match(/^https?:\/\/[^\/]+\/$/) !== null;
+                if (isOriginOnly) {
+                    println("origin policy: PASS (only origin sent)");
+                } else {
+                    println(`origin policy: FAIL (Referer was "${originReferer}")`);
+                }
+
+                done();
+            }
+        }, false);
+
+        const frame1 = document.createElement('iframe');
+        frame1.src = noReferrerIframeUrl;
+        document.body.appendChild(frame1);
+
+        const frame2 = document.createElement('iframe');
+        frame2.src = originIframeUrl;
+        document.body.appendChild(frame2);
+    });
+</script>


### PR DESCRIPTION
Previously, when creating a policy container from a fetch response, the Referrer-Policy HTTP header was not being parsed. This meant documents loaded with a Referrer-Policy header would ignore the policy and use the default.

This gains us ~400 WPT subtests in the `referrer-policy/` directory.