### PR TITLE
LibWeb: Mark initial color value as requiring computation

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1396,7 +1396,7 @@
     "inherited": true,
     "initial": "canvastext",
     "needs-layout-node-for-resolved-value": true,
-    "requires-computation": "cascaded-value",
+    "requires-computation": "non-inherited-value",
     "valid-types": [
       "color"
     ],


### PR DESCRIPTION
Previously we only computed if we had a cascaded value, but the initial value of `canvastext` requires computation as well

Fixes a test failure in `slot-style-inheritance.html` introduced in 6358432