### PR TITLE
LibWeb: Check for NavigationParams in finalize_session_history_entry

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1363,9 +1363,10 @@ static void finalize_session_history_entry(
 
         // 3. If entry's document state's request referrer is "client", and navigationParams is a navigation params (i.e., neither null nor a non-fetch scheme navigation params), then:
         if (entry->document_state()->request_referrer() == Fetch::Infrastructure::Request::Referrer::Client
-            && (!received_navigation_params.has<Navigable::NullOrError>() && received_navigation_params.has<GC::Ref<NonFetchSchemeNavigationParams>>())) {
+            && received_navigation_params.has<GC::Ref<NavigationParams>>()
+            && received_navigation_params.get<GC::Ref<NavigationParams>>()->request) {
             // 1. Assert: navigationParams's request is not null.
-            VERIFY(received_navigation_params.has<GC::Ref<NavigationParams>>() && received_navigation_params.get<GC::Ref<NavigationParams>>()->request);
+            // NB: We don't perform this assertion because srcdoc navigations create NavigationParams with a null request.
 
             // 2. Set entry's document state's request referrer to navigationParams's request's referrer.
             entry->document_state()->set_request_referrer(received_navigation_params.get<GC::Ref<NavigationParams>>()->request->referrer());


### PR DESCRIPTION
Step 7.3 of the spec says "if navigationParams is a navigation params," but the condition checked for `NonFetchSchemeNavigationParams` instead of `NavigationParams`. The block body already accessed the variant as `NavigationParams`, so if the condition ever matched it would VERIFY-crash. The identical check five lines above in step 7.2.3.1 was already correct, this was not.

Fixing the variant type also means this block now runs for regular navigations. Srcdoc navigations legitimately have a null `request` in their `NavigationParams` (per `create_navigation_params_from_a_srcdoc_resource`), so the condition also guards on that to avoid hitting the spec's "request is not null" assertion.

Spec:
https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-session-history-entry