### PR TITLE
LibWeb: Fix SVG partial relayout skipping abspos sibling updates

### DIFF
--- a/Tests/LibWeb/Text/expected/SVG/svg-foreignobject-abspos-outside-cb-sibling-characterdata.txt
+++ b/Tests/LibWeb/Text/expected/SVG/svg-foreignobject-abspos-outside-cb-sibling-characterdata.txt
@@ -1,0 +1,1 @@
+moved=true

--- a/Tests/LibWeb/Text/input/SVG/svg-foreignobject-abspos-outside-cb-sibling-characterdata.html
+++ b/Tests/LibWeb/Text/input/SVG/svg-foreignobject-abspos-outside-cb-sibling-characterdata.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    html, body { margin: 0; }
+    .container {
+        position: relative;
+        width: 300px;
+        height: 200px;
+    }
+    #flow {
+        font: 16px/16px serif;
+        width: 20px;
+    }
+    #abspos {
+        position: absolute;
+        width: 20px;
+        height: 10px;
+    }
+</style>
+<div class="container">
+    <svg width="300" height="200">
+        <foreignObject width="300" height="200">
+            <div id="flow">x</div>
+            <div id="abspos"></div>
+        </foreignObject>
+    </svg>
+</div>
+<script>
+    asyncTest(done => {
+        const flow = document.getElementById("flow");
+        const abspos = document.getElementById("abspos");
+        document.body.offsetWidth;
+
+        const before = abspos.getBoundingClientRect();
+
+        // CharacterData mutation is expected to take partial relayout path here.
+        flow.firstChild.data = "x x x x x x x x x x x x x x x x";
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                const after = abspos.getBoundingClientRect();
+                println(`moved=${after.x !== before.x || after.y !== before.y}`);
+                done();
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
When a CharacterData mutation inside a foreignObject triggered partial SVG relayout, sibling absolutely positioned elements whose containing block is outside the SVG were not being repositioned. This happened because the check only walked ancestors of the changed node looking for abspos elements — it never saw abspos siblings.

Fix by querying contained_abspos_children() on boxes outside the SVG subtree, which finds all abspos elements regardless of their position in the tree relative to the changed node.