### PR TITLE
LibWeb: Send InputEvent with right `.inputType` on insert and delete

### DIFF
--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
- * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
+ * Copyright (c) 2025-2026, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,7 +34,7 @@ void EditingHostManager::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_active_contenteditable_element);
 }
 
-void EditingHostManager::handle_insert(Utf16String const& value)
+void EditingHostManager::handle_insert(FlyString const&, Utf16String const& value)
 {
     // https://w3c.github.io/editing/docs/execCommand/#additional-requirements
     // When the user instructs the user agent to insert text inside an editing host, such as by typing on the keyboard
@@ -42,7 +42,6 @@ void EditingHostManager::handle_insert(Utf16String const& value)
     // relevant document, with value equal to the text the user provided. If the user inserts multiple characters at
     // once or in quick succession, this specification does not define whether it is treated as one insertion or several
     // consecutive insertions.
-
     auto editing_result = m_document->exec_command(Editing::CommandNames::insertText, false, value);
     if (editing_result.is_exception())
         dbgln("handle_insert(): editing resulted in exception: {}", editing_result.exception());
@@ -171,7 +170,7 @@ void EditingHostManager::decrement_cursor_position_to_previous_line(CollapseSele
         selection->move_offset_to_previous_line(collapse == CollapseSelection::Yes);
 }
 
-void EditingHostManager::handle_delete(DeleteDirection direction)
+void EditingHostManager::handle_delete(FlyString const& input_type)
 {
     // https://w3c.github.io/editing/docs/execCommand/#additional-requirements
     // When the user instructs the user agent to delete the previous character inside an editing host, such as by
@@ -180,7 +179,7 @@ void EditingHostManager::handle_delete(DeleteDirection direction)
     // When the user instructs the user agent to delete the next character inside an editing host, such as by pressing
     // the Delete key while the cursor is in an editable node, the user agent must call execCommand("forwarddelete") on
     // the relevant document.
-    auto command = direction == DeleteDirection::Backward ? Editing::CommandNames::delete_ : Editing::CommandNames::forwardDelete;
+    auto command = input_type == UIEvents::InputTypes::deleteContentBackward ? Editing::CommandNames::delete_ : Editing::CommandNames::forwardDelete;
     auto editing_result = m_document->exec_command(command, false, {});
     if (editing_result.is_exception())
         dbgln("handle_delete(): editing resulted in exception: {}", editing_result.exception());

--- a/Libraries/LibWeb/DOM/EditingHostManager.h
+++ b/Libraries/LibWeb/DOM/EditingHostManager.h
@@ -8,7 +8,6 @@
 
 #include <LibGC/CellAllocator.h>
 #include <LibJS/Heap/Cell.h>
-#include <LibJS/Runtime/Realm.h>
 #include <LibWeb/DOM/InputEventsTarget.h>
 #include <LibWeb/Forward.h>
 
@@ -23,8 +22,8 @@ class EditingHostManager
 public:
     [[nodiscard]] static GC::Ref<EditingHostManager> create(JS::Realm&, GC::Ref<Document>);
 
-    virtual void handle_insert(Utf16String const&) override;
-    virtual void handle_delete(DeleteDirection) override;
+    virtual void handle_insert(FlyString const& input_type, Utf16String const&) override;
+    virtual void handle_delete(FlyString const& input_type) override;
     virtual EventResult handle_return_key(FlyString const& ui_input_type) override;
     virtual void select_all() override;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) override;

--- a/Libraries/LibWeb/DOM/InputEventsTarget.h
+++ b/Libraries/LibWeb/DOM/InputEventsTarget.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2026, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,14 +19,9 @@ public:
 
     virtual GC::Ref<JS::Cell> as_cell() = 0;
 
-    virtual void handle_insert(Utf16String const&) = 0;
-    virtual EventResult handle_return_key(FlyString const& ui_input_type) = 0;
-
-    enum class DeleteDirection {
-        Backward,
-        Forward,
-    };
-    virtual void handle_delete(DeleteDirection) = 0;
+    virtual void handle_insert(FlyString const& input_type, Utf16String const&) = 0;
+    virtual EventResult handle_return_key(FlyString const& input_type) = 0;
+    virtual void handle_delete(FlyString const& input_type) = 0;
 
     virtual void select_all() = 0;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) = 0;

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ * Copyright (c) 2024-2026, Jelle Raaijmakers <jelle@ladybird.org>
  * Copyright (c) 2024, Tim Ledbetter <tim.ledbetter@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -28,7 +28,7 @@
 #include <LibWeb/HTML/ValidityState.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Selection/Selection.h>
+#include <LibWeb/UIEvents/InputTypes.h>
 
 namespace Web::HTML {
 
@@ -843,7 +843,7 @@ void FormAssociatedTextControlElement::set_the_selection_range(Optional<WebIDL::
     }
 }
 
