### PR TITLE
LibWeb/CSS: Update links to css-scoping and css-shadow-parts specs

### DIFF
--- a/Libraries/LibWeb/CSS/PseudoElements.json
+++ b/Libraries/LibWeb/CSS/PseudoElements.json
@@ -77,7 +77,7 @@
     "spec": "https://drafts.csswg.org/css-pseudo-4/#selectordef-marker"
   },
   "part": {
-    "spec": "https://drafts.csswg.org/css-shadow-parts/#selectordef-part",
+    "spec": "https://drafts.csswg.org/css-shadow-1/#selectordef-part",
     "type": "function",
     "function-syntax": "<ident>+"
   },
@@ -116,7 +116,7 @@
     "spec": "https://drafts.csswg.org/css-forms-1/#selectordef-slider-track"
   },
   "slotted": {
-    "spec": "https://drafts.csswg.org/css-scoping/#slotted-pseudo",
+    "spec": "https://drafts.csswg.org/css-shadow-1/#slotted-pseudo",
     "type": "function",
     "function-syntax": "<compound-selector>"
   },

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -505,7 +505,7 @@ static bool matches_open_state_pseudo_class(DOM::Element const& element, bool op
     return false;
 }
 
-// https://drafts.csswg.org/css-scoping/#host-selector
+// https://drafts.csswg.org/css-shadow-1/#host-selector
 static inline bool matches_host_pseudo_class(GC::Ref<DOM::Element const> element, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, CSS::SelectorList const& argument_selector_list)
 {
     // When evaluated in the context of a shadow tree, it matches the shadow tree’s shadow host if the shadow host,

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1024,7 +1024,7 @@ GC::Ref<DOMTokenList> Element::class_list()
     return *m_class_list;
 }
 
-// https://drafts.csswg.org/css-shadow-parts/#dom-element-part
+// https://drafts.csswg.org/css-shadow-1/#dom-element-part
 GC::Ref<DOMTokenList> Element::part_list()
 {
     // The part attribute’s getter must return a DOMTokenList object whose associated element is the context object and

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -129,7 +129,7 @@ interface Element : Node {
     undefined releasePointerCapture(long pointerId);
     boolean hasPointerCapture(long pointerId);
     
-    // https://drafts.csswg.org/css-shadow-parts/#idl
+    // https://drafts.csswg.org/css-shadow-1/#idl
     [SameObject, PutForwards=value, ImplementedAs=part_list] readonly attribute DOMTokenList part;
     
     // https://w3c.github.io/pointerlock/#requestPointerLock

--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -230,7 +230,7 @@ ElementByIdMap& ShadowRoot::element_by_id() const
     return *m_element_by_id;
 }
 
-// https://drafts.csswg.org/css-shadow-parts/#shadow-root-part-element-map
+// https://drafts.csswg.org/css-shadow-1/#shadow-root-part-element-map
 ShadowRoot::PartElementMap const& ShadowRoot::part_element_map() const
 {
     // FIXME: dom_tree_version() is crude and invalidates more than necessary.
@@ -242,7 +242,7 @@ ShadowRoot::PartElementMap const& ShadowRoot::part_element_map() const
     return m_part_element_map;
 }
 
-// https://drafts.csswg.org/css-shadow-parts/#calculate-the-part-element-map
+// https://drafts.csswg.org/css-shadow-1/#calculate-the-part-element-map
 void ShadowRoot::calculate_part_element_map()
 {
     // To calculate the part element map of a shadow root, outerRoot:


### PR DESCRIPTION
These have been merged together into a new "CSS Shadow Module" spec. No behaviour changes.

Corresponds to: https://github.com/w3c/csswg-drafts/commit/80d140567a8e91ddc9cc5eb817cae11cd3a11b1a