### PR TITLE
test-web: Always capture stdout/stderr and optionally tee output

### DIFF
--- a/Tests/LibWeb/test-web/Application.cpp
+++ b/Tests/LibWeb/test-web/Application.cpp
@@ -98,9 +98,4 @@ ErrorOr<void> Application::launch_test_fixtures()
     return {};
 }
 
-bool Application::should_capture_web_content_output() const
-{
-    return verbosity < Application::VERBOSITY_LEVEL_LOG_TEST_OUTPUT;
-}
-
 }

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -22,7 +22,8 @@ public:
 
     virtual void create_platform_arguments(Core::ArgsParser&) override;
     virtual void create_platform_options(WebView::BrowserOptions&, WebView::RequestServerOptions&, WebView::WebContentOptions&) override;
-    virtual bool should_capture_web_content_output() const override;
+    virtual bool should_capture_web_content_output() const override { return true; }
+
     ErrorOr<void> launch_test_fixtures();
 
     static constexpr u8 VERBOSITY_LEVEL_LOG_TEST_OUTPUT = 1;


### PR DESCRIPTION
I added the VERBOSITY_LEVEL_LOG_TEST_OUTPUT level for the case where I run test-web with a filter for a single file, in which case I want to just see the test output in the terminal. But for CI, we want to always capture output for the uploaded test artifacts.

This patch changes this verbosity level to instead tee the output. So we always create the results artifacts with all logs, and optionally echo the received output.