### PR TITLE
LibWeb: Replace static position ancestor walk with cumulative offset

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -516,9 +516,9 @@ void FlexFormattingContext::set_cross_size(FlexItem& item, CSSPixels size)
 void FlexFormattingContext::set_offset(FlexItem& item, CSSPixels main_offset, CSSPixels cross_offset)
 {
     if (is_row_layout())
-        item.used_values.offset = CSSPixelPoint { main_offset, cross_offset };
+        item.used_values.set_content_offset({ main_offset, cross_offset });
     else
-        item.used_values.offset = CSSPixelPoint { cross_offset, main_offset };
+        item.used_values.set_content_offset({ cross_offset, main_offset });
 }
 
 void FlexFormattingContext::set_main_axis_first_margin(FlexItem& item, CSSPixels margin)

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -113,8 +113,6 @@ public:
     [[nodiscard]] CSSPixelRect content_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixels box_baseline(Box const&) const;
-    [[nodiscard]] CSSPixelRect content_box_rect_in_static_position_ancestor_coordinate_space(Box const&) const;
-
     [[nodiscard]] CSSPixels containing_block_width_for(NodeWithStyleAndBoxModelMetrics const&) const;
 
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2129,7 +2129,7 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
     for (auto& grid_item : m_grid_items) {
         CSSPixelPoint margin_offset = { grid_item.used_values.margin_box_left(), grid_item.used_values.margin_box_top() };
         auto const grid_area_rect = get_grid_area_rect(grid_item);
-        grid_item.used_values.offset = grid_area_rect.top_left() + margin_offset;
+        grid_item.used_values.set_content_offset(grid_area_rect.top_left() + margin_offset);
         compute_inset(grid_item.box, grid_area_rect.size());
 
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_width()), AvailableSize::make_definite(grid_item.used_values.content_height()));

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -665,7 +665,8 @@ void LayoutState::UsedValues::materialize_from_paintable(Painting::PaintableBox 
     m_has_definite_width = true;
     m_has_definite_height = true;
 
-    offset = paintable.offset();
+    set_content_offset(paintable.offset());
+    m_cumulative_offset = paintable.absolute_rect().location();
 
     margin_left = box_model.margin.left;
     margin_right = box_model.margin.right;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -89,6 +89,18 @@ struct LayoutState {
         void set_content_x(CSSPixels x) { offset.set_x(x); }
         void set_content_y(CSSPixels y) { offset.set_y(y); }
 
+        // Offset from ICB (viewport) content edge to this box's content edge.
+        // Computed lazily by walking the containing block chain.
+        // For pre-populated nodes (partial relayout), returns the cached value from paintable absolute position.
+        CSSPixelPoint cumulative_offset() const
+        {
+            if (m_cumulative_offset.has_value())
+                return *m_cumulative_offset;
+            if (m_containing_block_used_values)
+                return m_containing_block_used_values->cumulative_offset() + offset;
+            return offset;
+        }
+
         // offset from top-left corner of content area of box's containing block to top-left corner of box's content area
         CSSPixelPoint offset;
 
@@ -179,6 +191,7 @@ struct LayoutState {
 
         GC::Ptr<Layout::NodeWithStyle const> m_node { nullptr };
         UsedValues const* m_containing_block_used_values { nullptr };
+        Optional<CSSPixelPoint> m_cumulative_offset;
 
         CSSPixels m_content_width { 0 };
         CSSPixels m_content_height { 0 };

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1211,9 +1211,9 @@ void TableFormattingContext::position_cell_boxes()
         // - for top: the height reserved for top captions (including margins), if any
         // - the padding-left/padding-top and border-left-width/border-top-width of the table
         // FIXME: Account for visibility.
-        cell_state.offset = row_state.offset.translated(
+        cell_state.set_content_offset(row_state.offset.translated(
             cell_state.border_box_left() + m_columns[cell.column_index].left_offset + cell.column_index * border_spacing_horizontal(),
-            cell_state.border_box_top());
+            cell_state.border_box_top()));
     }
 }
 

--- a/Tests/LibWeb/Layout/expected/abspos-relative-to-table-row.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-relative-to-table-row.txt
@@ -15,8 +15,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
               BlockContainer <td> at [11,15] table-cell [0+0+1 0 1+0+0] [0+0+1 0 1+0+0] [BFC] children: not-inline
-                BlockContainer <div> at [13,21] positioned [0+0+0 70.5625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 6, rect: [13,21 70.5625x18] baseline: 13.796875
+                BlockContainer <div> at [11,15] positioned [0+0+0 70.5625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [11,15 70.5625x18] baseline: 13.796875
                       "ABSPOS"
                   TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,7 +36,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableWithLines (BlockContainer<TD>) [10,10 2x2]
             PaintableBox (Box<TR>) [10,14 2x2]
               PaintableWithLines (BlockContainer<TD>) [10,14 2x2]
-                PaintableWithLines (BlockContainer<DIV>) [13,21 70.5625x18]
+                PaintableWithLines (BlockContainer<DIV>) [11,15 70.5625x18]
                   TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,18 784x0]
 


### PR DESCRIPTION
Replace content_box_rect_in_static_position_ancestor_coordinate_space() which walked the ancestor chain to compute the offset between an abspos element's static position containing block and its actual containing block.

Instead, add a cumulative_offset() method to UsedValues that computes the absolute offset from the ICB to a box's content edge by walking the containing block chain. For pre-populated nodes during partial relayout, it returns a cached value from the paintable's absolute position.

The static-CB-to-actual-CB offset is now a simple subtraction of two cumulative offsets, which also fixes a bug where table cells with position:relative ancestors got incorrect static positions due to the old function accumulating offsets in the wrong coordinate space.

Also route direct UsedValues::offset assignments in Flex, Grid, and Table formatting contexts through set_content_offset().