### PR TITLE
LibHTTP: Fix inverted Content-Range complete-length parsing

### DIFF
--- a/Libraries/LibHTTP/HeaderList.cpp
+++ b/Libraries/LibHTTP/HeaderList.cpp
@@ -289,7 +289,7 @@ static Optional<HeaderList::ContentRangeValues> parse_single_byte_content_range_
         return {};
 
     // complete-length = ( 1*DIGIT / "*" )
-    if (!lexer.consume_specific('*')) {
+    if (lexer.consume_specific('*')) {
         result.complete_length = {};
     } else {
         auto complete_length_result = lexer.consume_decimal_integer<u64>();
@@ -297,6 +297,9 @@ static Optional<HeaderList::ContentRangeValues> parse_single_byte_content_range_
             return {};
         result.complete_length = complete_length_result.release_value();
     }
+
+    if (!lexer.is_eof())
+        return {};
 
     return result;
 }


### PR DESCRIPTION
`parse_single_byte_content_range_as_values()` had its `consume_specific('*')` condition inverted, silently breaking the complete-length parsing for both cases:

- Numeric lengths like `bytes 0-999/1000` would discard the length and produce an empty optional
- Unknown lengths like `bytes 0-999/*` would try to parse digits after consuming the `*`, failing entirely

The only caller is `HTMLMediaElement::validate_add_byte_range_response()`, so this was silently breaking partial content handling for media elements.

Also added an EOF check to reject trailing garbage after an otherwise valid Content-Range value, matching the pattern in `parse_single_range_header_value()`.

Spec:
https://wicg.github.io/background-fetch/#single-byte-content-range