-void FormAssociatedTextControlElement::handle_insert(Utf16String const& data)
+void FormAssociatedTextControlElement::handle_insert(FlyString const& input_type, Utf16String const& data)
 {
     auto text_node = form_associated_element_to_text_node();
     if (!text_node || !is_mutable())
@@ -862,10 +862,10 @@ void FormAssociatedTextControlElement::handle_insert(Utf16String const& data)
     MUST(set_range_text(data_for_insertion, selection_start, selection_end, Bindings::SelectionMode::End));
 
     text_node->invalidate_style(DOM::StyleInvalidationReason::EditingInsertion);
-    did_edit_text_node();
+    did_edit_text_node(input_type);
 }
 
-void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
+void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type)
 {
     auto text_node = form_associated_element_to_text_node();
     if (!text_node || !is_mutable())
@@ -875,7 +875,7 @@ void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
     auto selection_end = this->selection_end();
 
     if (selection_start == selection_end) {
-        if (direction == DeleteDirection::Backward) {
+        if (input_type == UIEvents::InputTypes::deleteContentBackward) {
             if (auto offset = text_node->grapheme_segmenter().previous_boundary(m_selection_end); offset.has_value())
                 selection_start = *offset;
         } else {
@@ -887,7 +887,7 @@ void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
     MUST(set_range_text({}, selection_start, selection_end, Bindings::SelectionMode::End));
 
     text_node->invalidate_style(DOM::StyleInvalidationReason::EditingDeletion);
-    did_edit_text_node();
+    did_edit_text_node(input_type);
 }
 
 Optional<Utf16String> FormAssociatedTextControlElement::selected_text_for_stringifier() const

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ * Copyright (c) 2024-2026, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -237,13 +237,13 @@ public:
     bool has_scheduled_selectionchange_event() const { return m_has_scheduled_selectionchange_event; }
     void set_scheduled_selectionchange_event(bool value) { m_has_scheduled_selectionchange_event = value; }
 
-    virtual void did_edit_text_node() = 0;
+    virtual void did_edit_text_node(FlyString const& input_type) = 0;
 
     virtual GC::Ptr<DOM::Text> form_associated_element_to_text_node() = 0;
     virtual GC::Ptr<DOM::Text const> form_associated_element_to_text_node() const { return const_cast<FormAssociatedTextControlElement&>(*this).form_associated_element_to_text_node(); }
 
-    virtual void handle_insert(Utf16String const&) override;
-    virtual void handle_delete(DeleteDirection) override;
+    virtual void handle_insert(FlyString const& input_type, Utf16String const&) override;
+    virtual void handle_delete(FlyString const& input_type) override;
     virtual void select_all() override;
     virtual void set_selection_anchor(GC::Ref<DOM::Node>, size_t offset) override;
     virtual void set_selection_focus(GC::Ref<DOM::Node>, size_t offset) override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -234,7 +234,7 @@ public:
     Optional<String> selection_direction_binding() { return selection_direction(); }
 
     // ^FormAssociatedTextControlElement
-    virtual void did_edit_text_node() override;
+    virtual void did_edit_text_node(FlyString const& input_type) override;
     virtual GC::Ptr<DOM::Text> form_associated_element_to_text_node() override { return m_text_node; }
 
     // https://html.spec.whatwg.org/multipage/input.html#has-a-periodic-domain/
@@ -329,7 +329,7 @@ private:
     void handle_maxlength_attribute();
     WebIDL::ExceptionOr<void> handle_src_attribute(String const& value);
 
-    void user_interaction_did_change_input_value();
+    void user_interaction_did_change_input_value(FlyString const& input_type = {});
 
     // https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm
     Utf16String value_sanitization_algorithm(Utf16String const&) const;

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2020, the SerenityOS developers.
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2024, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
- * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ * Copyright (c) 2024-2026, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -125,7 +125,7 @@ public:
     void set_dirty_value_flag(Badge<FormAssociatedElement>, bool flag) { m_dirty_value = flag; }
 
     // ^FormAssociatedTextControlElement
-    virtual void did_edit_text_node() override;
+    virtual void did_edit_text_node(FlyString const& input_type) override;
     virtual GC::Ptr<DOM::Text> form_associated_element_to_text_node() override { return m_text_node; }
 
     // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element%3Asuffering-from-being-missing
@@ -164,6 +164,7 @@ private:
     GC::Ptr<DOM::Text> m_text_node;
 
     RefPtr<Core::Timer> m_input_event_timer;
+    FlyString m_pending_input_event_type;
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-dirty
     bool m_dirty_value { false };

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2020-2021, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
  * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
- * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
+ * Copyright (c) 2025-2026, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,7 +19,6 @@
 #include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLDialogElement.h>
-#include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/HTMLLabelElement.h>
@@ -1364,13 +1363,13 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     if (target) {
         if (key == UIEvents::KeyCode::Key_Backspace) {
             FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::deleteContentBackward, m_navigable, code_point));
-            target->handle_delete(InputEventsTarget::DeleteDirection::Backward);
+            target->handle_delete(UIEvents::InputTypes::deleteContentBackward);
             return EventResult::Handled;
         }
 
         if (key == UIEvents::KeyCode::Key_Delete) {
             FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::deleteContentForward, m_navigable, code_point));
-            target->handle_delete(InputEventsTarget::DeleteDirection::Forward);
+            target->handle_delete(UIEvents::InputTypes::deleteContentForward);
             return EventResult::Handled;
         }
 
