### PR TITLE
LibMedia: Dispose FFmpegDemuxer's tracks' format contexts

### DIFF
--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -24,7 +24,13 @@ FFmpegDemuxer::FFmpegDemuxer(NonnullRefPtr<MediaStream> const& stream)
 {
 }
 
-FFmpegDemuxer::~FFmpegDemuxer() = default;
+FFmpegDemuxer::~FFmpegDemuxer()
+{
+    for (auto& [track, context] : m_track_contexts) {
+        if (context->format_context != nullptr)
+            avformat_close_input(&context->format_context);
+    }
+}
 
 static DecoderErrorOr<void> initialize_format_context(AVFormatContext*& format_context, AVIOContext& io_context)
 {


### PR DESCRIPTION
This fixes a leak that was oddly enough only just detected in CI.