### PR TITLE
AK+LibMedia: Add a MPSC and SPSC ring buffer

### DIFF
--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -136,15 +136,6 @@ static inline V* atomic_load(T volatile** var, MemoryOrder order = memory_order_
     return __atomic_load_n(const_cast<V**>(var), order);
 }
 
-static inline void atomic_pause()
-{
-#if __has_builtin(__builtin_ia32_pause)
-    __builtin_ia32_pause();
-#elif __has_builtin(__builtin_arm_yield)
-    __builtin_arm_yield();
-#endif
-}
-
 template<typename T>
 static inline void atomic_store(T volatile* var, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
 {

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     CircularBuffer.cpp
     ConstrainedStream.cpp
     CountingStream.cpp
+    CpuBackoff.cpp
     Error.cpp
     FlyString.cpp
     Format.cpp

--- a/AK/CpuBackoff.cpp
+++ b/AK/CpuBackoff.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, Ryszard Goc <ryszardgoc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/CpuBackoff.h>
+
+#ifdef AK_OS_WINDOWS
+#    include <AK/Windows.h>
+#else
+#    include <sched.h>
+#endif
+
+namespace AK {
+
+void yield_thread()
+{
+#ifdef AK_OS_WINDOWS
+    (void)SwitchToThread();
+#else
+    (void)sched_yield();
+#endif
+}
+
+}

--- a/AK/CpuBackoff.h
+++ b/AK/CpuBackoff.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, Ryszard Goc <ryszardgoc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/Platform.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+static inline void cpu_pause()
+{
+#if __has_builtin(__builtin_ia32_pause)
+    __builtin_ia32_pause();
+#elif __has_builtin(__builtin_arm_isb)
+    __builtin_arm_isb(15);
+#elif __has_builtin(__builtin_riscv_pause)
+    __builtin_riscv_pause();
+#endif
+}
+
+void yield_thread();
+
+// As it is expected that this class may be constructed on the hot path each time, it has to be small
+class Backoff final {
+    AK_MAKE_NONCOPYABLE(Backoff);
+    AK_MAKE_NONMOVABLE(Backoff);
+
+public:
+    Backoff() = default;
+    ~Backoff() = default;
+
+    ALWAYS_INLINE void tick()
+    {
+        if (m_step < 5) {
+            // TODO: Implement a delay based on TPAUSE/MWAITX/WFET where possible.
+            u32 iterations = 0;
+#if ARCH(X86_64)
+            // Anywhere between 50-230 cycles
+            // Last step anywhere between 1600 - 7,300 cycles.
+            iterations = 1u << m_step;
+#elif ARCH(AARCH64)
+            // Using ISB, ~40 cycles per instruction
+            // Last step ~6400 cycles
+            iterations = 4u << m_step;
+#else
+            // This needs tuning from someone that has these machines
+            iterations = 1u << m_step;
+#endif
+            for (u64 i = 0; i < iterations; i++) {
+                cpu_pause();
+            }
+            m_step += 1;
+        } else {
+            yield_thread();
+        }
+    }
+
+private:
+    u64 m_step = 0;
+};
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::Backoff;
+using AK::cpu_pause;
+using AK::yield_thread;
+#endif

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -179,6 +179,10 @@ template<typename T, u32 Size>
 requires(is_power_of_two(Size) && IsMoveConstructible<T> && IsMoveAssignable<T> && !IsLvalueReference<T>)
 class MPSCRingBuffer;
 
+template<typename T, u64 Size>
+requires(is_power_of_two(Size) && IsMoveConstructible<T> && IsMoveAssignable<T> && !IsLvalueReference<T>)
+class SPSCRingBuffer;
+
 }
 
 #if USING_AK_GLOBALLY
@@ -228,6 +232,7 @@ using AK::SearchableCircularBuffer;
 using AK::SeekableStream;
 using AK::SinglyLinkedList;
 using AK::Span;
+using AK::SPSCRingBuffer;
 using AK::StackInfo;
 using AK::Stream;
 using AK::String;

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -175,6 +175,10 @@ requires(!IsRvalueReference<T>) class Vector;
 template<typename T, typename ErrorType = Error>
 class [[nodiscard]] ErrorOr;
 
+template<typename T, u32 Size>
+requires(is_power_of_two(Size) && IsMoveConstructible<T> && IsMoveAssignable<T> && !IsLvalueReference<T>)
+class MPSCRingBuffer;
+
 }
 
 #if USING_AK_GLOBALLY
@@ -213,6 +217,7 @@ using AK::JsonValue;
 using AK::LexicalPath;
 using AK::LittleEndianInputBitStream;
 using AK::LittleEndianOutputBitStream;
+using AK::MPSCRingBuffer;
 using AK::NonnullOwnPtr;
 using AK::NonnullRefPtr;
 using AK::Optional;

--- a/AK/RingBuffer.h
+++ b/AK/RingBuffer.h
@@ -100,6 +100,53 @@ public:
         }
     }
 
+    // Spins until pushing is possible
+    ALWAYS_INLINE void push(T value)
+    {
+        return emplace(move(value));
+    }
+
+    // Spins until pushing is possible
+    template<typename U>
+    requires(IsConvertible<U, T> && !IsSame<RemoveCVReference<U>, T>)
+    ALWAYS_INLINE void push(U&& value)
+    {
+        return emplace(forward<U>(value));
+    }
+
+    // Spins until emplacing is possible
+    template<typename... Args>
+    requires(IsConstructible<T, Args...>)
+    ALWAYS_INLINE void emplace(Args&&... args)
+    {
+        u32 head = m_head.load(MemoryOrder::memory_order_relaxed);
+        Backoff backoff;
+
+        while (true) {
+            Node& slot = m_data[get_offset(head)];
+            u32 sequence = slot.sequence.load(MemoryOrder::memory_order_acquire);
+            i32 diff = static_cast<i32>(sequence - head);
+
+            if (diff == 0) {
+                // Slot is free
+                if (m_head.compare_exchange_weak(head, head + 1, MemoryOrder::memory_order_acq_rel)) {
+                    // We now own the slot
+                    new (slot.data) T(forward<Args>(args)...);
+                    slot.sequence.store(head + 1, MemoryOrder::memory_order_release);
+                    break;
+                }
+                // The head was updated by another thread, try again
+                cpu_pause();
+            } else if (diff < 0) {
+                // Buffer full
+                backoff.tick();
+            } else {
+                //  Our head is stale
+                head = m_head.load(MemoryOrder::memory_order_relaxed);
+            }
+        }
+    }
+
     [[nodiscard]] ALWAYS_INLINE bool try_pop(T& value)
     {
         Node& slot = m_data[get_offset(m_tail)];
@@ -120,6 +167,57 @@ public:
         // In this case either the write wasn't finished ( sequence == read_index ) so diff == -1,
         // or the queue is empty and no write is happening, so diff == -Size
         return false;
+    }
+
+    // Made for working with non-default contructible types
+    // It is slower due to additional assignments needed for dealing with Optional
+    ALWAYS_INLINE Optional<T> try_pop()
+    {
+        Node& slot = m_data[get_offset(m_tail)];
+
+        u32 sequence = slot.sequence.load(MemoryOrder::memory_order_acquire);
+
+        i32 diff = static_cast<i32>(sequence - (m_tail + 1));
+
+        if (diff == 0) {
+            // The slot is ready for reading
+            T* ptr = reinterpret_cast<T*>(slot.data);
+            auto value = Optional<T>(move(*ptr));
+            ptr->~T();
+            slot.sequence.store(m_tail + Size, MemoryOrder::memory_order_release);
+            m_tail += 1;
+            return value;
+        }
+        // In this case either the write wasn't finished ( sequence == read_index ) so diff == -1,
+        // or the queue is empty and no write is happening, so diff == -Size
+        return {};
+    }
+
+    // Spin until pop succeeds
+    ALWAYS_INLINE void pop(T& value)
+    {
+        Backoff backoff;
+        // we are the only ones accessing tail
+        Node& slot = m_data[get_offset(m_tail)];
+        while (true) {
+            // We need to recheck the state of the sequence each loop
+            u32 sequence = slot.sequence.load(MemoryOrder::memory_order_acquire);
+
+            i32 diff = static_cast<i32>(sequence - (m_tail + 1));
+
+            if (diff == 0) {
+                // The slot is ready for reading
+                T* ptr = reinterpret_cast<T*>(slot.data);
+                value = move(*ptr);
+                ptr->~T();
+                slot.sequence.store(m_tail + Size, MemoryOrder::memory_order_release);
+                m_tail += 1;
+                break;
+            }
+            // In this case either the write wasn't finished ( sequence == read_index ) so diff == -1,
+            // or the queue is empty and no write is happening, so diff == -Size
+            backoff.tick();
+        }
     }
 
 private:
