### PR TITLE
LibWeb/CSS: Serialize shorthands with `var()` to original value

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -403,7 +403,7 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
         // https://drafts.csswg.org/css-values-5/#pending-substitution-value
         // Ensure we keep the longhand around until it can be resolved.
         set_longhand_property(property_id, value);
-        auto pending_substitution_value = PendingSubstitutionStyleValue::create();
+        auto pending_substitution_value = PendingSubstitutionStyleValue::create(value);
         for (auto longhand_id : longhands_for_shorthand(property_id)) {
             for_each_property_expanding_shorthands(longhand_id, pending_substitution_value, set_longhand_property);
         }

--- a/Libraries/LibWeb/CSS/StyleValues/PendingSubstitutionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/PendingSubstitutionStyleValue.h
@@ -13,10 +13,9 @@ namespace Web::CSS {
 // https://drafts.csswg.org/css-values-5/#pending-substitution-value
 class PendingSubstitutionStyleValue final : public StyleValueWithDefaultOperators<PendingSubstitutionStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<PendingSubstitutionStyleValue> create()
+    static ValueComparingNonnullRefPtr<PendingSubstitutionStyleValue> create(StyleValue const& original_shorthand_value)
     {
-        static ValueComparingNonnullRefPtr<PendingSubstitutionStyleValue> instance = adopt_ref(*new (nothrow) PendingSubstitutionStyleValue());
-        return instance;
+        return adopt_ref(*new (nothrow) PendingSubstitutionStyleValue(original_shorthand_value));
     }
     virtual ~PendingSubstitutionStyleValue() override = default;
     virtual void serialize(StringBuilder&, SerializationMode) const override { }
@@ -26,15 +25,20 @@ public:
         return { Parser::ComponentValue { Parser::GuaranteedInvalidValue {} } };
     }
 
+    StyleValue const& original_shorthand_value() const { return *m_original_shorthand_value; }
+
     // We shouldn't need to compare these, but in case we do: The nature of them is that their value is unknown, so
     // consider them all to be unique.
     bool properties_equal(PendingSubstitutionStyleValue const&) const { return false; }
 
 private:
-    PendingSubstitutionStyleValue()
+    explicit PendingSubstitutionStyleValue(StyleValue const& original_shorthand_value)
         : StyleValueWithDefaultOperators(Type::PendingSubstitution)
+        , m_original_shorthand_value(original_shorthand_value)
     {
     }
+
+    NonnullRefPtr<StyleValue const> m_original_shorthand_value;
 };
 
 }

--- a/Tests/LibWeb/Text/expected/css/getPropertyValue-shorthand-with-var.txt
+++ b/Tests/LibWeb/Text/expected/css/getPropertyValue-shorthand-with-var.txt
@@ -1,0 +1,2 @@
+var(--foo)
+var(--bar)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-align/gaps/legacy-gap-aliases-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-align/gaps/legacy-gap-aliases-001.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	grid-row-gap is a legacy name alias for row-gap
 Pass	grid-column-gap is a legacy name alias for column-gap
-Fail	grid-gap is a legacy name alias for gap
+Pass	grid-gap is a legacy name alias for gap

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/parsing/webkit-aliases.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/parsing/webkit-aliases.txt
@@ -2,15 +2,14 @@ Harness status: OK
 
 Found 12 tests
 
-10 Pass
-2 Fail
+12 Pass
 Pass	-webkit-align-content is a legacy name alias for align-content
 Pass	-webkit-align-items is a legacy name alias for align-items
 Pass	-webkit-align-self is a legacy name alias for align-self
-Fail	-webkit-flex is a legacy name alias for flex
+Pass	-webkit-flex is a legacy name alias for flex
 Pass	-webkit-flex-basis is a legacy name alias for flex-basis
 Pass	-webkit-flex-direction is a legacy name alias for flex-direction
-Fail	-webkit-flex-flow is a legacy name alias for flex-flow
+Pass	-webkit-flex-flow is a legacy name alias for flex-flow
 Pass	-webkit-flex-grow is a legacy name alias for flex-grow
 Pass	-webkit-flex-shrink is a legacy name alias for flex-shrink
 Pass	-webkit-flex-wrap is a legacy name alias for flex-wrap

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/stylevalue-normalization/normalize-tokens.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-typed-om/stylevalue-normalization/normalize-tokens.tentative.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 16 tests
 
-3 Pass
-13 Fail
+4 Pass
+12 Fail
 Fail	Normalizing "var(--A)" on a CSS property returns correct CSSUnparsedValue
 Fail	Normalizing "var(--A)" on a shorthand returns correct CSSUnparsedValue
 Fail	Normalizing "var(--A)" on a list-valued property returns correct CSSUnparsedValue
@@ -17,6 +17,6 @@ Fail	Normalizing "var(--A, var(--B))" on a shorthand returns correct CSSUnparsed
 Fail	Normalizing "var(--A, var(--B))" on a list-valued property returns correct CSSUnparsedValue
 Fail	Normalizing "var(--A, var(--B))" on a custom property returns correct CSSUnparsedValue
 Pass	Normalizing "calc(42px + var(--foo, 15em) + var(--bar, var(--far) + 15px))" on a CSS property returns correct CSSUnparsedValue
-Fail	Normalizing "calc(42px + var(--foo, 15em) + var(--bar, var(--far) + 15px))" on a shorthand returns correct CSSUnparsedValue
+Pass	Normalizing "calc(42px + var(--foo, 15em) + var(--bar, var(--far) + 15px))" on a shorthand returns correct CSSUnparsedValue
 Pass	Normalizing "calc(42px + var(--foo, 15em) + var(--bar, var(--far) + 15px))" on a list-valued property returns correct CSSUnparsedValue
 Pass	Normalizing "calc(42px + var(--foo, 15em) + var(--bar, var(--far) + 15px))" on a custom property returns correct CSSUnparsedValue

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-reference-shorthands-cssom.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-reference-shorthands-cssom.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	CSS variable references - shorthand properties - via CSSOM

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-reference-shorthands.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-reference-shorthands.txt
@@ -1,0 +1,21 @@
+Harness status: OK
+
+Found 16 tests
+
+16 Pass
+Pass	target1 margin
+Pass	target1 margin-left
+Pass	target1 margin-top
+Pass	target1 margin-right
+Pass	target1 margin-bottom
+Pass	target2 margin
+Pass	target2 margin-left
+Pass	target2 margin-top
+Pass	target2 margin-right
+Pass	target2 margin-bottom
+Pass	target3 margin
+Pass	target3 margin-left
+Pass	target3 margin-top
+Pass	target3 margin-right
+Pass	target3 margin-bottom
+Pass	target4 background

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/shorthand-serialization.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/shorthand-serialization.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 7 tests
 
-6 Pass
-1 Fail
+7 Pass
 Pass	Shorthand serialization with shorthand and longhands mixed.
 Pass	Shorthand serialization with just longhands.
-Fail	Shorthand serialization with variable and variable from other shorthand.
+Pass	Shorthand serialization with variable and variable from other shorthand.
 Pass	Shorthand serialization after setting
 Pass	Shorthand serialization with 'initial' value.
 Pass	Shorthand serialization with 'initial' value, one longhand with important flag.

