### PR TITLE
LibWeb: Validate grid-template-areas rectangles at parse time

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1737,10 +1737,11 @@ EmptyCells ComputedProperties::empty_cells() const
     return keyword_to_empty_cells(value.to_keyword()).release_value();
 }
 
-Vector<Vector<String>> ComputedProperties::grid_template_areas() const
+GridTemplateAreas ComputedProperties::grid_template_areas() const
 {
     auto const& value = property(PropertyID::GridTemplateAreas);
-    return value.as_grid_template_area().grid_template_area();
+    auto const& style_value = value.as_grid_template_area();
+    return { style_value.grid_areas(), style_value.row_count(), style_value.column_count() };
 }
 
 ObjectFit ComputedProperties::object_fit() const

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -184,7 +184,7 @@ public:
     GridTrackPlacement grid_row_start() const;
     BorderCollapse border_collapse() const;
     CSS::EmptyCells empty_cells() const;
-    Vector<Vector<String>> grid_template_areas() const;
+    GridTemplateAreas grid_template_areas() const;
     ObjectFit object_fit() const;
     Position object_position() const;
     TableLayout table_layout() const;

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -246,7 +246,7 @@ public:
     static Variant<LengthPercentage, NormalGap> row_gap() { return NormalGap {}; }
     static BorderCollapse border_collapse() { return BorderCollapse::Separate; }
     static EmptyCells empty_cells() { return EmptyCells::Show; }
-    static Vector<Vector<String>> grid_template_areas() { return {}; }
+    static GridTemplateAreas grid_template_areas() { return {}; }
     static Time transition_delay() { return Time::make_seconds(0); }
     static ObjectFit object_fit() { return ObjectFit::Fill; }
     static Position object_position() { return {}; }
@@ -589,7 +589,7 @@ public:
     Variant<LengthPercentage, NormalGap> const& row_gap() const { return m_noninherited.row_gap; }
     BorderCollapse border_collapse() const { return m_inherited.border_collapse; }
     EmptyCells empty_cells() const { return m_inherited.empty_cells; }
-    Vector<Vector<String>> const& grid_template_areas() const { return m_noninherited.grid_template_areas; }
+    GridTemplateAreas const& grid_template_areas() const { return m_noninherited.grid_template_areas; }
     ObjectFit object_fit() const { return m_noninherited.object_fit; }
     Position object_position() const { return m_noninherited.object_position; }
     Direction direction() const { return m_inherited.direction; }
@@ -854,7 +854,7 @@ protected:
         Size column_width { InitialValues::column_width() };
         Size column_height { InitialValues::column_height() };
         Variant<LengthPercentage, NormalGap> row_gap { InitialValues::row_gap() };
-        Vector<Vector<String>> grid_template_areas { InitialValues::grid_template_areas() };
+        GridTemplateAreas grid_template_areas { InitialValues::grid_template_areas() };
         Gfx::Color stop_color { InitialValues::stop_color() };
         float stop_opacity { InitialValues::stop_opacity() };
         Time transition_delay { InitialValues::transition_delay() };
@@ -1069,7 +1069,7 @@ public:
     void set_row_gap(Variant<LengthPercentage, NormalGap> const& row_gap) { m_noninherited.row_gap = row_gap; }
     void set_border_collapse(BorderCollapse const border_collapse) { m_inherited.border_collapse = border_collapse; }
     void set_empty_cells(EmptyCells const empty_cells) { m_inherited.empty_cells = empty_cells; }
-    void set_grid_template_areas(Vector<Vector<String>> const& grid_template_areas) { m_noninherited.grid_template_areas = grid_template_areas; }
+    void set_grid_template_areas(GridTemplateAreas grid_template_areas) { m_noninherited.grid_template_areas = move(grid_template_areas); }
     void set_grid_auto_flow(GridAutoFlow grid_auto_flow) { m_noninherited.grid_auto_flow = grid_auto_flow; }
     void set_transition_delay(Time const& transition_delay) { m_noninherited.transition_delay = transition_delay; }
     void set_table_layout(TableLayout value) { m_noninherited.table_layout = value; }

--- a/Libraries/LibWeb/CSS/GridTrackSize.h
+++ b/Libraries/LibWeb/CSS/GridTrackSize.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/HashMap.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/PercentageOr.h>
 #include <LibWeb/CSS/Size.h>
