### PR TITLE
LibCrypto: Add ChaCha20-Poly1305 support

### DIFF
--- a/Libraries/LibCrypto/CMakeLists.txt
+++ b/Libraries/LibCrypto/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     BigInt/UnsignedBigInteger.cpp
     Certificate/Certificate.cpp
     Cipher/AES.cpp
+    Cipher/ChaCha.cpp
     Curves/EdwardsCurve.cpp
     Curves/SECPxxxr1.cpp
     Hash/Argon2.cpp

--- a/Libraries/LibCrypto/Cipher/ChaCha.cpp
+++ b/Libraries/LibCrypto/Cipher/ChaCha.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, mikiubo <michele.uboldi@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCrypto/Cipher/ChaCha.h>
+#include <LibCrypto/OpenSSL.h>
+
+#include <openssl/evp.h>
+
+namespace Crypto::Cipher {
+
+static EVP_CIPHER const* chacha20_poly1305_cipher()
+{
+    return EVP_chacha20_poly1305();
+}
+
+ErrorOr<ByteBuffer> ChaCha20Poly1305::encrypt(ReadonlyBytes key, ReadonlyBytes nonce, ReadonlyBytes plaintext, ReadonlyBytes aad)
+{
+    if (key.size() != key_size)
+        return Error::from_string_literal("ChaCha20-Poly1305 key must be 32 bytes");
+
+    if (nonce.size() != nonce_size)
+        return Error::from_string_literal("ChaCha20-Poly1305 nonce must be 12 bytes");
+
+    auto ctx = TRY(OpenSSL_CIPHER_CTX::create());
+
+    OPENSSL_TRY(EVP_EncryptInit_ex(ctx.ptr(), chacha20_poly1305_cipher(), nullptr, nullptr, nullptr));
+
+    OPENSSL_TRY(EVP_CIPHER_CTX_ctrl(ctx.ptr(), EVP_CTRL_AEAD_SET_IVLEN, nonce.size(), nullptr));
+
+    OPENSSL_TRY(EVP_EncryptInit_ex(ctx.ptr(), nullptr, nullptr, key.data(), nonce.data()));
+
+    if (!aad.is_empty()) {
+        int aad_len = 0;
+        OPENSSL_TRY(EVP_EncryptUpdate(ctx.ptr(), nullptr, &aad_len, aad.data(), aad.size()));
+    }
+
+    auto ciphertext = TRY(ByteBuffer::create_uninitialized(plaintext.size()));
+    int out_len = 0;
+
+    OPENSSL_TRY(EVP_EncryptUpdate(ctx.ptr(), ciphertext.data(), &out_len, plaintext.data(), plaintext.size()));
+
+    int final_len = 0;
+    OPENSSL_TRY(EVP_EncryptFinal_ex(ctx.ptr(), ciphertext.data() + out_len, &final_len));
+
+    auto tag = TRY(ByteBuffer::create_uninitialized(tag_size));
+    OPENSSL_TRY(EVP_CIPHER_CTX_ctrl(ctx.ptr(), EVP_CTRL_AEAD_GET_TAG, tag_size, tag.data()));
+
+    auto result = TRY(ByteBuffer::create_uninitialized(ciphertext.size() + tag_size));
+    result.overwrite(0, ciphertext.data(), ciphertext.size());
+    result.overwrite(ciphertext.size(), tag.data(), tag.size());
+
+    return result;
+}
+
+ErrorOr<ByteBuffer> ChaCha20Poly1305::decrypt(ReadonlyBytes key, ReadonlyBytes nonce, ReadonlyBytes ciphertext_and_tag, ReadonlyBytes aad)
+{
+    if (key.size() != key_size)
+        return Error::from_string_literal("ChaCha20-Poly1305 key must be 32 bytes");
+
+    if (nonce.size() != nonce_size)
+        return Error::from_string_literal("ChaCha20-Poly1305 nonce must be 12 bytes");
+
+    if (ciphertext_and_tag.size() < tag_size)
+        return Error::from_string_literal("Ciphertext too short");
+
+    auto ciphertext_size = ciphertext_and_tag.size() - tag_size;
+    auto ciphertext = ciphertext_and_tag.slice(0, ciphertext_size);
+    auto tag = ciphertext_and_tag.slice(ciphertext_size, tag_size);
+
+    auto ctx = TRY(OpenSSL_CIPHER_CTX::create());
+
+    OPENSSL_TRY(EVP_DecryptInit_ex(ctx.ptr(), chacha20_poly1305_cipher(), nullptr, nullptr, nullptr));
+
+    OPENSSL_TRY(EVP_CIPHER_CTX_ctrl(ctx.ptr(), EVP_CTRL_AEAD_SET_IVLEN, nonce.size(), nullptr));
+
+    OPENSSL_TRY(EVP_DecryptInit_ex(ctx.ptr(), nullptr, nullptr, key.data(), nonce.data()));
+
+    OPENSSL_TRY(EVP_CIPHER_CTX_ctrl(ctx.ptr(), EVP_CTRL_AEAD_SET_TAG, tag.size(), const_cast<u8*>(tag.data())));
+
+    if (!aad.is_empty()) {
+        int aad_len = 0;
+        OPENSSL_TRY(EVP_DecryptUpdate(ctx.ptr(), nullptr, &aad_len, aad.data(), aad.size()));
+    }
+
+    auto plaintext = TRY(ByteBuffer::create_uninitialized(ciphertext.size()));
+    int out_len = 0;
+
+    OPENSSL_TRY(EVP_DecryptUpdate(ctx.ptr(), plaintext.data(), &out_len, ciphertext.data(), ciphertext.size()));
+
+    int final_len = 0;
+    OPENSSL_TRY(EVP_DecryptFinal_ex(ctx.ptr(), plaintext.data() + out_len, &final_len));
+
+    return plaintext.slice(0, out_len + final_len);
+}
+
+}

