### PR TITLE
LibWeb: Don't crash in Storage::broadcast() if document has no navigable

### DIFF
--- a/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Libraries/LibWeb/HTML/Storage.cpp
@@ -210,10 +210,15 @@ void Storage::broadcast(Optional<String> const& key, Optional<String> const& old
         if (type() == Type::Session) {
             auto& storage_document = *relevant_settings_object(storage).responsible_document();
 
-            // NOTE: It is possible the remote storage may have not been fully teared down immediately at the point it's document is made inactive.
+            // NB: It is possible the remote storage may have not been fully teared down immediately at the point it's
+            //     document is made inactive.
             if (!storage_document.navigable())
                 continue;
-            VERIFY(this_document.navigable());
+
+            // NB: It is possible for this storage's document to have lost its navigable if script holds a reference to
+            //     the Storage object after its browsing context has navigated to a new document.
+            if (!this_document.navigable())
+                continue;
 
             if (storage_document.navigable()->traversable_navigable() != this_document.navigable()->traversable_navigable())
                 continue;

--- a/Tests/LibWeb/Crash/HTML/session-storage-delete-after-iframe-navigated.html
+++ b/Tests/LibWeb/Crash/HTML/session-storage-delete-after-iframe-navigated.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<body>
+<script>
+    // Ensure the parent has a session Storage object so broadcast() iterates.
+    sessionStorage.setItem("parent-key", "value");
+
+    const iframe = document.createElement("iframe");
+    iframe.src = "../../Assets/blank.html";
+    let firstLoad = true;
+    iframe.onload = () => {
+        if (firstLoad) {
+            firstLoad = false;
+
+            const oldStorage = iframe.contentWindow.sessionStorage;
+            oldStorage.setItem("crash-test-key", "value");
+
+            iframe.addEventListener("load", () => {
+                oldStorage.removeItem("crash-test-key");
+                sessionStorage.removeItem("parent-key");
+            }, { once: true });
+
+            iframe.src = "../../Assets/blank.html";
+        }
+    };
+    document.body.appendChild(iframe);
+</script>
+</body>


### PR DESCRIPTION
Fixes crashes in these WPT tests:
* `/websockets/unload-a-document/004.html`
* `/websockets/unload-a-document/002.html?default`
* `/websockets/unload-a-document/003.html`
* `/websockets/unload-a-document/001.html?default`