### PR TITLE
LibGC: Enforce that a Cell type must declare the allocator to use

### DIFF
--- a/Libraries/LibGC/CellAllocator.h
+++ b/Libraries/LibGC/CellAllocator.h
@@ -13,11 +13,20 @@
 #include <LibGC/Forward.h>
 #include <LibGC/HeapBlock.h>
 
-#define GC_DECLARE_ALLOCATOR(ClassName) \
+// The default allocator, which isolates different Cell types from being allocated in the same blocks.
+#define GC_DECLARE_ALLOCATOR(ClassName)    \
+    using gc_allocator_marker = ClassName; \
     static GC::TypeIsolatingCellAllocator<ClassName> cell_allocator
 
 #define GC_DEFINE_ALLOCATOR(ClassName) \
     GC::TypeIsolatingCellAllocator<ClassName> ClassName::cell_allocator { #ClassName##sv, ClassName::OVERRIDES_MUST_SURVIVE_GARBAGE_COLLECTION, ClassName::OVERRIDES_FINALIZE }
+
+// The size-based allocator, which isolates different Cell types based on their size instead of their concrete type.
+// This should only be used if it's not possible or undesirable to use a type-isolated cell allocator.
+// Different Cell types can use the same blocks if they happen to have the same size, which allows type confusion
+// to occur if a Cell is used after it's freed.
+#define GC_DECLARE_SIZE_BASED_ALLOCATOR(ClassName) \
+    using gc_allocator_marker = ClassName
 
 namespace GC {
 

--- a/Libraries/LibGC/Function.h
+++ b/Libraries/LibGC/Function.h
@@ -15,6 +15,7 @@ namespace GC {
 template<typename T>
 class Function final : public Cell {
     GC_CELL(Function, Cell);
+    GC_DECLARE_ALLOCATOR(Function);
 
 public:
     static Ref<Function> create(Heap& heap, ESCAPING AK::Function<T> function)
@@ -46,5 +47,8 @@ static Ref<Function<T>> create_function(Heap& heap, ESCAPING Callable&& function
 {
     return Function<T>::create(heap, AK::Function<T> { forward<Callable>(function) });
 }
+
+template<typename T>
+GC_DEFINE_ALLOCATOR(Function<T>);
 
 }

--- a/Libraries/LibGC/HeapVector.h
+++ b/Libraries/LibGC/HeapVector.h
@@ -13,6 +13,7 @@ namespace GC {
 template<typename T>
 class HeapVector : public Cell {
     GC_CELL(HeapVector, Cell);
+    GC_DECLARE_ALLOCATOR(HeapVector);
 
 public:
     HeapVector() = default;
@@ -30,5 +31,8 @@ public:
 private:
     Vector<T> m_elements;
 };
+
+template<typename T>
+GC_DEFINE_ALLOCATOR(HeapVector<T>);
 
 }

--- a/Libraries/LibJS/Heap/Cell.h
+++ b/Libraries/LibJS/Heap/Cell.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGC/Cell.h>
+#include <LibGC/CellAllocator.h>
 #include <LibJS/Export.h>
 #include <LibJS/Forward.h>
 

--- a/Libraries/LibJS/Module.cpp
+++ b/Libraries/LibJS/Module.cpp
@@ -19,6 +19,7 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(Module);
 GC_DEFINE_ALLOCATOR(GraphLoadingState);
+GC_DEFINE_ALLOCATOR(GraphLoadingState::HostDefined);
 
 Module::Module(Realm& realm, ByteString filename, Script::HostDefined* host_defined)
     : m_realm(realm)

--- a/Libraries/LibJS/Module.h
+++ b/Libraries/LibJS/Module.h
@@ -65,6 +65,7 @@ struct GraphLoadingState : public Cell {
 public:
     struct HostDefined : Cell {
         GC_CELL(HostDefined, Cell);
+        GC_DECLARE_ALLOCATOR(HostDefined);
 
     public:
         virtual ~HostDefined() = default;

--- a/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Libraries/LibTest/JavaScriptTestRunner.h
@@ -168,6 +168,7 @@ protected:
 
 class TestRunnerGlobalObject final : public JS::GlobalObject {
     JS_OBJECT(TestRunnerGlobalObject, JS::GlobalObject);
+    GC_DECLARE_ALLOCATOR(TestRunnerGlobalObject);
 
 public:
     TestRunnerGlobalObject(JS::Realm& realm)

--- a/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -21,6 +21,8 @@ TestRunner* ::Test::TestRunner::s_the = nullptr;
 
 namespace JS {
 
+GC_DEFINE_ALLOCATOR(TestRunnerGlobalObject);
+
 RefPtr<::JS::VM> g_vm;
 bool g_collect_on_every_allocation = false;
 ByteString g_currently_running_test;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4189,6 +4189,7 @@ void Document::make_unsalvageable([[maybe_unused]] String reason)
 
 struct DocumentDestructionState : public GC::Cell {
     GC_CELL(DocumentDestructionState, GC::Cell);
+    GC_DECLARE_ALLOCATOR(DocumentDestructionState);
 
     static constexpr int TIMEOUT_MS = 15000;
 
@@ -4230,6 +4231,8 @@ struct DocumentDestructionState : public GC::Cell {
     GC::Ptr<GC::Function<void()>> after_all;
     GC::Ref<Platform::Timer> timeout;
 };
+
+GC_DEFINE_ALLOCATOR(DocumentDestructionState);
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document-and-its-descendants
 void Document::destroy_a_document_and_its_descendants(GC::Ptr<GC::Function<void()>> after_all_destruction)

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -105,6 +105,8 @@
 
 namespace Web::DOM {
 
+GC_DEFINE_ALLOCATOR(Element);
+
 Element::Element(Document& document, DOM::QualifiedName qualified_name)
     : ParentNode(document, NodeType::ELEMENT_NODE)
     , m_qualified_name(move(qualified_name))

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -118,6 +118,7 @@ class WEB_API Element
     , public ARIA::ARIAMixin
     , public Animations::Animatable {
     WEB_PLATFORM_OBJECT(Element, ParentNode);
+    GC_DECLARE_ALLOCATOR(Element);
 
 public:
     virtual ~Element() override;

--- a/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -14,6 +14,7 @@
 namespace Web::DOM {
 
 GC_DEFINE_ALLOCATOR(MutationObserver);
+GC_DEFINE_ALLOCATOR(RegisteredObserver);
 GC_DEFINE_ALLOCATOR(TransientRegisteredObserver);
 
 WebIDL::ExceptionOr<GC::Ref<MutationObserver>> MutationObserver::construct_impl(JS::Realm& realm, GC::Ptr<WebIDL::CallbackType> callback)

--- a/Libraries/LibWeb/DOM/MutationObserver.h
+++ b/Libraries/LibWeb/DOM/MutationObserver.h
@@ -68,6 +68,7 @@ private:
 // https://dom.spec.whatwg.org/#registered-observer
 class RegisteredObserver : public JS::Cell {
     GC_CELL(RegisteredObserver, JS::Cell);
+    GC_DECLARE_ALLOCATOR(RegisteredObserver);
 
 public:
     static GC::Ref<RegisteredObserver> create(MutationObserver&, MutationObserverInit const&);

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -27,6 +27,8 @@
 
 namespace Web::HTML {
 
+GC_DEFINE_ALLOCATOR(Environment);
+
 Environment::~Environment() = default;
 
 void Environment::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -24,6 +24,7 @@ namespace Web::HTML {
 // https://html.spec.whatwg.org/multipage/webappapis.html#environment
 struct WEB_API Environment : public JS::Cell {
     GC_CELL(Environment, JS::Cell);
+    GC_DECLARE_ALLOCATOR(Environment);
 
 public:
     virtual ~Environment() override;

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -15,6 +15,8 @@
 
 namespace Web::Layout {
 
+GC_DEFINE_ALLOCATOR(Box);
+
 Box::Box(DOM::Document& document, DOM::Node* node, GC::Ref<CSS::ComputedProperties> style)
     : NodeWithStyleAndBoxModelMetrics(document, node, move(style))
 {

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -27,6 +27,7 @@ struct IntrinsicSizes {
 
 class WEB_API Box : public NodeWithStyleAndBoxModelMetrics {
     GC_CELL(Box, NodeWithStyleAndBoxModelMetrics);
+    GC_DECLARE_ALLOCATOR(Box);
 
 public:
     Painting::PaintableBox const* paintable_box() const;

--- a/Libraries/LibWeb/Layout/SVGBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGBox.cpp
@@ -8,6 +8,8 @@
 
 namespace Web::Layout {
 
+GC_DEFINE_ALLOCATOR(SVGBox);
+
 SVGBox::SVGBox(DOM::Document& document, SVG::SVGElement& element, GC::Ref<CSS::ComputedProperties> style)
     : Box(document, &element, move(style))
 {

--- a/Libraries/LibWeb/Layout/SVGBox.h
+++ b/Libraries/LibWeb/Layout/SVGBox.h
@@ -14,6 +14,7 @@ namespace Web::Layout {
 
 class SVGBox : public Box {
     GC_CELL(SVGBox, Box);
+    GC_DECLARE_ALLOCATOR(SVGBox);
 
 public:
     SVGBox(DOM::Document&, SVG::SVGElement&, GC::Ref<CSS::ComputedProperties>);

--- a/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
@@ -10,6 +10,8 @@
 
 namespace Web::Layout {
 
+GC_DEFINE_ALLOCATOR(SVGGraphicsBox);
+
 SVGGraphicsBox::SVGGraphicsBox(DOM::Document& document, SVG::SVGGraphicsElement& element, GC::Ref<CSS::ComputedProperties> style)
     : SVGBox(document, element, style)
 {

--- a/Libraries/LibWeb/Layout/SVGGraphicsBox.h
+++ b/Libraries/LibWeb/Layout/SVGGraphicsBox.h
@@ -15,6 +15,7 @@ namespace Web::Layout {
 
 class WEB_API SVGGraphicsBox : public SVGBox {
     GC_CELL(SVGGraphicsBox, SVGBox);
+    GC_DECLARE_ALLOCATOR(SVGGraphicsBox);
 
 public:
     SVGGraphicsBox(DOM::Document&, SVG::SVGGraphicsElement&, GC::Ref<CSS::ComputedProperties>);

--- a/Libraries/LibWeb/Layout/SVGImageBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGImageBox.cpp
@@ -11,6 +11,8 @@
 
 namespace Web::Layout {
 
+GC_DEFINE_ALLOCATOR(SVGImageBox);
+
 SVGImageBox::SVGImageBox(DOM::Document& document, SVG::SVGGraphicsElement& element, GC::Ref<CSS::ComputedProperties> style)
     : SVGGraphicsBox(document, element, style)
 {

--- a/Libraries/LibWeb/Layout/SVGImageBox.h
+++ b/Libraries/LibWeb/Layout/SVGImageBox.h
@@ -14,6 +14,7 @@ namespace Web::Layout {
 
 class SVGImageBox : public SVGGraphicsBox {
     GC_CELL(SVGImageBox, SVGGraphicsBox);
+    GC_DECLARE_ALLOCATOR(SVGImageBox);
 
 public:
     SVGImageBox(DOM::Document&, SVG::SVGGraphicsElement&, GC::Ref<CSS::ComputedProperties>);

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -23,6 +23,8 @@
 
 namespace Web::SVG {
 
+GC_DEFINE_ALLOCATOR(SVGElement);
+
 SVGElement::SVGElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : Element(document, move(qualified_name))
 {

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -19,6 +19,7 @@ class WEB_API SVGElement
     , public HTML::GlobalEventHandlers
     , public HTML::HTMLOrSVGElement<SVGElement> {
     WEB_PLATFORM_OBJECT(SVGElement, DOM::Element);
+    GC_DECLARE_ALLOCATOR(SVGElement);
 
 public:
     virtual bool requires_svg_container() const override { return true; }

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -20,6 +20,8 @@
 
 namespace Web::SVG {
 
+GC_DEFINE_ALLOCATOR(SVGImageElement);
+
 SVGImageElement::SVGImageElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : SVGGraphicsElement(document, move(qualified_name))
 {

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -18,6 +18,7 @@ class SVGImageElement final
     , public SVGURIReferenceMixin<SupportsXLinkHref::Yes>
     , public Layout::ImageProvider {
     WEB_PLATFORM_OBJECT(SVGImageElement, SVGGraphicsElement);
+    GC_DECLARE_ALLOCATOR(SVGImageElement);
 
 public:
     ~SVGImageElement();

--- a/Libraries/LibWeb/ServiceWorker/Job.cpp
+++ b/Libraries/LibWeb/ServiceWorker/Job.cpp
@@ -148,6 +148,7 @@ static void register_(JS::VM& vm, GC::Ref<Job> job)
 // Used to share internal Update algorithm state b/w fetch callbacks
 class UpdateAlgorithmState : JS::Cell {
     GC_CELL(UpdateAlgorithmState, JS::Cell);
+    GC_DECLARE_ALLOCATOR(UpdateAlgorithmState);
 
 public:
     static GC::Ref<UpdateAlgorithmState> create(JS::VM& vm)
@@ -171,6 +172,8 @@ private:
     OrderedHashMap<URL::URL, GC::Ref<Fetch::Infrastructure::Response>> m_map;
     bool m_has_updated_resources { false };
 };
+
+GC_DEFINE_ALLOCATOR(UpdateAlgorithmState);
 
 // https://w3c.github.io/ServiceWorker/#update-algorithm
 static void update(JS::VM& vm, GC::Ref<Job> job)

--- a/Libraries/LibWeb/ServiceWorker/ServiceWorker.cpp
+++ b/Libraries/LibWeb/ServiceWorker/ServiceWorker.cpp
@@ -12,6 +12,8 @@
 
 namespace Web::ServiceWorker {
 
+GC_DEFINE_ALLOCATOR(ServiceWorker);
+
 ServiceWorker::ServiceWorker(JS::Realm& realm, ServiceWorkerRecord* service_worker_record)
     : DOM::EventTarget(realm)
     , m_service_worker_record(service_worker_record)

--- a/Libraries/LibWeb/ServiceWorker/ServiceWorker.h
+++ b/Libraries/LibWeb/ServiceWorker/ServiceWorker.h
@@ -18,6 +18,7 @@ namespace Web::ServiceWorker {
 // https://w3c.github.io/ServiceWorker/#serviceworker-interface
 class ServiceWorker : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(ServiceWorker, DOM::EventTarget);
+    GC_DECLARE_ALLOCATOR(ServiceWorker);
 
 public:
     [[nodiscard]] static GC::Ref<ServiceWorker> create(JS::Realm& realm, ServiceWorkerRecord*);

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.cpp
@@ -124,6 +124,7 @@ extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t* guard)
 
 class TestRunnerGlobalObject final : public JS::GlobalObject {
     JS_OBJECT(TestRunnerGlobalObject, JS::GlobalObject);
+    GC_DECLARE_ALLOCATOR(TestRunnerGlobalObject);
 
 public:
     TestRunnerGlobalObject(JS::Realm&);
@@ -133,6 +134,8 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(fuzzilli);
 };
+
+GC_DEFINE_ALLOCATOR(TestRunnerGlobalObject);
 
 TestRunnerGlobalObject::TestRunnerGlobalObject(JS::Realm& realm)
     : GlobalObject(realm)

--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -42,6 +42,7 @@ TESTJS_GLOBAL_FUNCTION(read_binary_wasm_file, readBinaryWasmFile)
 
 class WebAssemblyModule final : public JS::Object {
     JS_OBJECT(WebAssemblyModule, JS::Object);
+    GC_DECLARE_ALLOCATOR(WebAssemblyModule);
 
 public:
     explicit WebAssemblyModule(JS::Object& prototype)
@@ -152,6 +153,8 @@ private:
     RefPtr<Wasm::Module> m_module;
     OwnPtr<Wasm::ModuleInstance> m_module_instance;
 };
+
+GC_DEFINE_ALLOCATOR(WebAssemblyModule);
 
 Wasm::AbstractMachine WebAssemblyModule::m_machine;
 HashMap<Wasm::Linker::Name, Wasm::ExternValue> WebAssemblyModule::s_spec_test_namespace;

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -44,6 +44,7 @@ GC::Root<JS::Value> g_last_value = GC::make_root(JS::js_undefined());
 
 class ReplObject final : public JS::GlobalObject {
     JS_OBJECT(ReplObject, JS::GlobalObject);
+    GC_DECLARE_ALLOCATOR(ReplObject);
 
 public:
     ReplObject(JS::Realm& realm)
@@ -63,8 +64,11 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(print);
 };
 
+GC_DEFINE_ALLOCATOR(ReplObject);
+
 class ScriptObject final : public JS::GlobalObject {
     JS_OBJECT(ScriptObject, JS::GlobalObject);
+    GC_DECLARE_ALLOCATOR(ScriptObject);
 
 public:
     ScriptObject(JS::Realm& realm)
@@ -79,6 +83,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(load_json);
     JS_DECLARE_NATIVE_FUNCTION(print);
 };
+
+GC_DEFINE_ALLOCATOR(ScriptObject);
 
 static bool s_dump_ast = false;
 static bool s_as_module = false;


### PR DESCRIPTION
This ensures that we are explicitly declaring the allocator to use when allocating a cell(-inheriting) type, instead of silently falling back to size-based allocation.

Since this is done in allocate_cell, this will only be detected for types that are actively being allocated. However, since that means they're _not_ being allocated, that means it's safe to not declare an allocator to use for those. For example, the base TypedArray<T>, which is never directly allocated and only the defined specializations are ever allocated.