### PR TITLE
LibWeb: Prevent text wrapping inside select elements

### DIFF
--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -68,10 +68,6 @@ input[type=image] {
     cursor: pointer;
 }
 
-option {
-    display: none;
-}
-
 /* Custom <input type="range"> styles */
 input[type=range] {
     display: inline-block;
@@ -861,6 +857,20 @@ input[type=checkbox][switch]:checked {
 /* https://drafts.csswg.org/css-ui/#propdef-user-select */
 button, meter, progress, select {
     user-select: none;
+}
+
+/* https://html.spec.whatwg.org/multipage/rendering.html#the-select-element-2
+   FIXME: These styles apply to base appearance. We should differentiate between
+          native, primitive, and base appearance as per the spec. */
+select option {
+    min-inline-size: 24px;
+    min-block-size: max(24px, 1lh);
+    padding-inline: 0.5em;
+    padding-block-end: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    white-space: nowrap;
 }
 
 /* https://drafts.csswg.org/css-view-transitions-1/#ua-styles */

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -705,6 +705,7 @@ void HTMLSelectElement::create_shadow_tree_if_needed()
     m_inner_text_element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     m_inner_text_element->set_attribute_value(HTML::AttributeNames::style, R"~~~(
         flex: 1;
+        white-space: nowrap;
     )~~~"_string);
     MUST(border->append_child(*m_inner_text_element));
 

--- a/Tests/LibWeb/Layout/expected/select-text-nowrap.txt
+++ b/Tests/LibWeb/Layout/expected/select-text-nowrap.txt
@@ -1,0 +1,29 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 38 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 150x18] baseline: 16.796875
+      BlockContainer <select> at [13,10] inline-block [0+1+4 150 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
+        Box <div> at [13,10] flex-container(row) [0+0+0 150 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [13,10] flex-item [0+0+0 417.328125 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 50, rect: [13,10 417.328125x18] baseline: 13.796875
+                "This is some really long text that should not wrap"
+            TextNode <#text> (not painted)
+          BlockContainer <div> at [434.328125,11] flex-item [4+0+0 0 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from SVGSVGBox start: 0, length: 0, rect: [434.328125,24 0x0] baseline: 0
+            SVGSVGBox <svg> at [434.328125,24] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <path> at [434.328125,24] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x38]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x22]
+      PaintableWithLines (BlockContainer<SELECT>) [8,8 160x22] overflow: [9,9 421.328125x21]
+        PaintableBox (Box<DIV>) [13,10 150x18] overflow: [13,10 417.328125x18]
+          PaintableWithLines (BlockContainer<DIV>) [13,10 417.328125x18]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [434.328125,11 0x16]
+            SVGSVGPaintable (SVGSVGBox<svg>) [434.328125,24 0x0]
+              SVGPathPaintable (SVGGeometryBox<path>) [434.328125,24 0x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x38] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/select-text-nowrap.html
+++ b/Tests/LibWeb/Layout/input/select-text-nowrap.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+select {
+    width: 10em;
+}
+</style>
+<select>
+    <option>This is some really long text that should not wrap</option>
+</select>


### PR DESCRIPTION
## Summary

Fixes #7073

Add `white-space: nowrap !important` to the select element user-agent styles to prevent option text from wrapping onto multiple lines. This matches the behavior of Firefox and other major browsers.

## Test plan

- Added layout test: `Tests/LibWeb/Layout/input/select-text-nowrap.html`
- Test verifies text stays on single line even with constrained width
- Ran `test-web` - test passes