### PR TITLE
LibHTTP: Use `IdentityHashTraits` for `HashMap`s keyed by the cache key

### DIFF
--- a/Libraries/LibHTTP/Cache/CacheIndex.h
+++ b/Libraries/LibHTTP/Cache/CacheIndex.h
@@ -76,7 +76,7 @@ private:
     NonnullRawPtr<Database::Database> m_database;
     Statements m_statements;
 
-    HashMap<u64, Vector<Entry>> m_entries;
+    HashMap<u64, Vector<Entry>, IdentityHashTraits<u64>> m_entries;
 
     Limits m_limits;
 };

--- a/Libraries/LibHTTP/Cache/DiskCache.h
+++ b/Libraries/LibHTTP/Cache/DiskCache.h
@@ -82,8 +82,8 @@ private:
         NonnullOwnPtr<CacheEntry> entry;
         WeakPtr<CacheRequest> request;
     };
-    HashMap<u64, Vector<OpenCacheEntry, 1>> m_open_cache_entries;
-    HashMap<u64, Vector<WeakPtr<CacheRequest>, 1>> m_requests_waiting_completion;
+    HashMap<u64, Vector<OpenCacheEntry, 1>, IdentityHashTraits<u64>> m_open_cache_entries;
+    HashMap<u64, Vector<WeakPtr<CacheRequest>, 1>, IdentityHashTraits<u64>> m_requests_waiting_completion;
 
     LexicalPath m_cache_directory;
     CacheIndex m_index;

--- a/Libraries/LibHTTP/Cache/MemoryCache.h
+++ b/Libraries/LibHTTP/Cache/MemoryCache.h
@@ -40,8 +40,8 @@ public:
     void finalize_entry(URL::URL const&, StringView method, HeaderList const& request_headers, u32 status_code, HeaderList const& response_headers, ByteBuffer response_body);
 
 private:
-    HashMap<u64, Vector<Entry>> m_pending_entries;
-    HashMap<u64, Vector<Entry>> m_complete_entries;
+    HashMap<u64, Vector<Entry>, IdentityHashTraits<u64>> m_pending_entries;
+    HashMap<u64, Vector<Entry>, IdentityHashTraits<u64>> m_complete_entries;
 };
 
 }


### PR DESCRIPTION
The cache key itself is already an integral export of a SHA-1 hash of some request fields. We don't need to hash it again for these maps.