### PR TITLE
LibWeb: Expand PaintNestedDisplayList in internals.dumpDisplayList()

### DIFF
--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -10,6 +10,8 @@ SaveLayer@0
     SaveLayer@2
       ApplyEffects@3 opacity=1 has_filter=false
         PaintNestedDisplayList@3 rect=[-2,-2 119x119]
+          Translate@0 delta=[2,2]
+          FillPath@0 path_bounding_rect=[8,8 100x100]
       Restore@3
     Restore@3
   Restore@3
@@ -19,6 +21,8 @@ SaveLayer@0
       FillRect@3 rect=[8,8 100x100] color=rgb(0, 0, 0)
       ApplyEffects@2 opacity=1 has_filter=false
         PaintNestedDisplayList@2 rect=[-2,-2 119x119]
+          Translate@0 delta=[2,2]
+          FillPath@0 path_bounding_rect=[8,8 100x100]
       Restore@2
     Restore@2
   Restore@2


### PR DESCRIPTION
Previously, PaintNestedDisplayList was treated as an opaque command, printing only its name and rect without showing the nested display list's contents. This made it impossible to debug painting issues involving SVG masks/clips, CSS background-clip: text, and iframe content through display list dumps.

Refactor the command dump loop into a recursive lambda that expands nested display lists inline with increased indentation.