### PR TITLE
LibWeb: Fix backdrop-filter disappearing when combined with filter 

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -66,6 +66,9 @@ struct EffectsData {
     float opacity { 1.0f };
     Gfx::CompositingAndBlendingOperator blend_mode { Gfx::CompositingAndBlendingOperator::Normal };
     ResolvedCSSFilter filter;
+    ResolvedCSSFilter backdrop_filter;
+    CSSPixelRect backdrop_filter_rect;
+    BorderRadiiData backdrop_filter_clip_radii;
     bool isolate { false };
 
     bool needs_layer() const
@@ -73,6 +76,7 @@ struct EffectsData {
         return opacity < 1.0f
             || blend_mode != Gfx::CompositingAndBlendingOperator::Normal
             || filter.has_filters()
+            || backdrop_filter.has_filters()
             || isolate;
     }
 };

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -105,7 +105,17 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
                 Optional<Gfx::Filter> gfx_filter;
                 if (effects.filter.has_filters())
                     gfx_filter = to_gfx_filter(effects.filter, device_pixels_per_css_pixel);
-                apply_effects({ .opacity = effects.opacity, .compositing_and_blending_operator = effects.blend_mode, .filter = gfx_filter });
+
+                Optional<Gfx::Filter> gfx_backdrop_filter;
+                if (effects.backdrop_filter.has_filters())
+                    gfx_backdrop_filter = to_gfx_filter(effects.backdrop_filter, device_pixels_per_css_pixel);
+
+                Gfx::IntRect backdrop_rect;
+                if (gfx_backdrop_filter.has_value()) {
+                    backdrop_rect = device_pixel_converter.rounded_device_rect(effects.backdrop_filter_rect).to_type<int>();
+                }
+
+                apply_effects({ .opacity = effects.opacity, .compositing_and_blending_operator = effects.blend_mode, .filter = gfx_filter, .backdrop_filter = gfx_backdrop_filter, .backdrop_filter_rect = backdrop_rect, .backdrop_filter_border_radii = effects.backdrop_filter_clip_radii.as_corners(device_pixel_converter) });
             },
             [&](PerspectiveData const& perspective) {
                 save({});

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -375,6 +375,9 @@ struct ApplyEffects {
     float opacity { 1.0f };
     Gfx::CompositingAndBlendingOperator compositing_and_blending_operator { Gfx::CompositingAndBlendingOperator::Normal };
     Optional<Gfx::Filter> filter {};
+    Optional<Gfx::Filter> backdrop_filter {};
+    Gfx::IntRect backdrop_filter_rect {};
+    CornerRadii backdrop_filter_border_radii {};
 
     void dump(StringBuilder&) const;
 };

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -359,9 +359,9 @@ void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutt
         .vertical = vertical });
 }
 
-void DisplayListRecorder::apply_effects(float opacity, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Optional<Gfx::Filter> filter)
+void DisplayListRecorder::apply_effects(float opacity, Gfx::CompositingAndBlendingOperator compositing_and_blending_operator, Optional<Gfx::Filter> filter, Optional<Gfx::Filter> backdrop_filter, Gfx::IntRect backdrop_filter_rect, CornerRadii backdrop_filter_border_radii)
 {
-    APPEND(ApplyEffects { .opacity = opacity, .compositing_and_blending_operator = compositing_and_blending_operator, .filter = move(filter) });
+    APPEND(ApplyEffects { .opacity = opacity, .compositing_and_blending_operator = compositing_and_blending_operator, .filter = move(filter), .backdrop_filter = move(backdrop_filter), .backdrop_filter_rect = backdrop_filter_rect, .backdrop_filter_border_radii = backdrop_filter_border_radii });
 }
 
 void DisplayListRecorder::apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 matrix)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -111,7 +111,7 @@ public:
 
     void paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, CSSPixelFraction scroll_size, Color thumb_color, Color track_color, bool vertical);
 
-    void apply_effects(float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Gfx::Filter> filter = {});
+    void apply_effects(float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Gfx::Filter> filter = {}, Optional<Gfx::Filter> backdrop_filter = {}, Gfx::IntRect backdrop_filter_rect = {}, CornerRadii backdrop_filter_border_radii = {});
     void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4);
     void apply_mask_bitmap(Gfx::IntPoint origin, Gfx::ImmutableBitmap const&, Gfx::MaskKind);
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -468,7 +468,7 @@ void PaintableBox::paint(DisplayListRecordingContext& context, PaintPhase phase)
     };
 
     if (phase == PaintPhase::Background && !empty_cells_property_applies()) {
-        paint_backdrop_filter(context);
+
         paint_background(context);
         paint_box_shadow(context);
     }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -185,6 +185,9 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
             computed_values.opacity(),
             mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),
             paintable_box.filter(),
+            paintable_box.backdrop_filter(),
+            paintable_box.absolute_border_box_rect(),
+            paintable_box.normalized_border_radii_data(),
             computed_values.isolation() == CSS::Isolation::Isolate
         };
 


### PR DESCRIPTION
**Summary:**
This PR fixes a bug where `backdrop-filter` would stop working if a regular `filter` was also applied to the same element.

 **The Issue:**
When `filter` is applied, it typically creates a new stacking context and often a new compositing layer. In the previous implementation, the `backdrop-filter` was painted in `PaintableBox::paint`, but the subsequent `apply_effects` (for the regular filter) would create a new `SkCanvas::saveLayer`. This isolation meant that the `backdrop-filter` operation, or the subsequent filter application, was not correctly composing with the background. Specifically, the `filter` layer would effectively overwrite or obscure the `backdrop-filter` effect because the paint order didn't account for their interaction.

**The Fix:**
I moved the `backdrop-filter` painting logic into the `ApplyEffects` display list command. This ensures that `backdrop-filter` and `filter` are handled in the same context.

ladybird before the fix:
<img width="355" height="91" alt="ladybirdbefor" src="https://github.com/user-attachments/assets/e304524a-a866-4b4c-ba6a-d1fffa3ea15d" />

ladybird after the fix:
<img width="480" height="270" alt="Screenshot from 2026-01-23 03-50-05" src="https://github.com/user-attachments/assets/9c0480eb-8378-4626-9cb9-051ba3271bf9" />


fixes #3187

note: this is my first pull request
