### PR TITLE
LibWeb: Apply scroll offset to children of sticky elements with overflow

### DIFF
--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -334,8 +334,11 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
             }
         }
 
-        if (paintable_box.own_scroll_frame() && !paintable_box.is_sticky_position())
-            state_for_descendants = append_node(state_for_descendants, ScrollData { paintable_box.own_scroll_frame()->id(), false });
+        if (paintable_box.own_scroll_frame()) {
+            auto is_sticky_without_scrollable_overflow = paintable_box.is_sticky_position() && paintable_box.enclosing_scroll_frame() == paintable_box.own_scroll_frame();
+            if (!is_sticky_without_scrollable_overflow)
+                state_for_descendants = append_node(state_for_descendants, ScrollData { paintable_box.own_scroll_frame()->id(), false });
+        }
 
         paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
 

--- a/Tests/LibWeb/Ref/expected/sticky-overflow-scroll-ref.html
+++ b/Tests/LibWeb/Ref/expected/sticky-overflow-scroll-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0; }
+    .green {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<div class="green"></div>

--- a/Tests/LibWeb/Ref/input/sticky-overflow-scroll.html
+++ b/Tests/LibWeb/Ref/input/sticky-overflow-scroll.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/sticky-overflow-scroll-ref.html">
+<style>
+    body {
+        margin: 0;
+    }
+    .container {
+        position: sticky;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        overflow-y: scroll;
+        scrollbar-width: none;
+    }
+    .top {
+        height: 100px;
+        background: red;
+    }
+    .bottom {
+        height: 100px;
+        background: green;
+    }
+</style>
+<div class="container">
+    <div class="top"></div>
+    <div class="bottom"></div>
+</div>
+<script>
+    // Scroll so the red part is hidden and only green is visible
+    document.querySelector('.container').scrollTop = 100;
+</script>


### PR DESCRIPTION
Previously, sticky elements were excluded from propagating  their scroll frame to descendants' accumulated visual context. This meant that when a sticky element also had scrollable overflow, the scroll offset was never visually applied to its children during painting.

This makes the left sidebar work correctly on: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/