### PR TITLE
LibMedia+LibWeb: Stop ref counting PlaybackManager

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -354,7 +354,7 @@ private:
     GC::Weak<Fetch::Infrastructure::FetchController> m_fetch_controller;
     u32 m_current_fetch_generation { 0 };
 
-    RefPtr<Media::PlaybackManager> m_playback_manager;
+    OwnPtr<Media::PlaybackManager> m_playback_manager;
     GC::Ptr<VideoTrack> m_selected_video_track;
     RefPtr<Media::DisplayingVideoSink> m_selected_video_track_sink;
 

--- a/Tests/LibWeb/Crash/HTML/media-load-during-track-setup.html
+++ b/Tests/LibWeb/Crash/HTML/media-load-during-track-setup.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script>
+    video.preload = "none";
+    video.src = "../../Assets/test-webm.webm";
+    video.onsuspend = () => {
+        video.onsuspend = null;
+        video.load();
+    };
+</script>


### PR DESCRIPTION
PlaybackManager's ref counting was only used to keep it alive in a few callbacks. Instead, the callbacks can use weak references that can only be used from the thread that the PlaybackManager was created on, to ensure that the PlaybackManager can't be destroyed while being accessed.

This ensures that:
- The PlaybackManager is destroyed immediately when it is reassigned by HTMLMediaElement
- No callbacks are invoked after that point

This fixes the crash initially being addressed by #8081. The test from that PR has been included as a regression test.

CC @tcl3 