### PR TITLE
LibWeb: Throw NotFoundError in MediaList::delete_medium()

### DIFF
--- a/Libraries/LibWeb/CSS/MediaList.h
+++ b/Libraries/LibWeb/CSS/MediaList.h
@@ -29,7 +29,7 @@ public:
     size_t length() const { return m_media.size(); }
     Optional<String> item(u32 index) const;
     void append_medium(StringView);
-    void delete_medium(StringView);
+    WebIDL::ExceptionOr<void> delete_medium(StringView);
 
     virtual Optional<JS::Value> item_value(size_t index) const override;
 

--- a/Tests/LibWeb/Text/expected/css/MediaList-delete-medium.txt
+++ b/Tests/LibWeb/Text/expected/css/MediaList-delete-medium.txt
@@ -1,0 +1,7 @@
+Initial: screen, print
+Length: 2
+After removing print: screen
+Length: 1
+Remove nonexistent throws: NotFoundError
+Unchanged: screen
+Remove unknown throws: NotFoundError

--- a/Tests/LibWeb/Text/input/css/MediaList-delete-medium.html
+++ b/Tests/LibWeb/Text/input/css/MediaList-delete-medium.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+@media screen, print { body { color: red; } }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let sheet = document.styleSheets[0];
+        let mediaList = sheet.cssRules[0].media;
+
+        println(`Initial: ${mediaList.mediaText}`);
+        println(`Length: ${mediaList.length}`);
+
+        mediaList.deleteMedium("print");
+        println(`After removing print: ${mediaList.mediaText}`);
+        println(`Length: ${mediaList.length}`);
+
+        try {
+            mediaList.deleteMedium("print");
+        } catch (e) {
+            println(`Remove nonexistent throws: ${e.name}`);
+        }
+        println(`Unchanged: ${mediaList.mediaText}`);
+
+        try {
+            mediaList.deleteMedium("not-a-real-type");
+        } catch (e) {
+            println(`Remove unknown throws: ${e.name}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Implement the previously stubbed `NotFoundError` exception in `MediaList::delete_medium()` per the CSSOM specification.

Previously, if no matching media query was removed, the method silently did nothing (with a FIXME comment). Now it throws a `NotFoundError` DOMException as required by step 3 of the algorithm.

Spec: https://www.w3.org/TR/cssom-1/#dom-medialist-deletemedium

Includes a Text test covering successful removal, duplicate removal (throws), and unknown media type (throws).