@@ -162,7 +260,6 @@ public:
     // Handle initializer list and copy construction
     [[nodiscard]] ALWAYS_INLINE bool try_push(T value)
     {
-
         return try_emplace(move(value));
     }
 
@@ -188,6 +285,43 @@ public:
         return true;
     }
 
+    // Spins until pushing is possible
+    ALWAYS_INLINE void push(T value)
+    {
+        return emplace(move(value));
+    }
+
+    // Spins until pushing is possible
+    template<typename U>
+    requires(IsConvertible<U, T> && !IsSame<RemoveCVReference<U>, T>)
+    ALWAYS_INLINE void push(U&& value)
+    {
+        return emplace(forward<U>(value));
+    }
+
+    // Spins until emplacing is possible
+    template<typename... Args>
+    requires(IsConstructible<T, Args...>)
+    ALWAYS_INLINE void emplace(Args&&... args)
+    {
+        u64 head = m_head.load(MemoryOrder::memory_order_relaxed);
+
+        if (head - m_cached_tail == Size) {
+            Backoff backoff;
+            while (true) {
+                m_cached_tail = m_tail.load(MemoryOrder::memory_order_acquire);
+                if (head - m_cached_tail == Size) {
+                    backoff.tick();
+                    continue;
+                }
+                break;
+            }
+        }
+
+        new (m_data[get_offset(head)]) T(forward<Args>(args)...);
+        m_head.store(head + 1, MemoryOrder::memory_order_release);
+    }
+
     [[nodiscard]] ALWAYS_INLINE bool try_pop(T& value)
     {
         u64 tail = m_tail.load(MemoryOrder::memory_order_relaxed);
@@ -201,6 +335,27 @@ public:
         ptr->~T();
         m_tail.store(tail + 1, MemoryOrder::memory_order_release);
         return true;
+    }
+
+    ALWAYS_INLINE void pop(T& value)
+    {
+        u64 tail = m_tail.load(MemoryOrder::memory_order_relaxed);
+        if (tail == m_cached_head) {
+            Backoff backoff;
+            while (true) {
+                m_cached_head = m_head.load(MemoryOrder::memory_order_acquire);
+                if (tail == m_cached_head) {
+                    backoff.tick();
+                    continue;
+                }
+                break;
+            }
+        }
+
+        T* ptr = reinterpret_cast<T*>(m_data[get_offset(tail)]);
+        value = move(*ptr);
+        ptr->~T();
+        m_tail.store(tail + 1, MemoryOrder::memory_order_release);
     }
 
     [[nodiscard]] ALWAYS_INLINE bool is_empty() const

--- a/AK/RingBuffer.h
+++ b/AK/RingBuffer.h
@@ -136,8 +136,95 @@ private:
     AK_CACHE_ALIGNED Node m_data[Size];
 };
 
+// This is a single producer single consumer lockfree bounded ring buffer.
+// To make construction in shared memory simpler the data is stored inline.
+template<typename T, u64 Size>
+requires(is_power_of_two(Size) && IsMoveConstructible<T> && IsMoveAssignable<T> && !IsLvalueReference<T>)
+class SPSCRingBuffer {
+    AK_MAKE_NONCOPYABLE(SPSCRingBuffer);
+    AK_MAKE_NONMOVABLE(SPSCRingBuffer);
+
+public:
+    SPSCRingBuffer() = default;
+
+    ~SPSCRingBuffer()
+    {
+        u64 head = m_head.load(MemoryOrder::memory_order_acquire);
+        u64 tail = m_tail.load(MemoryOrder::memory_order_acquire);
+        for (; tail < head; tail++) {
+            T* ptr = reinterpret_cast<T*>(m_data[get_offset(tail)]);
+            ptr->~T();
+        }
+    }
+
+    // Handle initializer list and copy construction
+    [[nodiscard]] ALWAYS_INLINE bool try_push(T value)
+    {
+
+        return try_emplace(move(value));
+    }
+
+    template<typename U>
+    requires(IsConvertible<U, T> && !IsSame<RemoveCVReference<U>, T>)
+    [[nodiscard]] ALWAYS_INLINE bool try_push(U&& value)
+    {
+        return try_emplace(forward<U>(value));
+    }
+
+    template<typename... Args>
+    requires(IsConstructible<T, Args...>)
+    [[nodiscard]] ALWAYS_INLINE bool try_emplace(Args&&... args)
+    {
+        u64 head = m_head.load(MemoryOrder::memory_order_relaxed);
+        if (head - m_cached_tail == Size) {
+            m_cached_tail = m_tail.load(MemoryOrder::memory_order_acquire);
+            if (head - m_cached_tail == Size)
+                return false;
+        }
+        new (m_data[get_offset(head)]) T(forward<Args>(args)...);
+        m_head.store(head + 1, MemoryOrder::memory_order_release);
+        return true;
+    }
+
+    [[nodiscard]] ALWAYS_INLINE bool try_pop(T& value)
+    {
+        u64 tail = m_tail.load(MemoryOrder::memory_order_relaxed);
+        if (tail == m_cached_head) {
+            m_cached_head = m_head.load(MemoryOrder::memory_order_acquire);
+            if (tail == m_cached_head)
+                return false;
+        }
+        T* ptr = reinterpret_cast<T*>(m_data[get_offset(tail)]);
+        value = move(*ptr);
+        ptr->~T();
+        m_tail.store(tail + 1, MemoryOrder::memory_order_release);
+        return true;
+    }
+
+    [[nodiscard]] ALWAYS_INLINE bool is_empty() const
+    {
+        u64 tail = m_tail.load(AK::MemoryOrder::memory_order_relaxed);
+        u64 head = m_head.load(AK::MemoryOrder::memory_order_acquire);
+        return tail == head;
+    }
+
+private:
+    [[nodiscard]] ALWAYS_INLINE constexpr u64 get_offset(u64 index) const
+    {
+        return index & (Size - 1);
+    }
+
+    AK_CACHE_ALIGNED Atomic<u64> m_head { 0 };
+    AK_CACHE_ALIGNED Atomic<u64> m_tail { 0 };
+    AK_CACHE_ALIGNED u64 m_cached_head = 0;
+    AK_CACHE_ALIGNED u64 m_cached_tail = 0;
+    // Aligned to prevent false sharing the beginning of m_data
+    AK_CACHE_ALIGNED alignas(T) unsigned char m_data[Size][sizeof(T)];
+};
+
 }
 
 #ifdef USING_AK_GLOBALLY
 using AK::MPSCRingBuffer;
