### PR TITLE
LibWeb: Move rendering backpressure from main thread to RenderingThread

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2591,7 +2591,7 @@ bool Navigable::has_a_rendering_opportunity() const
     // Rendering opportunities typically occur at regular intervals.
 
     // FIXME: Return `false` here if we're an inactive browser tab.
-    return is_ready_to_paint();
+    return true;
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#inform-the-navigation-api-about-child-navigable-destruction
@@ -2760,15 +2760,9 @@ void Navigable::set_has_session_history_entry_and_ready_for_navigation()
     }
 }
 
-bool Navigable::is_ready_to_paint() const
-{
-    return m_number_of_queued_rasterization_tasks <= 1;
-}
-
 void Navigable::ready_to_paint()
 {
-    m_number_of_queued_rasterization_tasks--;
-    VERIFY(m_number_of_queued_rasterization_tasks >= 0 && m_number_of_queued_rasterization_tasks < 2);
+    m_rendering_thread.ready_to_paint();
 }
 
 void Navigable::record_display_list_and_scroll_state(PaintConfig paint_config)
@@ -2809,9 +2803,6 @@ void Navigable::paint_next_frame()
 {
     if (!is_top_level_traversable())
         return;
-
-    VERIFY(m_number_of_queued_rasterization_tasks <= 1);
-    m_number_of_queued_rasterization_tasks++;
 
     auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
     PaintConfig paint_config { .paint_overlay = true, .should_show_line_box_borders = m_should_show_line_box_borders, .canvas_fill_rect = Gfx::IntRect { {}, viewport_rect.size() } };

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -199,7 +199,6 @@ public:
 
     bool has_pending_navigations() const { return !m_pending_navigations.is_empty(); }
 
-    bool is_ready_to_paint() const;
     void ready_to_paint();
     void record_display_list_and_scroll_state(PaintConfig);
     void paint_next_frame();
@@ -288,7 +287,6 @@ private:
     bool m_needs_repaint { true };
     bool m_pending_set_browser_zoom_request { false };
     bool m_should_show_line_box_borders { false };
-    i32 m_number_of_queued_rasterization_tasks { 0 };
     GC::Ref<Painting::BackingStoreManager> m_backing_store_manager;
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
     RenderingThread m_rendering_thread;

--- a/Libraries/LibWeb/HTML/RenderingThread.h
+++ b/Libraries/LibWeb/HTML/RenderingThread.h
@@ -37,6 +37,8 @@ public:
     void present_frame(Gfx::IntRect);
     void request_screenshot(NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&& callback);
 
+    void ready_to_paint();
+
 private:
     NonnullRefPtr<ThreadData> m_thread_data;
     RefPtr<Threading::Thread> m_thread;


### PR DESCRIPTION
In preparation for handling input events on the rendering thread, move backpressure management to RenderingThread. The rendering thread needs to manage this independently without querying the main thread.

Previously, the main thread would block when the UI process hadn't yet released the backing surface. Now, the main thread can continue producing display lists while the UI process is busy, allowing more work to happen in parallel. When rasterization is slow and display lists are produced faster than they can be consumed, presentation requests are naturally coalesced using a flag-based approach - multiple present_frame() calls simply update the pending state, resulting in a single rasterization with the latest display list.