### PR TITLE
LibCore: Fix memory leak in anon_create() on BSD/macOS

### DIFF
--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -184,13 +184,6 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
         TRY(close(fd));
         return Error::from_errno(saved_errno);
     }
-
-    void* addr = ::mmap(NULL, size, PROT_WRITE, MAP_SHARED, fd, 0);
-    if (addr == MAP_FAILED) {
-        auto saved_errno = errno;
-        TRY(close(fd));
-        return Error::from_errno(saved_errno);
-    }
 #endif
     if (fd < 0)
         return Error::from_errno(errno);


### PR DESCRIPTION
The mmap() call here served no purpose - anon_create() is only meant to create and return a file descriptor. The actual mapping is done later by AnonymousBufferImpl::create().

This leaked an mmap of `size` bytes for every AnonymousBuffer created, which includes backing stores, shareable bitmaps, and more.