### PR TITLE
LibWeb: Don't resolve percentage heights against min-height (for GMail)

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/percentage-height-with-min-height-parent.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/percentage-height-with-min-height-parent.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 48 0+0+8] children: not-inline
+      BlockContainer <main> at [8,8] [0+0+0 784 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
+        BlockContainer <div#foo> at [8,8] [0+0+0 300 0+0+484] [0+0+0 0 0+0+0] children: not-inline
+        BlockContainer <div#bar> at [8,8] [0+0+0 784 0+0+0] [0+0+0 46 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,56] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x64]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x48]
+      PaintableWithLines (BlockContainer<MAIN>) [8,8 784x48]
+        PaintableWithLines (BlockContainer<DIV>#foo) [8,8 300x0]
+        PaintableWithLines (BlockContainer<DIV>#bar) [8,8 784x46]
+      PaintableWithLines (BlockContainer(anonymous)) [8,56 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x64] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/block-and-inline/percentage-height-with-min-height-parent.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/percentage-height-with-min-height-parent.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<style>
+    main {
+        min-height: 48px;
+        overflow: hidden;
+    }
+    #foo {
+        display: block;
+        width: 300px;
+        height: 100%;
+    }
+    #bar {
+        height: 46px;
+    }
+</style>
+<main><div id="foo"></div><div id="bar"></div></main>


### PR DESCRIPTION
Per CSS 2.1 Section 10.5, percentage heights should only resolve when the containing block's height is "specified explicitly". This means a containing block with `height: auto` and `min-height: 50px` does NOT provide a definite height for percentage resolution - the child's `height: 100%` should be treated as `auto`.

Previously, we checked `available_space.height.is_indefinite()` to determine if percentage heights should become auto. However, this conflated "available layout space" with "containing block height for percentage resolution" - these are distinct concepts.

Now we check the containing block's `has_definite_height()` flag, which correctly reflects whether the containing block has an explicit height property. This handles:

- Anonymous wrapper blocks (skip them to find real containing block)
- Quirks mode (has special percentage height handling)
- Absolutely positioned elements (excluded, different rules apply)

Also update `calculate_inner_height()` to use the containing block's actual used height when resolving percentages with indefinite available space, which fixes inline-block and similar cases.

Fixes the height of the GMail "search box".

Before:
<img width="1213" height="623" alt="Screenshot 2026-01-25 at 12 30 46" src="https://github.com/user-attachments/assets/c527d20f-1443-45d1-a3ef-a5f0f859d5ba" />

After:
<img width="1213" height="623" alt="Screenshot 2026-01-25 at 12 31 30" src="https://github.com/user-attachments/assets/ccdb3f6b-5152-418d-a21d-2192bd1facbb" />
