### PR TITLE
CI: Add Kitware's PPA to install a newer CMake version

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -50,6 +50,13 @@ jobs:
           repository: tc39/test262-parser-tests
           path: test262-parser-tests
 
+      # We are currently limited to CMake 3.28 in Ubuntu 24.04. Our build requires CMake 3.30 or later.
+      # If this step is removed in the future, then be sure stop specifying /usr/bin/cmake in the steps below.
+      - name: Set up CMake PPA
+        run: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+          sudo add-apt-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
+
       - name: Install dependencies
         run: |
           sudo apt-get update -y
@@ -66,6 +73,10 @@ jobs:
 
           # FIXME: Just use the setup action
           ./Toolchain/BuildVcpkg.py --ci
+
+      - name: Print CMake version
+        run: |
+          /usr/bin/cmake --version
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -97,9 +108,11 @@ jobs:
           #        Running as a normal user would make this a non-issue though
           export HOME=${{ github.workspace }}/home
           mkdir -p $HOME
+
+          # We specify /usr/bin/cmake below to ensure we use the apt-provided CMake over the image-bundled CMake (/usr/local/bin).
           env CC=clang-20 \
             CXX=clang++-20 \
-            cmake --preset Release -B libjs-test262/Build \
+            /usr/bin/cmake --preset Release -B libjs-test262/Build \
               -DCMAKE_C_COMPILER=clang-20 \
               -DCMAKE_CXX_COMPILER=clang++-20 \
               -DWASM_SPEC_TEST_SKIP_FORMATTING=ON \


### PR DESCRIPTION
The latest CMake version available on Ubuntu 24.04 is 3.28. We require 3.30 or later for our CMake presets. We can get a newer version from Kitware's PPA.