### PR TITLE
Meta: Support nullable BufferSource as Optional in IDL generator

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
 #include <LibGC/Ptr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/WebGL/WebGL2RenderingContextImpl.h>
@@ -24,7 +25,7 @@ public:
     WebGL2RenderingContextOverloads(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 
     void buffer_data(WebIDL::UnsignedLong target, WebIDL::LongLong size, WebIDL::UnsignedLong usage);
-    void buffer_data(WebIDL::UnsignedLong target, GC::Root<WebIDL::BufferSource> src_data, WebIDL::UnsignedLong usage);
+    void buffer_data(WebIDL::UnsignedLong target, Optional<GC::Root<WebIDL::BufferSource>> src_data, WebIDL::UnsignedLong usage);
     void buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, GC::Root<WebIDL::BufferSource> src_data);
     void buffer_data(WebIDL::UnsignedLong target, GC::Root<WebIDL::ArrayBufferView> src_data, WebIDL::UnsignedLong usage, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length);
     void buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, GC::Root<WebIDL::ArrayBufferView> src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length);

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
 #include <LibGC/Ptr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/WebGL/WebGLRenderingContextImpl.h>
@@ -24,7 +25,7 @@ public:
     WebGLRenderingContextOverloads(JS::Realm&, NonnullOwnPtr<OpenGLContext>);
 
     void buffer_data(WebIDL::UnsignedLong target, WebIDL::LongLong size, WebIDL::UnsignedLong usage);
-    void buffer_data(WebIDL::UnsignedLong target, GC::Root<WebIDL::BufferSource> data, WebIDL::UnsignedLong usage);
+    void buffer_data(WebIDL::UnsignedLong target, Optional<GC::Root<WebIDL::BufferSource>> data, WebIDL::UnsignedLong usage);
     void buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong offset, GC::Root<WebIDL::BufferSource> data);
     void compressed_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, GC::Root<WebIDL::ArrayBufferView> data);
     void compressed_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, GC::Root<WebIDL::ArrayBufferView> data);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -962,26 +962,53 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
         }
     } else if (is_javascript_builtin(parameter.type) || parameter.type->name() == "BufferSource"sv) {
-        if (optional) {
+        size_t buffer_source_nesting_level = optional ? 2 : 1;
+        auto buffer_source_indent = ByteString::repeated(' ', buffer_source_nesting_level * 4);
+        scoped_generator.set("buffer_source.indent", buffer_source_indent);
+
+        if (optional || parameter.type->is_nullable()) {
             scoped_generator.append(R"~~~(
     Optional<GC::Root<WebIDL::BufferSource>> @cpp_name@;
-    if (!@js_name@@js_suffix@.is_undefined()) {
 )~~~");
         } else {
             scoped_generator.append(R"~~~(
     GC::Root<WebIDL::BufferSource> @cpp_name@;
 )~~~");
         }
-        scoped_generator.append(R"~~~(
-    if (!@js_name@@js_suffix@.is_object() || !(is<JS::TypedArrayBase>(@js_name@@js_suffix@.as_object()) || is<JS::ArrayBuffer>(@js_name@@js_suffix@.as_object()) || is<JS::DataView>(@js_name@@js_suffix@.as_object())))
-        return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
-
-    @cpp_name@ = GC::make_root(realm.create<WebIDL::BufferSource>(@js_name@@js_suffix@.as_object()));
-)~~~");
 
         if (optional) {
             scoped_generator.append(R"~~~(
+    if (!@js_name@@js_suffix@.is_undefined()) {
+)~~~");
+        } else if (parameter.type->is_nullable()) {
+            scoped_generator.append(R"~~~(
+    if (@js_name@@js_suffix@.is_undefined())
+        return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
+)~~~");
         }
+
+        if (parameter.type->is_nullable()) {
+            scoped_generator.append(R"~~~(
+@buffer_source.indent@if (!@js_name@@js_suffix@.is_null()) {
+)~~~");
+        }
+
+        scoped_generator.append(R"~~~(
+@buffer_source.indent@    if (!@js_name@@js_suffix@.is_object() || !(is<JS::TypedArrayBase>(@js_name@@js_suffix@.as_object()) || is<JS::ArrayBuffer>(@js_name@@js_suffix@.as_object()) || is<JS::DataView>(@js_name@@js_suffix@.as_object())))
+@buffer_source.indent@        return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "@parameter.type.name@");
+
+@buffer_source.indent@    @cpp_name@ = GC::make_root(realm.create<WebIDL::BufferSource>(@js_name@@js_suffix@.as_object()));
+)~~~");
+
+        if (parameter.type->is_nullable()) {
+            scoped_generator.append(R"~~~(
+@buffer_source.indent@}
+)~~~");
+        }
+
+        if (optional) {
+            scoped_generator.append(R"~~~(
+    }
 )~~~");
         }
 


### PR DESCRIPTION
This IDL change is needed for webaudio's WaveShaperNode, where a null BufferSource for a curve attribute results in a zero-length buffer.

WebGL also has a nullable BufferSource arg in bufferData(...). But there, a null data/srcData value returns GL_INVALID_VALUE.