### PR TITLE
LibWeb: Resolve SVG `url()` references in shadow root scope

### DIFF
--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -101,8 +101,15 @@ protected:
         }
         if (!fragment.has_value())
             return {};
-        if (auto node = document().get_element_by_id(*fragment); node && is<T>(*node))
-            return static_cast<T&>(*node);
+        if (auto node = as_if<T>(document().get_element_by_id(*fragment).ptr()))
+            return *node;
+
+        auto containing_shadow = containing_shadow_root();
+        if (containing_shadow) {
+            if (auto node = as_if<T>(containing_shadow->get_element_by_id(*fragment).ptr()))
+                return *node;
+        }
+
         return {};
     }
 

--- a/Tests/LibWeb/Ref/expected/svg-url-in-shadow-root-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-url-in-shadow-root-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<body>
+    <div></div>
+</body>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background: crimson;
+    }
+</style>

--- a/Tests/LibWeb/Ref/input/svg-url-in-shadow-root.html
+++ b/Tests/LibWeb/Ref/input/svg-url-in-shadow-root.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<link rel="match" href="../expected/svg-url-in-shadow-root-ref.html" />
+</head>
+<body>
+    <svg>
+        <defs>
+            <lineargradient id="fill">
+                <stop stop-color="crimson"/>
+            </lineargradient>
+        </defs>
+        <rect width="100" height="100" fill="url(#fill)"/>
+    </svg>
+</body>
+<script>
+    const svg = document.querySelector("svg");
+    const shadowRoot = document.body.attachShadow({
+        mode: "open",
+    });
+
+    shadowRoot.innerHTML = svg.outerHTML;
+    svg.remove();
+</script>


### PR DESCRIPTION
Added a search in the containing shadow root when resolving SVG `url()` references

Fixes #3458