@@ -71,6 +72,24 @@ struct GridLineName {
     bool implicit { false };
 
     bool operator==(GridLineName const& other) const = default;
+};
+
+struct GridArea {
+    size_t row_start { 0 };
+    size_t row_end { 1 };
+    size_t column_start { 0 };
+    size_t column_end { 1 };
+
+    bool operator==(GridArea const& other) const = default;
+};
+
+struct GridTemplateAreas {
+    HashMap<String, GridArea> areas;
+    size_t row_count { 0 };
+    size_t column_count { 0 };
+
+    bool is_empty() const { return row_count == 0; }
+    bool operator==(GridTemplateAreas const& other) const = default;
 };
 
 class GridLineNames {

--- a/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.cpp
@@ -12,26 +12,35 @@
 
 namespace Web::CSS {
 
-ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue const> GridTemplateAreaStyleValue::create(Vector<Vector<String>> grid_template_area)
+ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue const> GridTemplateAreaStyleValue::create(HashMap<String, GridArea> grid_areas, size_t row_count, size_t column_count)
 {
-    return adopt_ref(*new (nothrow) GridTemplateAreaStyleValue(grid_template_area));
+    return adopt_ref(*new (nothrow) GridTemplateAreaStyleValue(move(grid_areas), row_count, column_count));
+}
+
+String GridTemplateAreaStyleValue::cell_name_at(size_t row, size_t column) const
+{
+    for (auto const& [name, area] : m_grid_areas) {
+        if (row >= area.row_start && row < area.row_end && column >= area.column_start && column < area.column_end)
+            return name;
+    }
+    return "."_string;
 }
 
 void GridTemplateAreaStyleValue::serialize(StringBuilder& builder, SerializationMode) const
 {
-    if (m_grid_template_area.is_empty()) {
+    if (m_row_count == 0) {
         builder.append("none"sv);
         return;
     }
 
-    for (size_t y = 0; y < m_grid_template_area.size(); ++y) {
+    for (size_t y = 0; y < m_row_count; ++y) {
         if (y != 0)
             builder.append(' ');
         StringBuilder row_builder;
-        for (size_t x = 0; x < m_grid_template_area[y].size(); ++x) {
+        for (size_t x = 0; x < m_column_count; ++x) {
             if (x != 0)
                 row_builder.append(' ');
-            row_builder.appendff("{}", m_grid_template_area[y][x]);
+            row_builder.append(cell_name_at(y, x));
         }
         serialize_a_string(builder, row_builder.string_view());
     }

--- a/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
@@ -9,28 +9,42 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
+#include <LibWeb/CSS/GridTrackSize.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 
 namespace Web::CSS {
 
 class GridTemplateAreaStyleValue final : public StyleValueWithDefaultOperators<GridTemplateAreaStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue const> create(Vector<Vector<String>> grid_template_area);
+    static ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue const> create(HashMap<String, GridArea> grid_areas, size_t row_count, size_t column_count);
     virtual ~GridTemplateAreaStyleValue() override = default;
 
-    Vector<Vector<String>> const& grid_template_area() const { return m_grid_template_area; }
+    HashMap<String, GridArea> const& grid_areas() const { return m_grid_areas; }
+    size_t row_count() const { return m_row_count; }
+    size_t column_count() const { return m_column_count; }
+    String cell_name_at(size_t row, size_t column) const;
     virtual void serialize(StringBuilder&, SerializationMode) const override;
 
-    bool properties_equal(GridTemplateAreaStyleValue const& other) const { return m_grid_template_area == other.m_grid_template_area; }
+    bool properties_equal(GridTemplateAreaStyleValue const& other) const
+    {
+        return m_row_count == other.m_row_count
+            && m_column_count == other.m_column_count
+            && m_grid_areas == other.m_grid_areas;
+    }
 
 private:
-    explicit GridTemplateAreaStyleValue(Vector<Vector<String>> grid_template_area)
+    explicit GridTemplateAreaStyleValue(HashMap<String, GridArea> grid_areas, size_t row_count, size_t column_count)
         : StyleValueWithDefaultOperators(Type::GridTemplateArea)
-        , m_grid_template_area(grid_template_area)
+        , m_grid_areas(move(grid_areas))
+        , m_row_count(row_count)
+        , m_column_count(column_count)
     {
     }
 
-    Vector<Vector<String>> m_grid_template_area;
+    HashMap<String, GridArea> m_grid_areas;
+    size_t m_row_count { 0 };
+    size_t m_column_count { 0 };
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -713,7 +713,7 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
         auto& rows = rows_value->as_grid_track_size_list();
         auto& columns = columns_value->as_grid_track_size_list();
 
-        if (areas.grid_template_area().size() == 0 && rows.grid_track_size_list().track_list().size() == 0 && columns.grid_track_size_list().track_list().size() == 0) {
+        if (areas.row_count() == 0 && rows.grid_track_size_list().track_list().size() == 0 && columns.grid_track_size_list().track_list().size() == 0) {
             builder.append("none"sv);
             return;
         }
@@ -729,14 +729,14 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
                     line_names->serialize(inner_builder);
                 }
                 if (auto* track_size = track_size_or_line_names.get_pointer<ExplicitGridTrack>()) {
-                    if (area_index < areas.grid_template_area().size()) {
+                    if (area_index < areas.row_count()) {
                         if (!inner_builder.is_empty())
                             inner_builder.append(' ');
                         inner_builder.append("\""sv);
-                        for (size_t y = 0; y < areas.grid_template_area()[area_index].size(); ++y) {
+                        for (size_t y = 0; y < areas.column_count(); ++y) {
                             if (y != 0)
                                 inner_builder.append(' ');
-                            inner_builder.append(areas.grid_template_area()[area_index][y]);
+                            inner_builder.append(areas.cell_name_at(area_index, y));
                         }
                         inner_builder.append("\""sv);
                     }
@@ -752,7 +752,7 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
             return MUST(inner_builder.to_string());
         };
 
-        if (areas.grid_template_area().is_empty()) {
+        if (areas.row_count() == 0) {
             rows.grid_track_size_list().serialize(builder, mode);
             builder.append(" / "sv);
             columns.grid_track_size_list().serialize(builder, mode);
@@ -767,7 +767,7 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
             builder.append(rows_serialization);
             return;
         }
-        builder.append(construct_rows_string());
+        builder.append(rows_serialization);
         builder.append(" / "sv);
         columns.grid_track_size_list().serialize(builder, mode);
         return;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -209,15 +209,6 @@ private:
         static GridTrack create_gap(CSSPixels size);
     };
 
-    struct GridArea {
-        String name;
-        size_t row_start { 0 };
-        size_t row_end { 1 };
-        size_t column_start { 0 };
-        size_t column_end { 1 };
-        bool invalid { false }; /* FIXME: Ignore ignore invalid areas during layout */
-    };
-
     Vector<Vector<CSS::GridLineName>> m_row_lines;
     Vector<Vector<CSS::GridLineName>> m_column_lines;
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/grid-definition/grid-support-grid-template-areas-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/grid-definition/grid-support-grid-template-areas-001.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 45 tests
 
-36 Pass
-9 Fail
+45 Pass
 Pass	'grid' with: grid-template-areas: none;
 Pass	'grid' with: grid-template-areas: "a";
 Pass	'grid' with: grid-template-areas: ".";
@@ -41,12 +40,12 @@ Pass	'grid' with: grid-template-areas: "a b c" "d e";
 Pass	'grid' with: grid-template-areas: "a b"-"c d";
 Pass	'grid' with: grid-template-areas: "a b" - "c d";
 Pass	'grid' with: grid-template-areas: "a b" . "c d";
-Fail	'grid' with: grid-template-areas: "a b a";
-Fail	'grid' with: grid-template-areas: "a" "b" "a";
-Fail	'grid' with: grid-template-areas: "a b" "b b";
-Fail	'grid' with: grid-template-areas: "b a" "b b";
-Fail	'grid' with: grid-template-areas: "a b" "b a";
-Fail	'grid' with: grid-template-areas: "a ." ". a";
-Fail	'grid' with: grid-template-areas: ",";
-Fail	'grid' with: grid-template-areas: "10%";
-Fail	'grid' with: grid-template-areas: "USD$";
+Pass	'grid' with: grid-template-areas: "a b a";
+Pass	'grid' with: grid-template-areas: "a" "b" "a";
+Pass	'grid' with: grid-template-areas: "a b" "b b";
+Pass	'grid' with: grid-template-areas: "b a" "b b";
+Pass	'grid' with: grid-template-areas: "a b" "b a";
+Pass	'grid' with: grid-template-areas: "a ." ". a";
+Pass	'grid' with: grid-template-areas: ",";
+Pass	'grid' with: grid-template-areas: "10%";
+Pass	'grid' with: grid-template-areas: "USD$";


### PR DESCRIPTION
Move grid area rectangle computation and validation from layout to the CSS parser. Named grid areas that don't form filled-in rectangles now correctly invalidate the declaration per spec.