### PR TITLE
Meta/IDLGenerators: Clean up is_platform_object()

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -112,7 +112,6 @@ static bool is_platform_object(Type const& type)
         "PerformanceMark"sv,
         "PerformanceNavigation"sv,
         "PeriodicWave"sv,
-        "PointerEvent"sv,
         "ReadableStreamBYOBReader"sv,
         "ReadableStreamDefaultReader"sv,
         "RadioNodeList"sv,
@@ -122,7 +121,6 @@ static bool is_platform_object(Type const& type)
         "Selection"sv,
         "ServiceWorkerContainer"sv,
         "ServiceWorkerRegistration"sv,
-        "SVGAnimationElement"sv,
         "SVGLength"sv,
         "SVGNumber"sv,
         "SVGTransform"sv,
@@ -245,7 +243,7 @@ static ByteString union_type_to_variant(UnionType const& union_type, Interface c
 
 CppType idl_type_name_to_cpp_type(Type const& type, Interface const& interface)
 {
-    if (is_platform_object(type) || type.name() == "WindowProxy"sv)
+    if (is_platform_object(type))
         return { .name = ByteString::formatted("GC::Root<{}>", type.name()), .sequence_storage_type = SequenceStorageType::RootVector };
 
     if (is_javascript_builtin(type))


### PR DESCRIPTION
Any type ending in "Event" or "Element" does not need to be added to the manually curated list of platform objects in is_platform_object(). Additionally, "WindowProxy" was already part of that list, so no need to check for it separately. No functional changes.