### PR TITLE
LibWeb: Remove unused cumulative_offset from scroll state tracking

### DIFF
--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -11,9 +11,9 @@ namespace Web::Painting {
 ScrollStateSnapshot ScrollStateSnapshot::create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames)
 {
     ScrollStateSnapshot snapshot;
-    snapshot.entries.ensure_capacity(scroll_frames.size());
+    snapshot.own_offsets.ensure_capacity(scroll_frames.size());
     for (auto const& scroll_frame : scroll_frames)
-        snapshot.entries.append({ scroll_frame->cumulative_offset(), scroll_frame->own_offset() });
+        snapshot.own_offsets.append({ scroll_frame->own_offset() });
     return snapshot;
 }
 

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -14,26 +14,15 @@ class ScrollStateSnapshot {
 public:
     static ScrollStateSnapshot create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames);
 
-    CSSPixelPoint cumulative_offset_for_frame_with_id(size_t id) const
-    {
-        if (id >= entries.size())
-            return {};
-        return entries[id].cumulative_offset;
-    }
-
     CSSPixelPoint own_offset_for_frame_with_id(size_t id) const
     {
-        if (id >= entries.size())
+        if (id >= own_offsets.size())
             return {};
-        return entries[id].own_offset;
+        return own_offsets[id];
     }
 
 private:
-    struct Entry {
-        CSSPixelPoint cumulative_offset;
-        CSSPixelPoint own_offset;
-    };
-    Vector<Entry> entries;
+    Vector<CSSPixelPoint> own_offsets;
 };
 
 class ScrollState {
@@ -50,11 +39,6 @@ public:
         auto scroll_frame = adopt_ref(*new ScrollFrame(paintable_box, m_scroll_frames.size(), true, move(parent)));
         m_scroll_frames.append(scroll_frame);
         return scroll_frame;
-    }
-
-    CSSPixelPoint cumulative_offset_for_frame_with_id(size_t id) const
-    {
-        return m_scroll_frames[id]->cumulative_offset();
     }
 
     CSSPixelPoint own_offset_for_frame_with_id(size_t id) const


### PR DESCRIPTION
The cumulative_offset was being tracked in ScrollStateSnapshot and ScrollState but was never actually used. This simplifies the code by removing cumulative_offset_for_frame_with_id() methods and storing only own_offset values in ScrollStateSnapshot.