### PR TITLE
CMake+CI: Use the same preset names on every platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
           - os_name: 'Windows'
             arch: 'x86_64'
-            build_preset: 'Windows_Experimental_Sanitizer'
+            build_preset: 'Sanitizer'
             toolchain: 'ClangCL'
             clang_plugins: false
             runner_labels: '["blacksmith-16vcpu-windows-2025"]'

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -193,7 +193,7 @@ jobs:
       # === TEST ===
 
       - name: Test
-        if: ${{ contains(inputs.build_preset, 'Sanitizer') }}
+        if: ${{ inputs.build_preset == 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: ctest --preset ${{ inputs.build_preset }} --output-on-failure --test-dir Build --timeout 1800
         env:
@@ -203,7 +203,7 @@ jobs:
           UBSAN_OPTIONS: 'log_path="${{ github.workspace }}/ubsan.log"'
 
       - name: Test
-        if: ${{ inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'All_Debug' && !contains(inputs.build_preset, 'Sanitizer') }}
+        if: ${{ inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'All_Debug' && inputs.build_preset != 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: ctest --output-on-failure --test-dir Build --timeout 1800
         env:
@@ -219,7 +219,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Sanitizer Output
-        if: ${{ !cancelled() && inputs.build_preset == 'Sanitizer' }}
+        if: ${{ !cancelled() && inputs.os_name != 'Windows' && inputs.build_preset == 'Sanitizer' }}
         working-directory: ${{ github.workspace }}
         run: |
           log_output=$(find . -maxdepth 1 \( -name 'asan.log.*' -o -name 'ubsan.log.*' \) -exec cat {} \; )

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -63,7 +63,7 @@ jobs:
 
           - os_name: 'Windows'
             arch: 'x86_64'
-            build_preset: 'Windows_Experimental_Sanitizer'
+            build_preset: 'Sanitizer'
             toolchain: 'ClangCL'
             clang_plugins: false
             runner_labels: '["blacksmith-8vcpu-windows-2025"]'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,365 +1,63 @@
 {
-  "version": 6,
+  "version": 9,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 25,
+    "minor": 30,
     "patch": 0
   },
-  "configurePresets": [
-    {
-      "hidden": true,
-      "name": "base",
-      "displayName": "Default Config",
-      "generator": "Ninja",
-      "binaryDir": "${fileDir}/Build/release",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "LADYBIRD_CACHE_DIR": "${fileDir}/Build/caches",
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "VCPKG_INSTALL_OPTIONS": "--no-print-usage",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/release-triplets"
-      },
-      "environment": {
-        "LADYBIRD_SOURCE_DIR": "${fileDir}",
-        "VCPKG_ROOT": "${fileDir}/Build/vcpkg",
-        "VCPKG_BINARY_SOURCES": "clear;files,${fileDir}/Build/caches/vcpkg-binary-cache,readwrite;$penv{VCPKG_BINARY_SOURCES}",
-        "X_VCPKG_ASSET_SOURCES": "clear;x-azurl,https://vcpkg-cache.app.ladybird.org/ladybird/source-assets/,$penv{VCPKG_CACHE_SAS},read$penv{VCPKG_CACHE_MODE}"
-      },
-      "vendor": {
-        "jetbrains.com/clion": {
-          "toolchain": "Default"
-        }
-      }
-    },
-    {
-      "hidden": true,
-      "name": "unix_base",
-      "inherits": "base",
-      "condition": {
-        "type": "notEquals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "hidden": true,
-      "name": "windows_base",
-      "inherits": "base",
-      "description": "Visual Studio via Clang/LLVM Toolchain",
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-cl",
-        "CMAKE_CXX_COMPILER": "clang-cl"
-      },
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "intelliSenseMode": "windows-clang-x64"
-        }
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "name": "Release",
-      "inherits": "unix_base",
-      "displayName": "Release Config",
-      "description": "Release Unix build"
-    },
-    {
-      "name": "Debug",
-      "inherits": "unix_base",
-      "displayName": "Debug Config",
-      "description": "Debug Unix build",
-      "binaryDir": "${fileDir}/Build/debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/debug-triplets"
-      }
-    },
-    {
-      "name": "All_Debug",
-      "inherits": "unix_base",
-      "displayName": "All Debug Config",
-      "description": "All Debug Unix build",
-      "binaryDir": "${fileDir}/Build/alldebug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/debug-triplets",
-        "ENABLE_ALL_THE_DEBUG_MACROS": "ON"
-      }
-    },
-    {
-      "name": "Windows_Experimental_Release",
-      "inherits": "windows_base",
-      "displayName": "Windows Experimental Release Config",
-      "description": "Experimental Windows Release build. Not all targets in this preset are built and there is minimal runtime support"
-    },
-    {
-      "name": "Windows_Experimental_Debug",
-      "inherits": "windows_base",
-      "displayName": "Windows Experimental Debug Config",
-      "description": "Experimental Windows Debug build. Not all targets in this preset are built and there is minimal runtime support",
-      "binaryDir": "${fileDir}/Build/debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/debug-triplets"
-      }
-    },
-    {
-      "name": "Distribution",
-      "inherits": "unix_base",
-      "displayName": "Distribution Config",
-      "description": "Distribution build with static libraries",
-      "binaryDir": "${fileDir}/Build/distribution",
-      "cacheVariables": {
-        "BUILD_SHARED_LIBS": "OFF",
-        "CMAKE_BUILD_TYPE": "Release",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/distribution-triplets"
-      }
-    },
-    {
-      "name": "Sanitizer",
-      "inherits": [
-        "unix_base",
-        "Release"
-      ],
-      "displayName": "Sanitizer Config",
-      "description": "Sanitizer Unix build",
-      "binaryDir": "${fileDir}/Build/sanitizers",
-      "cacheVariables": {
-        "ENABLE_UNDEFINED_SANITIZER": "ON",
-        "ENABLE_ADDRESS_SANITIZER": "ON",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/sanitizer-triplets"
-      }
-    },
-    {
-      "name": "Windows_Experimental_Sanitizer",
-      "inherits": "windows_base",
-      "displayName": "Windows Experimental Sanitizer Config",
-      "description": "Experimental Windows Sanitizer build. Not all targets in this preset are built and there is minimal runtime support",
-      "binaryDir": "${fileDir}/Build/sanitizers",
-      "cacheVariables": {
-        "ENABLE_UNDEFINED_SANITIZER": "ON",
-        "ENABLE_ADDRESS_SANITIZER": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/sanitizer-triplets"
-      }
-    },
-    {
-      "name": "Fuzzers",
-      "inherits": "unix_base",
-      "displayName": "Fuzzers Config",
-      "description": "Fuzzers Unix build",
-      "binaryDir": "${fileDir}/Build/fuzzers",
-      "cacheVariables": {
-        "BUILD_SHARED_LIBS": "OFF",
-        "ENABLE_QT": "OFF",
-        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/distribution-triplets",
-        "ENABLE_FUZZERS_LIBFUZZER": "ON",
-        "ENABLE_ADDRESS_SANITIZER": "ON"
-      }
-    },
-    {
-      "name": "Swift_Release",
-      "inherits": "unix_base",
-      "displayName": "Swift Release Config",
-      "description": "Swift-enabled Unix release build",
-      "binaryDir": "${fileDir}/Build/swift",
-      "cacheVariables": {
-        "ENABLE_SWIFT": "ON",
-        "CMAKE_C_COMPILER": "MustBeSetManually",
-        "CMAKE_CXX_COMPILER": "MustBeSetManually++"
-      },
-      "vendor": {
-        "jetbrains.com/clion": {
-          "toolchain": "Swift"
-        }
-      }
-    }
+  "include": [
+    "Meta/CMake/presets/CMake${hostSystemName}Presets.json"
   ],
   "buildPresets": [
     {
-      "hidden": true,
-      "name": "base",
-      "targets": [
-        "all"
-      ]
-    },
-    {
-      "hidden": true,
-      "name": "unix_base",
-      "inherits": "base",
-      "configurePreset": "unix_base",
-      "condition": {
-        "type": "notEquals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "hidden": true,
-      "name": "windows_base",
-      "inherits": "base",
-      "configurePreset": "windows_base",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
       "name": "Release",
-      "inherits": "unix_base",
+      "inherits": "base",
       "configurePreset": "Release",
       "displayName": "Release Build",
-      "description": "Build the project in release on Unix"
+      "description": "Build the project in release"
     },
     {
       "name": "Debug",
-      "inherits": "unix_base",
+      "inherits": "base",
       "configurePreset": "Debug",
       "displayName": "Debug Build",
-      "description": "Build the project in debug on Unix"
-    },
-    {
-      "name": "Windows_Experimental_Release",
-      "inherits": "windows_base",
-      "configurePreset": "Windows_Experimental_Release",
-      "displayName": "Windows Experimental Release Build",
-      "description": "Build the project in release on Windows. Not all targets in this preset are built and there is minimal runtime support"
-    },
-    {
-      "name": "Windows_Experimental_Debug",
-      "inherits": "windows_base",
-      "configurePreset": "Windows_Experimental_Debug",
-      "displayName": "Windows Experimental Debug Build",
-      "description": "Build the project in debug on Windows. Not all targets in this preset are built and there is minimal runtime support"
-    },
-    {
-      "name": "Distribution",
-      "inherits": "unix_base",
-      "configurePreset": "Distribution",
-      "displayName": "Distribution Build",
-      "description": "Build the project for distribution on Unix"
+      "description": "Build the project in debug"
     },
     {
       "name": "Sanitizer",
-      "inherits": "unix_base",
+      "inherits": "base",
       "configurePreset": "Sanitizer",
       "displayName": "Sanitizer Build",
       "description": "Build the project with Sanitizers on Unix"
-    },
-    {
-      "name": "Windows_Experimental_Sanitizer",
-      "inherits": "windows_base",
-      "configurePreset": "Windows_Experimental_Sanitizer",
-      "displayName": "Windows Experimental Sanitizer Build",
-      "description": "Build the project with Sanitizers on Windows. Not all targets in this preset are built and there is minimal runtime support"
-    },
-    {
-      "name": "Swift_Release",
-      "inherits": "unix_base",
-      "configurePreset": "Swift_Release",
-      "displayName": "Swift Release Build",
-      "description": "Build the project for Swift release on Unix"
     }
   ],
   "testPresets": [
     {
       "hidden": true,
-      "name": "base",
-      "output": {
-        "outputOnFailure": true
-      },
-      "execution": {
-        "noTestsAction": "error",
-        "stopOnFailure": true
-      },
+      "name": "root_base",
+      "inherits": "base",
       "environment": {
         "LADYBIRD_SOURCE_DIR": "${fileDir}"
       }
     },
     {
-      "hidden": true,
-      "name": "windows_base",
-      "configurePreset": "windows_base",
-      "inherits": "base",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "hidden": true,
-      "name": "unix_base",
-      "configurePreset": "unix_base",
-      "inherits": "base",
-      "condition": {
-        "type": "notEquals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "hidden": true,
-      "name": "sanitizer_base",
-      "environment": {
-        "ASAN_OPTIONS": "strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1:$penv{ASAN_OPTIONS}",
-        "UBSAN_OPTIONS": "print_stacktrace=1:print_summary=1:halt_on_error=1:$penv{UBSAN_OPTIONS}"
-      }
-    },
-    {
       "name": "Release",
-      "inherits": "unix_base",
+      "inherits": "root_base",
       "configurePreset": "Release"
     },
     {
       "name": "Debug",
-      "inherits": "unix_base",
+      "inherits": "root_base",
       "configurePreset": "Debug"
     },
     {
-      "name": "Windows_Experimental_Release",
-      "inherits": "windows_base",
-      "configurePreset": "Windows_Experimental_Release"
-    },
-    {
-      "name": "Windows_Experimental_Debug",
-      "inherits": "windows_base",
-      "configurePreset": "Windows_Experimental_Debug"
-    },
-    {
-      "name": "Distribution",
-      "inherits": "unix_base",
-      "configurePreset": "Distribution"
-    },
-    {
       "name": "Sanitizer",
-      "inherits": [
-        "unix_base",
-        "sanitizer_base"
-      ],
-      "configurePreset": "Sanitizer"
-    },
-    {
-      "name": "Windows_Experimental_Sanitizer",
-      "inherits":  [
-        "windows_base",
-        "sanitizer_base"
-      ],
-      "configurePreset": "Windows_Experimental_Sanitizer"
-    },
-    {
-      "name": "Swift_Release",
-      "inherits": "unix_base",
-      "configurePreset": "Swift_Release"
+      "inherits": "root_base",
+      "configurePreset": "Sanitizer",
+      "environment": {
+        "ASAN_OPTIONS": "strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1:$penv{ASAN_OPTIONS}",
+        "UBSAN_OPTIONS": "print_stacktrace=1:print_summary=1:halt_on_error=1:$penv{UBSAN_OPTIONS}"
+      }
     }
   ]
 }

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -7,7 +7,7 @@ Qt6 development packages, nasm, additional build tools, and a C++23 capable comp
 We currently use gcc-14 and clang-20 in our CI pipeline. If these versions are not available on your system, see
 [`Meta/find_compiler.py`](../Meta/find_compiler.py) for the minimum compatible version.
 
-CMake 3.25 or newer must be available in $PATH.
+CMake 3.30 or newer must be available in $PATH.
 
 ---
 
@@ -18,9 +18,9 @@ CMake 3.25 or newer must be available in $PATH.
 sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git libdrm-dev libgl1-mesa-dev libtool nasm ninja-build pkg-config python3-venv qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
 ```
 
-#### CMake 3.25 or newer:
+#### CMake 3.30 or newer:
 
-- Recommendation: Install `CMake 3.25` or newer from [Kitware's apt repository](https://apt.kitware.com/):
+- Recommendation: Install `CMake 3.30` or newer from [Kitware's apt repository](https://apt.kitware.com/):
 
 > [!NOTE]
 > This repository is Ubuntu-only

--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -6,7 +6,7 @@ In case of an error, you might find an answer of how to deal with it here.
 
 ### CMake fails to configure the build because it's outdated
 
-Ensure your CMake version is >= 3.25 with `cmake --version`. If your system doesn't provide a suitable
+Ensure your CMake version is >= 3.30 with `cmake --version`. If your system doesn't provide a suitable
 version of CMake, you can download a binary release from the [CMake website](https://cmake.org/download).
 
 ### GCC is missing or is outdated

--- a/Meta/CMake/presets/CMakeBasePresets.json
+++ b/Meta/CMake/presets/CMakeBasePresets.json
@@ -1,0 +1,152 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "hidden": true,
+      "name": "base",
+      "displayName": "Default Config",
+      "generator": "Ninja",
+      "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/release",
+      "cacheVariables": {
+        "LADYBIRD_CACHE_DIR": "$env{LADYBIRD_SOURCE_DIR}/Build/caches",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_INSTALL_OPTIONS": "--no-print-usage"
+      },
+      "environment": {
+        "LADYBIRD_SOURCE_DIR": "${fileDir}/../../..",
+        "VCPKG_ROOT": "$env{LADYBIRD_SOURCE_DIR}/Build/vcpkg",
+        "VCPKG_BINARY_SOURCES": "clear;files,$env{LADYBIRD_SOURCE_DIR}/Build/caches/vcpkg-binary-cache,readwrite;$penv{VCPKG_BINARY_SOURCES}",
+        "X_VCPKG_ASSET_SOURCES": "clear;x-azurl,https://vcpkg-cache.app.ladybird.org/ladybird/source-assets/,$penv{VCPKG_CACHE_SAS},read$penv{VCPKG_CACHE_MODE}"
+      },
+      "vendor": {
+        "jetbrains.com/clion": {
+          "toolchain": "Default"
+        }
+      }
+    },
+    {
+      "hidden": true,
+      "name": "Release_base",
+      "inherits": "base",
+      "displayName": "Release Config",
+      "description": "Release build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/release-triplets"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "Debug_base",
+      "inherits": "base",
+      "displayName": "Debug Config",
+      "description": "Debug build",
+      "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/debug-triplets"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "Sanitizer_base",
+      "inherits": "base",
+      "displayName": "Sanitizer Config",
+      "description": "Sanitizer build",
+      "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/sanitizers",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "ENABLE_UNDEFINED_SANITIZER": "ON",
+        "ENABLE_ADDRESS_SANITIZER": "ON",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/sanitizer-triplets"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "All_Debug_base",
+      "inherits": "base",
+      "displayName": "All Debug Config",
+      "description": "All Debug build",
+      "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/alldebug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/debug-triplets",
+        "ENABLE_ALL_THE_DEBUG_MACROS": "ON"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "Distribution_base",
+      "inherits": "base",
+      "displayName": "Distribution Config",
+      "description": "Distribution build with static libraries",
+      "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/distribution",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/distribution-triplets"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "Fuzzers_base",
+      "inherits": "base",
+      "displayName": "Fuzzers Config",
+      "description": "Fuzzers build",
+      "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/fuzzers",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "ENABLE_QT": "OFF",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/distribution-triplets",
+        "ENABLE_FUZZERS_LIBFUZZER": "ON",
+        "ENABLE_ADDRESS_SANITIZER": "ON"
+      }
+    },
+    {
+      "hidden": true,
+      "name": "Swift_Release_base",
+      "inherits": "base",
+      "displayName": "Swift Release Config",
+      "description": "Swift-enabled release build",
+      "binaryDir": "$env{LADYBIRD_SOURCE_DIR}/Build/swift",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "VCPKG_OVERLAY_TRIPLETS": "$env{LADYBIRD_SOURCE_DIR}/Meta/CMake/vcpkg/release-triplets",
+        "ENABLE_SWIFT": "ON",
+        "CMAKE_C_COMPILER": "MustBeSetManually",
+        "CMAKE_CXX_COMPILER": "MustBeSetManually++"
+      },
+      "vendor": {
+        "jetbrains.com/clion": {
+          "toolchain": "Swift"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "hidden": true,
+      "name": "base",
+      "targets": [
+        "all"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "hidden": true,
+      "name": "base",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      },
+      "environment": {
+        "LADYBIRD_SOURCE_DIR": "${fileDir}/../../.."
+      }
+    }
+  ]
+}

--- a/Meta/CMake/presets/CMakeDarwinPresets.json
+++ b/Meta/CMake/presets/CMakeDarwinPresets.json
@@ -1,0 +1,6 @@
+{
+  "version": 6,
+  "include": [
+    "CMakeUnixPresets.json"
+  ]
+}

--- a/Meta/CMake/presets/CMakeFreeBSDPresets.json
+++ b/Meta/CMake/presets/CMakeFreeBSDPresets.json
@@ -1,0 +1,6 @@
+{
+  "version": 6,
+  "include": [
+    "CMakeUnixPresets.json"
+  ]
+}

--- a/Meta/CMake/presets/CMakeLinuxPresets.json
+++ b/Meta/CMake/presets/CMakeLinuxPresets.json
@@ -1,0 +1,6 @@
+{
+  "version": 6,
+  "include": [
+    "CMakeUnixPresets.json"
+  ]
+}

--- a/Meta/CMake/presets/CMakeOpenBSDPresets.json
+++ b/Meta/CMake/presets/CMakeOpenBSDPresets.json
@@ -1,0 +1,6 @@
+{
+  "version": 6,
+  "include": [
+    "CMakeUnixPresets.json"
+  ]
+}

--- a/Meta/CMake/presets/CMakeUnixPresets.json
+++ b/Meta/CMake/presets/CMakeUnixPresets.json
@@ -1,0 +1,95 @@
+{
+  "version": 6,
+  "include": [
+    "CMakeBasePresets.json"
+  ],
+  "configurePresets": [
+    {
+      "hidden": true,
+      "name": "unix_base",
+      "inherits": "base",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "Release",
+      "inherits": [
+        "unix_base",
+        "Release_base"
+      ]
+    },
+    {
+      "name": "Debug",
+      "inherits": [
+        "unix_base",
+        "Debug_base"
+      ]
+    },
+    {
+      "name": "Sanitizer",
+      "inherits": [
+        "unix_base",
+        "Sanitizer_base"
+      ]
+    },
+    {
+      "name": "Distribution",
+      "inherits": [
+        "unix_base",
+        "Distribution_base"
+      ]
+    },
+    {
+      "name": "Fuzzers",
+      "inherits": [
+        "unix_base",
+        "Fuzzers_base"
+      ]
+    },
+    {
+      "name": "All_Debug",
+      "inherits": [
+        "unix_base",
+        "All_Debug_base"
+      ]
+    },
+    {
+      "name": "Swift_Release",
+      "inherits": [
+        "unix_base",
+        "Swift_Release_base"
+      ]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "Distribution",
+      "inherits": "base",
+      "configurePreset": "Distribution",
+      "displayName": "Distribution Build",
+      "description": "Build the project for distribution"
+    },
+    {
+      "name": "Swift_Release",
+      "inherits": "base",
+      "configurePreset": "Swift_Release",
+      "displayName": "Swift Release Build",
+      "description": "Build the project for Swift release on Unix"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "Distribution",
+      "inherits": "base",
+      "configurePreset": "Distribution"
+    },
+    {
+      "name": "Swift_Release",
+      "inherits": "base",
+      "configurePreset": "Swift_Release"
+    }
+  ]
+}

--- a/Meta/CMake/presets/CMakeWindowsPresets.json
+++ b/Meta/CMake/presets/CMakeWindowsPresets.json
@@ -1,0 +1,62 @@
+{
+  "version": 6,
+  "include": [
+    "CMakeBasePresets.json"
+  ],
+  "configurePresets": [
+    {
+      "hidden": true,
+      "name": "windows_base",
+      "inherits": "base",
+      "description": "Visual Studio via Clang/LLVM Toolchain",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-clang-x64"
+        }
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "Release",
+      "inherits": [
+        "windows_base",
+        "Release_base"
+      ],
+      "displayName": "Windows Experimental Release Config",
+      "description": "Experimental Windows Release build. Not all targets in this preset are built and there is minimal runtime support"
+    },
+    {
+      "name": "Debug",
+      "inherits": [
+        "windows_base",
+        "Debug_base"
+      ],
+      "displayName": "Windows Experimental Debug Config",
+      "description": "Experimental Windows Debug build. Not all targets in this preset are built and there is minimal runtime support"
+    },
+    {
+      "name": "Sanitizer",
+      "inherits": [
+        "windows_base",
+        "Sanitizer_base"
+      ],
+      "displayName": "Windows Experimental Sanitizer Config",
+      "description": "Experimental Windows Sanitizer build. Not all targets in this preset are built and there is minimal runtime support",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    }
+  ]
+}

--- a/Meta/ladybird.py
+++ b/Meta/ladybird.py
@@ -37,9 +37,7 @@ def main():
     preset_parser.add_argument(
         "--preset",
         required=False,
-        default=os.environ.get(
-            "BUILD_PRESET", "Windows_Experimental_Release" if platform.host_system == HostSystem.Windows else "Release"
-        ),
+        default=os.environ.get("BUILD_PRESET", "Release"),
     )
 
     compiler_parser = argparse.ArgumentParser(add_help=False)
@@ -276,9 +274,6 @@ def configure_build_env(platform: Platform, preset: str) -> tuple[Path, Path]:
         "Release": build_root_dir / "release",
         "Sanitizer": build_root_dir / "sanitizers",
         "Swift_Release": build_root_dir / "swift",
-        "Windows_Experimental_Debug": build_root_dir / "debug",
-        "Windows_Experimental_Release": build_root_dir / "release",
-        "Windows_Experimental_Sanitizer": build_root_dir / "sanitizers",
     }
 
     build_preset_dir = known_presets.get(preset, None)
@@ -300,8 +295,7 @@ def configure_build_env(platform: Platform, preset: str) -> tuple[Path, Path]:
 
 
 def validate_cmake_version():
-    # FIXME: This 3.25+ CMake version check may not be needed anymore due to vcpkg downloading a newer version
-    cmake_install_message = "Please install CMake version 3.25 or newer."
+    cmake_install_message = "Please install CMake version 3.30 or newer."
 
     cmake_version_output = run_command(["cmake", "--version"], return_output=True, exit_on_failure=True)
     assert cmake_version_output
@@ -315,7 +309,7 @@ def validate_cmake_version():
     minor = int(version_match.group(2))
     patch = int(version_match.group(3))
 
-    if major < 3 or (major == 3 and minor < 25):
+    if major < 3 or (major == 3 and minor < 30):
         print(f"CMake version {major}.{minor}.{patch} is too old. {cmake_install_message}", file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
Starting with CMake 3.30 and CMakePresets version 9, the include field supports interesting macro expansions. We can now define platform specific presets in separate files and include them in the top-level CMakePresets.json, while keeping the same preset names across all platforms. This avoids some preset explosion at the cost of some mostly empty json files for each unix platform.

The CMake minimum required in the top-level and Lagom CMakeLists.txt have not been adjusted in this patch, as that would have the effect of changing the default policy versions and is a bit out of scope.

https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#includes
