### PR TITLE
LibWeb: Resolve margins for block-level buttons with `width:auto`

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -234,14 +234,6 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     box_state.padding_left = padding_left.to_px_or_zero(box);
     box_state.padding_right = padding_right.to_px_or_zero(box);
 
-    // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
-    // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
-    if (auto const* html_element = as_if<HTML::HTMLElement>(box.dom_node()); html_element
-        && html_element->uses_button_layout() && computed_values.width().is_auto()) {
-        box_state.set_content_width(calculate_fit_content_width(box, available_space));
-        return;
-    }
-
     // NOTE: If we are calculating the min-content or max-content width of this box,
     //       and the width should be treated as auto, then we can simply return here,
     //       as the preferred width and min/max constraints are irrelevant for intrinsic sizing.
@@ -324,6 +316,14 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         }
         if (is<TableWrapper>(box))
             return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, remaining_available_space));
+
+        // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
+        // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
+        if (auto const* html_element = as_if<HTML::HTMLElement>(box.dom_node()); html_element
+            && html_element->uses_button_layout() && computed_values.width().is_auto()) {
+            return CSS::Length::make_px(calculate_fit_content_width(box, available_space));
+        }
+
         if (should_treat_width_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
         return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width()));

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-width.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-width.txt
@@ -7,7 +7,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             frag 0 from TextNode start: 0, length: 11, rect: [60.53125,10 94.921875x18] baseline: 13.796875
                 "200px width"
             TextNode <#text> (not painted)
-      BlockContainer <button.btn> at [13,32] [0+1+4 324.671875 4+1+0] [0+1+1 18 1+1+0] [BFC] children: not-inline
+      BlockContainer <button.btn> at [13,32] [0+1+4 324.671875 4+1+449.328125] [0+1+1 18 1+1+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> at [13,32] flex-container(column) [0+0+0 324.671875 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> at [13,32] flex-item [0+0+0 324.671875 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 39, rect: [13,32 324.671875x18] baseline: 13.796875

--- a/Tests/LibWeb/Layout/expected/block-button-margin-auto.txt
+++ b/Tests/LibWeb/Layout/expected/block-button-margin-auto.txt
@@ -1,0 +1,31 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 38 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 22 0+0+8] children: not-inline
+      BlockContainer <div.container> at [8,8] [0+0+0 400 0+0+384] [0+0+0 22 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,8] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <button> at [189.390625,10] [176.390625+1+4 37.21875 4+1+176.390625] [0+1+1 18 1+1+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [189.390625,10] flex-container(column) [0+0+0 37.21875 0+0+0] [0+0+0 18 0+0+0] [FFC] children: not-inline
+            BlockContainer <(anonymous)> at [189.390625,10] flex-item [0+0+0 37.21875 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 4, rect: [189.390625,10 37.21875x18] baseline: 13.796875
+                  "Test"
+              TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,30] [0+0+0 400 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,30] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x38]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x22]
+      PaintableWithLines (BlockContainer<DIV>.container) [8,8 400x22]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 400x0]
+        PaintableWithLines (BlockContainer<BUTTON>) [184.390625,8 47.21875x22]
+          PaintableWithLines (BlockContainer(anonymous)) [189.390625,10 37.21875x18]
+            PaintableWithLines (BlockContainer(anonymous)) [189.390625,10 37.21875x18]
+              TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,30 400x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,30 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x38] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/input-as-button-shrink-to-fit.txt
+++ b/Tests/LibWeb/Layout/expected/input-as-button-shrink-to-fit.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 36 0+0+8] children: not-inline
-      BlockContainer <input.btn> at [13,10] [0+1+4 195.796875 4+1+0] [0+1+1 32 1+1+0] children: not-inline
+      BlockContainer <input.btn> at [13,10] [0+1+4 195.796875 4+1+578.203125] [0+1+1 32 1+1+0] children: not-inline
         BlockContainer <(anonymous)> at [13,10] flex-container(column) [0+0+0 195.796875 0+0+0] [0+0+0 32 0+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> at [13,17.5] flex-item [0+0+0 195.796875 0+0+0] [0+0+0 17 0+0+0] [BFC] children: inline
             frag 0 from BlockContainer start: 0, length: 0, rect: [13,17.5 195.796875x17] baseline: 13

--- a/Tests/LibWeb/Layout/input/block-button-margin-auto.html
+++ b/Tests/LibWeb/Layout/input/block-button-margin-auto.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    .container {
+        width: 400px;
+    }
+    button {
+        margin: 0 auto;
+        display: block;
+    }
+</style>
+<div class="container">
+    <button>Test</button>
+</div>


### PR DESCRIPTION
Previously, buttons with `display: block` and `width: auto` would take an early return path in compute_width() that set the content width to fit-content but skipped all margin resolution. This meant `margin: auto` would not center the button horizontally.

Fixes the positioning of the "Start using Photopea" buttons on the Photopea home page.

Before:
<img width="768" height="492" alt="image" src="https://github.com/user-attachments/assets/620a5b7a-3b40-4586-abcf-2408343de249" />

After
<img width="768" height="492" alt="image" src="https://github.com/user-attachments/assets/6fb37af2-162c-4c19-af14-7c6a4e8e4105" />
