### PR TITLE
LibWeb: Don't rebuild layout tree on SVG transform change

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -109,6 +109,7 @@ enum class StyleInvalidationReason {
     X(KeyframeEffect)                                 \
     X(LayoutTreeUpdate)                               \
     X(NavigableSetViewportSize)                       \
+    X(SVGGraphicsElementTransformChange)              \
     X(SVGImageElementFetchTheDocument)                \
     X(SVGImageFilterFetch)                            \
     X(StyleChange)
@@ -133,7 +134,6 @@ enum class SetNeedsLayoutReason {
     X(NodeRemove)                                         \
     X(NodeSetTextContent)                                 \
     X(None)                                               \
-    X(SVGGraphicsElementTransformChange)                  \
     X(SVGViewBoxChange)                                   \
     X(StyleChange)
 

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -47,7 +47,8 @@ void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<Strin
         auto transform_list = AttributeParser::parse_transform(value.value_or(String {}));
         if (transform_list.has_value())
             m_transform = transform_from_transform_list(*transform_list);
-        set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::SVGGraphicsElementTransformChange);
+        if (layout_node())
+            layout_node()->set_needs_layout_update(DOM::SetNeedsLayoutReason::SVGGraphicsElementTransformChange);
     }
 }
 


### PR DESCRIPTION
The SVG `transform` attribute is stored on the DOM element and read directly during layout by
`SVGFormattingContext::layout_graphics_element()`. Since changing the transform doesn't affect which DOM nodes produce layout boxes or how they're structured, we only need to re-run layout on the existing tree instead of rebuild it from scratch.