### PR TITLE
LibJS: Consume identifier when matching an identifier name in bindings

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -3320,7 +3320,7 @@ RefPtr<BindingPattern const> Parser::parse_binding_pattern(Parser::AllowDuplicat
                         return {};
                     alias = binding_pattern.release_nonnull();
                 } else if (match_identifier_name()) {
-                    alias = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, consume().fly_string_value());
+                    alias = create_identifier_and_register_in_current_scope({ m_source_code, rule_start.position(), position() }, consume_identifier().fly_string_value());
                 } else {
                     expected("identifier or binding pattern");
                     return {};

--- a/Tests/LibJS/Runtime/regress/reserved-value-word-is-not-rejected-as-property-value-in-object-decl.js
+++ b/Tests/LibJS/Runtime/regress/reserved-value-word-is-not-rejected-as-property-value-in-object-decl.js
@@ -1,0 +1,13 @@
+test("reserved value word is not rejected when it appears in a nested object expression", () => {
+    expect("(({a:{b:null}}))").toEval();
+    expect("(({a:{b:true}}))").toEval();
+    expect("(({a:{b:false}}))").toEval();
+    expect("(({a:{b:{c:null}}}))").toEval();
+    expect("(({a:{b:null},c:()=>0}))").toEval();
+    expect("(({a:{b:true},c:()=>0}))").toEval();
+    expect("(({a:{b:false},c:()=>0}))").toEval();
+    expect("(({a:{b:{c:null}},c:()=>0}))").toEval();
+    expect("(({a:{b:{c:this}},c:()=>0}))").toEval();
+    expect("(({a:{b:{c:class{}}},c:()=>0}))").toEval();
+    expect("(({a:{b:{c:function(){}}},c:()=>0}))").toEval();
+});


### PR DESCRIPTION
Otherwise we'll fail to recognise that the identifier token is invalid (e.g. a keyword such as null) in a binding pattern and that it may not be a binding pattern after all, but an object expression.

Fixes some scripts on Discord failing to parse.