### PR TITLE
LibWebView+WebContent: Add ProcessPolicyRouter to broker process

### DIFF
--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     Process.cpp
     ProcessHandle.cpp
     ProcessManager.cpp
+    ProcessPolicyRouter.cpp
     SearchEngine.cpp
     Settings.cpp
     SiteIsolation.cpp

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -93,6 +93,12 @@ Optional<Process&> ProcessManager::find_process(pid_t pid)
     return m_processes.get(pid);
 }
 
+ProcessPolicyRouter const& ProcessManager::policy_router() const
+{
+    static ProcessPolicyRouter s_router;
+    return s_router;
+}
+
 void ProcessManager::add_process(WebView::Process&& process)
 {
     Threading::MutexLocker locker { m_lock };

--- a/Libraries/LibWebView/ProcessManager.h
+++ b/Libraries/LibWebView/ProcessManager.h
@@ -12,6 +12,7 @@
 #include <LibThreading/Mutex.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Process.h>
+#include <LibWebView/ProcessPolicyRouter.h>
 #include <LibWebView/ProcessType.h>
 
 namespace WebView {
@@ -25,6 +26,8 @@ class WEBVIEW_API ProcessManager {
 public:
     ProcessManager();
     ~ProcessManager();
+
+    ProcessPolicyRouter const& policy_router() const;
 
     void add_process(Process&&);
     Optional<Process> remove_process(pid_t);

--- a/Libraries/LibWebView/ProcessPolicyRouter.cpp
+++ b/Libraries/LibWebView/ProcessPolicyRouter.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, The Ladybird developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/ProcessPolicyRouter.h>
+
+namespace WebView {
+
+ProcessScope ProcessPolicyRouter::default_scope_for(ProcessType type)
+{
+    switch (type) {
+    case ProcessType::Browser:
+    case ProcessType::RequestServer:
+    case ProcessType::ImageDecoder:
+    case ProcessType::WebContent:
+        return ProcessScope::PerView;
+    case ProcessType::WebWorker:
+        return ProcessScope::PerRequest;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+bool ProcessPolicyRouter::should_maintain_spare_web_content_process(BrowserOptions const& options)
+{
+    // Disable spare processes when debugging WebContent. Otherwise, it breaks running
+    // gdb attach -p $(pidof WebContent).
+    if (options.debug_helper_process == ProcessType::WebContent)
+        return false;
+
+    // Disable spare processes when profiling WebContent. This reduces callgrind logging
+    // we are not interested in.
+    if (options.profile_helper_process == ProcessType::WebContent)
+        return false;
+
+    return true;
+}
+
+Vector<ProcessType> ProcessPolicyRouter::singleton_services_to_launch()
+{
+    // Keep this order stable: other code assumes these services exist early.
+    return {
+        ProcessType::RequestServer,
+        ProcessType::ImageDecoder,
+    };
+}
+
+}

--- a/Libraries/LibWebView/ProcessPolicyRouter.h
+++ b/Libraries/LibWebView/ProcessPolicyRouter.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, The Ladybird developers
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibWebView/Options.h>
+#include <LibWebView/ProcessType.h>
+
+namespace WebView {
+
+enum class ProcessScope : u8 {
+    // These scopes describe how the browser routes helper-process requests.
+    // The HTML spec models execution in terms of agents (an idealized thread
+    // of script execution) and agent clusters (an idealized process boundary).
+    // Ladybird's process model does not map 1:1 to the spec, but we try to keep
+    // the policy language compatible with those concepts.
+    Singleton,
+
+    // Cache one helper instance per top-level page (page_id). This is the
+    // closest approximation to "per agent cluster" for helpers that should not
+    // accumulate across navigations/tests.
+    PerView,
+
+    // Do not cache; spawn/connect a fresh helper instance per request.
+    PerRequest,
+};
+
+class ProcessPolicyRouter {
+public:
+    static ProcessScope default_scope_for(ProcessType);
+
+    // Encodes current behavior: keep one spare WebContent process unless it interferes
+    // with debugging/profiling.
+    static bool should_maintain_spare_web_content_process(BrowserOptions const&);
+
+    // Encodes current behavior: these are launched as singleton services at startup.
+    static Vector<ProcessType> singleton_services_to_launch();
+};
+
+}

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -54,7 +54,7 @@
 static ErrorOr<void> load_content_filters(StringView config_path);
 
 static ErrorOr<void> initialize_resource_loader(GC::Heap&, int request_server_socket);
-static ErrorOr<void> reinitialize_resource_loader(IPC::File const& image_decoder_socket);
+static ErrorOr<void> reinitialize_resource_loader(IPC::File const& request_server_socket);
 
 static ErrorOr<void> initialize_image_decoder(int image_decoder_socket);
 static ErrorOr<void> reinitialize_image_decoder(IPC::File const& image_decoder_socket);


### PR DESCRIPTION
Hopefully, one day this empty switch statement will be filled with workers, helpers, and service processes. This is a step towards breaking audio IO device management and playback out of WebContent and into a singleton AudioServer process. It's one step closer to not needing user privs for WebContent.