### PR TITLE
LibWasm: Use musttail on release builds only for GNU GCC 15

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -31,9 +31,13 @@ using namespace AK::SIMD;
 #ifdef AK_COMPILER_CLANG
 #    define TAILCALL [[clang::musttail]]
 #    define HAS_TAILCALL
-#elif defined(AK_COMPILER_GCC) && (__GNUC__ > 14)
-#    define TAILCALL [[gnu::musttail]]
-#    define HAS_TAILCALL
+#elif defined(AK_COMPILER_GCC)
+#    if ((__GNUC__ > 15) || ((__GNUC__ == 15) && defined(NDEBUG) && !defined(HAS_ADDRESS_SANITIZER)))
+#        define TAILCALL [[gnu::musttail]]
+#        define HAS_TAILCALL
+#    else
+#        define TAILCALL
+#    endif
 #else
 #    define TAILCALL
 #endif


### PR DESCRIPTION
In preperation for Ubuntu 26.04 LTS, which will most likely come default with GNU GCC 15.2.0 (but should have versions 14 and 16 available), found that musttail/tail-call optimization fails for non-release builds.

Testing done on Ubuntu 25.10 which has GNU GCC 15.2.0 as default, checking: Release, Debug, All_Debug, Sanitizer, and Distribution.

Fixes: #6745