### PR TITLE
LibJS: Use exact integer arithmetic in Number.prototype.toPrecision

### DIFF
--- a/Tests/LibJS/Runtime/builtins/Number/Number.prototype.toPrecision.js
+++ b/Tests/LibJS/Runtime/builtins/Number/Number.prototype.toPrecision.js
@@ -98,7 +98,16 @@ describe("correct behavior", () => {
             [0.1, 1, "0.1"],
             [0.0123, 3, "0.0123"],
             [0.0012345, 3, "0.00123"],
-            [0.0012345, 4, "0.001235"],
+            [0.0012345, 4, "0.001234"],
+        ].forEach(test => {
+            expect(test[0].toPrecision(test[1])).toBe(test[2]);
+        });
+    });
+
+    test("numbers exceeding the limits of a double", () => {
+        [
+            [1 + 11 / 31, 16, "1.354838709677419"],
+            [-1.2345e27, 21, "-1.23449999999999996184e+27"],
         ].forEach(test => {
             expect(test[0].toPrecision(test[1])).toBe(test[2]);
         });


### PR DESCRIPTION
Our previous implementation produced incorrect results for values near the limits of double precision. This new implementation avoid floating- point arithmetic entirely by:

1. Decomposing the double value into its exact binary form.
2. Computing the formulas from the spec using bigints.
3. Using Ryu to calculate the decimal exponent.

test262 diff:
```
test/built-ins/Temporal/Duration/prototype/total/relativeto-calendar-units-depend-on-relative-date.js ❌ -> ✅
test/staging/sm/Number/toPrecision-values.js                                                          ❌ -> ✅
```

We still don't pass `test/built-ins/Number/prototype/toPrecision/exponential.js`, but we make it further. We are failing to precisely store `new Number("0.000000000000000000001")`. 