### PR TITLE
LibWeb: Set the socket ready state to CLOSING immediately

### DIFF
--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -294,7 +294,11 @@ WebIDL::ExceptionOr<void> WebSocket::close(Optional<u16> code, Optional<String> 
     // -> If the WebSocket connection is not yet established [WSP]
     // -> If the WebSocket closing handshake has not yet been started [WSP]
     // -> Otherwise
-    // NOTE: All of these are handled by the WebSocket Protocol when calling close()
+    // NB: All of these are handled by the WebSocket Protocol when calling close(). We still set the ready state to
+    //     CLOSING now though (which every case above expects), to prevent handling any messages from the remote server
+    //     in the meantime.
+    m_websocket->set_ready_state(Requests::WebSocket::ReadyState::Closing);
+
     // FIXME: LibProtocol does not yet support sending empty Close messages, so we use default values for now
     m_websocket->close(code.value_or(1000), reason.value_or(String {}).to_byte_string());
     return {};


### PR DESCRIPTION
We currently wait for an IPC round trip to set the ready state. This leaves a window open where we can process a message from the remote server in the meantime. We will still receive that message now, but will not propagate it to JS.

This should fix the WebSocket echo test being flakey.