### PR TITLE
LibWeb: Use inverse scroll context for `background-attachment: fixed`

### DIFF
--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -132,7 +132,7 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
     }
     invalidation.repaint = true;
 
-    // Transform, perspective, clip, clip-path, and effects properties require rebuilding AccumulatedVisualContext tree.
+    // Transform, perspective, clip, clip-path, effects, and background-attachment properties require rebuilding AccumulatedVisualContext tree.
     if (AK::first_is_one_of(property_id,
             CSS::PropertyID::Transform,
             CSS::PropertyID::Rotate,
@@ -145,7 +145,8 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
             CSS::PropertyID::ClipPath,
             CSS::PropertyID::Opacity,
             CSS::PropertyID::MixBlendMode,
-            CSS::PropertyID::Filter)) {
+            CSS::PropertyID::Filter,
+            CSS::PropertyID::BackgroundAttachment)) {
         invalidation.rebuild_accumulated_visual_contexts = true;
     }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -124,6 +124,10 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
             [&](EffectsData const&) -> Optional<Gfx::FloatPoint> {
                 // Effects don't affect coordinate transforms
                 return point;
+            },
+            [&](ScrollCompensation const& compensation) -> Optional<Gfx::FloatPoint> {
+                point.translate_by(scroll_state.device_offset_for_index(compensation.scroll_frame_index));
+                return point;
             });
 
         if (!result.has_value())
@@ -188,6 +192,10 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
             [&](ScrollData const& scroll) {
                 rect.translate_by(scroll_state.device_offset_for_index(scroll.scroll_frame_index));
             },
+            [&](ScrollCompensation const& compensation) {
+                auto offset = scroll_state.device_offset_for_index(compensation.scroll_frame_index);
+                rect.translate_by(-offset);
+            },
             [&](ClipData const&) { /* clips don't affect rect coordinates */ },
             [&](ClipPathData const&) { /* clip paths don't affect rect coordinates */ },
             [&](EffectsData const&) { /* effects don't affect rect coordinates */ });
@@ -249,6 +257,9 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
                 has_content = true;
             }
             builder.append("]"sv);
+        },
+        [&](ScrollCompensation const& compensation) {
+            builder.appendff("scroll_compensation(frame_id={})", compensation.scroll_frame_index.value());
         });
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -73,7 +73,13 @@ struct EffectsData {
     }
 };
 
-using VisualContextData = Variant<ScrollData, ClipData, TransformData, PerspectiveData, ClipPathData, EffectsData>;
+// Negates a scroll frame's offset during display list replay. Used to keep fixed backgrounds stationary relative to
+// the viewport regardless of scroll position.
+struct ScrollCompensation {
+    ScrollFrameIndex scroll_frame_index;
+};
+
+using VisualContextData = Variant<ScrollData, ClipData, TransformData, PerspectiveData, ClipPathData, EffectsData, ScrollCompensation>;
 
 struct AccumulatedVisualContextNode {
     VisualContextData data;

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ScopeGuard.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibWeb/CSS/Sizing.h>
 #include <LibWeb/HTML/Navigable.h>
@@ -159,9 +160,15 @@ void paint_background(DisplayListRecordingContext& context, PaintableBox const& 
         auto image_rect = layer.image_rect;
         auto background_positioning_area = layer.background_positioning_area;
 
+        auto original_context = display_list_recorder.accumulated_visual_context();
+        ScopeGuard restore_context = [&] {
+            display_list_recorder.set_accumulated_visual_context(original_context);
+        };
+
         switch (layer.attachment) {
         case CSS::BackgroundAttachment::Fixed:
-            background_positioning_area.set_location(paintable_box.layout_node().root().navigable()->viewport_scroll_offset());
+            if (auto fixed_context = paintable_box.fixed_background_visual_context(); fixed_context.has_value())
+                display_list_recorder.set_accumulated_visual_context(*fixed_context);
             break;
         case CSS::BackgroundAttachment::Local:
             if (!paintable_box.is_viewport_paintable()) {
@@ -348,6 +355,18 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
             continue;
 
         auto background_positioning_area = get_box(layer.origin, border_box, paintable_box).rect;
+
+        // https://drafts.csswg.org/css-backgrounds-3/#background-origin
+        // If the background-attachment value for this layer is fixed, then this property has no effect: in this case
+        // the background positioning area is the initial containing block.
+        if (layer.attachment == CSS::BackgroundAttachment::Fixed
+            && paintable_box.fixed_background_visual_context().has_value()) {
+            if (auto navigable = paintable_box.navigable()) {
+                auto viewport_size = navigable->viewport_rect().size();
+                background_positioning_area = CSSPixelRect { { 0, 0 }, viewport_size };
+            }
+        }
+
         auto const& image = *layer.background_image;
 
         Optional<CSSPixels> specified_width {};

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -86,6 +86,12 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
                 if (!offset.is_zero())
                     translate({ .delta = offset.to_type<int>() });
             },
+            [&](ScrollCompensation const& compensation) {
+                save({});
+                auto offset = scroll_state.device_offset_for_index(compensation.scroll_frame_index);
+                if (!offset.is_zero())
+                    translate({ .delta = (-offset).to_type<int>() });
+            },
             [&](TransformData const& transform) {
                 save({});
                 apply_transform(transform.origin, transform.matrix);

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -167,7 +167,8 @@ void Paintable::paint_inspector_overlay(DisplayListRecordingContext& context) co
                     [](TransformData const&) { return true; },
                     [](PerspectiveData const&) { return true; },
                     [](ClipPathData const&) { return false; },
-                    [](EffectsData const&) { return false; });
+                    [](EffectsData const&) { return false; },
+                    [](ScrollCompensation const&) { return true; });
                 if (should_keep)
                     relevant_indices.append(i);
             }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -158,6 +158,7 @@ void PaintableBox::reset_for_relayout()
     m_own_scroll_frame_index = {};
     m_accumulated_visual_context_index = {};
     m_accumulated_visual_context_for_descendants_index = {};
+    m_fixed_background_visual_context = {};
 
     m_used_values_for_grid_template_columns = nullptr;
     m_used_values_for_grid_template_rows = nullptr;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -293,6 +293,9 @@ public:
         m_cached_phase_commands[to_underlying(phase)] = move(commands);
     }
 
