### PR TITLE
LibJS: Strength reduce basic math operations

### DIFF
--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -62,6 +62,11 @@ op ToString < Instruction
     m_value: Operand
 endop
 
+op ToNumber < Instruction
+    m_dst: Operand
+    m_value: Operand
+endop
+
 op BitwiseXor < Instruction
     m_dst: Operand
     m_lhs: Operand

--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -406,6 +406,15 @@ CodeGenerationErrorOr<GC::Ref<Executable>> Generator::compile(VM& vm, ASTNode co
                 }
             }
 
+            if (instruction.type() == Instruction::Type::Mov) {
+                auto& mov = static_cast<Bytecode::Op::Mov&>(instruction);
+
+                if (mov.dst() == mov.src()) {
+                    ++it;
+                    continue;
+                }
+            }
+
             // OPTIMIZATION: For `JumpIf` where one of the targets is the very next block,
             //               we can emit a `JumpTrue` or `JumpFalse` (to the other block) instead.
             if (instruction.type() == Instruction::Type::JumpIf) {

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -475,6 +475,7 @@ void Interpreter::run_bytecode(size_t entry_point)
             HANDLE_INSTRUCTION(BitwiseOr);
             HANDLE_INSTRUCTION(ToInt32);
             HANDLE_INSTRUCTION(ToString);
+            HANDLE_INSTRUCTION(ToNumber);
             HANDLE_INSTRUCTION(BitwiseXor);
             HANDLE_INSTRUCTION(Call);
             HANDLE_INSTRUCTION(CallBuiltin);
@@ -1686,6 +1687,15 @@ ThrowCompletionOr<void> ToString::execute_impl(Bytecode::Interpreter& interprete
 {
     auto& vm = interpreter.vm();
     interpreter.set(m_dst, Value { TRY(interpreter.get(m_value).to_primitive_string(vm)) });
+
+    return {};
+}
+
+ThrowCompletionOr<void> ToNumber::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& vm = interpreter.vm();
+    auto const value = interpreter.get(m_value);
+    interpreter.set(m_dst, TRY(value.to_numeric(vm)));
     return {};
 }
 

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -1587,6 +1587,12 @@ ThrowCompletionOr<Value> unary_plus(VM& vm, Value lhs)
 // UnaryExpression : - UnaryExpression
 ThrowCompletionOr<Value> unary_minus(VM& vm, Value lhs)
 {
+    // OPTIMIZATION: if lhs is an i32, negate and return directly
+    if (lhs.is_int32()) {
+        if (auto i = lhs.as_i32(); i != 0)
+            return Value(-i);
+    }
+
     // 1. Let expr be ? Evaluation of UnaryExpression.
     // NOTE: This is handled in the AST or Bytecode interpreter.
 

--- a/Tests/LibJS/Bytecode/expected/basic-strength-reduce-math-ops.txt
+++ b/Tests/LibJS/Bytecode/expected/basic-strength-reduce-math-ops.txt
@@ -1,0 +1,109 @@
+JS bytecode executable ""
+[   0]    0: GetGlobal dst:reg6, identifier:console
+[  10]       GetById dst:reg7, base:reg6, property:log, base_identifier:console
+[  28]       GetGlobal dst:reg9, identifier:multiply_by_one
+[  38]       Call dst:reg8, callee:reg9, this_value:Undefined, multiply_by_one, arguments:[Int32(123)]
+[  60]       Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+[  88]       GetGlobal dst:reg6, identifier:console
+[  98]       GetById dst:reg8, base:reg6, property:log, base_identifier:console
+[  b0]       GetGlobal dst:reg10, identifier:multiply_by_one_alt
+[  c0]       Call dst:reg9, callee:reg10, this_value:Undefined, multiply_by_one_alt, arguments:[Int32(123)]
+[  e8]       Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+[ 110]       GetGlobal dst:reg8, identifier:console
+[ 120]       GetById dst:reg6, base:reg8, property:log, base_identifier:console
+[ 138]       GetGlobal dst:reg10, identifier:multiply_by_negative_one
+[ 148]       Call dst:reg9, callee:reg10, this_value:Undefined, multiply_by_negative_one, arguments:[Int32(123)]
+[ 170]       Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+[ 198]       GetGlobal dst:reg6, identifier:console
+[ 1a8]       GetById dst:reg8, base:reg6, property:log, base_identifier:console
+[ 1c0]       GetGlobal dst:reg10, identifier:multiply_by_negative_one_alt
+[ 1d0]       Call dst:reg9, callee:reg10, this_value:Undefined, multiply_by_negative_one_alt, arguments:[Int32(123)]
+[ 1f8]       Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+[ 220]       GetGlobal dst:reg8, identifier:console
+[ 230]       GetById dst:reg6, base:reg8, property:log, base_identifier:console
+[ 248]       GetGlobal dst:reg10, identifier:divide_by_one
+[ 258]       Call dst:reg9, callee:reg10, this_value:Undefined, divide_by_one, arguments:[Int32(123)]
+[ 280]       Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+[ 2a8]       GetGlobal dst:reg6, identifier:console
+[ 2b8]       GetById dst:reg8, base:reg6, property:log, base_identifier:console
+[ 2d0]       GetGlobal dst:reg10, identifier:divide_by_negative_one
+[ 2e0]       Call dst:reg9, callee:reg10, this_value:Undefined, divide_by_negative_one, arguments:[Int32(123)]
+[ 308]       Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+[ 330]       GetGlobal dst:reg8, identifier:console
+[ 340]       GetById dst:reg6, base:reg8, property:log, base_identifier:console
+[ 358]       GetGlobal dst:reg10, identifier:square
+[ 368]       Call dst:reg9, callee:reg10, this_value:Undefined, square, arguments:[Int32(10)]
+[ 390]       Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+[ 3b8]       GetGlobal dst:reg6, identifier:console
+[ 3c8]       GetById dst:reg8, base:reg6, property:log, base_identifier:console
+[ 3e0]       GetGlobal dst:reg10, identifier:square_func
+[ 3f0]       Call dst:reg9, callee:reg10, this_value:Undefined, square_func, arguments:[Int32(10)]
+[ 418]       Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+[ 440]       GetGlobal dst:reg8, identifier:console
+[ 450]       GetById dst:reg6, base:reg8, property:log, base_identifier:console
+[ 468]       GetGlobal dst:reg10, identifier:power_of_one
+[ 478]       Call dst:reg9, callee:reg10, this_value:Undefined, power_of_one, arguments:[Int32(10)]
+[ 4a0]       Call dst:reg5, callee:reg6, this_value:reg8, console.log, arguments:[reg9]
+[ 4c8]       GetGlobal dst:reg6, identifier:console
+[ 4d8]       GetById dst:reg8, base:reg6, property:log, base_identifier:console
+[ 4f0]       GetGlobal dst:reg10, identifier:power_of_zero
+[ 500]       Call dst:reg9, callee:reg10, this_value:Undefined, power_of_zero, arguments:[Int32(10)]
+[ 528]       Call dst:reg7, callee:reg8, this_value:reg6, console.log, arguments:[reg9]
+[ 550]       End value:reg7
+
+JS bytecode executable "multiply_by_one"
+[   0]    0: ToNumber dst:reg5, value:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "multiply_by_one_alt"
+[   0]    0: ToNumber dst:reg5, value:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "multiply_by_negative_one"
+[   0]    0: UnaryMinus dst:reg5, src:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "multiply_by_negative_one_alt"
+[   0]    0: UnaryMinus dst:reg5, src:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "divide_by_one"
+[   0]    0: ToNumber dst:reg5, value:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "divide_by_negative_one"
+[   0]    0: UnaryMinus dst:reg5, src:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "square"
+[   0]    0: Mul dst:reg5, lhs:arg0, rhs:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "square_func"
+[   0]    0: GetGlobal dst:reg6, identifier:f
+[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, f
+[  30]       Mul dst:reg6, lhs:reg5, rhs:reg5
+[  40]       Return value:reg6
+
+JS bytecode executable "f"
+[   0]    0: Return value:Int32(2)
+
+JS bytecode executable "power_of_one"
+[   0]    0: ToNumber dst:reg5, value:arg0
+[  10]       Return value:reg5
+
+JS bytecode executable "power_of_zero"
+[   0]    0: ToNumber dst:reg5, value:arg0
+[  10]       Mov dst:reg5, src:Int32(1)
+[  20]       Return value:reg5
+
+123
+123
+-123
+-123
+123
+-123
+100
+4
+10
+1

--- a/Tests/LibJS/Bytecode/input/basic-strength-reduce-math-ops.js
+++ b/Tests/LibJS/Bytecode/input/basic-strength-reduce-math-ops.js
@@ -1,0 +1,48 @@
+function multiply_by_one(x) {
+    return x * 1;
+}
+function multiply_by_one_alt(x) {
+    return 1 * x;
+}
+function multiply_by_negative_one(x) {
+    return x * -1;
+}
+function multiply_by_negative_one_alt(x) {
+    return -1 * x;
+}
+
+function divide_by_negative_one(x) {
+    return x / -1;
+}
+function divide_by_one(x) {
+    return x / 1;
+}
+
+function f() {
+    return 2;
+}
+function square(x) {
+    return x ** 2;
+}
+function square_func() {
+    return f() ** 2;
+}
+function power_of_one(x) {
+    return x ** 1;
+}
+function power_of_zero(x) {
+    return x ** 0;
+}
+
+console.log(multiply_by_one(123));
+console.log(multiply_by_one_alt(123));
+console.log(multiply_by_negative_one(123));
+console.log(multiply_by_negative_one_alt(123));
+
+console.log(divide_by_one(123));
+console.log(divide_by_negative_one(123));
+
+console.log(square(10));
+console.log(square_func(10));
+console.log(power_of_one(10));
+console.log(power_of_zero(10));

--- a/Tests/LibJS/Runtime/exponentiation-basic.js
+++ b/Tests/LibJS/Runtime/exponentiation-basic.js
@@ -75,3 +75,27 @@ test("unary expression before exponentiation with brackets", () => {
     expect((+5) ** 2).toBe(25);
     expect((-5) ** 2).toBe(25);
 });
+
+test("optimized exponent operations", () => {
+    const square = x => x ** 2;
+    const pow1 = x => x ** 1;
+    const pow0 = x => x ** 0;
+
+    expect(square(0)).toBe(0);
+    expect(square(-0)).toBe(0);
+    expect(square(2)).toBe(4);
+    expect(square(10)).toBe(100);
+    expect(square(NaN)).toBe(NaN);
+
+    expect(pow1(0)).toBe(0);
+    expect(pow1(-0)).toBe(-0);
+    expect(pow1(2)).toBe(2);
+    expect(pow1(10)).toBe(10);
+    expect(pow1(NaN)).toBe(NaN);
+
+    expect(pow0(0)).toBe(1);
+    expect(pow0(-0)).toBe(1);
+    expect(pow0(2)).toBe(1);
+    expect(pow0(10)).toBe(1);
+    expect(pow0(NaN)).toBe(1);
+});

--- a/Tests/LibJS/Runtime/operators/divide.js
+++ b/Tests/LibJS/Runtime/operators/divide.js
@@ -1,0 +1,27 @@
+// Used to prevent const folding from happening at compile time
+const div = (lhs, rhs) => lhs / rhs;
+
+test("basic division", () => {
+    expect(div(10, 2)).toBe(5);
+    expect(div(10, -1)).toBe(-10);
+    expect(div(0, 10)).toBe(0);
+    expect(div(10, 0)).toBe(Infinity);
+});
+
+test("optimized division", () => {
+    // These are specially optimized operations which need extra tests
+    const divide_by_one = x => x / 1;
+    const divide_by_negative_one = x => x / -1;
+
+    expect(divide_by_one(0)).toBe(0);
+    expect(divide_by_one(10)).toBe(10);
+    expect(divide_by_one(-10)).toBe(-10);
+    expect(divide_by_one(NaN)).toBeNaN();
+    expect(divide_by_one("123")).toBe(123);
+
+    expect(divide_by_negative_one(0)).toBe(-0);
+    expect(divide_by_negative_one(10)).toBe(-10);
+    expect(divide_by_negative_one(-10)).toBe(10);
+    expect(divide_by_negative_one(NaN)).toBeNaN();
+    expect(divide_by_negative_one("123")).toBe(-123);
+});

--- a/Tests/LibJS/Runtime/operators/multiply.js
+++ b/Tests/LibJS/Runtime/operators/multiply.js
@@ -1,0 +1,40 @@
+// Used to prevent const folding from happening at compile time
+const mul = (lhs, rhs) => lhs * rhs;
+
+test("basic multiplication", () => {
+    expect(mul(2, 3)).toBe(6);
+    expect(mul(10, -1)).toBe(-10);
+    expect(mul(0, 10)).toBe(0);
+});
+
+test("optimized multiplication", () => {
+    // These are specially optimized operations which need extra tests
+    const mult_by_one = x => x * 1;
+    const mult_by_one_alt = x => 1 * x;
+    const mult_by_negative_one = x => x * -1;
+    const mult_by_negative_one_alt = x => -1 * x;
+
+    expect(mult_by_one(0)).toBe(0);
+    expect(mult_by_one(10)).toBe(10);
+    expect(mult_by_one(-10)).toBe(-10);
+    expect(mult_by_one(NaN)).toBeNaN();
+    expect(mult_by_one("123")).toBe(123);
+
+    expect(mult_by_one_alt(0)).toBe(0);
+    expect(mult_by_one_alt(10)).toBe(10);
+    expect(mult_by_one_alt(-10)).toBe(-10);
+    expect(mult_by_one_alt(NaN)).toBeNaN();
+    expect(mult_by_one_alt("123")).toBe(123);
+
+    expect(mult_by_negative_one(0)).toBe(-0);
+    expect(mult_by_negative_one(10)).toBe(-10);
+    expect(mult_by_negative_one(-10)).toBe(10);
+    expect(mult_by_negative_one(NaN)).toBeNaN();
+    expect(mult_by_negative_one("123")).toBe(-123);
+
+    expect(mult_by_negative_one_alt(0)).toBe(-0);
+    expect(mult_by_negative_one_alt(10)).toBe(-10);
+    expect(mult_by_negative_one_alt(-10)).toBe(10);
+    expect(mult_by_negative_one_alt(NaN)).toBeNaN();
+    expect(mult_by_negative_one_alt("123")).toBe(-123);
+});


### PR DESCRIPTION
The following math operations are now optimized to equivalent versions which require less operations and/or pre-checks:

* `x * 1` -> `x`
* `x * -1` -> `-x`
* `x / 1` -> `x`
* `x / -1` -> `-x`
* `x**2` -> `x * x` (evaluates `x` once)
* `x**1` -> `x`
* `x**0` -> `1` (still evaluates `x`)