### PR TITLE
LibWeb: Fire VisualViewport resize events for background tabs on show

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -578,6 +578,8 @@ public:
     void update_the_visibility_state(HTML::VisibilityState);
 
     void run_the_resize_steps();
+    Optional<Gfx::IntSize> const& last_viewport_size() const { return m_last_viewport_size; }
+    void set_last_viewport_size(Gfx::IntSize size) { m_last_viewport_size = size; }
     void run_the_scroll_steps();
 
     void evaluate_media_queries_and_report_changes();

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2594,6 +2594,16 @@ void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList inval
     if (m_viewport_size == size && invalidate_display_list == InvalidateDisplayList::No)
         return;
 
+    auto document = active_document();
+
+    // If the document's rendering updates were skipped run_the_resize_steps() will not have initialized
+    // m_last_viewport_size. Seed it with the current viewport size so that the next rendering update detects the change
+    // and fires VisualViewport resize events.
+    if (document) {
+        if (!document->last_viewport_size().has_value())
+            document->set_last_viewport_size(m_viewport_size.to_type<int>());
+    }
+
     m_viewport_size = size;
 
     if (!m_is_svg_page) {
@@ -2602,14 +2612,12 @@ void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList inval
         m_pending_set_browser_zoom_request = false;
     }
 
-    if (auto document = active_document()) {
+    if (document) {
         // NOTE: Resizing the viewport changes the reference value for viewport-relative CSS lengths.
         document->invalidate_style(DOM::StyleInvalidationReason::NavigableSetViewportSize);
         document->set_needs_media_query_evaluation();
         document->set_needs_layout_update(DOM::SetNeedsLayoutReason::NavigableSetViewportSize);
-    }
 
-    if (auto document = active_document()) {
         document->set_needs_display(invalidate_display_list);
 
         document->inform_all_viewport_clients_about_the_current_viewport_rect();


### PR DESCRIPTION
Tested manually by running `./Meta/ladybird.py run ladybird https://jeetsh4h.dev/terminal https://jeetsh4h.dev/terminal` and checking both tabs look the same.

Fixes #8008