### PR TITLE
LibWeb: Add presentational hints for clear attribute on BR elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -18,6 +18,8 @@ public:
     virtual ~HTMLBRElement() override;
 
     virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
+    virtual bool is_presentational_hint(FlyString const&) const override;
+    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
 private:

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<div style="max-width: 100px; height: 100px; background: green;"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The clear attribute applies the clear CSS property.</title>
+<link rel="author" title="Psychpsyo" href="mailto:psychpsyo@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3">
+<link rel=match href="../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/the-br-element/br-clear-presentational-hints-ref.html">
+<style>
+  body {
+    line-height: 0;
+  }
+  .test > div {
+    width: 25px;
+    height: 50px;
+    background: green;
+  }
+</style>
+<div style="max-width: 100px; display: flex; height: 100px; background: red;">
+  <div class="test">
+    <div style="float:right"></div>
+    <br clear="all">
+    <div></div>
+  </div>
+  <div class="test">
+    <div style="float:right"></div>
+    <br clear="both">
+    <div></div>
+  </div>
+  <div class="test">
+    <div style="float:right"></div>
+    <br clear="right">
+    <div></div>
+  </div>
+  <div class="test">
+    <div style="float:left"></div>
+    <br clear="left">
+    <div></div>
+  </div>
+</div>


### PR DESCRIPTION
The 'imported' WPT test is currently under review here: https://github.com/web-platform-tests/wpt/pull/57553

This fixes a layout bug on https://archive.org/details/mspaint_xp_version, where the "7 Original" download button in the download options on the right would otherwise spill out of the download options box. (And I assume the same bug happens on all archive.org pages that have download options)