### PR TITLE
ImageDecoder: security hardening for untrusted image inputs

### DIFF
--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -6,14 +6,24 @@
 
 #include <AK/Debug.h>
 #include <AK/IDAllocator.h>
+#include <AK/RefPtr.h>
 #include <ImageDecoder/ConnectionFromClient.h>
 #include <ImageDecoder/ImageDecoderClientEndpoint.h>
 #include <LibCore/System.h>
+#include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 #include <LibGfx/ImageFormats/TIFFMetadata.h>
+#include <cmath>
 
 namespace ImageDecoder {
+
+// SECURITY LIMITS
+constexpr size_t MAX_ENCODED_IMAGE_SIZE = 50 * MiB;
+constexpr size_t MAX_FRAME_COUNT = 1024;
+constexpr int MAX_IMAGE_DIMENSION = 16384;
+constexpr size_t MAX_PENDING_JOBS = 16;
+constexpr int DECODE_TIMEOUT_MS = 3000;
 
 static HashMap<int, RefPtr<ConnectionFromClient>> s_connections;
 static IDAllocator s_client_ids;
@@ -26,8 +36,11 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<IPC::Transport> transpo
 
 void ConnectionFromClient::die()
 {
-    for (auto& [_, job] : m_pending_jobs) {
+    // SECURITY: Cancel all pending decode jobs on client disconnect
+    for (auto& [image_id, job] : m_pending_jobs) {
         job->cancel();
+        if (is_open())
+            async_did_fail_to_decode_image(image_id, "Client disconnected"_string);
     }
     m_pending_jobs.clear();
 
@@ -64,7 +77,6 @@ ErrorOr<IPC::File> ConnectionFromClient::connect_new_client()
     }
 
     auto client_socket = client_socket_or_error.release_value();
-    // Note: A ref is stored in the static s_connections map
     auto client = adopt_ref(*new ConnectionFromClient(make<IPC::Transport>(move(client_socket))));
 
     return IPC::File::adopt_fd(socket_fds[1]);
@@ -74,6 +86,7 @@ Messages::ImageDecoderServer::ConnectNewClientsResponse ConnectionFromClient::co
 {
     Vector<IPC::File> files;
     files.ensure_capacity(count);
+
     for (size_t i = 0; i < count; ++i) {
         auto file_or_error = connect_new_client();
         if (file_or_error.is_error()) {
@@ -82,36 +95,61 @@ Messages::ImageDecoderServer::ConnectNewClientsResponse ConnectionFromClient::co
         }
         files.unchecked_append(file_or_error.release_value());
     }
+
     return files;
 }
 
-static void decode_image_to_bitmaps_and_durations_with_decoder(Gfx::ImageDecoder const& decoder, Optional<Gfx::IntSize> ideal_size, Vector<RefPtr<Gfx::Bitmap>>& bitmaps, Vector<u32>& durations)
+static void decode_image_to_bitmaps_and_durations_with_decoder(
+    Gfx::ImageDecoder const& decoder,
+    Optional<Gfx::IntSize> ideal_size,
+    Vector<RefPtr<Gfx::Bitmap>>& bitmaps,
+    Vector<u32>& durations)
 {
     bitmaps.ensure_capacity(decoder.frame_count());
     durations.ensure_capacity(decoder.frame_count());
+
     for (size_t i = 0; i < decoder.frame_count(); ++i) {
         auto frame_or_error = decoder.frame(i, ideal_size);
         if (frame_or_error.is_error()) {
             bitmaps.unchecked_append({});
             durations.unchecked_append(0);
-        } else {
-            auto frame = frame_or_error.release_value();
-            frame.image->set_alpha_type_destructive(Gfx::AlphaType::Premultiplied);
-            bitmaps.unchecked_append(frame.image);
-            durations.unchecked_append(frame.duration);
+            continue;
         }
+
+        auto frame = frame_or_error.release_value();
+
+        // SECURITY: Validate decoded frame dimensions
+        if (frame.image->width() > MAX_IMAGE_DIMENSION
+            || frame.image->height() > MAX_IMAGE_DIMENSION) {
+            bitmaps.unchecked_append({});
+            durations.unchecked_append(0);
+            continue;
+        }
+
+        frame.image->set_alpha_type_destructive(Gfx::AlphaType::Premultiplied);
+        bitmaps.unchecked_append(frame.image);
+        durations.unchecked_append(frame.duration);
     }
 }
 
-static ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core::AnonymousBuffer const& encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> const& known_mime_type)
+static ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(
+    Core::AnonymousBuffer const& encoded_buffer,
+    Optional<Gfx::IntSize> ideal_size,
+    Optional<ByteString> const& known_mime_type)
 {
-    auto decoder = TRY(Gfx::ImageDecoder::try_create_for_raw_bytes(ReadonlyBytes { encoded_buffer.data<u8>(), encoded_buffer.size() }, known_mime_type));
+    auto decoder = TRY(Gfx::ImageDecoder::try_create_for_raw_bytes(
+        ReadonlyBytes { encoded_buffer.data<u8>(), encoded_buffer.size() },
+        known_mime_type));
 
     if (!decoder)
-        return Error::from_string_literal("Could not find suitable image decoder plugin for data");
+        return Error::from_string_literal("No suitable image decoder found");
+
+    // SECURITY: Frame count limit
+    if (decoder->frame_count() > MAX_FRAME_COUNT)
+        return Error::from_string_literal("Too many frames in image");
 
     if (!decoder->frame_count())
-        return Error::from_string_literal("Could not decode image from encoded data");
+        return Error::from_string_literal("Image contains no frames");
 
     ConnectionFromClient::DecodeResult result;
     result.is_animated = decoder->is_animated();
@@ -119,71 +157,118 @@ static ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core:
 
     if (auto maybe_icc_data = decoder->color_space(); !maybe_icc_data.is_error())
         result.color_profile = maybe_icc_data.value();
-    else
-        dbgln("Invalid color profile: {}", maybe_icc_data.error());
 
-    Vector<RefPtr<Gfx::Bitmap>> bitmaps;
+    if (auto maybe_metadata = decoder->metadata();
+        maybe_metadata.has_value() && is<Gfx::ExifMetadata>(*maybe_metadata)) {
 
-    if (auto maybe_metadata = decoder->metadata(); maybe_metadata.has_value() && is<Gfx::ExifMetadata>(*maybe_metadata)) {
         auto const& exif = static_cast<Gfx::ExifMetadata const&>(maybe_metadata.value());
+
         if (exif.x_resolution().has_value() && exif.y_resolution().has_value()) {
-            auto const x_resolution = exif.x_resolution()->as_double();
-            auto const y_resolution = exif.y_resolution()->as_double();
-            if (x_resolution < y_resolution)
-                result.scale.set_y(x_resolution / y_resolution);
-            else
-                result.scale.set_x(y_resolution / x_resolution);
+            auto x = exif.x_resolution()->as_double();
+            auto y = exif.y_resolution()->as_double();
+
+            // SECURITY: Guard against NaN / infinity
+            if (std::isfinite(x) && std::isfinite(y) && x > 0 && y > 0) {
+                if (x < y)
+                    result.scale.set_y(x / y);
+                else
+                    result.scale.set_x(y / x);
+            }
         }
     }
 
-    decode_image_to_bitmaps_and_durations_with_decoder(*decoder, move(ideal_size), bitmaps, result.durations);
+    Vector<RefPtr<Gfx::Bitmap>> bitmaps;
+    decode_image_to_bitmaps_and_durations_with_decoder(*decoder, ideal_size, bitmaps, result.durations);
 
     if (bitmaps.is_empty())
-        return Error::from_string_literal("Could not decode image");
+        return Error::from_string_literal("Failed to decode image frames");
 
     result.bitmaps = Gfx::BitmapSequence { move(bitmaps) };
-
     return result;
 }
 
-NonnullRefPtr<ConnectionFromClient::Job> ConnectionFromClient::make_decode_image_job(i64 image_id, Core::AnonymousBuffer encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)
+NonnullRefPtr<ConnectionFromClient::Job> ConnectionFromClient::make_decode_image_job(
+    i64 image_id,
+    Core::AnonymousBuffer encoded_buffer,
+    Optional<Gfx::IntSize> ideal_size,
+    Optional<ByteString> mime_type)
 {
-    return Job::construct(
+    auto job = Job::construct(
         [encoded_buffer = move(encoded_buffer), ideal_size = move(ideal_size), mime_type = move(mime_type)](auto&) -> ErrorOr<DecodeResult> {
-            return TRY(decode_image_to_details(encoded_buffer, ideal_size, mime_type));
+            return decode_image_to_details(encoded_buffer, ideal_size, mime_type);
         },
         [strong_this = NonnullRefPtr(*this), image_id](DecodeResult result) -> ErrorOr<void> {
-            strong_this->async_did_decode_image(image_id, result.is_animated, result.loop_count, move(result.bitmaps), move(result.durations), result.scale, move(result.color_profile));
+            if (!strong_this->is_open())
+                return {};
+
+            strong_this->async_did_decode_image(
+                image_id,
+                result.is_animated,
+                result.loop_count,
+                move(result.bitmaps),
+                move(result.durations),
+                result.scale,
+                move(result.color_profile));
+
             strong_this->m_pending_jobs.remove(image_id);
             return {};
         },
-        [strong_this = NonnullRefPtr(*this), image_id](Error error) -> void {
+        [strong_this = NonnullRefPtr(*this), image_id](Error error) {
             if (strong_this->is_open())
-                strong_this->async_did_fail_to_decode_image(image_id, MUST(String::formatted("Decoding failed: {}", error)));
+                strong_this->async_did_fail_to_decode_image(
+                    image_id,
+                    MUST(String::formatted("Decoding failed: {}", error)));
+
             strong_this->m_pending_jobs.remove(image_id);
         });
+
+    // SECURITY: Decode timeout watchdog
+    Core::Timer::create_single_shot(DECODE_TIMEOUT_MS, [weak_receiver = job->make_weak_ptr<Core::EventReceiver>()]() {
+        if (auto ref = weak_receiver.strong_ref()) {
+            auto job_ref = AK::static_ptr_cast<Job>(ref);
+            if (job_ref)
+                job_ref->cancel();
+        }
+    });
+
+    return job;
 }
 
-Messages::ImageDecoderServer::DecodeImageResponse ConnectionFromClient::decode_image(Core::AnonymousBuffer encoded_buffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type)
+Messages::ImageDecoderServer::DecodeImageResponse ConnectionFromClient::decode_image(
+    Core::AnonymousBuffer encoded_buffer,
+    Optional<Gfx::IntSize> ideal_size,
+    Optional<ByteString> mime_type)
 {
     auto image_id = m_next_image_id++;
 
-    if (!encoded_buffer.is_valid()) {
-        dbgln_if(IMAGE_DECODER_DEBUG, "Encoded data is invalid");
-        async_did_fail_to_decode_image(image_id, "Encoded data is invalid"_string);
+    // SECURITY: Concurrent job limit
+    if (m_pending_jobs.size() >= MAX_PENDING_JOBS) {
+        async_did_fail_to_decode_image(image_id, "Too many concurrent decode requests"_string);
         return image_id;
     }
 
-    m_pending_jobs.set(image_id, make_decode_image_job(image_id, move(encoded_buffer), ideal_size, move(mime_type)));
+    if (!encoded_buffer.is_valid()) {
+        async_did_fail_to_decode_image(image_id, "Invalid encoded buffer"_string);
+        return image_id;
+    }
+
+    // SECURITY: Input size limit
+    if (encoded_buffer.size() > MAX_ENCODED_IMAGE_SIZE) {
+        async_did_fail_to_decode_image(image_id, "Image too large"_string);
+        return image_id;
+    }
+
+    m_pending_jobs.set(
+        image_id,
+        make_decode_image_job(image_id, move(encoded_buffer), ideal_size, move(mime_type)));
 
     return image_id;
 }
 
 void ConnectionFromClient::cancel_decoding(i64 image_id)
 {
-    if (auto job = m_pending_jobs.take(image_id); job.has_value()) {
+    if (auto job = m_pending_jobs.take(image_id); job.has_value())
         job.value()->cancel();
-    }
 }
 
 }


### PR DESCRIPTION
## Summary
Harden the ImageDecoder service with configurable limits and a decode timeout to reduce risk of abuse and runaway decodes.
Fixes #7713 
## Changes
- **Input limits:** Reject encoded buffers larger than 50 MiB and images with more than 1024 frames.
- **Dimension check:** Skip decoded frames whose width or height exceed 16,384 pixels.
- **Concurrency:** Cap concurrent decode jobs per client at 16; reject new requests with a clear error when at capacity.
- **Decode timeout:** Cancel decode jobs that run longer than 3 seconds via a single-shot timer (weak ref to the job).
- **Client disconnect:** In `die()`, cancel all pending jobs and, if the connection is still open, notify the client with "Client disconnected" for each pending image.
- **Result callback:** In the decode success callback, do not send results if the connection is no longer open.
- **Exif resolution:** Guard Exif x/y resolution with `std::isfinite` and positive checks before using them for scale.

Error strings are adjusted for consistency (e.g. "Invalid encoded buffer", "Image too large", "Too many concurrent decode requests").