### PR TITLE
LibJS: Constant fold `LogicalExpression`

### DIFF
--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -1181,6 +1181,10 @@ public:
     {
     }
 
+    LogicalOp op() const { return m_op; }
+    NonnullRefPtr<Expression const> lhs() const { return m_lhs; }
+    NonnullRefPtr<Expression const> rhs() const { return m_rhs; }
+
     virtual void dump(int indent) const override;
     virtual Bytecode::CodeGenerationErrorOr<Optional<Bytecode::ScopedOperand>> generate_bytecode(Bytecode::Generator&, Optional<Bytecode::ScopedOperand> preferred_dst = {}) const override;
 

--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -1732,6 +1732,14 @@ CodeGenerationErrorOr<Optional<ScopedOperand>> Generator::maybe_generate_builtin
         return add_constant(js_undefined());
     }
 
+    if (constant_name == "NaN"sv) {
+        return add_constant(js_nan());
+    }
+
+    if (constant_name == "Infinity"sv) {
+        return add_constant(js_infinity());
+    }
+
     if (!m_builtin_abstract_operations_enabled)
         return OptionalNone {};
 

--- a/Libraries/LibJS/Bytecode/Generator.h
+++ b/Libraries/LibJS/Bytecode/Generator.h
@@ -363,6 +363,13 @@ public:
         return m_constants[operand.operand().index()];
     }
 
+    [[nodiscard]] Optional<Value> try_get_constant(ScopedOperand const& operand) const
+    {
+        if (operand.operand().is_constant())
+            return get_constant(operand);
+        return {};
+    }
+
     UnwindContext const* current_unwind_context() const { return m_current_unwind_context; }
 
     [[nodiscard]] bool is_finished() const { return m_finished; }

--- a/Libraries/LibJS/Tests/operators/logical-and.js
+++ b/Libraries/LibJS/Tests/operators/logical-and.js
@@ -1,11 +1,21 @@
+const and = (lhs, rhs) => lhs && rhs;
+
 test("booleans", () => {
+    // const folded
     expect(true && true).toBeTrue();
     expect(false && false).toBeFalse();
     expect(true && false).toBeFalse();
     expect(false && true).toBeFalse();
+
+    // evaluated
+    expect(and(true, true)).toBeTrue();
+    expect(and(false, false)).toBeFalse();
+    expect(and(true, false)).toBeFalse();
+    expect(and(false, true)).toBeFalse();
 });
 
 test("strings", () => {
+    // const folded
     expect("" && "").toBe("");
     expect("" && false).toBe("");
     expect("" && true).toBe("");
@@ -16,29 +26,72 @@ test("strings", () => {
     expect("foo" && true).toBeTrue();
     expect(false && "bar").toBeFalse();
     expect(true && "bar").toBe("bar");
+
+    // evaluated
+    expect(and("", "")).toBe("");
+    expect(and("", false)).toBe("");
+    expect(and("", true)).toBe("");
+    expect(and(false, "")).toBeFalse();
+    expect(and(true, "")).toBe("");
+    expect(and("foo", "bar")).toBe("bar");
+    expect(and("foo", false)).toBeFalse();
+    expect(and("foo", true)).toBeTrue();
+    expect(and(false, "bar")).toBeFalse();
+    expect(and(true, "bar")).toBe("bar");
 });
 
 test("numbers", () => {
+    // const folded
     expect(false && 1 === 2).toBeFalse();
     expect(true && 1 === 2).toBeFalse();
     expect(0 && false).toBe(0);
     expect(0 && true).toBe(0);
+    expect(-0 && false).toBe(-0);
+    expect(-0 && true).toBe(-0);
     expect(42 && false).toBeFalse();
     expect(42 && true).toBeTrue();
     expect(false && 0).toBeFalse();
     expect(true && 0).toBe(0);
     expect(false && 42).toBeFalse();
     expect(true && 42).toBe(42);
+    expect(NaN && 42).toBe(NaN);
+    expect(Infinity && 42).toBe(42);
+    expect(-Infinity && 42).toBe(42);
+
+    // evaluated
+    expect(and(false, 1 === 2)).toBeFalse();
+    expect(and(true, 1 === 2)).toBeFalse();
+    expect(and(0, false)).toBe(0);
+    expect(and(0, true)).toBe(0);
+    expect(and(-0, false)).toBe(-0);
+    expect(and(-0, true)).toBe(-0);
+    expect(and(42, false)).toBeFalse();
+    expect(and(42, true)).toBeTrue();
+    expect(and(false, 0)).toBeFalse();
+    expect(and(true, 0)).toBe(0);
+    expect(and(false, 42)).toBeFalse();
+    expect(and(true, 42)).toBe(42);
+    expect(and(NaN, 42)).toBe(NaN);
+    expect(and(Infinity, 42)).toBe(42);
+    expect(and(-Infinity, 42)).toBe(42);
 });
 
 test("objects", () => {
+    // const folded
     expect([] && false).toBeFalse();
     expect([] && true).toBeTrue();
     expect(false && []).toBeFalse();
     expect(true && []).toHaveLength(0);
+
+    // evaluated
+    expect(and([], false)).toBeFalse();
+    expect(and([], true)).toBeTrue();
+    expect(and(false, [])).toBeFalse();
+    expect(and(true, [])).toHaveLength(0);
 });
 
 test("null & undefined", () => {
+    // const folded
     expect(null && false).toBeNull();
     expect(null && true).toBeNull();
     expect(false && null).toBeFalse();
@@ -47,4 +100,14 @@ test("null & undefined", () => {
     expect(undefined && true).toBeUndefined();
     expect(false && undefined).toBeFalse();
     expect(true && undefined).toBeUndefined();
+
+    // evaluated
+    expect(and(null, false)).toBeNull();
+    expect(and(null, true)).toBeNull();
+    expect(and(false, null)).toBeFalse();
+    expect(and(true, null)).toBeNull();
+    expect(and(undefined, false)).toBeUndefined();
+    expect(and(undefined, true)).toBeUndefined();
+    expect(and(false, undefined)).toBeFalse();
+    expect(and(true, undefined)).toBeUndefined();
 });

--- a/Libraries/LibJS/Tests/operators/logical-nullish-coalescing.js
+++ b/Libraries/LibJS/Tests/operators/logical-nullish-coalescing.js
@@ -1,11 +1,21 @@
+const coalesce = (lhs, rhs) => lhs ?? rhs;
+
 test("booleans", () => {
+    // const folded
     expect(true ?? true).toBeTrue();
     expect(false ?? false).toBeFalse();
     expect(true ?? false).toBeTrue();
     expect(false ?? true).toBeFalse();
+
+    // evaluated
+    expect(coalesce(true, true)).toBeTrue();
+    expect(coalesce(false, false)).toBeFalse();
+    expect(coalesce(true, false)).toBeTrue();
+    expect(coalesce(false, true)).toBeFalse();
 });
 
 test("strings", () => {
+    // const folded
     expect("" ?? "").toBe("");
     expect("" ?? false).toBe("");
     expect("" ?? true).toBe("");
@@ -16,9 +26,22 @@ test("strings", () => {
     expect("foo" ?? true).toBe("foo");
     expect(false ?? "bar").toBeFalse();
     expect(true ?? "bar").toBeTrue();
+
+    // evaluated
+    expect(coalesce("", "")).toBe("");
+    expect(coalesce("", false)).toBe("");
+    expect(coalesce("", true)).toBe("");
+    expect(coalesce(false, "")).toBeFalse();
+    expect(coalesce(true, "")).toBeTrue();
+    expect(coalesce("foo", "bar")).toBe("foo");
+    expect(coalesce("foo", false)).toBe("foo");
+    expect(coalesce("foo", true)).toBe("foo");
+    expect(coalesce(false, "bar")).toBeFalse();
+    expect(coalesce(true, "bar")).toBeTrue();
 });
 
 test("numbers", () => {
+    // const folded
     expect(false ?? 1 === 2).toBeFalse();
     expect(true ?? 1 === 2).toBeTrue();
     expect(0 ?? false).toBe(0);
@@ -29,16 +52,36 @@ test("numbers", () => {
     expect(true ?? 0).toBeTrue();
     expect(false ?? 42).toBeFalse();
     expect(true ?? 42).toBeTrue();
+
+    // evaluated
+    expect(coalesce(false, 1 === 2)).toBeFalse();
+    expect(coalesce(true, 1 === 2)).toBeTrue();
+    expect(coalesce(0, false)).toBe(0);
+    expect(coalesce(0, true)).toBe(0);
+    expect(coalesce(42, false)).toBe(42);
+    expect(coalesce(42, true)).toBe(42);
+    expect(coalesce(false, 0)).toBeFalse();
+    expect(coalesce(true, 0)).toBeTrue();
+    expect(coalesce(false, 42)).toBeFalse();
+    expect(coalesce(true, 42)).toBeTrue();
 });
 
 test("objects", () => {
+    // const folded
     expect([] ?? false).toHaveLength(0);
     expect([] ?? true).toHaveLength(0);
     expect(false ?? []).toBeFalse();
     expect(true ?? []).toBeTrue();
+
+    // evaluated
+    expect(coalesce([], false)).toHaveLength(0);
+    expect(coalesce([], true)).toHaveLength(0);
+    expect(coalesce(false, [])).toBeFalse();
+    expect(coalesce(true, [])).toBeTrue();
 });
 
 test("null & undefined", () => {
+    // const folded
     expect(null ?? false).toBeFalse();
     expect(null ?? true).toBeTrue();
     expect(false ?? null).toBeFalse();
@@ -47,4 +90,14 @@ test("null & undefined", () => {
     expect(undefined ?? true).toBeTrue();
     expect(false ?? undefined).toBeFalse();
     expect(true ?? undefined).toBeTrue();
+
+    // evaluated
+    expect(coalesce(null, false)).toBeFalse();
+    expect(coalesce(null, true)).toBeTrue();
+    expect(coalesce(false, null)).toBeFalse();
+    expect(coalesce(true, null)).toBeTrue();
+    expect(coalesce(undefined, false)).toBeFalse();
+    expect(coalesce(undefined, true)).toBeTrue();
+    expect(coalesce(false, undefined)).toBeFalse();
+    expect(coalesce(true, undefined)).toBeTrue();
 });

--- a/Libraries/LibJS/Tests/operators/logical-or.js
+++ b/Libraries/LibJS/Tests/operators/logical-or.js
@@ -1,11 +1,21 @@
+const or = (lhs, rhs) => lhs || rhs;
+
 test("booleans", () => {
+    // const folded
     expect(true || true).toBeTrue();
     expect(false || false).toBeFalse();
     expect(true || false).toBeTrue();
     expect(false || true).toBeTrue();
+
+    // evaluated
+    expect(or(true, true)).toBeTrue();
+    expect(or(false, false)).toBeFalse();
+    expect(or(true, false)).toBeTrue();
+    expect(or(false, true)).toBeTrue();
 });
 
 test("strings", () => {
+    // const folded
     expect("" || "").toBe("");
     expect("" || false).toBeFalse();
     expect("" || true).toBeTrue();
@@ -16,29 +26,72 @@ test("strings", () => {
     expect("foo" || true).toBe("foo");
     expect(false || "bar").toBe("bar");
     expect(true || "bar").toBeTrue();
+
+    // evaluated
+    expect(or("", "")).toBe("");
+    expect(or("", false)).toBeFalse();
+    expect(or("", true)).toBeTrue();
+    expect(or(false, "")).toBe("");
+    expect(or(true, "")).toBeTrue();
+    expect(or("foo", "bar")).toBe("foo");
+    expect(or("foo", false)).toBe("foo");
+    expect(or("foo", true)).toBe("foo");
+    expect(or(false, "bar")).toBe("bar");
+    expect(or(true, "bar")).toBeTrue();
 });
 
 test("numbers", () => {
+    // const folded
     expect(false || 1 === 2).toBeFalse();
     expect(true || 1 === 2).toBeTrue();
     expect(0 || false).toBeFalse();
     expect(0 || true).toBeTrue();
+    expect(-0 || false).toBeFalse();
+    expect(-0 || true).toBeTrue();
     expect(42 || false).toBe(42);
     expect(42 || true).toBe(42);
     expect(false || 0).toBe(0);
     expect(true || 0).toBeTrue();
     expect(false || 42).toBe(42);
     expect(true || 42).toBeTrue();
+    expect(NaN || 42).toBe(42);
+    expect(Infinity || 42).toBe(Infinity);
+    expect(-Infinity || 42).toBe(-Infinity);
+
+    // evaluated
+    expect(or(false, 1 === 2)).toBeFalse();
+    expect(or(true, 1 === 2)).toBeTrue();
+    expect(or(0, false)).toBeFalse();
+    expect(or(0, true)).toBeTrue();
+    expect(or(-0, false)).toBeFalse();
+    expect(or(-0, true)).toBeTrue();
+    expect(or(42, false)).toBe(42);
+    expect(or(42, true)).toBe(42);
+    expect(or(false, 0)).toBe(0);
+    expect(or(true, 0)).toBeTrue();
+    expect(or(false, 42)).toBe(42);
+    expect(or(true, 42)).toBeTrue();
+    expect(or(NaN, 42)).toBe(42);
+    expect(or(Infinity, 42)).toBe(Infinity);
+    expect(or(-Infinity, 42)).toBe(-Infinity);
 });
 
 test("objects", () => {
+    // const folded
     expect([] || false).toHaveLength(0);
     expect([] || true).toHaveLength(0);
     expect(false || []).toHaveLength(0);
     expect(true || []).toBeTrue();
+
+    // evaluated
+    expect(or([], false)).toHaveLength(0);
+    expect(or([], true)).toHaveLength(0);
+    expect(or(false, [])).toHaveLength(0);
+    expect(or(true, [])).toBeTrue();
 });
 
 test("null & undefined", () => {
+    // const folded
     expect(null || false).toBeFalse();
     expect(null || true).toBeTrue();
     expect(false || null).toBeNull();
@@ -47,4 +100,14 @@ test("null & undefined", () => {
     expect(undefined || true).toBeTrue();
     expect(false || undefined).toBeUndefined();
     expect(true || undefined).toBeTrue();
+
+    // evaluated
+    expect(or(null, false)).toBeFalse();
+    expect(or(null, true)).toBeTrue();
+    expect(or(false, null)).toBeNull();
+    expect(or(true, null)).toBeTrue();
+    expect(or(undefined, false)).toBeFalse();
+    expect(or(undefined, true)).toBeTrue();
+    expect(or(false, undefined)).toBeUndefined();
+    expect(or(true, undefined)).toBeTrue();
 });


### PR DESCRIPTION
Logical expressions like `true || false` are now constant folded. This also allows for dead code elimination if we know the right-hand side of the expression will never be evaluated (such as `false && f()` or `true || f()`).

In the test suites, the values are now being constant folded at compile time. To ensure that the actual evaluation logic is being called properly, I had to duplicate the tests and call them via a function so the compiler would not optimize the evaluation logic away.

This also demotes `NaN` and `Infinity` identifiers to `nan` and `inf` double literals, which will further help with const folding.

#### Example

Given the following JS code:

```js
function dead() {
    return "dead";
}

const a = true || dead();
const b = false && dead();

console.log(a);
console.log(b);
```

The following bytecode is emitted (compared to `master`):

```diff
-[   0]    0: Mov dst:reg5, src:Bool(true)
-[  10]       Jump target:@48
-[  18]    1: GetGlobal dst:reg6, dead, cache_index:0
-[  28]       Call dst:reg5, callee:reg6, this_value:Undefined, dead
-[  48]    2: InitializeLexicalBinding a, src:reg5
-[  60]       Mov dst:reg5, src:Bool(false)
-[  70]       Jump target:@a8
-[  78]    3: GetGlobal dst:reg6, dead, cache_index:1
-[  88]       Call dst:reg5, callee:reg6, this_value:Undefined, dead
-[  a8]    4: InitializeLexicalBinding b, src:reg5
-[  c0]       GetGlobal dst:reg6, console, cache_index:2
-[  d0]       GetById dst:reg7, base:reg6, console, cache_index:0
-[  e8]       GetGlobal dst:reg8, a, cache_index:3
-[  f8]       Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-[ 120]       GetGlobal dst:reg6, console, cache_index:4
-[ 130]       GetById dst:reg8, base:reg6, console, cache_index:1
-[ 148]       GetGlobal dst:reg9, b, cache_index:5
-[ 158]       Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
-[ 180]       End value:reg7
+[   0]    0: InitializeLexicalBinding a, src:Bool(true)
+[  18]       InitializeLexicalBinding b, src:Bool(false)

 ... ignore console log ops
```