### PR TITLE
CI: Switch back to actions/stale now that upstream issue is fixed

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,8 +15,7 @@ jobs:
       actions: write  # required for cache management (see https://github.com/actions/stale/issues/1133)
       pull-requests: write
     steps:
-      # replace `uses:` below with upstream actions/stale when https://github.com/actions/stale/issues/1136 is fixed
-      - uses: itchyny/actions-stale@0980a21d84c23bd4d8c62b0958f47f25822286f2
+      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d  # v10.1.1
         with:
           operations-per-run: 500
 


### PR DESCRIPTION
## Summary

Replace `itchyny/actions-stale` with `actions/stale` v10.1.1, now that the upstream issue ([actions/stale#1136](https://github.com/actions/stale/issues/1136)) has been resolved.

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| stale.yml | `itchyny/actions-stale@0980a21` | `actions/stale@9971854` (v10.1.1) |

- Removed the workaround comment that referenced the upstream issue
- Switched back to the official `actions/stale` action

Also replacing this pr: https://github.com/LadybirdBrowser/ladybird/pull/7768