### PR TITLE
LibWasm: Parse struct types and support multiple types in type section

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -320,7 +320,7 @@ private:
 class ModuleInstance {
 public:
     explicit ModuleInstance(
-        Vector<FunctionType> types, Vector<FunctionAddress> function_addresses, Vector<TableAddress> table_addresses, Vector<MemoryAddress> memory_addresses, Vector<GlobalAddress> global_addresses, Vector<DataAddress> data_addresses, Vector<TagAddress> tag_addresses, Vector<TagType> tag_types, Vector<ExportInstance> exports, size_t minimum_call_record_allocation_size)
+        Vector<TypeSection::Type> types, Vector<FunctionAddress> function_addresses, Vector<TableAddress> table_addresses, Vector<MemoryAddress> memory_addresses, Vector<GlobalAddress> global_addresses, Vector<DataAddress> data_addresses, Vector<TagAddress> tag_addresses, Vector<TagType> tag_types, Vector<ExportInstance> exports, size_t minimum_call_record_allocation_size)
         : cached_minimum_call_record_allocation_size(minimum_call_record_allocation_size)
         , m_types(move(types))
         , m_tag_types(move(tag_types))
@@ -361,7 +361,7 @@ public:
     size_t cached_minimum_call_record_allocation_size { 0 };
 
 private:
-    Vector<FunctionType> m_types;
+    Vector<TypeSection::Type> m_types;
     Vector<TagType> m_tag_types;
     Vector<FunctionAddress> m_functions;
     Vector<TableAddress> m_tables;

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -2008,7 +2008,7 @@ HANDLE_INSTRUCTION(call_indirect)
     TRAP_IN_LOOP_IF_NOT(element.ref().template has<Reference::Func>());
     auto address = element.ref().template get<Reference::Func>().address;
     auto const& type_actual = configuration.store().get(address)->visit([](auto& f) -> decltype(auto) { return f.type(); });
-    auto const& type_expected = configuration.frame().module().types()[args.type.value()];
+    auto const& type_expected = configuration.frame().module().types()[args.type.value()].unsafe_function();
     TRAP_IN_LOOP_IF_NOT(type_actual.parameters().size() == type_expected.parameters().size());
     TRAP_IN_LOOP_IF_NOT(type_actual.results().size() == type_expected.results().size());
     TRAP_IN_LOOP_IF_NOT(type_actual.parameters() == type_expected.parameters());
@@ -2035,7 +2035,7 @@ HANDLE_INSTRUCTION(return_call_indirect)
     TRAP_IN_LOOP_IF_NOT(element.ref().template has<Reference::Func>());
     auto address = element.ref().template get<Reference::Func>().address;
     auto const& type_actual = configuration.store().get(address)->visit([](auto& f) -> decltype(auto) { return f.type(); });
-    auto const& type_expected = configuration.frame().module().types()[args.type.value()];
+    auto const& type_expected = configuration.frame().module().types()[args.type.value()].unsafe_function();
     TRAP_IN_LOOP_IF_NOT(type_actual.parameters().size() == type_expected.parameters().size());
     TRAP_IN_LOOP_IF_NOT(type_actual.results().size() == type_expected.results().size());
     TRAP_IN_LOOP_IF_NOT(type_actual.parameters() == type_expected.parameters());

--- a/Libraries/LibWasm/AbstractMachine/Validator.h
+++ b/Libraries/LibWasm/AbstractMachine/Validator.h
@@ -22,8 +22,9 @@ struct Context {
         RedBlackTree<size_t, FunctionIndex> tree;
     };
 
-    COWVector<FunctionType> types;
+    COWVector<TypeSection::Type> types;
     COWVector<FunctionType> functions;
+    COWVector<StructType> structs;
     COWVector<TableType> tables;
     COWVector<MemoryType> memories;
     COWVector<GlobalType> globals;
@@ -433,5 +434,13 @@ struct AK::Formatter<Wasm::ValidationError> : public AK::Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Wasm::ValidationError const& error)
     {
         return Formatter<StringView>::format(builder, error.error_string);
+    }
+};
+
+template<>
+struct AK::Formatter<Wasm::TypeSection::Type> : public AK::Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Wasm::TypeSection::Type const& type)
+    {
+        return Formatter<StringView>::format(builder, type.name());
     }
 };

--- a/Libraries/LibWasm/Constants.h
+++ b/Libraries/LibWasm/Constants.h
@@ -33,6 +33,9 @@ static constexpr auto noexn_heap_reference_tag = 0x74;
 static constexpr auto nullable_reference_tag_tag = 0x63;
 static constexpr auto non_nullable_reference_tag_tag = 0x64;
 
+// Composite
+static constexpr auto struct_tag = 0x5f;
+
 // Function
 static constexpr auto function_signature_tag = 0x60;
 

--- a/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Libraries/LibWasm/Printer/Printer.cpp
@@ -728,6 +728,45 @@ void Printer::print(Wasm::TypeSection const& section)
     print(")\n");
 }
 
+void Printer::print(Wasm::TypeSection::Type const& type)
+{
+    type.description().visit(
+        [&](Wasm::FunctionType const& func) { print(func); },
+        [&](Wasm::StructType const& struct_) { print(struct_); });
+}
+
+void Printer::print(Wasm::StructType const& struct_)
+{
+    print_indent();
+    print("(type struct\n");
+    {
+        TemporaryChange change { m_indent, m_indent + 1 };
+        print_indent();
+        print("(fields\n");
+        {
+            TemporaryChange change { m_indent, m_indent + 1 };
+            for (auto& field : struct_.fields())
+                print(field);
+        }
+        print_indent();
+        print(")\n");
+    }
+    print_indent();
+    print(")\n");
+}
+
+void Printer::print(Wasm::FieldType const& type)
+{
+    print_indent();
+    print("({}mutable\n", type.is_mutable() ? "" : "im");
+    {
+        TemporaryChange change { m_indent, m_indent + 1 };
+        print(type.type());
+    }
+    print_indent();
+    print(")\n");
+}
+
 void Printer::print(Wasm::ValueType const& type)
 {
     print_indent();

--- a/Libraries/LibWasm/Printer/Printer.h
+++ b/Libraries/LibWasm/Printer/Printer.h
@@ -59,6 +59,9 @@ struct WASM_API Printer {
     void print(Wasm::TableSection::Table const&);
     void print(Wasm::TableType const&);
     void print(Wasm::TypeSection const&);
+    void print(Wasm::TypeSection::Type const&);
+    void print(Wasm::StructType const&);
+    void print(Wasm::FieldType const&);
     void print(Wasm::ValueType const&);
     void print(Wasm::TagType const&);
     void print(Wasm::Value const&);

--- a/Meta/wasm_unimplemented_tests.txt
+++ b/Meta/wasm_unimplemented_tests.txt
@@ -101,6 +101,8 @@ module select.0
 module struct.0
 module struct.10
 module struct.2
+module struct.3
+module struct.4
 module struct.5
 module struct.7
 module struct.9


### PR DESCRIPTION
This patch adds support for parsing structs in the type section.

It also removes the assumption that all types in the type section are
function types, adding appropriate validation.

Spec tests struct.3 and struct.4 have been disable as this would
require expanding `ValueType` to include more heap-types.