### PR TITLE
LibWeb: Fix input field placeholder vertical alignment

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -8,6 +8,7 @@
  * Copyright (c) 2024, Fernando Kiotheka <fer@k6a.dev>
  * Copyright (c) 2025, Felipe Muñoz Mazur <felipe.munoz.mazur@protonmail.com>
  * Copyright (c) 2025, Glenn Skrzypczak <glenn.skrzypczak@gmail.com>
+ * Copyright (c) 2026, Michiel Nijenhuis <michielmitsjol@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -862,7 +863,10 @@ static GC::Ref<CSS::CSSStyleProperties> placeholder_style_when_visible()
         style = CSS::CSSStyleProperties::create(internal_css_realm(), {}, {});
         style->set_declarations_from_text(R"~~~(
                 width: 100%;
+                height: 1lh;
                 align-items: center;
+                overflow: hidden;
+                scrollbar-width: none;
                 text-overflow: clip;
                 white-space: nowrap;
             )~~~"sv);

--- a/Tests/LibWeb/Layout/expected/empty-editable-shows-cursor.txt
+++ b/Tests/LibWeb/Layout/expected/empty-editable-shows-cursor.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 58 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 56 0+0+0] [BFC] children: not-inline
     BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
       TextNode <#text> (not painted)
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 42 0+0+8] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 40 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
-      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 42 0+0+0] children: inline
-        frag 0 from TextInputBox start: 0, length: 0, rect: [9,29 200x20] baseline: 15.796875
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 40 0+0+0] children: inline
+        frag 0 from TextInputBox start: 0, length: 0, rect: [9,25 200x20] baseline: 20
         frag 1 from TextNode start: 0, length: 1, rect: [210,30 8x18] baseline: 13.796875
             " "
         frag 2 from TextAreaBox start: 0, length: 0, rect: [221,11 160x30] baseline: 36
@@ -18,13 +18,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             " "
         frag 6 from TextAreaBox start: 0, length: 0, rect: [605,11 160x30] baseline: 36
         TextNode <#text> (not painted)
-        TextInputBox <input> at [9,29] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
-          Box <div> at [11,30] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
-            BlockContainer <div> at [11,30] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 0, rect: [11,30 0x18] baseline: 13.796875
+        TextInputBox <input> at [9,25] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
+          Box <div> at [11,26] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [11,26] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 0, rect: [11,26 0x18] baseline: 13.796875
               TextNode <#text> (not painted)
-            BlockContainer <div> at [11,30] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 5, rect: [11,30 36.84375x18] baseline: 13.796875
+            BlockContainer <div> at [11,26] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [11,26 36.84375x18] baseline: 13.796875
                   "hello"
               TextNode <#text> (not painted)
         TextNode <#text> (not painted)
@@ -52,17 +52,17 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x56]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x42]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x40]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x0]
-      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x42]
-        PaintableWithLines (TextInputBox<INPUT>) [8,28 202x22]
-          PaintableBox (Box<DIV>) [9,29 200x20]
-            PaintableWithLines (BlockContainer<DIV>) [11,30 0x18]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x40]
+        PaintableWithLines (TextInputBox<INPUT>) [8,24 202x22]
+          PaintableBox (Box<DIV>) [9,25 200x20]
+            PaintableWithLines (BlockContainer<DIV>) [11,26 0x18]
               TextPaintable (TextNode<#text>)
-            PaintableWithLines (BlockContainer<DIV>) [11,30 196x18]
+            PaintableWithLines (BlockContainer<DIV>) [11,26 196x18]
               TextPaintable (TextNode<#text>)
         TextPaintable (TextNode<#text>)
         PaintableWithLines (TextAreaBox<TEXTAREA>) [218,8 166x36]
@@ -83,4 +83,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x58] [children: 0] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x56] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/form-control-baseline-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/form-control-baseline-alignment.txt
@@ -3,7 +3,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 72 0+0+8] children: inline
       frag 0 from TextInputBox start: 0, length: 0, rect: [9,25 200x20] baseline: 20
       frag 1 from TextAreaBox start: 0, length: 0, rect: [243.1875,11 160x30] baseline: 36
