### PR TITLE
LibJS: Memoize failed arrow function attempts in Rust parser

### DIFF
--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -284,6 +284,12 @@ pub struct Parser<'a> {
 
     /// Side table owning all FunctionData produced during parsing.
     pub function_table: FunctionTable,
+
+    /// Memoization: offsets where arrow function parsing has already failed.
+    /// Prevents exponential re-processing of nested expressions like
+    /// `(a=(b=(c=0)))` where each failed arrow attempt would otherwise
+    /// re-attempt inner positions during grouping expression re-parse.
+    arrow_function_failed_positions: HashSet<usize>,
 }
 
 impl<'a> Parser<'a> {
@@ -329,6 +335,7 @@ impl<'a> Parser<'a> {
             scope_collector: ScopeCollector::new(),
             exported_names: HashSet::new(),
             function_table: FunctionTable::new(),
+            arrow_function_failed_positions: HashSet::new(),
         }
     }
 

--- a/Tests/LibJS/AST/expected/nested-paren-expressions.txt
+++ b/Tests/LibJS/AST/expected/nested-paren-expressions.txt
@@ -1,0 +1,35 @@
+Program (script) @5:1
+├─ VariableDeclaration (var) @5:1
+│  └─ VariableDeclarator @5:1
+│     ├─ Identifier "x" [global] (var) @5:5
+│     └─ AssignmentExpression (=) @5:12
+│        ├─ Identifier "a" [global] @5:10
+│        └─ AssignmentExpression (=) @5:17
+│           ├─ Identifier "b" [global] @5:15
+│           └─ AssignmentExpression (=) @5:22
+│              ├─ Identifier "c" [global] @5:20
+│              └─ AssignmentExpression (=) @5:27
+│                 ├─ Identifier "d" [global] @5:25
+│                 └─ AssignmentExpression (=) @5:32
+│                    ├─ Identifier "e" [global] @5:30
+│                    └─ AssignmentExpression (=) @5:37
+│                       ├─ Identifier "f" [global] @5:35
+│                       └─ AssignmentExpression (=) @5:42
+│                          ├─ Identifier "g" [global] @5:40
+│                          └─ AssignmentExpression (=) @5:47
+│                             ├─ Identifier "h" [global] @5:45
+│                             └─ NumericLiteral 0 @5:49
+└─ VariableDeclaration (var) @6:1
+   └─ VariableDeclarator @6:1
+      ├─ Identifier "y" [global] (var) @6:5
+      └─ AssignmentExpression (=) @6:12
+         ├─ Identifier "a" [global] @6:10
+         └─ ArrayExpression @6:14
+            ├─ Identifier "b" [global] @6:15
+            └─ AssignmentExpression (=) @6:21
+               ├─ Identifier "c" [global] @6:19
+               └─ ArrayExpression @6:23
+                  ├─ Identifier "d" [global] @6:24
+                  └─ AssignmentExpression (=) @6:30
+                     ├─ Identifier "e" [global] @6:28
+                     └─ NumericLiteral 0 @6:32

--- a/Tests/LibJS/AST/input/nested-paren-expressions.js
+++ b/Tests/LibJS/AST/input/nested-paren-expressions.js
@@ -1,0 +1,6 @@
+// Deeply nested parenthesized expressions where each level looks like it
+// could be an arrow function parameter with a default value.
+// Without memoization of failed arrow function attempts, the parser would
+// do exponential work re-attempting arrow parsing at the same positions.
+var x = (a = (b = (c = (d = (e = (f = (g = (h = 0))))))));
+var y = (a = [b, (c = [d, (e = 0)])]);


### PR DESCRIPTION
Cache failed arrow function attempts by token offset. Once we determine that '(' at offset N is not the start of an arrow function, skip re-attempting at the same offset.

Without memoization, nested expressions like `(a=(b=(c=(d=0))))` cause exponential work: each failed arrow attempt at an outer `(` re-parses all inner `(` positions during grouping expression re-parse, and each inner position triggers its own arrow attempts. With n nesting levels, the innermost position is processed O(2^n) times.

The C++ parser already has this optimization (via the `try_parse_arrow_function_expression_failed_at_position()` memoization cache).