### PR TITLE
LibWeb/HTML: Actually use charset encoding for linked style sheets

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -831,10 +831,9 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
         //     1. If the element has a charset attribute, get an encoding from that attribute's value. If that succeeds, return the resulting encoding. [ENCODING]
         //     2. Otherwise, return the document's character encoding. [DOM]
         Optional<StringView> environment_encoding;
-        if (auto charset = attribute(HTML::AttributeNames::charset); charset.has_value()) {
-            if (auto environment_encoding = TextCodec::get_standardized_encoding(charset.release_value()); environment_encoding.has_value())
-                environment_encoding = environment_encoding.value();
-        }
+        if (auto charset = attribute(HTML::AttributeNames::charset); charset.has_value())
+            environment_encoding = TextCodec::get_standardized_encoding(charset.release_value());
+
         if (!environment_encoding.has_value() && document().encoding().has_value())
             environment_encoding = document().encoding().value();
 


### PR DESCRIPTION
This code that used `charset` created a second `environment_encoding` variable which shadowed the outer one, making it a no-op. Now we actually use its value.