### PR TITLE
WebDriver: Fix use-after-return in client death callback

### DIFF
--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -139,10 +139,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         }
 
         auto client = maybe_client.release_value();
-        client->on_death = [&] {
+        client->on_death = [&clients, client] {
             clients.remove(client);
         };
-        clients.set(move(client));
+        clients.set(client);
     };
 
     TRY(server->listen(ipv4_address.value(), port, Core::TCPServer::AllowAddressReuse::Yes));


### PR DESCRIPTION
Previously, the WPT test `fetch/api/redirect/redirect-referrer-override.any.worker.html` was crashing when running via `WPT.sh` with sanitizers enabled.