### PR TITLE
LibWeb: Set referrer policy on navigation fetch requests

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1110,6 +1110,7 @@ static void create_navigation_params_by_fetching(GC::Ptr<SessionHistoryEntry> en
     request->set_replaces_client_id(active_document.relevant_settings_object().id);
     request->set_mode(Fetch::Infrastructure::Request::Mode::Navigate);
     request->set_referrer(entry->document_state()->request_referrer());
+    request->set_referrer_policy(entry->document_state()->request_referrer_policy());
     request->set_policy_container(source_snapshot_params.source_policy_container);
 
     // 4. If navigable is a top-level traversable, then set request's top-level navigation initiator origin to entry's

--- a/Tests/LibWeb/Text/expected/navigation/iframe-referrer-policy.txt
+++ b/Tests/LibWeb/Text/expected/navigation/iframe-referrer-policy.txt
@@ -1,0 +1,3 @@
+no-referrer: PASS
+origin: PASS
+unsafe-url: PASS

--- a/Tests/LibWeb/Text/input/navigation/iframe-referrer-policy.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-referrer-policy.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const html = `<!DOCTYPE html><script>parent.postMessage(document.referrer, "*");<\/script>`;
+
+        async function testReferrerPolicy(policy, validate) {
+            const url = await server.createEcho("GET", `/referrer-test-${policy}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: html,
+            });
+
+            const referrer = await new Promise(resolve => {
+                const iframe = document.createElement("iframe");
+                iframe.referrerPolicy = policy;
+                window.onmessage = e => {
+                    if (e.source === iframe.contentWindow) {
+                        iframe.remove();
+                        resolve(e.data);
+                    }
+                };
+                document.body.appendChild(iframe);
+                iframe.src = url;
+            });
+
+            println(`${policy}: ${validate(referrer) ? "PASS" : "FAIL"}`);
+        }
+
+        await testReferrerPolicy("no-referrer", r => r === "");
+        await testReferrerPolicy("origin", r => r.endsWith("/"));
+        await testReferrerPolicy("unsafe-url", r => r.includes(".html"));
+    });
+</script>


### PR DESCRIPTION
This gains us 33 WPT subtest passes in the `referrer-policy` directory.