### PR TITLE
LibWeb: Support MIME type sniffing for streaming HTTP responses

### DIFF
--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -412,7 +412,7 @@ bool can_load_document_with_type(MimeSniff::MimeType const& type)
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#loading-a-document
-GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing)
+GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing, ReadonlyBytes sniff_bytes)
 {
     // To load a document given navigation params navigationParams, source snapshot params sourceSnapshotParams,
     // and origin initiatorOrigin, perform the following steps. They return a Document or null.
@@ -422,10 +422,7 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
     // 1. Let type be the computed type of navigationParams's response.
     auto supplied_type = Fetch::Infrastructure::extract_mime_type(navigation_params.response->header_list());
     auto type = MimeSniff::Resource::sniff(
-        navigation_params.response->body()->source().visit(
-            [](Empty) { return ReadonlyBytes {}; },
-            [](ByteBuffer const& buffer) { return ReadonlyBytes { buffer }; },
-            [](GC::Root<FileAPI::Blob> const& blob) { return blob->raw_bytes(); }),
+        sniff_bytes,
         MimeSniff::SniffingConfiguration {
             .sniffing_context = MimeSniff::SniffingContext::Browsing,
             .supplied_type = move(supplied_type) });

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -8,14 +8,13 @@
 #pragma once
 
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/UserNavigationInvolvement.h>
 
 namespace Web {
 
 bool build_xml_document(DOM::Document& document, ByteBuffer const& data, Optional<String> content_encoding);
-GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing);
+GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_params, NonnullRefPtr<Core::Promise<Empty>> signal_to_continue_session_history_processing, ReadonlyBytes sniff_bytes);
 bool can_load_document_with_type(MimeSniff::MimeType const&);
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-ua-inline

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Fetch/Fetching/FetchedDataReceiver.h>
 #include <LibWeb/Fetch/Infrastructure/FetchParams.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/Fetch/Infrastructure/Task.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
@@ -30,11 +31,20 @@ FetchedDataReceiver::FetchedDataReceiver(GC::Ref<Infrastructure::FetchParams con
 
 FetchedDataReceiver::~FetchedDataReceiver() = default;
 
+void FetchedDataReceiver::set_body(GC::Ref<Fetch::Infrastructure::Body> body)
+{
+    m_body = body;
+    // Flush any bytes that were buffered before the body was set
+    if (!m_buffer.is_empty())
+        m_body->append_sniff_bytes(m_buffer);
+}
+
 void FetchedDataReceiver::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_fetch_params);
     visitor.visit(m_response);
+    visitor.visit(m_body);
     visitor.visit(m_stream);
     visitor.visit(m_pending_promise);
 }
@@ -61,10 +71,17 @@ void FetchedDataReceiver::handle_network_bytes(ReadonlyBytes bytes, NetworkState
     if (state == NetworkState::Complete) {
         VERIFY(bytes.is_empty());
         m_lifecycle_state = LifecycleState::CompletePending;
+        // Mark sniff bytes as complete when the stream ends
+        if (m_body)
+            m_body->set_sniff_bytes_complete();
     }
 
-    if (state == NetworkState::Ongoing)
+    if (state == NetworkState::Ongoing) {
         m_buffer.append(bytes);
+        // Capture bytes for MIME sniffing
+        if (m_body)
+            m_body->append_sniff_bytes(bytes);
+    }
 
     if (!m_pending_promise) {
         if (m_lifecycle_state == LifecycleState::CompletePending && buffer_is_eof() && !m_has_unfulfilled_promise)

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.h
@@ -25,6 +25,7 @@ public:
     void set_pending_promise(GC::Ref<WebIDL::Promise>);
 
     void set_response(GC::Ref<Fetch::Infrastructure::Response const> response) { m_response = response; }
+    void set_body(GC::Ref<Fetch::Infrastructure::Body> body);
 
     enum class NetworkState {
         Ongoing,
@@ -46,6 +47,7 @@ private:
 
     GC::Ref<Infrastructure::FetchParams const> m_fetch_params;
     GC::Ptr<Fetch::Infrastructure::Response const> m_response;
+    GC::Ptr<Fetch::Infrastructure::Body> m_body;
 
     GC::Ref<Streams::ReadableStream> m_stream;
     GC::Ptr<WebIDL::Promise> m_pending_promise;

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2131,7 +2131,9 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
         fetched_data_receiver->set_response(response);
 
         // 14. Set response’s body to a new body whose stream is stream.
-        response->set_body(Infrastructure::Body::create(vm, stream));
+        auto body = Infrastructure::Body::create(vm, stream);
+        response->set_body(body);
+        fetched_data_receiver->set_body(body);
 
         // 17. Return response.
         // NOTE: Typically response’s body’s stream is still being enqueued to after returning.


### PR DESCRIPTION
Previously, when loading a document, we would try to sniff the MIME type by reading from the response body's source. However, for streaming HTTP responses, the body source is `Empty` (the data comes through the stream instead), so we had no bytes to sniff.

This caused pages like https://hypr.land (which sends no `Content-Type` header) to be misidentified as plain text instead of HTML, since the MIME sniffing algorithm would receive zero bytes and fall back to the default type.

The fix captures the first bytes of the response body during fetch, storing them on the Body object. These bytes are the "resource header" defined by the [MIME Sniffing spec](https://mimesniff.spec.whatwg.org/#reading-the-resource-header) - up to 1445 bytes, which is enough to identify any MIME type the spec can detect.

Since bytes may arrive asynchronously during streaming, we use a callback mechanism: if bytes aren't ready yet when `load_document()` needs them, it registers a callback that fires once enough bytes have been captured (or the stream ends).

The flow is:
1. `FetchedDataReceiver` receives network bytes, buffers them
2. When `Body` is created, buffered bytes are flushed to `Body`'s sniff buffer, and subsequent bytes are appended as they arrive
3. Before calling `load_document()`, `Navigable` waits for sniff bytes
4. `load_document()` passes the bytes to `MimeSniff::Resource::sniff()`