### PR TITLE
LibWeb: Support :placeholder-shown pseudo-class for textarea elements

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -790,9 +790,13 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         // - input elements that have a placeholder attribute whose value is currently being presented to the user.
         if (is<HTML::HTMLInputElement>(element) && element.has_attribute(HTML::AttributeNames::placeholder)) {
             auto const& input_element = static_cast<HTML::HTMLInputElement const&>(element);
-            return input_element.placeholder_element() && input_element.placeholder_value().has_value();
+            return input_element.placeholder_element() && input_element.value().is_empty();
         }
-        // - FIXME: textarea elements that have a placeholder attribute whose value is currently being presented to the user.
+        // - textarea elements that have a placeholder attribute whose value is currently being presented to the user.
+        if (is<HTML::HTMLTextAreaElement>(element) && element.has_attribute(HTML::AttributeNames::placeholder)) {
+            auto const& textarea_element = static_cast<HTML::HTMLTextAreaElement const&>(element);
+            return textarea_element.placeholder_element() && textarea_element.value().is_empty();
+        }
         return false;
     }
     case CSS::PseudoClass::Open:

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -134,6 +134,8 @@ public:
     // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:concept-fe-mutable
     virtual bool is_mutable() const override;
 
+    GC::Ptr<DOM::Element const> placeholder_element() const { return m_placeholder_element; }
+
 private:
     HTMLTextAreaElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Tests/LibWeb/Text/expected/textarea-placeholder-shown.txt
+++ b/Tests/LibWeb/Text/expected/textarea-placeholder-shown.txt
@@ -1,0 +1,4 @@
+PASS
+PASS
+PASS
+PASS

--- a/Tests/LibWeb/Text/input/textarea-placeholder-shown.html
+++ b/Tests/LibWeb/Text/input/textarea-placeholder-shown.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<textarea id="a" placeholder="Enter text"></textarea>
+<textarea id="b" placeholder="Enter text">some value</textarea>
+<textarea id="c">no placeholder attr</textarea>
+<textarea id="d" placeholder=""></textarea>
+<script>
+    test(() => {
+        const a = document.getElementById("a");
+        const b = document.getElementById("b");
+        const c = document.getElementById("c");
+        const d = document.getElementById("d");
+
+        println(a.matches(":placeholder-shown") ? "PASS" : "FAIL");
+        println(!b.matches(":placeholder-shown") ? "PASS" : "FAIL");
+        println(!c.matches(":placeholder-shown") ? "PASS" : "FAIL");
+        println(d.matches(":placeholder-shown") ? "PASS" : "FAIL");
+    });
+</script>


### PR DESCRIPTION
The `:placeholder-shown` pseudo-class was only matching `<input>` elements. `<textarea>` elements with a placeholder attribute were always ignored, breaking floating-label form patterns that use `textarea:placeholder-shown`. This implements the missing textarea case per the HTML spec.

Spec:
https://html.spec.whatwg.org/multipage/semantics-other.html#selector-placeholder-shown

Includes a Text test covering `:placeholder-shown` matching for textareas with and without placeholder attributes and values.