### PR TITLE
LibWeb: Don't crash when painting cursor in a vertical writing mode

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -458,7 +458,6 @@ void paint_cursor_if_needed(DisplayListRecordingContext& context, TextPaintable 
         return;
 
     auto cursor_rect = fragment.range_rect(Paintable::SelectionState::StartAndEnd, cursor_position->offset(), cursor_position->offset());
-    VERIFY(cursor_rect.width() == 1);
 
     auto cursor_device_rect = context.rounded_device_rect(cursor_rect).to_type<int>();
 

--- a/Tests/LibWeb/Crash/CSS/vertical-writing-mode-cursor.html
+++ b/Tests/LibWeb/Crash/CSS/vertical-writing-mode-cursor.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    div {
+        writing-mode: vertical-lr;
+    }
+</style>
+<div contenteditable>test</div>
+<script>
+    document.querySelector("div").focus();
+</script>


### PR DESCRIPTION
This change removes an assertion, which is not true when a cursor is painted in a vertical writing mode.

This stops 7 WPT tests from crashing. These tests still don't work because they test `caret-shape`, which we haven't yet implemented.