### PR TITLE
LibWeb: Use correct condition and field for navigation initiator origin

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1120,8 +1120,8 @@ static void create_navigation_params_by_fetching(GC::Ptr<SessionHistoryEntry> en
 
     // 4. If navigable is a top-level traversable, then set request's top-level navigation initiator origin to entry's
     //    document state's initiator origin.
-    if (navigable->top_level_traversable()->parent() == nullptr)
-        request->set_top_level_navigation_initiator_origin(entry->document_state()->origin());
+    if (navigable->is_top_level_traversable())
+        request->set_top_level_navigation_initiator_origin(entry->document_state()->initiator_origin());
 
     // 5. If request's client is null:
     if (request->client() == nullptr) {


### PR DESCRIPTION
The condition guarding the assignment of `top_level_navigation_initiator_origin` on fetch requests was `navigable->top_level_traversable()->parent() == nullptr`, which is redundantly true for any navigable. `top_level_traversable()` already walks to the topmost traversable, whose parent is always null. This meant the field was set on every navigation, not just top-level ones.

The value assigned was also `document_state()->origin()` rather than `document_state()->initiator_origin()`, giving the document's own origin instead of the origin of whoever initiated the navigation. Both are now corrected to match the spec step.

Spec:
https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching