### PR TITLE
LibWeb: Do not allow margins to collapse

### DIFF
--- a/Tests/LibWeb/Layout/expected/margin-collapse-through-bfc.txt
+++ b/Tests/LibWeb/Layout/expected/margin-collapse-through-bfc.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      BlockContainer <div#outer> at [0,100] [0+0+0 800 0+0+0] [100+0+0 0 0+0+0] children: not-inline
+        BlockContainer <div> at [0,100] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [0,100] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x100]
+      PaintableWithLines (BlockContainer<DIV>#outer) [0,100 800x0]
+        PaintableWithLines (BlockContainer<DIV>) [0,100 800x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,100 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/margin-collapse-through-bfc.html
+++ b/Tests/LibWeb/Layout/input/margin-collapse-through-bfc.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html><style>
+    * { margin: 0; padding: 0; }
+    body { display: flow-root; }
+    #outer { margin-top: 100px; }
+</style><div id="outer"><div style="display:flow-root"></div></div>


### PR DESCRIPTION
Allows us to scroll down to the bottom of Internet Archive pages.
Closes #7794