### PR TITLE
LibJS: Add source locations to console.trace()

### DIFF
--- a/Libraries/LibJS/Console.h
+++ b/Libraries/LibJS/Console.h
@@ -55,9 +55,16 @@ public:
         String label;
     };
 
+    struct TraceFrame {
+        String function_name;
+        Optional<String> source_file;
+        Optional<size_t> line;
+        Optional<size_t> column;
+    };
+
     struct Trace {
         String label;
-        Vector<String> stack;
+        Vector<TraceFrame> stack;
     };
 
     void set_client(ConsoleClient& client) { m_client = &client; }

--- a/Libraries/LibJS/Runtime/Error.cpp
+++ b/Libraries/LibJS/Runtime/Error.cpp
@@ -24,15 +24,7 @@ SourceRange const& TracebackFrame::source_range() const
 {
     if (!cached_source_range)
         return dummy_source_range;
-    if (auto* unrealized = cached_source_range->source_range.get_pointer<UnrealizedSourceRange>()) {
-        auto source_range = [&] {
-            if (!unrealized->source_code)
-                return dummy_source_range;
-            return unrealized->realize();
-        }();
-        cached_source_range->source_range = move(source_range);
-    }
-    return cached_source_range->source_range.get<SourceRange>();
+    return cached_source_range->realize_source_range();
 }
 
 GC::Ref<Error> Error::create(Realm& realm)

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -33,6 +33,20 @@ public:
     {
     }
 
+    SourceRange const& realize_source_range()
+    {
+        static SourceRange dummy_source_range { SourceCode::create({}, {}), {}, {} };
+
+        if (auto* unrealized = source_range.get_pointer<UnrealizedSourceRange>()) {
+            if (unrealized->source_code) {
+                source_range = unrealized->realize();
+            } else {
+                source_range = dummy_source_range;
+            }
+        }
+        return source_range.get<SourceRange>();
+    }
+
     size_t program_counter { 0 };
     Variant<UnrealizedSourceRange, SourceRange> source_range;
 };

--- a/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
+++ b/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
@@ -46,8 +46,8 @@ JS::ThrowCompletionOr<JS::Value> WorkerDebugConsoleClient::printer(JS::Console::
         if (!trace.label.is_empty())
             builder.appendff("{}\033[36;1m{}\033[0m\n", indent, trace.label);
 
-        for (auto& function_name : trace.stack)
-            builder.appendff("{}-> {}\n", indent, function_name);
+        for (auto& frame : trace.stack)
+            builder.appendff("{}-> {}\n", indent, frame.function_name);
 
         dbgln("{}", builder.string_view());
         return JS::js_undefined();

--- a/Libraries/LibWebView/ConsoleOutput.cpp
+++ b/Libraries/LibWebView/ConsoleOutput.cpp
@@ -71,6 +71,24 @@ ErrorOr<WebView::ConsoleError> IPC::decode(Decoder& decoder)
 }
 
 template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::ConsoleTrace const& trace)
+{
+    TRY(encoder.encode(trace.label));
+    TRY(encoder.encode(trace.stack));
+
+    return {};
+}
+
+template<>
+ErrorOr<WebView::ConsoleTrace> IPC::decode(Decoder& decoder)
+{
+    auto label = TRY(decoder.decode<String>());
+    auto stack = TRY(decoder.decode<Vector<WebView::StackFrame>>());
+
+    return WebView::ConsoleTrace { move(label), move(stack) };
+}
+
+template<>
 ErrorOr<void> IPC::encode(Encoder& encoder, WebView::ConsoleOutput const& output)
 {
     TRY(encoder.encode(output.timestamp));
@@ -83,7 +101,7 @@ template<>
 ErrorOr<WebView::ConsoleOutput> IPC::decode(Decoder& decoder)
 {
     auto timestamp = TRY(decoder.decode<UnixDateTime>());
-    auto output = TRY(decoder.decode<Variant<WebView::ConsoleLog, WebView::ConsoleError>>());
+    auto output = TRY(decoder.decode<Variant<WebView::ConsoleLog, WebView::ConsoleError, WebView::ConsoleTrace>>());
 
     return WebView::ConsoleOutput { timestamp, move(output) };
 }

--- a/Libraries/LibWebView/ConsoleOutput.h
+++ b/Libraries/LibWebView/ConsoleOutput.h
@@ -36,9 +36,14 @@ struct WEBVIEW_API ConsoleError {
     bool inside_promise { false };
 };
 
+struct WEBVIEW_API ConsoleTrace {
+    String label;
+    Vector<StackFrame> stack;
+};
+
 struct WEBVIEW_API ConsoleOutput {
     UnixDateTime timestamp;
-    Variant<ConsoleLog, ConsoleError> output;
+    Variant<ConsoleLog, ConsoleError, ConsoleTrace> output;
 };
 
 }
