### PR TITLE
LibWeb: Handle keyword style values in string_from_style_value()

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.cpp
@@ -213,13 +213,16 @@ double number_from_style_value(NonnullRefPtr<StyleValue const> const& style_valu
     VERIFY_NOT_REACHED();
 }
 
-FlyString const& string_from_style_value(NonnullRefPtr<StyleValue const> const& style_value)
+FlyString string_from_style_value(NonnullRefPtr<StyleValue const> const& style_value)
 {
     if (style_value->is_string())
         return style_value->as_string().string_value();
 
     if (style_value->is_custom_ident())
         return style_value->as_custom_ident().custom_ident();
+
+    if (style_value->is_keyword())
+        return FlyString::from_utf8_without_validation(string_from_keyword(style_value->as_keyword().keyword()).bytes());
 
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValue.h
@@ -203,7 +203,7 @@ struct StyleValueWithDefaultOperators : public StyleValue {
 };
 
 double number_from_style_value(NonnullRefPtr<StyleValue const> const& style_value, Optional<double> percentage_basis);
-FlyString const& string_from_style_value(NonnullRefPtr<StyleValue const> const& style_value);
+FlyString string_from_style_value(NonnullRefPtr<StyleValue const> const& style_value);
 
 }
 

--- a/Tests/LibWeb/Text/expected/css/FontFaceSet-load.txt
+++ b/Tests/LibWeb/Text/expected/css/FontFaceSet-load.txt
@@ -1,4 +1,5 @@
 Load invalid font: PASS
 Load CSS keyword as font: PASS
 Load non-existent font: PASS
+Load generic font family: PASS
 Load valid font: PASS

--- a/Tests/LibWeb/Text/input/css/FontFaceSet-load.html
+++ b/Tests/LibWeb/Text/input/css/FontFaceSet-load.html
@@ -29,6 +29,14 @@
         }
 
         try {
+            const result = await fontFaceSet.load("16px sans-serif");
+            println(`Load generic font family: ${result.length == 0 ? "PASS" : "FAIL"}`);
+        } catch (e) {
+            println("Load generic font family: FAIL");
+            println(e);
+        }
+
+        try {
             const result = await fontFaceSet.load("1em Hash Sans");
             println(`Load valid font: ${result.length > 0 ? "PASS" : "FAIL"}`);
         } catch (e) {


### PR DESCRIPTION
Generic font families like `sans-serif` are represented as KeywordStyleValue, but string_from_style_value() only handled StringStyleValue and CustomIdentStyleValue, causing a crash when FontFaceSet.load() was called with a generic family name.