### PR TITLE
LibWeb: Move gradient color stops expansion to recording phase

### DIFF
--- a/Libraries/LibWeb/Painting/GradientData.h
+++ b/Libraries/LibWeb/Painting/GradientData.h
@@ -19,6 +19,7 @@ using ColorStopList = Vector<Gfx::ColorStop, 4>;
 struct ColorStopData {
     ColorStopList list;
     Optional<float> repeat_length;
+    bool repeating { false };
 };
 
 struct LinearGradientData {


### PR DESCRIPTION
Expand color stops during display list recording rather than playback. Recording happens once but the display list may be executed many times, so doing this work at record time is more efficient.