### PR TITLE
Tests/LibWeb: Sync WPT test for WASM global attribute setter

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/global/value-get-set.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wasm/jsapi/global/value-get-set.any.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 68 tests
 
-67 Pass
-1 Fail
+68 Pass
 Pass	Branding
 Pass	Immutable i32 (missing)
 Pass	Immutable i32 with ToNumber side-effects (missing)
@@ -70,5 +69,5 @@ Pass	Mutable f64 (one)
 Pass	Mutable f64 (string)
 Pass	Mutable f64 (true on prototype)
 Pass	i64 mutability
-Fail	Calling setter without argument
+Pass	Calling setter without argument
 Pass	Stray argument

--- a/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/global/value-get-set.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/wasm/jsapi/global/value-get-set.any.js
@@ -131,7 +131,14 @@ test(() => {
   const setter = desc.set;
   assert_equals(typeof setter, "function");
 
-  assert_throws_js(TypeError, () => setter.call(global));
+  assert_equals(global.value, 0);
+
+  assert_equals(setter.call(global, undefined), undefined);
+  assert_equals(global.value, 0);
+
+  // Should behave as if 'undefined' was passed as the argument.
+  assert_equals(setter.call(global), undefined);
+  assert_equals(global.value, 0);
 }, "Calling setter without argument");
 
 test(() => {


### PR DESCRIPTION
The regression in 932a20423fa248e59e809190b4317a1744ee654c turned out to be the specified behaviour changed as part of: whatwg/webidl#1498

And WPT has now been updated accordingly (technically not merged as I write this merge request, but is approved, making this before I forget, can merge when that is merged)