### PR TITLE
LibWeb: Avoid division by zero in multi-column column count calculation

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1497,10 +1497,11 @@ Optional<int> BlockFormattingContext::determine_used_value_for_column_count(CSSP
     }
     auto column_gap = get_column_gap_used_value_for_multicol(U);
     auto column_width = computed_values.column_width().to_px(root(), U);
-    if (computed_values.column_count().is_auto()) {
-        return max(1, ((U + column_gap) / (column_width + column_gap)).to_int());
-    }
-    return min(computed_values.column_count().value(), max(1, ((U + column_gap) / (column_width + column_gap)).to_int()));
+    auto divisor = column_width + column_gap;
+    auto column_count = divisor == 0 ? 1 : max(1, ((U + column_gap) / divisor).to_int());
+    if (computed_values.column_count().is_auto())
+        return column_count;
+    return min(computed_values.column_count().value(), column_count);
 }
 CSSPixels BlockFormattingContext::determine_used_value_for_column_width(CSSPixels const& U, int N) const
 {

--- a/Tests/LibWeb/Crash/Layout/multicol-zero-column-width.html
+++ b/Tests/LibWeb/Crash/Layout/multicol-zero-column-width.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+div {
+    column-width: 0;
+    column-gap: 0;
+}
+</style>
+<div>x</div>


### PR DESCRIPTION
Fixes a crash in https://wpt.live/css/css-multicol/zero-column-width-layout.html, but we don't implement enough multicol layout for the test to pass, so I've made a minimal crash test instead.