### PR TITLE
LibWeb/Bindings: Use DefineDataPropertyOrThrow in Replaceable setter

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -4488,8 +4488,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
             if (attribute.extended_attributes.contains("Replaceable"sv)) {
                 attribute_generator.append(R"~~~(
     // 1. Perform ? CreateDataPropertyOrThrow(jsValue, id, V).
-    JS::PropertyDescriptor descriptor { .value = value, .writable = true };
-    TRY(impl->internal_define_own_property("@attribute.name@"_utf16_fly_string, descriptor));
+    TRY(impl->create_data_property_or_throw("@attribute.name@"_utf16_fly_string, value));
 
     // 2. Return undefined.
     return JS::js_undefined();

--- a/Tests/LibWeb/Text/expected/wpt-import/webidl/ecmascript-binding/replaceable-setter-throws-if-defineownproperty-fails.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webidl/ecmascript-binding/replaceable-setter-throws-if-defineownproperty-fails.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Pass
+Pass	window.self setter throws TypeError if called on non-configurable accessor property
+Pass	window.parent setter throws TypeError if called on non-configurable accessor property
+Pass	window.origin setter throws TypeError if called on non-configurable accessor property
+Pass	window.innerWidth setter throws TypeError if called on non-configurable accessor property
+Pass	window.screen setter throws TypeError if called on non-configurable non-writable data property
+Pass	window.length setter throws TypeError if called on non-configurable non-writable data property
+Pass	window.event setter throws TypeError if called on non-configurable non-writable data property
+Pass	window.outerHeight setter throws TypeError if called on non-configurable non-writable data property

--- a/Tests/LibWeb/Text/input/wpt-import/webidl/ecmascript-binding/replaceable-setter-throws-if-defineownproperty-fails.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webidl/ecmascript-binding/replaceable-setter-throws-if-defineownproperty-fails.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>[Replaceable] setter throws TypeError if [[DefineOwnProperty]] fails</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<link rel="author" title="Alexey Shvayka" href="shvaikalesh@gmail.com">
+<link rel="help" href="https://webidl.spec.whatwg.org/#Replaceable">
+
+<body>
+<script>
+for (const key of ["self", "parent", "origin", "innerWidth"]) {
+    test(() => {
+        Object.defineProperty(window, key, { configurable: false });
+        assert_throws_js(TypeError, () => { window[key] = 1; });
+
+        const desc = Object.getOwnPropertyDescriptor(window, key);
+        assert_false("value" in desc);
+        assert_equals(typeof desc.get, "function");
+        assert_equals(typeof desc.set, "function");
+        assert_true(desc.enumerable);
+        assert_false(desc.configurable);
+    }, `window.${key} setter throws TypeError if called on non-configurable accessor property`);
+}
+
+for (const key of ["screen", "length", "event", "outerHeight"]) {
+    test(() => {
+        const { set } = Object.getOwnPropertyDescriptor(window, key);
+        Object.defineProperty(window, key, { value: 1, writable: false, configurable: false });
+        assert_throws_js(TypeError, () => { set.call(window, 2); });
+
+        const desc = Object.getOwnPropertyDescriptor(window, key);
+        assert_equals(desc.value, 1);
+        assert_false(desc.writable);
+        assert_true(desc.enumerable);
+        assert_false(desc.configurable);
+    }, `window.${key} setter throws TypeError if called on non-configurable non-writable data property`);
+}
+</script>


### PR DESCRIPTION
One more fix for attribute setters which I missed in https://github.com/LadybirdBrowser/ladybird/pull/7699