### PR TITLE
LibWeb: Use progressive fallback for password input masking character

### DIFF
--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -75,4 +75,25 @@ bool FontCascadeList::equals(FontCascadeList const& other) const
     return true;
 }
 
+u32 FontCascadeList::password_mask_character() const
+{
+    return m_cached_password_mask_character.ensure([&] {
+        // Check for available masking characters in order of preference:
+        // Preferred: U+25CF BLACK CIRCLE (●)
+        // Fallback 1: U+2022 BULLET (•) - this has wider support
+        // Fallback 2: U+002A ASTERISK (*) - available in all fonts
+        constexpr u32 black_circle = 0x25CF;
+        constexpr u32 bullet = 0x2022;
+        constexpr u32 asterisk = '*';
+
+        if (!font_for_code_point(black_circle).contains_glyph(black_circle)) {
+            if (font_for_code_point(bullet).contains_glyph(bullet))
+                return bullet;
+            return asterisk;
+        }
+
+        return black_circle;
+    });
+}
+
 }

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -41,6 +41,8 @@ public:
 
     bool equals(FontCascadeList const& other) const;
 
+    u32 password_mask_character() const;
+
     struct Entry {
         NonnullRefPtr<Font const> font;
         struct RangeData {
@@ -67,6 +69,7 @@ private:
     RefPtr<Font const> m_last_resort_font;
     mutable Vector<Entry> m_fonts;
     SystemFontFallbackCallback m_system_font_fallback_callback;
+    mutable Optional<u32> m_cached_password_mask_character;
 };
 
 }

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -308,7 +308,9 @@ Utf16String const& TextNode::text_for_rendering() const
 void TextNode::compute_text_for_rendering()
 {
     if (dom_node().is_password_input()) {
-        m_text_for_rendering = Utf16String::repeated(u'●', dom_node().data().length_in_code_points());
+        auto const& font_list = computed_values().font_list();
+        auto mask_char = font_list.password_mask_character();
+        m_text_for_rendering = Utf16String::repeated(mask_char, dom_node().data().length_in_code_points());
         return;
     }
 

--- a/Tests/LibWeb/Layout/expected/input-text-to-password.txt
+++ b/Tests/LibWeb/Layout/expected/input-text-to-password.txt
@@ -5,8 +5,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <input> at [9,9] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
         Box <div> at [11,10] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,10] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 7, rect: [11,10 40.90625x18] baseline: 13.796875
-                "●●●●●●●"
+            frag 0 from TextNode start: 0, length: 7, rect: [11,10 55.5625x18] baseline: 13.796875
+                "*******"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
       TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/unicode-password-input.txt
+++ b/Tests/LibWeb/Layout/expected/unicode-password-input.txt
@@ -5,8 +5,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <input> at [9,9] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
         Box <div> at [11,10] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,10] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 14, rect: [11,10 81.8125x18] baseline: 13.796875
-                "●●●●●●●●●●●●●●"
+            frag 0 from TextNode start: 0, length: 14, rect: [11,10 111.125x18] baseline: 13.796875
+                "**************"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
 


### PR DESCRIPTION
If BLACK CIRCLE (●) is not available, then fall back to BULLET (•), otherwise use the universally available asterisk.

This prevents the password being rendered as the missing glyph character if the preferred character is not available.