--- a/Libraries/LibCrypto/Cipher/ChaCha.h
+++ b/Libraries/LibCrypto/Cipher/ChaCha.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, mikiubo <michele.uboldi@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Error.h>
+#include <LibCrypto/OpenSSLForward.h>
+
+namespace Crypto::Cipher {
+
+class ChaCha20Poly1305 {
+public:
+    // 256 bits
+    static constexpr size_t key_size = 32;
+
+    // 96 bits
+    static constexpr size_t nonce_size = 12;
+
+    // 128 bits
+    static constexpr size_t tag_size = 16;
+
+    static ErrorOr<ByteBuffer> encrypt(
+        ReadonlyBytes key,
+        ReadonlyBytes nonce,
+        ReadonlyBytes plaintext,
+        ReadonlyBytes aad);
+
+    static ErrorOr<ByteBuffer> decrypt(
+        ReadonlyBytes key,
+        ReadonlyBytes nonce,
+        ReadonlyBytes ciphertext_and_tag,
+        ReadonlyBytes aad);
+};
+
+}

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -17,6 +17,7 @@
 #include <LibCrypto/Authentication/HMAC.h>
 #include <LibCrypto/Certificate/Certificate.h>
 #include <LibCrypto/Cipher/AES.h>
+#include <LibCrypto/Cipher/ChaCha.h>
 #include <LibCrypto/Curves/EdwardsCurve.h>
 #include <LibCrypto/Curves/SECPxxxr1.h>
 #include <LibCrypto/Hash/Argon2.h>
