### PR TITLE
RequestServer: Add --resource-map option for URL-to-file substitution

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -120,6 +120,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     bool disable_http_memory_cache = false;
     bool disable_http_disk_cache = false;
     bool disable_content_filter = false;
+    Optional<StringView> resource_substitution_map_path;
     bool enable_autoplay = false;
     bool expose_internals_object = false;
     bool force_cpu_painting = false;
@@ -182,6 +183,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     args_parser.add_option(use_dns_over_tls, "Use DNS over TLS", "dot");
     args_parser.add_option(validate_dnssec_locally, "Validate DNSSEC locally", "dnssec");
     args_parser.add_option(default_time_zone, "Default time zone", "default-time-zone", 0, "time-zone-id");
+    args_parser.add_option(resource_substitution_map_path, "Path to JSON file mapping URLs to local files", "resource-map", 0, "path");
 
     args_parser.add_option(Core::ArgsParser::Option {
         .argument_mode = Core::ArgsParser::OptionArgumentMode::Optional,
@@ -265,6 +267,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     m_request_server_options = {
         .certificates = move(certificates),
         .http_disk_cache_mode = disable_http_disk_cache ? HTTPDiskCacheMode::Disabled : HTTPDiskCacheMode::Enabled,
+        .resource_substitution_map_path = resource_substitution_map_path.has_value() ? Optional<ByteString> { *resource_substitution_map_path } : OptionalNone {},
     };
 
     m_web_content_options = {

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -234,6 +234,9 @@ ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process()
         arguments.append(server.value());
     }
 
+    if (request_server_options.resource_substitution_map_path.has_value())
+        arguments.append(ByteString::formatted("--resource-map={}", *request_server_options.resource_substitution_map_path));
+
     auto client = TRY(launch_server_process<Requests::RequestClient>("RequestServer"sv, move(arguments)));
 
     WebView::Application::settings().dns_settings().visit(

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -102,6 +102,7 @@ enum class HTTPDiskCacheMode {
 struct RequestServerOptions {
     Vector<ByteString> certificates;
     HTTPDiskCacheMode http_disk_cache_mode { HTTPDiskCacheMode::Disabled };
+    Optional<ByteString> resource_substitution_map_path;
 };
 
 enum class IsLayoutTestMode {

--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
     Request.cpp
     RequestPipe.cpp
     Resolver.cpp
+    ResourceSubstitutionMap.cpp
     WebSocketImplCurl.cpp
 )
 

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -78,14 +78,15 @@ public:
 
 private:
     enum class State : u8 {
-        Init,         // Decide whether to service this request from cache or the network.
-        ReadCache,    // Read the cached response from disk.
-        WaitForCache, // Wait for an existing cache entry to complete before proceeding.
-        DNSLookup,    // Resolve the URL's host.
-        Connect,      // Issue a network request to connect to the URL.
-        Fetch,        // Issue a network request to fetch the URL.
-        Complete,     // Finalize the request with the client.
-        Error,        // Any error occured during the request's lifetime.
+        Init,              // Decide whether to service this request from cache or the network.
+        ReadCache,         // Read the cached response from disk.
+        WaitForCache,      // Wait for an existing cache entry to complete before proceeding.
+        ServeSubstitution, // Serve content from a local file substitution.
+        DNSLookup,         // Resolve the URL's host.
+        Connect,           // Issue a network request to connect to the URL.
+        Fetch,             // Issue a network request to fetch the URL.
+        Complete,          // Finalize the request with the client.
+        Error,             // Any error occured during the request's lifetime.
     };
 
     static constexpr StringView state_name(State state)
@@ -97,6 +98,8 @@ private:
             return "ReadCache"sv;
         case State::WaitForCache:
             return "WaitForCache"sv;
+        case State::ServeSubstitution:
+            return "ServeSubstitution"sv;
         case State::DNSLookup:
             return "DNSLookup"sv;
         case State::Connect:
@@ -137,6 +140,7 @@ private:
 
     void handle_initial_state();
     void handle_read_cache_state();
+    void handle_serve_substitution_state();
     void handle_dns_lookup_state();
     void handle_connect_state();
     void handle_fetch_state();

--- a/Services/RequestServer/ResourceSubstitutionMap.cpp
+++ b/Services/RequestServer/ResourceSubstitutionMap.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
+#include <LibCore/File.h>
+#include <LibURL/Parser.h>
+#include <RequestServer/ResourceSubstitutionMap.h>
+
+namespace RequestServer {
+
+static String normalize_url(URL::URL const& url)
+{
+    auto normalized = url;
+    normalized.set_query({});
+    normalized.set_fragment({});
+    return normalized.serialize();
+}
+
+ErrorOr<NonnullOwnPtr<ResourceSubstitutionMap>> ResourceSubstitutionMap::load_from_file(StringView path)
+{
+    auto file = TRY(Core::File::open(path, Core::File::OpenMode::Read));
+    auto content = TRY(file->read_until_eof());
+    auto json = TRY(JsonValue::from_string(content));
+
+    if (!json.is_object())
+        return Error::from_string_literal("Resource substitution map must be a JSON object");
+
+    auto const& root = json.as_object();
+    auto substitutions_value = root.get("substitutions"sv);
+
+    if (!substitutions_value.has_value() || !substitutions_value->is_array())
+        return Error::from_string_literal("Resource substitution map must contain a 'substitutions' array");
+
+    auto map = adopt_own(*new ResourceSubstitutionMap);
+
+    for (auto const& entry : substitutions_value->as_array().values()) {
+        if (!entry.is_object()) {
+            warnln("Skipping non-object entry in resource substitution map");
+            continue;
+        }
+
+        auto const& obj = entry.as_object();
+
+        auto url_value = obj.get("url"sv);
+        auto file_value = obj.get("file"sv);
+
+        if (!url_value.has_value() || !url_value->is_string()) {
+            warnln("Skipping entry without valid 'url' string");
+            continue;
+        }
+
+        if (!file_value.has_value() || !file_value->is_string()) {
+            warnln("Skipping entry without valid 'file' string");
+            continue;
+        }
+
+        ResourceSubstitution substitution;
+        substitution.file_path = file_value->as_string().to_byte_string();
+
+        if (auto content_type_value = obj.get("content_type"sv); content_type_value.has_value() && content_type_value->is_string())
+            substitution.content_type = content_type_value->as_string();
+
+        if (auto status_code_value = obj.get("status_code"sv); status_code_value.has_value() && status_code_value->is_integer<u32>())
+            substitution.status_code = status_code_value->as_integer<u32>();
+
+        auto url = URL::Parser::basic_parse(url_value->as_string());
+        if (!url.has_value()) {
+            warnln("Skipping entry with invalid URL '{}'", url_value->as_string());
+            continue;
+        }
+
+        map->m_substitutions.set(normalize_url(*url), move(substitution));
+    }
+
+    return map;
+}
+
+Optional<ResourceSubstitution const&> ResourceSubstitutionMap::lookup(URL::URL const& url) const
+{
+    auto it = m_substitutions.find(normalize_url(url));
+    if (it == m_substitutions.end())
+        return {};
+    return it->value;
+}
+
+}

--- a/Services/RequestServer/ResourceSubstitutionMap.h
+++ b/Services/RequestServer/ResourceSubstitutionMap.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <AK/HashMap.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibURL/URL.h>
+
+namespace RequestServer {
+
+struct ResourceSubstitution {
+    ByteString file_path;
+    Optional<String> content_type;
+    u32 status_code { 200 };
+};
+
+class ResourceSubstitutionMap {
+public:
+    static ErrorOr<NonnullOwnPtr<ResourceSubstitutionMap>> load_from_file(StringView path);
+
+    Optional<ResourceSubstitution const&> lookup(URL::URL const&) const;
+
+private:
+    ResourceSubstitutionMap() = default;
+
+    HashMap<String, ResourceSubstitution> m_substitutions;
+};
+
+}


### PR DESCRIPTION
This adds support for intercepting network requests and serving local file content instead. When a URL matches an entry in the substitution map, the local file is served while preserving the original URL's origin for cross-origin checks.

Usage:
```
    Ladybird --resource-map=/path/to/map.json
```

The JSON file format is:
```json
    {
      "substitutions": [
        {
          "url": "https://example.com/script.js",
          "file": "/path/to/local/script.js",
          "content_type": "application/javascript",
          "status_code": 200
        }
      ]
    }
```

Fields:
  - `url` (required): Exact URL to intercept (query string and fragment are stripped before matching)
  - `file` (required): Absolute path to local file to serve
  - `content_type` (optional): Override Content-Type header (defaults to guessing from filename)
  - `status_code` (optional): HTTP status code (defaults to 200)

This is incredibly useful for debugging production websites: you can intercept any script, stylesheet, or other resource and replace it with a local copy containing your own debug instrumentation, console.log statements, or experimental fixes - all without modifying the actual site or setting up a local dev server.