### PR TITLE
LibJS: Use explicit completion records for try/finally dispatch

### DIFF
--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -147,12 +147,6 @@ op ConcatString < Instruction
     m_src: Operand
 endop
 
-op ContinuePendingUnwind < Instruction
-    @terminator
-    @nothrow
-    m_resume_target: Label
-endop
-
 op CopyObjectExcludingProperties < Instruction
     m_length: u32
     m_dst: Operand
@@ -618,10 +612,6 @@ op JumpUndefined < Instruction
     m_false_target: Label
 endop
 
-op LeaveFinally < Instruction
-    @nothrow
-endop
-
 op LeaveLexicalEnvironment < Instruction
     @nothrow
 endop
@@ -750,12 +740,6 @@ op Not < Instruction
     @nothrow
     m_dst: Operand
     m_src: Operand
-endop
-
-op PrepareYield < Instruction
-    @nothrow
-    m_dest: Operand
-    m_value: Operand
 endop
 
 op PostfixDecrement < Instruction
@@ -936,10 +920,6 @@ endop
 op ResolveThisBinding < Instruction
 endop
 
-op RestoreScheduledJump < Instruction
-    @nothrow
-endop
-
 op Return < Instruction
     @terminator
     @nothrow
@@ -950,12 +930,6 @@ op RightShift < Instruction
     m_dst: Operand
     m_lhs: Operand
     m_rhs: Operand
-endop
-
-op ScheduleJump < Instruction
-    @terminator
-    @nothrow
-    m_target: Label
 endop
 
 op SetCompletionType < Instruction

--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -43,7 +43,6 @@ public:
     }
 
     ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
-    ALWAYS_INLINE Value& saved_return_value() { return reg(Register::saved_return_value()); }
     Value& reg(Register const& r)
     {
         return m_running_execution_context->registers_and_constants_and_locals_and_arguments()[r.index()];
@@ -68,8 +67,6 @@ public:
     void enter_unwind_context();
     void leave_unwind_context();
     void catch_exception(Operand dst);
-    void restore_scheduled_jump();
-    void leave_finally();
 
     void enter_object_environment(Object&);
 

--- a/Libraries/LibJS/Bytecode/Register.h
+++ b/Libraries/LibJS/Bytecode/Register.h
@@ -19,14 +19,7 @@ public:
         return Register(accumulator_index);
     }
 
