### PR TITLE
LibWeb: Track deleted state on IndexedDb `Index` and `ObjectStore`

### DIFF
--- a/Libraries/LibWeb/IndexedDB/IDBCursor.h
+++ b/Libraries/LibWeb/IndexedDB/IDBCursor.h
@@ -53,6 +53,8 @@ public:
     WebIDL::ExceptionOr<GC::Ref<IDBRequest>> update(JS::Value);
     WebIDL::ExceptionOr<GC::Ref<IDBRequest>> delete_();
 
+    [[nodiscard]] bool is_source_or_object_store_deleted() const;
+
     [[nodiscard]] GC::Ref<IDBKeyRange> range() { return m_range; }
     [[nodiscard]] GC::Ptr<Key> position() { return m_position; }
     [[nodiscard]] GC::Ptr<Key> object_store_position() { return m_object_store_position; }

--- a/Libraries/LibWeb/IndexedDB/IDBDatabase.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBDatabase.cpp
@@ -188,6 +188,11 @@ WebIDL::ExceptionOr<void> IDBDatabase::delete_object_store(String const& name)
 
     // FIXME: 6. If there is an object store handle associated with store and transaction, remove all entries from its index set.
 
+    // AD-HOC: Mark the store and its indexes as deleted so that stale handles throw InvalidStateError.
+    store->set_deleted(true);
+    for (auto const& [_, index] : store->index_set())
+        index->set_deleted(true);
+
     // 7. Destroy store.
     database->remove_object_store(*store);
 

--- a/Libraries/LibWeb/IndexedDB/IDBIndex.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBIndex.cpp
@@ -66,7 +66,9 @@ WebIDL::ExceptionOr<void> IDBIndex::set_name(String const& value)
     if (!transaction->is_active())
         return WebIDL::TransactionInactiveError::create(realm, "Transaction is not active while updating index name"_utf16);
 
-    // FIXME: 6. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 6. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or its object store has been deleted"_utf16);
 
     // 7. If index’s name is equal to name, terminate these steps.
     if (index->name() == name)
