### PR TITLE
LibWeb/XPath: Register and attach namespaces for elements if needed

### DIFF
--- a/Libraries/LibWeb/XPath/XPath.cpp
+++ b/Libraries/LibWeb/XPath/XPath.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/DOM/NodeType.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/Namespace.h>
 #include <LibWeb/WebIDL/DOMException.h>
 
 #include <libxml/parser.h>
@@ -23,12 +24,13 @@
 #include <libxml/valid.h>
 #include <libxml/xmlstring.h>
 #include <libxml/xpath.h>
+#include <libxml/xpathInternals.h>
 
 #include "XPath.h"
 
 namespace Web::XPath {
 
-static xmlNodePtr mirror_node(xmlDocPtr doc, DOM::Node const& node)
+static xmlNodePtr mirror_node(xmlDocPtr doc, DOM::Node const& node, bool preserve_html_namespace)
 {
     switch (node.type()) {
     case DOM::NodeType::INVALID: {
@@ -37,22 +39,72 @@ static xmlNodePtr mirror_node(xmlDocPtr doc, DOM::Node const& node)
     case DOM::NodeType::ELEMENT_NODE: {
         auto const& element = static_cast<DOM::Element const&>(node);
         ByteString name = element.local_name().bytes_as_string_view();
+
         auto* xml_element = xmlNewDocNode(doc, nullptr, bit_cast<xmlChar const*>(name.characters()), nullptr);
         xml_element->_private = bit_cast<void*>(&node);
+
+        if (auto ns_uri = element.namespace_uri(); ns_uri.has_value() && !ns_uri->is_empty()) {
+            bool is_html_namespace = ns_uri == Namespace::HTML;
+            bool should_preserve = !is_html_namespace || preserve_html_namespace;
+
+            if (should_preserve) {
+                ByteString ns_uri_sv = ns_uri->bytes_as_string_view();
+                xmlChar const* prefix = nullptr;
+
+                if (auto const& opt_prefix = element.prefix(); opt_prefix.has_value() && !opt_prefix->is_empty()) {
+                    ByteString prefix_sv = opt_prefix->bytes_as_string_view();
+                    prefix = bit_cast<xmlChar const*>(prefix_sv.characters());
+                }
+
+                auto* ns = xmlNewNs(xml_element, bit_cast<xmlChar const*>(ns_uri_sv.characters()), prefix);
+                xmlSetNs(xml_element, ns);
+            }
+        }
+
         for (size_t i = 0; i < element.attribute_list_size(); ++i) {
             auto const& attribute = *element.attributes()->item(i);
-            ByteString attr_name = attribute.name().bytes_as_string_view();
-            ByteString attr_value = attribute.value().bytes_as_string_view();
-            auto* attr = xmlSetProp(xml_element, bit_cast<xmlChar const*>(attr_name.characters()), bit_cast<xmlChar const*>(attr_value.characters()));
+            ByteString attr_name_sv = attribute.local_name().bytes_as_string_view();
+            auto* attr_name_xml = bit_cast<xmlChar const*>(attr_name_sv.characters());
+            ByteString attr_value_sv = attribute.value().bytes_as_string_view();
+            auto* attr_value_xml = bit_cast<xmlChar const*>(attr_value_sv.characters());
+            xmlAttrPtr attr = nullptr;
+
+            if (auto attr_ns_uri = attribute.namespace_uri(); attr_ns_uri.has_value() && !attr_ns_uri->is_empty()) {
+                bool is_html_namespace = attr_ns_uri == Namespace::HTML;
+                bool should_preserve = !is_html_namespace || preserve_html_namespace;
+
+                if (should_preserve) {
+                    ByteString attr_ns_uri_sv = attr_ns_uri->bytes_as_string_view();
+                    auto* attr_ns_uri_xml = bit_cast<xmlChar const*>(attr_ns_uri_sv.characters());
+                    ByteString attr_prefix_bytes;
+                    xmlChar const* attr_prefix = nullptr;
+
+                    if (attribute.prefix().has_value() && !attribute.prefix()->is_empty()) {
+                        attr_prefix_bytes = attribute.prefix()->bytes_as_string_view();
+                        attr_prefix = bit_cast<xmlChar const*>(attr_prefix_bytes.characters());
+                    }
+
+                    auto* ns = xmlSearchNsByHref(doc, xml_element, attr_ns_uri_xml);
+                    if (!ns) {
+                        ns = xmlNewNs(xml_element, attr_ns_uri_xml, attr_prefix);
+                    }
+                    attr = xmlNewNsProp(xml_element, ns, attr_name_xml, attr_value_xml);
+                } else {
+                    attr = xmlSetProp(xml_element, attr_name_xml, attr_value_xml);
+                }
+            } else {
+                attr = xmlSetProp(xml_element, attr_name_xml, attr_value_xml);
+            }
+
             attr->_private = bit_cast<void*>(&attribute);
 
             if (attribute.name() == "id") {
-                xmlAddIDSafe(attr, bit_cast<xmlChar const*>(attr_value.characters()));
+                xmlAddIDSafe(attr, attr_value_xml);
             }
         }
         auto children = element.children_as_vector();
         for (auto& child : children) {
-            xmlAddChild(xml_element, mirror_node(doc, *child));
+            xmlAddChild(xml_element, mirror_node(doc, *child, preserve_html_namespace));
         }
 
         return xml_element;
@@ -92,7 +144,7 @@ static xmlNodePtr mirror_node(xmlDocPtr doc, DOM::Node const& node)
     }
     case DOM::NodeType::DOCUMENT_NODE: {
         auto const& document = static_cast<DOM::Document const&>(node);
-        return mirror_node(doc, *document.document_element());
+        return mirror_node(doc, *document.document_element(), preserve_html_namespace);
     }
     case DOM::NodeType::DOCUMENT_TYPE_NODE: {
         return nullptr; // Unused in libxml2
@@ -103,7 +155,7 @@ static xmlNodePtr mirror_node(xmlDocPtr doc, DOM::Node const& node)
         xml_fragment->_private = bit_cast<void*>(&node);
         auto children = fragment.children_as_vector();
         for (auto& child : children) {
-            xmlAddChild(xml_fragment, mirror_node(doc, *child));
+            xmlAddChild(xml_fragment, mirror_node(doc, *child, preserve_html_namespace));
         }
         return xml_fragment;
     }
@@ -182,7 +234,9 @@ WebIDL::ExceptionOr<GC::Ref<XPathResult>> evaluate(JS::Realm& realm, String cons
         xml_document->_private = bit_cast<void*>(&context_node.document());
     }
 
-    auto* xml_node = mirror_node(xml_document, context_node);
+    bool preserve_html_namespace = bytes.contains("html:"sv);
+
+    auto* xml_node = mirror_node(xml_document, context_node, preserve_html_namespace);
     if (!xml_node) {
         return WebIDL::OperationError::create(realm, "XPath evaluation failed"_utf16);
     }
@@ -191,6 +245,23 @@ WebIDL::ExceptionOr<GC::Ref<XPathResult>> evaluate(JS::Realm& realm, String cons
 
     auto* xpath_context = xmlXPathNewContext(xml_document);
     xmlXPathSetContextNode(xml_node, xpath_context);
+
+    auto register_prefix = [&](auto prefix, auto uri) {
+        xmlXPathRegisterNs(
+            xpath_context,
+            bit_cast<xmlChar const*>(prefix),
+            bit_cast<xmlChar const*>(ByteString(uri.bytes_as_string_view()).characters()));
+    };
+
+    register_prefix("mathml", Namespace::MathML);
+    register_prefix("xlink", Namespace::XLink);
+    register_prefix("svg", Namespace::SVG);
+    register_prefix("xmlns", Namespace::XMLNS);
+    register_prefix("xml", Namespace::XML);
+
+    if (preserve_html_namespace) {
+        register_prefix("html", Namespace::HTML);
+    }
 
     auto* xpath_result = xmlXPathCompiledEval(xpath_compiled, xpath_context);
 

--- a/Tests/LibWeb/Text/expected/wpt-import/domxpath/text-html-attributes.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domxpath/text-html-attributes.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 15 tests
 
-10 Pass
-5 Fail
+11 Pass
+4 Fail
 Pass	Select html element based on attribute
 Fail	Select html element based on attribute mixed case
 Pass	Select both HTML and SVG elements based on attribute
@@ -18,4 +18,4 @@ Pass	Select SVG elements with refX attribute lowercase
 Pass	Select SVG element with non-ascii attribute 1
 Pass	Select SVG element with non-ascii attribute 2
 Fail	xmlns attribute
-Fail	svg element with XLink attribute
+Pass	svg element with XLink attribute

--- a/Tests/LibWeb/Text/expected/wpt-import/domxpath/text-html-elements.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domxpath/text-html-elements.txt
@@ -2,13 +2,13 @@ Harness status: OK
 
 Found 11 tests
 
-4 Pass
-7 Fail
+7 Pass
+4 Fail
 Pass	HTML elements no namespace prefix
-Fail	HTML elements namespace prefix
+Pass	HTML elements namespace prefix
 Fail	HTML elements mixed use of prefix
-Fail	SVG elements no namespace prefix
-Fail	SVG elements namespace prefix
+Pass	SVG elements no namespace prefix
+Pass	SVG elements namespace prefix
 Fail	HTML elements mixed case
 Pass	SVG elements mixed case selector
 Pass	Non-ascii HTML element


### PR DESCRIPTION
# How

Register and attach all pre-defined namespaces for elements. Preserve HTML namespace optionally based on input expression, since both `//div` and `//html:div` XPaths should work according to WPT tests (unfortunately I was not able to find this information in XPath spec).

# Test plan

* http://wpt.live/domxpath/text-html-attributes.html [10 -> 11 passes]
    * Fixed: "svg element with XLink attribute"
*  https://wpt.live/domxpath/text-html-elements.html [4 -> 7 passes]
    * Fixed: "HTML elements namespace prefix"
    * Fixed: "SVG elements no namespace prefix"
    * Fixed: "SVG elements namespace prefix"