### PR TITLE
LibWeb: Better handling for union types in IDL code generation

### DIFF
--- a/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -59,19 +59,26 @@ WebIDL::ExceptionOr<GC::Ref<AudioContext>> AudioContext::construct_impl(JS::Real
         // 1. If sinkId is specified, let sinkId be the value of contextOptions.sinkId and run the following substeps:
 
         // 2. Set the internal latency of context according to contextOptions.latencyHint, as described in latencyHint.
-        switch (context_options->latency_hint) {
-        case Bindings::AudioContextLatencyCategory::Balanced:
-            // FIXME: Determine optimal settings for balanced.
-            break;
-        case Bindings::AudioContextLatencyCategory::Interactive:
-            // FIXME: Determine optimal settings for interactive.
-            break;
-        case Bindings::AudioContextLatencyCategory::Playback:
-            // FIXME: Determine optimal settings for playback.
-            break;
-        default:
-            VERIFY_NOT_REACHED();
-        }
+        context_options->latency_hint.visit(
+            [&](Bindings::AudioContextLatencyCategory category) {
+                switch (category) {
+                case Bindings::AudioContextLatencyCategory::Balanced:
+                    // FIXME: Determine optimal settings for balanced.
+                    break;
+                case Bindings::AudioContextLatencyCategory::Interactive:
+                    // FIXME: Determine optimal settings for interactive.
+                    break;
+                case Bindings::AudioContextLatencyCategory::Playback:
+                    // FIXME: Determine optimal settings for playback.
+                    break;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            },
+            [&](double latency_seconds) {
+                // FIXME: Determine optimal settings for numeric latency hint.
+                (void)latency_seconds;
+            });
 
         // 3: If contextOptions.sampleRate is specified, set the sampleRate of context to this value.
         if (context_options->sample_rate.has_value()) {

--- a/Libraries/LibWeb/WebAudio/AudioContext.h
+++ b/Libraries/LibWeb/WebAudio/AudioContext.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Variant.h>
 #include <LibWeb/Bindings/AudioContextPrototype.h>
 #include <LibWeb/HighResolutionTime/DOMHighResTimeStamp.h>
 #include <LibWeb/WebAudio/BaseAudioContext.h>
@@ -14,7 +15,7 @@
 namespace Web::WebAudio {
 
 struct AudioContextOptions {
-    Bindings::AudioContextLatencyCategory latency_hint = Bindings::AudioContextLatencyCategory::Interactive;
+    Variant<Bindings::AudioContextLatencyCategory, double> latency_hint = Bindings::AudioContextLatencyCategory::Interactive;
     Optional<float> sample_rate;
 };
 

--- a/Libraries/LibWeb/WebAudio/AudioContext.idl
+++ b/Libraries/LibWeb/WebAudio/AudioContext.idl
@@ -20,7 +20,7 @@ interface AudioContext : BaseAudioContext {
 };
 
 dictionary AudioContextOptions {
-    AudioContextLatencyCategory latencyHint = "interactive";
+    (AudioContextLatencyCategory or double) latencyHint = "interactive";
     float sampleRate;
 };
 

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.txt
@@ -1,12 +1,11 @@
-Harness status: Error
+Harness status: OK
 
-Found 32 tests
+Found 37 tests
 
-27 Pass
-5 Fail
+37 Pass
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "test-audiocontextoptions-latencyHint-basic"
-Fail	Executing "test-audiocontextoptions-latencyHint-double"
+Pass	Executing "test-audiocontextoptions-latencyHint-double"
 Pass	Executing "test-audiocontextoptions-sampleRate"
 Pass	Audit report
 Pass	> [test-audiocontextoptions-latencyHint-basic] Test creating contexts with basic latencyHint types.
@@ -21,12 +20,17 @@ Pass	  context = new AudioContext({'latencyHint': 'playback'}) did not throw an 
 Pass	  playback baseLatency is greater than or equal to 0.
 Pass	< [test-audiocontextoptions-latencyHint-basic] All assertions passed. (total 9 assertions)
 Pass	> [test-audiocontextoptions-latencyHint-double] Test creating contexts with explicit latencyHint values.
-Fail	X context = new AudioContext({'latencyHint': interactiveLatency/2}) incorrectly threw TypeError: "Invalid value '0' for enumeration type 'AudioContextLatencyCategory'".
+Pass	  context = new AudioContext({'latencyHint': interactiveLatency/2}) did not throw an exception.
 Pass	  double-constructor baseLatency small is less than or equal to 0.
-Fail	X context = new AudioContext({'latencyHint': validLatency}) incorrectly threw TypeError: "Invalid value '0' for enumeration type 'AudioContextLatencyCategory'".
+Pass	  context = new AudioContext({'latencyHint': validLatency}) did not throw an exception.
 Pass	  double-constructor baseLatency inrange 1 is greater than or equal to 0.
 Pass	  double-constructor baseLatency inrange 2 is less than or equal to 0.
-Fail	X creating two high latency contexts incorrectly threw TypeError: "Invalid value '0' for enumeration type 'AudioContextLatencyCategory'".
+Pass	  creating two high latency contexts did not throw an exception.
+Pass	  high latency context baseLatency is equal to 0.
+Pass	  high latency context baseLatency is greater than or equal to 0.
+Pass	  context = new AudioContext({'latencyHint': 'foo'}) threw TypeError: "Expected latencyHint to be a finite floating-point number".
+Pass	  context = new AudioContext('latencyHint') threw TypeError: "Not an object of type AudioContextOptions".
+Pass	< [test-audiocontextoptions-latencyHint-double] All assertions passed. (total 10 assertions)
 Pass	> [test-audiocontextoptions-sampleRate] Test creating contexts with non-default sampleRate values.
 Pass	  context = new AudioContext({sampleRate: 1}) threw NotSupportedError: "Sample rate is outside of allowed range".
 Pass	  context = new AudioContext({sampleRate: 1000000}) threw NotSupportedError: "Sample rate is outside of allowed range".
@@ -35,4 +39,4 @@ Pass	  context = new AudioContext({sampleRate: 0}) threw NotSupportedError: "Sam
 Pass	  context = new AudioContext({sampleRate: 24000}) did not throw an exception.
 Pass	  sampleRate inrange is equal to 24000.
 Pass	< [test-audiocontextoptions-sampleRate] All assertions passed. (total 6 assertions)
-Fail	# AUDIT TASK RUNNER FINISHED: 1 out of 3 tasks were failed.
+Pass	# AUDIT TASK RUNNER FINISHED: 3 tasks ran successfully.


### PR DESCRIPTION
First check if a string is a member of an enum before attempting numeric conversion. This generates correct code for fields like `AudioContextLatencyCategory | double`