### PR TITLE
LibWeb: Begin serializing global object as part of serialized ESO

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -584,6 +584,14 @@ bool is_non_secure_context(Environment const& environment)
 
 SerializedEnvironmentSettingsObject EnvironmentSettingsObject::serialize()
 {
+    auto serialized_global = [this]() -> SerializedGlobal {
+        if (auto const* window = as_if<Window>(global_object()))
+            return SerializedWindow { .associated_document { .url = window->associated_document().url() } };
+
+        VERIFY(is<WorkerGlobalScope>(global_object()));
+        return SerializedWorkerGlobalScope {};
+    }();
+
     return SerializedEnvironmentSettingsObject {
         .id = this->id,
         .creation_url = this->creation_url,
@@ -595,6 +603,7 @@ SerializedEnvironmentSettingsObject EnvironmentSettingsObject::serialize()
         .policy_container = policy_container()->serialize(),
         .cross_origin_isolated_capability = cross_origin_isolated_capability(),
         .time_origin = this->time_origin(),
+        .global = move(serialized_global),
     };
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2026, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +10,36 @@
 #include <LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h>
 
 namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::SerializedWindow const& window)
+{
+    TRY(encoder.encode(window.associated_document.url));
+
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::SerializedWindow> decode(Decoder& decoder)
+{
+    return Web::HTML::SerializedWindow {
+        .associated_document {
+            .url = TRY(decoder.decode<URL::URL>()),
+        },
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::HTML::SerializedWorkerGlobalScope const&)
+{
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::SerializedWorkerGlobalScope> decode(Decoder&)
+{
+    return Web::HTML::SerializedWorkerGlobalScope {};
+}
 
 template<>
 ErrorOr<void> encode(Encoder& encoder, Web::HTML::SerializedEnvironmentSettingsObject const& object)
@@ -23,6 +54,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::SerializedEnvironmentSettingsO
     TRY(encoder.encode(object.policy_container));
     TRY(encoder.encode(object.cross_origin_isolated_capability));
     TRY(encoder.encode(object.time_origin));
+    TRY(encoder.encode(object.global));
 
     return {};
 }
@@ -41,6 +73,7 @@ ErrorOr<Web::HTML::SerializedEnvironmentSettingsObject> decode(Decoder& decoder)
         .policy_container = TRY(decoder.decode<Web::HTML::SerializedPolicyContainer>()),
         .cross_origin_isolated_capability = TRY(decoder.decode<Web::HTML::CanUseCrossOriginIsolatedAPIs>()),
         .time_origin = TRY(decoder.decode<double>()),
+        .global = TRY(decoder.decode<Web::HTML::SerializedGlobal>()),
     };
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
@@ -20,6 +20,19 @@ enum class CanUseCrossOriginIsolatedAPIs : u8 {
     Yes,
 };
 
+struct SerializedDocument {
+    URL::URL url;
+};
+
+struct SerializedWindow {
+    SerializedDocument associated_document;
+};
+
+struct SerializedWorkerGlobalScope {
+};
+
+using SerializedGlobal = Variant<SerializedWindow, SerializedWorkerGlobalScope>;
+
 struct SerializedEnvironmentSettingsObject {
     String id;
     URL::URL creation_url;
@@ -32,11 +45,24 @@ struct SerializedEnvironmentSettingsObject {
     SerializedPolicyContainer policy_container;
     CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability;
     double time_origin;
+    SerializedGlobal global;
 };
 
 }
 
 namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::SerializedWindow const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::SerializedWindow> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::SerializedWorkerGlobalScope const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::SerializedWorkerGlobalScope> decode(Decoder&);
 
 template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::SerializedEnvironmentSettingsObject const&);

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -55,11 +55,7 @@ void WorkerAgentParent::initialize(JS::Realm& realm)
 
     auto serialized_outside_settings = m_outside_settings->serialize();
 
-    Optional<URL::URL> document_url_if_started_by_window_fixme;
-    if (auto* window = as_if<HTML::Window>(m_outside_settings->realm().global_object()))
-        document_url_if_started_by_window_fixme = window->associated_document().url();
-
-    m_worker_ipc->async_start_worker(m_url, m_worker_options.type, m_worker_options.credentials, m_worker_options.name, move(data_holder), serialized_outside_settings, m_agent_type, document_url_if_started_by_window_fixme);
+    m_worker_ipc->async_start_worker(m_url, m_worker_options.type, m_worker_options.credentials, m_worker_options.name, move(data_holder), serialized_outside_settings, m_agent_type);
 }
 
 void WorkerAgentParent::setup_worker_ipc_callbacks(JS::Realm& realm)

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -13,8 +13,7 @@ endpoint WebWorkerServer {
                  String name,
                  Web::HTML::TransferDataEncoder message_port,
                  Web::HTML::SerializedEnvironmentSettingsObject outside_settings,
-                 Web::Bindings::AgentType agent_type,
-                 Optional<URL::URL> document_url_if_started_by_window_fixme) =|
+                 Web::Bindings::AgentType agent_type) =|
 
     close_worker() =|
 

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -63,7 +63,7 @@ Web::Page const& ConnectionFromClient::page() const
     return m_page_host->page();
 }
 