-    constexpr static u32 saved_return_value_index = 1;
-
-    static constexpr Register saved_return_value()
-    {
-        return Register(saved_return_value_index);
-    }
-
-    static constexpr u32 exception_index = 2;
+    static constexpr u32 exception_index = 1;
 
     static constexpr Register exception()
     {
@@ -35,17 +28,17 @@ public:
 
     static constexpr Register this_value()
     {
-        constexpr u32 this_value_index = 3;
+        constexpr u32 this_value_index = 2;
         return Register(this_value_index);
     }
 
     static constexpr Register return_value()
     {
-        constexpr u32 return_value_index = 4;
+        constexpr u32 return_value_index = 3;
         return Register(return_value_index);
     }
 
-    static constexpr u32 reserved_register_count = 5;
+    static constexpr u32 reserved_register_count = 4;
 
     constexpr explicit Register(u32 index)
         : m_index(index)

--- a/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -122,7 +122,6 @@ NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const
         auto copy_rare_data = copy->ensure_rare_data();
         copy_rare_data->unwind_contexts = m_rare_data->unwind_contexts;
         copy_rare_data->saved_lexical_environments = m_rare_data->saved_lexical_environments;
-        copy_rare_data->previously_scheduled_jumps = m_rare_data->previously_scheduled_jumps;
     }
     copy->registers_and_constants_and_locals_and_arguments_count = registers_and_constants_and_locals_and_arguments_count;
     for (size_t i = 0; i < registers_and_constants_and_locals_and_arguments_count; ++i)

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -57,7 +57,6 @@ class JS_API ExecutionContextRareData final : public GC::Cell {
 
 public:
     Vector<Bytecode::UnwindInfo> unwind_contexts;
-    Vector<Optional<size_t>> previously_scheduled_jumps;
     Vector<GC::Ptr<Environment>> saved_lexical_environments;
 
     mutable GC::Ptr<CachedSourceRange> cached_source_range;
@@ -107,7 +106,6 @@ public:
     GC::Ptr<Environment> variable_environment;       // [[VariableEnvironment]]
     GC::Ptr<PrivateEnvironment> private_environment; // [[PrivateEnvironment]]
 
-    Optional<size_t> scheduled_jump;
     GC::Ptr<Object> global_object;
     GC::Ptr<DeclarativeEnvironment> global_declarative_environment;
     Utf16FlyString const* identifier_table { nullptr };

--- a/Tests/LibJS/Bytecode/expected/baseline.txt
+++ b/Tests/LibJS/Bytecode/expected/baseline.txt
@@ -1,13 +1,13 @@
 JS bytecode executable ""
-[   0]    0: GetGlobal dst:reg6, identifier:console
-[  10]       GetById dst:reg7, base:reg6, property:log, base_identifier:console
-[  28]       GetGlobal dst:reg9, identifier:add
-[  38]       Call dst:reg8, callee:reg9, this_value:Undefined, add, arguments:[Int32(1), Int32(2)]
-[  60]       Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
-[  88]       End value:reg5
+[   0]    0: GetGlobal dst:reg5, identifier:console
+[  10]       GetById dst:reg6, base:reg5, property:log, base_identifier:console
+[  28]       GetGlobal dst:reg8, identifier:add
+[  38]       Call dst:reg7, callee:reg8, this_value:Undefined, add, arguments:[Int32(1), Int32(2)]
+[  60]       Call dst:reg4, callee:reg6, this_value:reg5, console.log, arguments:[reg7]
+[  88]       End value:reg4
 
 JS bytecode executable "add"
-[   0]    0: Add dst:reg5, lhs:arg0, rhs:arg1
-[  10]       Return value:reg5
+[   0]    0: Add dst:reg4, lhs:arg0, rhs:arg1
+[  10]       Return value:reg4
 
 3

--- a/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
+++ b/Tests/LibJS/Bytecode/expected/condition-dead-code-elim.txt
@@ -1,27 +1,27 @@
 JS bytecode executable ""
-[   0]    0: GetGlobal dst:reg6, identifier:ternary_true
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, ternary_true
-[  30]       GetGlobal dst:reg7, identifier:ternary_truthy
-[  40]       Call dst:reg6, callee:reg7, this_value:Undefined, ternary_truthy
-[  60]       GetGlobal dst:reg7, identifier:ternary_false
-[  70]       Call dst:reg5, callee:reg7, this_value:Undefined, ternary_false
-[  90]       GetGlobal dst:reg7, identifier:ternary_falsey
-[  a0]       Call dst:reg6, callee:reg7, this_value:Undefined, ternary_falsey
-[  c0]       GetGlobal dst:reg7, identifier:while_falsey
-[  d0]       Call dst:reg5, callee:reg7, this_value:Undefined, while_falsey
-[  f0]       GetGlobal dst:reg7, identifier:do_while_falsey
-[ 100]       Call dst:reg6, callee:reg7, this_value:Undefined, do_while_falsey
-[ 120]       GetGlobal dst:reg7, identifier:if_falsely
-[ 130]       Call dst:reg5, callee:reg7, this_value:Undefined, if_falsely
-[ 150]       GetGlobal dst:reg7, identifier:if_truthy
-[ 160]       Call dst:reg6, callee:reg7, this_value:Undefined, if_truthy
-[ 180]       GetGlobal dst:reg7, identifier:if_exhausted
-[ 190]       Call dst:reg5, callee:reg7, this_value:Undefined, if_exhausted
-[ 1b0]       GetGlobal dst:reg7, identifier:for_false
-[ 1c0]       Call dst:reg6, callee:reg7, this_value:Undefined, for_false
-[ 1e0]       GetGlobal dst:reg7, identifier:for_true
-[ 1f0]       Call dst:reg5, callee:reg7, this_value:Undefined, for_true, arguments:[Bool(true)]
-[ 218]       End value:reg5
+[   0]    0: GetGlobal dst:reg5, identifier:ternary_true
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, ternary_true
+[  30]       GetGlobal dst:reg6, identifier:ternary_truthy
+[  40]       Call dst:reg5, callee:reg6, this_value:Undefined, ternary_truthy
+[  60]       GetGlobal dst:reg6, identifier:ternary_false
+[  70]       Call dst:reg4, callee:reg6, this_value:Undefined, ternary_false
+[  90]       GetGlobal dst:reg6, identifier:ternary_falsey
+[  a0]       Call dst:reg5, callee:reg6, this_value:Undefined, ternary_falsey
+[  c0]       GetGlobal dst:reg6, identifier:while_falsey
+[  d0]       Call dst:reg4, callee:reg6, this_value:Undefined, while_falsey
+[  f0]       GetGlobal dst:reg6, identifier:do_while_falsey
+[ 100]       Call dst:reg5, callee:reg6, this_value:Undefined, do_while_falsey
+[ 120]       GetGlobal dst:reg6, identifier:if_falsely
+[ 130]       Call dst:reg4, callee:reg6, this_value:Undefined, if_falsely
+[ 150]       GetGlobal dst:reg6, identifier:if_truthy
+[ 160]       Call dst:reg5, callee:reg6, this_value:Undefined, if_truthy
+[ 180]       GetGlobal dst:reg6, identifier:if_exhausted
+[ 190]       Call dst:reg4, callee:reg6, this_value:Undefined, if_exhausted
+[ 1b0]       GetGlobal dst:reg6, identifier:for_false
+[ 1c0]       Call dst:reg5, callee:reg6, this_value:Undefined, for_false
+[ 1e0]       GetGlobal dst:reg6, identifier:for_true
+[ 1f0]       Call dst:reg4, callee:reg6, this_value:Undefined, for_true, arguments:[Bool(true)]
+[ 218]       End value:reg4
 
 JS bytecode executable "ternary_true"
 [   0]    0: Return value:Int32(1)
@@ -36,47 +36,47 @@ JS bytecode executable "ternary_falsey"
 [   0]    0: Return value:Int32(1)
 
 JS bytecode executable "while_falsey"
-[   0]    0: GetGlobal dst:reg6, identifier:alive
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[   0]    0: GetGlobal dst:reg5, identifier:alive
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  30]       End value:Undefined
 
 JS bytecode executable "alive"
 [   0]    0: Return value:String("alive")
 
 JS bytecode executable "do_while_falsey"
