### PR TITLE
LibWeb: Return body from `activeElement()` when nothing is focused

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -466,7 +466,7 @@ public:
     HTML::FocusTrigger last_focus_trigger() const { return m_last_focus_trigger; }
     void set_last_focus_trigger(HTML::FocusTrigger trigger) { m_last_focus_trigger = trigger; }
 
-    Element const* active_element() const { return m_active_element.ptr(); }
+    Element const* active_element() const { return m_active_element ? m_active_element.ptr() : body(); }
     void set_active_element(GC::Ptr<Element>);
 
     Element const* target_element() const { return m_target_element.ptr(); }

--- a/Libraries/LibWeb/DOM/DocumentOrShadowRoot.h
+++ b/Libraries/LibWeb/DOM/DocumentOrShadowRoot.h
@@ -24,6 +24,13 @@ GC::Ptr<Element> calculate_active_element(T& self)
     // 1. Let candidate be this's node document's focused area's DOM anchor.
     Node* candidate = self.document().focused_area();
 
+    // AD-HOC: null focused_area indicates "viewport focus".
+    // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+    // If the focusable area is the viewport of a Document that has a non-null browsing context and is not inert then
+    // the DOM anchor is the document for which the viewport was created.
+    if (!candidate && self.document().browsing_context() && !self.document().is_inert())
+        candidate = &self.document();
+
     // 2. Set candidate to the result of retargeting candidate against this.
     candidate = as<Node>(retarget(candidate, &self));
 

--- a/Tests/LibWeb/Text/expected/html/activeElement-body.txt
+++ b/Tests/LibWeb/Text/expected/html/activeElement-body.txt
@@ -1,0 +1,3 @@
+document.activeElement === document.body: true
+document.activeElement is null: false
+document.activeElement tagName: BODY

--- a/Tests/LibWeb/Text/expected/wpt-import/html/interaction/focus/document-level-focus-apis/document-level-apis.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/interaction/focus/document-level-focus-apis/document-level-apis.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 4 tests
+
+3 Pass
+1 Fail
+Pass	The body element must be the active element if no element is focused
+Pass	The element must be the active element if it is focused
+Fail	The hasFocus() method must return false if the Document has no browsing context
+Pass	When a child browsing context is focused, its browsing context container is also focused

--- a/Tests/LibWeb/Text/input/html/activeElement-body.html
+++ b/Tests/LibWeb/Text/input/html/activeElement-body.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<body>
+<script src="../include.js"></script>
+<div id="content">Test content</div>
+<script>
+    test(() => {
+        // When nothing is explicitly focused, activeElement should return the body element
+        println("document.activeElement === document.body: " + (document.activeElement === document.body));
+        println("document.activeElement is null: " + (document.activeElement === null));
+        println("document.activeElement tagName: " + (document.activeElement ? document.activeElement.tagName : "null"));
+    });
+</script>
+</body>

--- a/Tests/LibWeb/Text/input/wpt-import/html/interaction/focus/document-level-focus-apis/document-level-apis.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/interaction/focus/document-level-focus-apis/document-level-apis.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: focus - document-level APIs</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#document-level-focus-apis">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<input id="test">
+<script>
+
+test(function () {
+  assert_equals(document.activeElement, document.body, "The active element should be the body element.");
+}, "The body element must be the active element if no element is focused");
+
+test(function () {
+  document.getElementById("test").focus();
+  assert_equals(document.activeElement, document.getElementById("test"), "The active element should be the input element.");
+}, "The element must be the active element if it is focused");
+
+function frame_load () {
+  test(function () {
+    document.getElementById("fr").contentDocument.getElementById("ipt").focus();
+    assert_equals(document.activeElement, document.getElementById("fr"), "The active element should be the iframe element.");
+  }, "When a child browsing context is focused, its browsing context container is also focused");
+}
+
+test(function () {
+  var doc = document.implementation.createHTMLDocument("test");
+  assert_false(doc.hasFocus(), "The hasFocus() method should return false.");
+}, "The hasFocus() method must return false if the Document has no browsing context");
+
+</script>
+<iframe id="fr" src="support/test.html" onload="frame_load()"></iframe>

--- a/Tests/LibWeb/Text/input/wpt-import/html/interaction/focus/document-level-focus-apis/support/test.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/interaction/focus/document-level-focus-apis/support/test.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: focus - document-level APIs</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<input id="ipt">


### PR DESCRIPTION
This matches the behavior of other browsers.

I encountered this issue on https://bbc.co.uk when attempting to dismiss a cookie banner.

This fixes one (1) subtest in the imported WPT test and fixes 12 timeouts in the WPT `focus/` directory.