+    void set_fixed_background_visual_context(VisualContextIndex index) { m_fixed_background_visual_context = index; }
+    [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const { return m_fixed_background_visual_context; }
+
     [[nodiscard]] ScrollFrameIndex enclosing_scroll_frame_index() const { return m_enclosing_scroll_frame_index; }
 
     [[nodiscard]] ScrollFrameIndex own_scroll_frame_index() const { return m_own_scroll_frame_index; }
@@ -338,6 +341,7 @@ private:
     ScrollFrameIndex m_own_scroll_frame_index {};
     VisualContextIndex m_accumulated_visual_context_index {};
     VisualContextIndex m_accumulated_visual_context_for_descendants_index {};
+    Optional<VisualContextIndex> m_fixed_background_visual_context;
 
     Optional<BordersDataWithElementKind> m_override_borders_data;
     Optional<TableCellCoordinates> m_table_cell_coordinates;

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -41,7 +41,7 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
             context.display_list_recorder().set_accumulated_visual_context(paintable_box->accumulated_visual_context_index());
     }
 
-    bool const skip_cache = !paintable_box || context.should_show_line_box_borders();
+    bool const skip_cache = !paintable_box || context.should_show_line_box_borders() || paintable_box->fixed_background_visual_context().has_value();
     if (!skip_cache && paintable_box->has_cached_commands(phase)) {
         context.display_list_recorder().replay_cached_commands(paintable_box->cached_commands(phase));
     } else if (!skip_cache) {

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/CSS/VisualViewport.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Range.h>
+#include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
@@ -430,6 +431,53 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
         }
 
         paintable_box.set_accumulated_visual_context(own_state);
