### PR TITLE
LibGfx+LibWeb: Cache SkTextBlob in GlyphRun

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -25,9 +25,14 @@ Gfx::IntRect PaintInnerBoxShadow::bounding_rect() const
     return box_shadow_params.device_content_rect;
 }
 
+Gfx::IntRect DrawGlyphRun::bounding_rect() const
+{
+    return glyph_run->cached_blob_bounds().translated(translation).to_rounded<int>();
+}
+
 void DrawGlyphRun::dump(StringBuilder& builder) const
 {
-    builder.appendff(" rect={} translation={} color={} scale={}", rect, translation, color, scale);
+    builder.appendff(" rect={} translation={} color={}", rect, translation, color);
 }
 
 void FillRect::dump(StringBuilder& builder) const
@@ -99,7 +104,7 @@ void PaintInnerBoxShadow::dump(StringBuilder& builder) const
 
 void PaintTextShadow::dump(StringBuilder& builder) const
 {
-    builder.appendff(" shadow_rect={} text_rect={} draw_location={} blur_radius={} color={} scale={}", shadow_bounding_rect, text_rect, draw_location, blur_radius, color, glyph_run_scale);
+    builder.appendff(" shadow_rect={} text_rect={} draw_location={} blur_radius={} color={}", shadow_bounding_rect, text_rect, draw_location, blur_radius, color);
 }
 
 void FillRectWithRoundedCorners::dump(StringBuilder& builder) const

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -40,14 +40,12 @@ struct DrawGlyphRun {
     static constexpr StringView command_name = "DrawGlyphRun"sv;
 
     NonnullRefPtr<Gfx::GlyphRun const> glyph_run;
-    double scale { 1 };
     Gfx::IntRect rect;
     Gfx::FloatPoint translation;
     Color color;
     Gfx::Orientation orientation { Gfx::Orientation::Horizontal };
-    Gfx::IntRect bounding_rectangle;
 
-    [[nodiscard]] Gfx::IntRect bounding_rect() const { return bounding_rectangle; }
+    [[nodiscard]] Gfx::IntRect bounding_rect() const;
     void dump(StringBuilder&) const;
 };
 
