### PR TITLE
Everywhere: Speculatively remove .clangd from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ Toolchain/Local
 compile_commands.json
 .cache
 .clang_complete
-.clangd
 .idea/
 cmake-build-debug/
 output/


### PR DESCRIPTION
It's confusing that it's in both the repo and .gitignore.

If this is intentional (to allow git --ignore-index shenanigans), I'm happy to learn about it