### PR TITLE
LibWeb: Fix off-by-one in Navigation::can_go_forward()

### DIFF
--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -183,9 +183,9 @@ bool Navigation::can_go_forward() const
     // 2. Assert: navigation's current entry index is not −1.
     VERIFY(m_current_entry_index != -1);
 
-    // 3. If this's current entry index is equal to this's entry list's size, then return false.
+    // 3. If this's current entry index is equal to this's entry list's size − 1, then return false.
     // 4. Return true.
-    return (m_current_entry_index != static_cast<i64>(m_entry_list.size()));
+    return (m_current_entry_index != static_cast<i64>(m_entry_list.size() - 1));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#history-handling-behavior

--- a/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Navigation-object-properties.txt
@@ -2,4 +2,4 @@ entries[length - 1] is current entry: true
 currentEntry is a [object NavigationHistoryEntry]
 transition is null: true
 canGoBack: true
-canGoForward: true
+canGoForward: false


### PR DESCRIPTION
`can_go_forward()` compared `m_current_entry_index` against `m_entry_list.size()`, which is a past-the-end value that never occurs for valid indices. This meant it always returned `true` regardless of position in the history, even when the current entry was the last one in the list and `forward()` would immediately throw `InvalidStateError`.

The fix compares against `size() - 1` instead, matching the symmetric `can_go_back()` and `forward()`.

Also rebaselined the Navigation-object-properties test expectation, which was reflecting the buggy behavior.

Spec:
https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoforward