### PR TITLE
LibWeb: Ensure mspace presentation hint is valid before setting it

### DIFF
--- a/Libraries/LibWeb/MathML/MathMLMspaceElement.cpp
+++ b/Libraries/LibWeb/MathML/MathMLMspaceElement.cpp
@@ -62,7 +62,8 @@ void MathMLMspaceElement::apply_presentational_hints(GC::Ref<CSS::CascadedProper
 
     if (height_value && depth_value) {
         auto height_string = MUST(String::formatted("calc({} + {})", attribute(AttributeNames::height).value(), attribute(AttributeNames::depth).value()));
-        cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Height, parse_css_type(parsing_params, height_string, CSS::ValueType::Length).release_nonnull());
+        if (auto height_value = parse_css_type(parsing_params, height_string, CSS::ValueType::Length))
+            cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Height, height_value.release_nonnull());
     } else if (height_value) {
         cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Height, height_value.release_nonnull());
     } else if (depth_value) {

--- a/Tests/LibWeb/Ref/expected/wpt-import/mathml/presentation-markup/operators/mo-lspace-rspace-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/mathml/presentation-markup/operators/mo-lspace-rspace-ref.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>mo-lspace-rspace (reference)</title>
+  </head>
+
+  <body>
+
+    <p>
+      <!-- not in the operator dictionary -->
+      <math>
+        <mtext>_</mtext>
+        <mspace width="0.2777777777777778em" height="0" depth="0"></mspace>
+        <mtext>MO</mtext>
+        <mspace width="0.2777777777777778em" height="0" depth="0"></mspace>
+        <mtext>_</mtext>
+      </math>
+    </p>
+
+    <p>
+      <!-- operator.\u223F.infix = lspace:3 rspace:3 # sine wave -->
+      <math>
+        <mtext>_</mtext>
+        <mspace width="0.16666666666666666em" height="0" depth="0"></mspace>
+        <mtext>&#x0223F;</mtext>
+        <mspace width="0.16666666666666666em" height="0" depth="0"></mspace>
+        <mtext>_</mtext>
+      </math>
+    </p>
+
+    <p>
+      <!-- Invisible operator -->
+      <math>
+        <mtext>_</mtext>
+        <mtext>&#x02061;</mtext>
+        <mtext>_</mtext>
+      </math>
+    </p>
+
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/mathml/presentation-markup/operators/mo-lspace-rspace.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/mathml/presentation-markup/operators/mo-lspace-rspace.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>mo-lspace-rspace</title>
+    <link rel="match" href="../../../../../expected/wpt-import/mathml/presentation-markup/operators/mo-lspace-rspace-ref.html">
+  </head>
+
+  <body>
+
+    <p>
+      <!-- not in the operator dictionary -->
+      <math>
+        <mtext>_</mtext>
+        <mo>MO</mo>
+        <mtext>_</mtext>
+      </math>
+    </p>
+
+    <p>
+      <!-- operator.\u223F.infix = lspace:3 rspace:3 # sine wave -->
+      <math>
+        <mtext>_</mtext>
+        <mo>&#x0223F;</mo>
+        <mtext>_</mtext>
+      </math>
+    </p>
+
+    <p>
+      <!-- Invisible operator -->
+      <math>
+        <mtext>_</mtext>
+        <mo>&#x02061;</mo>
+        <mtext>_</mtext>
+      </math>
+    </p>
+
+  </body>
+</html>


### PR DESCRIPTION
The height and depth attributes are parsed individually and then combined into a `calc()` expression. Bare zero is valid as a standalone CSS length but inside `calc()` it is typed as a number, so `calc(0 + 0)` fails to parse as a length. We now check the parsed value is valid to avoid a crash.

Fixes the imported WPT test.