### PR TITLE
LibWeb: Implement Navigator.maxTouchPoints

### DIFF
--- a/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Libraries/LibWeb/HTML/Navigator.cpp
@@ -145,8 +145,14 @@ GC::Ref<WebXR::XRSystem> Navigator::xr()
 // https://w3c.github.io/pointerevents/#dom-navigator-maxtouchpoints
 WebIDL::Long Navigator::max_touch_points()
 {
-    dbgln("FIXME: Unimplemented Navigator.maxTouchPoints");
-    return 0;
+    // The getter steps are:
+    // 1. Let emulated maxTouchPoints be the result of WebDriver BiDi emulated max touch points.
+    // 2. If emulated maxTouchPoints is not null, return emulated maxTouchPoints.
+    // 3. Return the maximum number of simultaneous touch contacts supported by the device.
+    //
+    // FIXME: Implement step 1/2 using WebDriver BiDi emulation once supported in Ladybird.
+    auto const& window = as<HTML::Window>(HTML::current_principal_global_object());
+    return window.page().max_touch_points();
 }
 
 GC::Ref<ServiceWorker::ServiceWorkerContainer> Navigator::service_worker()

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -164,6 +164,11 @@ CSS::PreferredMotion Page::preferred_motion() const
     return m_client->preferred_motion();
 }
 
+int Page::max_touch_points() const
+{
+    return m_client->max_touch_points();
+}
+
 CSSPixelPoint Page::device_to_css_point(DevicePixelPoint point) const
 {
     return {

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -222,6 +222,8 @@ public:
 
     bool pdf_viewer_supported() const { return m_pdf_viewer_supported; }
 
+    int max_touch_points() const;
+
     void clear_selection();
 
     enum class WrapAround {
@@ -438,6 +440,8 @@ public:
 
     virtual void page_did_set_browser_zoom([[maybe_unused]] double factor) { }
     virtual void page_did_set_device_pixel_ratio_for_testing([[maybe_unused]] double ratio) { }
+
+    virtual int max_touch_points() const { return 0; }
 
     virtual void page_did_change_theme_color(Gfx::Color) { }
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -151,6 +151,12 @@ void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState 
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
 }
 
+void ViewImplementation::set_max_touch_points(int max_touch_points)
+{
+    m_max_touch_points = max(0, max_touch_points);
+    client().async_set_max_touch_points(m_client_state.page_index, m_max_touch_points);
+}
+
 void ViewImplementation::load(URL::URL const& url)
 {
     m_url = url;
@@ -636,6 +642,8 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     client().async_set_window_handle(m_client_state.page_index, m_client_state.client_handle);
     client().async_set_zoom_level(m_client_state.page_index, m_zoom_level);
     client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio);
+    client().async_set_device_pixel_ratio(m_client_state.page_index, m_device_pixel_ratio);
+    client().async_set_max_touch_points(m_client_state.page_index, m_max_touch_points);
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
     client().async_set_document_cookie_version_buffer(m_client_state.page_index, m_document_cookie_version_buffer);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -79,6 +79,8 @@ public:
     double zoom_level() const { return m_zoom_level; }
     double device_pixel_ratio() const { return m_device_pixel_ratio; }
     double maximum_frames_per_second() const { return m_maximum_frames_per_second; }
+    int max_touch_points() const { return m_max_touch_points; }
+    void set_max_touch_points(int max_touch_points);
 
     void enqueue_input_event(Web::InputEvent);
     void did_finish_handling_input_event(Badge<WebContentClient>, Web::EventResult event_result);
@@ -323,6 +325,7 @@ protected:
     double m_zoom_level { 1.0 };
     double m_device_pixel_ratio { 1.0 };
     double m_maximum_frames_per_second { 60.0 };
+    int m_max_touch_points { 0 };
 
     RefPtr<Menu> m_page_context_menu;
     RefPtr<Menu> m_link_context_menu;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1196,6 +1196,18 @@ void ConnectionFromClient::set_is_scripting_enabled(u64 page_id, bool is_scripti
         page->set_is_scripting_enabled(is_scripting_enabled);
 }
 
+void ConnectionFromClient::set_max_touch_points(u64 page_id, i32 max_touch_points)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->set_max_touch_points(max_touch_points);
+}
+
+void ConnectionFromClient::set_device_pixel_ratio(u64 page_id, double device_pixel_ratio)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->set_device_pixel_ratio(device_pixel_ratio);
+}
+
 void ConnectionFromClient::set_zoom_level(u64 page_id, double zoom_level)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -116,6 +116,7 @@ private:
     virtual void set_enable_global_privacy_control(u64 page_id, bool) override;
     virtual void set_has_focus(u64 page_id, bool) override;
     virtual void set_is_scripting_enabled(u64 page_id, bool) override;
