### PR TITLE
LibCore: Avoid crash if notifier not registered if terminated by CTRL-C

### DIFF
--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -638,8 +638,9 @@ void EventLoopManagerUnix::unregister_timer(intptr_t timer_id)
 
 void EventLoopManagerUnix::register_notifier(Notifier& notifier)
 {
+    Threading::RWLockLocker<Threading::LockMode::Read> locker(s_thread_data_lock);
     auto& thread_data = ThreadData::the();
-    Threading::MutexLocker locker(thread_data.mutex);
+    Threading::MutexLocker thread_data_content_locker(thread_data.mutex);
 
     thread_data.notifier_to_index.set(&notifier, thread_data.poll_fds.size());
     thread_data.notifiers.append(&notifier);


### PR DESCRIPTION
In situations where some HTTP/3 traffic might be blocked by firewalls as in issue #7574, notifiers might not be registered as expected.

Found will testing #7600.

Fixes #7602 