### PR TITLE
LibWeb: Skip effect contexts for off-screen display list commands

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -86,6 +86,8 @@ public:
     VisualContextData const& data() const { return m_data; }
     RefPtr<AccumulatedVisualContext const> parent() const { return m_parent; }
 
+    bool is_effect() const { return m_data.has<EffectsData>(); }
+
     size_t depth() const { return m_depth; }
     size_t id() const { return m_id; }
 


### PR DESCRIPTION
When executing display list commands, check if commands with effect contexts (opacity, filters, blend modes) are outside the viewport before applying the effect. Since effects don't affect clip state, would_be_fully_clipped_by_painter() returns the same result before and after applying effects.

This avoids expensive saveLayer/restore cycles for off-screen commands with effects like blur, which is particularly beneficial for pages with many blurred decorative images (e.g., Discord's landing page has 70+ blurred star images).

The optimization only applies when switching to a new effect context, not for consecutive commands with the same context, to preserve correct blend mode compositing behavior.