### PR TITLE
LibWeb/CSS: Stop parsing media-features without parentheses

### DIFF
--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -74,21 +74,23 @@ String MediaFeature::to_string() const
 
     switch (m_type) {
     case Type::IsTrue:
-        return MUST(String::from_utf8(string_from_media_feature_id(m_id)));
+        return MUST(String::formatted("({})", string_from_media_feature_id(m_id)));
     case Type::ExactValue:
-        return MUST(String::formatted("{}: {}", string_from_media_feature_id(m_id), value().to_string(SerializationMode::Normal)));
+        return MUST(String::formatted("({}: {})", string_from_media_feature_id(m_id), value().to_string(SerializationMode::Normal)));
     case Type::MinValue:
-        return MUST(String::formatted("min-{}: {}", string_from_media_feature_id(m_id), value().to_string(SerializationMode::Normal)));
+        return MUST(String::formatted("(min-{}: {})", string_from_media_feature_id(m_id), value().to_string(SerializationMode::Normal)));
     case Type::MaxValue:
-        return MUST(String::formatted("max-{}: {}", string_from_media_feature_id(m_id), value().to_string(SerializationMode::Normal)));
+        return MUST(String::formatted("(max-{}: {})", string_from_media_feature_id(m_id), value().to_string(SerializationMode::Normal)));
     case Type::Range: {
         auto& range = this->range();
         StringBuilder builder;
+        builder.append('(');
         if (range.left_comparison.has_value())
             builder.appendff("{} {} ", range.left_value->to_string(SerializationMode::Normal), comparison_string(*range.left_comparison));
         builder.append(string_from_media_feature_id(m_id));
         if (range.right_comparison.has_value())
             builder.appendff(" {} {}", comparison_string(*range.right_comparison), range.right_value->to_string(SerializationMode::Normal));
+        builder.append(')');
 
         return builder.to_string_without_validation();
     }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/overflow-media-features.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/overflow-media-features.txt
@@ -2,13 +2,12 @@ Harness status: OK
 
 Found 28 tests
 
-26 Pass
-2 Fail
+28 Pass
 Pass	Should be known: '(overflow-inline)'
 Pass	Should be known: '(overflow-inline: none)'
 Pass	Should be known: '(overflow-inline: scroll)'
 Pass	Should be parseable: 'overflow-inline'
-Fail	Should be unknown: 'overflow-inline'
+Pass	Should be unknown: 'overflow-inline'
 Pass	Should be parseable: '(overflow-inline: ?)'
 Pass	Should be unknown: '(overflow-inline: ?)'
 Pass	Should be parseable: '(overflow-inline: 10px)'
@@ -20,7 +19,7 @@ Pass	Should be known: '(overflow-block: none)'
 Pass	Should be known: '(overflow-block: scroll)'
 Pass	Should be known: '(overflow-block: paged)'
 Pass	Should be parseable: 'overflow-block'
-Fail	Should be unknown: 'overflow-block'
+Pass	Should be unknown: 'overflow-block'
 Pass	Should be parseable: '(overflow-block: ?)'
 Pass	Should be unknown: '(overflow-block: ?)'
 Pass	Should be parseable: '(overflow-block: 10px)'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/test_media_queries.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/mediaqueries/test_media_queries.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 1345 tests
 
-1343 Pass
-2 Fail
+1345 Pass
 Pass	query_should_be_parseable: (orientation)
 Pass	query_should_be_parseable: not (orientation)
 Pass	expression_should_be_known: (orientation)
@@ -1262,8 +1261,8 @@ Pass	should_apply: [badsyntax],all
 Pass	should_not_apply: badmedium,[badsyntax]
 Pass	should_not_apply: [badsyntax],badmedium
 Pass	query_should_not_be_parseable: all and color :
-Fail	query_should_not_be_parseable: all and color : 1
-Fail	should_not_apply: all and min-color : 1
+Pass	query_should_not_be_parseable: all and color : 1
+Pass	should_not_apply: all and min-color : 1
 Pass	should_not_apply: (bogus)
 Pass	should_not_apply: not all and (bogus)
 Pass	should_not_apply: only all and (bogus)


### PR DESCRIPTION
Our parsing code was treating `foo` and `foo: bar` as `<media-feature>`s when really they need to be `(foo)` and `(foo: bar)` respectively. This previously worked for the valid case because boolean expressions can also have arbitrary `()` blocks. However, it meant we'd also allow them without the parentheses which isn't valid.

So instead, parse and serialize the parentheses as part of the `<media-feature>`. This gets us some WPT passes and fixes an Acid3 failure.