-      frag 2 from TextInputBox start: 0, length: 0, rect: [437.375,29 200x20] baseline: 15.796875
+      frag 2 from TextInputBox start: 0, length: 0, rect: [437.375,25 200x20] baseline: 20
       frag 3 from TextNode start: 0, length: 1, rect: [638.375,30 8x18] baseline: 13.796875
           " "
       frag 4 from TextAreaBox start: 0, length: 0, rect: [11,47 160x30] baseline: 36
@@ -25,13 +25,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         frag 0 from TextNode start: 0, length: 3, rect: [406.1875,30 30.1875x18] baseline: 13.796875
             "boo"
         TextNode <#text> (not painted)
-      TextInputBox <input> at [437.375,29] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
-        Box <div> at [439.375,30] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
-          BlockContainer <div> at [439.375,30] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 0, rect: [439.375,30 0x18] baseline: 13.796875
+      TextInputBox <input> at [437.375,25] inline-block [0+1+0 200 0+1+0] [0+1+0 20 0+1+0] [BFC] children: not-inline
+        Box <div> at [439.375,26] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [439.375,26] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 0, rect: [439.375,26 0x18] baseline: 13.796875
             TextNode <#text> (not painted)
-          BlockContainer <div> at [439.375,30] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 5, rect: [439.375,30 36.84375x18] baseline: 13.796875
+          BlockContainer <div> at [439.375,26] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 5, rect: [439.375,26 36.84375x18] baseline: 13.796875
                 "hello"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
