### PR TITLE
LibWeb: Don't lie about browsing context being top-level

### DIFF
--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -313,8 +313,6 @@ GC::Ref<TraversableNavigable> BrowsingContext::top_level_traversable() const
 // https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context
 bool BrowsingContext::is_top_level() const
 {
-    // FIXME: Remove this. The active document's navigable is sometimes null when it shouldn't be, failing assertions.
-    return true;
     // A top-level browsing context is a browsing context whose active document's node navigable is a traversable navigable.
     return active_document() != nullptr && active_document()->navigable() != nullptr && active_document()->navigable()->is_traversable();
 }

--- a/Libraries/LibWeb/HTML/BrowsingContextGroup.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContextGroup.cpp
@@ -58,8 +58,6 @@ auto BrowsingContextGroup::create_a_new_browsing_context_group_and_document(GC::
 // https://html.spec.whatwg.org/multipage/browsers.html#bcg-append
 void BrowsingContextGroup::append(BrowsingContext& browsing_context)
 {
-    VERIFY(browsing_context.is_top_level());
-
     // 1. Append browsingContext to group's browsing context set.
     m_browsing_context_set.set(browsing_context);
 


### PR DESCRIPTION
The VERIFY() this was triggering wasn't actually to spec, and by the time it gets encountered, the browsing context isn't technically a top-level context yet, because it has just been created and the definition of a top-level browsing context requires the document to be the navigables active document, which it only becomes once a history entry has been created for it.

Therefore we cannot just verify a top-level browsing context actually being a top-level browsing context when inserting it into the group, because that happens to early in its life-cycle as a top-level context.

This makes it so that JS console commands from the devtools no longer get sent to the last created nested frame in the tab, because nested frames no longer pretend to have a top-level browsing context.