### PR TITLE
IDLGenerators: Do not generate a plain type for default nullable values

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -606,7 +606,7 @@ static void generate_to_integral(SourceGenerator& scoped_generator, ParameterTyp
     scoped_generator.set("enforce_range", parameter.extended_attributes.contains("EnforceRange") ? "Yes" : "No");
     scoped_generator.set("clamp", parameter.extended_attributes.contains("Clamp") ? "Yes" : "No");
 
-    if ((!optional && !parameter.type->is_nullable()) || optional_default_value.has_value()) {
+    if ((!optional && !parameter.type->is_nullable()) || (optional_default_value.has_value() && optional_default_value != "null"sv)) {
         scoped_generator.append(R"~~~(
     @cpp_type@ @cpp_name@;
 )~~~");


### PR DESCRIPTION
Commit 1b8e81cd6f3b3aade74bcfa25ea05a38f2d32e33 added a check to prevent assigning a default value when the default value itself is null. But we had previously generated an uninitialized type, expecting it to become defaulted later on. So we would have generated code such as:

```c++
bool value;

if (!property.is_null() && !property.is_undefined())
    value = property.to_boolean();

options.value = value;
```

This is undefined behavior.

We know use the same default value check to ensure we generate Optional types instead. So the above `value` initializer becomes:
```c++
Optional<bool> value;
```

This fixes an UBSAN crash seen in Tests/LibWeb/WPT/wpt/notifications/constructor-basic.https.html: 
```
/usr/include/c++/14/bits/stl_construct.h:97:14: runtime error: load of value 7, which is not a valid value for type 'bool'
#0 0x7f0c025f873f in decltype (::new ((void*)(0)) bool((declval<bool&>)())) std::construct_at<bool, bool&>(bool*, bool&) /usr/include/c++/14/bits/stl_construct.h:97
#1 0x7f0c025f873f in _ZN2AK8OptionalIbEaSIRbEERS1_OT_Q15IsConstructibleIS5_JOTL0__EE ladybird/AK/Optional.h:300
#2 0x7f0c025f873f in Web::Bindings::NotificationConstructor::construct(JS::FunctionObject&) ladybird/Build/Lagom/Libraries/LibWeb/Bindings/NotificationConstructor.cpp:432
```