### PR TITLE
LibMedia: Skip DisplayingVideoSink::update() if the provider is null

### DIFF
--- a/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
+++ b/Libraries/LibMedia/Sinks/DisplayingVideoSink.cpp
@@ -49,6 +49,8 @@ RefPtr<VideoDataProvider> DisplayingVideoSink::provider(Track const& track) cons
 
 DisplayingVideoSinkUpdateResult DisplayingVideoSink::update()
 {
+    if (m_provider == nullptr)
+        return DisplayingVideoSinkUpdateResult::NoChange;
     if (m_pause_updates)
         return DisplayingVideoSinkUpdateResult::NoChange;
 


### PR DESCRIPTION
We could hit a VERIFY in RefPtr if there was a seek in flight while the PlaybackManager was being destroyed, since finishing a seek would run DisplayingVideoSink::resume_updates() which would then check if there is a new frame to display.