### PR TITLE
LibJS: Detect direct eval calls in parse_call_expression()

### DIFF
--- a/Tests/LibJS/Runtime/scope-local-eval-deopt.js
+++ b/Tests/LibJS/Runtime/scope-local-eval-deopt.js
@@ -381,4 +381,47 @@ describe("scope-local eval deoptimization", () => {
         expect(globalThis.sharedName111).toBe("global");
         delete globalThis.sharedName111;
     });
+
+    test("eval as subexpression of binary operator", () => {
+        function foo(n) {
+            let local = n | 0;
+            let code = "local + 11";
+            return eval(code) | 0;
+        }
+        expect(foo(3)).toBe(14);
+    });
+
+    test("eval as subexpression of ternary operator", () => {
+        function foo(n) {
+            let local = n;
+            return eval("local") ? "truthy" : "falsy";
+        }
+        expect(foo(1)).toBe("truthy");
+        expect(foo(0)).toBe("falsy");
+    });
+
+    test("eval as argument to another function call", () => {
+        function foo(n) {
+            let local = n * 2;
+            return String(eval("local"));
+        }
+        expect(foo(21)).toBe("42");
+    });
+
+    test("eval in comma expression", () => {
+        function foo(n) {
+            let local = n;
+            return (0, eval("local + 1"));
+        }
+        expect(foo(5)).toBe(6);
+    });
+
+    test("eval result used in assignment expression", () => {
+        function foo(n) {
+            let local = n;
+            let result = eval("local") + 100;
+            return result;
+        }
+        expect(foo(23)).toBe(123);
+    });
 });


### PR DESCRIPTION
The parser previously detected direct eval() calls at the end of parse_expression(), by checking if the final expression was a CallExpression with "eval" as the callee. This missed cases where eval() appeared as a subexpression, e.g. `eval(code) | 0`, since the final expression would be a BinaryExpression, not a CallExpression.

Move the detection into parse_call_expression() where the CallExpression is actually created. This ensures we always set the contains_direct_call_to_eval flag regardless of surrounding operators, so local variables are correctly placed in the declarative environment where eval'd code can find them.