### PR TITLE
LibWeb: Account for table padding in intrinsic table width calculation

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -459,6 +459,8 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(Box co
     auto const& table_box_computed_values = table_box->computed_values();
     table_box_state.border_left = table_box_computed_values.border_left().width;
     table_box_state.border_right = table_box_computed_values.border_right().width;
+    table_box_state.padding_left = table_box_computed_values.padding().left().to_px_or_zero(*table_box, width_of_containing_block);
+    table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(*table_box, width_of_containing_block);
 
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
     context->run_until_width_calculation(m_state.get(*table_box).available_inner_space_or_constraints_from(available_space));

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 94 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 78 0+0+8] children: not-inline
-      TableWrapper <(anonymous)> at [8,8] [0+0+0 143.609375 0+0+660.390625] [0+0+0 78 0+0+0] [BFC] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 143.609375 0+0+640.390625] [0+0+0 78 0+0+0] [BFC] children: not-inline
         Box <table> at [23,13] table-box [0+5+10 113.609375 10+5+0] [0+5+0 68 0+5+0] [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 100 0+0+8] children: not-inline
-      TableWrapper <(anonymous)> at [8,8] [0+0+0 24 0+0+780] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 24 0+0+760] [0+0+0 100 0+0+0] [BFC] children: not-inline
         Box <table> at [19,19] table-box [0+1+10 2 10+1+0] [0+1+10 78 10+1+0] [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/table/table-root-padding-intrinsic-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-root-padding-intrinsic-width.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 44 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 28 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 78.78125 0+0+705.21875] [0+0+0 28 0+0+0] [BFC] children: not-inline
+        Box <div> at [13,13] table-box [0+0+5 68.78125 5+0+0] [0+0+5 18 5+0+0] [TFC] children: inline
+          Box <(anonymous)> at [13,13] table-row [0+0+0 68.78125 0+0+0] [0+0+0 18 0+0+0] children: inline
+            BlockContainer <(anonymous)> at [13,13] table-cell [0+0+0 68.78125 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 7, rect: [13,13 68.78125x18] baseline: 13.796875
+                  "Foo Bar"
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,36] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x44]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x28]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 78.78125x28]
+        PaintableBox (Box<DIV>) [8,8 78.78125x28]
+          PaintableBox (Box(anonymous)) [13,13 68.78125x18]
+            PaintableWithLines (BlockContainer(anonymous)) [13,13 68.78125x18]
+              TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,36 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x44] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table/table-root-padding-intrinsic-width.html
+++ b/Tests/LibWeb/Layout/input/table/table-root-padding-intrinsic-width.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="display: table; padding: 5px;">Foo Bar</div>


### PR DESCRIPTION
Previously, we were ignoring the padding value, causing the returned `border_box_width()` to be too narrow.

Fixes this case: https://github.com/LadybirdBrowser/ladybird/issues/7830#issuecomment-3868051704