-[   0]    0: GetGlobal dst:reg6, identifier:alive
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  30]    1: GetGlobal dst:reg6, identifier:alive
-[  40]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  60]    2: GetGlobal dst:reg6, identifier:alive
-[  70]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  90]    3: GetGlobal dst:reg6, identifier:alive
-[  a0]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[   0]    0: GetGlobal dst:reg5, identifier:alive
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  30]    1: GetGlobal dst:reg5, identifier:alive
+[  40]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  60]    2: GetGlobal dst:reg5, identifier:alive
+[  70]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  90]    3: GetGlobal dst:reg5, identifier:alive
+[  a0]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  c0]       End value:Undefined
 
 JS bytecode executable "if_falsely"
-[   0]    0: GetGlobal dst:reg6, identifier:alive
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[   0]    0: GetGlobal dst:reg5, identifier:alive
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  30]       End value:Undefined
 
 JS bytecode executable "if_truthy"
-[   0]    0: GetGlobal dst:reg6, identifier:alive
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  30]       GetGlobal dst:reg6, identifier:alive
-[  40]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  60]       GetGlobal dst:reg6, identifier:alive
-[  70]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  90]       GetGlobal dst:reg6, identifier:alive
-[  a0]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[   0]    0: GetGlobal dst:reg5, identifier:alive
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  30]       GetGlobal dst:reg5, identifier:alive
+[  40]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  60]       GetGlobal dst:reg5, identifier:alive
+[  70]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  90]       GetGlobal dst:reg5, identifier:alive
+[  a0]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  c0]       End value:Undefined
 
 JS bytecode executable "if_exhausted"
