### PR TITLE
LibWeb: Store presentation callback in RenderingThread

### DIFF
--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -24,7 +24,9 @@ class RenderingThread {
     class ThreadData;
 
 public:
-    RenderingThread();
+    using PresentationCallback = Function<void(Gfx::IntRect const&, i32)>;
+
+    explicit RenderingThread(PresentationCallback);
     ~RenderingThread();
 
     void start(DisplayListPlayerType);
@@ -32,7 +34,7 @@ public:
 
     void update_display_list(NonnullRefPtr<Painting::DisplayList>, Painting::ScrollStateSnapshotByDisplayList&&);
     void update_backing_stores(RefPtr<Gfx::PaintingSurface> front, RefPtr<Gfx::PaintingSurface> back, i32 front_id, i32 back_id);
-    void present_frame(Function<void(i32)>&& callback);
+    void present_frame(Gfx::IntRect);
     void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
 private:


### PR DESCRIPTION
This is preparation for future work where the rendering thread will initiate rasterization independently and notify the UI process without requiring coordination with the main thread.