### PR TITLE
LibWeb/SVG: Fix normalized_diagonal_length in SVGCircle

### DIFF
--- a/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -63,7 +63,7 @@ static CSSPixels normalized_diagonal_length(CSSPixelSize viewport_size)
 {
     if (viewport_size.width() == viewport_size.height())
         return viewport_size.width();
-    return sqrt((viewport_size.width() * viewport_size.width()) + (viewport_size.height() * viewport_size.height())) / CSSPixels::nearest_value_for(AK::Sqrt2<float>);
+    return sqrt(((viewport_size.width() * viewport_size.width()) + (viewport_size.height() * viewport_size.height())) / 2);
 }
 
 Gfx::Path SVGCircleElement::get_path(CSSPixelSize viewport_size)

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/geometry/reftests/circle-ref.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/geometry/reftests/circle-ref.svg
@@ -1,0 +1,4 @@
+<svg width="340" height="140"
+  xmlns="http://www.w3.org/2000/svg">
+  <circle cx="204" cy="56" r="65" fill="blue" />
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/geometry/reftests/circle-003.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/geometry/reftests/circle-003.svg
@@ -1,0 +1,17 @@
+<svg width="340" height="140"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:html="http://www.w3.org/1999/xhtml">
+  <title>Circle coordinates and radius specified by percentage</title>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/geometry.html"/>
+  <html:link rel="match" href="../../../../../expected/wpt-import/svg/geometry/reftests/circle-ref.svg" />
+  <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2" />
+  <style>
+    circle {
+      cx: 60%; /* 60% of width 340 */
+      cy: 40%; /* 40% of height 140 */
+      r: 25%; /* 25% of normalized diagonal 260 */
+      fill: blue;
+    }
+  </style>
+  <circle />
+</svg>


### PR DESCRIPTION
The conversion of sqrt2 into CSSPixels caused the value to change from
1.41... to 1.42... This led to incorrect results. I moved the division
inside the  sqrt to prevent this conversion step.