### PR TITLE
LibWeb: Remove redundant flush() in DisplayListPlayer::execute_impl()

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -259,8 +259,6 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
         restore({});
         applied_depth--;
     }
-
-    flush();
 }
 
 }


### PR DESCRIPTION
The flush() call at the end of execute_impl() was accidentally left behind in 2d2af9cd3b. That commit moved flushing into execute(), but didn't remove the old call from execute_impl(). This caused every nested display list to trigger a redundant GPU flush.

On an M4 MacBook, this improves Discord from ~65 FPS to 120 FPS.