### PR TITLE
Everywhere: Combine viewport size and DPR into a single IPC message

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2571,9 +2571,9 @@ CSSPixelPoint Navigable::to_top_level_position(CSSPixelPoint a_position)
     return position;
 }
 
-void Navigable::set_viewport_size(CSSPixelSize size)
+void Navigable::set_viewport_size(CSSPixelSize size, InvalidateDisplayList invalidate_display_list)
 {
-    if (m_viewport_size == size)
+    if (m_viewport_size == size && invalidate_display_list == InvalidateDisplayList::No)
         return;
 
     m_viewport_size = size;
@@ -2593,7 +2593,7 @@ void Navigable::set_viewport_size(CSSPixelSize size)
     }
 
     if (auto document = active_document()) {
-        document->set_needs_display(InvalidateDisplayList::No);
+        document->set_needs_display(invalidate_display_list);
 
         document->inform_all_viewport_clients_about_the_current_viewport_rect();
 

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -169,7 +169,7 @@ public:
     CSSPixelPoint viewport_scroll_offset() const { return m_viewport_scroll_offset; }
     CSSPixelRect viewport_rect() const { return { m_viewport_scroll_offset, m_viewport_size }; }
     CSSPixelSize viewport_size() const { return m_viewport_size; }
-    void set_viewport_size(CSSPixelSize);
+    void set_viewport_size(CSSPixelSize, InvalidateDisplayList = InvalidateDisplayList::No);
     void perform_scroll_of_viewport_scrolling_box(CSSPixelPoint position);
 
     Painting::BackingStoreManager& backing_store_manager() { return *m_backing_store_manager; }

--- a/Libraries/LibWebView/HeadlessWebView.cpp
+++ b/Libraries/LibWebView/HeadlessWebView.cpp
@@ -59,7 +59,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
         m_viewport_size = size.template to_type<Web::DevicePixels>();
 
         client().async_set_window_size(m_client_state.page_index, m_viewport_size);
-        client().async_set_viewport_size(m_client_state.page_index, m_viewport_size);
+        client().async_set_viewport(m_client_state.page_index, m_viewport_size, m_device_pixel_ratio);
 
         client().async_did_update_window_rect(m_client_state.page_index);
     };
@@ -77,7 +77,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
 
         client().async_set_window_position(m_client_state.page_index, screen_rect.location());
         client().async_set_window_size(m_client_state.page_index, screen_rect.size());
-        client().async_set_viewport_size(m_client_state.page_index, screen_rect.size());
+        client().async_set_viewport(m_client_state.page_index, screen_rect.size(), m_device_pixel_ratio);
 
         client().async_did_update_window_rect(m_client_state.page_index);
     };
@@ -87,7 +87,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
 
         client().async_set_window_position(m_client_state.page_index, screen_rect.location());
         client().async_set_window_size(m_client_state.page_index, screen_rect.size());
-        client().async_set_viewport_size(m_client_state.page_index, screen_rect.size());
+        client().async_set_viewport(m_client_state.page_index, screen_rect.size(), m_device_pixel_ratio);
 
         client().async_did_update_window_rect(m_client_state.page_index);
     };
@@ -156,7 +156,7 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
     ViewImplementation::initialize_client(create_new_client);
 
     client().async_update_system_theme(m_client_state.page_index, m_theme);
-    client().async_set_viewport_size(m_client_state.page_index, viewport_size());
+    client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio);
     client().async_set_window_size(m_client_state.page_index, viewport_size());
     client().async_update_screen_rects(m_client_state.page_index, { { screen_rect } }, 0);
 }
@@ -164,7 +164,6 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
 void HeadlessWebView::update_zoom()
 {
     ViewImplementation::update_zoom();
-    client().async_set_viewport_size(m_client_state.page_index, m_viewport_size);
 }
 
 }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -613,7 +613,7 @@ void ViewImplementation::update_zoom()
 
 void ViewImplementation::handle_resize()
 {
-    client().async_set_viewport_size(page_id(), this->viewport_size());
+    client().async_set_viewport(page_id(), this->viewport_size(), m_device_pixel_ratio);
 }
 
 void ViewImplementation::initialize_client(CreateNewClient create_new_client)
@@ -630,7 +630,7 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     m_client_state.client_handle = MUST(Web::Crypto::generate_random_uuid());
     client().async_set_window_handle(m_client_state.page_index, m_client_state.client_handle);
     client().async_set_zoom_level(m_client_state.page_index, m_zoom_level);
