### PR TITLE
LibWeb: Unify abspos containing block resolution across FCs

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -149,16 +149,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
         floating_box->used_values.set_content_x(float_containing_block_width - floating_box->offset_from_edge);
     }
 
-    if (m_layout_mode == LayoutMode::Normal) {
-        // We can also layout absolutely positioned boxes within this BFC.
-        for (auto& child : root().contained_abspos_children()) {
-            auto& box = as<Box>(*child);
-            auto& cb_state = m_state.get(*box.containing_block());
-            auto available_width = AvailableSize::make_definite(cb_state.content_width() + cb_state.padding_left + cb_state.padding_right);
-            auto available_height = AvailableSize::make_definite(cb_state.content_height() + cb_state.padding_top + cb_state.padding_bottom);
-            layout_absolutely_positioned_element(box, AvailableSpace(available_width, available_height));
-        }
-    }
+    layout_absolutely_positioned_children();
 }
 
 bool BlockFormattingContext::box_should_avoid_floats_because_it_establishes_fc(Box const& box)

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -253,12 +253,7 @@ void FlexFormattingContext::parent_context_did_dimension_child_root_box()
         return IterationDecision::Continue;
     });
 
-    for (auto& child : flex_container().contained_abspos_children()) {
-        auto& box = as<Box>(*child);
-        auto available_width = AvailableSize::make_definite(m_flex_container_state.content_width() + m_flex_container_state.padding_left + m_flex_container_state.padding_right);
-        auto available_height = AvailableSize::make_definite(m_flex_container_state.content_height() + m_flex_container_state.padding_top + m_flex_container_state.padding_bottom);
-        layout_absolutely_positioned_element(box, AvailableSpace(available_width, available_height));
-    }
+    layout_absolutely_positioned_children();
 }
 
 // https://www.w3.org/TR/css-flexbox-1/#flex-direction-property

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -21,6 +21,40 @@ template<typename T>
     return ::max(min, ::min(value, max));
 }
 
+enum class Alignment {
+    Baseline,
+    Center,
+    End,
+    Normal,
+    Safe,
+    SelfEnd,
+    SelfStart,
+    SpaceAround,
+    SpaceBetween,
+    SpaceEvenly,
+    Start,
+    Stretch,
+    Unsafe,
+};
+
+enum class AbsposAxisMode {
+    // Both insets auto: offset = static_position + margin
+    StaticPosition,
+    // At least one explicit inset: offset = rect.origin + inset + margin
+    InsetFromRect,
+};
+
+struct AbsposContainingBlockInfo {
+    // Containing block rect in CB Box's content-edge coordinates.
+    CSSPixelRect rect;
+    AbsposAxisMode horizontal_axis_mode;
+    AbsposAxisMode vertical_axis_mode;
+    // Grid alignment for axes with auto CSS insets.
+    // When set, the base method applies alignment-driven insets after sizing.
+    Optional<Alignment> horizontal_alignment;
+    Optional<Alignment> vertical_alignment;
+};
+
 class FormattingContext {
 #if FORMATTING_CONTEXT_TRACE_DEBUG
     friend class FormattingContextTracer;
@@ -165,7 +199,9 @@ protected:
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&);
 
-    void layout_absolutely_positioned_element(Box const&, AvailableSpace const&);
+    void layout_absolutely_positioned_element(Box const&, AbsposContainingBlockInfo const&);
+    void layout_absolutely_positioned_children();
+    virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&);
     void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&);
     void compute_width_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&);
     void compute_width_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&);

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2171,10 +2171,9 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
 }
 
 // https://www.w3.org/TR/css-grid-2/#abspos-items
