### PR TITLE
Documentation: Add missing 'less' command to Arch Linux dependencies

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -73,7 +73,7 @@ sudo apt install libpulse-dev
 ### Arch Linux/Manjaro:
 
 ```
-sudo pacman -S --needed autoconf-archive base-devel ccache cmake curl git libgl nasm ninja python qt6-base qt6-tools ttf-liberation tar unzip zip
+sudo pacman -S --needed autoconf-archive base-devel ccache cmake curl git less libgl nasm ninja python qt6-base qt6-tools ttf-liberation tar unzip zip
 ```
 
 Optionally, install the PulseAudio headers for audio playback support:


### PR DESCRIPTION
After installing Arch Linux 2026.02.01 and following the instructions in Documentation/BuildInstructionsLadybird.md to install the dependencies, using git command will fail due to missing pager less.

```
$ git log
error: cannot run less: No such file or directory
fatal: unable to execute pager 'less'
```