### PR TITLE
RequestServer: Set HTTP/3 as default version with fallback to earlier

### DIFF
--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -497,6 +497,7 @@ void Request::handle_fetch_state()
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());
     set_option(CURLOPT_PORT, m_url.port_or_default());
     set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
+    set_option(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3);
     set_option(CURLOPT_PIPEWAIT, 1L);
     set_option(CURLOPT_ALTSVC, m_alt_svc_cache_path.characters());
 


### PR DESCRIPTION
Related to #7574 but doesn't directly fix it.

Still seems like a good change for certain network/router/firewall situations as those discussed in #7574 issue.