### PR TITLE
LibWeb: Fix fit-content() row clamping with indefinite available height

### DIFF
--- a/Libraries/LibWeb/CSS/GridTrackSize.cpp
+++ b/Libraries/LibWeb/CSS/GridTrackSize.cpp
@@ -29,6 +29,8 @@ bool GridSize::is_auto(Layout::AvailableSize const& available_size) const
     if (auto const* size = m_value.get_pointer<Size>()) {
         if (size->is_auto())
             return true;
+        if (size->is_fit_content())
+            return false;
         if (size->contains_percentage())
             return !available_size.is_definite();
         return false;

--- a/Libraries/LibWeb/CSS/Size.cpp
+++ b/Libraries/LibWeb/CSS/Size.cpp
@@ -90,9 +90,7 @@ bool Size::contains_percentage() const
     case Type::None:
         return false;
     case Type::FitContent:
-        // FIXME: This should return m_length_percentage.contains_percentage()
-        //        but we have to update a lot of code to handle this.
-        return false;
+        return m_length_percentage.has_value() && m_length_percentage->contains_percentage();
     default:
         return m_length_percentage->contains_percentage();
     }

--- a/Tests/LibWeb/Layout/expected/grid/fit-content-row-with-overflow-hidden.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fit-content-row-with-overflow-hidden.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] [GFC] children: not-inline
+        BlockContainer <div.wrapper> at [8,8] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+          BlockContainer <div.inner> at [8,8] [0+0+0 200 0+0+584] [0+0+0 200 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,108] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableBox (Box<DIV>.grid) [8,8 784x100]
+        PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 784x100] overflow: [8,8 784x200]
+          PaintableWithLines (BlockContainer<DIV>.inner) [8,8 200x200]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x116] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/fit-content-row-with-overflow-hidden.html
+++ b/Tests/LibWeb/Layout/input/grid/fit-content-row-with-overflow-hidden.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+.grid {
+    display: grid;
+    grid-template-rows: fit-content(100px);
+}
+.wrapper {
+    overflow: hidden;
+}
+.inner {
+    background: orange;
+    width: 200px;
+    height: 200px;
+}
+</style>
+<div class="grid"><div class="wrapper"><div class="inner"></div></div></div>


### PR DESCRIPTION
`grid-template-rows: fit-content(100px)` had no effect when the grid container lacked an explicit height, because the fit-content growth limit clamping was gated behind `available_size.is_definite()`.

Fix by normalizing fit-content tracks with unresolvable percentage arguments to max-content during track initialization, then applying the fit-content clamp unconditionally.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/7730