-[   0]    0: GetGlobal dst:reg6, identifier:alive
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  30]       GetGlobal dst:reg6, identifier:alive
-[  40]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
-[  60]       GetGlobal dst:reg6, identifier:alive
-[  70]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[   0]    0: GetGlobal dst:reg5, identifier:alive
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  30]       GetGlobal dst:reg5, identifier:alive
+[  40]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
+[  60]       GetGlobal dst:reg5, identifier:alive
+[  70]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  90]       End value:Undefined
 
 JS bytecode executable "for_false"
@@ -86,12 +86,12 @@ JS bytecode executable "for_false"
 [  18]    3: End value:Undefined
 [  20]    4: Jump target:@30
 [  28]    5: End value:Undefined
-[  30]    6: GetGlobal dst:reg5, identifier:call_this
-[  40]       Call dst:x~0, callee:reg5, this_value:Undefined, call_this
+[  30]    6: GetGlobal dst:reg4, identifier:call_this
+[  40]       Call dst:x~0, callee:reg4, this_value:Undefined, call_this
 [  60]       Jump target:@70
 [  68]    7: End value:Undefined
-[  70]    8: GetGlobal dst:reg6, identifier:alive
-[  80]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[  70]    8: GetGlobal dst:reg5, identifier:alive
+[  80]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  a0]       End value:Undefined
 
 JS bytecode executable "call_this"
@@ -99,19 +99,20 @@ JS bytecode executable "call_this"
 
 JS bytecode executable "for_true"
 [   0]    0: Jump target:@48
-[   8]    1: GetGlobal dst:reg6, identifier:alive
-[  18]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[   8]    1: GetGlobal dst:reg5, identifier:alive
+[  18]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  38]       JumpIf condition:arg0, true_target:@58, false_target:@60
 [  48]    2: Jump target:@8
 [  50]    3: Jump target:@a8
 [  58]    4: Jump target:@50
 [  60]    5: Jump target:@48
-[  68]    6: GetGlobal dst:reg6, identifier:alive
-[  78]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[  68]    6: GetGlobal dst:reg5, identifier:alive
+[  78]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  98]       JumpIf condition:arg0, true_target:@e8, false_target:@f0
 [  a8]    7: Jump target:@68
-[  b0]    8: GetGlobal dst:reg6, identifier:alive
-[  c0]       Call dst:reg5, callee:reg6, this_value:Undefined, alive
+[  b0]    8: GetGlobal dst:reg5, identifier:alive
+[  c0]       Call dst:reg4, callee:reg5, this_value:Undefined, alive
 [  e0]       End value:Undefined
 [  e8]    9: Jump target:@b0
 [  f0]   10: Jump target:@a8
+

--- a/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
+++ b/Tests/LibJS/Bytecode/expected/const-fold-template-literals.txt
@@ -5,51 +5,52 @@ JS bytecode executable ""
 [  48]       InitializeLexicalBinding identifier:d, src:String("abcxyz")
 [  60]       InitializeLexicalBinding identifier:e, src:String("abcxyz")
 [  78]       InitializeLexicalBinding identifier:f, src:String("abcxyz")
