### PR TITLE
Revert "LibCore: Use weak ownership in EventReceiver::deferred_invoke"

### DIFF
--- a/Libraries/LibCore/EventReceiver.cpp
+++ b/Libraries/LibCore/EventReceiver.cpp
@@ -8,7 +8,6 @@
 #include <AK/Assertions.h>
 #include <AK/Badge.h>
 #include <AK/JsonObject.h>
-#include <AK/WeakPtr.h>
 #include <LibCore/Event.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/EventReceiver.h>
@@ -61,12 +60,7 @@ void EventReceiver::stop_timer()
 
 void EventReceiver::deferred_invoke(Function<void()> invokee)
 {
-    Core::deferred_invoke([invokee = move(invokee), weak_this = make_weak_ptr()] {
-        auto strong_this = weak_this.strong_ref();
-        if (!strong_this)
-            return;
-        invokee();
-    });
+    Core::deferred_invoke([invokee = move(invokee), strong_this = NonnullRefPtr(*this)] { invokee(); });
 }
 
 void EventReceiver::dispatch_event(Core::Event& e)


### PR DESCRIPTION
This caused a crash for me when navigating to any new site.

This reverts commit 1ed94388e95c44cdd5e493aa0175f19997cecc74.

Reverts #7202
Fixes #7428

CC: @ayeteadoe 