### PR TITLE
test-web: Always create test dumps for failed tests

### DIFF
--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -35,7 +35,6 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     args_parser.add_option(test_concurrency, "Maximum number of tests to run at once", "test-concurrency", 'j', "jobs");
     args_parser.add_option(test_globs, "Only run tests matching the given glob", "filter", 'f', "glob");
     args_parser.add_option(python_executable_path, "Path to python3", "python-executable", 'P', "path");
-    args_parser.add_option(dump_failed_ref_tests, "Dump screenshots of failing ref tests", "dump-failed-ref-tests", 'D');
     args_parser.add_option(dump_gc_graph, "Dump GC graph", "dump-gc-graph", 'G');
     args_parser.add_option(test_dry_run, "List the tests that would be run, without running them", "dry-run");
     args_parser.add_option(rebaseline, "Rebaseline any executed layout or text tests", "rebaseline");

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -37,7 +37,6 @@ public:
 
     ByteString python_executable_path;
 
-    bool dump_failed_ref_tests { false };
     bool dump_gc_graph { false };
 
     bool test_dry_run { false };

--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -29,7 +29,7 @@ if (BUILD_TESTING)
 
     add_test(
         NAME LibWeb
-        COMMAND $<TARGET_FILE:test-web> --python-executable ${Python3_EXECUTABLE} --dump-failed-ref-tests --per-test-timeout 120 -v -v
+        COMMAND $<TARGET_FILE:test-web> --python-executable ${Python3_EXECUTABLE} --per-test-timeout 120 -v -v
     )
 
     set_tests_properties(LibWeb PROPERTIES


### PR DESCRIPTION
If tests fail, let's just always create the results page regardless of verbosity. This allows viewing logs afterwards, as well as uploading the test-dumps collection in CI.

As a result, this removes the `--dump-failed-ref-tests` flag. It's a bit overloaded with our new results format, and it would be awkward to keep
both separately working here.