### PR TITLE
LibCore: Notify write-only notifiers on POLLHUP

### DIFF
--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -408,7 +408,7 @@ try_select_again:
             if (has_flag(revents, POLLOUT))
                 type |= NotificationType::Write;
             if (has_flag(revents, POLLHUP))
-                type |= NotificationType::Read | NotificationType::HangUp;
+                type |= NotificationType::Read | NotificationType::Write | NotificationType::HangUp;
             if (has_flag(revents, POLLERR))
                 type |= NotificationType::Error;
 


### PR DESCRIPTION
This fixes an issue where RequestServer would churn as poll() returned immediately due to a file descriptor yielding POLLHUP.

In that case, we should just wake the notifier and let it figure out what to do.