### PR TITLE
LibJS: Reject surrogate code points in URI decoding

### DIFF
--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -475,7 +475,7 @@ static ThrowCompletionOr<ByteString> decode(VM& vm, ByteString const& string, St
         if (expected_continuation_bytes > 0) {
             decoded_builder.append(decoded_code_unit);
             expected_continuation_bytes--;
-            if (expected_continuation_bytes == 0 && !Utf8View(decoded_builder.string_view().substring_view(code_point_start_offset)).validate())
+            if (expected_continuation_bytes == 0 && !Utf8View(decoded_builder.string_view().substring_view(code_point_start_offset)).validate(AllowLonelySurrogates::No))
                 return vm.throw_completion<URIError>(ErrorType::URIMalformed);
             continue;
         }

--- a/Tests/LibJS/Runtime/builtins/functions/uriEncodeDecode.js
+++ b/Tests/LibJS/Runtime/builtins/functions/uriEncodeDecode.js
@@ -53,7 +53,21 @@ test("decodeURIComponent", () => {
 test("decodeURIComponent exception", () => {
     ["%", "%a", "%gh", "%%%"].forEach(test => {
         expect(() => {
-            decodeURI(test);
+            decodeURIComponent(test);
+        }).toThrowWithMessage(URIError, "URI malformed");
+    });
+});
+
+test("decodeURIComponent invalid UTF-8 sequences", () => {
+    [
+        "%ED%BF%BF", // surrogate code point (U+DFFF)
+        "%C0%AF", // overlong encoding
+        "%ED%7F%BF", // invalid continuation byte
+        "%ED%BF", // incomplete 3-byte sequence
+        "%F4%90%80%80", // code point beyond U+10FFFF
+    ].forEach(test => {
+        expect(() => {
+            decodeURIComponent(test);
         }).toThrowWithMessage(URIError, "URI malformed");
     });
 });


### PR DESCRIPTION
Reject surrogate code points in URI decoding

test262 diff:
```
Summary:
    Diff Tests:
        +2 ✅    -2 ❌   

Diff Tests:
    test/built-ins/decodeURIComponent/throw-URIError.js ❌ -> ✅
    test/staging/sm/global/bug660612.js                 ❌ -> ✅
```