### PR TITLE
LibWeb: Implement most `CredentialsContainer` methods

### DIFF
--- a/Libraries/LibWeb/CredentialManagement/Credential.cpp
+++ b/Libraries/LibWeb/CredentialManagement/Credential.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Altomani Gianluca <altomanigianluca@gmail.com>
+ * Copyright (c) 2026, Altomani Gianluca <altomanigianluca@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +8,30 @@
 #include <LibWeb/CredentialManagement/Credential.h>
 
 namespace Web::CredentialManagement {
+
+WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>, GC::Ref<CreateCredentialAlgorithm>>> CredentialInterface::create(JS::Realm&, URL::Origin const&, CredentialCreationOptions const&, bool) const
+{
+    // 1. Return null.
+    return Empty {};
+}
+
+WebIDL::ExceptionOr<void> CredentialInterface::store(JS::Realm& realm, bool) const
+{
+    // 1. Throw a NotSupportedError.
+    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "store"_utf16));
+}
+
+WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>>> CredentialInterface::discover_from_external_source(JS::Realm&, URL::Origin const&, CredentialRequestOptions const&, bool) const
+{
+    // 1. Return null.
+    return Empty {};
+}
+
+WebIDL::ExceptionOr<Vector<GC::Ref<Credential>>> CredentialInterface::collect_from_credential_store(JS::Realm&, URL::Origin const&, CredentialRequestOptions const&, bool) const
+{
+    // 1. Return an empty set.
+    return Vector<GC::Ref<Credential>> {};
+}
 
 // https://www.w3.org/TR/credential-management-1/#dom-credential-isconditionalmediationavailable
 GC::Ref<WebIDL::Promise> Credential::is_conditional_mediation_available(JS::VM& vm)

--- a/Libraries/LibWeb/CredentialManagement/Credential.h
+++ b/Libraries/LibWeb/CredentialManagement/Credential.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Altomani Gianluca <altomanigianluca@gmail.com>
+ * Copyright (c) 2026, Altomani Gianluca <altomanigianluca@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,6 +12,58 @@
 #include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::CredentialManagement {
