### PR TITLE
LibWeb: Paint element overlay during Foreground paint phase

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -90,8 +90,6 @@ static PaintPhase to_paint_phase(StackingContext::StackingContextPaintPhase phas
         return PaintPhase::Background;
     case StackingContext::StackingContextPaintPhase::Foreground:
         return PaintPhase::Foreground;
-    case StackingContext::StackingContextPaintPhase::FocusAndOverlay:
-        return PaintPhase::Overlay;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -113,7 +111,6 @@ void StackingContext::paint_node_as_stacking_context(Paintable const& paintable,
     paint_descendants(context, paintable, StackingContextPaintPhase::Foreground);
     paint_node(paintable, context, PaintPhase::Outline);
     paint_node(paintable, context, PaintPhase::Overlay);
-    paint_descendants(context, paintable, StackingContextPaintPhase::FocusAndOverlay);
 }
 
 void StackingContext::paint_svg(DisplayListRecordingContext& context, PaintableBox const& paintable, PaintPhase phase)
@@ -196,10 +193,7 @@ void StackingContext::paint_descendants(DisplayListRecordingContext& context, Pa
             paint_node(child, context, PaintPhase::Foreground);
             paint_descendants(context, child, phase);
             paint_node(child, context, PaintPhase::Outline);
-            break;
-        case StackingContextPaintPhase::FocusAndOverlay:
             paint_node(child, context, PaintPhase::Overlay);
-            paint_descendants(context, child, phase);
             break;
         }
 
@@ -227,7 +221,6 @@ void StackingContext::paint_internal(DisplayListRecordingContext& context) const
         paint_node(svg_svg_paintable, context, PaintPhase::Outline);
         if (context.should_paint_overlay()) {
             paint_node(svg_svg_paintable, context, PaintPhase::Overlay);
-            paint_descendants(context, svg_svg_paintable, StackingContextPaintPhase::FocusAndOverlay);
         }
         return;
     }
@@ -284,7 +277,6 @@ void StackingContext::paint_internal(DisplayListRecordingContext& context) const
 
     if (context.should_paint_overlay()) {
         paint_node(paintable_box(), context, PaintPhase::Overlay);
-        paint_descendants(context, paintable_box(), StackingContextPaintPhase::FocusAndOverlay);
     }
 }
 

--- a/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Libraries/LibWeb/Painting/StackingContext.h
@@ -31,7 +31,6 @@ public:
         Floats,
         BackgroundAndBordersForInlineLevelAndReplaced,
         Foreground,
-        FocusAndOverlay,
     };
 
     static void paint_node_as_stacking_context(Paintable const&, DisplayListRecordingContext&);

--- a/Tests/LibWeb/Ref/expected/resize-stacking-order-ref.html
+++ b/Tests/LibWeb/Ref/expected/resize-stacking-order-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    .overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 80px;
+        height: 80px;
+        background: red;
+    }
+</style>
+<div class="overlay"></div>

--- a/Tests/LibWeb/Ref/input/resize-stacking-order.html
+++ b/Tests/LibWeb/Ref/input/resize-stacking-order.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/resize-stacking-order-ref.html" />
+<style>
+    .resizable {
+        margin: 10px;
+        width: 50px;
+        height: 50px;
+        background: blue;
+    }
+
+    .overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 80px;
+        height: 80px;
+        background: red;
+        z-index: 1;
+    }
+</style>
+<textarea class="resizable"></textarea>
+<div class="overlay"></div>

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -12,5 +12,7 @@ SaveLayer@0
   FillPath@3 path_bounding_rect=[10,10 302x102]
   FillRect@5 rect=[11,11 400x80] color=rgb(240, 128, 128)
   DrawGlyphRun@5 rect=[11,11 178x18] translation=[11,24.796875] color=rgb(0, 0, 0) scale=1
+  PaintScrollBar@3
+  PaintScrollBar@1
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -9,5 +9,7 @@ SaveLayer@0
   FillPath@0 path_bounding_rect=[32,32 182x102]
   FillRect@3 rect=[33,33 300x200] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[33,33 179x18] translation=[33,46.796875] color=rgb(0, 0, 0) scale=1
+  PaintScrollBar@0
+  PaintScrollBar@0
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -17,7 +17,13 @@ SaveLayer@0
   FillPath@0 path_bounding_rect=[229,22 93x152]
   FillRect@7 rect=[230,23 200x300] color=rgb(173, 216, 230)
   DrawGlyphRun@3 rect=[23,23 71x18] translation=[23,36.796875] color=rgb(0, 0, 0) scale=1
+  PaintScrollBar@0
+  PaintScrollBar@0
   DrawGlyphRun@5 rect=[126,23 66x18] translation=[126.328125,36.796875] color=rgb(0, 0, 0) scale=1
+  PaintScrollBar@0
+  PaintScrollBar@0
   DrawGlyphRun@7 rect=[229,23 67x18] translation=[229.65625,36.796875] color=rgb(0, 0, 0) scale=1
+  PaintScrollBar@0
+  PaintScrollBar@0
 Restore@0
 


### PR DESCRIPTION
Textarea resize handles and scrollbars were being painted above high-z-index siblings.
Also removed the FocusAndOverlay phase because I believe it is now useless, please correct me if I am wrong.

Before:
<img width="160" height="133" alt="image" src="https://github.com/user-attachments/assets/30208f95-6547-4c88-92e4-3f543fb77c62" />
After:
<img width="165" height="134" alt="image" src="https://github.com/user-attachments/assets/c15f1735-49fe-40df-a90d-5cb15f5329b0" />
