### PR TITLE
Documentation: Adjust Arch Linux dependencies

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -73,7 +73,7 @@ sudo apt install libpulse-dev
 ### Arch Linux/Manjaro:
 
 ```
-sudo pacman -S --needed autoconf-archive automake base-devel ccache cmake curl libgl nasm ninja qt6-base qt6-tools qt6-wayland ttf-liberation tar unzip zip
+sudo pacman -S --needed autoconf-archive base-devel ccache cmake curl git libgl nasm ninja python qt6-base qt6-tools ttf-liberation tar unzip zip
 ```
 
 Optionally, install the PulseAudio headers for audio playback support:


### PR DESCRIPTION
- Remove automake: base-devel already depends directly on it.
- Remove qt6-wayland: QT 6.10 added Wayland support to qt6-base.
- Add Python and Git: Not part of base or base-devel and are listed for Ubuntu.