-[  90]       Mov dst:reg5, src:String("abc")
-[  a0]       ConcatString dst:reg5, src:String("xyz")
-[  b0]       InitializeLexicalBinding identifier:g, src:reg5
-[  c8]       GetGlobal dst:reg6, identifier:prefix
-[  d8]       Call dst:reg5, callee:reg6, this_value:Undefined, prefix, arguments:[String("abc")]
-[ 100]       InitializeLexicalBinding identifier:_prefix, src:reg5
-[ 118]       GetGlobal dst:reg6, identifier:suffix
-[ 128]       Call dst:reg5, callee:reg6, this_value:Undefined, suffix, arguments:[String("abc")]
-[ 150]       InitializeLexicalBinding identifier:_suffix, src:reg5
-[ 168]       GetGlobal dst:reg6, identifier:tostring
-[ 178]       Call dst:reg5, callee:reg6, this_value:Undefined, tostring, arguments:[String("abc")]
-[ 1a0]       InitializeLexicalBinding identifier:_tostring, src:reg5
-[ 1b8]       GetGlobal dst:reg6, identifier:multi
-[ 1c8]       Call dst:reg5, callee:reg6, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
-[ 1f8]       InitializeLexicalBinding identifier:_multi, src:reg5
-[ 210]       GetGlobal dst:reg6, identifier:literal
-[ 220]       Call dst:reg5, callee:reg6, this_value:Undefined, literal
-[ 240]       InitializeLexicalBinding identifier:_literal, src:reg5
-[ 258]       GetGlobal dst:reg6, identifier:empty
-[ 268]       Call dst:reg5, callee:reg6, this_value:Undefined, empty
-[ 288]       InitializeLexicalBinding identifier:_empty, src:reg5
+[  90]       Mov dst:reg4, src:String("abc")
+[  a0]       ConcatString dst:reg4, src:String("xyz")
+[  b0]       InitializeLexicalBinding identifier:g, src:reg4
+[  c8]       GetGlobal dst:reg5, identifier:prefix
+[  d8]       Call dst:reg4, callee:reg5, this_value:Undefined, prefix, arguments:[String("abc")]
+[ 100]       InitializeLexicalBinding identifier:_prefix, src:reg4
+[ 118]       GetGlobal dst:reg5, identifier:suffix
+[ 128]       Call dst:reg4, callee:reg5, this_value:Undefined, suffix, arguments:[String("abc")]
+[ 150]       InitializeLexicalBinding identifier:_suffix, src:reg4
+[ 168]       GetGlobal dst:reg5, identifier:tostring
+[ 178]       Call dst:reg4, callee:reg5, this_value:Undefined, tostring, arguments:[String("abc")]
+[ 1a0]       InitializeLexicalBinding identifier:_tostring, src:reg4
+[ 1b8]       GetGlobal dst:reg5, identifier:multi
+[ 1c8]       Call dst:reg4, callee:reg5, this_value:Undefined, multi, arguments:[Int32(1), Int32(2), Int32(3)]
+[ 1f8]       InitializeLexicalBinding identifier:_multi, src:reg4
+[ 210]       GetGlobal dst:reg5, identifier:literal
+[ 220]       Call dst:reg4, callee:reg5, this_value:Undefined, literal
+[ 240]       InitializeLexicalBinding identifier:_literal, src:reg4
+[ 258]       GetGlobal dst:reg5, identifier:empty
+[ 268]       Call dst:reg4, callee:reg5, this_value:Undefined, empty
+[ 288]       InitializeLexicalBinding identifier:_empty, src:reg4
 [ 2a0]       End value:Undefined
 
 JS bytecode executable "prefix"
-[   0]    0: Mov dst:reg5, src:String("prefix-")
-[  10]       ConcatString dst:reg5, src:arg0
-[  20]       Return value:reg5
+[   0]    0: Mov dst:reg4, src:String("prefix-")
+[  10]       ConcatString dst:reg4, src:arg0
+[  20]       Return value:reg4
 
 JS bytecode executable "suffix"
-[   0]    0: ToString dst:reg5, value:arg0
-[  10]       ConcatString dst:reg5, src:String("-suffix")
-[  20]       Return value:reg5
+[   0]    0: ToString dst:reg4, value:arg0
+[  10]       ConcatString dst:reg4, src:String("-suffix")
+[  20]       Return value:reg4
 
 JS bytecode executable "tostring"
-[   0]    0: ToString dst:reg5, value:arg0
-[  10]       Return value:reg5
+[   0]    0: ToString dst:reg4, value:arg0
+[  10]       Return value:reg4
 
 JS bytecode executable "multi"
-[   0]    0: ToString dst:reg5, value:arg0
-[  10]       ConcatString dst:reg5, src:arg1
-[  20]       ConcatString dst:reg5, src:arg2
-[  30]       Return value:reg5
+[   0]    0: ToString dst:reg4, value:arg0
+[  10]       ConcatString dst:reg4, src:arg1
+[  20]       ConcatString dst:reg4, src:arg2
+[  30]       Return value:reg4
 
 JS bytecode executable "literal"
 [   0]    0: Return value:String("hello world")
 
 JS bytecode executable "empty"
 [   0]    0: Return value:String("")
