### PR TITLE
LibGfx: Add missing SkiaBackendContext locks

### DIFF
--- a/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Libraries/LibGfx/ImmutableBitmap.h
@@ -80,6 +80,9 @@ private:
     mutable NonnullOwnPtr<ImmutableBitmapImpl> m_impl;
 
     explicit ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl> bitmap);
+
+    void lock_context();
+    void unlock_context();
 };
 
 }

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -157,20 +157,24 @@ PaintingSurface::~PaintingSurface()
 
 void PaintingSurface::read_into_bitmap(Bitmap& bitmap)
 {
+    lock_context();
     auto color_type = to_skia_color_type(bitmap.format());
     auto alpha_type = to_skia_alpha_type(bitmap.format(), bitmap.alpha_type());
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->readPixels(pixmap, 0, 0);
+    unlock_context();
 }
 
 void PaintingSurface::write_from_bitmap(Bitmap const& bitmap)
 {
+    lock_context();
     auto color_type = to_skia_color_type(bitmap.format());
     auto alpha_type = to_skia_alpha_type(bitmap.format(), bitmap.alpha_type());
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->writePixels(pixmap, 0, 0);
+    unlock_context();
 }
 
 IntSize PaintingSurface::size() const


### PR DESCRIPTION
This adds locking for:
- Creating a sk_image from ImmutableBitmap
- Destroying ImmutableBitmap's sk_image
- Read/writing PaintingSurface for Bitmaps