### PR TITLE
LibWeb: Resolve percentage table widths in wrapper width computation

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -462,6 +462,13 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(Box co
     table_box_state.padding_left = table_box_computed_values.padding().left().to_px_or_zero(*table_box, width_of_containing_block);
     table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(*table_box, width_of_containing_block);
 
+    // Propagate the containing block width so percentage table widths can resolve instead of being treated as "auto".
+    if (auto wrapper_containing_block = box.containing_block()) {
+        auto const& containing_block_state = m_state.get(*wrapper_containing_block);
+        if (containing_block_state.has_definite_width())
+            throwaway_state.get_mutable(*wrapper_containing_block).set_content_width(containing_block_state.content_width());
+    }
+
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
     context->run_until_width_calculation(m_state.get(*table_box).available_inner_space_or_constraints_from(available_space));
 

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
@@ -3,12 +3,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 32 0+0+8] children: not-inline
       Box <div.grid_layout> at [8,8] [0+0+0 784 0+0+0] [0+0+0 32 0+0+0] [GFC] children: not-inline
         BlockContainer <div> at [8,8] [0+0+0 200 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
-          TableWrapper <(anonymous)> at [8,8] [0+0+0 200 0+0+149.46875] [0+0+0 32 0+0+0] [BFC] children: not-inline
+          TableWrapper <(anonymous)> at [8,8] [0+0+0 200 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
             Box <table.outer> at [9,9] table-box [0+1+0 198 0+1+0] [0+1+0 30 0+1+0] [TFC] children: not-inline
               Box <tbody> at [11,11] table-row-group [0+0+0 194 0+0+0] [0+0+0 26 0+0+0] children: not-inline
                 Box <tr> at [11,11] table-row [0+0+0 194 0+0+0] [0+0+0 26 0+0+0] children: not-inline
                   BlockContainer <td> at [12,12] table-cell [0+0+1 192 1+0+0] [0+0+1 24 1+0+0] [BFC] children: not-inline
-                    TableWrapper <(anonymous)> at [12,12] [0+0+0 192 0+0+149.46875] [0+0+0 24 0+0+0] [BFC] children: not-inline
+                    TableWrapper <(anonymous)> at [12,12] [0+0+0 192 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
                       Box <table.inner> at [12,12] table-box [0+0+0 192 0+0+0] [0+0+0 24 0+0+0] [TFC] children: not-inline
                         Box <tbody> at [14,14] table-row-group [0+0+0 188 0+0+0] [0+0+0 20 0+0+0] children: not-inline
                           Box <tr> at [14,14] table-row [0+0+0 188 0+0+0] [0+0+0 20 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
@@ -2,22 +2,22 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 120 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 104 0+0+8] children: not-inline
       BlockContainer <center> at [8,8] [0+0+0 784 0+0+0] [0+0+0 104 0+0+0] children: not-inline
-        TableWrapper <(anonymous)> at [200,8] [0+0+0 392 0+0+384] [0+0+0 104 0+0+0] [BFC] children: not-inline
-          Box <table> at [200,8] table-box [0+0+0 392 0+0+200] [0+0+0 104 0+0+0] [TFC] children: not-inline
-            Box <tbody> at [202,10] table-row-group [0+0+0 388 0+0+0] [0+0+0 100 0+0+0] children: not-inline
-              Box <tr> at [202,10] table-row [0+0+0 388 0+0+0] [0+0+0 100 0+0+0] children: not-inline
-                BlockContainer <td> at [203,60] table-cell [0+0+1 386 1+0+0] [0+0+50 0 50+0+0] [BFC] children: inline
+        TableWrapper <(anonymous)> at [204,8] [0+0+0 392 0+0+392] [0+0+0 104 0+0+0] [BFC] children: not-inline
+          Box <table> at [204,8] table-box [0+0+0 392 0+0+196] [0+0+0 104 0+0+0] [TFC] children: not-inline
+            Box <tbody> at [206,10] table-row-group [0+0+0 388 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+              Box <tr> at [206,10] table-row [0+0+0 388 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+                BlockContainer <td> at [207,60] table-cell [0+0+1 386 1+0+0] [0+0+50 0 50+0+0] [BFC] children: inline
                   TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x120]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
       PaintableWithLines (BlockContainer<CENTER>) [8,8 784x104]
-        PaintableWithLines (TableWrapper(anonymous)) [200,8 392x104]
-          PaintableBox (Box<TABLE>) [200,8 392x104]
-            PaintableBox (Box<TBODY>) [202,10 388x100]
-              PaintableBox (Box<TR>) [202,10 388x100]
-                PaintableWithLines (BlockContainer<TD>) [202,10 388x100]
+        PaintableWithLines (TableWrapper(anonymous)) [204,8 392x104]
+          PaintableBox (Box<TABLE>) [204,8 392x104]
+            PaintableBox (Box<TBODY>) [206,10 388x100]
+              PaintableBox (Box<TR>) [206,10 388x100]
+                PaintableWithLines (BlockContainer<TD>) [206,10 388x100]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x120] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Ref/expected/table-margin-auto-inside-flex-item-ref.html
+++ b/Tests/LibWeb/Ref/expected/table-margin-auto-inside-flex-item-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    * { margin: 0; padding: 0; }
+    .flex { display: flex; flex-direction: column; }
+    .centering { min-width: 400px; margin: 0 auto; }
+    .block { width: 100%; background: green; }
+</style>
+<div class="flex">
+    <div class="centering">
+        <div class="block">content</div>
+    </div>
+</div>

--- a/Tests/LibWeb/Ref/input/table-margin-auto-inside-flex-item.html
+++ b/Tests/LibWeb/Ref/input/table-margin-auto-inside-flex-item.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/table-margin-auto-inside-flex-item-ref.html" />
+<style>
+    * { margin: 0; padding: 0; }
+    .flex { display: flex; flex-direction: column; }
+    .centering { min-width: 400px; margin: 0 auto; }
+    .table { display: table; width: 100%; margin: 0 auto; background: green; }
+</style>
+<div class="flex">
+    <div class="centering">
+        <div class="table">content</div>
+    </div>
+</div>


### PR DESCRIPTION
Previously, a table with `width: 100%` and `margin: auto` whose content was narrower than the viewport would be centered based on content width rather than filling the containing block. Resizing the viewport wider than the content would shift the table progressively further to the right.

Fixes #7987