+

--- a/Tests/LibJS/Bytecode/expected/eval-same-function.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-same-function.txt
@@ -1,16 +1,17 @@
 JS bytecode executable ""
-[   0]    0: GetGlobal dst:reg6, identifier:foo
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, foo
-[  30]       End value:reg5
+[   0]    0: GetGlobal dst:reg5, identifier:foo
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, foo
+[  30]       End value:reg4
 
 JS bytecode executable "foo"
 [   0]    0: CreateArguments is_immutable:false
-[  10]       GetCalleeAndThisFromEnvironment callee:reg6, this_value:reg7, identifier:eval
-[  28]       CallDirectEval dst:reg5, callee:reg6, this_value:reg7, eval, arguments:[String("var x = 1")]
-[  50]       GetBinding dst:reg6, identifier:Number
-[  68]       CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-[  88]       Return value:reg5
+[  10]       GetCalleeAndThisFromEnvironment callee:reg5, this_value:reg6, identifier:eval
+[  28]       CallDirectEval dst:reg4, callee:reg5, this_value:reg6, eval, arguments:[String("var x = 1")]
+[  50]       GetBinding dst:reg5, identifier:Number
+[  68]       CallConstruct dst:reg4, callee:reg5, Number, arguments:[Int32(42)]
+[  88]       Return value:reg4
 
 JS bytecode executable "eval"
 [   0]    0: SetLexicalBinding identifier:x, src:Int32(1)
 [  18]       End value:Undefined
+

--- a/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
+++ b/Tests/LibJS/Bytecode/expected/eval-scope-optimization.txt
@@ -1,13 +1,14 @@
 JS bytecode executable ""
-[   0]    0: GetGlobal dst:reg6, identifier:outer
-[  10]       Call dst:reg5, callee:reg6, this_value:Undefined, outer
-[  30]       End value:reg5
+[   0]    0: GetGlobal dst:reg5, identifier:outer
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, outer
+[  30]       End value:reg4
 
 JS bytecode executable "outer"
 [   0]    0: CreateVariable identifier:inner, is_immutable:false, is_global:false, is_strict:false
 [  10]       InitializeVariableBinding identifier:inner, src:Undefined
-[  28]       NewFunction dst:reg5
-[  40]       SetVariableBinding identifier:inner, src:reg5
-[  58]       GetGlobal dst:reg6, identifier:Number
-[  68]       CallConstruct dst:reg5, callee:reg6, Number, arguments:[Int32(42)]
-[  88]       Return value:reg5
+[  28]       NewFunction dst:reg4
+[  40]       SetVariableBinding identifier:inner, src:reg4
+[  58]       GetGlobal dst:reg5, identifier:Number
+[  68]       CallConstruct dst:reg4, callee:reg5, Number, arguments:[Int32(42)]
+[  88]       Return value:reg4
+

--- a/Tests/LibJS/Bytecode/expected/named-function-expression.txt
+++ b/Tests/LibJS/Bytecode/expected/named-function-expression.txt
@@ -1,10 +1,11 @@
 JS bytecode executable ""
 [   0]    0: CreateLexicalEnvironment capacity:0
 [  10]       CreateVariable identifier:Oops, is_immutable:true, is_global:false, is_strict:false
-[  20]       NewFunction dst:reg5
-[  38]       InitializeLexicalBinding identifier:Oops, src:reg5
+[  20]       NewFunction dst:reg4
+[  38]       InitializeLexicalBinding identifier:Oops, src:reg4
 [  50]       LeaveLexicalEnvironment
-[  58]       SetGlobal identifier:Oops, src:reg5
-[  68]       GetGlobal dst:reg6, identifier:Oops
-[  78]       GetById dst:reg7, base:reg6, property:x, base_identifier:Oops
-[  90]       End value:reg7
+[  58]       SetGlobal identifier:Oops, src:reg4
+[  68]       GetGlobal dst:reg5, identifier:Oops
+[  78]       GetById dst:reg6, base:reg5, property:x, base_identifier:Oops
+[  90]       End value:reg6
+

