### PR TITLE
LibWeb: Mark `StyleComputer` cache members as mutable

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1405,7 +1405,7 @@ void StyleComputer::compute_property_values(ComputedProperties& style, Optional<
     }
 
     if (abstract_element.has_value() && is<HTML::HTMLHtmlElement>(abstract_element->element()))
-        const_cast<StyleComputer&>(*this).m_root_element_font_metrics = calculate_root_element_font_metrics(style);
+        m_root_element_font_metrics = calculate_root_element_font_metrics(style);
 }
 
 ComputationContext const& StyleComputer::get_computation_context_for_property(PropertyID property_id, ComputedProperties const& style, Optional<DOM::AbstractElement> abstract_element) const
@@ -1436,7 +1436,7 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
         if (!m_cached_font_computation_context.has_value()) {
             auto inheritance_parent = abstract_element.map([](auto& element) { return element.element_to_inherit_style_from(); }).value_or(OptionalNone {});
 
-            const_cast<StyleComputer*>(this)->m_cached_font_computation_context = {
+            m_cached_font_computation_context = {
                 .length_resolution_context = inheritance_parent.has_value()
                     ? Length::ResolutionContext::for_element(inheritance_parent.value())
                     : Length::ResolutionContext::for_window(*m_document->window()),
@@ -1456,7 +1456,7 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
                 inheritance_parent.has_value() ? inheritance_parent->computed_properties()->line_height() : InitialValues::line_height()
             };
 
-            const_cast<StyleComputer*>(this)->m_cached_line_height_computation_context = {
+            m_cached_line_height_computation_context = {
                 .length_resolution_context = {
                     .viewport_rect = viewport_rect(),
                     .font_metrics = line_height_font_metrics,
@@ -1472,7 +1472,7 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
     }
     default: {
         if (!m_cached_generic_computation_context.has_value()) {
-            const_cast<StyleComputer*>(this)->m_cached_generic_computation_context = {
+            m_cached_generic_computation_context = {
                 .length_resolution_context = {
                     .viewport_rect = viewport_rect(),
                     .font_metrics = {
@@ -2018,7 +2018,7 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::AbstractEleme
     }
 
     if (is<HTML::HTMLHtmlElement>(abstract_element.element()))
-        const_cast<StyleComputer&>(*this).m_root_element_font_metrics = calculate_root_element_font_metrics(computed_style);
+        m_root_element_font_metrics = calculate_root_element_font_metrics(computed_style);
 
     // Compute the value of custom properties
     compute_custom_properties(computed_style, abstract_element);

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -191,11 +191,11 @@ private:
     [[nodiscard]] RuleCache const* rule_cache_for_cascade_origin(CascadeOrigin, Optional<FlyString const> qualified_layer_name, GC::Ptr<DOM::ShadowRoot const>) const;
 
     Length::FontMetrics m_default_font_metrics;
-    Length::FontMetrics m_root_element_font_metrics;
+    mutable Length::FontMetrics m_root_element_font_metrics;
 
-    Optional<ComputationContext> m_cached_font_computation_context;
-    Optional<ComputationContext> m_cached_line_height_computation_context;
-    Optional<ComputationContext> m_cached_generic_computation_context;
+    mutable Optional<ComputationContext> m_cached_font_computation_context;
+    mutable Optional<ComputationContext> m_cached_line_height_computation_context;
+    mutable Optional<ComputationContext> m_cached_generic_computation_context;
     ComputationContext const& get_computation_context_for_property(PropertyID, ComputedProperties const&, Optional<DOM::AbstractElement>) const;
     void clear_computation_context_caches() const
     {


### PR DESCRIPTION
This avoids some ugly `const_cast`s

Resolves a [review comment](https://github.com/LadybirdBrowser/ladybird/pull/7647#discussion_r2803587751) made in #7647