### PR TITLE
CI: Update stale URL for git-gloss

### DIFF
--- a/.github/workflows/notes-push.yml
+++ b/.github/workflows/notes-push.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: fregante/setup-git-user@v2
       - run: |
           git fetch origin "refs/notes/*:refs/notes/*"
-          curl -fsSLO https://sideshowbarker.github.io/git-gloss/git-gloss && bash ./git-gloss
+          curl -fsSLO https://github.com/gh-tui-tools/git-gloss/raw/refs/heads/main/git-gloss && bash ./git-gloss
           git push origin "refs/notes/*" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The notes-push.yml script was silently failing since the previous URL now 404s, causing notes to remain unupdated since January 18. This new URL should work for as long as the git-gloss repository exists.