### PR TITLE
Tests/LibWeb: Use hidden image workaround for flaky test

### DIFF
--- a/Tests/LibWeb/Ref/expected/body-background-image-rendering-propagation-ref.html
+++ b/Tests/LibWeb/Ref/expected/body-background-image-rendering-propagation-ref.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <style>
 html {
-    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAE0lEQVR4nGNgYGD4//8/GDMwAAAp5AX71ZPZmwAAAABJRU5ErkJggg==') no-repeat;
+    background: url('../data/2x2checkerboard.png') no-repeat;
     background-size: 100px 100px;
     image-rendering: pixelated;
 }
 </style>
+<img hidden src="../data/2x2checkerboard.png">

--- a/Tests/LibWeb/Ref/input/body-background-image-rendering-propagation.html
+++ b/Tests/LibWeb/Ref/input/body-background-image-rendering-propagation.html
@@ -2,8 +2,9 @@
 <link rel="match" href="../expected/body-background-image-rendering-propagation-ref.html">
 <style>
 body {
-    background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAE0lEQVR4nGNgYGD4//8/GDMwAAAp5AX71ZPZmwAAAABJRU5ErkJggg==') no-repeat;
+    background: url('../data/2x2checkerboard.png') no-repeat;
     background-size: 100px 100px;
     image-rendering: pixelated;
 }
 </style>
+<img hidden src="../data/2x2checkerboard.png">


### PR DESCRIPTION
We use this workaround in other tests as well. As a bonus, replace the data: URL with an image we already had available.