### PR TITLE
LibWeb: Paint SVG-in-img with a nested display list

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -44,6 +44,7 @@ private:
 
     RefPtr<Gfx::PaintingSurface> surface(size_t frame_index, Gfx::IntSize) const;
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
+    RefPtr<Painting::DisplayList> record_display_list(Gfx::IntSize) const;
 
     // FIXME: Remove this once everything is using surfaces instead.
     mutable HashMap<Gfx::IntSize, NonnullRefPtr<Gfx::ImmutableBitmap>> m_cached_rendered_bitmaps;

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -1,0 +1,27 @@
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=0 (ImagePaintable(ImageBox<IMG>))
+
+DisplayList:
+SaveLayer@0
+  Save@1
+    AddClipRect@1 rect=[8,13 300x200]
+    PaintNestedDisplayList@1 rect=[8,13 300x200]
+      SaveLayer@0
+        FillPath@1 path_bounding_rect=[5,0 55x56]
+        FillPath@1 path_bounding_rect=[1,50 55x55]
+        Save@1
+          AddClipRect@1 rect=[0,0 300x200]
+          SaveLayer@1
+            FillPath@1 path_bounding_rect=[5,0 55x56]
+            FillPath@1 path_bounding_rect=[1,50 55x55]
+            ApplyEffects@1 opacity=1 has_filter=false
+              PaintNestedDisplayList@1 rect=[0,0 300x200]
+                Translate@0 delta=[0,0]
+                FillPath@0 path_bounding_rect=[4,10 55x56]
+            Restore@1
+          Restore@1
+        Restore@1
+      Restore@0
+  Restore@1
+Restore@0
+

--- a/Tests/LibWeb/Text/input/display_list/svg-in-img-is-nested.html
+++ b/Tests/LibWeb/Text/input/display_list/svg-in-img-is-nested.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        const svgImg = document.createElement("img");
+        svgImg.onload = () => {
+            println(internals.dumpDisplayList());
+            done();
+        };
+        document.body.appendChild(svgImg);
+        svgImg.src = "data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHdpZHRoPSIzMDAiIGhlaWdodD0iMjAwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogICAgPGcgaWQ9InJvb3QiIHRyYW5zZm9ybT0ic2NhbGUoLjUgLjUpIj4KICAgICAgICA8ZyBpZD0ibWFza0NvbnRhaW5lciIgdHJhbnNmb3JtPSJzY2FsZSguNSAyKSI+CiAgICAgICAgICAgIDxjbGlwUGF0aCBpZD0ibWFza0dyb3VwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLDIwKSI+CiAgICAgICAgICAgICAgICA8cGF0aCBpZD0ibWFza1BhdGgiIGQ9Ik0wIDBoMTAwdjEwMEgweiIgLz4KICAgICAgICAgICAgPC9jbGlwUGF0aD4KICAgICAgICA8L2c+CiAgICAgICAgPGcgaWQ9InRhcmdldENvbnRhaW5lciIgdHJhbnNmb3JtPSJyb3RhdGUoNSkiPgogICAgICAgICAgICA8ZyB0cmFuc2Zvcm09InRyYW5zbGF0ZSgyMCwwKSI+CiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMCAwaDEwMHYxMDBIMHoiIHN0eWxlPSJmaWxsOnJlZCIgLz4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0wIDEwMGgxMDB2MTAwSDB6IiBzdHlsZT0iZmlsbDpyZWQiIC8+CiAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgPGcgaWQ9InRhcmdldEdyb3VwIiBjbGlwLXBhdGg9InVybCgjbWFza0dyb3VwKSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMjAsMCkiPgogICAgICAgICAgICAgICAgPHBhdGggaWQ9InRhcmdldFBhdGgxIiBkPSJNMCAwaDEwMHYxMDBIMHoiIHN0eWxlPSJmaWxsOmdyZWVuIiAvPgogICAgICAgICAgICAgICAgPHBhdGggaWQ9InRhcmdldFBhdGgyIiBkPSJNMCAxMDBoMTAwdjEwMEgweiIgc3R5bGU9ImZpbGw6Ymx1ZSIgLz4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+Cg==";
+    });
+</script>


### PR DESCRIPTION
This makes SVG-in-img appear sharp no matter the current (pinch-to-)zoom level.

Before:
<img width="1624" height="1000" alt="Screenshot 2026-02-24 at 16 12 38" src="https://github.com/user-attachments/assets/be7bf3ed-b8fc-4752-9ef1-a7cbfc66220d" />

After:
<img width="1624" height="1000" alt="Screenshot 2026-02-24 at 16 10 49" src="https://github.com/user-attachments/assets/2a3f3050-9103-4a2d-a5e6-43db00daeacb" />
