### PR TITLE
LibWeb: Compute SVG mask/clip transforms using layout tree hierarchy

### DIFF
--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -36,6 +36,8 @@ private:
     [[nodiscard]] Gfx::Path compute_path_for_text(SVGTextBox const&) const;
     [[nodiscard]] Gfx::Path compute_path_for_text_path(SVGTextPathBox const&) const;
 
+    [[nodiscard]] Gfx::AffineTransform get_parent_svg_transform(SVGGraphicsBox const&) const;
+
     Gfx::AffineTransform m_parent_viewbox_transform {};
 
     Optional<AvailableSpace> m_available_space {};

--- a/Libraries/LibWeb/Painting/SVGMaskable.h
+++ b/Libraries/LibWeb/Painting/SVGMaskable.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -25,6 +26,9 @@ public:
     // For <clipPath> element
     Optional<CSSPixelRect> get_svg_clip_area() const;
     RefPtr<DisplayList> calculate_svg_clip_display_list(DisplayListRecordingContext&, CSSPixelRect const& clip_area) const;
+
+private:
+    Gfx::AffineTransform target_svg_transform() const;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -124,15 +124,6 @@ Gfx::AffineTransform transform_from_transform_list(ReadonlySpan<Transform> trans
     return affine_transform;
 }
 
-Gfx::AffineTransform SVGGraphicsElement::get_transform() const
-{
-    Gfx::AffineTransform transform = m_transform;
-    for (auto* svg_ancestor = shadow_including_first_ancestor_of_type<SVGGraphicsElement>(); svg_ancestor; svg_ancestor = svg_ancestor->shadow_including_first_ancestor_of_type<SVGGraphicsElement>()) {
-        transform = Gfx::AffineTransform { svg_ancestor->element_transform() }.multiply(transform);
-    }
-    return transform;
-}
-
 static FillRule to_svg_fill_rule(CSS::FillRule fill_rule)
 {
     switch (fill_rule) {

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -63,8 +63,6 @@ public:
         return 0;
     }
 
-    Gfx::AffineTransform get_transform() const;
-
     Optional<Painting::PaintStyle> fill_paint_style(SVGPaintContext const&) const;
     Optional<Painting::PaintStyle> stroke_paint_style(SVGPaintContext const&) const;
 


### PR DESCRIPTION
No observable behavior change — this is a refactoring of how SVG transforms are computed for mask and clip content.

Previously, SVGGraphicsElement::get_transform() computed accumulated transforms by walking the DOM tree. This didn't work correctly for masks and clips because their DOM structure differs from layout: in the DOM, mask/clip elements are siblings or ancestors of their targets, but in the layout tree they become children of the target element. Walking the DOM tree caused transforms from the target's ancestors to incorrectly leak into mask/clip content.

The fix walks the layout tree instead of the DOM tree, which means transform computation must happen during layout (where we have access to the layout tree structure) rather than on-demand from the DOM element. This moves the logic to SVGFormattingContext and removes get_transform() since it can no longer serve its purpose — the DOM element only provides element_transform() for its own transform now.

During layout, we walk up the layout tree and stop at mask/clip boundaries, ensuring mask/clip content stays in its own coordinate space. The target's accumulated transform is applied separately at paint time.