### PR TITLE
LibHTTP: Implement the must-understand cache directive

### DIFF
--- a/Tests/LibHTTP/CMakeLists.txt
+++ b/Tests/LibHTTP/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestCacheUtilities.cpp
     TestHTTPUtils.cpp
 )
 

--- a/Tests/LibHTTP/TestCacheUtilities.cpp
+++ b/Tests/LibHTTP/TestCacheUtilities.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibHTTP/Cache/Utilities.h>
+#include <LibHTTP/HeaderList.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(is_cacheable_must_understand_ignores_no_store_for_understood_status)
+{
+    auto headers = HTTP::HeaderList::create({ { "Cache-Control", "must-understand, no-store, max-age=3600" } });
+    EXPECT(HTTP::is_cacheable(200, *headers));
+}
+
+TEST_CASE(is_cacheable_must_understand_rejects_unknown_status)
+{
+    auto headers = HTTP::HeaderList::create({ { "Cache-Control", "must-understand, no-store, max-age=3600" } });
+    EXPECT(!HTTP::is_cacheable(202, *headers));
+}
+
+TEST_CASE(is_cacheable_no_store_without_must_understand)
+{
+    auto headers = HTTP::HeaderList::create({ { "Cache-Control", "no-store, max-age=3600" } });
+    EXPECT(!HTTP::is_cacheable(200, *headers));
+}
+
+TEST_CASE(is_cacheable_must_understand_without_no_store_understood_status)
+{
+    auto headers = HTTP::HeaderList::create({ { "Cache-Control", "must-understand, max-age=3600" } });
+    EXPECT(HTTP::is_cacheable(200, *headers));
+}
+
+TEST_CASE(is_cacheable_must_understand_without_no_store_unknown_status)
+{
+    auto headers = HTTP::HeaderList::create({ { "Cache-Control", "must-understand, max-age=3600" } });
+    EXPECT(!HTTP::is_cacheable(299, *headers));
+}
+
+TEST_CASE(is_cacheable_must_understand_accepts_304_status)
+{
+    auto headers = HTTP::HeaderList::create({ { "Cache-Control", "must-understand, no-store, max-age=3600" } });
+    EXPECT(HTTP::is_cacheable(304, *headers));
+}


### PR DESCRIPTION
Responses with `Cache-Control: must-understand, no-store` were never cached, even though the cache understands all common status codes, due to the `must-understand` directive not being implemented.

This implements the directive per the spec: when `must-understand` is present and the cache understands the response status code, it ignores the `no-store` directive.

For status codes the cache does not understand, the response is not stored.

Spec:
https://httpwg.org/specs/rfc9111.html#cache-response-directive.must-understand