+
+typedef GC::Function<WebIDL::ExceptionOr<GC::Ref<Credential>>(JS::Object const&)> CreateCredentialAlgorithm;
+
+#define CREDENTIAL_INTERFACE(class_name) \
+public:                                  \
+    static class_name const& the()       \
+    {                                    \
+        static class_name s_instance;    \
+        return s_instance;               \
+    }
+
+// https://www.w3.org/TR/credential-management-1/#credential-internal-methods
+class CredentialInterface {
+    AK_MAKE_NONCOPYABLE(CredentialInterface);
+    AK_MAKE_NONMOVABLE(CredentialInterface);
+
+protected:
+    CredentialInterface() { }
+
+public:
+    virtual ~CredentialInterface() = default;
+
+    // https://w3c.github.io/webappsec-credential-management/#credential-type-registry-credential-type
+    virtual String type() const = 0;
+
+    // https://w3c.github.io/webappsec-credential-management/#credential-type-registry-options-member-identifier
+    virtual String options_member_identifier() const = 0;
+
+    // https://w3c.github.io/webappsec-credential-management/#credential-type-registry-get-permissions-policy
+    virtual Optional<String> get_permission_policy() const = 0;
+
+    // https://w3c.github.io/webappsec-credential-management/#credential-type-registry-create-permissions-policy
+    virtual Optional<String> create_permission_policy() const = 0;
+
+    // https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-slot
+    virtual String discovery() const = 0;
+
+    // NOTE: This is not explicitly present in the spec, it is inferred.
+    virtual bool supports_conditional_user_mediation() const = 0;
+
+    // https://w3c.github.io/webappsec-credential-management/#algorithm-create-cred
+    virtual WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>, GC::Ref<CreateCredentialAlgorithm>>> create(JS::Realm&, URL::Origin const&, CredentialCreationOptions const&, bool) const;
+
+    // https://w3c.github.io/webappsec-credential-management/#algorithm-store-cred
+    virtual WebIDL::ExceptionOr<void> store(JS::Realm& realm, bool) const;
+
+    // https://w3c.github.io/webappsec-credential-management/#algorithm-discover-creds
+    virtual WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>>> discover_from_external_source(JS::Realm&, URL::Origin const&, CredentialRequestOptions const&, bool) const;
+
+    // https://w3c.github.io/webappsec-credential-management/#algorithm-collect-creds
+    virtual WebIDL::ExceptionOr<Vector<GC::Ref<Credential>>> collect_from_credential_store(JS::Realm&, URL::Origin const&, CredentialRequestOptions const&, bool) const;
+};
 
 // https://www.w3.org/TR/credential-management-1/#credential
 class Credential : public Bindings::PlatformObject {
@@ -26,6 +78,7 @@ public:
     String const& id() const { return m_id; }
 
     virtual String type() const = 0;
+    virtual CredentialInterface const& interface() const = 0;
 
 protected:
     explicit Credential(JS::Realm&);

--- a/Libraries/LibWeb/CredentialManagement/CredentialsContainer.cpp
+++ b/Libraries/LibWeb/CredentialManagement/CredentialsContainer.cpp
@@ -5,6 +5,11 @@
  */
 
 #include <LibWeb/CredentialManagement/CredentialsContainer.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/Window.h>
+#include <LibWeb/Platform/EventLoopPlugin.h>
 
 namespace Web::CredentialManagement {
 
@@ -17,25 +22,486 @@ GC::Ref<CredentialsContainer> CredentialsContainer::create(JS::Realm& realm)
 
 CredentialsContainer::~CredentialsContainer() { }
 
-// https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-get
-GC::Ref<WebIDL::Promise> CredentialsContainer::get(CredentialRequestOptions const&)
+// https://w3c.github.io/webappsec-credential-management/#algorithm-same-origin-with-ancestors
+static bool is_same_origin_with_its_ancestors(HTML::EnvironmentSettingsObject& settings)
 {
-    auto* realm = vm().current_realm();
-    return WebIDL::create_rejected_promise_from_exception(*realm, vm().throw_completion<JS::InternalError>(JS::ErrorType::NotImplemented, "get"sv));
+    auto& global = settings.global_object();
+
+    // TODO: 1. If settings’s relevant global object has no associated Document, return false.
+    // 2. Let document be settings’ relevant global object's associated Document.
+    auto& document = as<HTML::Window>(global).associated_document();
+
+    // 3. If document has no browsing context, return false.
+    if (!document.browsing_context())
+        return false;
+
+    // 4. Let origin be settings’ origin.
+    auto origin = settings.origin();
+
+    // 5. Let navigable be document’s node navigable.
+    auto navigable = document.navigable();
+
+    // 6. While navigable has a non-null parent:
+    while (navigable->parent()) {
+        // 1. Set navigable to navigable’s parent.
+        navigable = navigable->parent();
+
+        // 2. If navigable’s active document's origin is not same origin with origin, return false.
+        if (!origin.is_same_origin(navigable->active_document()->origin()))
+            return false;
+    }
+
+    // 7. Return true.
+    return true;
 }
 
-// https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-store
-GC::Ref<WebIDL::Promise> CredentialsContainer::store(Credential const&)
+// https://w3c.github.io/webappsec-credential-management/#credentialrequestoptions-relevant-credential-interface-objects
+template<typename OptionsType>
+static Vector<CredentialInterface const&> relevant_credential_interface_objects(OptionsType const& options)
 {
-    auto* realm = vm().current_realm();
-    return WebIDL::create_rejected_promise_from_exception(*realm, vm().throw_completion<JS::InternalError>(JS::ErrorType::NotImplemented, "store"sv));
+    // 1. Let settings be the current settings object.
+    // 2. Let relevant interface objects be an empty set.
+    Vector<CredentialInterface const&> interfaces;
+
+    // 3. For each optionKey → optionValue of options:
+    // NOTE: We cannot iterate like the spec says.
+    //      1. Let credentialInterfaceObject be the Appropriate Interface Object (on settings’ global object) whose Options Member Identifier is optionKey.
+    //      2. Assert: credentialInterfaceObject’s [[type]] slot equals the Credential Type whose Options Member Identifier is optionKey.
+    //         NOTE: This is redundant for our implementation since they are hardcoded.
+    //      3. Append credentialInterfaceObject to relevant interface objects.
+
+#define APPEND_CREDENTIAL_INTERFACE_OBJECT(key, type_)               \
+    if (options.key.has_value()) {                                   \
+        auto& credential_interface_object = type_##Interface::the(); \
+        interfaces.append(credential_interface_object);              \
+    }
+
+    // https://w3c.github.io/webappsec-credential-management/#credential-type-registry-appropriate-interface-object
+    APPEND_CREDENTIAL_INTERFACE_OBJECT(password, PasswordCredential);
+    APPEND_CREDENTIAL_INTERFACE_OBJECT(federated, FederatedCredential);
+    // TODO: digital
+    // TODO: identity
+    // TODO: otp
+    // TODO: publicKey
+
+#undef APPEND_CREDENTIAL_INTERFACE_OBJECT
+
+    // 4. Return relevant interface objects.
+    return interfaces;
 }
 
-// https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-create
-GC::Ref<WebIDL::Promise> CredentialsContainer::create(CredentialCreationOptions const&)
+// https://w3c.github.io/webappsec-credential-management/#algorithm-collect-known
+static WebIDL::ExceptionOr<Vector<GC::Ref<Credential>>> collect_credentials_from_store(JS::Realm& realm, URL::Origin const& origin, CredentialRequestOptions const& options, bool same_origin_with_ancestors)
 {
-    auto* realm = vm().current_realm();
-    return WebIDL::create_rejected_promise_from_exception(*realm, vm().throw_completion<JS::InternalError>(JS::ErrorType::NotImplemented, "create"sv));
+    // 1. Let possible matches be an empty set.
+    Vector<GC::Ref<Credential>> possible_matches;
+
+    // 2. For each interface in options’ relevant credential interface objects:
+    for (auto& interface : relevant_credential_interface_objects(options)) {
+        // 1. Let r be the result of executing interface’s [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)
+        //    internal method on origin, options, and sameOriginWithAncestors. If that threw an exception, rethrow that exception.
+        auto r = TRY(interface.collect_from_credential_store(realm, origin, options, same_origin_with_ancestors));
+
+        // 2. Assert: r is a list of interface objects.
+        //    NOTE: This is implicit.
+
+        // 3. For each c in r:
+        for (auto& c : r) {
+            // 1. Append c to possible matches.
+            possible_matches.append(c);
+        }
+    }
+
+    // 3. Return possible matches.
+    return possible_matches;
+}
+
+// https://w3c.github.io/webappsec-credential-management/#abstract-opdef-ask-the-user-to-choose-a-credential
+static Variant<Empty, GC::Ref<Credential>, CredentialInterface*> ask_the_user_to_choose_a_credential(CredentialRequestOptions const&, Vector<GC::Ref<Credential>> const&)
+{
+    // TODO: This algorithm returns either null if the user chose not to share a credential with the site,
+    //       a Credential object if the user chose a specific credential, or a Credential interface object
+    //       if the user chose a type of credential.
+    return {};
+}
+
+// https://w3c.github.io/webappsec-credential-management/#credentialrequestoptions-matchable-a-priori
+static bool is_matchable_a_priori(CredentialRequestOptions const& options)
+{
+    // 1. For each interface in options’ relevant credential interface objects:
+    for (auto& interface : relevant_credential_interface_objects(options)) {
+        // 1. If interface’s [[discovery]] slot’s value is not "credential store", return false.
+        if (interface.discovery() != "credential store"_string)
+            return false;
+    }
+
+    // 2. Return true.
+    return true;
+}
+
+// https://w3c.github.io/webappsec-credential-management/#algorithm-request
+GC::Ref<WebIDL::Promise> CredentialsContainer::get(CredentialRequestOptions const& options)
+{
+    // 1. Let settings be the current settings object.
+    auto& settings = HTML::current_settings_object();
+
+    // 2. Assert: settings is a secure context.
+    VERIFY(HTML::is_secure_context(settings));
+
+    // 3. Let document be settings’s relevant global object's associated Document.
+    auto& document = as<HTML::Window>(settings.global_object()).associated_document();
+
+    // 4. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
+    if (!document.is_fully_active())
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::InvalidStateError::create(realm(), "Document is not fully active"_utf16));
+
+    // 5. If options.signal is aborted, then return a promise rejected with options.signal’s abort reason.
+    if (options.signal && options.signal->aborted())
+        return WebIDL::create_rejected_promise(realm(), options.signal->reason());
+
+    // 6. Let interfaces be options’s relevant credential interface objects.
+    auto interfaces = relevant_credential_interface_objects(options);
+
+    // 7. If interfaces is empty, then return a promise rejected with a "NotSupportedError" DOMException.
+    if (interfaces.is_empty())
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::NotSupportedError::create(realm(), "No credential types"_utf16));
+
+    // 8. For each interface of interfaces:
+    for (auto& interface : interfaces) {
+        // 1. If options.mediation is conditional and interface does not support conditional user mediation,
+        //    return a promise rejected with a "TypeError" DOMException.
+        if (options.mediation == Bindings::CredentialMediationRequirement::Conditional && !interface.supports_conditional_user_mediation())
+            return WebIDL::create_rejected_promise(realm(), JS::TypeError::create(realm(), "Conditional user mediation is not supported"sv));
+
+        // 2. TODO: If options.uiMode is immediate and interface does not support immediate user mediation,
+        //          return a promise rejected with a "TypeError" DOMException.
+
+        // 3. If settings’ active credential types contains interface’s [[type]],
+        //    return a promise rejected with a "NotAllowedError" DOMException.
+        if (settings.active_credential_types().contains_slow(interface.type()))
+            return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::NotAllowedError::create(realm(), "Credential type is not allowed"_utf16));
+
+        // 4. Append interface’s [[type]] to settings’ active credential types.
+        settings.active_credential_types().append(interface.type());
+    }
+
+    // 9. Let origin be settings’ origin.
+    auto origin = settings.origin();
+
+    // 10. Let sameOriginWithAncestors be true if settings is same-origin with its ancestors, and false otherwise.
+    auto same_origin_with_ancestors = is_same_origin_with_its_ancestors(settings);
+
+    // 11. For each interface in options’ relevant credential interface objects:
+    for (auto& interface : interfaces) {
+        // 1. Let permission be the interface’s [[type]] Get Permissions Policy.
+        auto permission = interface.get_permission_policy();
+
+        // 2. If permission is null, continue.
+        if (!permission.has_value())
+            continue;
+
+        // TODO: 3. If document is not allowed to use permission, return a promise rejected with a "NotAllowedError" DOMException.
+    }
+
+    // 12. Let p be a new promise.
+    auto promise = WebIDL::create_promise(realm());
+
+    // 13. Run the following steps in parallel:
+    //    FIXME: The promises resolving/rejection must be wrapped in a queued task.
+    //    https://github.com/w3c/webappsec-credential-management/issues/260
+    Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(realm().heap(), [this, promise, origin, options, same_origin_with_ancestors, &settings] {
+        HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+        // 1. Let credentials be the result of collecting Credentials from the credential store, given origin, options, and sameOriginWithAncestors.
+        auto maybe_credentials = collect_credentials_from_store(realm(), origin, options, same_origin_with_ancestors);
+
+        // 2. If credentials is an exception, reject p with credentials.
+        if (maybe_credentials.is_error()) {
+            WebIDL::reject_promise(realm(), *promise, Bindings::exception_to_throw_completion(realm().vm(), maybe_credentials.exception()).value());
+            return;
+        }
+
+        auto credentials = maybe_credentials.release_value();
+
+        // 3. If all of the following statements are true, resolve p with credentials[0] and skip the remaining steps:
+        //      1. credentials’ size is 1
+        //      TODO: 2. origin does not require user mediation
+        //      3. options is matchable a priori.
+        //      4. options.mediation is not "required".
+        //      5. options.mediation is not "conditional".
+        if (credentials.size() == 1
+            && is_matchable_a_priori(options)
+            && options.mediation != Bindings::CredentialMediationRequirement::Required
+            && options.mediation != Bindings::CredentialMediationRequirement::Conditional) {
+            WebIDL::resolve_promise(realm(), *promise, credentials[0]);
+            return;
+        }
+
+        // 4. If options’ mediation is "silent", resolve p with null, and skip the remaining steps.
+        if (options.mediation == Bindings::CredentialMediationRequirement::Silent) {
+            WebIDL::resolve_promise(realm(), *promise, JS::js_null());
+            return;
+        }
+
+        // 5. Let result be the result of asking the user to choose a Credential, given options and credentials.
+        auto result = ask_the_user_to_choose_a_credential(options, credentials);
+
+        // 6. If result is an interface object:
+        if (result.has<CredentialInterface*>()) {
+            // 1. Set result to the result of executing result’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors),
+            //    given origin, options, and sameOriginWithAncestors.
+            auto maybe_result = result.get<CredentialInterface*>()->discover_from_external_source(realm(), origin, options, same_origin_with_ancestors);
+            // If that threw an exception:
+            if (maybe_result.is_error()) {
+                // 1. Let e be the thrown exception.
+                auto e = maybe_result.exception();
+                // 2. Queue a task on global’s DOM manipulation task source to run the following substeps:
+                queue_global_task(HTML::Task::Source::DOMManipulation, settings.global_object(), GC::create_function(realm().heap(), [&] {
+                    HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+                    // 1. Reject p with e.
+                    WebIDL::reject_promise(realm(), *promise, Bindings::exception_to_throw_completion(realm().vm(), e).value());
+                }));
+                // 3. Terminate these substeps.
+                return;
+            }
+        }
+
+        // 7. Assert: result is null, or a Credential.
+        VERIFY(result.has<Empty>() || result.has<GC::Ref<Credential>>());
+
+        // 8. If result is a Credential, resolve p with result.
+        if (result.has<GC::Ref<Credential>>()) {
+            WebIDL::resolve_promise(realm(), *promise, result.get<GC::Ref<Credential>>());
+            return;
+        }
+
+        // 9. If result is null and options.mediation is not conditional, resolve p with result.
+        if (result.has<Empty>() && options.mediation != Bindings::CredentialMediationRequirement::Conditional)
+            WebIDL::resolve_promise(realm(), *promise, JS::js_null());
+
+        // NOTE: It is ok for the Promise to remain pending for conditional mediation.
+        // https://w3c.github.io/webappsec-credential-management/#dom-credentialmediationrequirement-conditional
+    }));
+
+    // 14. React to p:
+    auto on_completion = GC::create_function(realm().heap(), [&settings, interfaces = move(interfaces)](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+        // 1. For each interface in interfaces:
+        for (auto const& interface : interfaces) {
+            // 1. Remove interface’s [[type]] from settings’ active credential types.
+            settings.active_credential_types().remove_first_matching([&](auto& v) { return v == interface.type(); });
+        }
+
+        return JS::js_undefined();
+    });
+    WebIDL::react_to_promise(*promise, on_completion, on_completion);
+
+    // 15. Return p.
+    return promise;
+}
+
+// https://w3c.github.io/webappsec-credential-management/#algorithm-store
+GC::Ref<WebIDL::Promise> CredentialsContainer::store(Credential const& credential)
+{
+    // 1. Let settings be the current settings object.
+    auto& settings = HTML::current_settings_object();
+
+    // 2. Assert: settings is a secure context.
+    VERIFY(HTML::is_secure_context(settings));
+
+    // 3. If settings’s relevant global object's associated Document is not fully active,
+    //    then return a promise rejected with an "InvalidStateError" DOMException.
+    if (!as<HTML::Window>(settings.global_object()).associated_document().is_fully_active())
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::InvalidStateError::create(realm(), "Document is not fully active"_utf16));
+
+    // 4. Let sameOriginWithAncestors be true if the current settings object is same-origin with its ancestors, and false otherwise.
+    auto same_origin_with_ancestors = is_same_origin_with_its_ancestors(settings);
+
+    // 5. Let p be a new promise.
+    auto promise = WebIDL::create_promise(realm());
+
+    // 6. If settings’ active credential types contains credential’s [[type]], return a promise rejected with a "NotAllowedError" DOMException.
+    if (settings.active_credential_types().contains_slow(credential.type()))
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::NotAllowedError::create(realm(), "Credential type is not allowed"_utf16));
+
+    // 7. Append credential’s [[type]] to settings’ active credential types.
+    settings.active_credential_types().append(credential.type());
+
+    // 8. Run the following steps in parallel:
+    //    FIXME: The promises resolving/rejection must be wrapped in a queued task.
+    //    https://github.com/w3c/webappsec-credential-management/issues/260
+    Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(realm().heap(), [this, promise, &settings, &credential, same_origin_with_ancestors] {
+        HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+        // 1. Execute credential’s interface object's [[Store]](credential, sameOriginWithAncestors)
+        //    internal method on credential and sameOriginWithAncestors.
+        auto maybe_error = credential.interface().store(realm(), same_origin_with_ancestors);
+        // If that threw an exception:
+        if (maybe_error.is_error()) {
+            // 1. Let e be the thrown exception.
+            auto e = maybe_error.exception();
+            // 2. Queue a task on global’s DOM manipulation task source to run the following substeps:
+            queue_global_task(HTML::Task::Source::DOMManipulation, settings.global_object(), GC::create_function(realm().heap(), [&] {
+                HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+                // 1. Reject p with e.
+                WebIDL::reject_promise(realm(), *promise, Bindings::exception_to_throw_completion(realm().vm(), e).value());
+            }));
+        }
+        // Otherwise, resolve p with undefined.
+        else {
+            WebIDL::resolve_promise(realm(), *promise, JS::js_undefined());
+        }
+    }));
+
+    // 9. React to p:
+    auto on_completion = GC::create_function(realm().heap(), [&settings, &credential](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+        // 1. Remove credential’s [[type]] from settings’ active credential types.
+        settings.active_credential_types().remove_first_matching([&](auto& v) { return v == credential.type(); });
+
+        return JS::js_undefined();
+    });
+    WebIDL::react_to_promise(*promise, on_completion, on_completion);
+
+    // 10. Return p.
+    return promise;
+}
+
+// https://w3c.github.io/webappsec-credential-management/#algorithm-create
+GC::Ref<WebIDL::Promise> CredentialsContainer::create(CredentialCreationOptions const& options)
+{
+    // 1. Let settings be the current settings object.
+    auto& settings = HTML::current_settings_object();
+
+    // 2. Assert: settings is a secure context.
+    VERIFY(HTML::is_secure_context(settings));
+
+    // 3. Let global be settings’ global object.
+    auto& global = settings.global_object();
+
+    // 4. Let document be the relevant global object's associated Document.
+    auto& document = as<HTML::Window>(global).associated_document();
+
+    // 5. If document is not fully active, then return a promise rejected with an "InvalidStateError" DOMException.
+    if (!document.is_fully_active())
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::InvalidStateError::create(realm(), "Document is not fully active"_utf16));
+
+    // 6. Let sameOriginWithAncestors be true if the current settings object is same-origin with its ancestors, and false otherwise.
+    auto same_origin_with_ancestors = is_same_origin_with_its_ancestors(settings);
+
+    // 7. Let interfaces be the set of options’ relevant credential interface objects.
+    auto interfaces = relevant_credential_interface_objects(options);
+
+    // 8. Return a promise rejected with NotSupportedError if any of the following statements are true:
+    //    TODO: 1. global does not have an associated Document.
+    //    2. interfaces’ size is greater than 1.
+    if (interfaces.size() > 1)
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::NotSupportedError::create(realm(), "Too many crendetial types"_utf16));
+
+    // 9. For each interface in interfaces:
+    for (auto& interface : interfaces) {
+        // 1. Let permission be the interface’s [[type]] Create Permissions Policy.
+        auto permission = interface.create_permission_policy();
+
+        // 2. If permission is null, continue.
+        if (!permission.has_value())
+            continue;
+
+        // TODO: 3. If document is not allowed to use permission, return a promise rejected with a "NotAllowedError" DOMException.
+    }
+
+    // 10. If options.signal is aborted, then return a promise rejected with options.signal’s abort reason.
+    if (options.signal && options.signal->aborted())
+        return WebIDL::create_rejected_promise(realm(), options.signal->reason());
+
+    // NOTE: The spec does not mention this check
+    //       https://github.com/w3c/webappsec-credential-management/issues/267
+    if (interfaces.size() < 1)
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::NotSupportedError::create(realm(), "No credential types"_utf16));
+
+    // 11. Let type be interfaces[0]'s [[type]].
+    auto type = interfaces[0].type();
+
+    // 12. If settings’ active credential types contains type, return a promise rejected with a "NotAllowedError" DOMException.
+    if (settings.active_credential_types().contains_slow(type))
+        return WebIDL::create_rejected_promise_from_exception(realm(), WebIDL::NotAllowedError::create(realm(), "Credential type is not allowed"_utf16));
+
+    // 13. Append type to settings’ active credential types.
+    settings.active_credential_types().append(type);
+
+    // 14. Let origin be settings’s origin.
+    auto origin = settings.origin();
+
+    // 15. Let p be a new promise.
+    auto promise = WebIDL::create_promise(realm());
+
+    // 16. Run the following steps in parallel:
+    //    FIXME: The promises resolving/rejection must be wrapped in a queued task.
+    //    https://github.com/w3c/webappsec-credential-management/issues/260
+    Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(realm().heap(), [this, promise, &global, interfaces = move(interfaces), origin, options, same_origin_with_ancestors] {
+        HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+        // 1. Let r be the result of executing interfaces[0]'s [[Create]](origin, options, sameOriginWithAncestors)
+        //    internal method on origin, options, and sameOriginWithAncestors.
+        auto maybe_r = interfaces[0].create(realm(), origin, options, same_origin_with_ancestors);
+        // If that threw an exception:
+        if (maybe_r.is_error()) {
+            // 1. Let e be the thrown exception.
+            auto e = maybe_r.exception();
+            // 2. Queue a task on global’s DOM manipulation task source to run the following substeps:
+            queue_global_task(HTML::Task::Source::DOMManipulation, global, GC::create_function(realm().heap(), [&] {
+                HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+                // 1. Reject p with e.
+                WebIDL::reject_promise(realm(), *promise, Bindings::exception_to_throw_completion(realm().vm(), e).value());
+            }));
+            // 3. Terminate these substeps.
+            return;
+        }
+
+        auto r = maybe_r.release_value();
+
+        // 2. If r is a Credential or null, resolve p with r, and terminate these substeps.
+        if (r.has<Empty>()) {
+            WebIDL::resolve_promise(realm(), *promise, JS::js_null());
+            return;
+        }
+        if (r.has<GC::Ref<Credential>>()) {
+            auto& credential = r.get<GC::Ref<Credential>>();
+            WebIDL::resolve_promise(realm(), *promise, credential);
+            return;
+        }
+
+        // 3. Assert: r is an algorithm (as defined in §2.2.1.4 [[Create]] internal method).
+        VERIFY(r.has<GC::Ref<CreateCredentialAlgorithm>>());
+
+        // 4. Queue a task on global’s DOM manipulation task source to run the following substeps:
+        auto& r_algo = r.get<GC::Ref<CreateCredentialAlgorithm>>();
+        queue_global_task(HTML::Task::Source::DOMManipulation, global, GC::create_function(realm().heap(), [this, &global, promise, r_algo] {
+            HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+
+            // 1. Resolve p with the result of promise-calling r given global.
+            auto maybe_result = r_algo->function()(global);
+            if (maybe_result.is_error()) {
+                WebIDL::reject_promise(realm(), *promise, Bindings::exception_to_throw_completion(realm().vm(), maybe_result.exception()).value());
+                return;
+            }
+
+            auto& result = maybe_result.value();
+            WebIDL::resolve_promise(realm(), *promise, result);
+        }));
+    }));
+
+    // 17. React to p:
+    auto on_completion = GC::create_function(realm().heap(), [&settings, type](JS::Value) -> WebIDL::ExceptionOr<JS::Value> {
+        // 1. Remove type from settings’ active credential types.
+        settings.active_credential_types().remove_first_matching([&](auto& v) { return v == type; });
+
+        return JS::js_undefined();
+    });
+    WebIDL::react_to_promise(*promise, on_completion, on_completion);
+
+    // 18. Return p.
+    return promise;
 }
 
 // https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-preventsilentaccess

