### PR TITLE
LibWeb: Paint element outlines during Foreground paint phase

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -196,9 +196,9 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
         case StackingContextPaintPhase::Foreground:
             paint_node(child, context, PaintPhase::Foreground);
             paint_descendants(context, child, phase);
+            paint_node(child, context, PaintPhase::Outline);
             break;
         case StackingContextPaintPhase::FocusAndOverlay:
-            paint_node(child, context, PaintPhase::Outline);
             paint_node(child, context, PaintPhase::Overlay);
             paint_descendants(context, child, phase);
             break;

--- a/Tests/LibWeb/Ref/expected/outline-stacking-order-ref.html
+++ b/Tests/LibWeb/Ref/expected/outline-stacking-order-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    .overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 80px;
+        height: 80px;
+        background: red;
+    }
+</style>
+<div class="overlay"></div>

--- a/Tests/LibWeb/Ref/input/outline-stacking-order.html
+++ b/Tests/LibWeb/Ref/input/outline-stacking-order.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/outline-stacking-order-ref.html">
+<style>
+    .outlined {
+        margin: 10px;
+        width: 50px;
+        height: 50px;
+        background: blue;
+        outline: 10px solid lime;
+    }
+
+    .overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 80px;
+        height: 80px;
+        background: red;
+        z-index: 1;
+    }
+</style>
+<div class="outlined"></div>
+<div class="overlay"></div>


### PR DESCRIPTION
Previously, outlines for elements without their own stacking context were painted during the `FocusAndOverlay` phase, which runs after all child stacking contexts. This caused outlines to incorrectly appear on top of elements with higher z-index.

Fixes: #7105