--- a/Tests/LibJS/Bytecode/expected/try-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally.txt
@@ -1,0 +1,113 @@
+JS bytecode executable ""
+[   0]    0: GetGlobal dst:reg5, identifier:basicTryFinally
+[  10]       Call dst:reg4, callee:reg5, this_value:Undefined, basicTryFinally
+[  30]       GetGlobal dst:reg6, identifier:breakThroughFinally
+[  40]       Call dst:reg5, callee:reg6, this_value:Undefined, breakThroughFinally
+[  60]       GetGlobal dst:reg6, identifier:nestedTryFinallyWithBreak
+[  70]       Call dst:reg4, callee:reg6, this_value:Undefined, nestedTryFinallyWithBreak
+[  90]       End value:reg4
+
+JS bytecode executable "basicTryFinally"
+[   0]    0: EnterUnwindContext entry_point:@90
+[   8]    1: Catch dst:reg5
+[  10]       Mov dst:reg4, src:Int32(1)
+[  20]       LeaveUnwindContext
+[  28]    2: GetGlobal dst:reg7, identifier:console
+[  38]       GetById dst:reg8, base:reg7, property:log, base_identifier:console
+[  50]       Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[String("finally")]
+[  78]       JumpStrictlyEquals lhs:reg4, rhs:Int32(0), true_target:@b8, false_target:@c0
+[  90]    3: Mov dst:reg5, src:Int32(1)
+[  a0]       Mov dst:reg4, src:Int32(2)
+[  b0]       Jump target:@28
+[  b8]    4: End value:Undefined
+[  c0]    5: JumpStrictlyEquals lhs:reg4, rhs:Int32(2), true_target:@d8, false_target:@e0
+[  d8]    6: Return value:reg5
+[  e0]    7: Throw src:reg5
+
+Exception handlers:
+    from   90 to   b8 handler    0 finalizer    8
+
+JS bytecode executable "breakThroughFinally"
+[   0]    0: Mov dst:i~0, src:Int32(0)
+[  10]       Jump target:@30
+[  18]    1: EnterUnwindContext entry_point:@e8
+[  20]    2: PostfixIncrement dst:reg4, src:i~0
+[  30]    3: JumpLessThan lhs:i~0, rhs:Int32(10), true_target:@18, false_target:@48
+[  48]    4: End value:Undefined
+[  50]    5: Catch dst:reg5
+[  58]       Mov dst:reg4, src:Int32(1)
+[  68]       LeaveUnwindContext
+[  70]    6: GetGlobal dst:reg7, identifier:console
+[  80]       GetById dst:reg8, base:reg7, property:log, base_identifier:console
+[  98]       Mov dst:reg9, src:i~0
+[  a8]       Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+[  d0]       JumpStrictlyEquals lhs:reg4, rhs:Int32(0), true_target:@138, false_target:@140
+[  e8]    7: JumpStrictlyEquals lhs:i~0, rhs:Int32(5), true_target:@100, false_target:@118
+[ 100]    8: Mov dst:reg4, src:Int32(3)
+[ 110]       Jump target:@70
+[ 118]    9: Mov dst:reg4, src:Int32(0)
+[ 128]       LeaveUnwindContext
+[ 130]       Jump target:@70
+[ 138]   10: Jump target:@20
+[ 140]   11: JumpStrictlyEquals lhs:reg4, rhs:Int32(3), true_target:@48, false_target:@158
+[ 158]   12: JumpStrictlyEquals lhs:reg4, rhs:Int32(2), true_target:@170, false_target:@178
+[ 170]   13: Return value:reg5
+[ 178]   14: Throw src:reg5
+
+Exception handlers:
+    from   e8 to  138 handler    0 finalizer   50
+
+JS bytecode executable "nestedTryFinallyWithBreak"
+[   0]    0: Mov dst:i~0, src:Int32(0)
+[  10]    1: EnterUnwindContext entry_point:@c0
+[  18]    2: PostfixIncrement dst:reg4, src:i~0
+[  28]       Jump target:@10
+[  30]    3: End value:Undefined
+[  38]    4: Catch dst:reg5
+[  40]       Mov dst:reg4, src:Int32(1)
+[  50]       LeaveUnwindContext
+[  58]    5: GetGlobal dst:reg7, identifier:console
+[  68]       GetById dst:reg8, base:reg7, property:log, base_identifier:console
+[  80]       Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[String("outer")]
+[  a8]       JumpStrictlyEquals lhs:reg4, rhs:Int32(0), true_target:@200, false_target:@208
+[  c0]    6: EnterUnwindContext entry_point:@150
+[  c8]    7: Catch dst:reg7
+[  d0]       Mov dst:reg6, src:Int32(1)
+[  e0]       LeaveUnwindContext
+[  e8]    8: GetGlobal dst:reg9, identifier:console
+[  f8]       GetById dst:reg10, base:reg9, property:log, base_identifier:console
+[ 110]       Call dst:reg8, callee:reg10, this_value:reg9, console.log, arguments:[String("inner")]
+[ 138]       JumpStrictlyEquals lhs:reg6, rhs:Int32(0), true_target:@180, false_target:@1a0
+[ 150]    9: Mov dst:reg6, src:Int32(3)
+[ 160]       Jump target:@e8
+[ 168]   10: Mov dst:reg4, src:Int32(3)
+[ 178]       Jump target:@58
+[ 180]   11: Mov dst:reg4, src:Int32(0)
+[ 190]       LeaveUnwindContext
+[ 198]       Jump target:@58
+[ 1a0]   12: JumpStrictlyEquals lhs:reg6, rhs:Int32(3), true_target:@168, false_target:@1b8
+[ 1b8]   13: JumpStrictlyEquals lhs:reg6, rhs:Int32(2), true_target:@1d0, false_target:@1f8
+[ 1d0]   14: Mov dst:reg4, src:reg6
+[ 1e0]       Mov dst:reg5, src:reg7
+[ 1f0]       Jump target:@58
+[ 1f8]   15: Throw src:reg7
+[ 200]   16: Jump target:@18
+[ 208]   17: JumpStrictlyEquals lhs:reg4, rhs:Int32(3), true_target:@30, false_target:@220
+[ 220]   18: JumpStrictlyEquals lhs:reg4, rhs:Int32(2), true_target:@238, false_target:@240
+[ 238]   19: Return value:reg5
+[ 240]   20: Throw src:reg5
+
+Exception handlers:
+    from   c0 to  150 handler    0 finalizer   38
+    from  150 to  180 handler    0 finalizer   c8
+    from  180 to  200 handler    0 finalizer   38
+
+"finally"
+0
+1
+2
+3
+4
+5
+"inner"
+"outer"

