### PR TITLE
Implemented curl_code_to_network_error as an inline constexpr functio…

### DIFF
--- a/Services/RequestServer/CURL.cpp
+++ b/Services/RequestServer/CURL.cpp
@@ -7,6 +7,8 @@
 
 #include <AK/Enumerate.h>
 #include <RequestServer/CURL.h>
+#include <array>
+#include <utility>
 
 namespace RequestServer {
 
@@ -27,34 +29,6 @@ ByteString build_curl_resolve_list(DNS::LookupResult const& dns_result, StringVi
 
     dbgln_if(REQUESTSERVER_DEBUG, "RequestServer: Resolve list: {}", resolve_opt_builder.string_view());
     return resolve_opt_builder.to_byte_string();
-}
-
-Requests::NetworkError curl_code_to_network_error(int code)
-{
-    switch (code) {
-    case CURLE_COULDNT_RESOLVE_HOST:
-        return Requests::NetworkError::UnableToResolveHost;
-    case CURLE_COULDNT_RESOLVE_PROXY:
-        return Requests::NetworkError::UnableToResolveProxy;
-    case CURLE_COULDNT_CONNECT:
-        return Requests::NetworkError::UnableToConnect;
-    case CURLE_OPERATION_TIMEDOUT:
-        return Requests::NetworkError::TimeoutReached;
-    case CURLE_TOO_MANY_REDIRECTS:
-        return Requests::NetworkError::TooManyRedirects;
-    case CURLE_SSL_CONNECT_ERROR:
-        return Requests::NetworkError::SSLHandshakeFailed;
-    case CURLE_PEER_FAILED_VERIFICATION:
-        return Requests::NetworkError::SSLVerificationFailed;
-    case CURLE_URL_MALFORMAT:
-        return Requests::NetworkError::MalformedUrl;
-    case CURLE_PARTIAL_FILE:
-        return Requests::NetworkError::IncompleteContent;
-    case CURLE_BAD_CONTENT_ENCODING:
-        return Requests::NetworkError::InvalidContentEncoding;
-    default:
-        return Requests::NetworkError::Unknown;
-    }
 }
 
 }

--- a/Services/RequestServer/CURL.h
+++ b/Services/RequestServer/CURL.h
@@ -19,11 +19,39 @@
 #    include <AK/Windows.h> // Needed because curl.h includes winsock2.h
 #endif
 
+#include <array>
 #include <curl/curl.h>
 
 namespace RequestServer {
 
 ByteString build_curl_resolve_list(DNS::LookupResult const& dns_result, StringView host, u16 port);
-Requests::NetworkError curl_code_to_network_error(int code);
+
+struct ErrorMapping {
+    int curl_code;
+    Requests::NetworkError network_error;
+};
+
+inline constexpr Requests::NetworkError curl_code_to_network_error(int code)
+{
+    constexpr std::array<ErrorMapping, 10> error_map { {
+        { CURLE_COULDNT_RESOLVE_HOST, Requests::NetworkError::UnableToResolveHost },
+        { CURLE_COULDNT_RESOLVE_PROXY, Requests::NetworkError::UnableToResolveProxy },
+        { CURLE_COULDNT_CONNECT, Requests::NetworkError::UnableToConnect },
+        { CURLE_OPERATION_TIMEDOUT, Requests::NetworkError::TimeoutReached },
+        { CURLE_TOO_MANY_REDIRECTS, Requests::NetworkError::TooManyRedirects },
+        { CURLE_SSL_CONNECT_ERROR, Requests::NetworkError::SSLHandshakeFailed },
+        { CURLE_PEER_FAILED_VERIFICATION, Requests::NetworkError::SSLVerificationFailed },
+        { CURLE_URL_MALFORMAT, Requests::NetworkError::MalformedUrl },
+        { CURLE_PARTIAL_FILE, Requests::NetworkError::IncompleteContent },
+        { CURLE_BAD_CONTENT_ENCODING, Requests::NetworkError::InvalidContentEncoding },
+    } };
+
+    for (auto const& entry : error_map) {
+        if (entry.curl_code == code)
+            return entry.network_error;
+    }
+
+    return Requests::NetworkError::Unknown;
+}
 
 }

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -599,7 +599,7 @@ void Request::handle_complete_state()
             m_curl_result_code = CURLE_OK;
 
         if (m_curl_result_code != CURLE_OK) {
-            m_network_error = curl_code_to_network_error(*m_curl_result_code);
+            m_network_error = RequestServer::curl_code_to_network_error(*m_curl_result_code);
 
             if (m_network_error == Requests::NetworkError::Unknown) {
                 char const* curl_error_message = curl_easy_strerror(static_cast<CURLcode>(*m_curl_result_code));


### PR DESCRIPTION
Description:

This PR refactors the curl_code_to_network_error utility to use a constexpr lookup table instead of a procedural switch statement.

Changes:

Defined ErrorMapping struct to pair CURL codes with NetworkError enums.

Implemented curl_code_to_network_error as an inline constexpr function using std::array.
