### PR TITLE
LibWeb: Don't disentangle remote port when closing MessagePort

### DIFF
--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -151,13 +151,9 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_receiving_steps(HTML::TransferDa
 
 void MessagePort::disentangle()
 {
-    if (auto remote_port = m_remote_port) {
-        // Set the pointers to null before disentangling the remote port to prevent infinite recursion here.
+    if (m_remote_port) {
         m_remote_port->m_remote_port = nullptr;
         m_remote_port = nullptr;
-
-        if (remote_port)
-            remote_port->disentangle();
     }
 
     if (m_transport) {

--- a/Tests/LibWeb/Text/expected/HTML/message-port-still-delivers-message-even-when-its-immediately-closed.txt
+++ b/Tests/LibWeb/Text/expected/HTML/message-port-still-delivers-message-even-when-its-immediately-closed.txt
@@ -1,0 +1,1 @@
+Port 1 received message: Hello world!

--- a/Tests/LibWeb/Text/input/HTML/message-port-still-delivers-message-even-when-its-immediately-closed.html
+++ b/Tests/LibWeb/Text/input/HTML/message-port-still-delivers-message-even-when-its-immediately-closed.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        const messageChannel = new MessageChannel();
+        messageChannel.port1.onmessage = (event) => {
+            println(`Port 1 received message: ${event.data}`);
+            done();
+        };
+        messageChannel.port2.postMessage("Hello world!");
+        messageChannel.port2.close();
+    });
+</script>


### PR DESCRIPTION
Otherwise, the remote port will lose its transport and not receive
queued messages. The remote port will automatically close anyway when
EOF is received on the socket.

This allows https://www.tripadvisor.com/ to load, where it instantiates
a module by creating a MessageChannel, setting port1's onmessage to the
module's instantiation function, posting an undefined message on port2
and then immediately closing port2.