--- a/Libraries/LibWeb/CredentialManagement/FederatedCredential.cpp
+++ b/Libraries/LibWeb/CredentialManagement/FederatedCredential.cpp
@@ -18,7 +18,7 @@ WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> FederatedCredential::construct
     // 1. Let r be the result of executing Create a FederatedCredential from FederatedCredentialInit on data. If that
     // threw an exception, rethrow that exception.
     // 2. Return r.
-    return create_federated_credential(realm, data);
+    return create_federated_credential(realm, data, {});
 }
 
 FederatedCredential::~FederatedCredential()

--- a/Libraries/LibWeb/CredentialManagement/FederatedCredential.cpp
+++ b/Libraries/LibWeb/CredentialManagement/FederatedCredential.cpp
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2025, Altomani Gianluca <altomanigianluca@gmail.com>
+ * Copyright (c) 2026, Altomani Gianluca <altomanigianluca@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CredentialManagement/CredentialsContainer.h>
 #include <LibWeb/CredentialManagement/FederatedCredential.h>
 #include <LibWeb/CredentialManagement/FederatedCredentialOperations.h>
 
@@ -23,6 +24,20 @@ WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> FederatedCredential::construct
 
 FederatedCredential::~FederatedCredential()
 {
+}
+
+// https://w3c.github.io/webappsec-credential-management/#create-federatedcredential
+WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>, GC::Ref<CreateCredentialAlgorithm>>> FederatedCredentialInterface::create(JS::Realm& realm, URL::Origin const& origin, CredentialCreationOptions const& options, bool) const
+{
+    // 1. Assert: options["federated"] exists, and sameOriginWithAncestors is unused.
+    VERIFY(options.federated.has_value());
+
+    // 2. Set options["federated"]'s origin member’s value to origin’s value.
+    // NOTE: We don't carry the "origin" field in FederatedCredentialInit, so we don't need to set it here.
+
+    // 3. Return the result of executing Create a FederatedCredential from FederatedCredentialInit given options["federated"].
+    // If that threw an exception, then rethrow that exception.
+    return TRY(create_federated_credential(realm, *options.federated, origin));
 }
 
 FederatedCredential::FederatedCredential(JS::Realm& realm, FederatedCredentialInit const& init, URL::Origin origin)