+using AK::SPSCRingBuffer;
 #endif

--- a/AK/RingBuffer.h
+++ b/AK/RingBuffer.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, Ryszard Goc <ryszardgoc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Atomic.h>
+#include <AK/Concepts.h>
+#include <AK/Noncopyable.h>
+#include <AK/Platform.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/StdLibExtras.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+// This is a multiple producer single consumer lockfree bounded ring buffer.
+// To make construction in shared memory simpler the data is stored inline.
+// With each element a u32 sequence number is stored so sizeof(T) should be big to minimize space overhead.
+template<typename T, u32 Size>
+requires(is_power_of_two(Size) && IsMoveConstructible<T> && IsMoveAssignable<T> && !IsLvalueReference<T>)
+class MPSCRingBuffer {
+    AK_MAKE_NONCOPYABLE(MPSCRingBuffer);
+    AK_MAKE_NONMOVABLE(MPSCRingBuffer);
+
+public:
+    MPSCRingBuffer()
+    {
+        for (u64 i = 0; i < Size; i++) {
+            m_data[i].sequence.store(i, MemoryOrder::memory_order_relaxed);
+        }
+    }
+
+    ~MPSCRingBuffer()
+    {
+        for (;;) {
+            Node& slot = m_data[get_offset(m_tail)];
+
+            u32 sequence = slot.sequence.load(MemoryOrder::memory_order_acquire);
+
+            i32 diff = static_cast<i32>(sequence - (m_tail + 1));
+
+            if (diff == 0) {
+                // The slot is ready for reading
+                T* ptr = reinterpret_cast<T*>(slot.data);
+                ptr->~T();
+                m_tail += 1;
+                continue;
+            }
+            // In this case either the write wasn't finished ( sequence == read_index ) so diff == -1,
+            // or the queue is empty and no write is happening, so diff == -Size and we are finished
+            break;
+        }
+    }
+
+    [[nodiscard]] ALWAYS_INLINE bool try_push(T value)
+    {
+        return try_emplace(move(value));
+    }
+
+    template<typename U>
+    requires(IsConvertible<U, T> && !IsSame<RemoveCVReference<U>, T>)
+    [[nodiscard]] ALWAYS_INLINE bool try_push(U&& value)
+    {
+        return try_emplace(forward<U>(value));
+    }
+
+    template<typename... Args>
+    requires(IsConstructible<T, Args...>)
+    [[nodiscard]] ALWAYS_INLINE bool try_emplace(Args&&... args)
+    {
+        u32 head = m_head.load(MemoryOrder::memory_order_relaxed);
+
+        while (true) {
+            Node& slot = m_data[get_offset(head)];
+            u32 sequence = slot.sequence.load(MemoryOrder::memory_order_acquire);
+            i32 diff = static_cast<i32>(sequence - head);
+
+            if (diff == 0) {
+                // Slot is free
+                if (m_head.compare_exchange_weak(head, head + 1, MemoryOrder::memory_order_acq_rel)) {
+                    // We now own the slot
+                    new (slot.data) T(forward<Args>(args)...);
+                    slot.sequence.store(head + 1, MemoryOrder::memory_order_release);
+                    return true;
+                }
+                // The head was updated by another thread, try again
+                atomic_pause();
+            } else if (diff < 0) {
+                // Buffer full
+                return false;
+            } else {
+                //  Our head is stale
+                head = m_head.load(MemoryOrder::memory_order_relaxed);
+            }
+        }
+    }
+
+    [[nodiscard]] ALWAYS_INLINE bool try_pop(T& value)
+    {
+        Node& slot = m_data[get_offset(m_tail)];
+
+        u32 sequence = slot.sequence.load(MemoryOrder::memory_order_acquire);
+
+        i32 diff = static_cast<i32>(sequence - (m_tail + 1));
+
+        if (diff == 0) {
+            // The slot is ready for reading
+            T* ptr = reinterpret_cast<T*>(slot.data);
+            value = move(*ptr);
+            ptr->~T();
+            slot.sequence.store(m_tail + Size, MemoryOrder::memory_order_release);
+            m_tail += 1;
+            return true;
+        }
+        // In this case either the write wasn't finished ( sequence == read_index ) so diff == -1,
+        // or the queue is empty and no write is happening, so diff == -Size
+        return false;
+    }
+
+private:
+    ALWAYS_INLINE constexpr u32 get_offset(u32 index) const
+    {
+        return index & (Size - 1);
+    }
+
+    struct Node {
+        Atomic<u32> sequence;
+        alignas(T) unsigned char data[sizeof(T)];
+    };
+
+    AK_CACHE_ALIGNED Atomic<u32> m_head = 0;
+    AK_CACHE_ALIGNED u32 m_tail = 0;
+    AK_CACHE_ALIGNED Node m_data[Size];
+};
+
+}
+
+#ifdef USING_AK_GLOBALLY
+using AK::MPSCRingBuffer;
+#endif

--- a/AK/RingBuffer.h
+++ b/AK/RingBuffer.h
@@ -8,6 +8,8 @@
 
 #include <AK/Atomic.h>
 #include <AK/Concepts.h>
+#include <AK/CpuBackoff.h>
+#include <AK/Forward.h>
 #include <AK/Noncopyable.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtraDetails.h>
@@ -87,7 +89,7 @@ public:
                     return true;
                 }
                 // The head was updated by another thread, try again
-                atomic_pause();
+                cpu_pause();
             } else if (diff < 0) {
                 // Buffer full
                 return false;

--- a/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -14,6 +14,7 @@
 
 #include <AK/Atomic.h>
 #include <AK/ByteBuffer.h>
+#include <AK/CpuBackoff.h>
 #include <AK/Endian.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Agent.h>
@@ -472,7 +473,7 @@ JS_DEFINE_NATIVE_FUNCTION(AtomicsObject::pause)
 
     // The number of times the signal is sent for an integral Number N is less than or equal to the number times it is sent for N + 1 if both N and N + 1 have the same sign.
     for (; N != 0; N--)
-        AK::atomic_pause();
+        cpu_pause();
 
     // 3. Return undefined.
     return js_undefined();

--- a/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Atomic.h>
+#include <AK/RingBuffer.h>
 #include <AK/ScopeGuard.h>
 #include <AK/SourceLocation.h>
 #include <AK/Vector.h>
@@ -208,11 +209,9 @@ public:
             AudioOutputUnitStop(m_audio_unit);
     }
 
-    void queue_task(AudioTask task)
+    void queue_task(AudioTask&& task)
     {
-        Threading::MutexLocker lock(m_task_queue_mutex);
-        m_task_queue.append(move(task));
-        m_task_queue_is_empty = false;
+        m_task_buffer.push(forward<AudioTask>(task));
     }
 
     SampleSpecification const& sample_specification() const { return m_sample_specification; }
