### PR TITLE
Tests: Rebaseline `Layout/input/quirks/input-in-pre-quirks-mode.html`

### DIFF
--- a/Tests/LibWeb/Layout/expected/quirks/input-in-pre-quirks-mode.txt
+++ b/Tests/LibWeb/Layout/expected/quirks/input-in-pre-quirks-mode.txt
@@ -4,8 +4,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <(anonymous)> at [8,13] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <pre> at [8,13] [0+0+0 784 0+0+0] [13+0+0 19 0+0+13] children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,14 158x17] baseline: 13.390625
-        BlockContainer <input> at [9,14] inline-block [0+1+0 158 0+1+0] [0+1+0 17 0+1+0] [BFC] children: not-inline
+        frag 0 from TextInputBox start: 0, length: 0, rect: [9,14 158x17] baseline: 13.390625
+        TextInputBox <input> at [9,14] inline-block [0+1+0 158 0+1+0] [0+1+0 17 0+1+0] [BFC] children: not-inline
           Box <div> at [11,15] flex-container(row) [0+0+2 154 2+0+0] [0+0+1 15 1+0+0] [FFC] children: not-inline
             BlockContainer <div> at [11,15] flex-item [0+0+0 154 0+0+0] [0+0+0 15 0+0+0] [BFC] children: inline
               frag 0 from TextNode start: 0, length: 0, rect: [11,15 0x15] baseline: 11.390625
@@ -18,7 +18,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x610]
     PaintableWithLines (BlockContainer<BODY>) [8,13 784x584]
       PaintableWithLines (BlockContainer(anonymous)) [8,13 784x0]
       PaintableWithLines (BlockContainer<PRE>) [8,13 784x19]
-        PaintableWithLines (BlockContainer<INPUT>) [8,13 160x19]
+        PaintableWithLines (TextInputBox<INPUT>) [8,13 160x19]
           PaintableBox (Box<DIV>) [9,14 158x17]
             PaintableWithLines (BlockContainer<DIV>) [11,15 154x15]
               TextPaintable (TextNode<#text>)


### PR DESCRIPTION
#7028 introduced TextInputBox, which caused the expectations of this test to become outdated.