### PR TITLE
test-web: Add an explicit verbosity mode to disable live display

### DIFF
--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -101,12 +101,7 @@ ErrorOr<void> Application::launch_test_fixtures()
 
 bool Application::should_capture_web_content_output() const
 {
-    // Capture when results_directory is set OR when stdout is a TTY (to suppress spam during live display)
-    if (!results_directory.is_empty())
-        return true;
-
-    auto is_tty = Core::System::isatty(STDOUT_FILENO);
-    return !is_tty.is_error() && is_tty.value();
+    return verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT;
 }
 
 }

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -25,12 +25,13 @@ public:
     virtual bool should_capture_web_content_output() const override;
     ErrorOr<void> launch_test_fixtures();
 
-    static constexpr u8 VERBOSITY_LEVEL_LOG_TEST_DURATION = 1;
-    static constexpr u8 VERBOSITY_LEVEL_LOG_SLOWEST_TESTS = 2;
-    static constexpr u8 VERBOSITY_LEVEL_LOG_SKIPPED_TESTS = 3;
+    static constexpr u8 VERBOSITY_LEVEL_LOG_TEST_OUTPUT = 1;
+    static constexpr u8 VERBOSITY_LEVEL_LOG_TEST_DURATION = 2;
+    static constexpr u8 VERBOSITY_LEVEL_LOG_SLOWEST_TESTS = 3;
+    static constexpr u8 VERBOSITY_LEVEL_LOG_SKIPPED_TESTS = 4;
 
     ByteString test_root_path;
-    ByteString results_directory;
+    ByteString results_directory { "test-dumps/results"sv };
     size_t test_concurrency { 1 };
     Vector<ByteString> test_globs;
 

--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -29,7 +29,7 @@ if (BUILD_TESTING)
 
     add_test(
         NAME LibWeb
-        COMMAND $<TARGET_FILE:test-web> --python-executable ${Python3_EXECUTABLE} --dump-failed-ref-tests --per-test-timeout 120 --verbose
+        COMMAND $<TARGET_FILE:test-web> --python-executable ${Python3_EXECUTABLE} --dump-failed-ref-tests --per-test-timeout 120 -v -v
     )
 
     set_tests_properties(LibWeb PROPERTIES


### PR DESCRIPTION
We were previously using the absence of a results directory to decide if we should disable live display. However, this was never the case - the results directory would become unconditionally set in main(). This caused all test-web output in CI to become hidden.

Instead, let's add a verbosity mode to display test output explicitly. This is set for CI.

This also makes it much easier to debug single tests locally. The live capture and results file combo is a bit overkill for running a single test; we can now just add "-v" to the command line to see the output directly in the terminal.