### PR TITLE
LibWeb: Clear old PlaybackManager callbacks before creating a new one

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1492,6 +1492,14 @@ void HTMLMediaElement::on_metadata_parsed()
 // https://html.spec.whatwg.org/multipage/media.html#media-data-processing-steps-list
 void HTMLMediaElement::set_up_playback_manager(NonnullRefPtr<FetchData> const& fetch_data)
 {
+    if (m_playback_manager) {
+        m_playback_manager->on_track_added = nullptr;
+        m_playback_manager->on_metadata_parsed = nullptr;
+        m_playback_manager->on_unsupported_format_error = nullptr;
+        m_playback_manager->on_playback_state_change = nullptr;
+        m_playback_manager->on_duration_change = nullptr;
+    }
+
     m_playback_manager = Media::PlaybackManager::create();
 
     m_has_enabled_preferred_audio_track = false;

--- a/Tests/LibWeb/Crash/HTML/media-load-during-track-setup.html
+++ b/Tests/LibWeb/Crash/HTML/media-load-during-track-setup.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script>
+    video.preload = "none";
+    video.src = "../../Assets/test-webm.webm";
+    video.onsuspend = () => {
+        video.onsuspend = null;
+        video.load();
+    };
+</script>


### PR DESCRIPTION
Fixes http://wpt.live/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html. This test relies on python scripts provided by the WPT runner, so I made a  simpler test that causes the same crash.