### PR TITLE
LibGfx+LibWeb: Fall back to system fonts for missing glyphs

### DIFF
--- a/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Libraries/LibGfx/Font/FontDatabase.h
@@ -8,11 +8,28 @@
 
 #include <AK/FlyString.h>
 #include <AK/Function.h>
+#include <AK/HashFunctions.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Forward.h>
 
 namespace Gfx {
+
+struct CodePointFallbackKey {
+    u32 code_point { 0 };
+    u16 weight { 0 };
+    u16 width { 0 };
+    u8 slope { 0 };
+
+    bool operator==(CodePointFallbackKey const&) const = default;
+
+    unsigned hash() const
+    {
+        return pair_int_hash(
+            pair_int_hash(code_point, weight),
+            pair_int_hash(width, slope));
+    }
+};
 
 class SystemFontProvider {
 public:
@@ -29,6 +46,7 @@ public:
     SystemFontProvider& install_system_font_provider(NonnullOwnPtr<SystemFontProvider>);
 
     RefPtr<Gfx::Font> get(FlyString const& family, float point_size, unsigned weight, unsigned width, unsigned slope);
+    RefPtr<Gfx::Font> get_font_for_code_point(u32 code_point, float point_size, u16 weight, u16 width, u8 slope);
     void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>);
     [[nodiscard]] StringView system_font_provider_name() const;
 
@@ -39,6 +57,20 @@ private:
     ~FontDatabase() = default;
 
     OwnPtr<SystemFontProvider> m_system_font_provider;
+
+    struct CodePointFallbackEntry {
+        FlyString family_name;
+        RefPtr<Typeface const> typeface;
+    };
+    HashMap<CodePointFallbackKey, CodePointFallbackEntry> m_code_point_fallback_cache;
 };
 
 }
+
+template<>
+struct AK::Traits<Gfx::CodePointFallbackKey> : public AK::DefaultTraits<Gfx::CodePointFallbackKey> {
+    static unsigned hash(Gfx::CodePointFallbackKey const& key)
+    {
+        return key.hash();
+    }
+};

--- a/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Font/FontData.h>
 #include <LibGfx/Font/Typeface.h>
 
 namespace Gfx {
@@ -15,6 +16,8 @@ class TypefaceSkia : public Gfx::Typeface {
 
 public:
     static ErrorOr<NonnullRefPtr<TypefaceSkia>> load_from_buffer(ReadonlyBytes, int index = 0);
+    static ErrorOr<RefPtr<TypefaceSkia>> find_typeface_for_code_point(u32 code_point, u16 weight, u16 width, u8 slope);
+
     RefPtr<TypefaceSkia const> clone_with_variations(Vector<FontVariationAxis> const& axes) const;
 
     virtual u32 glyph_count() const override;
@@ -39,6 +42,7 @@ private:
 
     virtual bool is_skia() const override { return true; }
 
+    OwnPtr<FontData> m_font_data;
     ReadonlyBytes m_buffer;
     unsigned m_ttc_index { 0 };
 

--- a/Libraries/LibGfx/FontCascadeList.cpp
+++ b/Libraries/LibGfx/FontCascadeList.cpp
@@ -53,6 +53,14 @@ Gfx::Font const& FontCascadeList::font_for_code_point(u32 code_point) const
             return entry.font;
         }
     }
+
+    if (m_system_font_fallback_callback) {
+        if (auto fallback = m_system_font_fallback_callback(code_point, first())) {
+            m_fonts.append({ fallback.release_nonnull(), {} });
+            return *m_fonts.last().font;
+        }
+    }
+
     return *m_last_resort_font;
 }
 

--- a/Libraries/LibGfx/FontCascadeList.h
+++ b/Libraries/LibGfx/FontCascadeList.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/UnicodeRange.h>
 
@@ -13,6 +14,8 @@ namespace Gfx {
 
 class FontCascadeList : public RefCounted<FontCascadeList> {
 public:
+    using SystemFontFallbackCallback = Function<RefPtr<Font const>(u32, Font const&)>;
+
     static NonnullRefPtr<FontCascadeList> create()
     {
         return adopt_ref(*new FontCascadeList());
@@ -50,6 +53,7 @@ public:
     };
 
     void set_last_resort_font(NonnullRefPtr<Font> font) { m_last_resort_font = move(font); }
+    void set_system_font_fallback_callback(SystemFontFallbackCallback callback) { m_system_font_fallback_callback = move(callback); }
 
     Font const& first_text_face() const
     {
@@ -61,7 +65,8 @@ public:
 
 private:
     RefPtr<Font const> m_last_resort_font;
-    Vector<Entry> m_fonts;
+    mutable Vector<Entry> m_fonts;
+    SystemFontFallbackCallback m_system_font_fallback_callback;
 };
 
 }

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -505,6 +505,17 @@ NonnullRefPtr<Gfx::FontCascadeList const> FontComputer::compute_font_for_style_v
     // the requested code point, there is still a font available to provide a fallback glyph.
     font_list->set_last_resort_font(*default_font);
 
+    if (!Platform::FontPlugin::the().is_layout_test_mode()) {
+        font_list->set_system_font_fallback_callback([](u32 code_point, Gfx::Font const& reference_font) -> RefPtr<Gfx::Font const> {
+            return Gfx::FontDatabase::the().get_font_for_code_point(
+                code_point,
+                reference_font.point_size(),
+                reference_font.weight(),
+                reference_font.typeface().width(),
+                reference_font.slope());
+        });
+    }
+
     return font_list;
 }
 

--- a/Libraries/LibWeb/Platform/FontPlugin.h
+++ b/Libraries/LibWeb/Platform/FontPlugin.h
@@ -37,6 +37,8 @@ public:
 
     virtual FlyString generic_font_name(GenericFont) = 0;
     virtual Vector<FlyString> symbol_font_names() = 0;
+
+    virtual bool is_layout_test_mode() const = 0;
 };
 
 }

--- a/Libraries/LibWebView/Plugins/FontPlugin.h
+++ b/Libraries/LibWebView/Plugins/FontPlugin.h
@@ -23,6 +23,7 @@ public:
     virtual Gfx::Font& default_fixed_width_font() override;
     virtual FlyString generic_font_name(Web::Platform::GenericFont) override;
     virtual Vector<FlyString> symbol_font_names() override;
+    virtual bool is_layout_test_mode() const override { return m_is_layout_test_mode; }
 
     void update_generic_fonts();
 


### PR DESCRIPTION
When rendering text, if none of the fonts in the cascade list contain a glyph for a given code point, we now query Skia's font manager to find a system font that can render it.

The upside of using Skia here is that it works on both Linux and MacOS.

I haven't included any tests in the test suite for this. Testing is difficult because test mode deliberately retains its old behavior to maximize compatibility across platforms.


Previously, lots of non-Latin text would fail to render. Here's a before and after of [this test page](https://htmlpreview.github.io/?https://gist.githubusercontent.com/tcl3/9ac242fced0f35f42d3cbd19a9f9e84b/raw/test-rendering-test.html):

Before:
<img width="981" height="1365" alt="image" src="https://github.com/user-attachments/assets/55229049-a786-4a00-a9fb-7b9d1adf5018" />


After:
<img width="984" height="1251" alt="image" src="https://github.com/user-attachments/assets/12358cc9-4ff9-49d3-9c78-d80943b2cac1" />

Closes #91
Fixes: #2332