### PR TITLE
LibWeb: Fix scroll regression when pinch-to-zoom is applied

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2803,7 +2803,9 @@ RefPtr<Gfx::SkiaBackendContext> Navigable::skia_backend_context() const
 
 GC::Ref<WebIDL::Promise> Navigable::scroll_viewport_by_delta(CSSPixelPoint delta)
 {
-    return perform_a_scroll_of_the_viewport(m_viewport_scroll_offset + delta);
+    auto vv = active_document()->visual_viewport();
+    CSSPixelPoint page_position { CSSPixels(vv->page_left()), CSSPixels(vv->page_top()) };
+    return perform_a_scroll_of_the_viewport(page_position + delta);
 }
 
 // https://drafts.csswg.org/cssom-view/#viewport-perform-a-scroll

--- a/Tests/LibWeb/Text/expected/scroll-with-pinch-zoom-applied.txt
+++ b/Tests/LibWeb/Text/expected/scroll-with-pinch-zoom-applied.txt
@@ -1,0 +1,4 @@
+Initial: pageTop=0, scale=1
+After zoom: pageTop=33.328125, scale=1.5, offsetTop=33.328125
+pageTop changed by: 100
+PASS

--- a/Tests/LibWeb/Text/input/scroll-with-pinch-zoom-applied.html
+++ b/Tests/LibWeb/Text/input/scroll-with-pinch-zoom-applied.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        overflow: scroll;
+    }
+
+    .spacer {
+        height: 3000px;
+        background: linear-gradient(to bottom, red, blue);
+    }
+</style>
+<div class="spacer"></div>
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        const vv = window.visualViewport;
+        const scrollDelta = 100;
+
+        println(`Initial: pageTop=${vv.pageTop}, scale=${vv.scale}`);
+
+        // First, zoom in
+        vv.addEventListener("resize", function onResize() {
+            vv.removeEventListener("resize", onResize);
+
+            println(`After zoom: pageTop=${vv.pageTop}, scale=${vv.scale}, offsetTop=${vv.offsetTop}`);
+
+            const pageTopBefore = vv.pageTop;
+
+            // Scroll down
+            internals.wheel(100, 100, 0, scrollDelta);
+
+            // Poll for changes since scroll events may not fire for visual viewport panning
+            requestAnimationFrame(() => {
+                const pageTopAfter = vv.pageTop;
+                const scrolled = pageTopAfter - pageTopBefore;
+
+                println(`pageTop changed by: ${scrolled}`);
+
+                // The scroll amount should be approximately equal to the requested delta
+                // Allow small tolerance for floating point
+                if (Math.abs(scrolled - scrollDelta) < 1) {
+                    println("PASS");
+                } else {
+                    println(`FAIL: Expected scroll of ${scrollDelta}, got ${scrolled}`);
+                }
+                done();
+            });
+        });
+
+        requestAnimationFrame(() => {
+            // Zoom in (scale increases with positive delta)
+            internals.pinch(100, 100, 0.5);
+        });
+    });
+</script>


### PR DESCRIPTION
When scrolling with a visual viewport offset (from pinch-to-zoom), scroll_viewport_by_delta() was passing `m_viewport_scroll_offset + delta` to perform_a_scroll_of_the_viewport(). However, that function calculates the scroll delta as `position - page_top()`, where page_top() includes the visual viewport offset. This caused the effective scroll delta to be reduced by the visual offset amount.

Fix by using the current page position (which includes the visual offset) as the base for the delta calculation.

Regression from 0a57e1e8ac465f07af4674cb05850fdc13dc0009.