### PR TITLE
RequestServer: Do not flush the disk cache for unsuccessful requests

### DIFF
--- a/Libraries/LibHTTP/Cache/CacheEntry.cpp
+++ b/Libraries/LibHTTP/Cache/CacheEntry.cpp
@@ -209,7 +209,7 @@ ErrorOr<void> CacheEntryWriter::flush(NonnullRefPtr<HeaderList> request_headers,
     return {};
 }
 
-void CacheEntryWriter::on_network_error()
+void CacheEntryWriter::remove_incomplete_entry()
 {
     remove();
     close_and_destroy_cache_entry();

--- a/Libraries/LibHTTP/Cache/CacheEntry.h
+++ b/Libraries/LibHTTP/Cache/CacheEntry.h
@@ -93,7 +93,7 @@ public:
     ErrorOr<void> write_status_and_reason(u32 status_code, Optional<String> reason_phrase, HeaderList const& request_headers, HeaderList const& response_headers);
     ErrorOr<void> write_data(ReadonlyBytes);
     ErrorOr<void> flush(NonnullRefPtr<HeaderList> request_headers, NonnullRefPtr<HeaderList> response_headers);
-    void on_network_error();
+    void remove_incomplete_entry();
 
 private:
     CacheEntryWriter(DiskCache&, CacheIndex&, u64 cache_key, String url, CacheHeader, UnixDateTime request_time, AK::Duration current_time_offset_for_testing);


### PR DESCRIPTION
If a request failed, or was stopped, do not attempt to write the cache entry footer to disk. Note that at this point, the cache index will not have been created, thus this entry will not be used in the future. We do still delete any partial file on disk.

This serves as a more general fix for the issue addressed in commit 9f2ac14521d54c48b7301b24a3549a0d058a1d6a.