### PR TITLE
LibWeb: Pass scope through :has() pseudo class

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -141,10 +141,10 @@ static inline bool matches_lang_pseudo_class(DOM::Element const& element, Vector
 }
 
 // https://drafts.csswg.org/selectors-4/#relational
-static inline bool matches_relative_selector(CSS::Selector const& selector, size_t compound_index, DOM::Element const& element, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, GC::Ref<DOM::Element const> anchor)
+static inline bool matches_relative_selector(CSS::Selector const& selector, size_t compound_index, DOM::Element const& element, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, GC::Ref<DOM::Element const> anchor, GC::Ptr<DOM::ParentNode const> scope)
 {
     if (compound_index >= selector.compound_selectors().size())
-        return matches(selector, element, shadow_host, context, {}, {}, SelectorKind::Relative, anchor);
+        return matches(selector, element, shadow_host, context, {}, scope, SelectorKind::Relative, anchor);
 
     switch (selector.compound_selectors()[compound_index].combinator) {
     // Shouldn't be possible because we've parsed relative selectors, which always have a combinator, implicitly or explicitly.
@@ -157,7 +157,7 @@ static inline bool matches_relative_selector(CSS::Selector const& selector, size
             if (!descendant.is_element())
                 return TraversalDecision::Continue;
             auto const& descendant_element = static_cast<DOM::Element const&>(descendant);
-            if (matches(selector, descendant_element, shadow_host, context, {}, {}, SelectorKind::Relative, anchor)) {
+            if (matches(selector, descendant_element, shadow_host, context, {}, scope, SelectorKind::Relative, anchor)) {
                 has = true;
                 matching_descendant = &descendant_element;
                 return TraversalDecision::Break;
@@ -178,9 +178,9 @@ static inline bool matches_relative_selector(CSS::Selector const& selector, size
             if (!child.is_element())
                 return IterationDecision::Continue;
             auto const& child_element = static_cast<DOM::Element const&>(child);
-            if (!matches(selector, compound_index, child_element, shadow_host, context, {}, SelectorKind::Relative, anchor))
+            if (!matches(selector, compound_index, child_element, shadow_host, context, scope, SelectorKind::Relative, anchor))
                 return IterationDecision::Continue;
-            if (matches_relative_selector(selector, compound_index + 1, child_element, shadow_host, context, anchor)) {
+            if (matches_relative_selector(selector, compound_index + 1, child_element, shadow_host, context, anchor, scope)) {
                 has = true;
                 return IterationDecision::Break;
             }
@@ -195,18 +195,18 @@ static inline bool matches_relative_selector(CSS::Selector const& selector, size
         auto* sibling = element.next_element_sibling();
         if (!sibling)
             return false;
-        if (!matches(selector, compound_index, *sibling, shadow_host, context, {}, SelectorKind::Relative, anchor))
+        if (!matches(selector, compound_index, *sibling, shadow_host, context, scope, SelectorKind::Relative, anchor))
             return false;
-        return matches_relative_selector(selector, compound_index + 1, *sibling, shadow_host, context, anchor);
+        return matches_relative_selector(selector, compound_index + 1, *sibling, shadow_host, context, anchor, scope);
     }
     case CSS::Selector::Combinator::SubsequentSibling: {
         if (context.collect_per_element_selector_involvement_metadata) {
             const_cast<DOM::Element&>(*anchor).set_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator(true);
         }
         for (auto const* sibling = element.next_element_sibling(); sibling; sibling = sibling->next_element_sibling()) {
-            if (!matches(selector, compound_index, *sibling, shadow_host, context, {}, SelectorKind::Relative, anchor))
+            if (!matches(selector, compound_index, *sibling, shadow_host, context, scope, SelectorKind::Relative, anchor))
                 continue;
-            if (matches_relative_selector(selector, compound_index + 1, *sibling, shadow_host, context, anchor))
+            if (matches_relative_selector(selector, compound_index + 1, *sibling, shadow_host, context, anchor, scope))
                 return true;
         }
         return false;
@@ -218,14 +218,14 @@ static inline bool matches_relative_selector(CSS::Selector const& selector, size
 }
 
 // https://drafts.csswg.org/selectors-4/#relational
-static inline bool matches_has_pseudo_class(CSS::Selector const& selector, DOM::Element const& anchor, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context)
+static inline bool matches_has_pseudo_class(CSS::Selector const& selector, DOM::Element const& anchor, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, GC::Ptr<DOM::ParentNode const> scope)
 {
     if (context.has_result_cache) {
         if (auto cached = context.has_result_cache->get({ &selector, &anchor }); cached.has_value())
             return cached.value() == HasMatchResult::Matched;
     }
 
-    bool result = matches_relative_selector(selector, 0, anchor, shadow_host, context, anchor);
+    bool result = matches_relative_selector(selector, 0, anchor, shadow_host, context, anchor, scope);
 
     if (context.has_result_cache)
         context.has_result_cache->set({ &selector, &anchor }, result ? HasMatchResult::Matched : HasMatchResult::NotMatched);
@@ -650,20 +650,20 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         }
         // These selectors should be relative selectors (https://drafts.csswg.org/selectors-4/#relative-selector)
         for (auto& selector : pseudo_class.argument_selector_list) {
-            if (matches_has_pseudo_class(selector, element, shadow_host, context))
+            if (matches_has_pseudo_class(selector, element, shadow_host, context, scope))
                 return true;
         }
         return false;
     case CSS::PseudoClass::Is:
     case CSS::PseudoClass::Where:
         for (auto& selector : pseudo_class.argument_selector_list) {
-            if (matches(selector, element, shadow_host, context))
+            if (matches(selector, element, shadow_host, context, {}, scope))
                 return true;
         }
         return false;
     case CSS::PseudoClass::Not:
         for (auto& selector : pseudo_class.argument_selector_list) {
-            if (matches(selector, element, shadow_host, context))
+            if (matches(selector, element, shadow_host, context, {}, scope))
                 return false;
         }
         return true;

--- a/Tests/LibWeb/Text/expected/wpt-import/css/selectors/has-argument-with-explicit-scope.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/selectors/has-argument-with-explicit-scope.txt
@@ -2,12 +2,11 @@ Harness status: OK
 
 Found 13 tests
 
-12 Pass
-1 Fail
+13 Pass
 Pass	:has(:scope) matches expected elements on scope1
 Pass	:has(:scope .c) matches expected elements on scope1
 Pass	:has(.a :scope) matches expected elements on scope1
-Fail	.a:has(:scope) .c matches expected elements on scope1
+Pass	.a:has(:scope) .c matches expected elements on scope1
 Pass	.a:has(:scope) .c and :is(.a :scope .c) returns same elements on scope1
 Pass	.a:has(:scope) .c matches expected elements on scope2
 Pass	.a:has(:scope) .c and :is(.a :scope .c) returns same elements on scope2

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-closest.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-closest.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 29 tests
 
-28 Pass
-1 Fail
+29 Pass
 Pass	Element.closest with context node 'test12' and selector 'select'
 Pass	Element.closest with context node 'test13' and selector 'fieldset'
 Pass	Element.closest with context node 'test13' and selector 'div'
@@ -32,4 +31,4 @@ Pass	Element.closest with context node 'test11' and selector ':invalid'
 Pass	Element.closest with context node 'test4' and selector ':scope'
 Pass	Element.closest with context node 'test4' and selector 'select > :scope'
 Pass	Element.closest with context node 'test4' and selector 'div > :scope'
-Fail	Element.closest with context node 'test4' and selector ':has(> :scope)'
+Pass	Element.closest with context node 'test4' and selector ':has(> :scope)'


### PR DESCRIPTION
## Summary

The `:scope` pseudo-class inside `:has()`, `:is()`, `:where()`, and `:not()` selectors was not receiving the scoping root from outer selector contexts like `Element.closest()`. This caused selectors like `:has(> :scope)` and `:is(.a :scope .c)` to fail when used with scoped queries.

Relevant specifications:
- [CSS Selectors Level 4 - :scope pseudo-class](https://drafts.csswg.org/selectors-4/#the-scope-pseudo)
- [CSS Selectors Level 4 - :has() relational pseudo-class](https://drafts.csswg.org/selectors-4/#relational)
- [DOM Standard - Element.closest()](https://dom.spec.whatwg.org/#dom-element-closest)

## Implementation Approach

The fix propagates the `scope` parameter through internal selector matching functions:

1. `matches_relative_selector()` - Added `GC::Ptr<DOM::ParentNode const> scope` parameter
2. `matches_has_pseudo_class()` - Added `GC::Ptr<DOM::ParentNode const> scope` parameter
3. Updated `:is()`, `:where()`, and `:not()` cases in `matches_pseudo_class()` to pass scope through to `matches()`

Key changes:

```cpp
// In matches_relative_selector() and matches_has_pseudo_class()
// Before
if (matches(selector, element, shadow_host, context, {}, {}, SelectorKind::Relative, anchor))
// After
if (matches(selector, element, shadow_host, context, {}, scope, SelectorKind::Relative, anchor))

// In :is()/:where()/:not() cases
// Before
if (matches(selector, element, shadow_host, context))
// After
if (matches(selector, element, shadow_host, context, {}, scope))
```

This ensures that when `:scope` is evaluated inside any of these pseudo-classes, it correctly refers to the scoping root from the outer context.

## Testing

This change fixes the following WPT tests:

- `dom/nodes/Element-closest.html` - Now 29 Pass, 0 Fail (was 28 Pass, 1 Fail). The test case `Element.closest with context node 'test4' and selector ':has(> :scope)'` now passes.

- `css/selectors/has-argument-with-explicit-scope.html` - Now 13 Pass, 0 Fail (was 12 Pass, 1 Fail). The comparison test `.a:has(:scope) .c and :is(.a :scope .c) returns same elements` now passes because both selectors correctly resolve `:scope`.

## Changes

- `Libraries/LibWeb/CSS/SelectorEngine.cpp` - Added scope parameter to `matches_relative_selector()` and `matches_has_pseudo_class()`, and updated `:is()`, `:where()`, and `:not()` to pass scope through.
- `Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-closest.txt` - Updated expected results.
- `Tests/LibWeb/Text/expected/wpt-import/css/selectors/has-argument-with-explicit-scope.txt` - Updated expected results.
