### PR TITLE
LibWeb: Implement Document.hasFocus()

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/html/interaction/focus/document-level-focus-apis/document-level-apis.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/interaction/focus/document-level-focus-apis/document-level-apis.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 4 tests
 
-3 Pass
-1 Fail
+4 Pass
 Pass	The body element must be the active element if no element is focused
 Pass	The element must be the active element if it is focused
-Fail	The hasFocus() method must return false if the Document has no browsing context
+Pass	The hasFocus() method must return false if the Document has no browsing context
 Pass	When a child browsing context is focused, its browsing context container is also focused


### PR DESCRIPTION
## Summary

The `Document::has_focus()` method previously returned `true` unconditionally, which was incorrect for documents without a browsing context (such as those created via `document.implementation.createHTMLDocument()`). This implementation replaces the stub with the proper algorithm from the HTML specification's "has focus steps", allowing documents to correctly report whether they hold focus in the browsing context hierarchy.

Spec: https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps

## Implementation Approach

The implementation follows the spec with three main checks:

1. Return `false` if the document has no navigable (meaning it lacks a browsing context entirely).
2. Return `false` if the top-level traversable lacks system focus.
3. Walk the focus chain from the top-level traversable's active document to verify whether this document appears in the chain. Return `true` if found, `false` otherwise. When walking the chain, if a navigable container is encountered in the focused area with a non-null content navigable, advance to that navigable's active document.

```cpp
bool Document::has_focus() const
{
    auto navigable = this->navigable();
    if (!navigable)
        return false;

    auto traversable = navigable->traversable_navigable();
    if (!traversable || !traversable->is_focused())
        return false;

    auto candidate = traversable->active_document();
    while (candidate) {
        if (candidate == this)
            return true;

        auto focused_area = candidate->focused_area();
        if (auto* navigable_container = as_if<HTML::NavigableContainer>(focused_area.ptr())) {
            if (auto content_navigable = navigable_container->content_navigable()) {
                candidate = content_navigable->active_document();
                continue;
            }
        }
        return false;
    }
    return false;
}
```

## Changes

**Libraries/LibWeb/DOM/Document.cpp**: Implemented the "has focus steps" algorithm and added include for `NavigableContainer.h`.

**Tests/LibWeb/Text/expected/wpt-import/html/interaction/focus/document-level-focus-apis/document-level-apis.txt**: Updated expected results to reflect the now-passing test.
