### PR TITLE
LibURL: Strip trailing dot before running the PSL algorithm

### DIFF
--- a/Tests/LibWeb/Crash/Fetch/trailing-dot-registrable-domain.html
+++ b/Tests/LibWeb/Crash/Fetch/trailing-dot-registrable-domain.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script>
+fetch("https://trailingdot.invalid./").catch(() => {});
+</script>


### PR DESCRIPTION
This fixes a crash in the imported WPT test.