### PR TITLE
LibWeb/Layout: Ensure an element only has one `::backdrop`, as its previous sibling

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -58,7 +58,7 @@ private:
         Prepend,
     };
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
-    void create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, AppendOrPrepend);
+    GC::Ptr<NodeWithStyle> create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
     void restructure_block_node_in_inline_parent(NodeWithStyleAndBoxModelMetrics&);
 
     GC::Ptr<Layout::Node> m_layout_root;

--- a/Tests/LibWeb/Crash/CSS/backdrop-display-none.html
+++ b/Tests/LibWeb/Crash/CSS/backdrop-display-none.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<dialog id="d"><div id="x"></div></dialog>
+<script>
+    d.showModal();
+    document.body.offsetWidth;
+
+    const style = document.createElement('style');
+    style.textContent = "dialog::backdrop { display: none }";
+    document.head.appendChild(style);
+    document.body.offsetWidth;
+
+    x.hidden = true;
+    document.body.offsetWidth;
+    
+    // And now show it again, to ensure that works
+    style.textContent = "";
+    document.body.offsetWidth;
+</script>

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/maintain-single-backdrop-pseudo-element.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/maintain-single-backdrop-pseudo-element.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: inline
+      TextNode <#text> (not painted)
+  BlockContainer <(anonymous)> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <dialog#d> at [299,289] positioned [280+3+16 202 16+3+280] [270+3+16 22 16+3+270] [BFC] children: inline
+    frag 0 from BlockContainer start: 0, length: 0, rect: [300,290 200x20] baseline: 14.796875
+    BlockContainer <input> at [300,290] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
+      Box <div> at [302,291] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+        BlockContainer <div> at [302,291] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 0, rect: [302,291 0x18] baseline: 13.796875
+          TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+  PaintableWithLines (BlockContainer(anonymous)) [0,0 800x600]
+  PaintableWithLines (BlockContainer<DIALOG>#d) [280,270 240x60]
+    PaintableWithLines (BlockContainer<INPUT>) [299,289 202x22]
+      PaintableBox (Box<DIV>) [300,290 200x20]
+        PaintableWithLines (BlockContainer<DIV>) [302,291 196x18]
+          TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 3] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)
+ SC for BlockContainer(anonymous) [0,0 800x600] [children: 0] (z-index: auto)
+ SC for BlockContainer<DIALOG>#d [299,289 202x22] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/layout-tree-update/maintain-single-backdrop-pseudo-element.html
+++ b/Tests/LibWeb/Layout/input/layout-tree-update/maintain-single-backdrop-pseudo-element.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+dialog::backdrop {
+ background: rgba(0,0,0,0.5)
+}
+</style><dialog id="d"><input><div id="x"></div></dialog><script>
+    d.showModal();
+    
+    for (let i = 0; i < 5; ++i) {
+        x.hidden = !x.hidden;
+        document.body.offsetWidth; // force layout
+    }
+</script>


### PR DESCRIPTION
Fixes #7486.

Details in commits. tl;dr: We kept creating a new layout node for `::backdrop` when layout updated, without removing the old one; and the new one was always appended, so if the originating element (eg `<dialog>`) had a partial layout update and wasn't appended too, the new `::backdrop` would go in front of it.