### PR TITLE
LibHTTP: Handle InvalidURL in parse_error_to_string

### DIFF
--- a/Libraries/LibHTTP/HttpRequest.h
+++ b/Libraries/LibHTTP/HttpRequest.h
@@ -37,9 +37,10 @@ public:
             return "Out of memory"sv;
         case ParseError::UnsupportedMethod:
             return "Unsupported method"sv;
-        default:
-            VERIFY_NOT_REACHED();
+        case ParseError::InvalidURL:
+            return "Invalid URL"sv;
         }
+        VERIFY_NOT_REACHED();
     }
 
     enum Method {


### PR DESCRIPTION
A malformed URL in a WebDriver request caused a crash via `VERIFY_NOT_REACHED()` in `parse_error_to_string`, because the `ParseError::InvalidURL` variant was not handled. The variant can be returned by `from_raw_request()` and is passed to `parse_error_to_string` in `LibWeb/WebDriver/Client.cpp`.

This adds the missing case so the error is logged instead of crashing.