### PR TITLE
LibWeb: Apply intermediate stacking context effects to abspos elements

### DIFF
--- a/Tests/LibWeb/Ref/expected/abspos-inside-opacity-inside-relpos-ref.html
+++ b/Tests/LibWeb/Ref/expected/abspos-inside-opacity-inside-relpos-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+</style>
+<!-- A black box at 50% opacity should appear as gray (#808080) -->
+<div style="width: 100px; height: 100px; background: black; opacity: 0.5;"></div>

--- a/Tests/LibWeb/Ref/input/abspos-inside-opacity-inside-relpos.html
+++ b/Tests/LibWeb/Ref/input/abspos-inside-opacity-inside-relpos.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/abspos-inside-opacity-inside-relpos-ref.html">
+<style>
+body {
+    margin: 0;
+    background: white;
+}
+.relpos {
+    position: relative;
+    width: 200px;
+    height: 200px;
+}
+.opacity {
+    opacity: 0.5;
+}
+.abspos {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100px;
+    height: 100px;
+    background: black;
+}
+</style>
+<div class="relpos">
+    <div class="opacity">
+        <div class="abspos"></div>
+    </div>
+</div>

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
@@ -1,0 +1,11 @@
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
+      [5] effects=[opacity=0.5]
+        [6] effects=[opacity=0.3] (PaintableWithLines(BlockContainer<DIV>.abspos))
+
+DisplayList:
+SaveLayer@0
+  FillRect@6 rect=[8,8 100x100] color=rgb(0, 0, 0)
+Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
@@ -1,0 +1,10 @@
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
+      [4] effects=[opacity=0.5] (PaintableWithLines(BlockContainer<DIV>.abspos))
+
+DisplayList:
+SaveLayer@0
+  FillRect@4 rect=[8,8 100x100] color=rgb(0, 0, 0)
+Restore@0
+

--- a/Tests/LibWeb/Text/input/display_list/abspos-inside-nested-opacity-inside-relpos.html
+++ b/Tests/LibWeb/Text/input/display_list/abspos-inside-nested-opacity-inside-relpos.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .relpos {
+        position: relative;
+        width: 200px;
+        height: 200px;
+        overflow: hidden;
+    }
+    .outer-opacity {
+        opacity: 0.5;
+    }
+    .inner-opacity {
+        opacity: 0.3;
+    }
+    .abspos {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100px;
+        height: 100px;
+        background: black;
+    }
+</style>
+<div class="relpos">
+    <div class="outer-opacity">
+        <div class="inner-opacity">
+            <div class="abspos"></div>
+        </div>
+    </div>
+</div>
+<script>
+    test(() => {
+        println(internals.dumpDisplayList());
+    });
+</script>

--- a/Tests/LibWeb/Text/input/display_list/abspos-inside-opacity-inside-relpos.html
+++ b/Tests/LibWeb/Text/input/display_list/abspos-inside-opacity-inside-relpos.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .relpos {
+        position: relative;
+        width: 200px;
+        height: 200px;
+        overflow: hidden;
+    }
+    .opacity {
+        opacity: 0.5;
+    }
+    .abspos {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100px;
+        height: 100px;
+        background: black;
+    }
+</style>
+<div class="relpos">
+    <div class="opacity">
+        <div class="abspos"></div>
+    </div>
+</div>
+<script>
+    test(() => {
+        println(internals.dumpDisplayList());
+    });
+</script>


### PR DESCRIPTION
Previously, absolutely positioned elements jumped directly to their containing block's accumulated visual context, skipping effects (opacity, mix-blend-mode, isolation) from intermediate ancestors. Per CSS spec, these properties create stacking contexts that abspos elements cannot escape — they only escape scroll containers and overflow clips.