### PR TITLE
LibWeb: Precompute sticky constraints to avoid paintable tree lookups

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1346,16 +1346,6 @@ RefPtr<ScrollFrame const> PaintableBox::nearest_scroll_frame() const
     return nullptr;
 }
 
-CSSPixelRect PaintableBox::border_box_rect_relative_to_nearest_scrollable_ancestor() const
-{
-    auto result = absolute_border_box_rect();
-    auto const* nearest_scrollable_ancestor = this->nearest_scrollable_ancestor();
-    if (nearest_scrollable_ancestor) {
-        result.set_location(result.location() - nearest_scrollable_ancestor->absolute_rect().top_left());
-    }
-    return result;
-}
-
 PaintableBox const* PaintableBox::nearest_scrollable_ancestor() const
 {
     auto const* paintable = this->containing_block();

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -223,7 +223,6 @@ public:
 
     RefPtr<ScrollFrame const> nearest_scroll_frame() const;
 
-    CSSPixelRect border_box_rect_relative_to_nearest_scrollable_ancestor() const;
     PaintableBox const* nearest_scrollable_ancestor() const;
 
     struct StickyInsets {

--- a/Libraries/LibWeb/Painting/ScrollFrame.cpp
+++ b/Libraries/LibWeb/Painting/ScrollFrame.cpp
@@ -17,4 +17,13 @@ ScrollFrame::ScrollFrame(PaintableBox const& paintable_box, size_t id, bool stic
 {
 }
 
+RefPtr<ScrollFrame const> ScrollFrame::nearest_scrolling_ancestor() const
+{
+    for (auto ancestor = m_parent; ancestor; ancestor = ancestor->parent()) {
+        if (!ancestor->is_sticky())
+            return ancestor;
+    }
+    return nullptr;
+}
+
 }

--- a/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -13,6 +13,13 @@
 
 namespace Web::Painting {
 
+struct StickyConstraints {
+    CSSPixelPoint position_relative_to_scroll_ancestor;
+    CSSPixelSize border_box_size;
+    CSSPixelRect containing_block_region;
+    bool needs_parent_offset_adjustment { false };
+};
+
 class ScrollFrame : public RefCounted<ScrollFrame> {
 public:
     ScrollFrame(PaintableBox const& paintable_box, size_t id, bool sticky, RefPtr<ScrollFrame const> parent);
@@ -41,6 +48,11 @@ public:
     }
 
     RefPtr<ScrollFrame const> parent() const { return m_parent; }
+    RefPtr<ScrollFrame const> nearest_scrolling_ancestor() const;
+
+    void set_sticky_constraints(StickyConstraints constraints) { m_sticky_constraints = constraints; }
+    bool has_sticky_constraints() const { return m_sticky_constraints.has_value(); }
+    StickyConstraints const& sticky_constraints() const { return m_sticky_constraints.value(); }
 
 private:
     GC::Weak<PaintableBox> m_paintable_box;
@@ -48,6 +60,7 @@ private:
     bool m_sticky { false };
     RefPtr<ScrollFrame const> m_parent;
     CSSPixelPoint m_own_offset;
+    Optional<StickyConstraints> m_sticky_constraints;
 
     // Caching here relies on the fact that offsets of all scroll frames are invalidated when any of them changes,
     // so we don't need to worry about invalidating the cache when the parent's offset changes.


### PR DESCRIPTION
Precompute the geometric data needed for sticky positioning during scroll frame assignment. This avoids walking the paintable tree to query containing blocks and ancestor geometry during scroll state refresh, which runs on every scroll event.