### PR TITLE
LibWeb: Implement CSS Grid dense packing and fix span placement

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -150,6 +150,7 @@ public:
     int max_row_index() const { return m_max_row_index; }
 
     bool is_occupied(int column_index, int row_index) const;
+    bool is_area_occupied(int column_start, int row_start, int column_span, int row_span) const;
 
     FoundUnoccupiedPlace find_unoccupied_place(GridDimension dimension, int& column_index, int& row_index, int column_span, int row_span) const;
 
@@ -330,12 +331,13 @@ private:
         size_t span { 1 };
     };
     PlacementPosition resolve_grid_position(Box const& child_box, GridDimension dimension);
+    size_t resolve_grid_span(Box const& child_box, GridDimension dimension) const;
 
     void place_grid_items();
     void place_item_with_row_and_column_position(Box const& child_box);
     void place_item_with_row_position(Box const& child_box);
-    void place_item_with_column_position(Box const& child_box, int& auto_placement_cursor_x, int& auto_placement_cursor_y);
-    void place_item_with_no_declared_position(Box const& child_box, int& auto_placement_cursor_x, int& auto_placement_cursor_y);
+    void place_item_with_column_position(Box const& child_box, int& auto_placement_cursor_row);
+    void place_item_with_no_declared_position(Box const& child_box, int& auto_placement_cursor_column, int& auto_placement_cursor_row);
     void record_grid_placement(GridItem);
 
     void initialize_grid_tracks_from_definition(GridDimension);

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/placement/grid-container-change-named-grid-recompute-child-positions-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/placement/grid-container-change-named-grid-recompute-child-positions-001.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	.grid 1
+Pass	.grid 2
+Pass	.grid 3
+Pass	.grid 4

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-grid/placement/grid-container-change-named-grid-recompute-child-positions-001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-grid/placement/grid-container-change-named-grid-recompute-child-positions-001.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Grid: Change named grid lines.</title>
+<link rel="author" title="Julien Chaffraix" href="mailto:jchaffraix@chromium.org"/>
+<link rel="help" href="https://drafts.csswg.org/css-grid/#placement"/>
+<meta name="assert" content="Checks that updating the named grid lines definitions in grid-template-{rows|columns} recomputes the positions of automatically placed grid items."/>
+<link rel="issue" href="https://crbug.com/248151"/>
+<link href="../../../css/support/grid.css" rel="stylesheet"/>
+<link href="../../../css/support/alignment.css" rel="stylesheet">
+<link rel="stylesheet" type="text/css" href="../../../fonts/ahem.css"/>
+<style>
+.grid {
+    grid-auto-flow: row dense;
+}
+#firstGridItem {
+    grid-row: auto;
+    grid-column: column;
+}
+
+#secondGridItem {
+    grid-row: row;
+    grid-column: auto;
+}
+
+#thirdGridItem {
+    grid-row: auto;
+    grid-column: auto;
+}
+</style>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../resources/check-layout-th.js"></script>
+<script>
+function testGridDefinitions(gridTemplateRows, gridTemplateColumns, firstGridItemData, secondGridItemData, thirdGridItemData)
+{
+    var gridElement = document.getElementsByClassName("grid")[0];
+    gridElement.style.gridTemplateRows = gridTemplateRows;
+    gridElement.style.gridTemplateColumns = gridTemplateColumns;
+
+    var firstGridItem = document.getElementById("firstGridItem");
+    firstGridItem.setAttribute("data-expected-width", firstGridItemData.width);
+    firstGridItem.setAttribute("data-expected-height", firstGridItemData.height);
+    firstGridItem.setAttribute("data-offset-x", firstGridItemData.x);
+    firstGridItem.setAttribute("data-offset-y", firstGridItemData.y);
+
+    var secondGridItem = document.getElementById("secondGridItem");
+    secondGridItem.setAttribute("data-expected-width", secondGridItemData.width);
+    secondGridItem.setAttribute("data-expected-height", secondGridItemData.height);
+    secondGridItem.setAttribute("data-offset-x", secondGridItemData.x);
+    secondGridItem.setAttribute("data-offset-y", secondGridItemData.y);
+
+    var thirdGridItem = document.getElementById("thirdGridItem");
+    thirdGridItem.setAttribute("data-expected-width", thirdGridItemData.width);
+    thirdGridItem.setAttribute("data-expected-height", thirdGridItemData.height);
+    thirdGridItem.setAttribute("data-offset-x", thirdGridItemData.x);
+    thirdGridItem.setAttribute("data-offset-y", thirdGridItemData.y);
+
+    checkLayout(".grid", false);
+}
+
+function testChangingGridDefinitions()
+{
+    testGridDefinitions('10px [row] 20px', '30px [column]', { 'width': '0', 'height': '10', 'x': '30', 'y': '0' }, { 'width': '30', 'height': '20', 'x': '0', 'y': '10' }, { 'width': '30', 'height': '10', 'x': '0', 'y': '0' });
+    testGridDefinitions('10px [row] 20px', '30px', { 'width': '0', 'height': '10', 'x': '30', 'y': '0' }, { 'width': '30', 'height': '20', 'x': '0', 'y': '10' }, { 'width': '30', 'height': '10', 'x': '0', 'y': '0' });
+    testGridDefinitions('10px 20px [row]', '30px', { 'width': '0', 'height': '10', 'x': '30', 'y': '0' }, { 'width': '30', 'height': '0', 'x': '0', 'y': '30' }, { 'width': '30', 'height': '10', 'x': '0', 'y': '0' });
+    testGridDefinitions('10px 20px [row]', '30px [column]', { 'width': '0', 'height': '10', 'x': '30', 'y': '0' }, { 'width': '30', 'height': '0', 'x': '0', 'y': '30' }, { 'width': '30', 'height': '10', 'x': '0', 'y': '0' });
+    done();
+}
+
+</script>
+<script type="text/javascript">
+  setup({ explicit_done: true });
+</script>
+<body onload="document.fonts.ready.then(() => { testChangingGridDefinitions(); })">
+<div style="position: relative">
+    <div class="grid justifyContentStart">
+        <div class="sizedToGridArea" id="firstGridItem"></div>
+        <div class="sizedToGridArea" id="secondGridItem"></div>
+        <div class="sizedToGridArea" id="thirdGridItem"></div>
+    </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Implement the `dense` keyword for `grid-auto-flow` so auto-placed items backfill earlier gaps in the grid. The sparse/dense cursor logic is now centralized in `place_grid_items()` step 4: dense resets the cursor to the grid start before each search, while sparse keeps advancing forward.

Also fix a pre-existing bug where `find_unoccupied_place()` and several placement helpers only checked if a single cell was unoccupied, ignoring multi-cell spans. Add `OccupationGrid::is_area_occupied()` and use it throughout to correctly verify the entire rectangular area is available.