--- a/Tests/LibJS/Bytecode/input/try-finally.js
+++ b/Tests/LibJS/Bytecode/input/try-finally.js
@@ -1,0 +1,34 @@
+function basicTryFinally() {
+    try {
+        return 1;
+    } finally {
+        console.log("finally");
+    }
+}
+basicTryFinally();
+
+function breakThroughFinally() {
+    for (let i = 0; i < 10; i++) {
+        try {
+            if (i === 5) break;
+        } finally {
+            console.log(i);
+        }
+    }
+}
+breakThroughFinally();
+
+function nestedTryFinallyWithBreak() {
+    outer: for (let i = 0; ; i++) {
+        try {
+            try {
+                break outer;
+            } finally {
+                console.log("inner");
+            }
+        } finally {
+            console.log("outer");
+        }
+    }
+}
+nestedTryFinallyWithBreak();


### PR DESCRIPTION
Each finally scope gets two registers (`completion_type` and `completion_value`) that form an explicit completion record. Every path into the finally body sets these before jumping, and a dispatch chain after the finally body routes to the correct continuation.

This replaces the old implicit protocol that relied on the `exception` register, a `saved_return_value` register, and a `scheduled_jump` field on `ExecutionContext`, allowing us to remove:

- 5 opcodes (`ContinuePendingUnwind`, `ScheduleJump`, `LeaveFinally`, `RestoreScheduledJump`, `PrepareYield`)
- 1 reserved register (`saved_return_value`)
- 2 `ExecutionContext` fields (`scheduled_jump`, `previously_scheduled_jumps`)