### PR TITLE
Avoid crashing when PlaybackStream can't be created

### DIFF
--- a/Libraries/LibMedia/Sinks/AudioMixingSink.cpp
+++ b/Libraries/LibMedia/Sinks/AudioMixingSink.cpp
@@ -85,9 +85,15 @@ void AudioMixingSink::create_playback_stream()
         return self->write_audio_data_to_playback_stream(buffer);
     };
     constexpr u32 target_latency_ms = 100;
-    m_playback_stream = MUST(Audio::PlaybackStream::create(Audio::OutputState::Suspended, target_latency_ms, move(sample_specification_callback), move(data_callback)));
 
-    set_volume(m_volume);
+    auto stream_or_error = Audio::PlaybackStream::create(Audio::OutputState::Suspended, target_latency_ms, move(sample_specification_callback), move(data_callback));
+
+    if (!stream_or_error.is_error()) {
+        m_playback_stream = stream_or_error.value();
+        set_volume(m_volume);
+    } else {
+        dbgln("Failed to create playback stream: {}", stream_or_error.error());
+    }
 }
 
 ReadonlySpan<float> AudioMixingSink::write_audio_data_to_playback_stream(Span<float> buffer)


### PR DESCRIPTION
Hi, I have created this small PR after seeing the following error when trying to open https://grafana.com or https://sneyers.info/:

```
UNEXPECTED ERROR: Audio output is not available for this platform at /var/home/fede/Workspace/src/ladybird/Libraries/LibMedia/Sinks/AudioMixingSink.cpp:88
Stack trace (most recent call first):
#0  (inlined)          in Media::AudioMixingSink::create_playback_stream() at /var/home/fede/Workspace/src/ladybird/AK/HashTable.h:644:30
#1  0x00007fae8ae53ae7 in Media::AudioMixingSink::set_provider(Media::Track const&, AK::RefPtr<Media::AudioDataProvider> const&) at /var/home/fede/Workspace/src/ladybird/Libraries/LibMedia/Sinks/AudioMixingSink.cpp:41:27
#2  0x00007fae8ae3a25a in Media::PlaybackManager::enable_an_audio_track(Media::Track const&) at /var/home/fede/Workspace/src/ladybird/Libraries/LibMedia/PlaybackManager.cpp:260:31
#3  0x00007fae88b2b81e in Web::HTML::AudioTrack::set_enabled(bool) at /var/home/fede/Workspace/src/ladybird/Libraries/LibWeb/HTML/AudioTrack.cpp:61:44
#4  0x00007fae88c502e9 in Web::HTML::HTMLMediaElement::on_audio_track_added(Media::Track const&) at /var/home/fede/Workspace/src/ladybird/Libraries/LibWeb/HTML/HTMLMediaElement.cpp:1223:33
#5  (inlined)          in AK::Function<void (Media::TrackType, Media::Track const&)>::operator()(Media::TrackType, Media::Track const&) const at /var/home/fede/Workspace/src/ladybird/AK/Function.h:148:29
#6  0x00007fae8ae391cd in operator() at /var/home/fede/Workspace/src/ladybird/Libraries/LibMedia/PlaybackManager.cpp:103:49
#7  (inlined)          in AK::Function<void ()>::operator()() const at /var/home/fede/Workspace/src/ladybird/AK/Function.h:148:29
#8  0x00007fae87b94b0d in Core::ThreadEventQueue::process() at /var/home/fede/Workspace/src/ladybird/Libraries/LibCore/ThreadEventQueue.cpp:140:39
#9  (inlined)          in Core::EventLoop::pump(Core::EventLoop::WaitMode) at /var/home/fede/Workspace/src/ladybird/Libraries/LibCore/EventLoop.cpp:112:24
```

 Of note is that I noticed this warning when building Ladybird:
```
--   Package 'libpulse' not found
CMake Warning at Meta/CMake/audio.cmake:20 (message):
  No audio backend available
Call Stack (most recent call first):
  Libraries/LibMedia/CMakeLists.txt:1 (include)
```

This is on Fedora 43 Kinoite. I have not yet tried installing `libpulse` and rebuilding, but maybe finding this problem was a good (unexpected) thing.

My thought here then was that even if audio can't be played back due to `libpulse` not being available, or for any other reason, then the website should at least be displayed visually. I would argue this makes sense this the majority of websites center around visual content rather than audio content.

It would be better I imagine to display some sort of warning to the user when audio could not be played back.

With the small change I made, the failure to create a playback stream is instead converted into a warning log, and the two websites now load correctly.

(**Disclaimer**: I work at Grafana Labs, however this PR is not associated with my job in any way).