-    client().async_set_device_pixel_ratio(m_client_state.page_index, m_device_pixel_ratio);
+    client().async_set_viewport(m_client_state.page_index, viewport_size(), m_device_pixel_ratio);
     client().async_set_maximum_frames_per_second(m_client_state.page_index, m_maximum_frames_per_second);
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
     client().async_set_document_cookie_version_buffer(m_client_state.page_index, m_document_cookie_version_buffer);

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -195,10 +195,10 @@ void ConnectionFromClient::traverse_the_history_by_delta(u64 page_id, i32 delta)
         page->page().traverse_the_history_by_delta(delta);
 }
 
-void ConnectionFromClient::set_viewport_size(u64 page_id, Web::DevicePixelSize size)
+void ConnectionFromClient::set_viewport(u64 page_id, Web::DevicePixelSize size, double device_pixel_ratio)
 {
     if (auto page = this->page(page_id); page.has_value())
-        page->set_viewport_size(size);
+        page->set_viewport(size, device_pixel_ratio);
 }
 
 void ConnectionFromClient::ready_to_paint(u64 page_id)
@@ -1193,12 +1193,6 @@ void ConnectionFromClient::set_is_scripting_enabled(u64 page_id, bool is_scripti
 {
     if (auto page = this->page(page_id); page.has_value())
         page->set_is_scripting_enabled(is_scripting_enabled);
-}
-
-void ConnectionFromClient::set_device_pixel_ratio(u64 page_id, double device_pixel_ratio)
-{
-    if (auto page = this->page(page_id); page.has_value())
-        page->set_device_pixel_ratio(device_pixel_ratio);
 }
 
 void ConnectionFromClient::set_zoom_level(u64 page_id, double zoom_level)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -71,7 +71,7 @@ private:
     virtual void load_html(u64 page_id, ByteString) override;
     virtual void reload(u64 page_id) override;
     virtual void traverse_the_history_by_delta(u64 page_id, i32 delta) override;
-    virtual void set_viewport_size(u64 page_id, Web::DevicePixelSize) override;
+    virtual void set_viewport(u64 page_id, Web::DevicePixelSize, double device_pixel_ratio) override;
     virtual void key_event(u64 page_id, Web::KeyEvent) override;
     virtual void mouse_event(u64 page_id, Web::MouseEvent) override;
     virtual void drag_event(u64 page_id, Web::DragEvent) override;
@@ -117,7 +117,6 @@ private:
     virtual void set_has_focus(u64 page_id, bool) override;
     virtual void set_is_scripting_enabled(u64 page_id, bool) override;
     virtual void set_zoom_level(u64 page_id, double zoom_level) override;
-    virtual void set_device_pixel_ratio(u64 page_id, double device_pixel_ratio) override;
     virtual void set_maximum_frames_per_second(u64 page_id, double) override;
     virtual void set_window_position(u64 page_id, Web::DevicePixelPoint) override;
     virtual void set_window_size(u64 page_id, Web::DevicePixelSize) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -206,18 +206,21 @@ void PageClient::report_finished_handling_input_event(u64 page_id, Web::EventRes
     client().async_did_finish_handling_input_event(page_id, event_was_handled);
 }
 
-void PageClient::set_viewport_size(Web::DevicePixelSize const& size)
+void PageClient::set_viewport(Web::DevicePixelSize const& size, double device_pixel_ratio)
 {
+    auto invalidate = m_device_pixel_ratio != device_pixel_ratio
+        ? Web::InvalidateDisplayList::Yes
+        : Web::InvalidateDisplayList::No;
+
     m_viewport_size = size;
-    page().top_level_traversable()->set_viewport_size(page().device_to_css_size(size));
+    m_device_pixel_ratio = device_pixel_ratio;
+
+    page().top_level_traversable()->set_viewport_size(page().device_to_css_size(size), invalidate);
 }
 
-void PageClient::set_device_pixel_ratio(double device_pixel_ratio)
+void PageClient::set_zoom_level(double zoom_level)
 {
-    if (m_device_pixel_ratio == device_pixel_ratio)
-        return;
-
-    m_device_pixel_ratio = device_pixel_ratio;
+    m_zoom_level = zoom_level;
     page().top_level_traversable()->set_viewport_size(page().device_to_css_size(m_viewport_size));
 }
 
@@ -388,7 +391,7 @@ void PageClient::page_did_set_browser_zoom(double factor)
 
 void PageClient::page_did_set_device_pixel_ratio_for_testing(double ratio)
 {
-    set_device_pixel_ratio(ratio);
+    set_viewport(m_viewport_size, ratio);
 }
 
 void PageClient::page_did_request_context_menu(Web::CSSPixelPoint content_position)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -52,14 +52,13 @@ public:
     virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;
 
     void set_palette_impl(Gfx::PaletteImpl&);
-    void set_viewport_size(Web::DevicePixelSize const&);
+    void set_viewport(Web::DevicePixelSize const&, double device_pixel_ratio);
     void set_screen_rects(Vector<Web::DevicePixelRect> const& rects, size_t main_screen_index)
     {
         m_all_screen_rects = rects;
         m_main_screen_index = main_screen_index;
     }
-    void set_device_pixel_ratio(double device_pixel_ratio);
-    void set_zoom_level(double zoom_level) { m_zoom_level = zoom_level; }
+    void set_zoom_level(double zoom_level);
     void set_maximum_frames_per_second(u64 maximum_frames_per_second);
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -41,7 +41,7 @@ endpoint WebContentServer
 
     ready_to_paint(u64 page_id) =|
 
-    set_viewport_size(u64 page_id, Web::DevicePixelSize size) =|
+    set_viewport(u64 page_id, Web::DevicePixelSize size, double device_pixel_ratio) =|
 
     key_event(u64 page_id, Web::KeyEvent event) =|
     mouse_event(u64 page_id, Web::MouseEvent event) =|
@@ -103,7 +103,6 @@ endpoint WebContentServer
     set_enable_global_privacy_control(u64 page_id, bool enable) =|
     set_has_focus(u64 page_id, bool has_focus) =|
     set_is_scripting_enabled(u64 page_id, bool is_scripting_enabled) =|
-    set_device_pixel_ratio(u64 page_id, double device_pixel_ratio) =|
     set_zoom_level(u64 page_id, double zoom_level) =|
     set_maximum_frames_per_second(u64 page_id, double maximum_frames_per_second) =|
 

--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -58,7 +58,7 @@ void TestWebView::on_test_complete(TestCompletion completion)
     m_pending_screenshot.clear();
     m_pending_dialog = Web::Page::PendingDialog::None;
     m_pending_prompt_text.clear();
-    client().async_set_device_pixel_ratio(m_client_state.page_index, 1.0);
+    client().async_set_viewport(m_client_state.page_index, viewport_size(), 1.0);
 
     m_test_promise->resolve(move(completion));
 }

