### PR TITLE
test-web: Fix tests without expectation files incorrectly passing

### DIFF
--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -734,7 +734,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
         };
     } else if (test.mode == TestMode::Text) {
         // Set up variant detection callback.
-        view.on_test_variant_metadata = [&view, &context, test_index](JsonValue metadata) {
+        view.on_test_variant_metadata = [&view, &context, test_index, on_test_complete](JsonValue metadata) {
             // Verify this IPC response is for the current test on this view (use index to avoid dangling pointer issues)
             auto current_index = s_current_test_index_by_view.get(&view);
             if (!current_index.has_value() || *current_index != test_index)
@@ -760,7 +760,7 @@ static void run_dump_test(TestWebView& view, TestRunContext& context, Test& test
             auto& test_after_check = context.tests[test_index];
             test_after_check.did_check_variants = true;
             if (test_after_check.did_finish_test)
-                view.on_test_complete({ test_index, TestResult::Pass });
+                on_test_complete();
         };
 
         view.on_load_finish = [&view, &context, test_index, on_test_complete, url](auto const& loaded_url) {


### PR DESCRIPTION
This fixes a regression introduced in bf77aeb3dc029b2b4633463a5984cdaa439d0e8a which added support for WPT variant meta tags.

The problem occurs when a text test has no corresponding expectation file. The test should fail, but instead it passes. This happens because of the following execution flow:

1. Test loads and on_load_finish is called
2. internals.loadTestVariants() is executed (for all text tests)
3. The test JS calls signalTestIsDone(), setting did_finish_test = true
4. The variant metadata callback fires with an empty array (no variants)
5. In on_test_variant_metadata, since did_finish_test is true, it directly calls view.on_test_complete({ test_index, TestResult::Pass })

The bug is in step 5: the code bypasses handle_completed_test() which is where the expectation file comparison happens. Instead of calling on_test_complete() (the lambda that invokes handle_completed_test), it directly returns Pass.

The fix captures on_test_complete in the on_test_variant_metadata lambda and calls it instead of directly returning Pass, ensuring that the expectation file check is performed.