### PR TITLE
LibWeb: Present canvas before snapshotting in drawImage()

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
@@ -58,6 +58,7 @@ RefPtr<Gfx::ImmutableBitmap> canvas_image_source_bitmap(CanvasImageSource const&
             return element->default_image_bitmap();
         },
         [](GC::Root<HTMLCanvasElement> const& canvas) -> RefPtr<Gfx::ImmutableBitmap> {
+            canvas->present();
             auto surface = canvas->surface();
             if (!surface)
                 return Gfx::ImmutableBitmap::create(*canvas->get_bitmap_from_surface());


### PR DESCRIPTION
When a WebGL canvas is used as a CanvasImageSource, the underlying PaintingSurface may not yet reflect the most recent GL commands. This caused drawImage() to capture stale or empty content unless gl.flush() was called manually from JS.

Call HTMLCanvasElement::present() before creating the snapshot so that WebGL content is properly synchronized with the surface prior to readback.

Fix #7901