### PR TITLE
LibHTTP+RequestServer: Send revalidation attributes without parsing

### DIFF
--- a/Libraries/LibHTTP/Cache/Utilities.cpp
+++ b/Libraries/LibHTTP/Cache/Utilities.cpp
@@ -470,8 +470,8 @@ CacheLifetimeStatus cache_lifetime_status(HeaderList const& request_headers, Hea
 RevalidationAttributes RevalidationAttributes::create(HeaderList const& headers)
 {
     RevalidationAttributes attributes;
-    attributes.etag = headers.get("ETag"sv).map([](auto const& etag) { return etag; });
-    attributes.last_modified = parse_http_date(headers.get("Last-Modified"sv));
+    attributes.etag = headers.get("ETag"sv);
+    attributes.last_modified = headers.get("Last-Modified"sv);
 
     return attributes;
 }

--- a/Libraries/LibHTTP/Cache/Utilities.h
+++ b/Libraries/LibHTTP/Cache/Utilities.h
@@ -46,7 +46,7 @@ struct RevalidationAttributes {
     static RevalidationAttributes create(HeaderList const&);
 
     Optional<ByteString> etag;
-    Optional<UnixDateTime> last_modified;
+    Optional<ByteString> last_modified;
 };
 
 void store_header_and_trailer_fields(HeaderList&, HeaderList const&);

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -576,14 +576,13 @@ void Request::handle_fetch_state()
         VERIFY(revalidation_attributes.etag.has_value() || revalidation_attributes.last_modified.has_value());
 
         if (revalidation_attributes.etag.has_value()) {
-            // There is no CURLOPT for If-None-Match, so we must set the header value directly.
             auto header_string = ByteString::formatted("If-None-Match: {}", *revalidation_attributes.etag);
             curl_headers = curl_slist_append(curl_headers, header_string.characters());
         }
 
         if (revalidation_attributes.last_modified.has_value()) {
-            set_option(CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
-            set_option(CURLOPT_TIMEVALUE, revalidation_attributes.last_modified->seconds_since_epoch());
+            auto header_string = ByteString::formatted("If-Modified-Since: {}", *revalidation_attributes.last_modified);
+            curl_headers = curl_slist_append(curl_headers, header_string.characters());
         }
     }
 

--- a/Tests/LibWeb/Text/input/Cache/http-disk-cache.html
+++ b/Tests/LibWeb/Text/input/Cache/http-disk-cache.html
@@ -530,6 +530,33 @@
                 headers: {
                     Age: "2",
                     "Cache-Control": "max-age=5,must-revalidate",
+                    "Last-Modified": new Date().toUTCString().replace("GMT", "+0000"),
+                },
+            });
+
+            response = await cacheFetch(url);
+            expectCacheStatus(url, response, "written-to-cache");
+
+            response = await cacheFetch(url);
+            expectCacheStatus(url, response, "read-from-cache");
+
+            // By not attaching a TEST_CACHE_RESPOND_WITH_NOT_MODIFIED header, we tell http-test-server to respond to
+            // revalidation requests with an HTTP 200 (i.e. revalidation fails).
+            response = await cacheFetch(url, {
+                headers: {
+                    [TEST_CACHE_REQUEST_TIME_OFFSET]: "5",
+                },
+            });
+            expectCacheStatus(url, response, "written-to-cache");
+        })();
+
+        // Expired responses are cached until their max-age directive is reached. A must-revalidate cache directive
+        // with an unsuccessful revalidation results in the cache being refreshed.
+        await (async () => {
+            url = await createRequest("/cache-test/expired-and-refreshed-due-to-unsuccessful-revalidation", {
+                headers: {
+                    Age: "2",
+                    "Cache-Control": "max-age=5,must-revalidate",
                     "Last-Modified": new Date().toUTCString(),
                 },
             });


### PR DESCRIPTION
The caching RFC is quite strict about the format of date strings. If we received a revalidation attribute with an invalid date string, we would previously fail a runtime assertion. This was because to start a revalidation request, we would simply check for the presence of any revalidation header; but then when we issued the request, we would fail to parse the header, and end up with all attributes being null.

We now don't parse the revalidation attributes at all. Whatever we receive in the `Last-Modified` response header is what we will send in the `If-Modified-Since` request header, verbatim. For better or worse, this is how other browsers behave. So if the server sends us an invalid date string, it can receive its own date format for revalidation.

<hr />

This fixes a crash during revalidation on http://tweakers.net, where we received:
```
Last-Modified: Mon, 9 Feb 2026 21:46:56 +0000
```

However, other browsers seem to literally receive the string "Invalid date". A printf in chromium where the raw headers are read from the network confirmed this. Curl on the command line does as well:
```bash
❯ curl -iv --raw "https://api.smartocto.com/api/brands/tentacles?i=i3njb9c9jq6yp04ifcl73wqq94ja7jb7"

< HTTP/2 200
HTTP/2 200
< x-powered-by: smartocto
x-powered-by: smartocto
< x-cache: HIT from smartocto cache
x-cache: HIT from smartocto cache
< max-age: 10
max-age: 10
< last-modified: Invalid date
last-modified: Invalid date
```

So I'm not sure what is going on with this server. But we at least now behave the same as the big 3 browsers.