### PR TITLE
LibWeb: Account for `<col>` span attribute during table grid formation

### DIFF
--- a/Libraries/LibWeb/Layout/TableGrid.cpp
+++ b/Libraries/LibWeb/Layout/TableGrid.cpp
@@ -123,8 +123,12 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
     auto process_col_group = [&](auto& col_group) {
         auto dom_node = col_group.dom_node();
         dom_node->for_each_in_subtree([&](auto& descendant) {
-            if (descendant.layout_node() && descendant.layout_node()->display().is_table_column())
-                x_width += 1;
+            if (descendant.layout_node() && descendant.layout_node()->display().is_table_column()) {
+                u32 span = 1;
+                if (auto const* col_element = as_if<HTML::HTMLTableColElement>(descendant))
+                    span = col_element->span();
+                x_width += span;
+            }
             return TraversalDecision::Continue;
         });
     };

--- a/Tests/LibWeb/Crash/Layout/table-col-span.html
+++ b/Tests/LibWeb/Crash/Layout/table-col-span.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<table>
+    <colgroup><col span="2"><col><col></colgroup>
+    <tr><td></td><td></td><td></td></tr>
+</table>

--- a/Tests/LibWeb/Layout/expected/table/col-span-crash.txt
+++ b/Tests/LibWeb/Layout/expected/table/col-span-crash.txt
@@ -1,8 +1,8 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
-      TableWrapper <(anonymous)> at [8,8] [0+0+0 4 0+0+780] [0+0+0 2 0+0+0] [BFC] children: not-inline
-        Box <table> at [8,8] table-box [0+0+0 4 0+0+0] [0+0+0 2 0+0+0] [TFC] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 20 0+0+764] [0+0+0 2 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,8] table-box [0+0+0 20 0+0+0] [0+0+0 2 0+0+0] [TFC] children: not-inline
           BlockContainer <colgroup> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
       BlockContainer <(anonymous)> at [8,10] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
@@ -13,8 +13,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 4x2]
-        PaintableBox (Box<TABLE>) [8,8 4x2]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 20x2]
+        PaintableBox (Box<TABLE>) [8,8 20x2]
       PaintableWithLines (BlockContainer(anonymous)) [8,10 784x18]
         TextPaintable (TextNode<#text>)
 


### PR DESCRIPTION
Previously, the column count was always incremented by 1. This led to a mismatch with `compute_outer_content_sizes()`, which did use the `span` attribute to advance the column index. This mismatch caused an out-of-bounds access when the column index was greater than the expected number of columns.

Prevents a crash in http://wpt.live/css/css-tables/paint/col-change-span-bg-invalidation-002.html. The test itself still fails, so I created a simpler crash test that exercises the same issue. 