### PR TITLE
LibGfx+LibRegex: Prevent double hashing of values

### DIFF
--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -50,9 +50,9 @@ struct FontCacheKey {
 
     unsigned hash() const
     {
-        auto h = pair_int_hash(u32_hash(bit_cast<u32>(point_size)), axes.size());
+        auto h = pair_int_hash(bit_cast<u32>(point_size), axes.size());
         for (auto const& axis : axes)
-            h = pair_int_hash(h, pair_int_hash(axis.tag.to_u32(), u32_hash(bit_cast<u32>(axis.value))));
+            h = pair_int_hash(h, pair_int_hash(axis.tag.to_u32(), bit_cast<u32>(axis.value)));
         h = pair_int_hash(h, Traits<Gfx::ShapeFeatures>::hash(shape_features));
         return h;
     }

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -721,6 +721,6 @@ template<typename Parser>
 struct AK::Traits<regex::CacheKey<Parser>> : public AK::DefaultTraits<regex::CacheKey<Parser>> {
     static unsigned hash(regex::CacheKey<Parser> const& key)
     {
-        return pair_int_hash(key.pattern.hash(), u32_hash(to_underlying(key.options.value())));
+        return pair_int_hash(key.pattern.hash(), to_underlying(key.options.value()));
     }
 };


### PR DESCRIPTION
We had three instances of `pair_int_hash()` being called with a value that was pulled through `u32_hash()`, which is not necessary - both arguments to `pair_int_hash()` will be properly hashed.