### PR TITLE
LibWeb: Remove a WTF comment that got moved outside of its context

### DIFF
--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -326,8 +326,6 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     //       area of a top-level traversable. For example, if the currently focused area of a top-level traversable is a
     //       viewport, then it will usually keep its focus regardless until another focusable area is explicitly focused
     //       with the focusing steps.
-
-    // What? It already doesn't have system focus, what possible platform-specific conventions are there?
 }
 
 }


### PR DESCRIPTION
This comment at the end of LibWeb/HTML/Focus.cpp:
```
  // What? It already doesn't have system focus, what possible
  // platform-specific conventions are there?

```
Originally followed and referred to this FIXME on line 319:
```
  // FIXME: Otherwise, apply any relevant platform-specific conventions
  // for removing system focus from topDocument's
  // browsing context, and run the focus update steps with old chain,
  // an empty list, and null respectively.
```
During the course of #7233, it was accidentally moved and attached to a different context, following this comment below on line 325:
```
  // NOTE: The unfocusing steps do not always result in the focus
  // changing, even when applied to the currently focused
  // area of a top-level traversable. For example, if the currently
  // focused area of a top-level traversable is a
  // viewport, then it will usually keep its focus regardless until
  // another focusable area is explicitly focused
  // with the focusing steps.
```

Rather than move it to the correct place and become its git blame villain in the process, I once more seek to remove it.