### PR TITLE
LibWeb: Account for generic font families in FontFaceSet::load()

### DIFF
--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -229,6 +229,10 @@ static WebIDL::ExceptionOr<GC::Ref<JS::Set>> find_matching_font_faces(JS::Realm&
     //    faces that match the font style, and add them to matched font faces. The use of the unicodeRange attribute means
     //    that this may be more than just a single font face.
     for (auto const& font_family : font_family_list.values()) {
+        // NB: Skip generic font family keywords
+        if (font_family->is_keyword())
+            continue;
+
         // FIXME: The matching below is super basic. We currently just match font family names by their string value.
         auto font_family_name = string_from_style_value(font_family);
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/generic-family-keywords-003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-fonts/generic-family-keywords-003.txt
@@ -1,0 +1,21 @@
+Harness status: OK
+
+Found 15 tests
+
+11 Pass
+4 Fail
+Pass	@font-face matching for quoted and unquoted serif (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted sans-serif (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted cursive (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted fantasy (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted monospace (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted system-ui (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted math (drawing text in a canvas)
+Fail	@font-face matching for quoted and unquoted generic(fangsong) (drawing text in a canvas)
+Fail	@font-face matching for quoted and unquoted generic(kai) (drawing text in a canvas)
+Fail	@font-face matching for quoted and unquoted generic(khmer-mul) (drawing text in a canvas)
+Fail	@font-face matching for quoted and unquoted generic(nastaliq) (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted ui-serif (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted ui-sans-serif (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted ui-monospace (drawing text in a canvas)
+Pass	@font-face matching for quoted and unquoted ui-rounded (drawing text in a canvas)

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/generic-family-keywords-003.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-fonts/generic-family-keywords-003.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<title>Test quotes vs. no-quotes matchings of generic font family keywords in a CanvasRenderingContext2D</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts-4/#family-name-syntax">
+<link rel="author" title="Frédéric Wang" href="mailto:fwang@igalia.com">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/css-fonts/support/font-family-keywords.js"></script>
+<link rel="stylesheet" type="text/css" href="../../fonts/ahem.css"/>
+<body>
+<canvas id="canvas" width="400" height="150"></canvas>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("load", () => { document.fonts.load("25px Ahem").then(runTests); });
+  function runTests() {
+    const measured_text = "|||||";
+    const canvas = document.getElementById("canvas");
+    const ctx = canvas.getContext("2d");
+    ctx.font = `25px Ahem`;
+    let ahem_expected_width = ctx.measureText(measured_text).width;
+
+    kGenericFontFamilyKeywords.forEach(keyword => {
+      promise_test(async function() {
+         ctx.font = `25px ${keyword}`;
+         let expected_width = ctx.measureText(measured_text).width;
+
+        // Insert the @font-face rules for quoted and unquoted keywords.
+        document.documentElement.insertAdjacentHTML('beforeend', `
+<style>
+@font-face {
+  font-family: ${keyword};
+  src: local(Ahem), url('../../fonts/Ahem.ttf');
+}
+</style>
+<style>
+@font-face {
+  font-family: "${keyword}";
+  src: local(Ahem), url('../../fonts/Ahem.ttf');
+}
+</style>`);
+
+        await document.fonts.load(`25px ${keyword}`);
+        ctx.font = `25px ${keyword}`;
+        let unquoted_width = ctx.measureText(measured_text).width;
+        assert_equals(unquoted_width, expected_width, `unquoted ${keyword} does not match @font-face rule`);
+
+        await document.fonts.load(`25px "${keyword}"`);
+        ctx.font = `25px "${keyword}"`;
+        let quoted_width = ctx.measureText(measured_text).width;
+        assert_equals(quoted_width, ahem_expected_width, `quoted ${keyword} matches  @font-face rule`);
+      }, `@font-face matching for quoted and unquoted ${keyword} (drawing text in a canvas)`);
+    });
+    done();
+  }
+</script>
+</body>


### PR DESCRIPTION
Fixes a regression in d998a0a which was crashing the imported test