+    virtual void set_max_touch_points(u64 page_id, i32 max_touch_points) override;
     virtual void set_zoom_level(u64 page_id, double zoom_level) override;
     virtual void set_maximum_frames_per_second(u64 page_id, double) override;
     virtual void set_window_position(u64 page_id, Web::DevicePixelPoint) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -181,6 +181,11 @@ void PageClient::set_is_scripting_enabled(bool is_scripting_enabled)
     page().set_is_scripting_enabled(is_scripting_enabled);
 }
 
+void PageClient::set_max_touch_points(int max_touch_points)
+{
+    m_max_touch_points = max(0, max_touch_points);
+}
+
 void PageClient::set_window_position(Web::DevicePixelPoint position)
 {
     page().set_window_position(position);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -65,6 +65,7 @@ public:
     void set_preferred_motion(Web::CSS::PreferredMotion);
     void set_has_focus(bool);
     void set_is_scripting_enabled(bool);
+    void set_max_touch_points(int max_touch_points);
     void set_window_position(Web::DevicePixelPoint);
     void set_window_size(Web::DevicePixelSize);
 
@@ -98,6 +99,7 @@ public:
     virtual double zoom_level() const override { return m_zoom_level; }
     virtual double device_pixel_ratio() const override { return m_device_pixel_ratio; }
     virtual double device_pixels_per_css_pixel() const override { return m_device_pixel_ratio * m_zoom_level; }
+    virtual int max_touch_points() const override { return m_max_touch_points; }
 
     virtual Web::DisplayListPlayerType display_list_player_type() const override;
 
@@ -210,6 +212,7 @@ private:
     double m_device_pixel_ratio { 1.0 };
     double m_zoom_level { 1.0 };
     double m_maximum_frames_per_second { 60.0 };
+    int m_max_touch_points { 0 };
     u64 m_id { 0 };
     bool m_has_focus { false };
 

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -103,6 +103,8 @@ endpoint WebContentServer
     set_enable_global_privacy_control(u64 page_id, bool enable) =|
     set_has_focus(u64 page_id, bool has_focus) =|
     set_is_scripting_enabled(u64 page_id, bool is_scripting_enabled) =|
+    set_max_touch_points(u64 page_id, i32 max_touch_points) =|
+    set_device_pixel_ratio(u64 page_id, double device_pixel_ratio) =|
     set_zoom_level(u64 page_id, double zoom_level) =|
     set_maximum_frames_per_second(u64 page_id, double maximum_frames_per_second) =|
 
@@ -140,6 +142,6 @@ endpoint WebContentServer
     cookies_changed(u64 page_id, Vector<HTTP::Cookie::Cookie> cookies) =|
 
     request_close(u64 page_id) =|
-    
+
     exit_fullscreen(u64 page_id) =|
 }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -38,6 +38,7 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPalette>
+#include <QPointingDevice>
 #include <QScrollBar>
 #include <QTextEdit>
 #include <QTimer>
@@ -663,6 +664,20 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli
 
     update_palette();
     update_screen_rects();
+
+    int max_touch_points = 0;
+    for (auto const* input_device : QInputDevice::devices()) {
+        if (!input_device)
+            continue;
+
+        if (input_device->type() != QInputDevice::DeviceType::TouchScreen) {
+            continue;
+        }
+
+        auto const* pointing_device = static_cast<QPointingDevice const*>(input_device);
+        max_touch_points = max(max_touch_points, pointing_device->maximumPoints());
+    }
+    set_max_touch_points(max_touch_points);
 }
 
 void WebContentView::update_cursor(Gfx::Cursor cursor)


### PR DESCRIPTION
Implemented `Navigator.maxTouchPoints` by plumbing platform touch capability from UI/Qt through LibWebView and WebContent into LibWeb.

Addresses one of the problems noted (within Non-CSS) in the Issue #1298 

> Note: Supersedes stale PR #7171 .