### PR TITLE
LibWeb: Stop inline elements after table-cell being swallowed into table

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -553,7 +553,7 @@ static bool is_ignorable_whitespace(Layout::Node const& node)
                     contains_only_white_space = false;
                     return TraversalDecision::Break;
                 }
-            } else if (descendant.is_out_of_flow()) {
+            } else if (descendant.is_out_of_flow() || !descendant.is_anonymous()) {
                 contains_only_white_space = false;
                 return TraversalDecision::Break;
             }

--- a/Tests/LibWeb/Layout/expected/table/inline-after-table-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-after-table-cell.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 0 0+0+784] [0+0+0 0 0+0+0] [BFC] children: not-inline
+        Box <(anonymous)> at [8,8] table-box [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [TFC] children: not-inline
+          Box <(anonymous)> at [8,8] table-row [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+            BlockContainer <div> at [8,8] table-cell [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        InlineNode <span> at [8,8] [0+3+0 0 0+3+0] [0+3+0 18 0+3+0]
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 0x0]
+        PaintableBox (Box(anonymous)) [8,8 0x0]
+          PaintableBox (Box(anonymous)) [8,8 0x0]
+            PaintableWithLines (BlockContainer<DIV>) [8,8 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+        PaintableWithLines (InlineNode<SPAN>) [5,5 6x24]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table/inline-after-table-cell.html
+++ b/Tests/LibWeb/Layout/input/table/inline-after-table-cell.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<div style="display:table-cell"></div>
+<span style="border:solid"></span>


### PR DESCRIPTION
The `is_ignorable_whitespace()` check in table fixup traverses anonymous block wrappers to see if they contain only whitespace. It rejected out-of-flow and text descendants but silently skipped in-flow non-text elements like `<span>`, misclassifying wrappers with real content as ignorable and absorbing them into the table structure.

Fixes: #7803