-void ConnectionFromClient::start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataEncoder implicit_port, Web::HTML::SerializedEnvironmentSettingsObject outside_settings, Web::Bindings::AgentType agent_type, Optional<URL::URL> document_url_if_started_by_window_fixme)
+void ConnectionFromClient::start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataEncoder implicit_port, Web::HTML::SerializedEnvironmentSettingsObject outside_settings, Web::Bindings::AgentType agent_type)
 {
     m_worker_host = make_ref_counted<WorkerHost>(move(url), type, move(name));
 
@@ -72,7 +72,7 @@ void ConnectionFromClient::start_worker(URL::URL url, Web::Bindings::WorkerType 
 
     // FIXME: Add an assertion that the agent_type passed here is the same that was passed at process creation to initialize_main_thread_vm()
 
-    m_worker_host->run(page(), move(implicit_port), outside_settings, credentials, is_shared, document_url_if_started_by_window_fixme);
+    m_worker_host->run(page(), move(implicit_port), outside_settings, credentials, is_shared);
 }
 
 void ConnectionFromClient::handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id)

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -41,7 +41,7 @@ private:
     Web::Page& page();
     Web::Page const& page() const;
 
-    virtual void start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject, Web::Bindings::AgentType, Optional<URL::URL>) override;
+    virtual void start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, String name, Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject, Web::Bindings::AgentType) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) override;
 
     GC::Root<PageHost> m_page_host;

--- a/Services/WebWorker/WorkerHost.cpp
+++ b/Services/WebWorker/WorkerHost.cpp
@@ -36,7 +36,7 @@ WorkerHost::WorkerHost(URL::URL url, Web::Bindings::WorkerType type, String name
 WorkerHost::~WorkerHost() = default;
 
 // https://html.spec.whatwg.org/multipage/workers.html#run-a-worker
-void WorkerHost::run(GC::Ref<Web::Page> page, Web::HTML::TransferDataEncoder message_port_data, Web::HTML::SerializedEnvironmentSettingsObject const& outside_settings_snapshot, Web::Bindings::RequestCredentials credentials, bool is_shared, Optional<URL::URL> document_url_if_started_by_window_fixme)
+void WorkerHost::run(GC::Ref<Web::Page> page, Web::HTML::TransferDataEncoder message_port_data, Web::HTML::SerializedEnvironmentSettingsObject const& outside_settings_snapshot, Web::Bindings::RequestCredentials credentials, bool is_shared)
 {
     // 3. Let unsafeWorkerCreationTime be the unsafe shared current time.
     auto unsafe_worker_creation_time = Web::HighResolutionTime::unsafe_shared_current_time();
@@ -90,8 +90,8 @@ void WorkerHost::run(GC::Ref<Web::Page> page, Web::HTML::TransferDataEncoder mes
     //       This causes the Referrer-Policy spec's "determine request's referrer" algorithm to read the ESO's creation
     //       URL, whereas it would normally read the document's URL. To hack around this, we overwrite the creation URL
     //       (which is only used in the initial worker script fetch).
-    if (document_url_if_started_by_window_fixme.has_value())
-        outside_settings->creation_url = document_url_if_started_by_window_fixme.release_value();
+    if (auto const* window = outside_settings_snapshot.global.get_pointer<Web::HTML::SerializedWindow>())
+        outside_settings->creation_url = window->associated_document.url;
 
     // 10. If is shared is true, then:
     if (is_shared) {

--- a/Services/WebWorker/WorkerHost.h
+++ b/Services/WebWorker/WorkerHost.h
@@ -21,7 +21,7 @@ public:
     explicit WorkerHost(URL::URL url, Web::Bindings::WorkerType type, String name);
     ~WorkerHost();
 
-    void run(GC::Ref<Web::Page>, Web::HTML::TransferDataEncoder message_port_data, Web::HTML::SerializedEnvironmentSettingsObject const&, Web::Bindings::RequestCredentials, bool is_shared, Optional<URL::URL> document_url_if_started_by_window_fixme);
+    void run(GC::Ref<Web::Page>, Web::HTML::TransferDataEncoder message_port_data, Web::HTML::SerializedEnvironmentSettingsObject const&, Web::Bindings::RequestCredentials, bool is_shared);
 
 private:
     GC::Root<Web::HTML::WorkerDebugConsoleClient> m_console;


### PR DESCRIPTION
Instead of passing through window's associated document's URL as
an extra argument to starting up a worker. This will allow for
improving the representation of 'outside settings' when setting
up a Worker.

(I'm trying to resolve the hack mentioned here: https://github.com/LadybirdBrowser/ladybird/blob/77a3de45619b1c6c26c3595d0f5f28c8395569c6/Services/WebWorker/WorkerHost.cpp#L88 for which this is a precursor, but I'm having some trouble getting that working for nested workers, but this is a standalone improvement anyhow)