### PR TITLE
LibCore: Add Core::System::fsync()

### DIFF
--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -327,6 +327,13 @@ ErrorOr<void> fchmod(int fd, mode_t mode)
     return {};
 }
 
+ErrorOr<void> fsync(int fd)
+{
+    if (::fsync(fd) < 0)
+        return Error::from_syscall("fsync"sv, errno);
+    return {};
+}
+
 ErrorOr<void> fchown(int fd, uid_t uid, gid_t gid)
 {
     if (::fchown(fd, uid, gid) < 0)

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -103,6 +103,7 @@ ErrorOr<void> chdir(StringView path);
 ErrorOr<void> rmdir(StringView path);
 ErrorOr<int> mkstemp(Span<char> pattern);
 ErrorOr<void> fchmod(int fd, mode_t mode);
+ErrorOr<void> fsync(int fd);
 ErrorOr<void> rename(StringView old_path, StringView new_path);
 ErrorOr<void> unlink(StringView path);
 ErrorOr<void> utimensat(int fd, StringView path, struct timespec const times[2], int flag);


### PR DESCRIPTION
Add fsync() to LibCore system library for POSIX and with special handling for Windows