### PR TITLE
LibWeb: Don't crash in WebDriver call when element has no client rects

### DIFF
--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -204,7 +204,7 @@ static ErrorOr<CSSPixelPoint, WebDriver::Error> get_coordinates_relative_to_orig
             auto element = TRY(actions_options.get_element_origin(browsing_context, origin));
 
             // 3. Let x element and y element be the result of calculating the in-view center point of element.
-            auto position = in_view_center_point(element, viewport);
+            auto position = TRY(in_view_center_point(element, viewport));
 
             // 4. Let x equal x element + x offset, and y equal y element + y offset.
             return position.translated(offset);

--- a/Libraries/LibWeb/WebDriver/ElementReference.h
+++ b/Libraries/LibWeb/WebDriver/ElementReference.h
@@ -58,6 +58,6 @@ bool is_shadow_root_detached(Web::DOM::ShadowRoot const&);
 
 WEB_API String element_rendered_text(DOM::Node&);
 
-CSSPixelPoint in_view_center_point(DOM::Element const& element, CSSPixelRect viewport);
+ErrorOr<CSSPixelPoint, WebDriver::Error> in_view_center_point(DOM::Element const& element, CSSPixelRect viewport);
 
 }


### PR DESCRIPTION
Previously, the `in_view_center_point()` function unconditionally called `first()` on the result of `getClientRects()`, which hits an assertion when the element has no rendered box. We now return an error from `in_view_center_point()` in this case.

This prevents 7 WPT test crashes in `/html/semantics/forms/the-select-element/customizable-select`.

I haven't added a test for this, since we don't have an automated way to test WebDriver changes.