### PR TITLE
LibWeb: Clear textarea with empty string for WebDriver

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -127,7 +127,7 @@ void HTMLTextAreaElement::clear_algorithm()
     m_dirty_value = false;
 
     // and set the raw value of element to an empty string.
-    set_raw_value(child_text_content());
+    set_raw_value({});
 
     // Unlike their associated reset algorithms, changes made to form controls as part of these algorithms do count as
     // changes caused by the user (and thus, e.g. do cause input events to fire).

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -23,6 +23,7 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Window.h>
@@ -523,6 +524,12 @@ void Internals::perform_per_test_cleanup()
 void Internals::set_highlighted_node(GC::Ptr<DOM::Node> node)
 {
     window().associated_document().set_highlighted_node(node, {});
+}
+
+void Internals::clear_element(HTML::HTMLElement& element)
+{
+    auto& form_associated_element = as<HTML::FormAssociatedElement>(element);
+    form_associated_element.clear_algorithm();
 }
 
 }

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -104,6 +104,8 @@ public:
 
     void set_highlighted_node(GC::Ptr<DOM::Node> node);
 
+    void clear_element(HTML::HTMLElement&);
+
 private:
     explicit Internals(JS::Realm&);
 

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -83,4 +83,6 @@ interface Internals {
 
     undefined setHighlightedNode(Node? node);
 
+    undefined clearElement(HTMLElement element);
+
 };

--- a/Tests/LibWeb/Text/expected/textarea-clear.txt
+++ b/Tests/LibWeb/Text/expected/textarea-clear.txt
@@ -1,0 +1,2 @@
+1. value after clear: ""
+2. defaultValue after clear: "initial content"

--- a/Tests/LibWeb/Text/input/textarea-clear.html
+++ b/Tests/LibWeb/Text/input/textarea-clear.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const textarea = document.createElement('textarea');
+        textarea.textContent = 'initial content';
+        document.body.appendChild(textarea);
+
+        textarea.value = 'user modified';
+        internals.clearElement(textarea);
+        println(`1. value after clear: "${textarea.value}"`);
+        println(`2. defaultValue after clear: "${textarea.defaultValue}"`);
+
+        document.body.removeChild(textarea);
+    });
+</script>


### PR DESCRIPTION
The WebDriver clear handler for textarea elements set the raw value to `child_text_content()` instead of an empty string. This was a copy-paste error from the adjacent reset handler, which correctly uses `child_text_content()` per its own spec (reset restores the textarea to its initial DOM content). The clear handler should empty the textarea entirely.

Also adds an `internals.clearElement()` helper to expose the WebDriver clear algorithm to the test harness, with a regression test covering the fix.

Spec:
https://w3c.github.io/webdriver/#dfn-clear-algorithm