### PR TITLE
(WIP) AK: Make a limited form of custom formatted Error objects possible

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Error.h>
+#include <AK/String.h>
 
 #ifdef AK_OS_WINDOWS
 #    include <AK/ByteString.h>
@@ -30,5 +31,76 @@ Error Error::from_windows_error()
     return from_windows_error(GetLastError());
 }
 #endif
+
+template<typename R>
+R Error::format_impl() const
+{
+    static_assert(IsSame<R, ErrorOr<AK::String>>);
+
+    if (auto* ptr = m_data.get_pointer<ErrnoCode>())
+        return AK::String::formatted("Errno {}: {}", ptr->code, strerror(ptr->code));
+    if (auto* ptr = m_data.get_pointer<Syscall>())
+        return AK::String::formatted("{} failed with errno {}: {}", ptr->name, ptr->code, strerror(ptr->code));
+#ifdef AK_OS_WINDOWS
+    if (auto* ptr = m_data.get_pointer<WindowsError>())
+        return Formatter<Error>::format_windows_error(*this);
+#endif
+    if (auto* ptr = m_data.get_pointer<StringView>())
+        return AK::String::from_utf8(*ptr);
+
+    auto& format_data = m_data.get<FormattedString>();
+    struct FormatParams {
+        alignas(TypeErasedFormatParams) u8 format_params_bits[sizeof(TypeErasedFormatParams)];
+        alignas(AK::TypeErasedParameter) u8 params_bits[sizeof(AK::TypeErasedParameter) * ((64 - sizeof(StringView)) / 2)];
+    } data;
+    auto* params = bit_cast<AK::TypeErasedParameter*>(&data.params_bits[0]);
+    size_t count = 0;
+    size_t offset = 0;
+
+    u8 aligned_local_storage[1 * KiB] {};
+    size_t aligned_local_storage_offset = 0;
+    auto allocate_aligned_on_local_storage = [&]<typename T>(u8 const* p) {
+        auto start_offset = align_up_to(aligned_local_storage_offset, alignof(T));
+        VERIFY(array_size(aligned_local_storage) >= start_offset + sizeof(T));
+        __builtin_memcpy(&aligned_local_storage[start_offset], p, sizeof(T));
+        aligned_local_storage_offset = start_offset + sizeof(T);
+        return bit_cast<T const*>(&aligned_local_storage[start_offset]);
+    };
+
+    for (; format_data.buffer[offset] != 0;) {
+        auto type = static_cast<FormattedString::Type>(format_data.buffer[offset]);
+        offset += 1;
+        switch (type) {
+        case FormattedString::Type::Nothing:
+            VERIFY_NOT_REACHED();
+
+#define CASE(Name, T)                                                                              \
+    case FormattedString::Type::Name:                                                              \
+        params[count++] = AK::TypeErasedParameter {                                                \
+            allocate_aligned_on_local_storage.template operator()<T>(&format_data.buffer[offset]), \
+        };                                                                                         \
+        offset += sizeof(T);                                                                       \
+        break
+
+            CASE(ExplicitStaticString, StringView);
+            CASE(U8, u8);
+            CASE(U16, u16);
+            CASE(U32, u32);
+            CASE(U64, u64);
+            CASE(I8, i8);
+            CASE(I16, i16);
+            CASE(I32, i32);
+            CASE(I64, i64);
+            CASE(Bool, bool);
+
+#undef CASE
+        }
+    }
+
+    auto* format_params = bit_cast<TypeErasedFormatParams*>(&data.format_params_bits[0]);
+    return AK::String::vformatted(format_data.format_string, *format_params);
+}
+
+template ErrorOr<String> Error::format_impl<ErrorOr<String>>() const;
 
 }

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -1186,17 +1186,8 @@ ErrorOr<void> Formatter<Error>::format_windows_error(FormatBuilder&, Error const
 
 ErrorOr<void> Formatter<Error>::format(FormatBuilder& builder, Error const& error)
 {
-    switch (error.kind()) {
-    case Error::Kind::Syscall:
-        return Formatter<FormatString>::format(builder, "{}: {} (errno={})"sv, error.string_literal(), strerror(error.code()), error.code());
-    case Error::Kind::Errno:
-        return Formatter<FormatString>::format(builder, "{} (errno={})"sv, strerror(error.code()), error.code());
-    case Error::Kind::Windows:
-        return Formatter<Error>::format_windows_error(builder, error);
-    case Error::Kind::StringLiteral:
-        return Formatter<FormatString>::format(builder, "{}"sv, error.string_literal());
-    }
-    VERIFY_NOT_REACHED();
+    Formatter<FormatString> formatter;
+    return formatter.format(builder, "{}"sv, TRY(error.format_impl<ErrorOr<String>>()));
 }
 
 #ifdef AK_OS_ANDROID


### PR DESCRIPTION
Error::formatted("...", ...) a la AK::Format, which currently accepts only integral values and strings explicitly marked ExplicitStaticString.

cc @vkoskiv.