### PR TITLE
LibWeb: Allow selecting text in dialog and label elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/HTMLLabelElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/Painting/Paintable.h>
+#include <LibWeb/Selection/Selection.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 
 namespace Web::HTML {
@@ -51,6 +52,11 @@ void HTMLLabelElement::activation_behavior(DOM::Event const& event)
 
     auto control_element = control();
     if (!control_element)
+        return;
+
+    // NB: If the click resulted in a selection being made on the label element, do not propagate the click event to the
+    //     input element. This allows the user to e.g. copy the label's text.
+    if (auto selection = document().get_selection(); selection && !selection->is_collapsed())
         return;
 
     if (auto* form_control = as_if<FormAssociatedElement>(*control_element)) {

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -72,6 +72,8 @@ private:
     EventResult focus_next_element();
     EventResult focus_previous_element();
 
+    GC::Ptr<DOM::Node> focus_candidate_for_position(CSSPixelPoint) const;
+
     EventResult fire_keyboard_event(FlyString const& event_name, HTML::Navigable&, UIEvents::KeyCode, unsigned modifiers, u32 code_point, bool repeat);
     [[nodiscard]] EventResult input_event(FlyString const& event_name, FlyString const& input_type, HTML::Navigable&, Variant<u32, Utf16String> code_point_or_string);
     CSSPixelPoint compute_mouse_event_client_offset(CSSPixelPoint event_page_position) const;

--- a/Tests/LibWeb/Text/expected/select-text-dialog.txt
+++ b/Tests/LibWeb/Text/expected/select-text-dialog.txt
@@ -1,0 +1,2 @@
+" is a di"
+<DIALOG id="dialog">

--- a/Tests/LibWeb/Text/expected/select-text-label.txt
+++ b/Tests/LibWeb/Text/expected/select-text-label.txt
@@ -1,0 +1,2 @@
+"s is a l"
+<BODY>

--- a/Tests/LibWeb/Text/input/select-text-dialog.html
+++ b/Tests/LibWeb/Text/input/select-text-dialog.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<dialog id="dialog" open>
+    <p id="text">This is a dialog</p>
+</dialog>
+<script>
+    test(() => {
+        let { x, y, width, height } = text.getBoundingClientRect();
+        x += width / 4;
+        y += height / 2;
+
+        internals.mouseDown(x, y);
+
+        x += width / 2;
+        internals.mouseMove(x, y);
+        internals.mouseUp(x, y);
+
+        println(`"${window.getSelection()}"`);
+        printElement(document.activeElement);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/select-text-label.html
+++ b/Tests/LibWeb/Text/input/select-text-label.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<label for="input" id="label">This is a label</label>
+<input id="input" value="This is an input" />
+<script>
+    test(() => {
+        let { x, y, width, height } = label.getBoundingClientRect();
+        x += width / 4;
+        y += height / 2;
+
+        internals.mouseDown(x, y);
+
+        x += width / 2;
+        internals.mouseMove(x, y);
+        internals.mouseUp(x, y);
+
+        println(`"${window.getSelection()}"`);
+        printElement(document.activeElement);
+    });
+</script>


### PR DESCRIPTION
We were previously not allowing the user to select text when the clicked position represented a click-focusable area. This included text within dialogs (as the dialog element is click-focusable) and labels (as the associated input element would be considered click-focusable).

We now no longer consider associated input elements when clicking on a label. This is handled separately already by the label's activation behavior steps, so there is no loss of functionality here. In those steps, though, we now no longer propagate the click event to the input element if a selection was made during the click. This matches the behavior of Firefox and Chrome.

With label elements no longer considered here, we can then enter the character selection mode when click-focusable areas are clicked.

Fixes #7975