-void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
+AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block_info(Box const& box)
 {
-    auto& box_state = m_state.get_mutable(box);
-    auto const& computed_values = box.computed_values();
+    auto& abspos_box_state = m_state.get_mutable(box);
 
     auto grid_area_rect = [&] -> CSSPixelRect {
         // NOTE: Grid areas form containing blocks for abspos elements, but
@@ -2195,7 +2194,7 @@ void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
             return get_grid_area_rect(item);
         }
 
-        GridItem item { as<Box>(*containing_grid_item), box_state, {}, {}, {}, {} };
+        GridItem item { as<Box>(*containing_grid_item), abspos_box_state, {}, {}, {}, {} };
         auto is_auto_row = is_auto_positioned_track(computed_values.grid_row_start(), computed_values.grid_row_end());
         auto is_auto_column = is_auto_positioned_track(computed_values.grid_column_start(), computed_values.grid_column_end());
 
@@ -2212,91 +2211,14 @@ void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
         return get_grid_area_rect(item);
     }();
 
-    auto available_width = AvailableSize::make_definite(grid_area_rect.width());
-    auto available_height = AvailableSize::make_definite(grid_area_rect.height());
-    AvailableSpace available_space { available_width, available_height };
-
-    // The border computed values are not changed by the compute_height & width calculations below.
-    // The spec only adjusts and computes sizes, insets and margins.
-    box_state.border_left = box.computed_values().border_left().width;
-    box_state.border_right = box.computed_values().border_right().width;
-    box_state.border_top = box.computed_values().border_top().width;
-    box_state.border_bottom = box.computed_values().border_bottom().width;
-    box_state.padding_left = box.computed_values().padding().left().to_px_or_zero(grid_container(), grid_area_rect.width());
-    box_state.padding_right = box.computed_values().padding().right().to_px_or_zero(grid_container(), grid_area_rect.width());
-    box_state.padding_top = box.computed_values().padding().top().to_px_or_zero(grid_container(), grid_area_rect.width());
-    box_state.padding_bottom = box.computed_values().padding().bottom().to_px_or_zero(grid_container(), grid_area_rect.width());
-
-    compute_width_for_absolutely_positioned_element(box, available_space);
-
-    // NOTE: We compute height before *and* after doing inside layout.
-    //       This is done so that inside layout can resolve percentage heights.
-    //       In some situations, e.g with non-auto top & bottom values, the height can be determined early.
-    compute_height_for_absolutely_positioned_element(box, available_space, BeforeOrAfterInsideLayout::Before);
-
-    auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, box_state.available_inner_space_or_constraints_from(available_space));
-
-    compute_height_for_absolutely_positioned_element(box, available_space, BeforeOrAfterInsideLayout::After);
-
-    if (computed_values.inset().left().is_auto() && computed_values.inset().right().is_auto()) {
-        auto width_left_for_alignment = grid_area_rect.width() - box_state.margin_box_width();
-        switch (alignment_for_item(box, GridDimension::Column)) {
-        case Alignment::Normal:
-        case Alignment::Stretch:
-            break;
-        case Alignment::Center:
-            box_state.inset_left = width_left_for_alignment / 2;
-            box_state.inset_right = width_left_for_alignment / 2;
-            break;
-        case Alignment::Start:
-            box_state.inset_right = width_left_for_alignment;
-            break;
-        case Alignment::End:
-            box_state.inset_left = width_left_for_alignment;
-            break;
-        default:
-            break;
-        }
-    }
-
-    if (computed_values.inset().top().is_auto() && computed_values.inset().bottom().is_auto()) {
-        auto height_left_for_alignment = grid_area_rect.height() - box_state.margin_box_height();
-        switch (alignment_for_item(box, GridDimension::Row)) {
-        case Alignment::Baseline:
-            // FIXME: Not implemented
-        case Alignment::Stretch:
-        case Alignment::Normal:
-            break;
-        case Alignment::Start:
-        case Alignment::SelfStart:
-            box_state.inset_bottom = height_left_for_alignment;
-            break;
-        case Alignment::End:
-        case Alignment::SelfEnd: {
-            box_state.inset_top = height_left_for_alignment;
-            break;
-        }
-        case Alignment::Center:
-            box_state.inset_top = height_left_for_alignment / 2;
-            box_state.inset_bottom = height_left_for_alignment / 2;
-            break;
-        default:
-            break;
-        }
-    }
-
-    // If an absolutely positioned element’s containing block is generated by a grid container,
-    // the containing block corresponds to the grid area determined by its grid-placement properties.
-    // The offset properties (top/right/bottom/left) then indicate offsets inwards from the corresponding
-    // edges of this containing block, as normal.
-    CSSPixelPoint used_offset;
-    used_offset.set_x(grid_area_rect.x() + box_state.inset_left + box_state.margin_box_left());
-    used_offset.set_y(grid_area_rect.y() + box_state.inset_top + box_state.margin_box_top());
-
-    box_state.set_content_offset(used_offset);
-
-    if (independent_formatting_context)
-        independent_formatting_context->parent_context_did_dimension_child_root_box();
+    // Grid always uses InsetFromRect — alignment handles auto inset cases
+    return {
+        grid_area_rect,
+        AbsposAxisMode::InsetFromRect,
+        AbsposAxisMode::InsetFromRect,
+        alignment_for_item(box, GridDimension::Column),
+        alignment_for_item(box, GridDimension::Row),
+    };
 }
 
 void GridFormattingContext::parent_context_did_dimension_child_root_box()
