### PR TITLE
CI: Allow clang_plugins to be used in more CI jobs

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -213,7 +213,7 @@ jobs:
         if: ${{ always() && inputs.build_preset != 'Fuzzers' && inputs.build_preset != 'All_Debug' }}
         uses: actions/upload-artifact@v6
         with:
-          name: libweb-test-artifacts-${{ inputs.os_name }}-${{ inputs.build_preset }}-${{ inputs.toolchain }}-${{ inputs.clang_plugins }}
+          name: libweb-test-artifacts-${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.build_preset }}-${{ inputs.toolchain }}-${{ inputs.clang_plugins }}
           path: ${{ github.workspace }}/Build/Lagom/Tests/LibWeb/test-web/test-dumps/
           retention-days: 0
           if-no-files-found: ignore


### PR DESCRIPTION
Due to the name used to upload the test-web artificats missing the 'arch' value, a duplicate name could be generated if multiple CI jobs use clang_plugins set to true causing artifact upload failure.

Currently not possible to use clang_plugins for these at the same time:

Linux, x86_64, Sanitizer, Clang
Linux, arm64, Sanitizer, Clang

As more CI jobs are added, more possibility of a conflict if using clang_plugins in more situations.

If the name conflicts the following may by reported:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```