### PR TITLE
LibWeb: Reset line height for select elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
+#include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>
@@ -85,6 +86,9 @@ void HTMLSelectElement::adjust_computed_style(CSS::ComputedProperties& style)
     //         This is required for the internal shadow tree to work correctly in layout.
     if (style.display().is_inline_outside() && style.display().is_flow_inside())
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
+
+    // AD-HOC: Enforce normal line-height for select elements. This matches the behavior of other engines.
+    style.set_property(CSS::PropertyID::LineHeight, CSS::KeywordStyleValue::create(CSS::Keyword::Normal));
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#concept-select-size

--- a/Tests/LibWeb/Ref/expected/select-line-height-ignored-ref.html
+++ b/Tests/LibWeb/Ref/expected/select-line-height-ignored-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<select>
+    <option>Test</option>
+</select>

--- a/Tests/LibWeb/Ref/input/select-line-height-ignored.html
+++ b/Tests/LibWeb/Ref/input/select-line-height-ignored.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/select-line-height-ignored-ref.html">
+<style>
+    select {
+        line-height: 200px;
+    }
+</style>
+<select>
+    <option>Test</option>
+</select>


### PR DESCRIPTION
I tested all form control types with `line-height: 200px`  and these were the only differences I found between us and other engines.

EDIT: Actually I've removed the `::file-selector-button` commit, since the exact behavior seems to vary across browsers.

Fixes #7750