--- a/Libraries/LibWeb/CredentialManagement/FederatedCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/FederatedCredential.h
@@ -14,6 +14,24 @@
 
 namespace Web::CredentialManagement {
 
+class FederatedCredentialInterface final : public CredentialInterface {
+    CREDENTIAL_INTERFACE(FederatedCredentialInterface);
+
+public:
+    virtual String type() const override { return "federated"_string; }
+    virtual String options_member_identifier() const override { return "federated"_string; }
+    virtual Optional<String> get_permission_policy() const override { return {}; }
+    virtual Optional<String> create_permission_policy() const override { return {}; }
+
+    virtual String discovery() const override { return "credential store"_string; }
+    virtual bool supports_conditional_user_mediation() const override
+    {
+        // NOTE: FederatedCredential does not override is_conditional_mediation_available(),
+        //       therefore conditional mediation is not supported.
+        return false;
+    }
+};
+
 // https://w3c.github.io/webappsec-credential-management/#federatedcredential
 class FederatedCredential final
     : public Credential
@@ -31,6 +49,10 @@ public:
     URL::Origin const& origin() const { return m_origin; }
 
     String type() const override { return "federated"_string; }
+    virtual CredentialInterface const& interface() const override
+    {
+        return FederatedCredentialInterface::the();
+    }
 
 private:
     FederatedCredential(JS::Realm&, FederatedCredentialInit const&, URL::Origin);

--- a/Libraries/LibWeb/CredentialManagement/FederatedCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/FederatedCredential.h
@@ -30,6 +30,9 @@ public:
         //       therefore conditional mediation is not supported.
         return false;
     }
