### PR TITLE
Tests: Improve robustness of `local-storage-usage-after-nav.html` test

### DIFF
--- a/Tests/LibWeb/Text/data/local-storage-iframe.html
+++ b/Tests/LibWeb/Text/data/local-storage-iframe.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <script>
-    localStorage.setItem("foo", "barbaz");
+    const key = new URLSearchParams(location.search).get("key");
+    localStorage.setItem(key, "barbaz");
     parent.postMessage("local storage set", "*");
 </script>

--- a/Tests/LibWeb/Text/input/HTML/local-storage-usage-after-nav.html
+++ b/Tests/LibWeb/Text/input/HTML/local-storage-usage-after-nav.html
@@ -2,11 +2,14 @@
 <script src="../include.js"></script>
 <script>
     asyncTest(done => {
+        const key = `foo_${crypto.randomUUID()}`;
+
         window.onmessage = () => {
            try {
-                println(localStorage.getItem("foo"));
-                localStorage.setItem("foo", "bar");
-                println(localStorage.getItem("foo"));
+                println(localStorage.getItem(key));
+                localStorage.setItem(key, "bar");
+                println(localStorage.getItem(key));
+                localStorage.removeItem(key);
             } catch (e) {
                 println(e);
             }
@@ -15,7 +18,7 @@
         };
 
         const frame = document.createElement("iframe");
-        frame.src = "../../data/local-storage-iframe.html";
+        frame.src = `../../data/local-storage-iframe.html?key=${key}`;
         document.body.appendChild(frame);
     });
 </script>


### PR DESCRIPTION
A unique key is now used to ensure that the key can't interfere with any other test. The iframe is now set up programmatically rather than in HTML to ensure that `postMessage()` cannot fire before the `onmessage` handler is set up.