### PR TITLE
LibWeb: Skip pseudo-element generated text in background-clip:text

### DIFF
--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2026, mikiubo <michele.uboldi@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -41,8 +42,14 @@ static RefPtr<DisplayList> compute_text_clip_paths(DisplayListRecordingContext& 
         display_list_recorder.draw_glyph_run(baseline_start, *glyph_run, Gfx::Color::Black, fragment_absolute_device_rect.to_type<int>(), scale, fragment.orientation());
     };
 
-    paintable.for_each_in_inclusive_subtree([&](auto& paintable) {
-        if (auto* paintable_lines = as_if<PaintableWithLines>(paintable)) {
+    paintable.for_each_in_inclusive_subtree([&](auto& sub_paintable) {
+        // https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-text
+        if (&sub_paintable != &paintable) {
+            auto& layout_node = sub_paintable.layout_node();
+            if (!layout_node.is_in_flow() && !layout_node.is_floating())
+                return TraversalDecision::SkipChildrenAndContinue;
+        }
+        if (auto* paintable_lines = as_if<PaintableWithLines>(sub_paintable)) {
             for (auto const& fragment : paintable_lines->fragments()) {
                 if (is<Layout::TextNode>(fragment.layout_node()))
                     add_text_clip_path(fragment);

--- a/Tests/LibWeb/Ref/expected/css/background-clip-text-float.html
+++ b/Tests/LibWeb/Ref/expected/css/background-clip-text-float.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <style>
+   div {
+    background: linear-gradient(red, blue);
+    background-clip: text;
+    color: transparent;
+    font: bold 40px sans-serif;
+   }
+  </style>
+ </head>
+ <body>
+  <div>HelloWorld</div>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/css/background-clip-text-pseudo-element.html
+++ b/Tests/LibWeb/Ref/expected/css/background-clip-text-pseudo-element.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+ <head>
+ </head>
+ <body>
+  <h1>test</h1>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/css/background-clip-text-float.html
+++ b/Tests/LibWeb/Ref/input/css/background-clip-text-float.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <link rel="match" href="../../expected/css/background-clip-text-float.html" />
+  <style>
+   div {
+    background: linear-gradient(red, blue);
+    background-clip: text;
+    color: transparent;
+    font: bold 40px sans-serif;
+   }
+  </style>
+ </head>
+ <body>
+  <div>World<span style="float: left">Hello</span></div>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/css/background-clip-text-pseudo-element.html
+++ b/Tests/LibWeb/Ref/input/css/background-clip-text-pseudo-element.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <link rel="match" href="../../expected/css/background-clip-text-pseudo-element.html" />
+  <style>
+    h1 {
+      background: black;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    h1:before {
+      content: attr(data-text);
+      position: absolute;
+      left: 200px;
+    }
+  </style>
+ </head>
+ <body>
+  <h1 data-text="test">test</h1>
+ </body>
+</html>


### PR DESCRIPTION
Ignore fragments generated for pseudo-elements when computing text clip paths.
These should not contribute to the element’s text clipping per CSS backgrounds and borders.

Fixes #7498