### PR TITLE
LibWeb: Use generic layout for input elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -130,23 +130,27 @@ GC::Ptr<Layout::Node> HTMLInputElement::create_layout_node(GC::Ref<CSS::Computed
         return heap().allocate<Layout::ImageBox>(document(), *this, move(style), *this);
     }
 
-    // https://drafts.csswg.org/css-ui/#appearance-switching
-    // This specification introduces the appearance property to provide some control over this behavior.
-    // In particular, using appearance: none allows authors to suppress the native appearance of widgets,
-    // giving them a primitive appearance where CSS can be used to restyle them.
-    if (style->appearance() == CSS::Appearance::None) {
-        return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
-    }
-
     switch (type_state()) {
 
     case TypeAttributeState::SubmitButton:
     case TypeAttributeState::Button:
     case TypeAttributeState::ResetButton:
+        // NB: For button inputs with appearance: none, use generic layout
+        // https://drafts.csswg.org/css-ui/#appearance-switching
+        if (style->appearance() == CSS::Appearance::None)
+            return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
         return heap().allocate<Layout::BlockContainer>(document(), this, move(style));
     case TypeAttributeState::Checkbox:
+        // NB: For checkbox inputs with appearance: none, use generic layout
+        // https://drafts.csswg.org/css-ui/#appearance-switching
+        if (style->appearance() == CSS::Appearance::None)
+            return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
         return heap().allocate<Layout::CheckBox>(document(), *this, move(style));
     case TypeAttributeState::RadioButton:
+        // NB: For radio inputs with appearance: none, use generic layout
+        // https://drafts.csswg.org/css-ui/#appearance-switching
+        if (style->appearance() == CSS::Appearance::None)
+            return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
         return heap().allocate<Layout::RadioButton>(document(), *this, move(style));
     case TypeAttributeState::Text:
     case TypeAttributeState::Search:
@@ -155,6 +159,10 @@ GC::Ptr<Layout::Node> HTMLInputElement::create_layout_node(GC::Ref<CSS::Computed
     case TypeAttributeState::Email:
     case TypeAttributeState::Password:
     case TypeAttributeState::Number:
+        // NB: Text-like inputs retain TextInputBox layout even with appearance: none.
+        //     The primitive appearance behavior for form controls is currently under-specified,
+        //     and other browsers retain some native presentation aspects (like sizing) even with appearance: none.
+        //     See: https://html.spec.whatwg.org/multipage/rendering.html#the-input-element-as-a-text-entry-widget
         // FIXME: text padding issues
         return heap().allocate<Layout::TextInputBox>(document(), *this, move(style));
     default:

--- a/Tests/LibWeb/Layout/expected/input-appearance-none-in-flexbox.txt
+++ b/Tests/LibWeb/Layout/expected/input-appearance-none-in-flexbox.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 46 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 30 0+0+8] children: not-inline
+      Box <div> at [10,10] flex-container(row) [0+2+0 780 0+2+0] [0+2+0 26 0+2+0] [FFC] children: not-inline
+        Box <div> at [12,12] flex-container(row) flex-item [0+2+0 202 0+2+0] [0+2+0 22 0+2+0] [FFC] children: not-inline
+          TextInputBox <input> at [13,13] flex-item [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
+            Box <div> at [15,14] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 20 1+0+0] [FFC] children: not-inline
+              BlockContainer <div> at [15,15] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 0, rect: [15,15 0x18] baseline: 13.796875
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,38] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x46]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x30]
+      PaintableBox (Box<DIV>) [8,8 784x30]
+        PaintableBox (Box<DIV>) [10,10 206x26]
+          PaintableWithLines (TextInputBox<INPUT>) [12,12 202x22]
+            PaintableBox (Box<DIV>) [13,13 200x22]
+              PaintableWithLines (BlockContainer<DIV>) [15,15 196x18]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,38 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x46] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/input-appearance-none-in-flexbox.html
+++ b/Tests/LibWeb/Layout/input/input-appearance-none-in-flexbox.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+  input {
+    appearance: none;
+    width: 100%;
+    border: 1px solid black;
+  }
+  div {
+    display: flex;
+    border: 2px solid red;
+  }
+  * {
+    font-family: 'SerenitySans';
+  }
+</style>
+<div><div><input></div></div>


### PR DESCRIPTION
Makes the search bar on pinball.com wider
Closes #7900 