@@ -9700,6 +9701,304 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> CShake::digest(AlgorithmParams con
 
     // 6. Return result.
     return JS::ArrayBuffer::create(m_realm, maybe_result.release_value());
+}
+
+AeadParams::~AeadParams() = default;
+
+JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AeadParams::from_value(JS::VM& vm, JS::Value value)
+{
+    auto& object = value.as_object();
+
+    auto iv_value = TRY(object.get("iv"_utf16_fly_string));
+    if (!iv_value.is_object() || !(is<JS::TypedArrayBase>(iv_value.as_object()) || is<JS::ArrayBuffer>(iv_value.as_object()) || is<JS::DataView>(iv_value.as_object())))
+        return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
+    auto iv = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(iv_value.as_object()));
+
+    auto maybe_additional_data = Optional<ByteBuffer> {};
+    if (MUST(object.has_property("additionalData"_utf16_fly_string))) {
+        auto additional_data_value = TRY(object.get("additionalData"_utf16_fly_string));
+        if (!additional_data_value.is_object() || !(is<JS::TypedArrayBase>(additional_data_value.as_object()) || is<JS::ArrayBuffer>(additional_data_value.as_object()) || is<JS::DataView>(additional_data_value.as_object())))
+            return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
+        maybe_additional_data = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(additional_data_value.as_object()));
+    }
+
+    auto maybe_tag_length = Optional<u8> {};
+    if (MUST(object.has_property("tagLength"_utf16_fly_string))) {
+        auto tag_length_value = TRY(object.get("tagLength"_utf16_fly_string));
+        maybe_tag_length = TRY(tag_length_value.to_u8(vm));
+    }
+
+    return adopt_own<AlgorithmParams>(*new AeadParams { iv, maybe_additional_data, maybe_tag_length });
+}
+
+// https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-encrypt
+WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> ChaCha20Poly1305::encrypt(AlgorithmParams const& params, GC::Ref<CryptoKey> key, ByteBuffer const& plaintext)
+{
+    auto const& normalized_algorithm = static_cast<AeadParams const&>(params);
+
+    // 1. If the iv member of normalizedAlgorithm does not have a length of 12 bytes, then throw an OperationError.
+    if (normalized_algorithm.iv.size() != 12)
+        return WebIDL::OperationError::create(m_realm, "IV must have a length of 12 bytes"_utf16);
+
+    // 2. If the tagLength member of normalizedAlgorithm is present and is not 128, then throw an OperationError.
+    if (normalized_algorithm.tag_length.has_value() && normalized_algorithm.tag_length.value() != 128)
+        return WebIDL::OperationError::create(m_realm, "tagLength must be 128"_utf16);
+
+    // 3. Let additionalData be the additionalData member of normalizedAlgorithm if present or the empty octet string otherwise.
+    auto const& additional_data = normalized_algorithm.additional_data.value_or(ByteBuffer {});
+
+    // 4. Let ciphertext be the output that results from performing the AEAD_CHACHA20_POLY1305 encryption algorithm
+    //    described in Section 2.8 of [RFC8439], using the key represented by [[handle]] internal slot of key as the
+    //    key input parameter, the iv member of normalizedAlgorithm as the nonce input parameter, plaintext as the
+    //    plaintext input parameter, and additionalData as the additional authenticated data (AAD) input parameter.
+    VERIFY(key->handle().has<ByteBuffer>());
+    auto const maybe_ciphertext = ::Crypto::Cipher::ChaCha20Poly1305::encrypt(
+        key->handle().get<ByteBuffer>(),
+        normalized_algorithm.iv,
+        plaintext,
+        additional_data);
+
+    if (maybe_ciphertext.is_error())
+        return WebIDL::OperationError::create(m_realm, Utf16String::formatted("Encryption failed: {}", maybe_ciphertext.error()));
+
+    // 5. Return ciphertext.
+    return JS::ArrayBuffer::create(m_realm, maybe_ciphertext.value());
+}
+
+// If ciphertext has a length less than 128 bits, then throw an OperationError
+WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> ChaCha20Poly1305::decrypt(AlgorithmParams const& params, GC::Ref<CryptoKey> key, ByteBuffer const& ciphertext)
+{
+    auto const& normalized_algorithm = static_cast<AeadParams const&>(params);
+
+    // 1. If the iv member of normalizedAlgorithm does not have a length of 12 bytes, then throw an OperationError. .
+    if (normalized_algorithm.iv.size() != 12)
+        return WebIDL::OperationError::create(m_realm, "IV must have a length of 12 bytes"_utf16);
+
+    // 2. If the tagLength member of normalizedAlgorithm is present and is not 128, then throw an OperationError.
+    if (normalized_algorithm.tag_length.has_value() && normalized_algorithm.tag_length.value() != 128)
+        return WebIDL::OperationError::create(m_realm, "tagLength must be 128"_utf16);
+
+    // 3. If ciphertext has a length less than 128 bits, then throw an OperationError.
+    if (ciphertext.size() < 16)
+        return WebIDL::OperationError::create(m_realm, "Ciphertext must be at least 128 bits"_utf16);
+
+    // 4. Let additionalData be the additionalData member of normalizedAlgorithm if present or the empty octet string otherwise.
+    auto const& additional_data = normalized_algorithm.additional_data.value_or(ByteBuffer {});
+
+    // 5. Perform the AEAD_CHACHA20_POLY1305 decryption algorithm described in Section 2.8 of [RFC8439], using the key
+    //    represented by [[handle]] internal slot of key as the key input parameter, the iv member of normalizedAlgorithm
+    //    as the nonce input parameter, ciphertext as the ciphertext input parameter, and additionalData as the additional
+    //    authenticated data (AAD) input parameter.
+    VERIFY(key->handle().has<ByteBuffer>());
+    auto const maybe_plaintext = ::Crypto::Cipher::ChaCha20Poly1305::decrypt(
+        key->handle().get<ByteBuffer>(),
+        normalized_algorithm.iv,
+        ciphertext,
+        additional_data);
+
+    // If the result of the algorithm is the indication of authentication failure:
+    //       throw an OperationError
+    //    Otherwise:
+    //       Let plaintext be the resulting plaintext.
+    if (maybe_plaintext.is_error())
+        return WebIDL::OperationError::create(m_realm, Utf16String::formatted("Decryption failed: {}", maybe_plaintext.error()));
+
+    // 6. Return plaintext.
+    return JS::ArrayBuffer::create(m_realm, maybe_plaintext.value());
+}
+
+// https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-generate-key
+WebIDL::ExceptionOr<Variant<GC::Ref<CryptoKey>, GC::Ref<CryptoKeyPair>>> ChaCha20Poly1305::generate_key(AlgorithmParams const&, bool extractable, Vector<Bindings::KeyUsage> const& key_usages)
+{
+    // 1. If usages contains any entry which is not one of "encrypt", "decrypt", "wrapKey" or "unwrapKey", then throw a SyntaxError.
+    for (auto const& usage : key_usages) {
+        if (usage != Bindings::KeyUsage::Encrypt && usage != Bindings::KeyUsage::Decrypt && usage != Bindings::KeyUsage::Wrapkey && usage != Bindings::KeyUsage::Unwrapkey) {
+            return WebIDL::SyntaxError::create(m_realm, Utf16String::formatted("Invalid key usage '{}'", idl_enum_to_string(usage)));
+        }
+    }
+
+    // 2. Generate a 256-bit key.
+    auto key_buffer = TRY(generate_random_key(m_realm->vm(), 256));
+
+    // 3. If the key generation step fails, then throw an OperationError.
+    // Note: Cannot happen in our implementation; and if we OOM, then allocating the Exception is probably going to crash anyway.
+
+    // 4. Let key be a new CryptoKey object representing the generated key.
+    auto key = CryptoKey::create(m_realm, CryptoKey::InternalKeyData { key_buffer });
+
+    // 5. Set the [[type]] internal slot of key to "secret".
+    key->set_type(Bindings::KeyType::Secret);
+
+    // 6. Let algorithm be a new KeyAlgorithm.
+    auto algorithm = KeyAlgorithm::create(m_realm);
+
+    // 7. Set the name attribute of algorithm to "ChaCha20-Poly1305".
+    algorithm->set_name("ChaCha20-Poly1305"_string);
+
+    // 8. Set the [[algorithm]] internal slot of key to algorithm.
+    key->set_algorithm(algorithm);
+
+    // 9. Set the [[extractable]] internal slot of key to be extractable.
+    key->set_extractable(extractable);
+
+    // 10. Set the [[usages]] internal slot of key to be usages.
+    key->set_usages(key_usages);
+
+    // 11. Return key.
+    return { key };
+}
+
+// https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-import-key
+WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ChaCha20Poly1305::import_key(AlgorithmParams const&, Bindings::KeyFormat format, CryptoKey::InternalKeyData key_data, bool extractable, Vector<Bindings::KeyUsage> const& usages)
+{
+    // 1. Let keyData be the key data to be imported.
+
+    // 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or "unwrapKey", then throw a SyntaxError.
+    for (auto const& usage : usages) {
+        if (usage != Bindings::KeyUsage::Encrypt && usage != Bindings::KeyUsage::Decrypt && usage != Bindings::KeyUsage::Wrapkey && usage != Bindings::KeyUsage::Unwrapkey) {
+            return WebIDL::SyntaxError::create(m_realm, Utf16String::formatted("Invalid key usage '{}'", idl_enum_to_string(usage)));
+        }
+    }
+
+    ByteBuffer data;
+
+    // 3. If format is "raw-secret":
+    if (format == Bindings::KeyFormat::RawSecret) {
+        // 1. Let data be keyData.
+        data = move(key_data.get<ByteBuffer>());
+
+        // 2. If the length in bits of data is not 256 then throw a DataError.
+        if (data.size() != 32)
+            return WebIDL::DataError::create(m_realm, "Key data must be 256 bits"_utf16);
+    }
+    // 3. If format is "jwk":
+    else if (format == Bindings::KeyFormat::Jwk) {
+        // 1. If keyData is a JsonWebKey dictionary:
+        //        Let jwk equal keyData.
+        //    Otherwise:
+        //        Throw a DataError.
+        if (!key_data.has<Bindings::JsonWebKey>())
+            return WebIDL::DataError::create(m_realm, "Invalid JWK key data"_utf16);
+
+        auto const& jwk = key_data.get<Bindings::JsonWebKey>();
+
+        // 2. If the kty field of jwk is not "oct", then throw a DataError.
+        if (jwk.kty != "oct"_string)
+            return WebIDL::DataError::create(m_realm, "Invalid key type"_utf16);
+
+        // 3. If jwk does not meet the requirements of Section 6.4 of JSON Web Algorithms [JWA], then throw a DataError.
+        // Specifically, those requirements are:
+        // * the member "k" is used to represent a symmetric key (or another key whose value is a single octet sequence).
+        // * An "alg" member SHOULD also be present to identify the algorithm intended to be used with the key,
+        //   unless the application uses another means or convention to determine the algorithm used.
+        // NOTE: "k" is already checked in step 4.
+        if (!jwk.alg.has_value())
+            return WebIDL::DataError::create(m_realm, "Missing 'alg' field"_utf16);
+
+        // 4. Let data be the octet string obtained by decoding the k field of jwk.
+        data = TRY(parse_jwk_symmetric_key(m_realm, jwk));
+
+        // 5. If the alg field of jwk is present, and is not "C20P", then throw a DataError.
+        if (jwk.alg.has_value() && jwk.alg.value() != "C20P"_string)
+            return WebIDL::DataError::create(m_realm, "Invalid alg field"_utf16);
+
+        // 6. If usages is non-empty and the use field of jwk is present and is not "enc", then throw a DataError.
+        if (!usages.is_empty() && jwk.use.has_value() && *jwk.use != "enc"_string)
+            return WebIDL::DataError::create(m_realm, "Invalid use field"_utf16);
+
+        // 7. If the key_ops field of jwk is present, and is invalid according to the requirements of JSON Web Key [JWK]
+        //    or does not contain all of the specified usages values, then throw a DataError.
+        TRY(validate_jwk_key_ops(m_realm, jwk, usages));
+
+        // 8. If the ext field of jwk is present and has the value false and extractable is true, then throw a DataError.
+        if (jwk.ext.has_value() && !*jwk.ext && extractable)
+            return WebIDL::DataError::create(m_realm, "Invalid ext field"_utf16);
+    }
+    // 2. Otherwise:
+    else {
+        // 1. throw a NotSupportedError.
+        return WebIDL::NotSupportedError::create(m_realm, "Only raw-secret and jwk formats are supported"_utf16);
+    }
+
+    // 4. Let key be a new CryptoKey object representing a key with value data.
+    auto key = CryptoKey::create(m_realm, move(data));
+
+    // 5. Set the [[type]] internal slot of key to "secret".
+    key->set_type(Bindings::KeyType::Secret);
+
+    // 6. Let algorithm be a new KeyAlgorithm.
+    auto algorithm = KeyAlgorithm::create(m_realm);
+
+    // 7. Set the name attribute of algorithm to "ChaCha20-Poly1305".
+    algorithm->set_name("ChaCha20-Poly1305"_string);
+
+    // 8. Set the [[algorithm]] internal slot of key to algorithm.
+    key->set_algorithm(algorithm);
+
+    // 9. Return key.
+    return key;
+}
+
+// https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-export-key
+WebIDL::ExceptionOr<GC::Ref<JS::Object>> ChaCha20Poly1305::export_key(Bindings::KeyFormat format, GC::Ref<CryptoKey> key)
+{
+    // 1. If the underlying cryptographic key material represented by the [[handle]] internal slot of key cannot be accessed, then throw an OperationError.
+    // Note: In our impl this is always accessible
+
+    GC::Ptr<JS::Object> result = nullptr;
+
+    // 2. If format is "raw-secret":
+    if (format == Bindings::KeyFormat::RawSecret) {
+        // 1. Let data be the raw octets of the key represented by [[handle]] internal slot of key.
+        auto data = key->handle().get<ByteBuffer>();
+
+        // 2. Let result be data.
+        result = JS::ArrayBuffer::create(m_realm, data);
+    }
+    // 2. If format is "jwk":
+    else if (format == Bindings::KeyFormat::Jwk) {
+        // 1. Let jwk be a new JsonWebKey dictionary.
+        Bindings::JsonWebKey jwk = {};
+
+        // 2. Set the kty attribute of jwk to the string "oct".
+        jwk.kty = "oct"_string;
+
+        // 3. Set the k attribute of jwk to be a string containing the raw octets of the key represented by [[handle]] internal slot of key,
+        //    encoded according to Section 6.4 of JSON Web Algorithms [JWA].
+        auto const& key_bytes = key->handle().get<ByteBuffer>();
+        jwk.k = TRY_OR_THROW_OOM(m_realm->vm(), encode_base64url(key_bytes, AK::OmitPadding::Yes));
+
+        // 4. Set the alg attribute of jwk to the string "C20P".
+        jwk.alg = "C20P"_string;
+
+        // 5. Set the key_ops attribute of jwk to the usages attribute of key.
+        jwk.key_ops = Vector<String> {};
+        jwk.key_ops->ensure_capacity(key->internal_usages().size());
+        for (auto const& usage : key->internal_usages()) {
+            jwk.key_ops->unchecked_append(Bindings::idl_enum_to_string(usage));
+        }
+
+        // 6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of key.
+        jwk.ext = key->extractable();
+
+        // 7. Let result be jwk.
+        return TRY(jwk.to_object(m_realm));
+    }
+    // 2. Otherwise:
+    else {
+        // 1. throw a NotSupportedError.
+        return WebIDL::NotSupportedError::create(m_realm, "Cannot export to unsupported format"_utf16);
+    }
+
+    // 3. Return result.
+    return GC::Ref { *result };
+}
+
+// https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-get-key-length
+WebIDL::ExceptionOr<JS::Value> ChaCha20Poly1305::get_key_length(AlgorithmParams const&)
+{
+    // 1. Return 256.
+    return JS::Value(256);
 }
 
 }

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -839,6 +839,42 @@ struct CShakeParams : public AlgorithmParams {
     static JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> from_value(JS::VM&, JS::Value);
 };
 