+
+        Vector<CSS::BackgroundLayerData> const* background_layers = &computed_values.background_layers();
+        if (paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
+            if (auto* html_element = as_if<HTML::HTMLHtmlElement>(paintable_box.dom_node().ptr())) {
+                if (html_element->should_use_body_background_properties())
+                    background_layers = paintable_box.document().background_layers();
+            }
+        }
+
+        if (background_layers) {
+            bool has_fixed_background = false;
+            for (auto const& layer : *background_layers) {
+                if (layer.attachment == CSS::BackgroundAttachment::Fixed) {
+                    has_fixed_background = true;
+                    break;
+                }
+            }
+
+            if (has_fixed_background) {
+                // https://drafts.csswg.org/css-transforms-1/#transform-rendering
+                // For elements that are effected by a transform (i.e. have a transform applied to them, or to any of
+                // their ancestor elements) and do not have their background propagated to the canvas, a value of fixed
+                // for the background-attachment property is treated as if it had a value of scroll.
+                auto has_transform_ancestor = false;
+                if (!paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
+                    for (auto const* node = &paintable_box.layout_node(); node && !node->is_viewport(); node = node->parent()) {
+                        if (node->has_css_transform()) {
+                            has_transform_ancestor = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!has_transform_ancestor) {
+                    // Build a context that negates all scroll frames in the ancestor chain. This keeps the background
+                    // fixed relative to the viewport.
+                    auto fixed_background_context = own_state;
+                    for (auto index = own_state; index.value(); index = m_visual_context_tree->node_at(index).parent_index) {
+                        auto const& node = m_visual_context_tree->node_at(index);
+                        if (auto const* scroll = node.data.get_pointer<ScrollData>()) {
+                            fixed_background_context = append_node(fixed_background_context, ScrollCompensation { scroll->scroll_frame_index });
+                        }
+                    }
+                    paintable_box.set_fixed_background_visual_context(fixed_background_context);
+                }
+            }
+        }
 
         // Build state for descendants: own state + perspective + clip + scroll.
         VisualContextIndex state_for_descendants = own_state;

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-backgrounds/background-attachment-fixed-inside-transform-1-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-backgrounds/background-attachment-fixed-inside-transform-1-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Background: background-attachment: background-attachment:fixed inside a transform</title>
+    <link rel="author" title="Botond Ballo" href="mailto:botond@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <style type="text/css">
+      body {
+        height: 4000px;
+        margin: 0;
+      }
+
+      #outer {
+        margin: 200px;
+        height: 700px;
+        width: 300px;
+        transform: rotate(45deg);
+        overflow: hidden;
+      }
+
+      #inner {
+        height: 700px;
+        background-image: radial-gradient(farthest-corner at center, blue, black);
+        background-size: 300px 300px;
+        background-position: 200px 200px;
+        background-color: lime;
+        background-repeat: no-repeat;
+        background-attachment: scroll;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="outer">
+      <div id="inner">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-backgrounds/background-attachment-fixed-inside-transform-1.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-backgrounds/background-attachment-fixed-inside-transform-1.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Background: background-attachment: background-attachment:fixed inside a transform</title>
+    <link rel="author" title="Botond Ballo" href="mailto:botond@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://www.w3.org/TR/css-transforms-1/#transform-rendering">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-backgrounds/background-attachment-fixed-inside-transform-1-ref.html">
+    <meta name="assert" content="Test checks whether background-attachment: 'fixed' inside a transform behaves like background-attachment: 'scroll'.">
+    <style>
+      body {
+        height: 4000px;
+        margin: 0;
+      }
+
+      #outer {
+        margin: 200px;
+        height: 700px;
+        width: 300px;
+        transform: rotate(45deg);
+        overflow: hidden;
+      }
+
+      #inner {
+        height: 700px;
+        background-image: radial-gradient(farthest-corner at center, blue, black);
+        background-size: 300px 300px;
+        background-position: 200px 200px;
+        background-color: lime;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+      }
+    </style>
+  </head>
+    <body>
+      <div id="outer">
+        <div id="inner">
+        </div>
+      </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
@@ -1,0 +1,11 @@
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] scroll_compensation(frame_id=1)
+
+DisplayList:
+SaveLayer@0
+  Save@1
+    PaintLinearGradient@2 rect=[0,0 800x600]
+  Restore@1
+Restore@0
+

--- a/Tests/LibWeb/Text/input/display_list/background-attachment-fixed.html
+++ b/Tests/LibWeb/Text/input/display_list/background-attachment-fixed.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+        height: 200vh;
+        background-attachment: fixed;
+        background-image: linear-gradient(green, blue);
+        background-size: 100% 100vh;
+        background-repeat: no-repeat;
+    }
+</style>
+<script>
+    test(() => {
+        println(internals.dumpDisplayList());
+    });
+</script>


### PR DESCRIPTION
Previously, fixed backgrounds incorrectly scrolled with content when scrolling incrementally. We now negate the viewport scroll offset during display list replay for fixed backgrounds. This keeps the background static relative to the viewport.

This fixes the background rendering issue seen on http://futo.org in the latest [Ladybird update video](https://www.youtube.com/watch?v=7_qhUidegUM&t=1141s).

Fixes #4981