### PR TITLE
LibWeb: Ensure JS execution context exists in view transition callbacks

### DIFF
--- a/Tests/LibWeb/Crash/CSS/view-transition-skip-no-execution-context.html
+++ b/Tests/LibWeb/Crash/CSS/view-transition-skip-no-execution-context.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<script>
+    document.startViewTransition();
+    document.startViewTransition();
+</script>


### PR DESCRIPTION
This change moves `TemporaryExecutionContext` creation to ensure that all promise operations are covered.

This prevents 13 WPT test crashes in `css/css-view-transitions`. Most of these tests still fail, so I've created a minimal crash test that exercises this issue instead.