### PR TITLE
Meta: Allow a couple of extra characters in long URLs in commit messages

### DIFF
--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -49,7 +49,7 @@ jobs:
                 error: "Commit title ends in a period",
               },
               {
-                pattern: /^(.{0,72}|\s*[a-z]+:\/\/([a-z0-9\-]+\.)+[a-z]{2,}(:\d+)?(\/[a-zA-Z_0-9@:%+.~?&=\-]+)*)$/,
+                pattern: /^(.{0,72}|\s*[a-z]+:\/\/([a-z0-9\-]+\.)+[a-z]{2,}(:\d+)?(\/[a-zA-Z_0-9@#:;%+.~?&=\-]+)*)$/,
                 error: "Commit message lines are too long (maximum allowed is 72 characters, except for URLs on their own line)",
               },
               {

--- a/Meta/lint-commit.sh
+++ b/Meta/lint-commit.sh
@@ -54,7 +54,7 @@ while read -r line; do
     error "Commit title ends in a period"
   fi
 
-  url_pattern='^\s*[a-z]+:\/\/([a-z0-9\-]+\.)+[a-z]{2,}(:\d+)?(\/[a-zA-Z_0-9@:%+.~?&=\-]+)*$'
+  url_pattern='^\s*[a-z]+:\/\/([a-z0-9\-]+\.)+[a-z]{2,}(:\d+)?(\/[a-zA-Z_0-9@#:;%+.~?&=\-]+)*$'
   if [[ $line_length -gt 72 ]] && (echo "$line" | grep -E -v -q "$url_pattern"); then
     error "Commit message lines are too long (maximum allowed is 72 characters, except for URLs on their own line)"
   fi


### PR DESCRIPTION
This allows the number sign (for anchors) and semi-colons.

Adding this for #7415. Apparently this cannot be in the same PR, as the workflow pulls the job from the master branch.

Validated on regex101:
<img width="1096" height="405" alt="re" src="https://github.com/user-attachments/assets/e689a838-ca40-4890-b779-b5834f72aab1" />
