### PR TITLE
Meta: Fix build failure on Python 3.15

### DIFF
--- a/Meta/generate_encoding_indexes.py
+++ b/Meta/generate_encoding_indexes.py
@@ -215,21 +215,21 @@ namespace TextCodec {
 
 def main():
     parser = argparse.ArgumentParser(description="Generate text codec lookup tables", add_help=False)
-    parser.add_argument("-H", action="help", help="Show this help message and exit")
+    parser.add_argument("--help", action="help", help="Show this help message and exit")
     parser.add_argument(
-        "-h", "-generated-header-path", required=True, help="Path to the lookup table header file to generate"
+        "-h", "--generated-header-path", required=True, help="Path to the lookup table header file to generate"
     )
     parser.add_argument(
         "-c",
-        "-generated_implementation_path",
+        "--generated-implementation-path",
         required=True,
         help="Path to the lookup table implementation file to generate",
     )
-    parser.add_argument("-j", "-json-path", required=True, help="Path to the JSON file to read from")
+    parser.add_argument("-j", "--json-path", required=True, help="Path to the JSON file to read from")
 
     args = parser.parse_args()
 
-    with open(args.j, "r") as f:
+    with open(args.json_path, "r") as f:
         data = json.load(f)
 
     gb18030_table = prepare_table(data["gb18030"], GenerateAccessor.YES)
@@ -300,8 +300,8 @@ def main():
         },
     )
 
-    generate_header_file(tables, Path(args.h))
-    generate_implementation_file(tables, Path(args.c))
+    generate_header_file(tables, Path(args.generated_header_path))
+    generate_implementation_file(tables, Path(args.generated_implementation_path))
 
 
 if __name__ == "__main__":

--- a/Meta/generate_public_suffix_data.py
+++ b/Meta/generate_public_suffix_data.py
@@ -137,17 +137,16 @@ Optional<String> PublicSuffixData::get_public_suffix(StringView string)
 
 def main():
     parser = argparse.ArgumentParser(description="Generate public suffix data files", add_help=False)
-    parser.add_argument("-H", action="help", help="Show this help message and exit")
-    parser.add_argument("-h", "-generated-header-path", required=True, help="Path to the header file to generate")
+    parser.add_argument("--help", action="help", help="Show this help message and exit")
+    parser.add_argument("-h", "--generated-header-path", required=True, help="Path to the header file to generate")
     parser.add_argument(
-        "-c", "-generated_implementation_path", required=True, help="Path to the implementation file to generate"
+        "-c", "--generated-implementation-path", required=True, help="Path to the implementation file to generate"
     )
-    parser.add_argument("-p", "-public-suffix-list-path", required=True, help="Path to the public suffix list")
-
+    parser.add_argument("-p", "--public-suffix-list-path", required=True, help="Path to the public suffix list")
     args = parser.parse_args()
 
-    generate_header_file(Path(args.h))
-    generate_implementation_file(Path(args.p), Path(args.c))
+    generate_header_file(Path(args.generated_header_path))
+    generate_implementation_file(Path(args.public_suffix_list_path), Path(args.generated_implementation_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
argparse on Python 3.15 will be changed to prefer `-foo` over `-f` for attribute names. Double dash arguments are unaffected.

https://docs.python.org/3.15/library/argparse.html#dest

```
  File "<...>/ladybird/Meta/generate_public_suffix_data.py", line 149, in main
    generate_header_file(Path(args.h))
                              ^^^^^^
AttributeError: 'Namespace' object has no attribute 'h'
```

To be honest I couldn't figure out why there are single dash arguments in the first place. Is there a reason for it? Changing to double dashes would also fix the problem.