### PR TITLE
CI: Fix Windows Sanitizer job with missing All_Debug preset

### DIFF
--- a/Meta/CMake/presets/CMakeWindowsPresets.json
+++ b/Meta/CMake/presets/CMakeWindowsPresets.json
@@ -57,6 +57,15 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
+    },
+    {
+      "name": "All_Debug",
+      "inherits": [
+        "windows_base",
+        "Debug_base"
+      ],
+      "displayName": "Windows Experimental All Debug Config",
+      "description": "Experimental Windows All Debug build. Not all targets in this preset are built and there is minimal runtime support"
     }
   ]
 }


### PR DESCRIPTION
CI for Windows Sanitizer is failing due to missing All_Debug

```
Run cmake --preset Sanitizer -B Build `
  cmake --preset Sanitizer -B Build `
    -DENABLE_CI_BASELINE_CPU=ON
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    LADYBIRD_SOURCE_DIR: C:\runner\_work\ladybird\ladybird
    CCACHE_DIR: C:\runner\_work\ladybird\ladybird/.ccache
    VCPKG_ROOT: C:\runner\_work\ladybird\ladybird/Build/vcpkg
    CCACHE_COMPILERCHECK: %compiler% -v
    GITHUB_REPO_NAME: LadybirdBrowser/ladybird
    pythonLocation: C:\hostedtoolcache\windows\Python\3.12.10\x64
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.12.10\x64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.12.10\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.12.10\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.12.10\x64
    VCPKG_CACHE_SAS: 
    VCPKG_CACHE_MODE: 
CMake Error: Could not read presets from C:/runner/_work/ladybird/ladybird:
Invalid "configurePreset": "All_Debug"
Error: Process completed with exit code 1.

```

Example failing job

https://github.com/LadybirdBrowser/ladybird/actions/runs/21101694797/job/60686802822