### PR TITLE
LibWeb: Force position:static on non-root SVG elements

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1357,8 +1357,8 @@ void FormattingContext::layout_absolutely_positioned_children()
 void FormattingContext::layout_absolutely_positioned_element(Box const& box, AbsposContainingBlockInfo const& containing_block_info)
 {
     if (box.is_svg_box()) {
-        dbgln("FIXME: Implement support for absolutely positioned SVG elements.");
-        return;
+        // SVG elements cannot be absolutely positioned.
+        VERIFY_NOT_REACHED();
     }
 
     auto const available_space = AvailableSpace(AvailableSize::make_definite(containing_block_info.rect.width()), AvailableSize::make_definite(containing_block_info.rect.height()));

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleValues/KeywordStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/SVG/SVGDescElement.h>
@@ -278,6 +279,19 @@ void SVGElement::remove_from_use_element_that_reference_this()
         use_element.svg_element_removed(*this);
         return TraversalDecision::Continue;
     });
+}
+
+void SVGElement::adjust_computed_style(CSS::ComputedProperties& computed_properties)
+{
+    Base::adjust_computed_style(computed_properties);
+
+    // The outermost <svg> element (no ancestor <svg>) participates in CSS box layout
+    // and may be positioned. All other SVG elements, including nested <svg> elements,
+    // use SVG's coordinate system and must be forced to position:static.
+    if (is<SVGSVGElement>(*this) && !owner_svg_element())
+        return;
+
+    computed_properties.set_property(CSS::PropertyID::Position, CSS::KeywordStyleValue::create(CSS::Keyword::Static));
 }
 
 // https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__classNames

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -48,6 +48,7 @@ protected:
     virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void inserted() override;
     virtual void removed_from(Node* old_parent, Node& old_root) override;
+    MUST_UPCALL virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 
     void update_use_elements_that_reference_this();
     void remove_from_use_element_that_reference_this();

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -37,6 +37,8 @@ void SVGSymbolElement::visit_edges(Cell::Visitor& visitor)
 
 void SVGSymbolElement::adjust_computed_style(CSS::ComputedProperties& computed_properties)
 {
+    Base::adjust_computed_style(computed_properties);
+
     if (is_direct_child_of_use_shadow_tree()) {
         // The generated instance of a ‘symbol’ that is the direct referenced element of a ‘use’ element must always have a computed value of inline for the display property.
         computed_properties.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Inline)));

--- a/Tests/LibWeb/Layout/expected/svg/abspos-svg-polygon.txt
+++ b/Tests/LibWeb/Layout/expected/svg/abspos-svg-polygon.txt
@@ -4,7 +4,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <div> at [8,8] positioned [0+0+0 784 0+0+0] [0+0+0 200 0+0+0] children: inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
         SVGSVGBox <svg> at [8,8] [0+0+0 200 0+0+0] [0+0+0 200 0+0+0] [SVG] children: not-inline
-          SVGGeometryBox <polygon> at [48,18] positioned [0+0+0 120 0+0+0] [0+0+0 170 0+0+0] [BFC] children: not-inline
+          SVGGeometryBox <polygon> at [48,18] [0+0+0 120 0+0+0] [0+0+0 170 0+0+0] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]


### PR DESCRIPTION
SVG elements (except the outermost <svg>) use SVG's coordinate system, not the CSS box model, so CSS positioning doesn't apply to them.

This adds SVGElement::adjust_computed_style() to force position:static on all SVG elements except the outermost <svg> element (which has no owner_svg_element()). SVGSymbolElement's existing override now calls Base::adjust_computed_style() to inherit this behavior.

With this in place, the FIXME in layout_absolutely_positioned_element() for SVG boxes becomes unreachable and is replaced with VERIFY_NOT_REACHED().