### PR TITLE
LibWeb: Protect against null navigables in lineage chain more thoroughly

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4103,9 +4103,17 @@ Vector<GC::Root<HTML::Navigable>> const Document::descendant_navigables() const
 // https://html.spec.whatwg.org/multipage/document-sequences.html#inclusive-descendant-navigables
 Vector<GC::Root<HTML::Navigable>> Document::inclusive_descendant_navigables()
 {
+    // FIXME: The document's node navigable should not be null here. But we currently do not implement the "unload a
+    //        document and its descendants" steps correctly, and the navigable becomes null during unloading. We are
+    //        essentially destroying the document too early. See Document::unload_a_document_and_its_descendants. See:
+    //        https://github.com/LadybirdBrowser/ladybird/issues/7825
+    auto document_node_navigable = navigable();
+    if (!document_node_navigable)
+        return {};
+
     // 1. Let navigables be « document's node navigable ».
     Vector<GC::Root<HTML::Navigable>> navigables;
-    navigables.append(*navigable());
+    navigables.append(*document_node_navigable);
 
     // 2. Extend navigables with document's descendant navigables.
     navigables.extend(descendant_navigables());
@@ -4117,8 +4125,11 @@ Vector<GC::Root<HTML::Navigable>> Document::inclusive_descendant_navigables()
 // https://html.spec.whatwg.org/multipage/document-sequences.html#ancestor-navigables
 Vector<GC::Root<HTML::Navigable>> Document::ancestor_navigables()
 {
-    // NOTE: This isn't in the spec, but if we don't have a navigable, we can't have ancestors either.
-    auto document_node_navigable = this->navigable();
+    // FIXME: The document's node navigable should not be null here. But we currently do not implement the "unload a
+    //        document and its descendants" steps correctly, and the navigable becomes null during unloading. We are
+    //        essentially destroying the document too early. See Document::unload_a_document_and_its_descendants. See:
+    //        https://github.com/LadybirdBrowser/ladybird/issues/7825
+    auto document_node_navigable = navigable();
     if (!document_node_navigable)
         return {};
 
@@ -4149,11 +4160,19 @@ Vector<GC::Root<HTML::Navigable>> const Document::ancestor_navigables() const
 // https://html.spec.whatwg.org/multipage/document-sequences.html#inclusive-ancestor-navigables
 Vector<GC::Root<HTML::Navigable>> Document::inclusive_ancestor_navigables()
 {
+    // FIXME: The document's node navigable should not be null here. But we currently do not implement the "unload a
+    //        document and its descendants" steps correctly, and the navigable becomes null during unloading. We are
+    //        essentially destroying the document too early. See Document::unload_a_document_and_its_descendants. See:
+    //        https://github.com/LadybirdBrowser/ladybird/issues/7825
+    auto document_node_navigable = navigable();
+    if (!document_node_navigable)
+        return {};
+
     // 1. Let navigables be document's ancestor navigables.
     auto navigables = ancestor_navigables();
 
     // 2. Append document's node navigable to navigables.
-    navigables.append(*navigable());
+    navigables.append(*document_node_navigable);
 
     // 3. Return navigables.
     return navigables;

--- a/Tests/LibWeb/Text/data/window-opener-post-message.html
+++ b/Tests/LibWeb/Text/data/window-opener-post-message.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script>
+    window.opener.postMessage("hello", "*");
+</script>

--- a/Tests/LibWeb/Text/expected/DOM/window-open-and-reopen-custom-target.txt
+++ b/Tests/LibWeb/Text/expected/DOM/window-open-and-reopen-custom-target.txt
@@ -1,0 +1,2 @@
+1: Target matches source: true
+2: Target matches source: true

--- a/Tests/LibWeb/Text/input/DOM/window-open-and-reopen-custom-target.html
+++ b/Tests/LibWeb/Text/input/DOM/window-open-and-reopen-custom-target.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    const runTest = id => {
+        return new Promise(resolve => {
+            window.onmessage = e => {
+                let target = window.open("", `test-${id}`);
+
+                println(`${id}: Target matches source: ${target === e.source}`);
+                e.source.close();
+
+                resolve();
+            };
+
+            window.open("../../data/window-opener-post-message.html", `test-${id}`);
+        });
+    };
+
+    asyncTest(async done => {
+        await runTest(1);
+        await runTest(2);
+        done();
+    });
+</script>


### PR DESCRIPTION
This extends the null navigable check added in commit b118c99c271e34e2c5020022d062a4371f199a71 to include all ancestor and descendant list lookups. Fixes a crash in the following WPT test `/cookies/schemeful-same-site/schemeful-navigation.tentative.html`