### PR TITLE
LibWeb: Implement CSSKeyframeRule::set_key_text()

### DIFF
--- a/Libraries/LibWeb/CSS/CSSKeyframeRule.h
+++ b/Libraries/LibWeb/CSS/CSSKeyframeRule.h
@@ -28,15 +28,13 @@ public:
     CSS::Percentage key() const { return m_key; }
     GC::Ref<CSSStyleProperties> style() const { return m_declarations; }
 
+    // https://drafts.csswg.org/css-animations/#dom-csskeyframerule-keytext
     String key_text() const
     {
         return m_key.to_string();
     }
 
-    void set_key_text(String const& key_text)
-    {
-        dbgln("FIXME: CSSKeyframeRule::set_key_text is not implemented: {}", key_text);
-    }
+    WebIDL::ExceptionOr<void> set_key_text(String const& key_text);
 
 private:
     CSSKeyframeRule(JS::Realm&, CSS::Percentage, CSSStyleProperties&);

--- a/Tests/LibWeb/Text/expected/css/CSSKeyframeRule-set-key-text.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSKeyframeRule-set-key-text.txt
@@ -1,0 +1,8 @@
+Initial: 0%
+After 50%: 50%
+After to: 100%
+After from: 0%
+Invalid throws: SyntaxError
+Unchanged after invalid: 0%
+Out of range throws: SyntaxError
+Unchanged after out-of-range: 0%

--- a/Tests/LibWeb/Text/input/css/CSSKeyframeRule-set-key-text.html
+++ b/Tests/LibWeb/Text/input/css/CSSKeyframeRule-set-key-text.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+@keyframes test {
+    from { opacity: 0; }
+}
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let sheet = document.styleSheets[0];
+        let keyframesRule = sheet.cssRules[0];
+        let keyframeRule = keyframesRule.cssRules[0];
+
+        println(`Initial: ${keyframeRule.keyText}`);
+
+        keyframeRule.keyText = "50%";
+        println(`After 50%: ${keyframeRule.keyText}`);
+
+        keyframeRule.keyText = "to";
+        println(`After to: ${keyframeRule.keyText}`);
+
+        keyframeRule.keyText = "from";
+        println(`After from: ${keyframeRule.keyText}`);
+
+        try {
+            keyframeRule.keyText = "invalid";
+        } catch (e) {
+            println(`Invalid throws: ${e.name}`);
+        }
+        println(`Unchanged after invalid: ${keyframeRule.keyText}`);
+
+        try {
+            keyframeRule.keyText = "150%";
+        } catch (e) {
+            println(`Out of range throws: ${e.name}`);
+        }
+        println(`Unchanged after out-of-range: ${keyframeRule.keyText}`);
+    });
+</script>


### PR DESCRIPTION
Implement the previously stubbed `CSSKeyframeRule::set_key_text()` method per the CSS Animations Level 1 specification.

Parses the keyframe selector string ("from", "to", or a percentage in [0,100]) and updates the key. Throws a `SyntaxError` DOMException if the input is invalid.

Spec: https://drafts.csswg.org/css-animations/#dom-csskeyframerule-keytext

Includes a Text test covering valid inputs, normalization, and error cases.
