### PR TITLE
LibWeb: Handle ancestors without layout nodes in offsetParent

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -546,17 +546,19 @@ GC::Ptr<DOM::Element> HTMLElement::offset_parent() const
         // 2. If ancestor is not closed-shadow-hidden from the element and satisfies at least one of the following,
         //    terminate this algorithm and return ancestor.
         if (!ancestor_is_closed_shadow_hidden) {
+            // NB: An ancestor in the flat tree may not have a layout node (e.g., it has display: none).
+            //     Such ancestors can't be positioned or establish containing blocks, so we skip those checks.
             // - The element is in a fixed position containing block, and ancestor is a containing block for
             //   fixed-positioned descendants.
             // FIXME: This is ambiguous but I believe it means any ancestor establishes a fixed position containing block.
             //        https://github.com/w3c/csswg-drafts/pull/12531/commits/48e905bb3859f80ce822299f7e6b76515d867fc3#r2623785087
-            if (!no_ancestor_establishes_a_fixed_position_containing_block && ancestor->layout_node()->establishes_a_fixed_positioning_containing_block())
+            if (!no_ancestor_establishes_a_fixed_position_containing_block && ancestor->layout_node() && ancestor->layout_node()->establishes_a_fixed_positioning_containing_block())
                 return const_cast<Element*>(ancestor);
             // - The element is not in a fixed position containing block, and:
             if (no_ancestor_establishes_a_fixed_position_containing_block) {
                 // - ancestor is a containing block of absolutely-positioned descendants (regardless of whether there
                 //   are any absolutely-positioned descendants).
-                if (ancestor->layout_node()->is_positioned())
+                if (ancestor->layout_node() && ancestor->layout_node()->is_positioned())
                     return const_cast<Element*>(ancestor);
                 // - It is the body element.
                 if (ancestor->is_html_body_element())

--- a/Tests/LibWeb/Crash/wpt-import/dom/nodes/moveBefore/chrome-433696404-crash.html
+++ b/Tests/LibWeb/Crash/wpt-import/dom/nodes/moveBefore/chrome-433696404-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://crbug.com/433696404">
+<p>Passes if no crash</p>
+<div id="host">
+  <template shadowrootmode="open">
+    <div><div style="display: none;"><slot></slot></div></div>
+  </template>
+</div>
+<span id="span">Text in light DOM</span>
+<script>
+  span.offsetTop;
+  host.moveBefore(span, null);
+  span.offsetTop;
+</script>


### PR DESCRIPTION
When walking the flat tree in HTMLElement::offset_parent(), ancestors may not have layout nodes (e.g., they have display:none). This can happen when an element is slotted into a shadow root where the slot is inside a display:none container.

Guard layout_node() accesses with null checks. If an ancestor has no layout node, it cannot be positioned or establish a containing block, so it cannot be the offset parent for those reasons.

Fixes a crash in WPT/dom/nodes/moveBefore/chrome-433696404-crash.html