--- a/Tests/LibWeb/Text/input/css/getPropertyValue-shorthand-with-var.html
+++ b/Tests/LibWeb/Text/input/css/getPropertyValue-shorthand-with-var.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+div {
+    transition: var(--foo);
+    animation: var(--bar);
+}
+</style>
+<script>
+    test(() => {
+        const declaration = document.styleSheets[0].cssRules[0].style;
+        println(declaration.getPropertyValue("transition"));
+        println(declaration.getPropertyValue("animation"));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-reference-shorthands-cssom.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-reference-shorthands-cssom.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS variable references - shorthand properties - via CSSOM</title>
+
+    <meta rel="author" title="Kevin Babbitt">
+    <meta rel="author" title="Greg Whitworth">
+    <link rel="author" title="Microsoft Corporation" href="http://microsoft.com" />
+    <link rel="help" href="http://www.w3.org/TR/css-variables-1/#serializing-custom-props">
+
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<div id="target"></div>
+
+<script type="text/javascript">
+    "use strict";
+
+    function runTest() {
+        var target = document.getElementById("target");
+
+        target.style.setProperty("margin", "var(--prop)");
+        assert_equals(target.style.margin, "var(--prop)", "margin property value after calling setProperty");
+        assert_equals(target.style.getPropertyValue("margin"), "var(--prop)", "getPropertyValue('margin') after calling setProperty");
+
+        target.style.removeProperty("margin");
+        assert_equals(target.style.margin, "", "margin property value after calling removeProperty");
+        assert_equals(target.style.getPropertyValue("margin"), "", "getPropertyValue('margin') after calling removeProperty");
+    }
+
+    test(runTest);
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-reference-shorthands.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-reference-shorthands.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Parse, store, and serialize CSS variable references - shorthand properties</title>
+
+    <meta rel="author" title="Kevin Babbitt">
+    <meta rel="author" title="Greg Whitworth">
+    <link rel="author" title="Microsoft Corporation" href="http://microsoft.com" />
+    <link rel="help" href="http://www.w3.org/TR/css-variables-1/#serializing-custom-props">
+
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+
+<div id="target1" style="margin: var(--prop); margin-top: 10px"></div>
+<div id="target2" style="margin: var(--prop) !important; margin-top: 10px"></div>
+<div id="target3" style="margin: var(--prop); margin-top: 10px !important"></div>
+<div id="target4" style="background: var(--prop);"></div>
+
+<script type="text/javascript">
+    "use strict";
+
+    var testcases = [
+        { element: "target1",   propertyName: "margin",         expectedPropertyValue: "" },
+        { element: "target1",   propertyName: "margin-left",    expectedPropertyValue: "" },
+        { element: "target1",   propertyName: "margin-top",     expectedPropertyValue: "10px" },
+        { element: "target1",   propertyName: "margin-right",   expectedPropertyValue: "" },
+        { element: "target1",   propertyName: "margin-bottom",  expectedPropertyValue: "" },
+
+        { element: "target2",   propertyName: "margin",         expectedPropertyValue: "var(--prop)" },
+        { element: "target2",   propertyName: "margin-left",    expectedPropertyValue: "" },
+        { element: "target2",   propertyName: "margin-top",     expectedPropertyValue: "" },
+        { element: "target2",   propertyName: "margin-right",   expectedPropertyValue: "" },
+        { element: "target2",   propertyName: "margin-bottom",  expectedPropertyValue: "" },
+
+        { element: "target3",   propertyName: "margin",         expectedPropertyValue: "" },
+        { element: "target3",   propertyName: "margin-left",    expectedPropertyValue: "" },
+        { element: "target3",   propertyName: "margin-top",     expectedPropertyValue: "10px" },
+        { element: "target3",   propertyName: "margin-right",   expectedPropertyValue: "" },
+        { element: "target3",   propertyName: "margin-bottom",  expectedPropertyValue: "" },
+
+        { element: "target4",   propertyName: "background",     expectedPropertyValue: "var(--prop)" }
+    ];
+
+    testcases.forEach(function (testcase) {
+        test( function () {
+            var div = document.getElementById(testcase.element);
+            var actualPropertyValue = div.style.getPropertyValue(testcase.propertyName).trim();
+            assert_equals(actualPropertyValue, testcase.expectedPropertyValue);
+        }, testcase.element + " " + testcase.propertyName);
+    });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR fixes serialization of shorthand properties when `var()` is used.

To achieve this I've made `PendingSubstitutionStyleValue` store its original value.

Prevents a crash when clicking on the short videos on https://bbc.co.uk/news (the videos don't play yet, but let's take one step at a time)

Fixes #7194