### PR TITLE
Tests: Use `Internals::mouseMove` instead of `Internals::movePointerTo`

### DIFF
--- a/Tests/LibWeb/Text/input/UIEvents/pointer-boundary-events.html
+++ b/Tests/LibWeb/Text/input/UIEvents/pointer-boundary-events.html
@@ -40,15 +40,15 @@ body {
     });
 
     test(() => {
-        internals.movePointerTo(150, 150);
+        internals.mouseMove(150, 150);
 
         println("> move pointer over #inner");
-        internals.movePointerTo(10, 10);
+        internals.mouseMove(10, 10);
 
         println("> move pointer over #outer (leaving #inner)");
-        internals.movePointerTo(60, 60);
+        internals.mouseMove(60, 60);
 
         println("> move pointer outside (leaving #outer)");
-        internals.movePointerTo(150, 150);
+        internals.mouseMove(150, 150);
     });
 </script>


### PR DESCRIPTION
This method was renamed in f55fe69. Fixes a test failure on master

CC @tcl3 