+// https://wicg.github.io/webcrypto-modern-algos/#dfn-AeadParams
+// NOTE: The AeadParams dictionary is identical to the AesGcmParams
+struct AeadParams : public AlgorithmParams {
+    virtual ~AeadParams() override;
+    AeadParams(ByteBuffer iv, Optional<ByteBuffer> additional_data, Optional<u8> tag_length)
+        : iv(move(iv))
+        , additional_data(move(additional_data))
+        , tag_length(tag_length)
+    {
+    }
+
+    ByteBuffer iv;
+    Optional<ByteBuffer> additional_data;
+    Optional<u8> tag_length;
+
+    static JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> from_value(JS::VM&, JS::Value);
+};
+
+class ChaCha20Poly1305 : public AlgorithmMethods {
+public:
+    virtual WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> encrypt(AlgorithmParams const&, GC::Ref<CryptoKey>, ByteBuffer const&) override;
+    virtual WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> decrypt(AlgorithmParams const&, GC::Ref<CryptoKey>, ByteBuffer const&) override;
+    virtual WebIDL::ExceptionOr<Variant<GC::Ref<CryptoKey>, GC::Ref<CryptoKeyPair>>> generate_key(AlgorithmParams const&, bool, Vector<Bindings::KeyUsage> const&) override;
+    virtual WebIDL::ExceptionOr<GC::Ref<CryptoKey>> import_key(AlgorithmParams const&, Bindings::KeyFormat, CryptoKey::InternalKeyData, bool, Vector<Bindings::KeyUsage> const&) override;
+    virtual WebIDL::ExceptionOr<GC::Ref<JS::Object>> export_key(Bindings::KeyFormat, GC::Ref<CryptoKey>) override;
+    virtual WebIDL::ExceptionOr<JS::Value> get_key_length(AlgorithmParams const&) override;
+
+    static NonnullOwnPtr<AlgorithmMethods> create(JS::Realm& realm) { return adopt_own(*new ChaCha20Poly1305(realm)); }
+
+private:
+    explicit ChaCha20Poly1305(JS::Realm& realm)
+        : AlgorithmMethods(realm)
+    {
+    }
+};
+
 ErrorOr<String> base64_url_uint_encode(::Crypto::UnsignedBigInteger);
 WebIDL::ExceptionOr<ByteBuffer> base64_url_bytes_decode(JS::Realm&, String const& base64_url_string);
 WebIDL::ExceptionOr<::Crypto::UnsignedBigInteger> base64_url_uint_decode(JS::Realm&, String const& base64_url_string);

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -1612,6 +1612,14 @@ SupportedAlgorithmsMap const& supported_algorithms()
         define_an_algorithm<Argon2>("get key length"_string, algorithm);
     }
 
