### PR TITLE
LibWeb: Only apply overflow clipping to applicable element types

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -356,6 +356,22 @@ bool PaintableBox::could_be_scrolled_by_wheel_event() const
     return could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal) || could_be_scrolled_by_wheel_event(ScrollDirection::Vertical);
 }
 
+bool PaintableBox::overflow_property_applies() const
+{
+    // https://drafts.csswg.org/css-overflow-3/#overflow-control
+    // Overflow properties apply to block containers, flex containers and grid containers.
+    // FIXME: Ideally we would check whether overflow applies positively rather than listing exceptions. However,
+    //        not all elements that should support overflow are currently identifiable that way.
+    auto const& display = computed_values().display();
+    if (layout_node().is_inline_node())
+        return false;
+    if (display.is_ruby_inside())
+        return false;
+    if (display.is_internal() && !display.is_table_cell() && !display.is_table_caption())
+        return false;
+    return true;
+}
+
 CSSPixels PaintableBox::available_scrollbar_length(ScrollDirection direction, ChromeMetrics const& metrics) const
 
 {

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -129,6 +129,8 @@ public:
             || computed_values.scale();
     }
 
+    [[nodiscard]] bool overflow_property_applies() const;
+
     [[nodiscard]] Optional<CSSPixelRect> scrollable_overflow_rect() const
     {
         if (!m_overflow_data.has_value())

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -312,7 +312,8 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
         auto overflow_y = computed_values.overflow_y();
         auto has_hidden_overflow = overflow_x != CSS::Overflow::Visible || overflow_y != CSS::Overflow::Visible;
 
-        if (has_hidden_overflow || paintable_box.layout_node().has_paint_containment()) {
+        auto should_clip_overflow = has_hidden_overflow && paintable_box.overflow_property_applies();
+        if (should_clip_overflow || paintable_box.layout_node().has_paint_containment()) {
             bool clip_x = overflow_x != CSS::Overflow::Visible;
             bool clip_y = overflow_y != CSS::Overflow::Visible;
 

--- a/Tests/LibWeb/Ref/expected/overflow-hidden-inline-ref.html
+++ b/Tests/LibWeb/Ref/expected/overflow-hidden-inline-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<span style="display: inline-block; border: 3px solid red;">TEXT</span>

--- a/Tests/LibWeb/Ref/input/overflow-hidden-inline.html
+++ b/Tests/LibWeb/Ref/input/overflow-hidden-inline.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/overflow-hidden-inline-ref.html">
+<span style="overflow: hidden;">
+    <span style="display: inline-block; border: 3px solid red;">TEXT</span>
+</span>


### PR DESCRIPTION
This fixes the rendering of issue labels on GitHub.

Before:

<img width="1144" height="423" alt="image" src="https://github.com/user-attachments/assets/2829969a-504a-451f-af0d-83bd2d33b8b5" />


After: 

<img width="1144" height="423" alt="image" src="https://github.com/user-attachments/assets/766365e1-25af-4902-9831-1f06c9c36931" />

