### PR TITLE
UI+LibWebView: Add "Open in New Window" option in right-click context menu

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -400,6 +400,11 @@ void Application::open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML:
         open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
 }
 
+void Application::open_url_in_new_window(URL::URL const& url)
+{
+    dbgln("open_url_in_new_window() is unsupported on this platform (url: {})", url);
+}
+
 static ErrorOr<NonnullRefPtr<WebContentClient>> create_web_content_client(Optional<ViewImplementation&> view)
 {
     auto request_server_handle = TRY(connect_new_request_server_client());

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -88,6 +88,7 @@ public:
     void open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab) const;
 
     Main::Arguments const& command_line_arguments() const { return m_arguments; }
+    virtual void open_url_in_new_window(URL::URL const& url);
 
     void add_child_process(Process&&);
 

--- a/Libraries/LibWebView/Menu.h
+++ b/Libraries/LibWebView/Menu.h
@@ -58,6 +58,7 @@ enum class ActionID {
     ViewSource,
 
     OpenInNewTab,
+    OpenInNewWindow,
     CopyURL,
 
     OpenImage,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1006,6 +1006,9 @@ void ViewImplementation::initialize_context_menus()
     m_open_in_new_tab_action = Action::create("Open in New Tab"sv, ActionID::OpenInNewTab, [this]() {
         Application::the().open_url_in_new_tab(m_context_menu_url, Web::HTML::ActivateTab::No);
     });
+    m_open_in_new_window_action = Action::create("Open in New Window"sv, ActionID::OpenInNewWindow, [this]() {
+        Application::the().open_url_in_new_window(m_context_menu_url);
+    });
     m_copy_url_action = Action::create("Copy URL"sv, ActionID::CopyURL, [this]() {
         Application::the().insert_clipboard_entry({ url_text_to_copy(m_context_menu_url), "text/plain"_string });
     });
@@ -1088,6 +1091,7 @@ void ViewImplementation::initialize_context_menus()
 
     m_link_context_menu = Menu::create("Link Context Menu"sv);
     m_link_context_menu->add_action(*m_open_in_new_tab_action);
+    m_link_context_menu->add_action(*m_open_in_new_window_action);
     m_link_context_menu->add_action(*m_copy_url_action);
 
     m_image_context_menu = Menu::create("Image Context Menu"sv);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -364,6 +364,7 @@ protected:
     RefPtr<Action> m_take_full_screenshot_action;
 
     RefPtr<Action> m_open_in_new_tab_action;
+    RefPtr<Action> m_open_in_new_window_action;
     RefPtr<Action> m_copy_url_action;
     URL::URL m_context_menu_url;
 

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -22,6 +22,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
+    virtual void open_url_in_new_window(URL::URL const& url) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(StringView file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -60,6 +60,12 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
     return [[tab web_view] view];
 }
 
+void Application::open_url_in_new_window(URL::URL const& url)
+{
+    ApplicationDelegate* delegate = [NSApp delegate];
+    (void)[delegate createNewTab:url fromTab:nil activateTab:Web::HTML::ActivateTab::Yes];
+}
+
 Optional<ByteString> Application::ask_user_for_download_path(StringView file) const
 {
     auto* panel = [NSSavePanel savePanel];

--- a/UI/AppKit/Interface/Menu.mm
+++ b/UI/AppKit/Interface/Menu.mm
@@ -271,6 +271,9 @@ static void initialize_native_icon(WebView::Action& action, id control)
     case WebView::ActionID::OpenInNewTab:
         set_control_image(control, @"plus.square.on.square");
         break;
+    case WebView::ActionID::OpenInNewWindow:
+        set_control_image(control, @"macwindow.badge.plus");
+        break;
     case WebView::ActionID::CopyURL:
         set_control_image(control, @"document.on.document");
         break;

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -150,6 +150,11 @@ Optional<WebView::ViewImplementation&> Application::open_blank_new_tab(Web::HTML
     return tab.view();
 }
 
+void Application::open_url_in_new_window(URL::URL const& url)
+{
+    this->new_window({ url });
+}
+
 Optional<ByteString> Application::ask_user_for_download_path(StringView file) const
 {
     auto default_path = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -38,6 +38,7 @@ private:
 
     virtual Optional<WebView::ViewImplementation&> active_web_view() const override;
     virtual Optional<WebView::ViewImplementation&> open_blank_new_tab(Web::HTML::ActivateTab) const override;
+    virtual void open_url_in_new_window(URL::URL const& url) override;
 
     virtual Optional<ByteString> ask_user_for_download_path(StringView file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -193,6 +193,10 @@ static void initialize_native_control(WebView::Action& action, QAction& qaction,
     case WebView::ActionID::OpenInNewTab:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/new-tab.png"sv));
         break;
+    case WebView::ActionID::OpenInNewWindow:
+        // FIXME: should be a separate icon for new window.
+        qaction.setIcon(load_icon_from_uri("resource://icons/16x16/new-tab.png"sv));
+        break;
     case WebView::ActionID::CopyURL:
         qaction.setIcon(load_icon_from_uri("resource://icons/16x16/edit-copy.png"sv));
         break;


### PR DESCRIPTION
~~Also fix behavior for Qt when a new window is opened with an empty URL list. Open the new tab link by default so one tab is always open in a window.~~

As pointed out by @Zaggy1024, it has already been addressed in commit (c35c29993a11eaa223ccb87d00d061795d02d8bb).