### PR TITLE
LibWeb: Don't select text when multi-clicking user-select:none node

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1200,6 +1200,8 @@ EventResult EventHandler::handle_doubleclick(CSSPixelPoint visual_viewport_posit
                 return EventResult::Accepted;
             if (!is<Painting::TextPaintable>(*result->paintable))
                 return EventResult::Accepted;
+            if (result->paintable->layout_node().user_select_used_value() == CSS::UserSelect::None)
+                return EventResult::Accepted;
 
             auto& hit_paintable = static_cast<Painting::TextPaintable const&>(*result->paintable);
             auto& hit_dom_node = const_cast<DOM::Text&>(as<DOM::Text>(*hit_paintable.dom_node()));
@@ -1280,6 +1282,8 @@ EventResult EventHandler::handle_tripleclick(CSSPixelPoint visual_viewport_posit
             if (!hit->paintable->dom_node())
                 return EventResult::Accepted;
             if (!is<DOM::Text>(*hit->paintable->dom_node()))
+                return EventResult::Accepted;
+            if (hit->paintable->layout_node().user_select_used_value() == CSS::UserSelect::None)
                 return EventResult::Accepted;
 
             auto& hit_dom_node = const_cast<DOM::Text&>(as<DOM::Text>(*hit->paintable->dom_node()));

--- a/Tests/LibWeb/Text/expected/multi-click-user-select-none-element.txt
+++ b/Tests/LibWeb/Text/expected/multi-click-user-select-none-element.txt
@@ -1,0 +1,2 @@
+double-click selected: ""
+triple-click selected: ""

--- a/Tests/LibWeb/Text/input/multi-click-user-select-none-element.html
+++ b/Tests/LibWeb/Text/input/multi-click-user-select-none-element.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div style="font-size:20px">
+    super<span style="user-select:none">califragilistic</span>expialidocious
+</div>
+<script>
+    test(() => {
+        internals.click(80, 20, 2);
+        println(`double-click selected: "${window.getSelection()}"`);
+
+        internals.click(80, 20, 3);
+        println(`triple-click selected: "${window.getSelection()}"`);
+    });
+</script>


### PR DESCRIPTION
The double-click case of the test also passes without this change due to https://github.com/LadybirdBrowser/ladybird/issues/7983 but I've included it anyways for when that bug gets fixed.