### PR TITLE
Tests/LibWeb: Normalize paths when removing test files via glob matches

### DIFF
--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -572,8 +572,11 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
             "*/wpt-import/common/*"sv,
             "*/wpt-import/images/*"sv,
         };
-        bool is_support_file = any_of(support_file_patterns, [&](auto pattern) { return test.input_path.matches(pattern); });
-        bool match_glob = any_of(app.test_globs, [&](auto const& glob) { return test.relative_path.matches(glob, CaseSensitivity::CaseSensitive); });
+        auto normalize_path = [](ByteString const& path) { return path.replace("\\"sv, "/"sv); };
+        auto const test_input_path = normalize_path(test.input_path);
+        auto const test_relative_path = normalize_path(test.relative_path);
+        bool is_support_file = any_of(support_file_patterns, [&](auto pattern) { return test_input_path.matches(pattern); });
+        bool match_glob = any_of(app.test_globs, [&](auto const& glob) { return test_relative_path.matches(glob, CaseSensitivity::CaseSensitive); });
         return is_support_file || !match_glob;
     });
 


### PR DESCRIPTION
See commit for details.

### Demo

<details>

<summary>Before</summary>

**Test Glob Matching:** Unable to match the `\`-based test paths to a `/`-based glob
```
C:\Users\ayeteadoe\Development\ladybird>py Meta\ladybird.py run --preset Windows_CI test-web -f Text/input/test-http-test-server.html
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\release'
ninja: no work to do.
Runtime error: No tests found matching filter
```

**Test Support File Matching:** Unable to filter out any of the support files with the `/`-based glob, which causes us to crash as those files don't contain the expected content for Ref tests.
```
C:\Users\ayeteadoe\Development\ladybird>py Meta\ladybird.py run --preset Windows_CI test-web -f Ref
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\release'
ninja: no work to do.
Running 822 tests...
67/822: Ref\input\css\stacking-context-with-unclipped-transformed-descendant.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
WebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
131/822: Ref\input\object-fit-scale-down.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
140/822: Ref\input\ol-render-multiple-changes.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
150/822: Ref\input\ol-render-node-insert-last-group.htmlfile:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/mismatch-test.html: Screenshot mismatch: pixel error count 480000, with maximum error 255. (No fuzzy config defined)
197/822: Ref\input\scrollable-overflow-viewport-bug.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
198/822: Ref\input\scrolled-svg-path-with-transform.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
212/822: Ref\input\svg\image-prefer-href-to-xlink-href.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
232/822: Ref\input\svg-mask-in-defs.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
250/822: Ref\input\transform-2d-translate.htmlWebContent: AttributeParser::parse_drawto failed to match: 'i'
WebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
267/822: Ref\input\wpt-import\css\css-cascade\support\test-red.cssNo match or mismatch references in `file:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/wpt-import/common/rendering-utils.js`! Metadata: {"match_references":[],"mismatch_references":[],"fuzzy":[]}
VERIFICATION FAILED: false at C:\Users\ayeteadoe\Development\ladybird\Tests\LibWeb\test-web\main.cpp:405
```

</details>


<details>

<summary>After</summary>

**Test Glob Matching:**
```
C:\Users\ayeteadoe\Development\ladybird>py Meta\ladybird.py run --preset Windows_CI test-web -f Text/input/test-http-test-server.html
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\release'
ninja: no work to do.
Running 1 tests...
Done!
==========================================================
Pass: 1, Fail: 0, Skipped: 0, Timeout: 0, Crashed: 0
==========================================================
```

**Test Support File Matching:**
```
C:\Users\ayeteadoe\Development\ladybird>py Meta\ladybird.py run --preset Windows_CI test-web -f Ref
ninja: Entering directory `C:\Users\ayeteadoe\Development\ladybird\Build\release'
ninja: no work to do.
Running 788 tests...
67/788: Ref\input\css\stacking-context-with-unclipped-transformed-descendant.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
WebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
132/788: Ref\input\object-fit-with-zoom-0.5.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
135/788: Ref\input\ol-change-reversed-attribute.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
152/788: Ref\input\ol-render-node-insert-no-child-group.htmlfile:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/mismatch-test.html: Screenshot mismatch: pixel error count 480000, with maximum error 255. (No fuzzy config defined)
194/788: Ref\input\scrollable-contains-rotated-boxes.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
WebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
207/788: Ref\input\sticky-positioned-box-with-border.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
228/788: Ref\input\svg-image-in-iframe.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
244/788: Ref\input\table-collapse-ignored-in-cells.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
WebContent: AttributeParser::parse_drawto failed to match: 'i'
361/788: Ref\input\wpt-import\css\css-contain\contain-layout-formatting-context-margin-001.htmlWebContent: FIXME: CSS display 'ruby-text' not implemented yet.
378/788: Ref\input\wpt-import\css\css-contain\contain-paint-024.htmlWebContent: FIXME: CSS display 'ruby-text' not implemented yet.
398/788: Ref\input\wpt-import\css\css-contain\contain-size-replaced-004.htmlWebContent: ResourceLoader: Failed load of: "file:///C:/css/support/60x60-red.png", Error: No such file or directory (errno=2), Duration: 1ms
491/788: Ref\input\wpt-import\css\css-transforms\perspective-origin-004.htmlfile:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/wpt-import/css/css-pseudo/file-selector-button-001.html: Screenshot mismatch: pixel error count 2040, with maximum error 255. (No fuzzy config defined)
505/788: Ref\input\wpt-import\css\css-values\attr-in-slotted.htmlfile:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/wpt-import/css/css-text-decor/text-underline-offset-negative.html: Screenshot mismatch: pixel error count 969, with maximum error 255. (No fuzzy config defined)
511/788: Ref\input\wpt-import\css\css-variables\css-vars-custom-property-inheritance.htmlfile:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/wpt-import/css/css-text-decor/text-underline-offset-001.html: Screenshot mismatch: pixel error count 320, with maximum error 255. (No fuzzy config defined)
515/788: Ref\input\wpt-import\css\css-will-change\will-change-stacking-context-clip-path-1.htmlWebContent: Unhandled JavaScript exception (in promise): AbortError: Document.startViewTransition() was called
531/788: Ref\input\wpt-import\css\CSS2\cascade\at-import-009.xhtfile:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-rotatex-perspective-002.html: Screenshot mismatch: pixel error count 1265, with maximum error 255. (No fuzzy config defined)
534/788: Ref\input\wpt-import\css\CSS2\floats\float-in-inline-anonymous-block-with-overflow-hidden.htmlfile:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-rotatex-perspective-001.html: Screenshot mismatch: pixel error count 604, with maximum error 255. (No fuzzy config defined)
613/788: Ref\input\wpt-import\css\CSS2\floats\negative-block-margin-pushing-float-out-of-block-formatting-context.ht707/788: Ref\input\wpt-import\css\selectors\invalidation\nth-child-of-class.htmlWebContent: Unhandled JavaScript exception: SyntaxError: Failed to parse selector
759/788: Ref\input\wpt-import\html\rendering\sections\headingoffset-and-headingreset.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
WebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
760/788: Ref\input\wpt-import\html\rendering\the-css-user-agent-style-sheet-and-presentational-hints\pre-margin-bloc766/788: Ref\input\wpt-import\html\semantics\links\linktypes\link-type-stylesheet\process-stylesheet-linked-resource777/788: Ref\input\wpt-import\svg\coordinate-systems\view-invalid-viewBox.htmlImageDecoder:4292: libpng warning: iCCP: unexpected zlib return code
WebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
779/788: Ref\input\wpt-import\svg\embedded\image-embedding-svg-with-auto-height.svgWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
WebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
788/788: Ref\input\zero-area-child-creating-scrollable-overflow.htmlWebContent: FIXME: Handle null navigation_request in navigation response Content Security Policy check.
file:///C:/Users/ayeteadoe/Development/ladybird/Tests/LibWeb/Ref/input/wpt-import/infrastructure/reftest/reftest_mismatch.html: Screenshot mismatch: pixel error count 480000, with maximum error 255. (No fuzzy config defined)
Done!
==========================================================
Pass: 736, Fail: 0, Skipped: 52, Timeout: 0, Crashed: 0
==========================================================
```

</details>


This will allow all Ref tests to run and pass with https://github.com/LadybirdBrowser/ladybird/pull/6661
