### PR TITLE
LibWeb: Allow importing ChaCha20-Poly1305 JWK without alg

### DIFF
--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -9887,13 +9887,9 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ChaCha20Poly1305::import_key(AlgorithmPa
             return WebIDL::DataError::create(m_realm, "Invalid key type"_utf16);
 
         // 3. If jwk does not meet the requirements of Section 6.4 of JSON Web Algorithms [JWA], then throw a DataError.
-        // Specifically, those requirements are:
-        // * the member "k" is used to represent a symmetric key (or another key whose value is a single octet sequence).
-        // * An "alg" member SHOULD also be present to identify the algorithm intended to be used with the key,
-        //   unless the application uses another means or convention to determine the algorithm used.
-        // NOTE: "k" is already checked in step 4.
-        if (!jwk.alg.has_value())
-            return WebIDL::DataError::create(m_realm, "Missing 'alg' field"_utf16);
+        // NB: Specifically, those requirements are:
+        // - ".k" is a valid bas64url encoded octet stream, which we do by just parsing it, in step 4.
+        // - ".alg" is checked only in step 5.
 
         // 4. Let data be the octet string obtained by decoding the k field of jwk.
         data = TRY(parse_jwk_symmetric_key(m_realm, jwk));

--- a/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-import-chacha20poly1305.txt
+++ b/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-import-chacha20poly1305.txt
@@ -1,0 +1,4 @@
+true
+ChaCha20-Poly1305
+secret
+encrypt

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-chacha20poly1305.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-chacha20poly1305.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+
+    // Jwk format wants Base 64 without the typical padding at the end.
+    function byteArrayToUnpaddedBase64(byteArray){
+        var binaryString = "";
+        for (var i=0; i<byteArray.byteLength; i++){
+            binaryString += String.fromCharCode(byteArray[i]);
+        }
+        var base64String = btoa(binaryString);
+
+        return base64String.replace(/=/g, "");
+    }
+
+    asyncTest(async done => {
+        var subtle = self.crypto.subtle;
+
+
+        var keyData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+
+        var jwk = {
+            kty: "oct",
+            k: byteArrayToUnpaddedBase64(keyData)
+            // alg MISSING
+        };
+
+        var key = await subtle.importKey(
+            "jwk",
+            jwk,
+            { name: "ChaCha20-Poly1305" },
+            true,
+            ["encrypt"]
+        );
+
+        println(key.extractable);
+        println(key.algorithm.name);
+        println(key.type);
+        println(key.usages.join(","));
+
+        done();
+    });
+
+</script>


### PR DESCRIPTION
The WebCrypto specification does not require the "alg" member to be present when importing a symmetric JWK, as long as the key material itself is valid.

Add tests covering JWK import without an "alg" field.

This fixes the following WPT:
WebCryptoAPI/import_export/ChaCha20-Poly1305_importKey