### PR TITLE
LibWeb: Ensure favicon URL is valid before fetching it

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -977,8 +977,14 @@ void HTMLLinkElement::load_fallback_favicon_if_needed(GC::Ref<DOM::Document> doc
     //    the Document object's URL, client is the Document object's relevant settings object, destination is "image",
     //    synchronous flag is set, credentials mode is "include", and whose use-URL-credentials flag is set.
     // NOTE: Fetch requests no longer have a synchronous flag, see https://github.com/whatwg/fetch/pull/1165
+    auto favicon_url = document->encoding_parse_url("/favicon.ico"sv);
+
+    // It is possible for the URL parser to fail if the document's base URL is invalid.
+    if (!favicon_url.has_value())
+        return;
+
     auto request = Fetch::Infrastructure::Request::create(vm);
-    request->set_url(*document->encoding_parse_url("/favicon.ico"sv));
+    request->set_url(favicon_url.release_value());
     request->set_client(&document->relevant_settings_object());
     request->set_destination(Fetch::Infrastructure::Request::Destination::Image);
     request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::Include);

--- a/Tests/LibWeb/Crash/HTML/fallback-favicon-invalid-base.html
+++ b/Tests/LibWeb/Crash/HTML/fallback-favicon-invalid-base.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<base href="invalid:">

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -302,6 +302,9 @@ Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input
 Text/input/wpt-import/navigation-api/navigation-methods/reload-state-and-info.html
 Text/input/wpt-import/navigation-api/navigation-methods/reload-state-undefined.html
 
+; Fallback favicon fetch requires HTTP(S) scheme.
+Crash/HTML/fallback-favicon-invalid-base.html
+
 ; Trusted Types requires tuple origin.
 ; Fails in other browsers too when loaded from file://.
 Text/input/wpt-import/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html


### PR DESCRIPTION
Previously, we would crash when attempting to fetch the favicon if the `<base>` element had an invalid URL.

I haven't included a test for this because the crashing code path is only invoked for http(s) URLs. Tested manually by running this from a local web server:
```html
<!DOCTYPE html>
<base href="invalid:">
```
Fixes this WPT crash test: https://wpt.live/svg/pservers/pattern-with-invalid-base-cloned-thcrash.html