### PR TITLE
LibWeb: Decode Set-Cookie response headers before parsing

### DIFF
--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -13,6 +13,7 @@
 #include <LibGC/Function.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
+#include <LibTextCodec/Decoder.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
@@ -106,7 +107,7 @@ static ByteString sanitized_url_for_logging(URL::URL const& url)
 
 static void store_response_cookies(Page& page, URL::URL const& url, ByteString const& set_cookie_entry)
 {
-    auto cookie = Cookie::parse_cookie(url, set_cookie_entry);
+    auto cookie = Cookie::parse_cookie(url, TextCodec::isomorphic_decode(set_cookie_entry));
     if (!cookie.has_value())
         return;
     page.client().page_did_set_cookie(url, cookie.value(), Cookie::Source::Http);

--- a/Tests/LibWeb/Crash/Cookie/invalid-cookie.html
+++ b/Tests/LibWeb/Crash/Cookie/invalid-cookie.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="../../Text/input/include.js"></script>
+<script>
+    const TEST_SERVER_SET_INVALID_COOKIE = "X-Ladybird-Set-Invalid-Cookie";
+
+    const ACCESS_CONTROL_ALLOW_HEADERS = [TEST_SERVER_SET_INVALID_COOKIE].join(", ");
+    const ACCESS_CONTROL_EXPOSE_HEADERS = ["Set-Cookie"].join(", ");
+
+    const server = httpTestServer();
+
+    async function createRequest(path) {
+        await server.createEcho("OPTIONS", path, {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Credentials": "true",
+                "Access-Control-Allow-Headers": ACCESS_CONTROL_ALLOW_HEADERS,
+                "Access-Control-Allow-Methods": "GET",
+                "Access-Control-Allow-Origin": location.origin,
+            },
+        });
+
+        return server.createEcho("GET", path, {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Credentials": "true",
+                "Access-Control-Allow-Origin": location.origin,
+                "Access-Control-Expose-Headers": ACCESS_CONTROL_EXPOSE_HEADERS,
+            },
+            reflect_headers_in_body: true,
+        });
+    }
+
+    (async () => {
+        let url = await createRequest("/invalid-cookie");
+
+        await fetch(url, {
+            method: "GET",
+            credentials: "include",
+            mode: "cors",
+            headers: {
+                [TEST_SERVER_SET_INVALID_COOKIE]: "1",
+            }
+        });
+    })();
+</script>

--- a/Tests/LibWeb/Fixtures/http-test-server.py
+++ b/Tests/LibWeb/Fixtures/http-test-server.py
@@ -139,6 +139,8 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         send_incomplete_response = "X-Ladybird-Respond-With-Incomplete-Response" in self.headers
 
+        set_invalid_cookie = "X-Ladybird-Set-Invalid-Cookie" in self.headers
+
         if key in echo_store:
             echo = echo_store[key]
             response_headers = echo.headers.copy()
@@ -157,6 +159,9 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
                 elif send_incomplete_response:
                     # We emulate an incomplete response by advertising a 10KB file, but only sending 2KB.
                     response_headers["Content-Length"] = str(10 * 1024)
+
+            if set_invalid_cookie:
+                response_headers["Set-Cookie"] = "invalid=foo; Domain=\xc3\xa9\x6c\xc3\xa8\x76\x65\xff"
 
             # Set only the headers defined in the echo definition
             if response_headers:


### PR DESCRIPTION
It's possible for the cookie value from a Set-Cookie header to contain invalid UTF-8. We must isomorphic decode this header.

This fixes the `/cookies/domain/domain-attribute-idn-host.sub.https.html` WPT test. The test added here is a crash test rather than a text test because we cannot access the received Set-Cookie header from JS on the `file://` test URL.