### PR TITLE
LibWeb: Correct body null check in navigation params fetch

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -994,7 +994,7 @@ static void perform_navigation_params_fetch(JS::Realm& realm, GC::Ref<Navigation
         }
 
         // 8. If request's body is null, then set entry's document state's resource to null.
-        if (!state_holder->request->body().has<Empty>()) {
+        if (state_holder->request->body().has<Empty>()) {
             state_holder->entry->document_state()->set_resource(Empty {});
         }
 


### PR DESCRIPTION
Step 8 of "create navigation params by fetching" says "if request's body is null, set entry's document state's resource to null." The condition checked `!body().has<Empty>()`, entering the block when the body was non-null instead of null. For navigation that included POST requests this was especially bad as most will contain bodies, and it originally cleared the POSTResource from the session history entry, breaking form re-submission on backward/forward navigation.

Spec:
https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching