### PR TITLE
LibWeb: Visit ImportMapParseResult in HTMLScriptElement::visit_edges

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -48,8 +48,10 @@ void HTMLScriptElement::initialize(JS::Realm& realm)
 void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    if (auto* script = m_result.get_pointer<GC::Ref<Script>>())
-        visitor.visit(*script);
+    m_result.visit(
+        [](ResultState::Uninitialized) {},
+        [](ResultState::Null) {},
+        [&]<typename T>(GC::Ref<T> result) { visitor.visit(result); });
     visitor.visit(m_parser_document);
     visitor.visit(m_preparation_time_document);
 }

--- a/Libraries/LibWeb/HTML/Scripting/ImportMapParseResult.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ImportMapParseResult.cpp
@@ -40,11 +40,6 @@ GC::Ref<ImportMapParseResult> ImportMapParseResult::create(JS::Realm& realm, Byt
     return result;
 }
 
-void ImportMapParseResult::visit_host_defined_self(Visitor& visitor)
-{
-    visitor.visit(*this);
-}
-
 void ImportMapParseResult::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Libraries/LibWeb/HTML/Scripting/ImportMapParseResult.h
+++ b/Libraries/LibWeb/HTML/Scripting/ImportMapParseResult.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <LibJS/Heap/Cell.h>
-#include <LibJS/Script.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/Scripting/ImportMap.h>
@@ -16,9 +15,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#import-map-parse-result
-class ImportMapParseResult
-    : public JS::Cell
-    , public JS::Script::HostDefined {
+class ImportMapParseResult : public JS::Cell {
     GC_CELL(ImportMapParseResult, JS::Cell);
     GC_DECLARE_ALLOCATOR(ImportMapParseResult);
 
@@ -41,8 +38,6 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
 private:
-    virtual void visit_host_defined_self(Visitor&) override;
-
     // https://html.spec.whatwg.org/multipage/webappapis.html#impr-import-map
     Optional<ImportMap> m_import_map;
 


### PR DESCRIPTION
`HTMLScriptElement::visit_edges` traced the `GC::Ref<Script>` arm of `m_result` but not the `GC::Ref<ImportMapParseResult>` arm. When a `<script type="importmap">` element was processed, the `ImportMapParseResult` GC cell had no tracing path and could be collected while `m_result` still held a reference to it.

`ImportMapParseResult` inherited from `JS::Script::HostDefined` and implemented `visit_host_defined_self`, but no `JS::Script` or `JS::Module` ever stored it as `host_defined` data, so that path was dead code. This removes the `HostDefined` inheritance and switches `m_result` visitation to `Variant::visit` with a lambda that catches all `GC::Ref` arms.