### PR TITLE
LibWeb: Improve sequential focus navigation

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4452,6 +4452,20 @@ bool Element::is_focusable() const
     return HTML::parse_integer(get_attribute_value(HTML::AttributeNames::tabindex)).has_value();
 }
 
+// https://html.spec.whatwg.org/multipage/interaction.html#sequentially-focusable
+bool Element::is_sequentially_focusable() const
+{
+    for (auto element = this; element; element = element->parent_element()) {
+        if (element->computed_properties() && element->computed_properties()->display().is_none())
+            return false;
+    }
+
+    auto tabindex = HTML::parse_integer(get_attribute_value(HTML::AttributeNames::tabindex)).value_or(default_tab_index_value());
+    auto is_hidden = computed_properties() && computed_properties()->visibility() == CSS::Visibility::Hidden;
+
+    return is_focusable() && tabindex >= 0 && !is_hidden;
+}
+
 void Element::set_had_duplicate_attribute_during_tokenization(Badge<HTML::HTMLParser>)
 {
     m_had_duplicate_attribute_during_tokenization = true;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -319,6 +319,7 @@ public:
     virtual void did_lose_focus() { }
     bool should_indicate_focus() const;
     virtual bool is_focusable() const override;
+    virtual bool is_sequentially_focusable() const override;
 
     static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, GC::Ref<CSS::ComputedProperties>, Element*);
 

--- a/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Libraries/LibWeb/DOM/EventTarget.h
@@ -28,6 +28,7 @@ public:
     static WebIDL::ExceptionOr<GC::Ref<EventTarget>> construct_impl(JS::Realm&);
 
     virtual bool is_focusable() const { return false; }
+    virtual bool is_sequentially_focusable() const { return false; }
 
     void add_event_listener(FlyString const& type, IDLEventListener* callback, Variant<AddEventListenerOptions, bool> const& options);
     void remove_event_listener(FlyString const& type, IDLEventListener* callback, Variant<EventListenerOptions, bool> const& options);

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1141,7 +1141,7 @@ EventResult EventHandler::focus_next_element()
         auto* element = m_navigable->active_document()->first_child_of_type<DOM::Element>();
 
         for (; element; element = element->next_element_in_pre_order()) {
-            if (element->is_focusable()) {
+            if (element->is_sequentially_focusable()) {
                 HTML::run_focusing_steps(element, nullptr, HTML::FocusTrigger::Key);
                 return EventResult::Handled;
             }
@@ -1154,7 +1154,7 @@ EventResult EventHandler::focus_next_element()
     if (!node)
         return set_focus_to_first_focusable_element();
 
-    for (node = node->next_in_pre_order(); node && !node->is_focusable(); node = node->next_in_pre_order())
+    for (node = node->next_in_pre_order(); node && !node->is_sequentially_focusable(); node = node->next_in_pre_order())
         ;
 
     if (!node)
@@ -1176,7 +1176,7 @@ EventResult EventHandler::focus_previous_element()
         auto* element = m_navigable->active_document()->last_child_of_type<DOM::Element>();
 
         for (; element; element = element->previous_element_in_pre_order()) {
-            if (element->is_focusable()) {
+            if (element->is_sequentially_focusable()) {
                 HTML::run_focusing_steps(element, nullptr, HTML::FocusTrigger::Key);
                 return EventResult::Handled;
             }
@@ -1189,7 +1189,7 @@ EventResult EventHandler::focus_previous_element()
     if (!node)
         return set_focus_to_last_focusable_element();
 
-    for (node = node->previous_in_pre_order(); node && !node->is_focusable(); node = node->previous_in_pre_order())
+    for (node = node->previous_in_pre_order(); node && !node->is_sequentially_focusable(); node = node->previous_in_pre_order())
         ;
 
     if (!node)

--- a/Tests/LibWeb/Text/expected/sequential-navigation.txt
+++ b/Tests/LibWeb/Text/expected/sequential-navigation.txt
@@ -1,0 +1,4 @@
+<BUTTON id="button">
+<INPUT id="input">
+<DIV id="tabindex-zero">
+<BUTTON id="visibility-hidden-override">

--- a/Tests/LibWeb/Text/input/sequential-navigation.html
+++ b/Tests/LibWeb/Text/input/sequential-navigation.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<button id="button"></button>
+<input id="input">
+<div id="tabindex-zero" tabindex="0"></div>
+<input id="negative-tabindex" tabindex="-1">
+<button id="display-none" style="display: none;"></button>
+<button id="visibility-hidden" style="visibility: hidden;"></button>
+<div style="display: none">
+    <button id="display-none-child"></button>
+</div>
+<div style="visibility: hidden">
+    <button id="visibility-hidden-override" style="visibility: visible"></button>
+</div>
+<button id="display-none-tabindex-zero" style="display: none" tabindex="0"></button>
+
+<script src="include.js"></script>
+<script>
+    test(() => {
+        // Focus elements sequentially and print the focusable ones until it wraps to the beginning
+
+        const focusedElements = [];
+
+        internals.sendKey(document.body, "Tab");
+
+        while (!focusedElements.includes(document.activeElement.id)) {
+            focusedElements.push(document.activeElement.id);
+
+            printElement(document.activeElement);
+
+            internals.sendKey(document.activeElement, "Tab");
+        }
+    });
+</script>


### PR DESCRIPTION
This PR improves navigation using tab by implementing a new function to check if an element should be tab navigatable (sequentially focusable).

Previously, tab navigation used the `is_focusable()` method which is wrong, as it includes invisible elements and serves a different purpose.

According to spec (https://html.spec.whatwg.org/multipage/interaction.html#sequentially-focusable), the user agent decides the algorithm here. I wrote a simple algorithm to make sure the element is visible on the page (no display:none; ancestors and is itself not visibility:hidden;), although it is not perfect, so I'm open to feedback here.

I couldn't figure out a good way to write a test for this (again, please tell me if you have ideas), but it can be tested manually using some HTML like this:

```html
<button>should focus</button>
<button tabindex="-1">should not focus</button>
<button style="display: none">should not focus</button>
<button style="display: none" tabindex="0">should not focus</button>
<button style="visibility: hidden">should not focus</button>
<div style="display: none">
    <button>should not focus</button>
</div>
<div style="visibility: hidden">
    <button style="visibility: visible">should focus</button>
</div>
```

Three buttons will be visible, two of which should be focusable using tab navigation.
