### PR TITLE
LibWeb: Remove unused PaintableBox::absolute_paint_rect()

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -186,27 +186,6 @@ CSSPixelRect PaintableBox::absolute_rect() const
     return *m_absolute_rect;
 }
 
-CSSPixelRect PaintableBox::compute_absolute_paint_rect() const
-{
-    // FIXME: This likely incomplete:
-    auto rect = absolute_border_box_rect();
-    if (has_scrollable_overflow()) {
-        auto scrollable_overflow_rect = this->scrollable_overflow_rect().value();
-        if (computed_values().overflow_x() == CSS::Overflow::Visible)
-            rect.unite_horizontally(scrollable_overflow_rect);
-        if (computed_values().overflow_y() == CSS::Overflow::Visible)
-            rect.unite_vertically(scrollable_overflow_rect);
-    }
-    for (auto const& shadow : box_shadow_data()) {
-        if (shadow.placement == ShadowPlacement::Inner)
-            continue;
-        auto inflate = shadow.spread_distance + shadow.blur_radius;
-        auto shadow_rect = rect.inflated(inflate, inflate, inflate, inflate).translated(shadow.offset_x, shadow.offset_y);
-        rect.unite(shadow_rect);
-    }
-    return rect;
-}
-
 CSSPixelRect PaintableBox::absolute_padding_box_rect() const
 {
     auto absolute_rect = this->absolute_rect();
@@ -250,13 +229,6 @@ CSSPixelRect PaintableBox::overflow_clip_edge_rect() const
 {
     // FIXME: Apply overflow-clip-margin-* properties
     return absolute_padding_box_rect();
-}
-
-CSSPixelRect PaintableBox::absolute_paint_rect() const
-{
-    if (!m_absolute_paint_rect.has_value())
-        m_absolute_paint_rect = compute_absolute_paint_rect();
-    return *m_absolute_paint_rect;
 }
 
 template<typename Callable>

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -80,7 +80,6 @@ public:
     CSSPixelRect absolute_padding_box_rect() const;
     CSSPixelRect absolute_border_box_rect() const;
     CSSPixelRect overflow_clip_edge_rect() const;
-    CSSPixelRect absolute_paint_rect() const;
 
     // These united versions of the above rects take continuation into account.
     CSSPixelRect absolute_united_border_box_rect() const;
@@ -267,7 +266,6 @@ protected:
     virtual void paint_inspector_overlay_internal(DisplayListRecordingContext&) const override;
 
     virtual CSSPixelRect compute_absolute_rect() const;
-    virtual CSSPixelRect compute_absolute_paint_rect() const;
 
     struct ScrollbarData {
         CSSPixelRect gutter_rect;
@@ -317,7 +315,6 @@ private:
     CSSPixelSize m_content_size;
 
     Optional<CSSPixelRect> mutable m_absolute_rect;
-    Optional<CSSPixelRect> mutable m_absolute_paint_rect;
 
     RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
     RefPtr<ScrollFrame const> m_own_scroll_frame;


### PR DESCRIPTION
This method was initially introduced to calculate the total paint area including effects like box-shadows that paint outside the border box. It was used in StackingContext for sizing bitmaps when painting elements with opacity or transforms, and later for clip-path bounds.

This functionality is no longer needed as stacking context painting and clip-path handling have been refactored to use different approaches (AccumulatedVisualContext now handles clip-path).