### PR TITLE
LibWeb: Do not create a layer when CSS isolation is set to isolate

### DIFF
--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -128,8 +128,7 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
             CSS::PropertyID::ClipPath,
             CSS::PropertyID::Opacity,
             CSS::PropertyID::MixBlendMode,
-            CSS::PropertyID::Filter,
-            CSS::PropertyID::Isolation)) {
+            CSS::PropertyID::Filter)) {
         invalidation.rebuild_accumulated_visual_contexts = true;
     }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -196,11 +196,6 @@ void AccumulatedVisualContext::dump(StringBuilder& builder) const
                 effects.filter.dump(builder);
                 has_content = true;
             }
-            if (effects.isolate) {
-                if (has_content)
-                    builder.append(' ');
-                builder.append("isolate"sv);
-            }
             builder.append("]"sv);
         });
 }

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -66,14 +66,12 @@ struct EffectsData {
     float opacity { 1.0f };
     Gfx::CompositingAndBlendingOperator blend_mode { Gfx::CompositingAndBlendingOperator::Normal };
     ResolvedCSSFilter filter;
-    bool isolate { false };
 
     bool needs_layer() const
     {
         return opacity < 1.0f
             || blend_mode != Gfx::CompositingAndBlendingOperator::Normal
-            || filter.has_filters()
-            || isolate;
+            || filter.has_filters();
     }
 };
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -240,8 +240,7 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
         EffectsData effects {
             computed_values.opacity(),
             mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),
-            box.filter(),
-            computed_values.isolation() == CSS::Isolation::Isolate
+            box.filter()
         };
         if (!effects.needs_layer())
             return {};


### PR DESCRIPTION
This is entirely unnecessary. All that this property does is create a stacking context.

I don't think this needs any tests since it's just removing something that, from what I can tell, is a no-op.