### PR TITLE
Documentation: Add missing parent for AK/

### DIFF
--- a/Documentation/EditorConfiguration/QtCreatorConfiguration.md
+++ b/Documentation/EditorConfiguration/QtCreatorConfiguration.md
@@ -24,6 +24,7 @@ First, make sure you have a working toolchain and can build and run Ladybird. Go
     ./
     Libraries/
     Services/
+    Build/release/Lagom/
     Build/release/Lagom/Libraries/
     Build/release/Lagom/Services/
     Build/release/vcpkg_installed/x64-linux/include/skia/


### PR DESCRIPTION
Without this includedir, files like `AK/Debug.h` cannot be resolved.