### PR TITLE
Tests: Explicitly wait for link activation in SVG link activation test

### DIFF
--- a/Tests/LibWeb/Text/input/svg-a-element-activation-behavior.html
+++ b/Tests/LibWeb/Text/input/svg-a-element-activation-behavior.html
@@ -2,19 +2,25 @@
 <script src="include.js"></script>
 <iframe id="target-frame" name="target-frame"></iframe>
 <svg>
-    <a id="basic-link" href="javascript:println('basic link activated')">
+    <a id="basic-link" href="javascript:println('basic link activated'), window.resolveLinkActivated()">
         <text y="20">Basic Link</text>
     </a>
-    <a id="target-link" href="javascript:parent.println('target link activated in iframe')" target="target-frame">
+    <a id="target-link" href="javascript:parent.println('target link activated in iframe'), parent.resolveLinkActivated()" target="target-frame">
         <text y="40">Target Link</text>
     </a>
 </svg>
 <script>
-promiseTest(async () => {
-    document.getElementById("basic-link").dispatchEvent(new MouseEvent("click"));
-    await animationFrame();
+function waitForLinkActivation() {
+    return new Promise(resolve => window.resolveLinkActivated = resolve);
+}
 
+promiseTest(async () => {
+    let activated = waitForLinkActivation();
+    document.getElementById("basic-link").dispatchEvent(new MouseEvent("click"));
+    await activated;
+
+    activated = waitForLinkActivation();
     document.getElementById("target-link").dispatchEvent(new MouseEvent("click"));
-    await animationFrame();
+    await activated;
 });
 </script>


### PR DESCRIPTION
Previously, we assumed a single call to `requestAnimationFrame()` would give enough time for the link to activate.

I've seen this test flake on CI. This should reduce the chance of future flakes.