--- a/UI/Android/src/main/cpp/WebViewImplementationNative.cpp
+++ b/UI/Android/src/main/cpp/WebViewImplementationNative.cpp
@@ -61,7 +61,7 @@ void WebViewImplementationNative::initialize_client(WebView::ViewImplementation:
     m_client_state.client_handle = MUST(Web::Crypto::generate_random_uuid());
     client().async_set_window_handle(0, m_client_state.client_handle);
 
-    client().async_set_device_pixel_ratio(0, m_device_pixel_ratio);
+    client().async_set_viewport(0, viewport_size(), m_device_pixel_ratio);
     client().async_set_zoom_level(0, m_zoom_level);
 
     set_system_visibility_state(Web::HTML::VisibilityState::Visible);
@@ -91,7 +91,7 @@ void WebViewImplementationNative::set_viewport_geometry(int w, int h)
 void WebViewImplementationNative::set_device_pixel_ratio(double f)
 {
     m_device_pixel_ratio = f;
-    client().async_set_device_pixel_ratio(0, m_device_pixel_ratio);
+    handle_resize();
 }
 
 void WebViewImplementationNative::set_zoom_level(double f)

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -37,7 +37,6 @@ WebViewBridge::~WebViewBridge() = default;
 void WebViewBridge::set_device_pixel_ratio(double device_pixel_ratio)
 {
     m_device_pixel_ratio = device_pixel_ratio;
-    client().async_set_device_pixel_ratio(m_client_state.page_index, m_device_pixel_ratio);
 }
 
 void WebViewBridge::set_zoom_level(double zoom_level)

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -549,13 +549,12 @@ void WebContentView::resizeEvent(QResizeEvent* event)
 void WebContentView::set_viewport_rect(Gfx::IntRect rect)
 {
     m_viewport_size = rect.size();
-    client().async_set_viewport_size(m_client_state.page_index, rect.size().to_type<Web::DevicePixels>());
+    handle_resize();
 }
 
 void WebContentView::set_device_pixel_ratio(double device_pixel_ratio)
 {
     m_device_pixel_ratio = device_pixel_ratio;
-    client().async_set_device_pixel_ratio(m_client_state.page_index, m_device_pixel_ratio);
     update_viewport_size();
     handle_resize();
 }


### PR DESCRIPTION
The set_viewport_size and set_device_pixel_ratio IPC messages were sent separately, potentially causing a race condition when the DPR changes (e.g. moving a window between screens): the DPR message would arrive and use a stale viewport size, computing a temporarily wrong CSS viewport. Combine both into a single set_viewport IPC that updates the device viewport size and DPR together.