### PR TITLE
LibWeb: Allow table fixup to find internal table boxes in inline parents

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1423,6 +1423,10 @@ bool NodeWithStyleAndBoxModelMetrics::should_create_inline_continuation() const
     if (display().is_contents())
         return false;
 
+    // Internal table display types and table captions are handled by the table fixup algorithm.
+    if (display().is_internal_table() || display().is_table_caption())
+        return false;
+
     // Parent element must not be <foreignObject>
     if (is<SVG::SVGForeignObjectElement>(parent()->dom_node()))
         return false;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1133,7 +1133,7 @@ void TreeBuilder::generate_missing_child_wrappers(NodeWithStyle& root)
 Vector<GC::Root<Box>> TreeBuilder::generate_missing_parents(NodeWithStyle& root)
 {
     Vector<GC::Root<Box>> table_roots_to_wrap;
-    root.for_each_in_inclusive_subtree_of_type<Box>([&](auto& parent) {
+    root.for_each_in_inclusive_subtree_of_type<NodeWithStyle>([&](auto& parent) {
         // 1. An anonymous table-row box must be generated around each sequence of consecutive table-cell boxes whose
         //    parent is not a table-row.
         if (is_not_table_row(parent)) {
@@ -1173,13 +1173,14 @@ Vector<GC::Root<Box>> TreeBuilder::generate_missing_parents(NodeWithStyle& root)
         }
 
         // 3. An anonymous table-wrapper box must be generated around each table-root.
-        if (parent.display().is_table_inside()) {
-            if (parent.has_been_wrapped_in_table_wrapper()) {
+        if (auto* box = as_if<Box>(parent); box && box->display().is_table_inside()) {
+            if (box->has_been_wrapped_in_table_wrapper()) {
                 VERIFY(parent.parent());
                 VERIFY(parent.parent()->is_table_wrapper());
                 return TraversalDecision::Continue;
             }
-            table_roots_to_wrap.append(parent);
+
+            table_roots_to_wrap.append(*box);
         }
 
         return TraversalDecision::Continue;

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-tables/fixup-dynamic-anonymous-inline-table-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-tables/fixup-dynamic-anonymous-inline-table-003.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>CSS Test: CSS Tables fixup merge anonymous inline table siblings (cell + cell)</title>
+<link rel="author" title="Rune Lillesveen" href="mailto:futhark@chromium.org">
+<link rel="match" href="../../../../expected/wpt-import/css/css-tables/../reference/ref-filled-green-100px-square-only.html">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#fixup-algorithm">
+<style>
+  .cell {
+    display: table-cell;
+  }
+  .filler {
+    width: 50px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px">
+  <span>
+    <span class="cell">
+      <div class="filler"></div>
+    </span>
+    <span id="rm">Remove me</span>
+    <span class="cell">
+      <div class="filler"></div>
+    </span>
+  </span>
+</div>
+<script>
+  rm.offsetTop;
+  rm.remove();
+</script>


### PR DESCRIPTION
This ensures that elements with internal display types, which have inline parents are not incorrectly split by the inline continuation mechanism

Fixes #7830