@@ -1444,7 +1443,7 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
 
             FIRE(input_event(UIEvents::EventNames::beforeinput, input_type, m_navigable, code_point));
             if (target->handle_return_key(input_type) != EventResult::Handled)
-                target->handle_insert(Utf16String::from_code_point(code_point));
+                target->handle_insert(input_type, Utf16String::from_code_point(code_point));
 
             return EventResult::Handled;
         }
@@ -1452,7 +1451,7 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         // FIXME: Text editing shortcut keys (copy/paste etc.) should be handled here.
         if (!should_ignore_keydown_event(code_point, modifiers)) {
             FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::insertText, m_navigable, code_point));
-            target->handle_insert(Utf16String::from_code_point(code_point));
+            target->handle_insert(UIEvents::InputTypes::insertText, Utf16String::from_code_point(code_point));
             return EventResult::Handled;
         }
     } else if (auto selection = document->get_selection(); selection && !selection->is_collapsed()) {
@@ -1546,7 +1545,7 @@ EventResult EventHandler::handle_paste(Utf16String const& text)
         return EventResult::Dropped;
 
     FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::insertFromPaste, m_navigable, text));
-    target->handle_insert(text);
+    target->handle_insert(UIEvents::InputTypes::insertFromPaste, text);
 
     return EventResult::Handled;
 }

--- a/Tests/LibWeb/Text/expected/input-event-inputType.txt
+++ b/Tests/LibWeb/Text/expected/input-event-inputType.txt
@@ -1,0 +1,7 @@
+Input element: inputType="insertText" (type: string)
+Textarea element: inputType="insertText" (type: string)
+Backspace: inputType="deleteContentBackward"
+Delete: inputType="deleteContentForward"
+Event is InputEvent: true
+Event has data property: true
+Event has isComposing property: true

--- a/Tests/LibWeb/Text/input/input-event-inputType.html
+++ b/Tests/LibWeb/Text/input/input-event-inputType.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<input id="textInput" type="text">
+<textarea id="textArea"></textarea>
+<script src="include.js"></script>
+<script>
+    asyncTest(async done => {
+        const input = document.getElementById("textInput");
+        const textarea = document.getElementById("textArea");
+
+        // Test 1: inputType property exists and is "insertText" for HTMLInputElement
+        await new Promise(resolve => {
+            input.addEventListener("input", e => {
+                println(`Input element: inputType="${e.inputType}" (type: ${typeof e.inputType})`);
+                resolve();
+            }, { once: true });
+            input.focus();
+            internals.sendText(input, "a");
+        });
+
+        // Test 2: inputType for insertText on HTMLTextAreaElement
+        await new Promise(resolve => {
+            textarea.addEventListener("input", e => {
+                println(`Textarea element: inputType="${e.inputType}" (type: ${typeof e.inputType})`);
+                resolve();
+            }, { once: true });
+            textarea.focus();
+            internals.sendText(textarea, "b");
+        });
+
+        // Test 3: inputType for deleteContentBackward (backspace)
+        await new Promise(resolve => {
+            input.addEventListener("input", e => {
+                println(`Backspace: inputType="${e.inputType}"`);
+                resolve();
+            }, { once: true });
+            input.focus();
+            internals.sendKey(input, "Backspace");
+        });
+
+        // Test 4: inputType for deleteContentForward (delete key)
+        input.value = "test";
+        input.setSelectionRange(0, 0);
+        await new Promise(resolve => {
+            input.addEventListener("input", e => {
+                println(`Delete: inputType="${e.inputType}"`);
+                resolve();
+            }, { once: true });
+            input.focus();
+            internals.sendKey(input, "Delete");
+        });
+
+        // Test 5: Verify the event is an InputEvent instance with expected properties
+        await new Promise(resolve => {
+            input.addEventListener("input", e => {
+                println(`Event is InputEvent: ${e instanceof InputEvent}`);
+                println(`Event has data property: ${"data" in e}`);
+                println(`Event has isComposing property: ${"isComposing" in e}`);
+                resolve();
+            }, { once: true });
+            input.focus();
+            internals.sendText(input, "c");
+        });
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Applies to `<input>` and `<textarea>`. Editing commands in `contenteditable` already sent the right events and input types.

Relates to #7668