### PR TITLE
LibWeb: Make RenderingThread own display list and backing stores

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -201,8 +201,9 @@ public:
 
     bool is_ready_to_paint() const;
     void ready_to_paint();
+    void record_display_list_and_scroll_state(PaintConfig);
     void paint_next_frame();
-    void start_display_list_rendering(Gfx::PaintingSurface&, PaintConfig, Function<void()>&& callback);
+    void render_screenshot(Gfx::PaintingSurface&, PaintConfig, Function<void()>&& callback);
 
     bool needs_repaint() const { return m_needs_repaint; }
     void set_needs_repaint() { m_needs_repaint = true; }
@@ -210,6 +211,8 @@ public:
     [[nodiscard]] bool has_inclusive_ancestor_with_visibility_hidden() const;
 
     RefPtr<Gfx::SkiaBackendContext> skia_backend_context() const;
+
+    RenderingThread& rendering_thread() { return m_rendering_thread; }
 
     void set_pending_set_browser_zoom_request(bool value) { m_pending_set_browser_zoom_request = value; }
     bool pending_set_browser_zoom_request() const { return m_pending_set_browser_zoom_request; }

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2025-2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,17 +12,167 @@
 
 namespace Web::HTML {
 
+struct BackingStoreState {
+    RefPtr<Gfx::PaintingSurface> front_store;
+    RefPtr<Gfx::PaintingSurface> back_store;
+    i32 front_bitmap_id { -1 };
+    i32 back_bitmap_id { -1 };
+
+    void swap()
+    {
+        AK::swap(front_store, back_store);
+        AK::swap(front_bitmap_id, back_bitmap_id);
+    }
+
+    bool is_valid() const { return front_store && back_store; }
+};
+
+struct UpdateDisplayListCommand {
+    NonnullRefPtr<Painting::DisplayList> display_list;
+    Painting::ScrollStateSnapshotByDisplayList scroll_state_snapshot;
+};
+
+struct UpdateBackingStoresCommand {
+    RefPtr<Gfx::PaintingSurface> front_store;
+    RefPtr<Gfx::PaintingSurface> back_store;
+    i32 front_bitmap_id;
+    i32 back_bitmap_id;
+};
+
+struct PresentFrameCommand {
+    Function<void(i32)> callback;
+};
+
+struct ScreenshotCommand {
+    NonnullRefPtr<Gfx::PaintingSurface> target_surface;
+    Function<void()> callback;
+};
+
+using CompositorCommand = Variant<UpdateDisplayListCommand, UpdateBackingStoresCommand, PresentFrameCommand, ScreenshotCommand>;
+
+class RenderingThread::ThreadData final : public AtomicRefCounted<ThreadData> {
+public:
+    ThreadData(Core::EventLoop& main_thread_event_loop)
+        : m_main_thread_event_loop(main_thread_event_loop)
+    {
+    }
+
+    ~ThreadData() = default;
+
+    void set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player)
+    {
+        m_skia_player = move(player);
+    }
+
+    bool has_skia_player() const { return m_skia_player != nullptr; }
+
+    void exit()
+    {
+        Threading::MutexLocker const locker { m_mutex };
+        m_exit = true;
+        m_command_ready.signal();
+    }
+
+    void enqueue_command(CompositorCommand&& command)
+    {
+        Threading::MutexLocker const locker { m_mutex };
+        m_command_queue.enqueue(move(command));
+        m_command_ready.signal();
+    }
+
+    void compositor_loop()
+    {
+        while (true) {
+            auto command = [this]() -> Optional<CompositorCommand> {
+                Threading::MutexLocker const locker { m_mutex };
+                while (m_command_queue.is_empty() && !m_exit) {
+                    m_command_ready.wait();
+                }
+                if (m_exit)
+                    return {};
+                return m_command_queue.dequeue();
+            }();
+
+            if (!command.has_value()) {
+                VERIFY(m_exit);
+                break;
+            }
+
+            command->visit(
+                [this](UpdateDisplayListCommand& cmd) {
+                    m_cached_display_list = move(cmd.display_list);
+                    m_cached_scroll_state_snapshot = move(cmd.scroll_state_snapshot);
+                },
+                [this](UpdateBackingStoresCommand& cmd) {
+                    m_backing_stores.front_store = move(cmd.front_store);
+                    m_backing_stores.back_store = move(cmd.back_store);
+                    m_backing_stores.front_bitmap_id = cmd.front_bitmap_id;
+                    m_backing_stores.back_bitmap_id = cmd.back_bitmap_id;
+                },
+                [this](PresentFrameCommand& cmd) {
+                    if (!m_cached_display_list || !m_backing_stores.is_valid())
+                        return;
+
+                    m_skia_player->execute(*m_cached_display_list, Painting::ScrollStateSnapshotByDisplayList(m_cached_scroll_state_snapshot), *m_backing_stores.back_store);
+                    i32 rendered_bitmap_id = m_backing_stores.back_bitmap_id;
+                    m_backing_stores.swap();
+
+                    if (cmd.callback) {
+                        invoke_on_main_thread([callback = move(cmd.callback), rendered_bitmap_id]() mutable {
+                            callback(rendered_bitmap_id);
+                        });
+                    }
+                },
+                [this](ScreenshotCommand& cmd) {
+                    if (!m_cached_display_list)
+                        return;
+                    m_skia_player->execute(*m_cached_display_list, Painting::ScrollStateSnapshotByDisplayList(m_cached_scroll_state_snapshot), *cmd.target_surface);
+                    if (cmd.callback) {
+                        invoke_on_main_thread([callback = move(cmd.callback)]() mutable {
+                            callback();
+                        });
+                    }
+                });
+
+            if (m_exit)
+                break;
+        }
+    }
+
+private:
+    template<typename Invokee>
+    void invoke_on_main_thread(Invokee invokee)
+    {
+        if (m_exit)
+            return;
+        m_main_thread_event_loop.deferred_invoke([self = NonnullRefPtr(*this), invokee = move(invokee)]() mutable {
+            invokee();
+        });
+    }
+
+    Core::EventLoop& m_main_thread_event_loop;
+
+    mutable Threading::Mutex m_mutex;
+    mutable Threading::ConditionVariable m_command_ready { m_mutex };
+    Atomic<bool> m_exit { false };
+
+    Queue<CompositorCommand> m_command_queue;
+
+    OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
+    RefPtr<Painting::DisplayList> m_cached_display_list;
+    Painting::ScrollStateSnapshotByDisplayList m_cached_scroll_state_snapshot;
+    BackingStoreState m_backing_stores;
+};
+
 RenderingThread::RenderingThread()