@@ -62,6 +67,12 @@ ErrorOr<void> encode(Encoder&, WebView::ConsoleError const&);
 
 template<>
 ErrorOr<WebView::ConsoleError> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::ConsoleTrace const&);
+
+template<>
+ErrorOr<WebView::ConsoleTrace> decode(Decoder&);
 
 template<>
 WEBVIEW_API ErrorOr<void> encode(Encoder&, WebView::ConsoleOutput const&);

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -446,8 +446,8 @@ public:
             if (!trace.label.is_empty())
                 builder.appendff("{}\033[36;1m{}\033[0m\n", indent, trace.label);
 
-            for (auto& function_name : trace.stack)
-                builder.appendff("{}-> {}\n", indent, function_name);
+            for (auto& frame : trace.stack)
+                builder.appendff("{}-> {}\n", indent, frame.function_name);
 
             outln("{}", builder.string_view());
             return JS::js_undefined();


### PR DESCRIPTION
## Summary

This change enhances the `console.trace()` implementation to include source location information (filename, line number, and column number) for each frame in the stack trace. Previously, `console.trace()` only displayed function names, making it difficult to locate the exact source of a trace call. With this change, developers can see the exact source location in DevTools, matching the behavior of other browsers.

The implementation follows the [Console Standard](https://console.spec.whatwg.org/#trace) which specifies that trace should provide "some implementation-defined, potentially-interactive representation of the callstack."

## Implementation Approach

The implementation required changes across several layers of the codebase:

**1. Enhanced TraceFrame structure in LibJS**

The `Console::Trace` structure previously stored only function names as strings. A new `TraceFrame` struct was introduced to hold complete location information:

```cpp
struct TraceFrame {
    String function_name;
    Optional<String> source_file;
    Optional<size_t> line;
    Optional<size_t> column;
};
```

**2. Stack trace extraction refactoring**

The `Console::trace()` function was updated to use `vm.stack_trace()` instead of directly iterating the execution context stack. This provides access to the `CachedSourceRange` objects which contain the source location information. A helper method `realize_source_range()` was added to `CachedSourceRange` to centralize the logic for extracting source range data, which was previously duplicated in `Error.cpp`.

**3. IPC layer updates**

A new `ConsoleTrace` struct was added to the WebView IPC layer, alongside the existing `ConsoleLog` and `ConsoleError` types. The `ConsoleOutput::output` variant was extended to include this new type, along with the necessary IPC encode/decode implementations.

**4. DevTools integration**

The `DevToolsConsoleClient` now handles `LogLevel::Trace` separately, constructing the appropriate `ConsoleTrace` output. The `FrameActor` was updated to format trace messages for the Firefox DevTools Protocol, including the full stack trace with source locations.

## Testing

This change can be tested by opening the browser DevTools console and running `console.trace()` from any JavaScript context. The trace output should now display clickable source locations alongside function names. See the screenshots attached. 

## Changes

- `Libraries/LibJS/Console.h` - Added `TraceFrame` struct, updated `Trace::stack` to use `Vector<TraceFrame>`
- `Libraries/LibJS/Console.cpp` - Updated `trace()` to extract source location information using `vm.stack_trace()`
- `Libraries/LibJS/Runtime/ExecutionContext.h` - Added `realize_source_range()` helper method to `CachedSourceRange`
- `Libraries/LibJS/Runtime/Error.cpp` - Refactored to use the new `realize_source_range()` helper
- `Libraries/LibWebView/ConsoleOutput.h` - Added `ConsoleTrace` struct and IPC declarations
- `Libraries/LibWebView/ConsoleOutput.cpp` - Added IPC encode/decode implementations for `ConsoleTrace`
- `Services/WebContent/DevToolsConsoleClient.cpp` - Added `LogLevel::Trace` handling for DevTools output
- `Libraries/LibDevTools/Actors/FrameActor.cpp` - Added `ConsoleTrace` visitor for DevTools Protocol
- `Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp` - Updated to use `TraceFrame::function_name`
- `Utilities/js.cpp` - Updated console client to use `TraceFrame::function_name`

### Before
<img width="1473" height="936" alt="Screenshot 2026-01-17 at 13 08 58" src="https://github.com/user-attachments/assets/e4865e4d-a54e-44d9-aba0-8b153b08d40a" />

### After 
<img width="1473" height="936" alt="Screenshot 2026-01-17 at 10 16 59" src="https://github.com/user-attachments/assets/7f16f27d-0f5e-470f-b918-031895dae3ff" />
