### PR TITLE
Tests/LibWeb: Skip Text/input/device-pixel-ratio-media-query.html

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,6 +20,9 @@ Text/input/css/transition-basics.html
 ; Times out on CI, possibly animation related: https://github.com/LadybirdBrowser/ladybird/issues/7742
 Crash/wpt-import/editing/crashtests/designMode-caret-change.html
 
+; Times out on CI - https://github.com/LadybirdBrowser/ladybird/issues/7790
+Text/input/device-pixel-ratio-media-query.html
+
 ; Worker tests are flaky on CI
 Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-close-after-postMessage.html


### PR DESCRIPTION
It's flaky on CI.