### PR TITLE
LibWeb: Check WWW-Authenticate on response, not request

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1879,7 +1879,7 @@ GC::Ref<PendingResponse> http_network_or_cache_fetch(JS::Realm& realm, Infrastru
             && request->traversable_for_user_prompts().has<GC::Ptr<HTML::TraversableNavigable>>()
             // AD-HOC: Require at least one WWW-Authenticate header to be set before automatically retrying an authenticated
             //         request (see rule 1 below). See: https://github.com/whatwg/fetch/issues/1766
-            && request->header_list()->contains("WWW-Authenticate"sv)) {
+            && response->header_list()->contains("WWW-Authenticate"sv)) {
             // 1. Needs testing: multiple `WWW-Authenticate` headers, missing, parsing issues.
             // (Red box in the spec, no-op)
 


### PR DESCRIPTION
The AD-HOC guard for HTTP 401 retry in `http_network_or_cache_fetch` checked whether the *request* contained a `WWW-Authenticate` header, but `WWW-Authenticate` is expected as a response header sent by the server. The check used `request->header_list()` where `response->header_list()` was intended. Since requests never carry this header, the guard never matched and the entire 401 retry path was dead code.

See:
https://github.com/whatwg/fetch/issues/1766