### PR TITLE
LibJS: Don't duplicate var-scoped declarations per bound identifier

### DIFF
--- a/Libraries/LibJS/ScopeCollector.cpp
+++ b/Libraries/LibJS/ScopeCollector.cpp
@@ -163,8 +163,6 @@ void ScopeCollector::add_declaration(NonnullRefPtr<Declaration const> declaratio
                 VERIFY(scope->parent != nullptr);
                 scope = scope->parent;
             }
-            VERIFY(scope->is_top_level() && scope->ast_node);
-            scope->ast_node->add_var_scoped_declaration(declaration);
         }));
 
         VERIFY(m_current->top_level);

--- a/Tests/LibJS/Runtime/var-many-declarators.js
+++ b/Tests/LibJS/Runtime/var-many-declarators.js
@@ -1,0 +1,8 @@
+test("var statement with many declarators does not hang", () => {
+    const count = 50000;
+    const names = Array.from({ length: count }, (_, i) => `v${i}`);
+    const source = `var ${names.join(",")};`;
+    const start = Date.now();
+    eval(source);
+    expect(Date.now() - start).toBeLessThan(5000);
+});


### PR DESCRIPTION
ScopeCollector::add_declaration() was adding var declarations to the top-level scope's m_var_declarations once per bound identifier and once more after the for_each_bound_identifier loop - so a `var a, b, c` would be added 4 times instead of 1.

The Script constructor iterates m_var_declarations and expands each entry's bound identifiers, resulting in O(N²) work for a single var statement with N declarators.

Running the Emscripten-compiled version of ScummVM with a 32,174- declarator var statement, this produced over 1 billion entries, consuming 14+ GB of RAM and blocking the event loop for 35+ seconds. After this fix, this drops down to 200 MB and just short of 200ms.

No test262 regressions.