### PR TITLE
Tests/LibWeb: Only report fuzzy mismatches if we expect a match

### DIFF
--- a/Tests/LibWeb/test-web/Fuzzy.h
+++ b/Tests/LibWeb/test-web/Fuzzy.h
@@ -28,7 +28,8 @@ struct FuzzyMatch {
     FuzzyRange pixel_error_count;
 };
 
-bool fuzzy_screenshot_match(URL::URL const& test_url, URL::URL const& reference, Gfx::Bitmap const&, Gfx::Bitmap const&, Vector<FuzzyMatch> const&);
+bool fuzzy_screenshot_match(URL::URL const& test_url, URL::URL const& reference, Gfx::Bitmap const&,
+    Gfx::Bitmap const&, ReadonlySpan<FuzzyMatch>, bool should_match);
 ErrorOr<FuzzyMatch> parse_fuzzy_match(Optional<URL::URL const&> reference, String const&);
 ErrorOr<FuzzyRange> parse_fuzzy_range(String const&);
 

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -839,8 +839,8 @@ static void run_ref_test(TestWebView& view, TestRunContext& context, Test& test,
         auto& test = context.tests[test_index];
         VERIFY(test.ref_test_expectation_type.has_value());
         auto should_match = test.ref_test_expectation_type == RefTestExpectationType::Match;
-        auto screenshot_matches = fuzzy_screenshot_match(
-            url, view.url(), *test.actual_screenshot, *test.expectation_screenshot, test.fuzzy_matches);
+        auto screenshot_matches = fuzzy_screenshot_match(url, view.url(), *test.actual_screenshot,
+            *test.expectation_screenshot, test.fuzzy_matches, should_match);
         if (should_match == screenshot_matches)
             return TestResult::Pass;
 


### PR DESCRIPTION
Reduces the fuzzy matching noise `test-web` produces.