### PR TITLE
LibWeb/test-web: Add WptResourceMap.json for root-relative url mapping

### DIFF
--- a/Tests/LibWeb/WptResourceMap.json
+++ b/Tests/LibWeb/WptResourceMap.json
@@ -1,0 +1,3 @@
+{
+  "file:///webaudio/resources/": "Text/input/wpt-import/webaudio/resources/"
+}

--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -6,6 +6,7 @@
 
 #include "TestWebView.h"
 
+#include "Application.h"
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ShareableBitmap.h>
 
@@ -23,6 +24,100 @@ TestWebView::TestWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewp
     : WebView::HeadlessWebView(move(theme), viewport_size)
     , m_test_promise(TestPromise::construct())
 {
+    load_wpt_resource_map();
+
+    // test-web loads tests with the file:// scheme. WPT has root-relative URLs like
+    // "/webaudio/resources/..." then resolve to file:///webaudio/resources/..., which
+    // is not within the repository. Use Tests/LibWeb/WptResourceMap.json to remap these
+    // file URLs into the in-tree imported WPT files.
+    on_request_file = [this](ByteString const& path, i32 request_id) {
+        ByteString mapped_path = path;
+
+        if (auto url = URL::create_with_file_scheme(path); url.has_value()) {
+            if (auto substituted = map_file_path_from_url(*url); substituted.has_value())
+                mapped_path = substituted.release_value();
+        }
+        auto file = Core::File::open(mapped_path, Core::File::OpenMode::Read);
+        if (file.is_error()) {
+            client().async_handle_file_return(page_id(), file.error().code(), {}, request_id);
+        } else {
+            client().async_handle_file_return(page_id(), 0, IPC::File::adopt_file(file.release_value()), request_id);
+        }
+    };
+}
+
+static String normalize_url(URL::URL const& url)
+{
+    auto normalized = url;
+    normalized.set_query({});
+    normalized.set_fragment({});
+    return normalized.serialize();
+}
+
+void TestWebView::load_wpt_resource_map()
+{
+    auto json_path = LexicalPath::join(Application::the().test_root_path, "WptResourceMap.json"sv).string();
+
+    auto file_or_error = Core::File::open(json_path, Core::File::OpenMode::Read);
+    if (file_or_error.is_error()) {
+        if (file_or_error.error().code() == ENOENT)
+            return;
+        warnln("test-web: Unable to open WPT resource map '{}': {}", json_path, file_or_error.error());
+        return;
+    }
+
+    auto content_or_error = file_or_error.value()->read_until_eof();
+    if (content_or_error.is_error()) {
+        warnln("test-web: Unable to read WPT resource map '{}': {}", json_path, content_or_error.error());
+        return;
+    }
+
+    auto json_or_error = JsonValue::from_string(content_or_error.value());
+    if (json_or_error.is_error()) {
+        warnln("test-web: Unable to parse WPT resource map '{}': {}", json_path, json_or_error.error());
+        return;
+    }
+
+    auto json = json_or_error.release_value();
+    if (!json.is_object()) {
+        warnln("test-web: WPT resource map must be a JSON object");
+        return;
+    }
+
+    auto const& root = json.as_object();
+
+    // Simple prefix map: { "file:///webaudio/resources/": "Text/input/wpt-import/webaudio/resources/" }
+    root.for_each_member([&](auto const& url_prefix, auto const& file_prefix_value) {
+        if (!file_prefix_value.is_string())
+            return;
+
+        ByteString file_prefix = file_prefix_value.as_string().to_byte_string();
+        if (!LexicalPath { file_prefix }.is_absolute())
+            file_prefix = LexicalPath::join(Application::the().test_root_path, file_prefix).string();
+
+        m_wpt_file_substitutions.set(url_prefix, move(file_prefix));
+    });
+}
+
+Optional<ByteString> TestWebView::map_file_path_from_url(URL::URL const& url) const
+{
+    auto normalized = normalize_url(url);
+    Optional<String> best_prefix;
+    Optional<ByteString> best_file_prefix;
+
+    for (auto const& it : m_wpt_file_substitutions) {
+        if (!normalized.starts_with_bytes(it.key.bytes_as_string_view()))
+            continue;
+        if (!best_prefix.has_value() || it.key.byte_count() > best_prefix->byte_count()) {
+            best_prefix = it.key;
+            best_file_prefix = it.value;
+        }
+    }
+    if (!best_prefix.has_value())
+        return {};
+
+    String suffix = MUST(normalized.substring_from_byte_offset(best_prefix->byte_count()));
+    return LexicalPath::join(*best_file_prefix, suffix.to_byte_string()).string();
 }
 
 void TestWebView::clear_content_filters()
@@ -47,7 +142,14 @@ NonnullRefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> TestWebView::take_screen
 
 void TestWebView::did_receive_screenshot(Badge<WebView::WebContentClient>, Gfx::ShareableBitmap const& screenshot)
 {
-    VERIFY(m_pending_screenshot);
+    if (!m_pending_screenshot) {
+        static bool warned_about_stray_screenshot = false;
+        if (!warned_about_stray_screenshot) {
+            warned_about_stray_screenshot = true;
+            warnln("Ignoring screenshot response with no pending request");
+        }
+        return;
+    }
 
     auto pending_screenshot = move(m_pending_screenshot);
     pending_screenshot->resolve(screenshot.bitmap());
@@ -59,7 +161,7 @@ void TestWebView::on_test_complete(TestCompletion completion)
     m_pending_dialog = Web::Page::PendingDialog::None;
     m_pending_prompt_text.clear();
 
-    m_test_promise->resolve(move(completion));
+    m_test_promise->resolve(completion);
 }
 
 }

--- a/Tests/LibWeb/test-web/TestWebView.h
+++ b/Tests/LibWeb/test-web/TestWebView.h
@@ -9,12 +9,15 @@
 #include "TestWeb.h"
 
 #include <AK/Badge.h>
+#include <AK/HashMap.h>
 #include <AK/RefPtr.h>
 #include <LibCore/Forward.h>
 #include <LibCore/Promise.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/HeadlessWebView.h>
+
+#include <LibURL/URL.h>
 
 namespace TestWeb {
 
@@ -34,11 +37,16 @@ public:
 private:
     TestWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewport_size);
 
+    void load_wpt_resource_map();
+    Optional<ByteString> map_file_path_from_url(URL::URL const&) const;
+
     virtual void did_receive_screenshot(Badge<WebView::WebContentClient>, Gfx::ShareableBitmap const& screenshot) override;
 
     RefPtr<Core::Promise<RefPtr<Gfx::Bitmap const>>> m_pending_screenshot;
 
     NonnullRefPtr<TestPromise> m_test_promise;
+
+    HashMap<String, ByteString> m_wpt_file_substitutions;
 };
 
 }


### PR DESCRIPTION
Many web platform tests (in particular those for webaudio) use root-relative links to resources. test-web then attempts to resolve these against the filesystem root and fails or times out.

This hack allows test-web to remap them via a WptResourceMap.json file consisting of entries like:
```json
{
  ...
  "file:///webaudio/resources/": "Text/input/wpt-import/webaudio/resources/",
  ...
}
```

The above entry will map href="/webaudio/resources/some44KHz.wav" to "Text/input/wpt-import/webaudio/resources/some44KHz.wav" so test-web can find it.