-    : m_main_thread_event_loop(Core::EventLoop::current())
+    : m_thread_data(adopt_ref(*new ThreadData(Core::EventLoop::current())))
     , m_main_thread_exit_promise(Core::Promise<NonnullRefPtr<Core::EventReceiver>>::construct())
 {
     // FIXME: Come up with a better "event loop exited" notification mechanism.
-    m_main_thread_exit_promise->on_rejection = [this](Error const&) -> void {
-        Threading::MutexLocker const locker { m_rendering_task_mutex };
-        m_exit = true;
-        m_rendering_task_ready_wake_condition.signal();
+    m_main_thread_exit_promise->on_rejection = [thread_data = m_thread_data](Error const&) -> void {
+        thread_data->exit();
     };
-    m_main_thread_event_loop.add_job(m_main_thread_exit_promise);
+    Core::EventLoop::current().add_job(m_main_thread_exit_promise);
 }
 
 RenderingThread::~RenderingThread()
@@ -34,12 +184,11 @@ RenderingThread::~RenderingThread()
     }
 }
 
-void RenderingThread::start(DisplayListPlayerType display_list_player_type)
+void RenderingThread::start(DisplayListPlayerType)
 {
-    m_display_list_player_type = display_list_player_type;
-    VERIFY(m_skia_player);
-    m_thread = Threading::Thread::construct([this] {
-        rendering_thread_loop();
+    VERIFY(m_thread_data->has_skia_player());
+    m_thread = Threading::Thread::construct([thread_data = m_thread_data] {
+        thread_data->compositor_loop();
         return static_cast<intptr_t>(0);
     });
     m_thread->start();
@@ -47,39 +196,27 @@ void RenderingThread::start(DisplayListPlayerType display_list_player_type)
 
 void RenderingThread::set_skia_player(OwnPtr<Painting::DisplayListPlayerSkia>&& player)
 {
-    m_skia_player = move(player);
+    m_thread_data->set_skia_player(move(player));
 }
 
-void RenderingThread::rendering_thread_loop()
+void RenderingThread::update_display_list(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshotByDisplayList&& scroll_state_snapshot)
 {
-    while (true) {
-        auto task = [this]() -> Optional<Task> {
-            Threading::MutexLocker const locker { m_rendering_task_mutex };
-            while (m_rendering_tasks.is_empty() && !m_exit) {
-                m_rendering_task_ready_wake_condition.wait();
-            }
-            if (m_exit)
-                return {};
-            return m_rendering_tasks.dequeue();
-        }();
-
-        if (!task.has_value()) {
-            VERIFY(m_exit);
-            break;
-        }
-
-        m_skia_player->execute(*task->display_list, move(task->scroll_state_snapshot_by_display_list), task->painting_surface);
-        if (m_exit)
-            break;
-        task->callback();
-    }
+    m_thread_data->enqueue_command(UpdateDisplayListCommand { move(display_list), move(scroll_state_snapshot) });
 }
 
-void RenderingThread::enqueue_rendering_task(NonnullRefPtr<Painting::DisplayList> display_list, Painting::ScrollStateSnapshotByDisplayList&& scroll_state_snapshot_by_display_list, NonnullRefPtr<Gfx::PaintingSurface> painting_surface, Function<void()>&& callback)
+void RenderingThread::update_backing_stores(RefPtr<Gfx::PaintingSurface> front, RefPtr<Gfx::PaintingSurface> back, i32 front_id, i32 back_id)
 {
-    Threading::MutexLocker const locker { m_rendering_task_mutex };
-    m_rendering_tasks.enqueue(Task { move(display_list), move(scroll_state_snapshot_by_display_list), move(painting_surface), move(callback) });
-    m_rendering_task_ready_wake_condition.signal();
+    m_thread_data->enqueue_command(UpdateBackingStoresCommand { move(front), move(back), front_id, back_id });
+}
+
+void RenderingThread::present_frame(Function<void(i32)>&& callback)
+{
+    m_thread_data->enqueue_command(PresentFrameCommand { move(callback) });
+}
+
+void RenderingThread::request_screenshot(NonnullRefPtr<Gfx::PaintingSurface> target_surface, Function<void()>&& callback)
+{
+    m_thread_data->enqueue_command(ScreenshotCommand { move(target_surface), move(callback) });
 }
 
 }

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1444,7 +1444,7 @@ void TraversableNavigable::process_screenshot_requests()
             auto bitmap = bitmap_or_error.release_value();
             auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
             PaintConfig paint_config { .canvas_fill_rect = rect.to_type<int>() };
-            start_display_list_rendering(painting_surface, paint_config, [bitmap, &client] {
+            render_screenshot(painting_surface, paint_config, [bitmap, &client] {
                 client.page_did_take_screenshot(bitmap->to_shareable_bitmap());
             });
         } else {
@@ -1458,7 +1458,7 @@ void TraversableNavigable::process_screenshot_requests()
             auto bitmap = bitmap_or_error.release_value();
             auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
             PaintConfig paint_config { .paint_overlay = true, .canvas_fill_rect = rect.to_type<int>() };
-            start_display_list_rendering(painting_surface, paint_config, [bitmap, &client] {
+            render_screenshot(painting_surface, paint_config, [bitmap, &client] {
                 client.page_did_take_screenshot(bitmap->to_shareable_bitmap());
             });
         }

--- a/Libraries/LibWeb/Painting/BackingStoreManager.h
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2024-2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -27,27 +27,19 @@ public:
     void reallocate_backing_stores(Gfx::IntSize);
     void restart_resize_timer();
 
-    struct BackingStore {
-        i32 bitmap_id { -1 };
-        RefPtr<Gfx::PaintingSurface> store;
-    };
-
-    BackingStore acquire_store_for_next_frame();
-
     virtual void visit_edges(Cell::Visitor& visitor) override;
 
     BackingStoreManager(HTML::Navigable&);
 
 private:
-    void swap_back_and_front();
-
     GC::Ref<HTML::Navigable> m_navigable;
 
     i32 m_front_bitmap_id { -1 };
     i32 m_back_bitmap_id { -1 };
-    RefPtr<Gfx::PaintingSurface> m_front_store;
-    RefPtr<Gfx::PaintingSurface> m_back_store;
     int m_next_bitmap_id { 0 };
+
+    // Used to track if backing stores need reallocation
+    Gfx::IntSize m_allocated_size;
 
     RefPtr<Core::Timer> m_backing_store_shrink_timer;
 };

--- a/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -58,7 +58,7 @@ ErrorOr<GC::Ref<HTML::HTMLCanvasElement>, WebDriver::Error> draw_bounding_box_fr
     auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
     IGNORE_USE_IN_ESCAPING_LAMBDA bool did_paint = false;
     HTML::PaintConfig paint_config { .canvas_fill_rect = paint_rect };
-    browsing_context.active_document()->navigable()->start_display_list_rendering(painting_surface, paint_config, [&did_paint] {
+    browsing_context.active_document()->navigable()->render_screenshot(painting_surface, paint_config, [&did_paint] {
         did_paint = true;
     });
     HTML::main_thread_event_loop().spin_until(GC::create_function(HTML::main_thread_event_loop().heap(), [&] {


### PR DESCRIPTION
This change prepares for a future where the rendering thread handles input events directly, allowing it to trigger repainting without waiting for the main thread. To support this, the compositor needs to own the display list, scroll state, and backing stores rather than receiving them per-frame from the main thread.