### PR TITLE
LibWeb: Skip microtask checkpoint in reentrant event loops

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -610,13 +610,13 @@ void EventLoop::perform_a_microtask_checkpoint()
     if (execution_paused())
         return;
 
-    // NOTE: This assertion is per requirement 9.5 of the ECMA-262 spec, see: https://tc39.es/ecma262/#sec-jobs
-    // > At some future point in time, when there is no running context in the agent for which the job is scheduled and that agent's execution context stack is empty...
-    VERIFY(vm().execution_context_stack().is_empty());
-
     // 1. If the event loop's performing a microtask checkpoint is true, then return.
     if (m_performing_a_microtask_checkpoint)
         return;
+
+    // NOTE: This assertion is per requirement 9.5 of the ECMA-262 spec, see: https://tc39.es/ecma262/#sec-jobs
+    // > At some future point in time, when there is no running context in the agent for which the job is scheduled and that agent's execution context stack is empty...
+    VERIFY(vm().execution_context_stack().is_empty());
 
     // 2. Set the event loop's performing a microtask checkpoint to true.
     m_performing_a_microtask_checkpoint = true;

--- a/Tests/LibWeb/Text/expected/regress/microtask-checkpoint-reentrancy-via-responsexml-script.txt
+++ b/Tests/LibWeb/Text/expected/regress/microtask-checkpoint-reentrancy-via-responsexml-script.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/regress/microtask-checkpoint-reentrancy-via-responsexml-script.html
+++ b/Tests/LibWeb/Text/input/regress/microtask-checkpoint-reentrancy-via-responsexml-script.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const xhr = new XMLHttpRequest();
+        xhr.responseType = "document";
+        xhr.open(
+            "GET",
+            "data:text/xml,<root xmlns:h='http://www.w3.org/1999/xhtml'><h:script>void 0</h:script></root>",
+            true
+        );
+
+        xhr.addEventListener("load", () => {
+            queueMicrotask(() => {
+                void xhr.responseXML;
+
+                println("PASS (didn't crash)");
+                done();
+            });
+        });
+
+        xhr.send();
+    });
+</script>


### PR DESCRIPTION
[ECMAScript’s jobs model](https://tc39.es/ecma262/#sec-jobs) requires jobs to run when no execution context is actively running, and HTML adheres to and mirrors that by triggering checkpoints from script cleanup when the execution-context stack is empty. Guarding against reentrant checkpoints preserves the requirements for correct microtask execution.

HTML defines the host hook for those ECMAScript promise jobs in its microtask queue implementation: [HostEnqueuePromiseJob](https://html.spec.whatwg.org/multipage/webappapis.html#hostenqueuepromisejob)