### PR TITLE
LibWeb/HTML: Assume WorkerGlobalScope runs in a SecureContext

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -556,6 +556,8 @@ bool is_secure_context(Environment const& environment)
         if (is<WorkerGlobalScope>(global)) {
             // FIXME: 1. If global's owner set[0]'s relevant settings object is a secure context, then return true.
             // NOTE: We only need to check the 0th item since they will necessarily all be consistent.
+            if (true)
+                return true;
 
             // 2. Return false.
             return false;


### PR DESCRIPTION
As a stopgap until we have things wired up fully, consider
WorkerGlobalScope as a SecureContext so that IDL marked with
[SecureContext] is still exposed.