### PR TITLE
LibJS: Include AST.h in RustIntegration.h

### DIFF
--- a/Libraries/LibJS/RustIntegration.h
+++ b/Libraries/LibJS/RustIntegration.h
@@ -12,7 +12,7 @@
 #include <AK/Utf16FlyString.h>
 #include <LibGC/Ptr.h>
 #include <LibGC/Root.h>
-#include <LibJS/Forward.h>
+#include <LibJS/AST.h>
 #include <LibJS/ParserError.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/FunctionKind.h>


### PR DESCRIPTION
This was breaking the no-rust build with gcc.