### PR TITLE
LibWeb: Add internals.dumpLayoutTree(node) API

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/DOM/NodeList.h>
 #include <LibWeb/DOMURL/DOMURL.h>
+#include <LibWeb/Dump.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/Navigable.h>
@@ -461,6 +462,19 @@ bool Internals::headless()
 String Internals::dump_display_list()
 {
     return window().associated_document().dump_display_list();
+}
+
+String Internals::dump_layout_tree(GC::Ref<DOM::Node> node)
+{
+    node->document().update_layout(DOM::UpdateLayoutReason::Debugging);
+
+    auto* layout_node = node->layout_node();
+    if (!layout_node)
+        return "(no layout node)"_string;
+
+    StringBuilder builder;
+    Web::dump_tree(builder, *layout_node);
+    return builder.to_string_without_validation();
 }
 
 String Internals::dump_stacking_context_tree()

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -89,6 +89,7 @@ public:
     bool headless();
 
     String dump_display_list();
+    String dump_layout_tree(GC::Ref<DOM::Node>);
     String dump_stacking_context_tree();
     String dump_gc_graph();
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -70,6 +70,7 @@ interface Internals {
     readonly attribute boolean headless;
 
     DOMString dumpDisplayList();
+    DOMString dumpLayoutTree(Node node);
     DOMString dumpStackingContextTree();
     DOMString dumpGCGraph();
 

--- a/Tests/LibWeb/Text/expected/Internals/dump-layout-tree.txt
+++ b/Tests/LibWeb/Text/expected/Internals/dump-layout-tree.txt
@@ -1,0 +1,8 @@
+BlockContainer <div#target> at [8,8] [0+0+0 100 0+0+684] [0+0+0 50 0+0+0] children: inline
+  TextNode <#text> (not painted)
+  InlineNode <span> at [8,8] [0+0+0 39.78125 0+0+0] [0+0+0 18 0+0+0]
+    frag 0 from TextNode start: 0, length: 5, rect: [8,8 39.78125x18] baseline: 13.796875
+        "Hello"
+    TextNode <#text> (not painted)
+  TextNode <#text> (not painted)
+

--- a/Tests/LibWeb/Text/input/Internals/dump-layout-tree.html
+++ b/Tests/LibWeb/Text/input/Internals/dump-layout-tree.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target" style="width: 100px; height: 50px;">
+    <span>Hello</span>
+</div>
+<script>
+    test(() => {
+        const el = document.getElementById("target");
+        println(internals.dumpLayoutTree(el));
+    });
+</script>


### PR DESCRIPTION
This new testing API dumps the layout subtree rooted at a given DOM node. It will be useful for testing partial layout tree rebuilds, where we need to verify the layout tree structure for specific subtrees rather than the entire document.