### PR TITLE
LibMedia: Serialize AudioConverter access in AudioDataProvider

### DIFF
--- a/Libraries/LibMedia/Providers/AudioDataProvider.cpp
+++ b/Libraries/LibMedia/Providers/AudioDataProvider.cpp
@@ -110,6 +110,7 @@ void AudioDataProvider::ThreadData::set_block_end_time_handler(BlockEndTimeHandl
 
 void AudioDataProvider::ThreadData::set_output_sample_specification(Audio::SampleSpecification sample_specification)
 {
+    Threading::MutexLocker locker { m_converter_mutex };
     m_converter->set_output_sample_specification(sample_specification).release_value_but_fixme_should_propagate_errors();
 }
 
@@ -279,6 +280,7 @@ DecoderErrorOr<void> AudioDataProvider::ThreadData::retrieve_next_block(AudioBlo
 {
     TRY(m_decoder->write_next_block(block));
 
+    Threading::MutexLocker locker { m_converter_mutex };
     auto convert_result = m_converter->convert(block);
     if (convert_result.is_error())
         return DecoderError::format(DecoderErrorCategory::NotImplemented, "Sample specification conversion failed: {}", convert_result.error().string_literal());

--- a/Libraries/LibMedia/Providers/AudioDataProvider.h
+++ b/Libraries/LibMedia/Providers/AudioDataProvider.h
@@ -114,6 +114,7 @@ private:
         OwnPtr<AudioDecoder> m_decoder;
         bool m_decoder_needs_keyframe_next_seek { false };
         NonnullOwnPtr<Audio::AudioConverter> m_converter;
+        mutable Threading::Mutex m_converter_mutex;
         i64 m_last_sample { NumericLimits<i64>::min() };
 
         size_t m_queue_max_size { 8 };


### PR DESCRIPTION
Sample spec updates can be triggered by output device changes while audio blocks are being converted. Guard AudioConverter with a mutex so set_output_sample_specification() and convert() don't step on each other