### PR TITLE
LibWeb: Correctly parse logical `border-*-*-radius` shorthands

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -558,6 +558,10 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_css_value(Pr
     case PropertyID::BorderTopRightRadius:
     case PropertyID::BorderBottomRightRadius:
     case PropertyID::BorderBottomLeftRadius:
+    case PropertyID::BorderEndEndRadius:
+    case PropertyID::BorderEndStartRadius:
+    case PropertyID::BorderStartEndRadius:
+    case PropertyID::BorderStartStartRadius:
         return parse_all_as(tokens, [this](auto& tokens) { return parse_border_radius_value(tokens); });
     case PropertyID::BorderRadius:
         return parse_all_as(tokens, [this](auto& tokens) { return parse_border_radius_shorthand_value(tokens); });

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -618,17 +618,12 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     computed_values.set_font_variation_settings(computed_style.font_variation_settings());
 
     auto border_radius_data_from_style_value = [](CSS::StyleValue const& value) -> Optional<CSS::BorderRadiusData> {
-        if (value.is_border_radius()) {
-            return CSS::BorderRadiusData {
-                CSS::LengthPercentage::from_style_value(value.as_border_radius().horizontal_radius()),
-                CSS::LengthPercentage::from_style_value(value.as_border_radius().vertical_radius())
-            };
-        }
-        if (value.is_percentage() || value.is_length() || value.is_calculated()) {
-            auto length_percentage = CSS::LengthPercentage::from_style_value(value);
-            return CSS::BorderRadiusData { length_percentage, length_percentage };
-        }
-        return {};
+        return CSS::BorderRadiusData {
+            CSS::LengthPercentage::from_style_value(value.as_border_radius().horizontal_radius()),
+            CSS::LengthPercentage::from_style_value(value.as_border_radius().vertical_radius())
+        };
+
+        VERIFY_NOT_REACHED();
     };
 
     auto const& border_bottom_left_radius = computed_style.property(CSS::PropertyID::BorderBottomLeftRadius);

--- a/Tests/LibWeb/Text/expected/css/logical-border-radius-computed.txt
+++ b/Tests/LibWeb/Text/expected/css/logical-border-radius-computed.txt
@@ -6,3 +6,11 @@ border-start-start-radius: calc(10px + 5px) -> 15px
 border-start-end-radius: calc(50% - 10%) -> 40%
 border-end-start-radius: calc(20px * 2) -> 40px
 border-end-end-radius: calc(100% / 4) -> 25%
+border-start-start-radius: 50% 0% -> 50% 0%
+border-start-end-radius: 45% 5% -> 45% 5%
+border-end-start-radius: 40% 10% -> 40% 10%
+border-end-end-radius: 35% 15% -> 35% 15%
+border-start-start-radius: 30% / 20% -> 30% 20%
+border-start-end-radius: 25% / 15% -> 25% 15%
+border-end-start-radius: 20% / 10% -> 20% 10%
+border-end-end-radius: 15% / 5% -> 15% 5%

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-logical/inheritance.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-logical/inheritance.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 68 tests
 
-61 Pass
-7 Fail
+65 Pass
+3 Fail
 Pass	Property block-size has initial value 0px
 Pass	Property block-size does not inherit
 Pass	Property border-block-end-color has initial value rgb(0, 0, 255)
@@ -19,9 +19,9 @@ Pass	Property border-block-start-style does not inherit
 Pass	Property border-block-start-width has initial value 3px
 Pass	Property border-block-start-width does not inherit
 Pass	Property border-end-end-radius has initial value 0px
-Fail	Property border-end-end-radius does not inherit
+Pass	Property border-end-end-radius does not inherit
 Pass	Property border-end-start-radius has initial value 0px
-Fail	Property border-end-start-radius does not inherit
+Pass	Property border-end-start-radius does not inherit
 Pass	Property border-inline-end-color has initial value rgb(0, 0, 255)
 Pass	Property border-inline-end-color does not inherit
 Pass	Property border-inline-end-style has initial value none
@@ -35,9 +35,9 @@ Pass	Property border-inline-start-style does not inherit
 Pass	Property border-inline-start-width has initial value 3px
 Pass	Property border-inline-start-width does not inherit
 Pass	Property border-start-end-radius has initial value 0px
-Fail	Property border-start-end-radius does not inherit
+Pass	Property border-start-end-radius does not inherit
 Pass	Property border-start-start-radius has initial value 0px
-Fail	Property border-start-start-radius does not inherit
+Pass	Property border-start-start-radius does not inherit
 Pass	Property inline-size has initial value 294px
 Pass	Property inline-size does not inherit
 Pass	Property inset-block-end has initial value auto

--- a/Tests/LibWeb/Text/input/css/logical-border-radius-computed.html
+++ b/Tests/LibWeb/Text/input/css/logical-border-radius-computed.html
@@ -39,5 +39,37 @@ test(() => {
 
     target.style.borderEndEndRadius = "calc(100% / 4)";
     println(`border-end-end-radius: calc(100% / 4) -> ${getComputedStyle(target).borderBottomRightRadius}`);
+
+    // Reset
+    target.style.cssText = "width: 200px; height: 100px;";
+
+    // Test <length-percentage>{2} values
+    target.style.borderStartStartRadius = "50% 0%";
+    println(`border-start-start-radius: 50% 0% -> ${getComputedStyle(target).borderTopLeftRadius}`);
+
+    target.style.borderStartEndRadius = "45% 5%";
+    println(`border-start-end-radius: 45% 5% -> ${getComputedStyle(target).borderTopRightRadius}`);
+
+    target.style.borderEndStartRadius = "40% 10%";
+    println(`border-end-start-radius: 40% 10% -> ${getComputedStyle(target).borderBottomLeftRadius}`);
+
+    target.style.borderEndEndRadius = "35% 15%";
+    println(`border-end-end-radius: 35% 15% -> ${getComputedStyle(target).borderBottomRightRadius}`);
+
+    // Reset
+    target.style.cssText = "width: 200px; height: 100px;";
+
+    // Test <slash-separated-border-radius-syntax> values
+    target.style.borderStartStartRadius = "30% / 20%";
+    println(`border-start-start-radius: 30% / 20% -> ${getComputedStyle(target).borderTopLeftRadius}`);
+
+    target.style.borderStartEndRadius = "25% / 15%";
+    println(`border-start-end-radius: 25% / 15% -> ${getComputedStyle(target).borderTopRightRadius}`);
+
+    target.style.borderEndStartRadius = "20% / 10%";
+    println(`border-end-start-radius: 20% / 10% -> ${getComputedStyle(target).borderBottomLeftRadius}`);
+
+    target.style.borderEndEndRadius = "15% / 5%";
+    println(`border-end-end-radius: 15% / 5% -> ${getComputedStyle(target).borderBottomRightRadius}`);
 });
 </script>


### PR DESCRIPTION
Builds on #7609 by parsing these properties correctly in the first place