### PR TITLE
LibHTTP: Avoid UAF while deleting exempt cache headers

### DIFF
--- a/Libraries/LibHTTP/Cache/CacheIndex.cpp
+++ b/Libraries/LibHTTP/Cache/CacheIndex.cpp
@@ -118,14 +118,9 @@ void CacheIndex::create_entry(u64 cache_key, u64 vary_key, String url, NonnullRe
     auto now = UnixDateTime::now();
 
     auto remove_exempted_headers = [](HeaderList& headers) {
-        for (size_t i = 0; i < headers.headers().size();) {
-            auto const& header = headers.headers()[i];
-
-            if (is_header_exempted_from_storage(header.name))
-                headers.delete_(header.name);
-            else
-                ++i;
-        }
+        headers.delete_all_matching([&](auto const& header) {
+            return is_header_exempted_from_storage(header.name);
+        });
     };
 
     remove_exempted_headers(request_headers);

--- a/Libraries/LibHTTP/HeaderList.h
+++ b/Libraries/LibHTTP/HeaderList.h
@@ -53,6 +53,12 @@ public:
     [[nodiscard]] Vector<ByteString> unique_names() const;
 
     template<typename Callback>
+    void delete_all_matching(Callback&& callback)
+    {
+        m_headers.remove_all_matching(forward<Callback>(callback));
+    }
+
+    template<typename Callback>
     void for_each_header_value(StringView name, Callback&& callback) const
     {
         for (auto const& header : m_headers) {


### PR DESCRIPTION
`HeaderList::delete` involves a `Vector::remove_all_matching` internally. So if an exempt header appeared again later in the header list, we would be accessing the name string of the previously deleted header.