+    // https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-registration
+    define_an_algorithm<ChaCha20Poly1305, AeadParams>("encrypt"_string, "ChaCha20-Poly1305"_string);
+    define_an_algorithm<ChaCha20Poly1305, AeadParams>("decrypt"_string, "ChaCha20-Poly1305"_string);
+    define_an_algorithm<ChaCha20Poly1305>("generateKey"_string, "ChaCha20-Poly1305"_string);
+    define_an_algorithm<ChaCha20Poly1305>("importKey"_string, "ChaCha20-Poly1305"_string);
+    define_an_algorithm<ChaCha20Poly1305>("exportKey"_string, "ChaCha20-Poly1305"_string);
+    define_an_algorithm<ChaCha20Poly1305>("get key length"_string, "ChaCha20-Poly1305"_string);
+
     return internal_object;
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/encrypt_decrypt/chacha20_poly1305.tentative.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/encrypt_decrypt/chacha20_poly1305.tentative.https.any.txt
@@ -1,0 +1,33 @@
+Harness status: OK
+
+Found 28 tests
+
+28 Pass
+Pass	ChaCha20-Poly1305 encryption with empty additional data, empty data
+Pass	ChaCha20-Poly1305 decryption with empty additional data, empty data
+Pass	ChaCha20-Poly1305 encryption with empty additional data, short data
+Pass	ChaCha20-Poly1305 decryption with empty additional data, short data
+Pass	ChaCha20-Poly1305 encryption with empty additional data, medium data
+Pass	ChaCha20-Poly1305 decryption with empty additional data, medium data
+Pass	ChaCha20-Poly1305 encryption with empty additional data, long data
+Pass	ChaCha20-Poly1305 decryption with empty additional data, long data
+Pass	ChaCha20-Poly1305 encryption with short additional data, empty data
+Pass	ChaCha20-Poly1305 decryption with short additional data, empty data
+Pass	ChaCha20-Poly1305 encryption with short additional data, short data
+Pass	ChaCha20-Poly1305 decryption with short additional data, short data
+Pass	ChaCha20-Poly1305 encryption with short additional data, medium data
+Pass	ChaCha20-Poly1305 decryption with short additional data, medium data
+Pass	ChaCha20-Poly1305 encryption with short additional data, long data
+Pass	ChaCha20-Poly1305 decryption with short additional data, long data
+Pass	ChaCha20-Poly1305 encryption with medium additional data, empty data
+Pass	ChaCha20-Poly1305 decryption with medium additional data, empty data
+Pass	ChaCha20-Poly1305 encryption with medium additional data, short data
+Pass	ChaCha20-Poly1305 decryption with medium additional data, short data
+Pass	ChaCha20-Poly1305 encryption with medium additional data, medium data
+Pass	ChaCha20-Poly1305 decryption with medium additional data, medium data
+Pass	ChaCha20-Poly1305 encryption with medium additional data, long data
+Pass	ChaCha20-Poly1305 decryption with medium additional data, long data
+Pass	ChaCha20-Poly1305 round-trip encrypt/decrypt
+Pass	ChaCha20-Poly1305 decryption with wrong additional data should fail
+Pass	ChaCha20-Poly1305 decryption with wrong IV should fail
+Pass	ChaCha20-Poly1305 encryption with invalid IV size should fail

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/encrypt_decrypt/chacha20_poly1305.tentative.https.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/encrypt_decrypt/chacha20_poly1305.tentative.https.any.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>WebCryptoAPI: encrypt()/decrypt() ChaCha20-Poly1305</title>
+<meta name="timeout" content="long">
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../WebCryptoAPI/encrypt_decrypt/chacha20_poly1305.tentative.https.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/encrypt_decrypt/chacha20_poly1305.tentative.https.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/WebCryptoAPI/encrypt_decrypt/chacha20_poly1305.tentative.https.any.js
@@ -1,0 +1,340 @@
+// META: title=WebCryptoAPI: encrypt()/decrypt() ChaCha20-Poly1305
+// META: timeout=long
+
+var subtle = crypto.subtle; // Change to test prefixed implementations
+
+var sourceData = {
+  empty: new Uint8Array(0),
+  short: new Uint8Array([
+    21, 110, 234, 124, 193, 76, 86, 203, 148, 219, 3, 10, 74, 157, 149, 255,
+  ]),
+  medium: new Uint8Array([
+    182, 200, 249, 223, 100, 140, 208, 136, 183, 15, 56, 231, 65, 151, 177, 140,
+    184, 30, 30, 67, 80, 213, 11, 204, 184, 251, 90, 115, 121, 200, 123, 178,
+    227, 214, 237, 84, 97, 237, 30, 159, 54, 243, 64, 163, 150, 42, 68, 107,
+    129, 91, 121, 75, 75, 212, 58, 68, 3, 80, 32, 119, 178, 37, 108, 200, 7,
+    131, 127, 58, 172, 209, 24, 235, 75, 156, 43, 174, 184, 151, 6, 134, 37,
+    171, 172, 161, 147,
+  ]),
+  long: new Uint8Array(
+    Array(65)
+      .fill(0)
+      .map((_, i) => i % 256)
+  ),
+};
+
+var additionalData = {
+  empty: new Uint8Array(0),
+  short: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+  medium: new Uint8Array([
+    9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+  ]),
+};
+
+var iv = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]); // 96-bit IV (only valid size for ChaCha20-Poly1305)
+
+var keyBytes = new Uint8Array([
+  52, 138, 105, 103, 105, 3, 94, 254, 59, 241, 159, 138, 189, 254, 153, 191,
+  228, 172, 165, 239, 117, 172, 19, 206, 219, 9, 205, 138, 45, 87, 166, 89,
+]);
+
+var encryptedData = {
+  empty_ad: {
+    empty: new Uint8Array([
+      202, 31, 160, 169, 169, 221, 162, 53, 252, 126, 127, 237, 158, 98, 86, 41,
+    ]),
+    short: new Uint8Array([
+      226, 238, 222, 234, 202, 96, 116, 202, 205, 199, 126, 40, 167, 93, 65,
+      172, 87, 45, 146, 68, 245, 236, 87, 162, 200, 89, 228, 51, 2, 249, 103,
+      255,
+    ]),
+    medium: new Uint8Array([
+      65, 72, 205, 73, 111, 160, 242, 137, 238, 19, 69, 197, 172, 87, 101, 223,
+      97, 245, 255, 57, 226, 43, 36, 125, 205, 218, 211, 252, 102, 45, 234, 179,
+      23, 71, 87, 156, 145, 16, 106, 98, 75, 140, 67, 249, 230, 124, 37, 127,
+      192, 145, 40, 129, 203, 31, 15, 182, 15, 226, 211, 111, 132, 132, 114,
+      204, 73, 36, 245, 199, 212, 187, 239, 33, 46, 203, 124, 134, 76, 21, 242,
+      233, 119, 179, 216, 193, 210, 145, 43, 48, 105, 153, 28, 62, 49, 175, 154,
+      142, 222, 68, 219, 229, 66,
+    ]),
+    long: new Uint8Array([
+      247, 129, 54, 149, 15, 41, 36, 6, 81, 21, 119, 41, 225, 205, 218, 92, 201,
+      250, 243, 105, 166, 235, 57, 166, 109, 56, 147, 148, 3, 248, 143, 30, 212,
+      176, 152, 235, 212, 216, 82, 218, 85, 86, 41, 113, 92, 123, 79, 59, 113,
+      251, 99, 249, 180, 254, 3, 197, 52, 139, 201, 35, 10, 156, 32, 59, 14,
+      225, 117, 48, 100, 126, 58, 112, 157, 195, 18, 185, 178, 97, 215, 233,
+      113,
+    ]),
+  },
+  short_ad: {
+    empty: new Uint8Array([
+      0, 176, 175, 37, 156, 39, 141, 93, 198, 224, 223, 214, 239, 212, 50, 215,
+    ]),
+    short: new Uint8Array([
+      226, 238, 222, 234, 202, 96, 116, 202, 205, 199, 126, 40, 167, 93, 65,
+      172, 40, 45, 199, 67, 109, 80, 99, 203, 246, 137, 82, 206, 183, 23, 175,
+      176,
+    ]),
+    medium: new Uint8Array([
+      65, 72, 205, 73, 111, 160, 242, 137, 238, 19, 69, 197, 172, 87, 101, 223,
+      97, 245, 255, 57, 226, 43, 36, 125, 205, 218, 211, 252, 102, 45, 234, 179,
+      23, 71, 87, 156, 145, 16, 106, 98, 75, 140, 67, 249, 230, 124, 37, 127,
+      192, 145, 40, 129, 203, 31, 15, 182, 15, 226, 211, 111, 132, 132, 114,
+      204, 73, 36, 245, 199, 212, 187, 239, 33, 46, 203, 124, 134, 76, 21, 242,
+      233, 119, 179, 216, 193, 210, 199, 121, 7, 153, 245, 137, 122, 100, 72,
+      102, 113, 169, 244, 218, 111, 105,
+    ]),
+    long: new Uint8Array([
+      247, 129, 54, 149, 15, 41, 36, 6, 81, 21, 119, 41, 225, 205, 218, 92, 201,
+      250, 243, 105, 166, 235, 57, 166, 109, 56, 147, 148, 3, 248, 143, 30, 212,
+      176, 152, 235, 212, 216, 82, 218, 85, 86, 41, 113, 92, 123, 79, 59, 113,
+      251, 99, 249, 180, 254, 3, 197, 52, 139, 201, 35, 10, 156, 32, 59, 14,
+      137, 0, 55, 193, 166, 74, 124, 251, 91, 36, 191, 112, 236, 204, 35, 102,
+    ]),
+  },
+  medium_ad: {
+    empty: new Uint8Array([
+      163, 122, 139, 166, 205, 190, 132, 236, 17, 19, 31, 4, 16, 47, 13, 242,
+    ]),
+    short: new Uint8Array([
+      226, 238, 222, 234, 202, 96, 116, 202, 205, 199, 126, 40, 167, 93, 65,
+      172, 18, 242, 253, 220, 52, 138, 67, 162, 201, 38, 125, 119, 44, 53, 147,
+      119,
+    ]),
+    medium: new Uint8Array([
+      65, 72, 205, 73, 111, 160, 242, 137, 238, 19, 69, 197, 172, 87, 101, 223,
+      97, 245, 255, 57, 226, 43, 36, 125, 205, 218, 211, 252, 102, 45, 234, 179,
+      23, 71, 87, 156, 145, 16, 106, 98, 75, 140, 67, 249, 230, 124, 37, 127,
+      192, 145, 40, 129, 203, 31, 15, 182, 15, 226, 211, 111, 132, 132, 114,
+      204, 73, 36, 245, 199, 212, 187, 239, 33, 46, 203, 124, 134, 76, 21, 242,
+      233, 119, 179, 216, 193, 210, 161, 250, 192, 51, 193, 133, 185, 55, 148,
+      21, 194, 168, 212, 203, 252, 184,
+    ]),
+    long: new Uint8Array([
+      247, 129, 54, 149, 15, 41, 36, 6, 81, 21, 119, 41, 225, 205, 218, 92, 201,
+      250, 243, 105, 166, 235, 57, 166, 109, 56, 147, 148, 3, 248, 143, 30, 212,
+      176, 152, 235, 212, 216, 82, 218, 85, 86, 41, 113, 92, 123, 79, 59, 113,
+      251, 99, 249, 180, 254, 3, 197, 52, 139, 201, 35, 10, 156, 32, 59, 14, 88,
+      20, 159, 185, 145, 230, 1, 242, 106, 255, 55, 7, 60, 85, 179, 184,
+    ]),
+  },
+};
+
+function equalBuffers(a, b) {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+  var aBytes = new Uint8Array(a);
+  var bBytes = new Uint8Array(b);
+  for (var i = 0; i < a.byteLength; i++) {
+    if (aBytes[i] !== bBytes[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Test ChaCha20-Poly1305 encryption/decryption
+var algorithmName = 'ChaCha20-Poly1305';
+
+// Test with different additional data combinations
+Object.keys(additionalData).forEach(function (adName) {
+  var ad = additionalData[adName];
+
+  Object.keys(sourceData).forEach(function (dataName) {
+    var plaintext = sourceData[dataName];
+    var ciphertext = encryptedData[adName + '_ad'][dataName];
+
+    promise_test(function (test) {
+      var operation = subtle
+        .importKey('raw-secret', keyBytes, { name: algorithmName }, false, [
+          'encrypt',
+          'decrypt',
+        ])
+        .then(
+          function (key) {
+            return subtle.encrypt(
+              { name: algorithmName, iv: iv, additionalData: ad },
+              key,
+              plaintext
+            );
+          },
+          function (err) {
+            assert_unreached(
+              'importKey failed unexpectedly: ' + err.toString()
+            );
+          }
+        )
+        .then(
+          function (result) {
+            assert_true(
+              equalBuffers(result, ciphertext),
+              'Encrypted data should match expected result'
+            );
+            return result;
+          },
+          function (err) {
+            assert_unreached('encrypt failed unexpectedly: ' + err.toString());
+          }
+        );
+
+      return operation;
+    }, algorithmName +
+      ' encryption with ' +
+      adName +
+      ' additional data, ' +
+      dataName +
+      ' data');
+
+    promise_test(function (test) {
+      var operation = subtle
+        .importKey('raw-secret', keyBytes, { name: algorithmName }, false, [
+          'encrypt',
+          'decrypt',
+        ])
+        .then(
+          function (key) {
+            return subtle.decrypt(
+              { name: algorithmName, iv: iv, additionalData: ad },
+              key,
+              ciphertext
+            );
+          },
+          function (err) {
+            assert_unreached(
+              'importKey failed unexpectedly: ' + err.toString()
+            );
+          }
+        )
+        .then(
+          function (result) {
+            assert_true(
+              equalBuffers(result, plaintext),
+              'Decrypted data should match original plaintext'
+            );
+          },
+          function (err) {
+            assert_unreached('decrypt failed unexpectedly: ' + err.toString());
+          }
+        );
+
+      return operation;
+    }, algorithmName +
+      ' decryption with ' +
+      adName +
+      ' additional data, ' +
+      dataName +
+      ' data');
+  });
+});
+
+// Test round-trip encryption/decryption without fixed vectors
+promise_test(function (test) {
+  var key;
+  var plaintext = sourceData.medium;
+  var ad = additionalData.short;
+
+  return subtle
+    .generateKey({ name: algorithmName }, false, ['encrypt', 'decrypt'])
+    .then(function (result) {
+      key = result;
+      return subtle.encrypt(
+        { name: algorithmName, iv: iv, additionalData: ad },
+        key,
+        plaintext
+      );
+    })
+    .then(function (encrypted) {
+      return subtle.decrypt(
+        { name: algorithmName, iv: iv, additionalData: ad },
+        key,
+        encrypted
+      );
+    })
+    .then(function (decrypted) {
+      assert_true(
+        equalBuffers(decrypted, plaintext),
+        'Round-trip encryption/decryption should return original plaintext'
+      );
+    });
+}, algorithmName + ' round-trip encrypt/decrypt');
+
+// Test decryption with wrong additional data should fail
+promise_test(function (test) {
+  var key;
+  var plaintext = sourceData.short;
+  var correctAd = additionalData.short;
+  var wrongAd = additionalData.medium;
+
+  return subtle
+    .generateKey({ name: algorithmName }, false, ['encrypt', 'decrypt'])
+    .then(function (result) {
+      key = result;
+      return subtle.encrypt(
+        { name: algorithmName, iv: iv, additionalData: correctAd },
+        key,
+        plaintext
+      );
+    })
+    .then(function (encrypted) {
+      return promise_rejects_dom(
+        test,
+        'OperationError',
+        subtle.decrypt(
+          { name: algorithmName, iv: iv, additionalData: wrongAd },
+          key,
+          encrypted
+        )
+      );
+    });
+}, algorithmName + ' decryption with wrong additional data should fail');
+
+// Test decryption with wrong IV should fail
+promise_test(function (test) {
+  var key;
+  var correctIv = iv;
+  var wrongIv = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]); // Different 96-bit IV
+  var plaintext = sourceData.short;
+  var ad = additionalData.empty;
+
+  return subtle
+    .generateKey({ name: algorithmName }, false, ['encrypt', 'decrypt'])
+    .then(function (result) {
+      key = result;
+      return subtle.encrypt(
+        { name: algorithmName, iv: correctIv, additionalData: ad },
+        key,
+        plaintext
+      );
+    })
+    .then(function (encrypted) {
+      return promise_rejects_dom(
+        test,
+        'OperationError',
+        subtle.decrypt(
+          { name: algorithmName, iv: wrongIv, additionalData: ad },
+          key,
+          encrypted
+        )
+      );
+    });
+}, algorithmName + ' decryption with wrong IV should fail');
+
+// Test invalid IV size should fail
+promise_test(function (test) {
+  var invalidIv = new Uint8Array(16); // 128-bit IV is invalid for ChaCha20-Poly1305
+
+  return subtle
+    .generateKey({ name: algorithmName }, false, ['encrypt'])
+    .then(function (key) {
+      return promise_rejects_dom(
+        test,
+        'OperationError',
+        subtle.encrypt(
+          { name: algorithmName, iv: invalidIv },
+          key,
+          sourceData.short
+        )
+      );
+    });
+}, algorithmName + ' encryption with invalid IV size should fail');


### PR DESCRIPTION
Implement ChaCha20-Poly1305 AEAD using OpenSSL and expose it through the WebCrypto API, including key management and AEAD parameters.

Add WPT:
/encrypt_decrypt/chacha20_poly1305.tentative.https.any.worker.html