### PR TITLE
LibWeb: Fix logical border-radius properties not being applied

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -617,34 +617,32 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     computed_values.set_font_features(computed_style.font_features());
     computed_values.set_font_variation_settings(computed_style.font_variation_settings());
 
+    auto border_radius_data_from_style_value = [](CSS::StyleValue const& value) -> Optional<CSS::BorderRadiusData> {
+        if (value.is_border_radius()) {
+            return CSS::BorderRadiusData {
+                CSS::LengthPercentage::from_style_value(value.as_border_radius().horizontal_radius()),
+                CSS::LengthPercentage::from_style_value(value.as_border_radius().vertical_radius())
+            };
+        }
+        if (value.is_percentage() || value.is_length() || value.is_calculated()) {
+            auto length_percentage = CSS::LengthPercentage::from_style_value(value);
+            return CSS::BorderRadiusData { length_percentage, length_percentage };
+        }
+        return {};
+    };
+
     auto const& border_bottom_left_radius = computed_style.property(CSS::PropertyID::BorderBottomLeftRadius);
-    if (border_bottom_left_radius.is_border_radius()) {
-        computed_values.set_border_bottom_left_radius(
-            CSS::BorderRadiusData {
-                CSS::LengthPercentage::from_style_value(border_bottom_left_radius.as_border_radius().horizontal_radius()),
-                CSS::LengthPercentage::from_style_value(border_bottom_left_radius.as_border_radius().vertical_radius()) });
-    }
+    if (auto data = border_radius_data_from_style_value(border_bottom_left_radius); data.has_value())
+        computed_values.set_border_bottom_left_radius(data.release_value());
     auto const& border_bottom_right_radius = computed_style.property(CSS::PropertyID::BorderBottomRightRadius);
-    if (border_bottom_right_radius.is_border_radius()) {
-        computed_values.set_border_bottom_right_radius(
-            CSS::BorderRadiusData {
-                CSS::LengthPercentage::from_style_value(border_bottom_right_radius.as_border_radius().horizontal_radius()),
-                CSS::LengthPercentage::from_style_value(border_bottom_right_radius.as_border_radius().vertical_radius()) });
-    }
+    if (auto data = border_radius_data_from_style_value(border_bottom_right_radius); data.has_value())
+        computed_values.set_border_bottom_right_radius(data.release_value());
     auto const& border_top_left_radius = computed_style.property(CSS::PropertyID::BorderTopLeftRadius);
-    if (border_top_left_radius.is_border_radius()) {
-        computed_values.set_border_top_left_radius(
-            CSS::BorderRadiusData {
-                CSS::LengthPercentage::from_style_value(border_top_left_radius.as_border_radius().horizontal_radius()),
-                CSS::LengthPercentage::from_style_value(border_top_left_radius.as_border_radius().vertical_radius()) });
-    }
+    if (auto data = border_radius_data_from_style_value(border_top_left_radius); data.has_value())
+        computed_values.set_border_top_left_radius(data.release_value());
     auto const& border_top_right_radius = computed_style.property(CSS::PropertyID::BorderTopRightRadius);
-    if (border_top_right_radius.is_border_radius()) {
-        computed_values.set_border_top_right_radius(
-            CSS::BorderRadiusData {
-                CSS::LengthPercentage::from_style_value(border_top_right_radius.as_border_radius().horizontal_radius()),
-                CSS::LengthPercentage::from_style_value(border_top_right_radius.as_border_radius().vertical_radius()) });
-    }
+    if (auto data = border_radius_data_from_style_value(border_top_right_radius); data.has_value())
+        computed_values.set_border_top_right_radius(data.release_value());
     computed_values.set_display(computed_style.display());
     computed_values.set_display_before_box_type_transformation(computed_style.display_before_box_type_transformation());
 

--- a/Tests/LibWeb/Text/expected/css/logical-border-radius-computed.txt
+++ b/Tests/LibWeb/Text/expected/css/logical-border-radius-computed.txt
@@ -1,0 +1,8 @@
+border-start-start-radius: 50% -> 50%
+border-start-end-radius: 25% -> 25%
+border-end-start-radius: 10% -> 10%
+border-end-end-radius: 75% -> 75%
+border-start-start-radius: calc(10px + 5px) -> 15px
+border-start-end-radius: calc(50% - 10%) -> 40%
+border-end-start-radius: calc(20px * 2) -> 40px
+border-end-end-radius: calc(100% / 4) -> 25%

--- a/Tests/LibWeb/Text/input/css/logical-border-radius-computed.html
+++ b/Tests/LibWeb/Text/input/css/logical-border-radius-computed.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+#target {
+    width: 200px;
+    height: 100px;
+}
+</style>
+<div id="target"></div>
+<script>
+test(() => {
+    const target = document.getElementById("target");
+
+    // Test percentage values
+    target.style.borderStartStartRadius = "50%";
+    println(`border-start-start-radius: 50% -> ${getComputedStyle(target).borderTopLeftRadius}`);
+
+    target.style.borderStartEndRadius = "25%";
+    println(`border-start-end-radius: 25% -> ${getComputedStyle(target).borderTopRightRadius}`);
+
+    target.style.borderEndStartRadius = "10%";
+    println(`border-end-start-radius: 10% -> ${getComputedStyle(target).borderBottomLeftRadius}`);
+
+    target.style.borderEndEndRadius = "75%";
+    println(`border-end-end-radius: 75% -> ${getComputedStyle(target).borderBottomRightRadius}`);
+
+    // Reset
+    target.style.cssText = "width: 200px; height: 100px;";
+
+    // Test calc() values
+    target.style.borderStartStartRadius = "calc(10px + 5px)";
+    println(`border-start-start-radius: calc(10px + 5px) -> ${getComputedStyle(target).borderTopLeftRadius}`);
+
+    target.style.borderStartEndRadius = "calc(50% - 10%)";
+    println(`border-start-end-radius: calc(50% - 10%) -> ${getComputedStyle(target).borderTopRightRadius}`);
+
+    target.style.borderEndStartRadius = "calc(20px * 2)";
+    println(`border-end-start-radius: calc(20px * 2) -> ${getComputedStyle(target).borderBottomLeftRadius}`);
+
+    target.style.borderEndEndRadius = "calc(100% / 4)";
+    println(`border-end-end-radius: calc(100% / 4) -> ${getComputedStyle(target).borderBottomRightRadius}`);
+});
+</script>


### PR DESCRIPTION
Logical border-radius properties are parsed as Percentage/Length values, not BorderRadiusStyleValue. Handle these types when applying style.

Before:
<img width="2620" height="1690" alt="CleanShot 2026-01-24 at 17 56 21@2x" src="https://github.com/user-attachments/assets/593a70bd-01aa-48cb-a12d-2a8e081d8ba9" />

After:
<img width="2620" height="1690" alt="CleanShot 2026-01-24 at 17 55 59@2x" src="https://github.com/user-attachments/assets/92b71660-eaae-4d48-9c56-523f5ea9a308" />
