### PR TITLE
LibWeb+LibWebView+WebContent: Perform cookie URL filtering in the UI

### DIFF
--- a/Libraries/LibWeb/CookieStore/CookieStore.h
+++ b/Libraries/LibWeb/CookieStore/CookieStore.h
@@ -67,7 +67,7 @@ public:
     void set_onchange(WebIDL::CallbackType*);
     WebIDL::CallbackType* onchange();
 
-    void process_cookie_changes(Vector<Cookie::Cookie> const&);
+    void process_cookie_changes(Vector<Cookie::Cookie>);
 
 private:
     CookieStore(JS::Realm&, PageClient&);

--- a/Libraries/LibWebView/CookieJar.h
+++ b/Libraries/LibWebView/CookieJar.h
@@ -90,6 +90,9 @@ private:
         }
 
     private:
+        using CookieEntry = decltype(declval<Cookies>().take_all_matching(nullptr))::ValueType;
+        static void send_cookie_changed_notifications(ReadonlySpan<CookieEntry>);
+
         Cookies m_cookies;
         Cookies m_dirty_cookies;
     };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -259,6 +259,11 @@ void ViewImplementation::set_preferred_motion(Web::CSS::PreferredMotion motion)
     client().async_set_preferred_motion(page_id(), motion);
 }
 
+void ViewImplementation::notify_cookies_changed(ReadonlySpan<Web::Cookie::Cookie> cookies)
+{
+    client().async_cookies_changed(page_id(), cookies);
+}
+
 ByteString ViewImplementation::selected_text()
 {
     return client().get_selected_text(page_id());

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -86,6 +86,8 @@ public:
     void set_preferred_contrast(Web::CSS::PreferredContrast);
     void set_preferred_motion(Web::CSS::PreferredMotion);
 
+    void notify_cookies_changed(ReadonlySpan<Web::Cookie::Cookie>);
+
     ByteString selected_text();
     Optional<String> selected_text_with_whitespace_collapsed();
     void select_all();

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1354,13 +1354,14 @@ void ConnectionFromClient::system_time_zone_changed()
     Unicode::clear_system_time_zone_cache();
 }
 
-void ConnectionFromClient::cookies_changed(Vector<Web::Cookie::Cookie> cookies)
+void ConnectionFromClient::cookies_changed(u64 page_id, Vector<Web::Cookie::Cookie> cookies)
 {
-    for (auto& navigable : Web::HTML::all_navigables()) {
-        auto window = navigable->active_window();
+    if (auto page = this->page(page_id); page.has_value()) {
+        auto window = page->page().top_level_traversable()->active_window();
         if (!window)
             return;
-        window->cookie_store()->process_cookie_changes(cookies);
+
+        window->cookie_store()->process_cookie_changes(move(cookies));
     }
 }
 

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -162,7 +162,7 @@ private:
     virtual void paste(u64 page_id, Utf16String text) override;
 
     virtual void system_time_zone_changed() override;
-    virtual void cookies_changed(Vector<Web::Cookie::Cookie>) override;
+    virtual void cookies_changed(u64 page_id, Vector<Web::Cookie::Cookie>) override;
 
     NonnullOwnPtr<PageHost> m_page_host;
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -133,5 +133,6 @@ endpoint WebContentServer
     set_user_style(u64 page_id, String source) =|
 
     system_time_zone_changed() =|
-    cookies_changed(Vector<Web::Cookie::Cookie> cookies) =|
+
+    cookies_changed(u64 page_id, Vector<Web::Cookie::Cookie> cookies) =|
 }


### PR DESCRIPTION
When cookies change or expire, we currently send a list of all changed cookies to all WebContent processes. We then filter that list in the WebContent process for cookies that match the page's URL before sending out cookie change events to JS.

We now perform this filtering in the UI process, so each WebContent process only receives the cookies it would be interested in, if any. This serves two purposes:

1. Less IPC chatter.
2. This will let each ViewImplementation know that its cookie value has actually changed.

(2) is for an upcoming change that will introduce a cookie cache, and will allow each view to know it should bust that cache.

Note that for this filtering to work, we must iterate ViewImplementation instances rather than WebContentClient in order to have the view's URL. We must then associate the IPC with the view's page ID.

No changes to the /cookiestore WPT subtests.