### PR TITLE
LibWeb: Support `@-webkit-keyframes` as an alias for `@keyframes`

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/RuleContext.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleContext.cpp
@@ -49,7 +49,7 @@ RuleContext rule_context_type_for_at_rule(FlyString const& name)
         return RuleContext::AtMedia;
     if (name.equals_ignoring_ascii_case("font-face"sv))
         return RuleContext::AtFontFace;
-    if (name.equals_ignoring_ascii_case("keyframes"sv))
+    if (name.equals_ignoring_ascii_case("keyframes"sv) || name.equals_ignoring_ascii_case("-webkit-keyframes"sv))
         return RuleContext::AtKeyframes;
     if (name.equals_ignoring_ascii_case("supports"sv))
         return RuleContext::AtSupports;

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -91,6 +91,11 @@ GC::Ptr<CSSRule> Parser::convert_to_rule(Rule const& rule, Nested nested)
 {
     return rule.visit(
         [this, nested](AtRule const& at_rule) -> GC::Ptr<CSSRule> {
+            // https://compat.spec.whatwg.org/#css-at-rules
+            // @-webkit-keyframes must be supported as an alias of @keyframes.
+            if (at_rule.name.equals_ignoring_ascii_case("keyframes"sv) || at_rule.name.equals_ignoring_ascii_case("-webkit-keyframes"sv))
+                return convert_to_keyframes_rule(at_rule);
+
             if (has_ignored_vendor_prefix(at_rule.name))
                 return {};
 
@@ -99,9 +104,6 @@ GC::Ptr<CSSRule> Parser::convert_to_rule(Rule const& rule, Nested nested)
 
             if (at_rule.name.equals_ignoring_ascii_case("import"sv))
                 return convert_to_import_rule(at_rule);
-
-            if (at_rule.name.equals_ignoring_ascii_case("keyframes"sv))
-                return convert_to_keyframes_rule(at_rule);
 
             if (at_rule.name.equals_ignoring_ascii_case("layer"sv))
                 return convert_to_layer_rule(at_rule, nested);

--- a/Tests/LibWeb/Text/expected/css/webkit-keyframes-alias.txt
+++ b/Tests/LibWeb/Text/expected/css/webkit-keyframes-alias.txt
@@ -1,0 +1,4 @@
+Rule type: 7
+Rule is CSSKeyframesRule: true
+Animation name: test-animation
+Number of keyframes: 2

--- a/Tests/LibWeb/Text/input/css/webkit-keyframes-alias.html
+++ b/Tests/LibWeb/Text/input/css/webkit-keyframes-alias.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style id="test-style">
+@-webkit-keyframes test-animation {
+    0% { opacity: 0; }
+    100% { opacity: 1; }
+}
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const sheet = document.getElementById("test-style").sheet;
+        const rule = sheet.cssRules[0];
+
+        println(`Rule type: ${rule.type}`);
+        println(`Rule is CSSKeyframesRule: ${rule instanceof CSSKeyframesRule}`);
+        println(`Animation name: ${rule.name}`);
+        println(`Number of keyframes: ${rule.cssRules.length}`);
+    });
+</script>


### PR DESCRIPTION
This is listed as mandatory in the compat spec.

With this change https://app.diagrams.net/ is now usable:

<img width="1865" height="778" alt="diagrams net" src="https://github.com/user-attachments/assets/1daf27dd-8c31-4ca5-bcc9-00c2322e8b25" />