@@ -2311,10 +2233,7 @@ void GridFormattingContext::parent_context_did_dimension_child_root_box()
         return IterationDecision::Continue;
     });
 
-    for (auto const& child : grid_container().contained_abspos_children()) {
-        auto const& box = as<Box>(*child);
-        layout_absolutely_positioned_element(box);
-    }
+    layout_absolutely_positioned_children();
 }
 
 void GridFormattingContext::determine_intrinsic_size_of_grid_container(AvailableSpace const& available_space)

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -17,22 +17,6 @@ enum class GridDimension {
     Column
 };
 
-enum class Alignment {
-    Baseline,
-    Center,
-    End,
-    Normal,
-    Safe,
-    SelfEnd,
-    SelfStart,
-    SpaceAround,
-    SpaceBetween,
-    SpaceEvenly,
-    Start,
-    Stretch,
-    Unsafe,
-};
-
 struct GridPosition {
     int row;
     int column;
@@ -325,7 +309,7 @@ private:
     void determine_grid_container_height();
     void determine_intrinsic_size_of_grid_container(AvailableSpace const& available_space);
 
-    void layout_absolutely_positioned_element(Box const&);
+    virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&) override;
     virtual void parent_context_did_dimension_child_root_box() override;
 
     void resolve_grid_item_sizes(GridDimension dimension);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1701,13 +1701,7 @@ void TableFormattingContext::parent_context_did_dimension_child_root_box()
         return TraversalDecision::Continue;
     });
 
-    for (auto& child : context_box().contained_abspos_children()) {
-        auto& box = as<Box>(*child);
-        auto& cb_state = m_state.get(*box.containing_block());
-        auto available_width = AvailableSize::make_definite(cb_state.content_width() + cb_state.padding_left + cb_state.padding_right);
-        auto available_height = AvailableSize::make_definite(cb_state.content_height() + cb_state.padding_top + cb_state.padding_bottom);
-        layout_absolutely_positioned_element(box, AvailableSpace(available_width, available_height));
-    }
+    layout_absolutely_positioned_children();
 }
 
 void TableFormattingContext::run(AvailableSpace const& available_space)


### PR DESCRIPTION
Introduce AbsposContainingBlockInfo and a virtual
resolve_abspos_containing_block_info() method on FormattingContext that computes the containing block rect, per-axis positioning mode (static position vs inset-from-rect), and optional grid alignment — all in one place.

The base implementation handles the common case: padding-box rect of the containing block, with inline containing block support. GFC overrides it to return the grid area rect with alignment info.

This replaces the per-context abspos loops that BFC, FFC, TFC, and GFC each had, with a shared layout_absolutely_positioned_children() + layout_absolutely_positioned_element() pair. The offset computation is simplified from ~40 lines of branching to a data-driven dispatch on the axis mode, and GFC's ~130-line custom layout method is replaced by a ~30-line resolve override.