@@ -175,7 +173,6 @@ struct PaintTextShadow {
     static constexpr StringView command_name = "PaintTextShadow"sv;
 
     NonnullRefPtr<Gfx::GlyphRun const> glyph_run;
-    double glyph_run_scale { 1 };
     Gfx::IntRect shadow_bounding_rect;
     Gfx::IntRect text_rect;
     Gfx::FloatPoint draw_location;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -240,14 +240,13 @@ void DisplayListRecorder::draw_glyph_run(Gfx::FloatPoint baseline_start, Gfx::Gl
 {
     if (color.alpha() == 0)
         return;
+    glyph_run.ensure_text_blob(scale);
     APPEND(DrawGlyphRun {
         .glyph_run = glyph_run,
-        .scale = scale,
         .rect = rect,
         .translation = baseline_start,
         .color = color,
         .orientation = orientation,
-        .bounding_rectangle = glyph_run.bounding_rect().scaled(scale).translated(baseline_start).to_type<int>(),
     });
 }
 
@@ -299,9 +298,9 @@ void DisplayListRecorder::paint_inner_box_shadow(PaintBoxShadowParams params)
 
 void DisplayListRecorder::paint_text_shadow(int blur_radius, Gfx::IntRect bounding_rect, Gfx::IntRect text_rect, Gfx::GlyphRun const& glyph_run, double glyph_run_scale, Color color, Gfx::FloatPoint draw_location)
 {
+    glyph_run.ensure_text_blob(glyph_run_scale);
     APPEND(PaintTextShadow {
         .glyph_run = glyph_run,
-        .glyph_run_scale = glyph_run_scale,
         .shadow_bounding_rect = bounding_rect,
         .text_rect = text_rect,
         .draw_location = draw_location,

--- a/Tests/LibWeb/Text/expected/css/text-underline-position.txt
+++ b/Tests/LibWeb/Text/expected/css/text-underline-position.txt
@@ -3,10 +3,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  DrawGlyphRun@1 rect=[35,8 8x18] translation=[35.15625,21.796875] color=rgb(0, 0, 0) scale=1
-  DrawGlyphRun@1 rect=[8,8 28x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@1 rect=[35,8 8x18] translation=[35.15625,21.796875] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,8 28x18] translation=[8,21.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[8,24] to=[35,24] color=rgb(0, 0, 0) thickness=2
-  DrawGlyphRun@1 rect=[43,8 28x18] translation=[43.15625,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@1 rect=[43,8 28x18] translation=[43.15625,21.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[43,27] to=[71,27] color=rgb(0, 0, 0) thickness=2
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
+++ b/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
@@ -5,7 +5,7 @@ DisplayList:
 SaveLayer@0
   FillRect@1 rect=[8,8 106x22] color=rgb(212, 208, 200)
   FillPath@1 path_bounding_rect=[8,8 106x22]
-  DrawGlyphRun@1 rect=[13,10 96x18] translation=[13,23.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@1 rect=[13,10 96x18] translation=[13,23.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[13,26] to=[109,26] color=rgb(0, 0, 0) thickness=2
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
@@ -6,7 +6,7 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
-  DrawGlyphRun@2 rect=[8,13 30x18] translation=[8,26.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,13 30x18] translation=[8,26.796875] color=rgb(0, 0, 0)
 Restore@0
 
 After clip change:
@@ -17,6 +17,6 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
-  DrawGlyphRun@2 rect=[8,13 30x18] translation=[8,26.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,13 30x18] translation=[8,26.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
@@ -6,7 +6,7 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
-  DrawGlyphRun@2 rect=[8,8 30x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,8 30x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0
 
 After clip-path change:
@@ -17,6 +17,6 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
-  DrawGlyphRun@2 rect=[8,8 30x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,8 30x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
+++ b/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
@@ -5,7 +5,7 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,13 150x150] color=rgb(128, 0, 128)
-  DrawGlyphRun@2 rect=[8,13 71x18] translation=[8,26.796875] color=rgb(0, 0, 0) scale=1
-  DrawGlyphRun@2 rect=[8,31 72x18] translation=[8,44.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,13 71x18] translation=[8,26.796875] color=rgb(0, 0, 0)
+  DrawGlyphRun@2 rect=[8,31 72x18] translation=[8,44.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
+++ b/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
@@ -14,12 +14,12 @@ SaveLayer@0
   FillPath@2 path_bounding_rect=[10,10 195x200]
   FillPath@2 path_bounding_rect=[215,10 195x200]
   FillRect@4 rect=[16,16 150x80] color=rgb(255, 0, 0)
-  DrawGlyphRun@4 rect=[16,16 15x18] translation=[16,29.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@4 rect=[16,16 15x18] translation=[16,29.796875] color=rgb(0, 0, 0)
   FillRect@5 rect=[16,101 150x80] color=rgb(0, 128, 0)
-  DrawGlyphRun@5 rect=[16,101 10x18] translation=[16,114.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@5 rect=[16,101 10x18] translation=[16,114.796875] color=rgb(0, 0, 0)
   FillRect@7 rect=[221,16 150x80] color=rgb(0, 0, 255)
-  DrawGlyphRun@7 rect=[221,16 11x18] translation=[221,29.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@7 rect=[221,16 11x18] translation=[221,29.796875] color=rgb(0, 0, 0)
   FillRect@8 rect=[221,101 150x80] color=rgb(255, 165, 0)
-  DrawGlyphRun@8 rect=[221,101 12x18] translation=[221,114.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@8 rect=[221,101 12x18] translation=[221,114.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
@@ -5,8 +5,8 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,8 150x50] color=rgb(0, 128, 0)
-  DrawGlyphRun@2 rect=[8,8 56x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,8 56x18] translation=[8,21.796875] color=rgb(0, 0, 0)
   FillRect@0 rect=[10,10 80x40] color=rgb(255, 0, 0)
-  DrawGlyphRun@0 rect=[10,10 44x18] translation=[10,23.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@0 rect=[10,10 44x18] translation=[10,23.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
@@ -8,8 +8,8 @@ DisplayList:
 SaveLayer@0
   FillPath@1 path_bounding_rect=[118,8 102x102]
   FillRect@4 rect=[119,9 150x150] color=rgb(173, 216, 230)
-  DrawGlyphRun@4 rect=[119,9 55x18] translation=[119,22.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@4 rect=[119,9 55x18] translation=[119,22.796875] color=rgb(0, 0, 0)
   FillRect@2 rect=[8,8 100x100] color=rgb(255, 127, 80)
-  DrawGlyphRun@2 rect=[8,8 88x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,8 88x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
@@ -14,12 +14,12 @@ SaveLayer@0
   FillPath@2 path_bounding_rect=[20,20 145x250]
   FillPath@2 path_bounding_rect=[175,20 145x250]
   FillRect@4 rect=[26,26 133x40] color=rgb(255, 136, 136)
-  DrawGlyphRun@4 rect=[26,26 20x18] translation=[26,39.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@4 rect=[26,26 20x18] translation=[26,39.796875] color=rgb(0, 0, 0)
   FillRect@5 rect=[26,71 133x40] color=rgb(136, 255, 136)
-  DrawGlyphRun@5 rect=[26,71 22x18] translation=[26,84.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@5 rect=[26,71 22x18] translation=[26,84.796875] color=rgb(0, 0, 0)
   FillRect@7 rect=[181,26 133x40] color=rgb(136, 136, 255)
-  DrawGlyphRun@7 rect=[181,26 22x18] translation=[181,39.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@7 rect=[181,26 22x18] translation=[181,39.796875] color=rgb(0, 0, 0)
   FillRect@8 rect=[181,71 133x40] color=rgb(255, 255, 136)
-  DrawGlyphRun@8 rect=[181,71 25x18] translation=[181,84.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@8 rect=[181,71 25x18] translation=[181,84.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -11,7 +11,7 @@ SaveLayer@0
   FillRect@3 rect=[10,10 302x102] color=rgb(255, 255, 224)
   FillPath@3 path_bounding_rect=[10,10 302x102]
   FillRect@5 rect=[11,11 400x80] color=rgb(240, 128, 128)
-  DrawGlyphRun@5 rect=[11,11 178x18] translation=[11,24.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@5 rect=[11,11 178x18] translation=[11,24.796875] color=rgb(0, 0, 0)
   PaintScrollBar@3
   PaintScrollBar@1
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
@@ -6,6 +6,6 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@3 rect=[8,8 100x100] color=rgb(0, 0, 255)
-  DrawGlyphRun@3 rect=[8,8 21x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[8,8 21x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
@@ -7,6 +7,6 @@ SaveLayer@0
   FillRect@2 rect=[8,8 200x200] color=rgb(211, 211, 211)
   FillRect@2 rect=[8,8 200x90] color=rgb(173, 216, 230)
   FillRect@2 rect=[33,33 100x50] color=rgb(255, 127, 80)
-  DrawGlyphRun@2 rect=[33,33 84x18] translation=[33,46.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[33,33 84x18] translation=[33,46.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
+++ b/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
@@ -8,6 +8,6 @@ SaveLayer@0
   FillRect@1 rect=[8,8 300x300] color=rgb(211, 211, 211)
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   FillRect@3 rect=[13,13 100x100] color=rgb(255, 127, 80)
-  DrawGlyphRun@3 rect=[13,13 65x18] translation=[13,26.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[13,13 65x18] translation=[13,26.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -8,7 +8,7 @@ SaveLayer@0
   FillPath@0 path_bounding_rect=[20,20 204x154]
   FillPath@0 path_bounding_rect=[32,32 182x102]
   FillRect@3 rect=[33,33 300x200] color=rgb(240, 128, 128)
-  DrawGlyphRun@3 rect=[33,33 179x18] translation=[33,46.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[33,33 179x18] translation=[33,46.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0
   PaintScrollBar@0
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -11,7 +11,7 @@ SaveLayer@0
   FillRect@3 rect=[9,9 150x120] color=rgb(240, 128, 128)
   FillPath@1 path_bounding_rect=[130,8 102x82]
   FillRect@5 rect=[131,9 150x120] color=rgb(144, 238, 144)
-  DrawGlyphRun@3 rect=[9,9 110x18] translation=[9,22.796875] color=rgb(0, 0, 0) scale=1
-  DrawGlyphRun@5 rect=[131,9 119x18] translation=[131,22.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[9,9 110x18] translation=[9,22.796875] color=rgb(0, 0, 0)
+  DrawGlyphRun@5 rect=[131,9 119x18] translation=[131,22.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -16,13 +16,13 @@ SaveLayer@0
   FillRect@5 rect=[126,23 200x300] color=rgb(144, 238, 144)
   FillPath@0 path_bounding_rect=[229,22 93x152]
   FillRect@7 rect=[230,23 200x300] color=rgb(173, 216, 230)
-  DrawGlyphRun@3 rect=[23,23 71x18] translation=[23,36.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[23,23 71x18] translation=[23,36.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0
   PaintScrollBar@0
-  DrawGlyphRun@5 rect=[126,23 66x18] translation=[126.328125,36.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@5 rect=[126,23 66x18] translation=[126.328125,36.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0
   PaintScrollBar@0
-  DrawGlyphRun@7 rect=[229,23 67x18] translation=[229.65625,36.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@7 rect=[229,23 67x18] translation=[229.65625,36.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0
   PaintScrollBar@0
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
@@ -6,8 +6,8 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,8 80x80] color=rgb(255, 0, 0)
-  DrawGlyphRun@2 rect=[8,8 15x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,8 15x18] translation=[8,21.796875] color=rgb(0, 0, 0)
   FillRect@3 rect=[98,8 80x80] color=rgb(0, 0, 255)
-  DrawGlyphRun@3 rect=[98,8 10x18] translation=[98,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[98,8 10x18] translation=[98,21.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -7,6 +7,6 @@ DisplayList:
 SaveLayer@0
   FillPath@1 path_bounding_rect=[8,8 204x104]
   FillRect@3 rect=[10,10 300x150] color=rgb(240, 128, 128)
-  DrawGlyphRun@3 rect=[10,10 38x18] translation=[10,23.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[10,10 38x18] translation=[10,23.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
+++ b/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
@@ -7,10 +7,10 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,8 60x60] color=rgb(255, 0, 0)
-  DrawGlyphRun@2 rect=[8,8 7x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,8 7x18] translation=[8,21.796875] color=rgb(0, 0, 0)
   FillRect@3 rect=[73,8 60x60] color=rgb(0, 128, 0)
-  DrawGlyphRun@3 rect=[73,8 9x18] translation=[73,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[73,8 9x18] translation=[73,21.796875] color=rgb(0, 0, 0)
   FillRect@4 rect=[138,8 60x60] color=rgb(0, 0, 255)
-  DrawGlyphRun@4 rect=[138,8 10x18] translation=[138,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@4 rect=[138,8 10x18] translation=[138,21.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
@@ -5,6 +5,6 @@ AccumulatedVisualContext Tree:
 DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 0, 255)
-  DrawGlyphRun@2 rect=[8,8 38x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@2 rect=[8,8 38x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
@@ -7,6 +7,6 @@ DisplayList:
 SaveLayer@0
   FillRect@2 rect=[8,8 200x200] color=rgb(173, 216, 230)
   FillRect@3 rect=[8,8 100x100] color=rgb(255, 127, 80)
-  DrawGlyphRun@3 rect=[8,8 52x18] translation=[8,21.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@3 rect=[8,8 52x18] translation=[8,21.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
@@ -8,6 +8,6 @@ DisplayList:
 SaveLayer@0
   FillPath@1 path_bounding_rect=[8,8 154x154]
   FillRect@4 rect=[10,10 200x200] color=rgb(144, 238, 144)
-  DrawGlyphRun@4 rect=[10,10 185x18] translation=[10,23.796875] color=rgb(0, 0, 0) scale=1
+  DrawGlyphRun@4 rect=[10,10 185x18] translation=[10,23.796875] color=rgb(0, 0, 0)
 Restore@0
 


### PR DESCRIPTION
Previously, SkTextBlob was built on every paint in DisplayListPlayerSkia::draw_glyph_run(), which meant:
- Repeated work when the same display list is painted multiple times
- Glyph arrays were allocated and populated on each paint

Now the blob is built once during display list recording and cached in GlyphRun.