+
+    // https://w3c.github.io/webappsec-credential-management/#create-federatedcredential
+    virtual WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>, GC::Ref<CreateCredentialAlgorithm>>> create(JS::Realm&, URL::Origin const&, CredentialCreationOptions const&, bool) const override;
 };
 
 // https://w3c.github.io/webappsec-credential-management/#federatedcredential

--- a/Libraries/LibWeb/CredentialManagement/FederatedCredentialOperations.cpp
+++ b/Libraries/LibWeb/CredentialManagement/FederatedCredentialOperations.cpp
@@ -10,7 +10,7 @@
 namespace Web::CredentialManagement {
 
 // https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit
-WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> create_federated_credential(JS::Realm& realm, FederatedCredentialInit const& init)
+WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> create_federated_credential(JS::Realm& realm, FederatedCredentialInit const& init, Optional<URL::Origin> const& origin)
 {
     // 1. Let c be a new FederatedCredential object.
     // 2. If any of the following are the empty string, throw a TypeError exception:
@@ -21,11 +21,17 @@ WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> create_federated_credential(JS
     if (init.provider.is_empty())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "'provider' must not be empty."sv };
 
-    // AD-HOC: Aligning with how Chromium retrieves the origin by parsing the URL from init.provider.
-    auto url = URL::Parser::basic_parse(init.provider);
-    if (!url.has_value())
-        WebIDL::SyntaxError::create(realm, "'provider' is not a valid url."_utf16);
-    auto origin = url.value().origin();
+    URL::Origin resolved_origin = TRY([&realm, &init, &origin] -> WebIDL::ExceptionOr<URL::Origin> {
+        if (origin.has_value()) {
+            return origin.value();
+        }
+
+        // AD-HOC: Aligning with how Chromium retrieves the origin by parsing the URL from init.provider.
+        auto url = URL::Parser::basic_parse(init.provider);
+        if (!url.has_value())
+            return WebIDL::SyntaxError::create(realm, "'provider' is not a valid url."_utf16);
+        return url.value().origin();
+    }());
 
     // 3. Set c’s properties as follows:
     //    - id
@@ -40,7 +46,7 @@ WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> create_federated_credential(JS
     //      - init.origin's value.
     //      NOTE: origin is retrieved by parsing the URL from init.provider.
     // 4. Return c.
-    return realm.create<FederatedCredential>(realm, init, move(origin));
+    return realm.create<FederatedCredential>(realm, init, move(resolved_origin));
 }
 
 }

--- a/Libraries/LibWeb/CredentialManagement/FederatedCredentialOperations.h
+++ b/Libraries/LibWeb/CredentialManagement/FederatedCredentialOperations.h
@@ -10,6 +10,6 @@
 
 namespace Web::CredentialManagement {
 
-WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> create_federated_credential(JS::Realm& realm, FederatedCredentialInit const&);
+WebIDL::ExceptionOr<GC::Ref<FederatedCredential>> create_federated_credential(JS::Realm& realm, FederatedCredentialInit const&, Optional<URL::Origin> const&);
 
 }

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.cpp
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.cpp
@@ -1,11 +1,14 @@
 /*
- * Copyright (c) 2025, Altomani Gianluca <altomanigianluca@gmail.com>
+ * Copyright (c) 2026, Altomani Gianluca <altomanigianluca@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CredentialManagement/CredentialsContainer.h>
 #include <LibWeb/CredentialManagement/PasswordCredential.h>
 #include <LibWeb/CredentialManagement/PasswordCredentialOperations.h>
+#include <LibWeb/HTML/AutocompleteElement.h>
+#include <LibWeb/XHR/FormData.h>
 
 namespace Web::CredentialManagement {
 
@@ -49,6 +52,29 @@ void PasswordCredential::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(PasswordCredential);
     Base::initialize(realm);
+}
+
+// https://w3c.github.io/webappsec-credential-management/#create-passwordcredential
+WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>, GC::Ref<CreateCredentialAlgorithm>>> PasswordCredentialInterface::create(JS::Realm& realm, URL::Origin const& origin, CredentialCreationOptions const& options, bool) const
+{
+    // 1. Assert: options["password"] exists, and sameOriginWithAncestors is unused.
+    VERIFY(options.password.has_value());
+
+    return TRY(options.password->visit(
+        // 2. If options["password"] is an HTMLFormElement, return the result of executing Create a PasswordCredential
+        //    from an HTMLFormElement given options["password"] and origin. Rethrow any exceptions.
+        [&](GC::Root<HTML::HTMLFormElement> const& form) {
+            return create_password_credential(realm, *form, origin);
+        },
+        // 3. If options["password"] is a PasswordCredentialData, return the result of executing
+        //     Create a PasswordCredential from PasswordCredentialData given options["password"]. Rethrow any exceptions.
+        [&](PasswordCredentialData const& data) {
+            return create_password_credential(realm, data, origin);
+        },
+        // 4. Throw a TypeError exception.
+        [&](auto const&) {
+            return realm.vm().throw_completion<JS::TypeError>("options.password must be an HTMLFormElement or a PasswordCredentialData"sv);
+        }));
 }
 
 }

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
@@ -31,6 +31,9 @@ public:
         //       therefore conditional mediation is not supported.
         return false;
     }
+
+    // https://w3c.github.io/webappsec-credential-management/#create-passwordcredential
+    virtual WebIDL::ExceptionOr<Variant<Empty, GC::Ref<Credential>, GC::Ref<CreateCredentialAlgorithm>>> create(JS::Realm&, URL::Origin const&, CredentialCreationOptions const&, bool) const override;
 };
 
 // https://www.w3.org/TR/credential-management-1/#passwordcredential

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Altomani Gianluca <altomanigianluca@gmail.com>
+ * Copyright (c) 2026, Altomani Gianluca <altomanigianluca@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,6 +14,24 @@
 #include <LibWeb/HTML/HTMLFormElement.h>
 
 namespace Web::CredentialManagement {
+
+class PasswordCredentialInterface final : public CredentialInterface {
+    CREDENTIAL_INTERFACE(PasswordCredentialInterface);
+
+public:
+    virtual String type() const override { return "password"_string; }
+    virtual String options_member_identifier() const override { return "password"_string; }
+    virtual Optional<String> get_permission_policy() const override { return {}; }
+    virtual Optional<String> create_permission_policy() const override { return {}; }
+
+    virtual String discovery() const override { return "credential store"_string; }
+    virtual bool supports_conditional_user_mediation() const override
+    {
+        // NOTE: PasswordCredential does not override is_conditional_mediation_available(),
+        //       therefore conditional mediation is not supported.
+        return false;
+    }
+};
 
 // https://www.w3.org/TR/credential-management-1/#passwordcredential
 class PasswordCredential final
@@ -32,6 +50,10 @@ public:
     URL::Origin const& origin() const { return m_origin; }
 
     String type() const override { return "password"_string; }
+    virtual CredentialInterface const& interface() const override
+    {
+        return PasswordCredentialInterface::the();
+    }
 
 private:
     PasswordCredential(JS::Realm&, PasswordCredentialData const&, URL::Origin);

--- a/Libraries/LibWeb/CredentialManagement/PasswordCredential.idl
+++ b/Libraries/LibWeb/CredentialManagement/PasswordCredential.idl
@@ -9,7 +9,10 @@ interface PasswordCredential : Credential {
 PasswordCredential includes CredentialUserData;
 
 partial dictionary CredentialRequestOptions {
-    boolean password = false;
+    // FIXME: Spec bug?
+    // https://github.com/w3c/webappsec-credential-management/issues/270
+    // boolean password = false;
+    boolean password;
 };
 
 dictionary PasswordCredentialData : CredentialData {

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -595,4 +595,10 @@ GC::Ref<ServiceWorker::ServiceWorker> EnvironmentSettingsObject::get_service_wor
     return *object_map.get(service_worker);
 }
 
+// https://w3c.github.io/webappsec-credential-management/#active-credential-types
+Vector<String>& EnvironmentSettingsObject::active_credential_types()
+{
+    return m_active_credential_types;
+}
+
 }

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -139,6 +139,9 @@ public:
     // https://w3c.github.io/ServiceWorker/#get-the-service-worker-object
     GC::Ref<ServiceWorker::ServiceWorker> get_service_worker_object(ServiceWorker::ServiceWorkerRecord*);
 
+    // https://w3c.github.io/webappsec-credential-management/#active-credential-types
+    Vector<String>& active_credential_types();
+
     [[nodiscard]] bool discarded() const { return m_discarded; }
     void set_discarded(bool b) { m_discarded = b; }
 
@@ -191,6 +194,10 @@ private:
     // An environment settings object has a service worker object map,
     // a map where the keys are service workers and the values are ServiceWorker objects.
     HashMap<ServiceWorker::ServiceWorkerRecord*, GC::Ref<ServiceWorker::ServiceWorker>> m_service_worker_object_map;
+
+    // https://w3c.github.io/webappsec-credential-management/#active-credential-types
+    // Each environment settings object has an associated active credential types, a set which is initially empty.
+    Vector<String> m_active_credential_types;
 
     // https://w3c.github.io/ServiceWorker/#service-worker-client-discarded-flag
     // A service worker client has an associated discarded flag. It is initially unset.

--- a/Tests/LibWeb/Text/expected/wpt-import/credential-management/credentialscontainer-create-basics.https.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/credential-management/credentialscontainer-create-basics.https.txt
@@ -2,22 +2,22 @@ Harness status: OK
 
 Found 17 tests
 
-6 Pass
-11 Fail
-Fail	navigator.credentials.create() with no argument.
-Fail	navigator.credentials.create() with empty argument.
-Fail	navigator.credentials.create() with valid PasswordCredentialData
-Fail	navigator.credentials.create() with valid HTMLFormElement
+15 Pass
+2 Fail
+Pass	navigator.credentials.create() with no argument.
+Pass	navigator.credentials.create() with empty argument.
+Pass	navigator.credentials.create() with valid PasswordCredentialData
+Pass	navigator.credentials.create() with valid HTMLFormElement
 Pass	navigator.credentials.create() with bogus password data
-Fail	navigator.credentials.create() with valid FederatedCredentialData
+Pass	navigator.credentials.create() with valid FederatedCredentialData
 Pass	navigator.credentials.create() with bogus federated data
 Fail	navigator.credentials.create() with bogus publicKey data
-Fail	navigator.credentials.create() with both PasswordCredentialData and FederatedCredentialData
+Pass	navigator.credentials.create() with both PasswordCredentialData and FederatedCredentialData
 Pass	navigator.credentials.create() with bogus password and federated data
 Pass	navigator.credentials.create() with bogus federated and publicKey data
 Pass	navigator.credentials.create() with bogus password and publicKey data
 Pass	navigator.credentials.create() with bogus password, federated, and publicKey data
-Fail	navigator.credentials.create() with bogus data
-Fail	navigator.credentials.create() aborted with custom reason
-Fail	navigator.credentials.create() aborted with different objects
+Pass	navigator.credentials.create() with bogus data
+Pass	navigator.credentials.create() aborted with custom reason
+Pass	navigator.credentials.create() aborted with different objects
 Fail	navigator.credentials.create() rejects when aborted after the promise creation

--- a/Tests/LibWeb/Text/expected/wpt-import/credential-management/credentialscontainer-get-basics.https.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/credential-management/credentialscontainer-get-basics.https.txt
@@ -2,10 +2,11 @@ Harness status: OK
 
 Found 6 tests
 
-6 Fail
-Fail	Calling navigator.credentials.get() without a valid matching interface.
+3 Pass
+3 Fail
+Pass	Calling navigator.credentials.get() without a valid matching interface.
 Fail	Calling navigator.credentials.get() with invalid combinations of credential types.
 Fail	Calling navigator.credentials.get() with valid combination (password + federated).
-Fail	navigator.credentials.get() aborted with custom reason
-Fail	navigator.credentials.get() aborted with different objects
+Pass	navigator.credentials.get() aborted with custom reason
+Pass	navigator.credentials.get() aborted with different objects
 Fail	navigator.credentials.get() rejects when aborted after the promise creation


### PR DESCRIPTION
This PR mplements `get`, `store`, `create` on `CredentialsContainer`, leaving out only `prevent_silent_access`. This is a revival of #3495 with some improvements.

Notably, it also introduces the `CredentialInterface` singleton abstract class to deal with credentials internal methods.

The spec isn't the best and contains some bugs:
- The `options.signal && options.signal->aborted()` check in `get` and `create` is not deferred therefore fails two WPT tests
- The `interfaces.size() < 1` check in `create` is custom and avoids an out of bound access in the next step -> [Spec issue](https://github.com/w3c/webappsec-credential-management/issues/267)
- The `CredentialRequestOptions` IDL dictionary has a default value for `password` which renders the credential type always active -> [Spec issue](https://github.com/w3c/webappsec-credential-management/issues/270)
- Others are linked directly in the code

This foundation should be enough to start working on WebAuthn. The interactive part is still missing as `ask_the_user_to_choose_a_credential` is stubbed out.