### PR TITLE
CI: Install gnupg2 instead of gnupg

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up CMake PPA
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y gnupg
+          sudo apt-get install -y gnupg2
 
           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
           sudo add-apt-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"


### PR DESCRIPTION
This is what the GitHub runners have:
https://github.com/actions/runner-images/blob/ubuntu24/20260119.4/images/ubuntu/Ubuntu2404-Readme.md#installed-apt-packages