### PR TITLE
LibWeb: Treat content-visibility `auto` as non-hidden in interpolation

### DIFF
--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -747,7 +747,7 @@ ValueComparingRefPtr<StyleValue const> interpolate_property(DOM::Element& elemen
                 return from;
 
             auto from_is_hidden = from->to_keyword() == Keyword::Hidden;
-            auto to_is_hidden = to->to_keyword() == Keyword::Hidden || to->to_keyword() == Keyword::Auto;
+            auto to_is_hidden = to->to_keyword() == Keyword::Hidden;
 
             if (from_is_hidden || to_is_hidden) {
                 auto non_hidden_value = from_is_hidden ? to : from;

--- a/Tests/LibWeb/Text/expected/css/content-visibility-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/css/content-visibility-interpolation.txt
@@ -1,0 +1,4 @@
+progress 0: visible
+progress 0.4: visible
+progress 0.6: auto
+progress 1: auto

--- a/Tests/LibWeb/Text/input/css/content-visibility-interpolation.html
+++ b/Tests/LibWeb/Text/input/css/content-visibility-interpolation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<div id="target"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const div = document.getElementById("target");
+        const animation = div.animate(
+            { contentVisibility: ["visible", "auto"] },
+            { duration: 1000, fill: "both" }
+        );
+
+        animation.currentTime = 0;
+        println(`progress 0: ${getComputedStyle(div).contentVisibility}`);
+
+        animation.currentTime = 400;
+        println(`progress 0.4: ${getComputedStyle(div).contentVisibility}`);
+
+        animation.currentTime = 600;
+        println(`progress 0.6: ${getComputedStyle(div).contentVisibility}`);
+
+        animation.currentTime = 1000;
+        println(`progress 1: ${getComputedStyle(div).contentVisibility}`);
+
+        animation.cancel();
+    });
+</script>


### PR DESCRIPTION
This matches the interpolation behavior of the `visibility` property and of other engines.