### PR TITLE
LibWeb: Add more lies to the User-Agent string for compatibility

### DIFF
--- a/Libraries/LibWeb/Loader/UserAgent.h
+++ b/Libraries/LibWeb/Loader/UserAgent.h
@@ -65,7 +65,7 @@ namespace Web {
 // NB: Some web servers treat us very badly unless we pretend to be one of the major browsers.
 //     This token is appended to the User-Agent string to improve compatibility.
 //     We will need to update this periodically to match a somewhat recent version.
-#define SAD_COMPATIBILITY_HACK "Chrome/140.0.0.0"
+#define SAD_COMPATIBILITY_HACK "Chrome/140.0.0.0 AppleWebKit/537.36 Safari/537.36"
 
 constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") " BROWSER_NAME "/" BROWSER_VERSION " " SAD_COMPATIBILITY_HACK ""sv;
 constexpr auto default_platform = OS_STRING " " CPU_STRING ""sv;


### PR DESCRIPTION
We recently added "Chrome/140.0.0.0" to our User-Agent string which fixed an issue with some web servers ignoring or throttling us.

Unfortunately we were still being served crappy version of many major websites.

This patch improves the situation by adding more lies, specifically "AppleWebKit/537.36 Safari/537.36". This gives us modern versions of sites like Google, GMail, Instagram, and many more.

Note that "Ladybird" is still in there. We're not hiding. Just playing the (dumb) game :)

Many many visual progressions.

Google before:
<img width="1271" height="731" alt="Screenshot 2026-01-26 at 10 50 22" src="https://github.com/user-attachments/assets/5dd999ab-8723-4d0c-91b6-ac28552af1a6" />

Google after:
<img width="1271" height="731" alt="Screenshot 2026-01-26 at 10 51 16" src="https://github.com/user-attachments/assets/3f4e53e5-b259-4b0e-9831-3e1f995374f9" />

GMail before:
<img width="1271" height="731" alt="Screenshot 2026-01-26 at 10 49 26" src="https://github.com/user-attachments/assets/657c2c80-2cf4-4ec7-81be-ea23c611f52f" />

GMail after:
<img width="1271" height="731" alt="Screenshot 2026-01-26 at 10 50 50" src="https://github.com/user-attachments/assets/34d12ccc-2ca1-4b51-9a9c-624b2f887a91" />

Instagram before:
<img width="1271" height="731" alt="Screenshot 2026-01-26 at 10 50 15" src="https://github.com/user-attachments/assets/d5fa1f94-0f05-4a5d-a05d-0ab77d282f2c" />

Instagram after:
<img width="1271" height="731" alt="Screenshot 2026-01-26 at 10 51 10" src="https://github.com/user-attachments/assets/47d38df9-6673-42e6-a3c8-7134789b72df" />