@@ -229,19 +228,6 @@ private:
     {
     }
 
-    Optional<AudioTask> dequeue_task()
-    {
-        // OPTIMIZATION: We can avoid taking a lock in the audio decoder thread if there are no queued commands, which
-        //               will be the case most of the time.
-        if (m_task_queue_is_empty.load())
-            return {};
-
-        Threading::MutexLocker lock(m_task_queue_mutex);
-
-        m_task_queue_is_empty = m_task_queue.size() == 1;
-        return m_task_queue.take_first();
-    }
-
     static OSStatus on_audio_unit_buffer_request(void* user_data, AudioUnitRenderActionFlags*, AudioTimeStamp const* time_stamp, UInt32 element, UInt32 frames_to_render, AudioBufferList* output_buffer_list)
     {
         VERIFY(element == AUDIO_UNIT_OUTPUT_BUS);
@@ -256,7 +242,7 @@ private:
         auto last_sample_time = static_cast<i64>(sample_time_seconds * 1000.0);
         state.m_last_sample_time.store(last_sample_time);
 
-        if (auto task = state.dequeue_task(); task.has_value()) {
+        if (auto task = state.m_task_buffer.try_pop(); task.has_value()) {
             OSStatus error = noErr;
 
             switch (task->type) {
@@ -305,9 +291,7 @@ private:
     AudioComponentInstance m_audio_unit { nullptr };
     SampleSpecification m_sample_specification;
 
-    Threading::Mutex m_task_queue_mutex;
-    Vector<AudioTask, 4> m_task_queue;
-    Atomic<bool> m_task_queue_is_empty { true };
+    MPSCRingBuffer<AudioTask, 128> m_task_buffer;
 
     enum class Paused {
         Yes,

--- a/Libraries/LibMedia/Audio/PlaybackStreamWasapi.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamWasapi.cpp
@@ -12,11 +12,13 @@
 #include <AK/Error.h>
 #include <AK/FixedArray.h>
 #include <AK/Format.h>
+#include <AK/Forward.h>
 #include <AK/Math.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Platform.h>
 #include <AK/Queue.h>
 #include <AK/RefPtr.h>
+#include <AK/RingBuffer.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
@@ -26,7 +28,6 @@
 #include <LibMedia/Audio/ChannelMap.h>
 #include <LibMedia/Audio/PlaybackStreamWasapi.h>
 #include <LibMedia/Audio/SampleSpecification.h>
-#include <LibThreading/Mutex.h>
 #include <LibThreading/Thread.h>
 
 #include <AK/Windows.h>
@@ -71,6 +72,8 @@ struct TaskDiscardAndSuspend {
     NonnullRefPtr<Core::ThreadedPromise<void>> promise;
 };
 
+using TaskVariant = Variant<TaskPlay, TaskDrainAndSuspend, TaskDiscardAndSuspend>;
+
 class ComUninitializer {
 public:
     ~ComUninitializer()
@@ -101,8 +104,9 @@ struct PlaybackStreamWASAPI::AudioState : public AtomicRefCounted<PlaybackStream
     PlaybackStreamWASAPI::AudioDataRequestCallback data_request_callback;
     Function<void()> underrun_callback;
 
-    Threading::Mutex task_queue_mutex;
-    Queue<Variant<TaskPlay, TaskDrainAndSuspend, TaskDiscardAndSuspend>> task_queue;
+    // NOTE: Tune size if needed
+    MPSCRingBuffer<TaskVariant, 128> task_buffer;
+
     // FIXME: Create a owning handle type to be shared in the codebase
     HANDLE task_event = 0;
 
@@ -355,9 +359,9 @@ int PlaybackStreamWASAPI::AudioState::render_thread_loop(PlaybackStreamWASAPI::A
         DWORD result = WaitForMultipleObjects(handles.size(), handles.data(), FALSE, INFINITE);
         switch (result) {
         case WAIT_OBJECT_0: {
-            state.task_queue_mutex.lock();
-            while (!state.task_queue.is_empty()) {
-                auto task = state.task_queue.dequeue();
+            Optional<TaskVariant> maybe_task = state.task_buffer.try_pop();
+            while (maybe_task.has_value()) {
+                auto task = maybe_task.release_value();
                 task.visit(
                     [&state](TaskPlay const& task) {
                         HRESULT hr = state.audio_client->Start();
@@ -395,8 +399,8 @@ int PlaybackStreamWASAPI::AudioState::render_thread_loop(PlaybackStreamWASAPI::A
                         state.playing = false;
                         task.promise->resolve();
                     });
+                maybe_task = state.task_buffer.try_pop();
             }
-            state.task_queue_mutex.unlock();
             DWORD res = WaitForSingleObject(handles[1], 0);
             // Both the task event and buffer event were signaled
             if (res == WAIT_OBJECT_0)
@@ -458,12 +462,9 @@ void PlaybackStreamWASAPI::set_underrun_callback(Function<void()> underrun_callb
 NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> PlaybackStreamWASAPI::resume()
 {
     auto promise = Core::ThreadedPromise<AK::Duration>::create();
-    TaskPlay task = { .promise = promise };
 
-    m_state->task_queue_mutex.lock();
-    m_state->task_queue.enqueue(move(task));
+    m_state->task_buffer.push(TaskPlay { .promise = promise });
     SetEvent(m_state->task_event);
-    m_state->task_queue_mutex.unlock();
 
     return promise;
 }
@@ -471,12 +472,9 @@ NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> PlaybackStreamWASAPI::resume(
 NonnullRefPtr<Core::ThreadedPromise<void>> PlaybackStreamWASAPI::drain_buffer_and_suspend()
 {
     auto promise = Core::ThreadedPromise<void>::create();
-    TaskDrainAndSuspend task = { .promise = promise };
 
-    m_state->task_queue_mutex.lock();
-    m_state->task_queue.enqueue(move(task));
+    m_state->task_buffer.push(TaskDrainAndSuspend { .promise = promise });
     SetEvent(m_state->task_event);
-    m_state->task_queue_mutex.unlock();
 
     return promise;
 }
@@ -484,12 +482,9 @@ NonnullRefPtr<Core::ThreadedPromise<void>> PlaybackStreamWASAPI::drain_buffer_an
 NonnullRefPtr<Core::ThreadedPromise<void>> PlaybackStreamWASAPI::discard_buffer_and_suspend()
 {
     auto promise = Core::ThreadedPromise<void>::create();
-    TaskDiscardAndSuspend task = { .promise = promise };
 
-    m_state->task_queue_mutex.lock();
-    m_state->task_queue.enqueue(move(task));
+    m_state->task_buffer.push(TaskDiscardAndSuspend { .promise = promise });
     SetEvent(m_state->task_event);
-    m_state->task_queue_mutex.unlock();
 
     return promise;
 }

--- a/Libraries/LibMedia/Audio/PlaybackStreamWasapi.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamWasapi.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/Atomic.h>
 #include <AK/AtomicRefCounted.h>
+#include <AK/CpuBackoff.h>
 #include <AK/Error.h>
 #include <AK/FixedArray.h>
 #include <AK/Format.h>
@@ -379,7 +380,7 @@ int PlaybackStreamWASAPI::AudioState::render_thread_loop(PlaybackStreamWASAPI::A
                             if (padding == 0)
                                 dbgln_if(AUDIO_DEBUG, "------- PlaybackStreamWASAPI: overslept draining buffer --------");
                             while (padding > 0) {
-                                AK::atomic_pause();
+                                cpu_pause();
                                 MUST_HR(state.audio_client->GetCurrentPadding(&padding));
                             }
                         }

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -60,6 +60,7 @@ set(AK_TEST_SOURCES
     TestRandom.cpp
     TestRedBlackTree.cpp
     TestRefPtr.cpp
+    TestRingBuffer.cpp
     TestSegmentedVector.cpp
     TestSinglyLinkedList.cpp
     TestSourceGenerator.cpp
@@ -97,6 +98,8 @@ endif()
 foreach(source IN LISTS AK_TEST_SOURCES)
     ladybird_test("${source}" AK)
 endforeach()
+
+target_link_libraries(TestRingBuffer PRIVATE LibThreading)
 
 if (WIN32)
     # FIXME: Windows on ARM

--- a/Tests/AK/TestRingBuffer.cpp
+++ b/Tests/AK/TestRingBuffer.cpp
@@ -7,6 +7,7 @@
 #include <AK/Atomic.h>
 #include <AK/CpuBackoff.h>
 #include <AK/Function.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/RingBuffer.h>
 #include <AK/Vector.h>
 #include <LibTest/TestCase.h>
@@ -111,6 +112,75 @@ TEST_CASE(mpsc_complex_object)
     EXPECT(buffer.try_pop(val));
     EXPECT_EQ(val.x, 3);
     EXPECT_EQ(val.y, 4);
+}
+
+TEST_CASE(mpsc_blocking_push_pop)
+{
+    MPSCRingBuffer<int, 4> buffer;
+    int value = 0;
+
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+
+    buffer.pop(value);
+    EXPECT_EQ(value, 1);
+
+    buffer.pop(value);
+    EXPECT_EQ(value, 2);
+
+    buffer.pop(value);
+    EXPECT_EQ(value, 3);
+}
+
+TEST_CASE(mpsc_blocking_threaded)
+{
+    static constexpr size_t NUM_PRODUCERS = 4;
+    static constexpr size_t ITEMS_PER_PRODUCER = 10000;
+    static constexpr size_t BUFFER_SIZE = 64;
+
+    using RingBufferType = MPSCRingBuffer<int, BUFFER_SIZE>;
+    auto buffer = make<RingBufferType>();
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<size_t> producer_done_count { 0 };
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<size_t> total_consumed { 0 };
+
+    Vector<NonnullRefPtr<Threading::Thread>> producers;
+
+    for (size_t i = 0; i < NUM_PRODUCERS; ++i) {
+        auto thread = Threading::Thread::construct(ByteString::formatted("Producer_{}", i), [buffer = buffer.ptr(), id = i, &producer_done_count] {
+            for (size_t k = 0; k < ITEMS_PER_PRODUCER; ++k) {
+                buffer->push(static_cast<int>((id * ITEMS_PER_PRODUCER) + k));
+            }
+            producer_done_count.fetch_add(1);
+            return 0;
+        });
+        producers.append(thread);
+    }
+
+    auto consumer = Threading::Thread::construct("Consumer"sv, [buffer = buffer.ptr(), &total_consumed, &producer_done_count] {
+        size_t consumed = 0;
+        while (producer_done_count.load() < NUM_PRODUCERS || consumed < (NUM_PRODUCERS * ITEMS_PER_PRODUCER)) {
+            int value;
+            if (buffer->try_pop(value)) {
+                consumed++;
+            } else {
+                cpu_pause();
+            }
+        }
+        total_consumed.store(consumed);
+        return 0;
+    });
+
+    consumer->start();
+    for (auto& t : producers)
+        t->start();
+
+    for (auto& t : producers)
+        (void)t->join();
+    (void)consumer->join();
+
+    EXPECT_EQ(total_consumed.load(), NUM_PRODUCERS * ITEMS_PER_PRODUCER);
 }
 
 TEST_CASE(mpsc_threaded)
@@ -220,9 +290,7 @@ BENCHMARK_CASE(mpsc_throughput_threaded)
     for (size_t i = 0; i < NUM_PRODUCERS; ++i) {
         auto thread = Threading::Thread::construct(ByteString::formatted("Producer_{}", i), [buffer = buffer.ptr(), &producer_done_count] {
             for (size_t k = 0; k < ITEMS_PER_PRODUCER; ++k) {
-                while (!buffer->try_push(1)) {
-                    cpu_pause();
-                }
+                buffer->push(1);
             }
             producer_done_count.fetch_add(1);
             return 0;
@@ -344,6 +412,94 @@ TEST_CASE(spsc_complex_object)
     EXPECT(buffer.try_pop(val));
     EXPECT_EQ(val.x, 3);
     EXPECT_EQ(val.y, 4);
+}
+
+TEST_CASE(spsc_blocking_push_pop)
+{
+    SPSCRingBuffer<int, 4> buffer;
+    int value = 0;
+
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+
+    buffer.pop(value);
+    EXPECT_EQ(value, 1);
+
+    buffer.pop(value);
+    EXPECT_EQ(value, 2);
+
+    buffer.pop(value);
+    EXPECT_EQ(value, 3);
+}
+
+TEST_CASE(spsc_blocking_emplace)
+{
+    struct Complex {
+        int a;
+        int b;
+        Complex(int a, int b)
+            : a(a)
+            , b(b)
+        {
+        }
+        Complex()
+            : a(0)
+            , b(0)
+        {
+        }
+    };
+
+    SPSCRingBuffer<Complex, 4> buffer;
+    buffer.emplace(1, 2);
+
+    Complex val;
+    buffer.pop(val);
+    EXPECT_EQ(val.a, 1);
+    EXPECT_EQ(val.b, 2);
+}
+
+TEST_CASE(spsc_blocking_threaded)
+{
+    static constexpr size_t ITEMS_COUNT = 100000;
+    static constexpr size_t BUFFER_SIZE = 128;
+
+    using RingBufferType = SPSCRingBuffer<int, BUFFER_SIZE>;
+    auto buffer = make<RingBufferType>();
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<size_t> total_consumed { 0 };
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<bool> producer_done { false };
+
+    auto producer = Threading::Thread::construct("Producer"sv, [buffer = buffer.ptr(), &producer_done] {
+        for (size_t k = 0; k < ITEMS_COUNT; ++k) {
+            buffer->push(static_cast<int>(k));
+        }
+        producer_done.store(true);
+        return 0;
+    });
+
+    auto consumer = Threading::Thread::construct("Consumer"sv, [buffer = buffer.ptr(), &total_consumed, &producer_done] {
+        size_t consumed = 0;
+        while (!producer_done.load() || consumed < ITEMS_COUNT) {
+            int value;
+            if (buffer->try_pop(value)) {
+                EXPECT_EQ(value, static_cast<int>(consumed));
+                consumed++;
+            } else {
+                cpu_pause();
+            }
+        }
+        total_consumed.store(consumed);
+        return 0;
+    });
+
+    consumer->start();
+    producer->start();
+
+    (void)producer->join();
+    (void)consumer->join();
+
+    EXPECT_EQ(total_consumed.load(), ITEMS_COUNT);
 }
 
 TEST_CASE(spsc_convertible_push)

--- a/Tests/AK/TestRingBuffer.cpp
+++ b/Tests/AK/TestRingBuffer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Atomic.h>
+#include <AK/CpuBackoff.h>
 #include <AK/Function.h>
 #include <AK/RingBuffer.h>
 #include <AK/Vector.h>
@@ -130,7 +131,7 @@ TEST_CASE(mpsc_threaded)
         auto thread = Threading::Thread::construct(ByteString::formatted("Producer_{}", i), [buffer = buffer.ptr(), id = i, &producer_done_count] {
             for (size_t k = 0; k < ITEMS_PER_PRODUCER; ++k) {
                 while (!buffer->try_push(static_cast<int>((id * ITEMS_PER_PRODUCER) + k))) {
-                    AK::atomic_pause();
+                    cpu_pause();
                 }
             }
             producer_done_count.fetch_add(1);
@@ -147,7 +148,7 @@ TEST_CASE(mpsc_threaded)
             if (buffer->try_pop(value)) {
                 consumed++;
             } else {
-                AK::atomic_pause();
+                cpu_pause();
             }
         }
         total_consumed.store(consumed);
@@ -220,7 +221,7 @@ BENCHMARK_CASE(mpsc_throughput_threaded)
         auto thread = Threading::Thread::construct(ByteString::formatted("Producer_{}", i), [buffer = buffer.ptr(), &producer_done_count] {
             for (size_t k = 0; k < ITEMS_PER_PRODUCER; ++k) {
                 while (!buffer->try_push(1)) {
-                    AK::atomic_pause();
+                    cpu_pause();
                 }
             }
             producer_done_count.fetch_add(1);
@@ -236,7 +237,7 @@ BENCHMARK_CASE(mpsc_throughput_threaded)
             if (buffer->try_pop(value)) {
                 consumed++;
             } else {
-                AK::atomic_pause();
+                cpu_pause();
             }
         }
         return 0;
@@ -405,7 +406,7 @@ TEST_CASE(spsc_threaded)
     auto producer = Threading::Thread::construct("Producer"sv, [buffer = buffer.ptr(), &producer_done] {
         for (size_t k = 0; k < ITEMS_COUNT; ++k) {
             while (!buffer->try_push(static_cast<int>(k))) {
-                AK::atomic_pause();
+                cpu_pause();
             }
         }
         producer_done.store(true);
@@ -420,7 +421,7 @@ TEST_CASE(spsc_threaded)
                 EXPECT_EQ(value, static_cast<int>(consumed));
                 consumed++;
             } else {
-                AK::atomic_pause();
+                cpu_pause();
             }
         }
         total_consumed.store(consumed);
@@ -487,7 +488,7 @@ BENCHMARK_CASE(spsc_throughput_threaded)
     auto producer = Threading::Thread::construct("Producer"sv, [buffer = buffer.ptr(), &producer_done] {
         for (size_t k = 0; k < ITEMS_COUNT; ++k) {
             while (!buffer->try_push(static_cast<int>(k))) {
-                AK::atomic_pause();
+                cpu_pause();
             }
         }
         producer_done.store(true);
@@ -501,7 +502,7 @@ BENCHMARK_CASE(spsc_throughput_threaded)
             if (buffer->try_pop(value)) {
                 consumed++;
             } else {
-                AK::atomic_pause();
+                cpu_pause();
             }
         }
         return 0;

--- a/Tests/AK/TestRingBuffer.cpp
+++ b/Tests/AK/TestRingBuffer.cpp
@@ -11,7 +11,7 @@
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
 
-TEST_CASE(basic_push_pop)
+TEST_CASE(mpsc_basic_push_pop)
 {
     MPSCRingBuffer<int, 4> buffer;
     int value = 0;
@@ -32,7 +32,7 @@ TEST_CASE(basic_push_pop)
     EXPECT(!buffer.try_pop(value));
 }
 
-TEST_CASE(buffer_full)
+TEST_CASE(mpsc_buffer_full)
 {
     MPSCRingBuffer<int, 4> buffer;
     EXPECT(buffer.try_push(1));
@@ -51,14 +51,14 @@ TEST_CASE(buffer_full)
     EXPECT(buffer.try_push(5));
 }
 
-TEST_CASE(buffer_empty)
+TEST_CASE(mpsc_buffer_empty)
 {
     MPSCRingBuffer<int, 4> buffer;
     int value;
     EXPECT(!buffer.try_pop(value));
 }
 
-TEST_CASE(wrap_around_logic)
+TEST_CASE(mpsc_wrap_around_logic)
 {
     // Test that the sequence logic handles wrapping correctly
     // Size 2 implies mask is 1. Indices will wrap quickly in the buffer,
@@ -90,7 +90,7 @@ TEST_CASE(wrap_around_logic)
     EXPECT_EQ(value, 13);
 }
 
-TEST_CASE(complex_object)
+TEST_CASE(mpsc_complex_object)
 {
     struct Obj {
         int x;
@@ -112,7 +112,7 @@ TEST_CASE(complex_object)
     EXPECT_EQ(val.y, 4);
 }
 
-TEST_CASE(threaded_mpsc)
+TEST_CASE(mpsc_threaded)
 {
     static constexpr size_t NUM_PRODUCERS = 4;
     static constexpr size_t ITEMS_PER_PRODUCER = 10000;
@@ -184,7 +184,7 @@ TEST_CASE(mpsc_non_default_constructible)
     MPSCRingBuffer<Foo, 128> ring;
 }
 
-BENCHMARK_CASE(throughput_batch)
+BENCHMARK_CASE(mpsc_throughput_batch)
 {
     static constexpr size_t NUM_BATCHES = 10'000;
     static constexpr size_t BATCH_SIZE = 128;
@@ -248,5 +248,268 @@ BENCHMARK_CASE(mpsc_throughput_threaded)
 
     for (auto& t : producers)
         (void)t->join();
+    (void)consumer->join();
+}
+
+TEST_CASE(spsc_basic_push_pop)
+{
+    SPSCRingBuffer<int, 4> buffer;
+    int value = 0;
+
+    EXPECT(buffer.try_push(1));
+    EXPECT(buffer.try_push(2));
+    EXPECT(buffer.try_push(3));
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 1);
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 2);
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 3);
+
+    EXPECT(!buffer.try_pop(value));
+}
+
+TEST_CASE(spsc_buffer_full)
+{
+    SPSCRingBuffer<int, 4> buffer;
+    EXPECT(buffer.try_push(1));
+    EXPECT(buffer.try_push(2));
+    EXPECT(buffer.try_push(3));
+    EXPECT(buffer.try_push(4));
+
+    EXPECT(!buffer.try_push(5));
+
+    int value;
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 1);
+
+    EXPECT(buffer.try_push(5));
+}
+
+TEST_CASE(spsc_buffer_empty)
+{
+    SPSCRingBuffer<int, 4> buffer;
+    int value;
+    EXPECT(!buffer.try_pop(value));
+}
+
+TEST_CASE(spsc_wrap_around_logic)
+{
+    SPSCRingBuffer<int, 2> buffer;
+    int value;
+
+    EXPECT(buffer.try_push(10));
+    EXPECT(buffer.try_push(11));
+    EXPECT(!buffer.try_push(12));
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 10);
+
+    EXPECT(buffer.try_push(12));
+    EXPECT(!buffer.try_push(13));
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 11);
+
+    EXPECT(buffer.try_push(13));
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 12);
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 13);
+}
+
+TEST_CASE(spsc_complex_object)
+{
+    struct Obj {
+        int x;
+        int y;
+        bool operator==(Obj const& other) const { return x == other.x && y == other.y; }
+    };
+
+    SPSCRingBuffer<Obj, 4> buffer;
+    EXPECT(buffer.try_push({ 1, 2 }));
+    EXPECT(buffer.try_push({ 3, 4 }));
+
+    Obj val;
+    EXPECT(buffer.try_pop(val));
+    EXPECT_EQ(val.x, 1);
+    EXPECT_EQ(val.y, 2);
+
+    EXPECT(buffer.try_pop(val));
+    EXPECT_EQ(val.x, 3);
+    EXPECT_EQ(val.y, 4);
+}
+
+TEST_CASE(spsc_convertible_push)
+{
+    SPSCRingBuffer<ByteString, 4> buffer;
+    EXPECT(buffer.try_push("foo"));
+    ByteString val;
+    EXPECT(buffer.try_pop(val));
+    EXPECT_EQ(val, "foo");
+}
+
+TEST_CASE(spsc_try_emplace)
+{
+    struct Complex {
+        int a;
+        int b;
+        Complex(int a, int b)
+            : a(a)
+            , b(b)
+        {
+        }
+        Complex()
+            : a(0)
+            , b(0)
+        {
+        } // Currently required
+    };
+
+    SPSCRingBuffer<Complex, 4> buffer;
+    EXPECT(buffer.try_emplace(1, 2));
+
+    Complex val;
+    EXPECT(buffer.try_pop(val));
+    EXPECT_EQ(val.a, 1);
+    EXPECT_EQ(val.b, 2);
+}
+
+TEST_CASE(spsc_is_empty)
+{
+    SPSCRingBuffer<int, 4> buffer;
+    EXPECT(buffer.is_empty());
+    EXPECT(buffer.try_push(1));
+    EXPECT(!buffer.is_empty());
+    int val;
+    EXPECT(buffer.try_pop(val));
+    EXPECT(buffer.is_empty());
+}
+
+TEST_CASE(spsc_threaded)
+{
+    static constexpr size_t ITEMS_COUNT = 100000;
+    static constexpr size_t BUFFER_SIZE = 128;
+
+    using RingBufferType = SPSCRingBuffer<int, BUFFER_SIZE>;
+    auto buffer = make<RingBufferType>();
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<size_t> total_consumed { 0 };
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<bool> producer_done { false };
+
+    auto producer = Threading::Thread::construct("Producer"sv, [buffer = buffer.ptr(), &producer_done] {
+        for (size_t k = 0; k < ITEMS_COUNT; ++k) {
+            while (!buffer->try_push(static_cast<int>(k))) {
+                AK::atomic_pause();
+            }
+        }
+        producer_done.store(true);
+        return 0;
+    });
+
+    auto consumer = Threading::Thread::construct("Consumer"sv, [buffer = buffer.ptr(), &total_consumed, &producer_done] {
+        size_t consumed = 0;
+        while (!producer_done.load() || consumed < ITEMS_COUNT) {
+            int value;
+            if (buffer->try_pop(value)) {
+                EXPECT_EQ(value, static_cast<int>(consumed));
+                consumed++;
+            } else {
+                AK::atomic_pause();
+            }
+        }
+        total_consumed.store(consumed);
+        return 0;
+    });
+
+    consumer->start();
+    producer->start();
+
+    (void)producer->join();
+    (void)consumer->join();
+
+    EXPECT_EQ(total_consumed.load(), ITEMS_COUNT);
+}
+
+TEST_CASE(spsc_non_default_constructible)
+{
+    struct Foo {
+        Foo() = delete;
+        Foo(int a)
+            : m_a(a)
+        {
+        }
+        int get() const
+        {
+            return m_a;
+        }
+
+    private:
+        int m_a;
+    };
+    SPSCRingBuffer<Foo, 128> ring;
+}
+
+BENCHMARK_CASE(spsc_throughput_batch)
+{
+    static constexpr size_t NUM_BATCHES = 100'000;
+    static constexpr size_t BATCH_SIZE = 128;
+    SPSCRingBuffer<int, 256> buffer;
+
+    for (size_t i = 0; i < NUM_BATCHES; ++i) {
+        for (size_t j = 0; j < BATCH_SIZE; ++j) {
+            while (!buffer.try_push(1))
+                ;
+        }
+        for (size_t j = 0; j < BATCH_SIZE; ++j) {
+            int val;
+            while (!buffer.try_pop(val))
+                ;
+        }
+    }
+}
+
+BENCHMARK_CASE(spsc_throughput_threaded)
+{
+    static constexpr size_t ITEMS_COUNT = 10'000'000;
+    static constexpr size_t BUFFER_SIZE = 1024;
+
+    using RingBufferType = SPSCRingBuffer<int, BUFFER_SIZE>;
+    auto buffer = make<RingBufferType>();
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<bool> producer_done { false };
+
+    auto producer = Threading::Thread::construct("Producer"sv, [buffer = buffer.ptr(), &producer_done] {
+        for (size_t k = 0; k < ITEMS_COUNT; ++k) {
+            while (!buffer->try_push(static_cast<int>(k))) {
+                AK::atomic_pause();
+            }
+        }
+        producer_done.store(true);
+        return 0;
+    });
+
+    auto consumer = Threading::Thread::construct("Consumer"sv, [buffer = buffer.ptr(), &producer_done] {
+        size_t consumed = 0;
+        while (!producer_done.load() || consumed < ITEMS_COUNT) {
+            int value;
+            if (buffer->try_pop(value)) {
+                consumed++;
+            } else {
+                AK::atomic_pause();
+            }
+        }
+        return 0;
+    });
+
+    consumer->start();
+    producer->start();
+
+    (void)producer->join();
     (void)consumer->join();
 }

--- a/Tests/AK/TestRingBuffer.cpp
+++ b/Tests/AK/TestRingBuffer.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026, Ryszard Goc <ryszardgoc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Atomic.h>
+#include <AK/Function.h>
+#include <AK/RingBuffer.h>
+#include <AK/Vector.h>
+#include <LibTest/TestCase.h>
+#include <LibThreading/Thread.h>
+
+TEST_CASE(basic_push_pop)
+{
+    MPSCRingBuffer<int, 4> buffer;
+    int value = 0;
+
+    EXPECT(buffer.try_push(1));
+    EXPECT(buffer.try_push(2));
+    EXPECT(buffer.try_push(3));
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 1);
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 2);
+
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 3);
+
+    EXPECT(!buffer.try_pop(value));
+}
+
+TEST_CASE(buffer_full)
+{
+    MPSCRingBuffer<int, 4> buffer;
+    EXPECT(buffer.try_push(1));
+    EXPECT(buffer.try_push(2));
+    EXPECT(buffer.try_push(3));
+    EXPECT(buffer.try_push(4));
+
+    // Buffer is size 4, so it should be full now
+    EXPECT(!buffer.try_push(5));
+
+    int value;
+    EXPECT(buffer.try_pop(value));
+    EXPECT_EQ(value, 1);
+
+    // Now we should be able to push again
+    EXPECT(buffer.try_push(5));
+}
+
+TEST_CASE(buffer_empty)
+{
+    MPSCRingBuffer<int, 4> buffer;
+    int value;
+    EXPECT(!buffer.try_pop(value));
+}
+
+TEST_CASE(wrap_around_logic)
+{
+    // Test that the sequence logic handles wrapping correctly
+    // Size 2 implies mask is 1. Indices will wrap quickly in the buffer,
+    // but the sequence numbers will grow monotonously.
+    MPSCRingBuffer<int, 2> buffer;
+    int value;
+
+    // Generation 0
+    EXPECT(buffer.try_push(10));
+    EXPECT(buffer.try_push(11));
+    EXPECT(!buffer.try_push(12)); // Full
+
+    EXPECT(buffer.try_pop(value)); // Pops 10
+    EXPECT_EQ(value, 10);
+
+    // Generation 1 (for slot 0)
+    EXPECT(buffer.try_push(12));  // Pushes to slot 0 (index 2)
+    EXPECT(!buffer.try_push(13)); // Full (slot 1 is still occupied by 11)
+
+    EXPECT(buffer.try_pop(value)); // Pops 11
+    EXPECT_EQ(value, 11);
+
+    EXPECT(buffer.try_push(13)); // Pushes to slot 1 (index 3)
+
+    EXPECT(buffer.try_pop(value)); // Pops 12
+    EXPECT_EQ(value, 12);
+
+    EXPECT(buffer.try_pop(value)); // Pops 13
+    EXPECT_EQ(value, 13);
+}
+
+TEST_CASE(complex_object)
+{
+    struct Obj {
+        int x;
+        int y;
+        bool operator==(Obj const& other) const { return x == other.x && y == other.y; }
+    };
+
+    MPSCRingBuffer<Obj, 4> buffer;
+    EXPECT(buffer.try_push({ 1, 2 }));
+    EXPECT(buffer.try_push({ 3, 4 }));
+
+    Obj val;
+    EXPECT(buffer.try_pop(val));
+    EXPECT_EQ(val.x, 1);
+    EXPECT_EQ(val.y, 2);
+
+    EXPECT(buffer.try_pop(val));
+    EXPECT_EQ(val.x, 3);
+    EXPECT_EQ(val.y, 4);
+}
+
+TEST_CASE(threaded_mpsc)
+{
+    static constexpr size_t NUM_PRODUCERS = 4;
+    static constexpr size_t ITEMS_PER_PRODUCER = 10000;
+    static constexpr size_t BUFFER_SIZE = 64; // Small buffer to force contention
+
+    using RingBufferType = MPSCRingBuffer<int, BUFFER_SIZE>;
+    auto buffer = make<RingBufferType>();
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<size_t> producer_done_count { 0 };
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<size_t> total_consumed { 0 };
+
+    Vector<NonnullRefPtr<Threading::Thread>> producers;
+
+    for (size_t i = 0; i < NUM_PRODUCERS; ++i) {
+        auto thread = Threading::Thread::construct(ByteString::formatted("Producer_{}", i), [buffer = buffer.ptr(), id = i, &producer_done_count] {
+            for (size_t k = 0; k < ITEMS_PER_PRODUCER; ++k) {
+                while (!buffer->try_push(static_cast<int>((id * ITEMS_PER_PRODUCER) + k))) {
+                    AK::atomic_pause();
+                }
+            }
+            producer_done_count.fetch_add(1);
+            return 0;
+        });
+        producers.append(thread);
+    }
+
+    auto consumer = Threading::Thread::construct("Consumer"sv, [buffer = buffer.ptr(), &total_consumed, &producer_done_count] {
+        size_t consumed = 0;
+        // Continue consuming until all producers are done AND we have consumed everything
+        while (producer_done_count.load() < NUM_PRODUCERS || consumed < (NUM_PRODUCERS * ITEMS_PER_PRODUCER)) {
+            int value;
+            if (buffer->try_pop(value)) {
+                consumed++;
+            } else {
+                AK::atomic_pause();
+            }
+        }
+        total_consumed.store(consumed);
+        return 0;
+    });
+
+    consumer->start();
+    for (auto& t : producers)
+        t->start();
+
+    for (auto& t : producers)
+        (void)t->join();
+    (void)consumer->join();
+
+    EXPECT_EQ(total_consumed.load(), NUM_PRODUCERS * ITEMS_PER_PRODUCER);
+}
+
+TEST_CASE(mpsc_non_default_constructible)
+{
+    struct Foo {
+        Foo() = delete;
+        Foo(int a)
+            : m_a(a)
+        {
+        }
+        int get() const
+        {
+            return m_a;
+        }
+
+    private:
+        int m_a;
+    };
+    MPSCRingBuffer<Foo, 128> ring;
+}
+
+BENCHMARK_CASE(throughput_batch)
+{
+    static constexpr size_t NUM_BATCHES = 10'000;
+    static constexpr size_t BATCH_SIZE = 128;
+    MPSCRingBuffer<int, 256> buffer;
+
+    for (size_t i = 0; i < NUM_BATCHES; ++i) {
+        for (size_t j = 0; j < BATCH_SIZE; ++j) {
+            while (!buffer.try_push(1))
+                ;
+        }
+        for (size_t j = 0; j < BATCH_SIZE; ++j) {
+            int val;
+            while (!buffer.try_pop(val))
+                ;
+        }
+    }
+}
+
+BENCHMARK_CASE(mpsc_throughput_threaded)
+{
+    static constexpr size_t NUM_PRODUCERS = 4;
+    static constexpr size_t ITEMS_PER_PRODUCER = 1'000'000;
+    static constexpr size_t BUFFER_SIZE = 1024;
+
+    using RingBufferType = MPSCRingBuffer<int, BUFFER_SIZE>;
+    auto buffer = make<RingBufferType>();
+
+    IGNORE_USE_IN_ESCAPING_LAMBDA Atomic<size_t> producer_done_count { 0 };
+
+    Vector<NonnullRefPtr<Threading::Thread>> producers;
+
+    for (size_t i = 0; i < NUM_PRODUCERS; ++i) {
+        auto thread = Threading::Thread::construct(ByteString::formatted("Producer_{}", i), [buffer = buffer.ptr(), &producer_done_count] {
+            for (size_t k = 0; k < ITEMS_PER_PRODUCER; ++k) {
+                while (!buffer->try_push(1)) {
+                    AK::atomic_pause();
+                }
+            }
+            producer_done_count.fetch_add(1);
+            return 0;
+        });
+        producers.append(thread);
+    }
+
+    auto consumer = Threading::Thread::construct("Consumer"sv, [buffer = buffer.ptr(), &producer_done_count] {
+        size_t consumed = 0;
+        while (producer_done_count.load() < NUM_PRODUCERS || consumed < (NUM_PRODUCERS * ITEMS_PER_PRODUCER)) {
+            int value;
+            if (buffer->try_pop(value)) {
+                consumed++;
+            } else {
+                AK::atomic_pause();
+            }
+        }
+        return 0;
+    });
+
+    consumer->start();
+    for (auto& t : producers)
+        t->start();
+
+    for (auto& t : producers)
+        (void)t->join();
+    (void)consumer->join();
+}


### PR DESCRIPTION
This PR adds an MPSC and SPSC ring buffer in AK/RingBuffer.h. The implementation approach is using nodes that each hold an atomic sequence number for the MPSC buffer. This has a larger space overhead, but a lower latency due to lesser contention on the atomics. However ideally the types should be large when used with this ring buffer. The SPSC implementation just uses two atomics. 

The playback stream implementations on windows and MacOS use this instead of a queue protected by a muetx. This avoids a mutex in the render callback.