### PR TITLE
LibWeb/Painting: Delete unused union_max_radii() in BorderRadiiData

### DIFF
--- a/Libraries/LibWeb/Painting/BorderRadiiData.h
+++ b/Libraries/LibWeb/Painting/BorderRadiiData.h
@@ -40,12 +40,6 @@ struct WEB_API BorderRadiusData {
         if (vertical_radius != 0)
             vertical_radius = max(CSSPixels(0), vertical_radius - vertical);
     }
-
-    inline void union_max_radii(BorderRadiusData const& other)
-    {
-        horizontal_radius = max(horizontal_radius, other.horizontal_radius);
-        vertical_radius = max(vertical_radius, other.vertical_radius);
-    }
 };
 
 struct CornerRadii {
@@ -69,14 +63,6 @@ struct BorderRadiiData {
     inline bool has_any_radius() const
     {
         return top_left || top_right || bottom_right || bottom_left;
-    }
-
-    inline void union_max_radii(BorderRadiiData const& other)
-    {
-        top_left.union_max_radii(other.top_left);
-        top_right.union_max_radii(other.top_right);
-        bottom_right.union_max_radii(other.bottom_right);
-        bottom_left.union_max_radii(other.bottom_left);
     }
 
     inline void shrink(CSSPixels top, CSSPixels right, CSSPixels bottom, CSSPixels left)


### PR DESCRIPTION
No longer used after we got rid of ClipFrame tree.