@@ -65,11 +65,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (InlineNode<SPAN>) [406.1875,30 30.1875x18]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (TextInputBox<INPUT>) [436.375,28 202x22]
-        PaintableBox (Box<DIV>) [437.375,29 200x20]
-          PaintableWithLines (BlockContainer<DIV>) [439.375,30 0x18]
+      PaintableWithLines (TextInputBox<INPUT>) [436.375,24 202x22]
+        PaintableBox (Box<DIV>) [437.375,25 200x20]
+          PaintableWithLines (BlockContainer<DIV>) [439.375,26 0x18]
             TextPaintable (TextNode<#text>)
-          PaintableWithLines (BlockContainer<DIV>) [439.375,30 196x18]
+          PaintableWithLines (BlockContainer<DIV>) [439.375,26 196x18]
             TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
       PaintableWithLines (InlineNode<SPAN>) [646.375,30 30.1875x18]

--- a/Tests/LibWeb/Layout/expected/input-element-placeholder-position.txt
+++ b/Tests/LibWeb/Layout/expected/input-element-placeholder-position.txt
@@ -1,0 +1,77 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 129.875 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [8,21.4375] [8+0+0 784 0+0+8] [8+0+0 100.4375 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,21.4375] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <h1> at [8,21.4375] [0+0+0 784 0+0+0] [21.4375+0+0 37 0+0+21.4375] children: inline
+        frag 0 from TextNode start: 0, length: 37, rect: [8,21.4375 613.1875x37] baseline: 28.09375
+            "Input Field Placeholder Position Test"
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,79.875] [0+0+0 784 0+0+0] [0+0+0 42 0+0+0] children: inline
+        frag 0 from TextInputBox start: 0, length: 0, rect: [19,90.875 200x20] baseline: 30
+        frag 1 from TextNode start: 0, length: 1, rect: [230,95.875 8x18] baseline: 13.796875
+            " "
+        frag 2 from TextInputBox start: 0, length: 0, rect: [249,90.875 200x20] baseline: 30
+        frag 3 from TextNode start: 0, length: 1, rect: [460,95.875 8x18] baseline: 13.796875
+            " "
+        frag 4 from TextInputBox start: 0, length: 0, rect: [479,90.875 200x20] baseline: 30
+        TextNode <#text> (not painted)
+        TextInputBox <input> at [19,90.875] inline-block [0+1+10 200 10+1+0] [0+1+10 20 10+1+0] [BFC] children: not-inline
+          Box <div> at [21,91.875] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [21,91.875] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 0, rect: [21,91.875 0x18] baseline: 13.796875
+              TextNode <#text> (not painted)
+            BlockContainer <div> at [21,91.875] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 11, rect: [21,91.875 87.328125x18] baseline: 13.796875
+                  "Empty field"
+              TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+        TextInputBox <input> at [249,90.875] inline-block [0+1+10 200 10+1+0] [0+1+10 20 10+1+0] [BFC] children: not-inline
+          Box <div> at [251,91.875] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [251,91.875] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 12, rect: [251,91.875 81.96875x18] baseline: 13.796875
+                  "Filled field"
+              TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+        TextInputBox <input> at [479,90.875] inline-block [0+1+10 200 10+1+0] [0+1+10 20 10+1+0] [BFC] children: not-inline
+          Box <div> at [481,91.875] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 18 1+0+0] [FFC] children: not-inline
+            BlockContainer <div> at [481,91.875] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 0, rect: [481,91.875 0x18] baseline: 13.796875
+              TextNode <#text> (not painted)
+            BlockContainer <div> at [481,91.875] flex-item [0+0+0 196 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 9, rect: [481,91.875 81.171875x18] baseline: 13.796875
+                  "Type here"
+              TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x129.875]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,21.4375 784x100.4375]
+      PaintableWithLines (BlockContainer(anonymous)) [8,21.4375 784x0]
+      PaintableWithLines (BlockContainer<H1>) [8,21.4375 784x37]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,79.875 784x42]
+        PaintableWithLines (TextInputBox<INPUT>) [8,79.875 222x42]
+          PaintableBox (Box<DIV>) [19,90.875 200x20]
+            PaintableWithLines (BlockContainer<DIV>) [21,91.875 0x18]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>) [21,91.875 196x18]
+              TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (TextInputBox<INPUT>) [238,79.875 222x42]
+          PaintableBox (Box<DIV>) [249,90.875 200x20]
+            PaintableWithLines (BlockContainer<DIV>) [251,91.875 196x18]
+              TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (TextInputBox<INPUT>) [468,79.875 222x42]
+          PaintableBox (Box<DIV>) [479,90.875 200x20]
+            PaintableWithLines (BlockContainer<DIV>) [481,91.875 0x18]
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<DIV>) [481,91.875 196x18]
+              TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x129.875] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/input-placeholder-with-text-align.txt
+++ b/Tests/LibWeb/Layout/expected/input-placeholder-with-text-align.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 118 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 102 0+0+8] children: inline
-      frag 0 from TextInputBox start: 0, length: 0, rect: [9,9 400x100] baseline: 56.796875
+      frag 0 from TextInputBox start: 0, length: 0, rect: [9,9 400x100] baseline: 61
       TextInputBox <input> at [9,9] inline-block [0+1+0 400 0+1+0] [0+1+0 100 0+1+0] [BFC] children: not-inline
         Box <div> at [11,10] flex-container(row) [0+0+2 396 2+0+0] [0+0+1 100 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,51] flex-item [0+0+0 0 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/input-placeholder.txt
+++ b/Tests/LibWeb/Layout/expected/input-placeholder.txt
@@ -4,11 +4,11 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       frag 0 from TextInputBox start: 0, length: 0, rect: [9,9 200x25] baseline: 25
       frag 1 from TextNode start: 0, length: 1, rect: [210,15 10x23] baseline: 17.5
           " "
-      frag 2 from TextInputBox start: 0, length: 0, rect: [221,14 200x25] baseline: 19.5
+      frag 2 from TextInputBox start: 0, length: 0, rect: [221,9 200x25] baseline: 25
       frag 3 from TextNode start: 0, length: 1, rect: [422,15 10x23] baseline: 17.5
           " "
       frag 4 from TextInputBox start: 0, length: 0, rect: [433,9 200x25] baseline: 25
-      frag 5 from TextInputBox start: 0, length: 0, rect: [9,36 200x25] baseline: 19.5
+      frag 5 from TextInputBox start: 0, length: 0, rect: [9,36 200x25] baseline: 25
       TextInputBox <input> at [9,9] inline-block [0+1+0 200 0+1+0] [0+1+0 25 0+1+0] [BFC] children: not-inline
         Box <div> at [11,10] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 23 1+0+0] [FFC] children: not-inline
           BlockContainer <div> at [11,10] flex-item [0+0+0 196 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
@@ -16,13 +16,13 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 "text"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
-      TextInputBox <input> at [221,14] inline-block [0+1+0 200 0+1+0] [0+1+0 25 0+1+0] [BFC] children: not-inline
-        Box <div> at [223,15] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 23 1+0+0] [FFC] children: not-inline
-          BlockContainer <div> at [223,15] flex-item [0+0+0 0 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 0, rect: [223,15 0x23] baseline: 17.5
+      TextInputBox <input> at [221,9] inline-block [0+1+0 200 0+1+0] [0+1+0 25 0+1+0] [BFC] children: not-inline
+        Box <div> at [223,10] flex-container(row) [0+0+2 196 2+0+0] [0+0+1 23 1+0+0] [FFC] children: not-inline
+          BlockContainer <div> at [223,10] flex-item [0+0+0 0 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 0, rect: [223,10 0x23] baseline: 17.5
             TextNode <#text> (not painted)
-          BlockContainer <div> at [223,15] flex-item [0+0+0 196 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 34, rect: [223,15 344.546875x23] baseline: 17.5
+          BlockContainer <div> at [223,10] flex-item [0+0+0 196 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 34, rect: [223,10 344.546875x23] baseline: 17.5
                 "This placeholder should be visible"
             TextNode <#text> (not painted)
       TextNode <#text> (not painted)
@@ -53,11 +53,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableWithLines (BlockContainer<DIV>) [11,10 196x23]
             TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (TextInputBox<INPUT>) [220,13 202x27]
-        PaintableBox (Box<DIV>) [221,14 200x25]
-          PaintableWithLines (BlockContainer<DIV>) [223,15 0x23]
+      PaintableWithLines (TextInputBox<INPUT>) [220,8 202x27]
+        PaintableBox (Box<DIV>) [221,9 200x25]
+          PaintableWithLines (BlockContainer<DIV>) [223,10 0x23]
             TextPaintable (TextNode<#text>)
-          PaintableWithLines (BlockContainer<DIV>) [223,15 196x23]
+          PaintableWithLines (BlockContainer<DIV>) [223,10 196x23] overflow: [223,10 344.546875x23]
             TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
       PaintableWithLines (TextInputBox<INPUT>) [432,8 202x27]
@@ -68,7 +68,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<DIV>) [9,36 200x25]
           PaintableWithLines (BlockContainer<DIV>) [11,37 0x23]
             TextPaintable (TextNode<#text>)
-          PaintableWithLines (BlockContainer<DIV>) [11,37 196x23]
+          PaintableWithLines (BlockContainer<DIV>) [11,37 196x23] overflow: [11,37 396.171875x23]
             TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/input-element-placeholder-position.html
+++ b/Tests/LibWeb/Layout/input/input-element-placeholder-position.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        input {
+            font-size: 16px;
+            padding: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Input Field Placeholder Position Test</h1>
+    <input type="text" placeholder="Empty field">
+    <input type="text" value="Filled field">
+    <input type="text" placeholder="Type here">
+</body>
+</html>


### PR DESCRIPTION
Input elements with a placeholder were positioned lower than inputs without a placeholder or inputs with text. This was caused by the placeholder element missing height height and overflow properties that the inner text element had.

This fix makes sure both the placeholder and inner text elements let show the same position of the input field. I also have tested this in firefox and chrome and now I get the same behaviour in ladybird.

## This was before:
<img width="576" height="201" alt="Screenshot 2026-02-21 at 14 45 09" src="https://github.com/user-attachments/assets/dbe14cc9-0f28-4fa3-8755-44c30e955fea" />

<img width="592" height="172" alt="Screenshot 2026-02-21 at 14 45 21" src="https://github.com/user-attachments/assets/c2e16a39-df2d-41db-941f-491d79673df0" />

---
## This is after:
<img width="592" height="169" alt="Screenshot 2026-02-21 at 14 46 06" src="https://github.com/user-attachments/assets/ce1e6cb3-7189-4999-81ab-0f8be4d96bf7" />

<img width="608" height="156" alt="Screenshot 2026-02-21 at 14 46 14" src="https://github.com/user-attachments/assets/eaed9fe1-c68b-4cba-89e4-f8f02bfc7ecb" />
