### PR TITLE
LibWeb: Return computed content width from TFC automatic_content_width()

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1722,7 +1722,7 @@ void TableFormattingContext::run(AvailableSpace const& available_space)
 
 CSSPixels TableFormattingContext::automatic_content_width() const
 {
-    return greatest_child_width(context_box());
+    return m_state.get(table_box()).content_width();
 }
 
 CSSPixels TableFormattingContext::automatic_content_height() const

--- a/Tests/LibWeb/Layout/expected/table/table-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-max-content-width.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 140 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 124 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 126 0+0+658] [0+0+0 124 0+0+0] [BFC] children: not-inline
-        Box <table.table> at [18,18] table-box [0+10+0 106 0+10+106] [0+10+0 104 0+10+0] [TFC] children: not-inline
+        Box <table.table> at [18,18] table-box [0+10+0 106 0+10+0] [0+10+0 104 0+10+0] [TFC] children: not-inline
           Box <tbody> at [20,20] table-row-group [0+0+0 102 0+0+0] [0+0+0 100 0+0+0] children: not-inline
             Box <tr> at [20,20] table-row [0+0+0 102 0+0+0] [0+0+0 100 0+0+0] children: not-inline
               BlockContainer <td> at [21,70] table-cell [0+0+1 100 1+0+0] [0+0+50 0 50+0+0] [BFC] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/table-width-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width-max-content.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 425.828125 0+0+366.171875] [8+0+0 18 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 425.828125 0+0+0] [0+0+0 18 0+0+0] [BFC] children: not-inline
-        Box <div> at [8,8] table-box [0+0+0 425.828125 0+0+425.828125] [0+0+0 18 0+0+0] [TFC] children: inline
+        Box <div> at [8,8] table-box [0+0+0 425.828125 0+0+0] [0+0+0 18 0+0+0] [TFC] children: inline
           Box <(anonymous)> at [8,8] table-row [0+0+0 425.828125 0+0+0] [0+0+0 18 0+0+0] children: inline
             BlockContainer <(anonymous)> at [8,8] table-cell [0+0+0 425.828125 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
               frag 0 from TextNode start: 1, length: 56, rect: [8,8 425.828125x18] baseline: 13.796875

--- a/Tests/LibWeb/Layout/expected/table/table-width-min-content.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width-min-content.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 178 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 55.359375 0+0+736.640625] [8+0+0 162 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 55.359375 0+0+0] [0+0+0 162 0+0+0] [BFC] children: not-inline
-        Box <div> at [8,8] table-box [0+0+0 55.359375 0+0+55.359375] [0+0+0 162 0+0+0] [TFC] children: inline
+        Box <div> at [8,8] table-box [0+0+0 55.359375 0+0+0] [0+0+0 162 0+0+0] [TFC] children: inline
           Box <(anonymous)> at [8,8] table-row [0+0+0 55.359375 0+0+0] [0+0+0 162 0+0+0] children: inline
             BlockContainer <(anonymous)> at [8,8] table-cell [0+0+0 55.359375 0+0+0] [0+0+0 162 0+0+0] [BFC] children: inline
               frag 0 from TextNode start: 1, length: 4, rect: [8,8 28.40625x18] baseline: 13.796875

--- a/Tests/LibWeb/Ref/expected/floated-table-intrinsic-width-ref.html
+++ b/Tests/LibWeb/Ref/expected/floated-table-intrinsic-width-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+div {
+    display: table;
+    float: left;
+    width: 120px;
+}
+img {
+    max-width: 100%;
+}
+</style>
+<div>
+    <img src="../../Assets/120.png">
+</div>

--- a/Tests/LibWeb/Ref/input/floated-table-intrinsic-width.html
+++ b/Tests/LibWeb/Ref/input/floated-table-intrinsic-width.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/floated-table-intrinsic-width-ref.html">
+<style>
+div {
+    display: table;
+    float: left;
+}
+img {
+    max-width: 100%;
+}
+</style>
+<div>
+    <img src="../../Assets/120.png">
+</div>


### PR DESCRIPTION
Previously, `greatest_child_width()` was used, which finds the maximum margin box width among direct children. This is incorrect for tables, whose width is determined by column distribution rather than by simply finding the widest child. We now return the table's computed content width instead, which already holds the correct value after layout.

This improves layout of image boxes on Wikipedia. Here's an example from: https://en.wikipedia.org/wiki/Software_bug#Prevention:

| Before | After |
|  ---  | --- |
| <img width="1222" height="611" alt="image" src="https://github.com/user-attachments/assets/0f403fcd-191c-4339-a9b0-a968410a580e" /> | <img width="1222" height="611" alt="image" src="https://github.com/user-attachments/assets/6e98f578-0c9f-4f10-b83d-75ef16e6c871" /> |


Fixes: #5764