### PR TITLE
LibWeb: Fix crash in style inheritance for pseudo-element slots

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1743,6 +1743,10 @@ GC::Ptr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractEleme
 
         auto style = compute_style(abstract_element_for_pseudo_element);
 
+        // Copy cascaded properties to the element itself so that elements
+        // slotted into this slot can find them via element_to_inherit_style_from().
+        abstract_element.set_cascaded_properties(abstract_element_for_pseudo_element.cascaded_properties());
+
         // Merge back inline styles
         if (auto inline_style = element.inline_style()) {
             for (auto const& property : inline_style->properties())

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4534,7 +4534,7 @@ GC::Ref<WebIDL::Promise> Element::request_pointer_lock(Optional<PointerLockOptio
 
 // The element to inherit style from.
 // If a pseudo-element is specified, this will return the element itself.
-// Otherwise, if this element is slotted somewhere, it will return the slot's element to inherit style from.
+// Otherwise, if this element is slotted somewhere, it will return the slot.
 // Otherwise, it will return the parent or shadow host element of this element.
 GC::Ptr<Element const> Element::element_to_inherit_style_from(Optional<CSS::PseudoElement> pseudo_element) const
 {

--- a/Tests/LibWeb/Crash/CSS/details-slot-monospace-font-crash.html
+++ b/Tests/LibWeb/Crash/CSS/details-slot-monospace-font-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<details open>
+<summary>Summary</summary>
+<pre>monospace text in details</pre>
+</details>


### PR DESCRIPTION
Elements in internal shadow trees that represent CSS pseudo-elements (e.g. the DetailsContent slot in `<details>`) store their cascaded properties on the host element's pseudo-element data, not on the element itself. This meant that when slotted elements walked the inheritance chain and encountered such a slot, they would dereference null cascaded properties and crash.

Fix this by copying the cascaded properties onto the slot element itself after computing its style, keeping both cascaded and computed properties accessible in the same place.