@@ -112,9 +114,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_cursor(JS::Value query, 
     auto transaction = this->transaction();
 
     // 2. Let index be this’s index.
-    [[maybe_unused]] auto index = this->index();
+    auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or its object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -152,7 +156,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::get(JS::Value query)
     // 2. Let index be this’s index.
     auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or its object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -183,7 +189,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::get_key(JS::Value query)
     // 2. Let index be this’s index.
     auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or its object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -230,7 +238,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::count(JS::Value query)
     // 2. Let index be this’s index.
     auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or its object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -259,9 +269,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBIndex::open_key_cursor(JS::Value que
     auto transaction = this->transaction();
 
     // 2. Let index be this’s index.
-    [[maybe_unused]] auto index = this->index();
+    auto index = this->index();
 
-    // FIXME: 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+    if (index->is_deleted() || index->object_store()->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Index or its object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())

--- a/Libraries/LibWeb/IndexedDB/IDBObjectStore.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBObjectStore.cpp
@@ -73,7 +73,9 @@ WebIDL::ExceptionOr<void> IDBObjectStore::set_name(String const& value)
     // 3. Let store be this’s object store.
     auto& store = m_store;
 
-    // FIXME: 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 5. If transaction is not an upgrade transaction, throw an "InvalidStateError" DOMException.
     if (!transaction->is_upgrade_transaction())
@@ -158,7 +160,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBIndex>> IDBObjectStore::create_index(String const
     if (!transaction->is_upgrade_transaction())
         return WebIDL::InvalidStateError::create(realm, "Transaction is not an upgrade transaction"_utf16);
 
-    // FIXME: 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 5. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -200,9 +204,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBIndex>> IDBObjectStore::index(String const& name)
     auto transaction = this->transaction();
 
     // 2. Let store be this’s object store.
-    [[maybe_unused]] auto store = this->store();
+    auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm(), "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is finished, then throw an "InvalidStateError" DOMException.
     if (transaction->state() == IDBTransaction::TransactionState::Finished)
@@ -232,7 +238,9 @@ WebIDL::ExceptionOr<void> IDBObjectStore::delete_index(String const& name)
     if (!transaction->is_upgrade_transaction())
         return WebIDL::InvalidStateError::create(realm, "Transaction is not an upgrade transaction"_utf16);
 
-    // FIXME: 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 5. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -245,6 +253,9 @@ WebIDL::ExceptionOr<void> IDBObjectStore::delete_index(String const& name)
 
     // 7. Remove index from this’s index set.
     m_indexes.remove(name);
+
+    // AD-HOC: Mark the index as deleted so that stale handles throw InvalidStateError.
+    index.value()->set_deleted(true);
 
     // 8. Destroy index.
     store->index_set().remove(name);
@@ -263,7 +274,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::add_or_put(GC::Ref<IDBO
     // 2. Let store be handle’s object store.
     auto& store = *handle->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store.is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -372,7 +385,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::count(Optional<JS::Valu
     // 2. Let store be this's object store.
     auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -403,7 +418,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::get(JS::Value query)
     // 2. Let store be this's object store.
     auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -431,10 +448,12 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::open_cursor(JS::Value q
     // 1. Let transaction be this's transaction.
     auto transaction = this->transaction();
 
-    // 2. Let store be this's object store.
-    [[maybe_unused]] auto store = this->store();
+    // 2. Let store be this’s object store.
+    auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -474,7 +493,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::delete_(JS::Value query
     // 2. Let store be this’s object store.
     auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -509,7 +530,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::clear()
     // 2. Let store be this’s object store.
     auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -541,7 +564,9 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::get_key(JS::Value query
     // 2. Let store be this’s object store.
     auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())
@@ -578,9 +603,11 @@ WebIDL::ExceptionOr<GC::Ref<IDBRequest>> IDBObjectStore::open_key_cursor(JS::Val
     auto transaction = this->transaction();
 
     // 2. Let store be this’s object store.
-    [[maybe_unused]] auto store = this->store();
+    auto store = this->store();
 
-    // FIXME: 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    // 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+    if (store->is_deleted())
+        return WebIDL::InvalidStateError::create(realm, "Object store has been deleted"_utf16);
 
     // 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
     if (!transaction->is_active())

--- a/Libraries/LibWeb/IndexedDB/Internal/Index.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Index.h
@@ -34,6 +34,9 @@ public:
     [[nodiscard]] AK::ReadonlySpan<IndexRecord> records() const { return m_records; }
     [[nodiscard]] KeyPath const& key_path() const { return m_key_path; }
 
+    [[nodiscard]] bool is_deleted() const { return m_deleted; }
+    void set_deleted(bool deleted) { m_deleted = deleted; }
+
     [[nodiscard]] bool has_record_with_key(GC::Ref<Key> key);
     void clear_records();
     Optional<IndexRecord&> first_in_range(GC::Ref<IDBKeyRange> range);
@@ -68,6 +71,8 @@ private:
 
     // The keys are derived from the referenced object store’s values using a key path.
     KeyPath m_key_path;
+
+    bool m_deleted { false };
 };
 
 }

--- a/Libraries/LibWeb/IndexedDB/Internal/ObjectStore.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/ObjectStore.h
@@ -42,6 +42,9 @@ public:
     bool uses_a_key_generator() const { return m_key_generator.has_value(); }
     AK::HashMap<String, GC::Ref<Index>>& index_set() { return m_indexes; }
 
+    [[nodiscard]] bool is_deleted() const { return m_deleted; }
+    void set_deleted(bool deleted) { m_deleted = deleted; }
+
     GC::Ref<Database> database() const { return m_database; }
     ReadonlySpan<ObjectStoreRecord> records() const { return m_records; }
 
@@ -77,6 +80,8 @@ private:
 
     // An object store has a list of records
     Vector<ObjectStoreRecord> m_records;
+
+    bool m_deleted { false };
 };
 
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbindex-query-exception-order.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbindex-query-exception-order.any.txt
@@ -2,17 +2,16 @@ Harness status: OK
 
 Found 12 tests
 
-6 Pass
-6 Fail
-Fail	IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError
+12 Pass
+Pass	IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBIndex.get exception order: TransactionInactiveError vs. DataError
-Fail	IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBIndex.getAll exception order: TransactionInactiveError vs. DataError
-Fail	IDBIndex.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBIndex.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError
-Fail	IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBIndex.count exception order: TransactionInactiveError vs. DataError
-Fail	IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBIndex.openCursor exception order: TransactionInactiveError vs. DataError
-Fail	IDBIndex.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBIndex.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBIndex.openKeyCursor exception order: TransactionInactiveError vs. DataError

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbindex-rename-errors.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbindex-rename-errors.any.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	IndexedDB deleted index rename throws
+Pass	IndexedDB index rename throws in a readonly transaction
+Pass	IndexedDB index rename throws in a readwrite transaction
+Pass	IndexedDB index rename throws in an inactive transaction
+Pass	IndexedDB index rename to the name of another index throws
+Pass	IndexedDB index rename handles exceptions when stringifying names

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbobjectstore-add-put-exception-order.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbobjectstore-add-put-exception-order.any.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-4 Pass
-2 Fail
-Fail	IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError
+6 Pass
+Pass	IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError
 Pass	IDBObjectStore.put exception order: ReadOnlyError vs. DataError
-Fail	IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError
 Pass	IDBObjectStore.add exception order: ReadOnlyError vs. DataError

--- a/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbobjectstore-query-exception-order.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/IndexedDB/idbobjectstore-query-exception-order.any.txt
@@ -2,17 +2,16 @@ Harness status: OK
 
 Found 12 tests
 
-6 Pass
-6 Fail
-Fail	IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError
+12 Pass
+Pass	IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.get exception order: TransactionInactiveError vs. DataError
-Fail	IDBObjectStore.getAll exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBObjectStore.getAll exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.getAll exception order: TransactionInactiveError vs. DataError
-Fail	IDBObjectStore.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBObjectStore.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.getAllKeys exception order: TransactionInactiveError vs. DataError
-Fail	IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.count exception order: TransactionInactiveError vs. DataError
-Fail	IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.openCursor exception order: TransactionInactiveError vs. DataError
-Fail	IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError
+Pass	IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError
 Pass	IDBObjectStore.openKeyCursor exception order: TransactionInactiveError vs. DataError

--- a/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbindex-rename-errors.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbindex-rename-errors.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: index renaming error handling</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/support-promises.js"></script>
+<div id=log></div>
+<script src="../IndexedDB/idbindex-rename-errors.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbindex-rename-errors.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/IndexedDB/idbindex-rename-errors.any.js
@@ -1,0 +1,154 @@
+// META: title=IndexedDB: index renaming error handling
+// META: global=window,worker
+// META: script=resources/support-promises.js
+
+// Spec: "https://w3c.github.io/IndexedDB/#dom-idbindex-name"
+
+'use strict';
+
+promise_test(testCase => {
+  return createDatabase(
+             testCase,
+             (database, transaction) => {
+               createBooksStore(testCase, database);
+             })
+      .then(database => {
+        database.close();
+      })
+      .then(
+          () => migrateDatabase(
+              testCase, 2,
+              (database, transaction) => {
+                const store = transaction.objectStore('books');
+                const index = store.index('by_author');
+                store.deleteIndex('by_author');
+                assert_throws_dom(
+                    'InvalidStateError',
+                    () => index.name = 'renamed_by_author');
+              }))
+      .then(database => database.close());
+}, 'IndexedDB deleted index rename throws');
+
+promise_test(testCase => {
+  return createDatabase(testCase, (database, transaction) => {
+           createBooksStore(testCase, database);
+         }).then(database => {
+    const transaction = database.transaction('books', 'readonly');
+    const store = transaction.objectStore('books');
+    const index = store.index('by_author');
+
+    assert_throws_dom(
+        'InvalidStateError', () => index.name = 'renamed_by_author');
+    database.close();
+  });
+}, 'IndexedDB index rename throws in a readonly transaction');
+
+promise_test(testCase => {
+  return createDatabase(testCase, (database, transaction) => {
+           createBooksStore(testCase, database);
+         }).then(database => {
+    const transaction = database.transaction('books', 'readwrite');
+    const store = transaction.objectStore('books');
+    const index = store.index('by_author');
+
+    assert_throws_dom(
+        'InvalidStateError', () => index.name = 'renamed_by_author');
+    database.close();
+  });
+}, 'IndexedDB index rename throws in a readwrite transaction');
+
+promise_test(testCase => {
+  let authorIndex = null;
+  return createDatabase(testCase, (database, transaction) => {
+           const store = createBooksStore(testCase, database);
+           authorIndex = store.index('by_author');
+         }).then(database => {
+    assert_throws_dom(
+        'TransactionInactiveError',
+        () => authorIndex.name = 'renamed_by_author');
+    database.close();
+  });
+}, 'IndexedDB index rename throws in an inactive transaction');
+
+promise_test(testCase => {
+  return createDatabase(
+             testCase,
+             (database, transaction) => {
+               createBooksStore(testCase, database);
+             })
+      .then(database => {
+        database.close();
+      })
+      .then(
+          () => migrateDatabase(
+              testCase, 2,
+              (database, transaction) => {
+                const store = transaction.objectStore('books');
+                const index = store.index('by_author');
+
+                assert_throws_dom(
+                    'ConstraintError', () => index.name = 'by_title');
+                assert_array_equals(
+                    store.indexNames, ['by_author', 'by_title'],
+                    'An index rename that throws an exception should not change the ' +
+                        'index\'s IDBObjectStore.indexNames');
+              }))
+      .then(database => {
+        const transaction = database.transaction('books', 'readonly');
+        const store = transaction.objectStore('books');
+        assert_array_equals(
+            store.indexNames, ['by_author', 'by_title'],
+            'Committing a transaction with a failed store rename attempt ' +
+                'should not change the index\'s IDBObjectStore.indexNames');
+        const index = store.index('by_author');
+        return checkAuthorIndexContents(
+                   testCase, index,
+                   'Committing a transaction with a failed rename attempt should ' +
+                       'not change the index\'s contents')
+            .then(() => database.close());
+      });
+}, 'IndexedDB index rename to the name of another index throws');
+
+promise_test(testCase => {
+  return createDatabase(
+             testCase,
+             (database, transaction) => {
+               createBooksStore(testCase, database);
+             })
+      .then(database => {
+        database.close();
+      })
+      .then(
+          () => migrateDatabase(
+              testCase, 2,
+              (database, transaction) => {
+                const store = transaction.objectStore('books');
+                const index = store.index('by_author');
+                const exception = {name: 'Custom stringifying error'};
+                assert_throws_exactly(exception, () => {
+                  index.name = {
+                    toString: () => {
+                      throw exception;
+                    }
+                  };
+                }, 'IDBObjectStore rename should re-raise toString() exception');
+                assert_array_equals(
+                    store.indexNames, ['by_author', 'by_title'],
+                    'An index rename that throws an exception should not change the ' +
+                        'index\'s IDBObjectStore.indexNames');
+              }))
+      .then(database => {
+        const transaction = database.transaction('books', 'readonly');
+        const store = transaction.objectStore('books');
+        assert_array_equals(
+            store.indexNames, ['by_author', 'by_title'],
+            'Committing a transaction with a failed store rename attempt ' +
+                'should not change the index\'s IDBObjectStore.indexNames');
+        const index = store.index('by_author');
+        return checkAuthorIndexContents(
+                   testCase, index,
+                   'Committing a transaction with a failed rename attempt should ' +
+                       'not change the index\'s contents')
+            .then(() => database.close());
+      });
+}, 'IndexedDB index rename handles exceptions when stringifying names');


### PR DESCRIPTION
An `InvalidStateError` is now thrown when an attempt is made to interact with an index or object store that has been deleted.

Fixes a crash in https://wpt.live/IndexedDB/idbindex-rename-errors.any.html

Gains us +133 `IndexedDB` WPT passes