### PR TITLE
LibWeb: Do not mark CSSFontFeatureValuesMap::map_entries as virtual

### DIFF
--- a/Libraries/LibWeb/CSS/CSSFontFeatureValuesMap.h
+++ b/Libraries/LibWeb/CSS/CSSFontFeatureValuesMap.h
@@ -20,7 +20,7 @@ class CSSFontFeatureValuesMap final : public Bindings::PlatformObject {
 public:
     static GC::Ref<CSSFontFeatureValuesMap> create(JS::Realm&, size_t max_value_count);
 
-    virtual GC::Ref<JS::Map> map_entries() { return m_map_entries; }
+    GC::Ref<JS::Map> map_entries() { return m_map_entries; }
 
     WebIDL::ExceptionOr<void> set(String const& feature_value_name, Variant<u32, Vector<u32>> const& values);
 


### PR DESCRIPTION
This is a final class, and thus this cannot be overridden. Caught by clang 21.