### PR TITLE
LibWeb: Chain all accept attribute checks in parse_accept_attribute()

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -333,12 +333,12 @@ FileFilter HTMLInputElement::parse_accept_attribute() const
 
         // The string "video/*"
         //     Indicates that video files are accepted.
-        if (value.equals_ignoring_ascii_case("video/*"sv))
+        else if (value.equals_ignoring_ascii_case("video/*"sv))
             filter.add_filter(FileFilter::FileType::Video);
 
         // The string "image/*"
         //     Indicates that image files are accepted.
-        if (value.equals_ignoring_ascii_case("image/*"sv))
+        else if (value.equals_ignoring_ascii_case("image/*"sv))
             filter.add_filter(FileFilter::FileType::Image);
 
         // A valid MIME type string with no parameters


### PR DESCRIPTION
The wildcard checks for `audio/*` and `video/*` in `parse_accept_attribute()` were standalone `if` statements, while the MIME type and extension branches were `else if` chained only to the `image/*` check. When a token like `"audio/*"` arrived, it matched the first `if` (adding `FileType::Audio`) and then fell through to the MIME type `else if`. `MimeType::parse()` accepts the wildcard because `*` is a valid HTTP token code point, so a second `MimeType{"audio/*"}` entry was added. `FileFilter::add_filter()` deduplicates within variant types but cannot catch this cross-type duplication, resulting in redundant entries in the file picker dialog.

This chains all five conditions into a single `if`/`else if`, matching the spec's mutually exclusive "one of the following" wording.

Spec:
https://html.spec.whatwg.org/multipage/input.html#attr-input-accept