### PR TITLE
LibWeb: Replace OrderedHashMap with page-table Vector in LayoutState

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1501,7 +1501,11 @@ void Document::update_layout(UpdateLayoutReason reason)
         }
     }
 
+    u32 layout_index_counter = 0;
     m_layout_root->for_each_in_inclusive_subtree([&](auto& layout_node) {
+        if (auto* node_with_style = as_if<Layout::NodeWithStyle>(layout_node))
+            node_with_style->set_layout_index(layout_index_counter++);
+
         layout_node.recompute_containing_block({});
 
         auto* box = as_if<Layout::Box>(layout_node);
@@ -1530,6 +1534,7 @@ void Document::update_layout(UpdateLayoutReason reason)
     });
 
     Layout::LayoutState layout_state;
+    layout_state.ensure_capacity(layout_index_counter);
 
     {
         Layout::BlockFormattingContext root_formatting_context(layout_state, Layout::LayoutMode::Normal, *m_layout_root, nullptr);

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1259,7 +1259,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
     if (!block_container)
         return {};
 
-    auto const* block_container_used_values = state.used_values_per_layout_node.get(*block_container).value_or(nullptr);
+    auto const* block_container_used_values = state.try_get(*block_container);
     if (!block_container_used_values)
         return {};
 
@@ -1296,7 +1296,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
 
     // Expand the bounding rect by the inline's padding to get the padding box.
     // Per CSS, the containing block is formed by the padding edge.
-    auto const* inline_used_values = state.used_values_per_layout_node.get(inline_node).value_or(nullptr);
+    auto const* inline_used_values = state.try_get(inline_node);
     if (inline_used_values) {
         bounding_rect->set_x(bounding_rect->x() - inline_used_values->padding_left);
         bounding_rect->set_y(bounding_rect->y() - inline_used_values->padding_top);
@@ -1309,7 +1309,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
     // Walk from block_container up to abspos_containing_block, accumulating offsets.
     CSSPixelPoint offset_to_containing_block;
     for (Node const* ancestor = block_container; ancestor && ancestor != &abspos_containing_block; ancestor = ancestor->parent()) {
-        if (auto const* ancestor_used_values = state.used_values_per_layout_node.get(*ancestor).value_or(nullptr)) {
+        if (auto const* ancestor_used_values = state.try_get(*ancestor)) {
             offset_to_containing_block.translate_by(ancestor_used_values->offset);
         }
     }

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -282,6 +282,9 @@ public:
 
     void set_computed_values(NonnullOwnPtr<CSS::ComputedValues>);
 
+    u32 layout_index() const { return m_layout_index; }
+    void set_layout_index(u32 index) { m_layout_index = index; }
+
 protected:
     NodeWithStyle(DOM::Document&, DOM::Node*, GC::Ref<CSS::ComputedProperties>);
     NodeWithStyle(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
@@ -295,6 +298,7 @@ private:
 
     NonnullOwnPtr<CSS::ComputedValues> m_computed_values;
     RefPtr<CSS::AbstractImageStyleValue const> m_list_style_image;
+    u32 m_layout_index { 0 };
 };
 
 template<>


### PR DESCRIPTION
Each NodeWithStyle is assigned a sequential layout index during the pre-layout tree traversal. LayoutState stores UsedValues in a PagedStore — a two-level page table that gives O(1) lookup via two array accesses. Pages are allocated lazily on first write, so throwaway LayoutState objects (intrinsic sizing, SVG relayout) that only visit a handful of nodes avoid allocating for the entire tree, without paying the hashing cost of a HashMap.

This cuts ensure_used_values_for() from ~14% to ~7% in profiles on https://www.nyan.cat/.