### PR TITLE
LibWeb: Reset abspos offset before static position computation

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1460,6 +1460,12 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Abs
         }
     }
 
+    // AD-HOC: Reset offset to zero before recomputing. Table cells with percentage heights are laid out twice - before
+    //         and after table height is determined. Each pass re-enters layout_absolutely_positioned_element for abspos
+    //         descendants. Without this reset, the stale offset from the first pass triggers the assertion in
+    //         content_box_rect_in_static_position_ancestor_coordinate_space.
+    box_state.set_content_offset({ 0, 0 });
+
     CSSPixelPoint used_offset;
 
     auto static_position = m_state.get(box).static_position();

--- a/Tests/LibWeb/Crash/Layout/table-cell-percentage-height-with-abspos.html
+++ b/Tests/LibWeb/Crash/Layout/table-cell-percentage-height-with-abspos.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+.cell {
+    display: table-cell;
+    height: 100%;
+}
+.cb {
+    position: relative;
+    padding: 1px;
+}
+.cb::after {
+    position: absolute;
+    content: "";
+    top: 0;
+    left: 0;
+}
+</style>
+<div style="display: table"><div class="cell"><div class="cb"></div></div></div>


### PR DESCRIPTION
When a table cell has a percentage height, `TableFormattingContext` performs two layout passes on the cell. If the cell contains an absolutely positioned descendant, the first pass sets its offset via `layout_absolutely_positioned_element()`. On the second pass, the stale non-zero offset triggers an assertion in
`content_box_rect_in_static_position_ancestor_coordinate_space()`.

We now reset the offset to zero at the start of the offset computation in `layout_absolutely_positioned_element()`.

Fixes: #6905
Fixes: #7874