### PR TITLE
CMake: Create CACHEDIR.TAG file in `Build` directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ endif()
 # vcpkg flags depend on what linker we are using
 include("Meta/CMake/use_linker.cmake")
 
+# cache directory tag creation
+include("Meta/CMake/cachedir_tag.cmake")
+
 if (APPLE AND NOT CMAKE_OSX_DEPLOYMENT_TARGET)
     set(CMAKE_OSX_DEPLOYMENT_TARGET 14.0)
 endif()

--- a/Meta/CMake/cachedir_tag.cmake
+++ b/Meta/CMake/cachedir_tag.cmake
@@ -1,0 +1,17 @@
+# This creates a CACHEDIR.TAG file in the build directory so that backup 
+# tools automatically skip it.
+set(CACHEDIR_TAG_CONTENT 
+"Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by the Ladybird project.
+# For information about cache directory tags, see:
+# https://bford.info/cachedir/
+")
+
+cmake_path(SET ROOT_BUILD_DIR "${CMAKE_BINARY_DIR}")
+cmake_path(GET ROOT_BUILD_DIR PARENT_PATH ROOT_BUILD_DIR)
+
+set(CACHEDIR_TAG_PATH "${ROOT_BUILD_DIR}/CACHEDIR.TAG")
+
+if(NOT EXISTS "${CACHEDIR_TAG_PATH}")
+    file(WRITE "${CACHEDIR_TAG_PATH}" "${CACHEDIR_TAG_CONTENT}")
+endif()


### PR DESCRIPTION
This incorporates the Cache Directory Tagging Specification, see: https://bford.info/cachedir/
...so that backup tools won't save the build artifacts.

There are probably other places we could incorporate this as well (e.g. the disk cache directory) but just tag the build for now.