### PR TITLE
LibJS: Fix export default of parenthesized named class expression

### DIFF
--- a/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -4359,19 +4359,8 @@ Optional<ScopedOperand> ExportStatement::generate_bytecode(Bytecode::Generator& 
         return m_statement->generate_bytecode(generator);
     }
 
-    if (is<ClassExpression>(*m_statement)) {
-        auto value = generator.emit_named_evaluation_if_anonymous_function(static_cast<ClassExpression const&>(*m_statement), generator.intern_identifier("default"_utf16_fly_string));
-
-        if (!static_cast<ClassExpression const&>(*m_statement).has_name()) {
-            generator.emit<Bytecode::Op::InitializeLexicalBinding>(
-                generator.intern_identifier(ExportStatement::local_name_for_default),
-                value);
-        }
-
-        return value;
-    }
-
     // ExportDeclaration : export default AssignmentExpression ;
+    // Always initialize the *default* binding per step 5 of the spec.
     VERIFY(is<Expression>(*m_statement));
     auto value = generator.emit_named_evaluation_if_anonymous_function(static_cast<Expression const&>(*m_statement), generator.intern_identifier("default"_utf16_fly_string));
     generator.emit<Bytecode::Op::InitializeLexicalBinding>(

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -4436,12 +4436,6 @@ NonnullRefPtr<ExportStatement const> Parser::parse_export_statement(Program& pro
 
             if (!special_case_declaration_without_name)
                 consume_or_insert_semicolon();
-
-            if (is<ClassExpression>(*expression)) {
-                auto const& class_expression = static_cast<ClassExpression const&>(*expression);
-                if (class_expression.has_name())
-                    local_name = class_expression.name();
-            }
         } else {
             expected("Declaration or assignment expression");
             local_name = "!!invalid!!"_utf16_fly_string;

--- a/Tests/LibJS/Runtime/modules/basic-modules.js
+++ b/Tests/LibJS/Runtime/modules/basic-modules.js
@@ -209,6 +209,10 @@ describe("in- and exports", () => {
         expectModulePassed("./top-level-dispose.mjs");
     });
 
+    test("default export of parenthesized named class expression", () => {
+        expectModulePassed("./default-export-named-class-expression.mjs");
+    });
+
     test("can export default a RegExp", () => {
         const result = expectModulePassed("./default-regexp-export.mjs");
         expect(result.default).toBeInstanceOf(RegExp);

--- a/Tests/LibJS/Runtime/modules/default-export-named-class-expression.mjs
+++ b/Tests/LibJS/Runtime/modules/default-export-named-class-expression.mjs
@@ -1,0 +1,8 @@
+export default (class MyClass {
+    valueOf() {
+        return 45;
+    }
+});
+import C from "./default-export-named-class-expression.mjs";
+
+export const passed = new C().valueOf() === 45 && C.name === "MyClass";


### PR DESCRIPTION
For `export default (class Name { })`, two things were wrong:

The parser extracted the class expression's name as the export's local binding name instead of `*default*`. Per the spec, this is `export default AssignmentExpression ;` whose BoundNames is `*default*`, not the class name.

The bytecode generator had a special case for ClassExpression that skipped emitting InitializeLexicalBinding for named classes.

These two bugs compensated for each other (no crash, but wrong behavior). Fix both: always use `*default*` as the local binding name for expression exports, and always emit InitializeLexicalBinding for the `*default*` binding.