### PR TITLE
LibWebView+UI/AppKit: Present IOSurfaces directly

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -582,13 +582,18 @@ void ViewImplementation::did_allocate_iosurface_backing_stores(i32 front_id, Cor
 
     auto bytes_per_row = front_iosurface.bytes_per_row();
 
+    auto* front_ref = front_iosurface.core_foundation_pointer();
+    auto* back_ref = back_iosurface.core_foundation_pointer();
+
     auto front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, front_size, bytes_per_row, front_iosurface.data(), [handle = move(front_iosurface)] { });
     auto back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, back_size, bytes_per_row, back_iosurface.data(), [handle = move(back_iosurface)] { });
 
     m_client_state.front_bitmap.bitmap = front_bitmap.release_value_but_fixme_should_propagate_errors();
     m_client_state.front_bitmap.id = front_id;
+    m_client_state.front_bitmap.iosurface_ref = front_ref;
     m_client_state.back_bitmap.bitmap = back_bitmap.release_value_but_fixme_should_propagate_errors();
     m_client_state.back_bitmap.id = back_id;
+    m_client_state.back_bitmap.iosurface_ref = back_ref;
 }
 #endif
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -300,6 +300,9 @@ protected:
         i32 id { -1 };
         Web::DevicePixelSize last_painted_size;
         RefPtr<Gfx::Bitmap const> bitmap;
+#ifdef AK_OS_MACOS
+        void* iosurface_ref { nullptr };
+#endif
     };
 
     struct ClientState {

--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -26,7 +26,7 @@ target_compile_features(ladybird_impl PUBLIC cxx_std_23)
 add_executable(ladybird MACOSX_BUNDLE
    main.mm
 )
-target_link_libraries(ladybird_impl PUBLIC "-framework Cocoa -framework UniformTypeIdentifiers" LibUnicode)
+target_link_libraries(ladybird_impl PUBLIC "-framework Cocoa -framework Metal -framework QuartzCore -framework UniformTypeIdentifiers" LibUnicode)
 target_link_libraries(ladybird PRIVATE ladybird_impl)
 
 create_ladybird_bundle(ladybird)

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -94,10 +94,12 @@ Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
 {
     Gfx::Bitmap const* bitmap = nullptr;
     Gfx::IntSize bitmap_size;
+    void* iosurface_ref = nullptr;
 
     if (m_client_state.has_usable_bitmap) {
         bitmap = m_client_state.front_bitmap.bitmap.ptr();
         bitmap_size = m_client_state.front_bitmap.last_painted_size.to_type<int>();
+        iosurface_ref = m_client_state.front_bitmap.iosurface_ref;
     } else {
         bitmap = m_backup_bitmap.ptr();
         bitmap_size = m_backup_bitmap_size.to_type<int>();
@@ -105,7 +107,7 @@ Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
 
     if (!bitmap)
         return {};
-    return Paintable { *bitmap, bitmap_size };
+    return Paintable { *bitmap, bitmap_size, iosurface_ref };
 }
 
 void WebViewBridge::update_zoom()

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.h
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.h
@@ -41,6 +41,7 @@ public:
     struct Paintable {
         Gfx::Bitmap const& bitmap;
         Gfx::IntSize bitmap_size;
+        void* iosurface_ref { nullptr };
     };
     Optional<Paintable> paintable();
 


### PR DESCRIPTION
Instead of copying the Bitmap that wraps the IOSurface, we can just present the IOSurface directly. This significantly reduces CPU usage in the UI process, particularly at high refresh rates such as 120Hz where it would saturate a full CPU core.

This is done by using CAMetalLayer and blitting the IOSurface to the next drawable buffer, which handles triple buffering, locking the IOSurface and vsync automatically. This also allows the Metal HUD to work, but the only accurate stat is the frame intervals/FPS because it's in the UI layer, not WebContent. However, that's still useful to detect frame drops.

https://github.com/user-attachments/assets/e61e703b-e28f-4643-a2ea-f2cba69d3856
