### PR TITLE
LibWeb/CSS: Mark CSSStyleSheetInit::baseURL as nullable

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.idl
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.idl
@@ -23,7 +23,7 @@ interface CSSStyleSheet : StyleSheet {
 };
 
 dictionary CSSStyleSheetInit {
-    DOMString baseURL = null;
+    DOMString? baseURL = null;
     (MediaList or DOMString) media = "";
     boolean disabled = false;
 };


### PR DESCRIPTION
Corresponds to: https://github.com/w3c/csswg-drafts/commit/f0635e6e10d8ca1ab5fe2d5afd4de65e5383877a

Assigning null to a non-nullable DOMString didn't make sense. Apparently our bindings generator didn't care though. It's already nullable on the C++ side by being an `Optional<String>`.