### PR TITLE
LibWeb: Only invalidate layout on SVG viewBox/preserveAspectRatio change

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -112,6 +112,7 @@ enum class StyleInvalidationReason {
     X(SVGGraphicsElementTransformChange)              \
     X(SVGImageElementFetchTheDocument)                \
     X(SVGImageFilterFetch)                            \
+    X(SVGViewBoxChange)                               \
     X(StyleChange)
 
 enum class SetNeedsLayoutReason {
@@ -134,7 +135,6 @@ enum class SetNeedsLayoutReason {
     X(NodeRemove)                                         \
     X(NodeSetTextContent)                                 \
     X(None)                                               \
-    X(SVGViewBoxChange)                                   \
     X(StyleChange)
 
 enum class SetNeedsLayoutTreeUpdateReason {

--- a/Libraries/LibWeb/SVG/SVGFitToViewBox.cpp
+++ b/Libraries/LibWeb/SVG/SVGFitToViewBox.cpp
@@ -6,6 +6,7 @@
 
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGAnimatedRect.h>
 #include <LibWeb/SVG/SVGFitToViewBox.h>
@@ -35,10 +36,12 @@ void SVGFitToViewBox::attribute_changed(DOM::Element& element, FlyString const& 
                 m_view_box_for_bindings->set_anim_val(Gfx::DoubleRect { m_view_box->min_x, m_view_box->min_y, m_view_box->width, m_view_box->height });
             }
         }
-        element.set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::SVGViewBoxChange);
+        if (auto layout_node = element.layout_node())
+            layout_node->set_needs_layout_update(DOM::SetNeedsLayoutReason::SVGViewBoxChange);
     } else if (name.equals_ignoring_ascii_case(SVG::AttributeNames::preserveAspectRatio)) {
         m_preserve_aspect_ratio = AttributeParser::parse_preserve_aspect_ratio(value.value_or(String {}));
-        element.set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::SVGViewBoxChange);
+        if (auto layout_node = element.layout_node())
+            layout_node->set_needs_layout_update(DOM::SetNeedsLayoutReason::SVGViewBoxChange);
     }
 }
 


### PR DESCRIPTION
These attributes are consumed during layout in SVGFormattingContext to compute the viewbox transform. They don't affect the layout tree structure, so a layout-only invalidation is sufficient instead of a full layout tree rebuild.