### PR TITLE
LibWeb: Abort stylesheet processing if linked resource becomes stale

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -203,9 +203,9 @@ private:
     void preconnect(LinkProcessingOptions const&);
     void preload(LinkProcessingOptions&, GC::Ptr<GC::Function<void(Fetch::Infrastructure::Response&)>> process_response = {});
 
-    void process_linked_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer);
+    void process_linked_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer, u64 fetch_generation);
     void process_icon_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer);
-    void process_stylesheet_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer);
+    void process_stylesheet_resource(bool success, Fetch::Infrastructure::Response const&, ByteBuffer, u64 fetch_generation);
 
     bool should_fetch_and_process_resource_type() const;
 
@@ -243,6 +243,8 @@ private:
     Optional<String> m_mime_type;
 
     GC::Weak<DOM::Document> m_parser_document;
+
+    u64 m_fetch_generation { 0 };
 };
 
 }

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/semantics/document-metadata/the-link-element/stylesheet-change-href-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/semantics/document-metadata/the-link-element/stylesheet-change-href-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  p {
+    color: green;
+  }
+</style>
+<p>This text should be green on a white background

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/resources/bad.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/resources/bad.css
@@ -1,0 +1,4 @@
+p {
+    background-color: red;
+    color: black;
+}

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/resources/good.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/resources/good.css
@@ -1,0 +1,3 @@
+p {
+    color: green;
+}

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/stylesheet-change-href.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/stylesheet-change-href.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Obtaining a new stylesheet removes styles from the previous stylesheet.</title>
+<link rel=match href=../../../../../../expected/wpt-import/html/semantics/document-metadata/the-link-element/stylesheet-change-href-ref.html>
+<script>
+  function changeHref() {
+    var elem = document.getElementById('stylesheet');
+    elem.href = 'resources/good.css';
+    elem.onload = null;
+  }
+</script>
+<link id=stylesheet rel=stylesheet href="resources/bad.css" onload="changeHref()">
+<p>This text should be green on a white background


### PR DESCRIPTION
We now increment a counter every time a new linked resource fetch starts. Stylesheet processing is aborted if the counter changes while the resource is being fetched.

Fixes the imported WPT test.