### PR TITLE
Meta: Disallow using Homebrew's LLVM 21 on macOS for now

### DIFF
--- a/Meta/find_compiler.py
+++ b/Meta/find_compiler.py
@@ -65,6 +65,16 @@ def major_compiler_version_if_supported(platform: Platform, compiler: str, clang
             return apple_build_version
 
     elif version.find("clang") != -1:
+        # LLVM 21 on macOS interacts poorly with the system libc++. We encounter linker errors referring to a function
+        # that is present in LLVM's libc++, but not in the system libc++ (std::__1::__hash_memory). We would need to set
+        # both LDFLAGS and RPATH flags to link against and run with the LLVM libc++. Attempts to do so work for some
+        # vcpkg ports, but for some reason, skia does not pick up these flags. See:
+        #
+        # https://github.com/llvm/llvm-project/issues/77653
+        # https://github.com/llvm/llvm-project/issues/155531
+        if platform.host_system == HostSystem.macOS and major_version == 21:
+            return None
+
         if major_version >= CLANG_MINIMUM_VERSION:
             return major_version
 


### PR DESCRIPTION
We encounter linker errors with LLVM 21 that are proving a pain to overcome. The issues linked in the comments have quite a bit of chatter about this matter. Let's disallow it for now until we figure out a better solution or a fix is released.