### PR TITLE
CI: Switch back to Linux for code linting

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'LLVM version to install'
     required: false
     default: '21'
+  type:
+    description: 'Whether the setup is for building or linting'
+    required: false
+    default: 'build'
 
 outputs:
   gcc_version:
@@ -43,9 +47,14 @@ runs:
       shell: bash
       run: |
         python3 -m pip install --upgrade pip
-        pip install pyyaml requests six
 
-    - name: 'Install Dependencies'
+        if ${{ inputs.type == 'build' }} ; then
+          pip3 install pyyaml requests six
+        else
+          pip3 install ruff
+        fi
+
+    - name: Install apt repositories
       if: ${{ inputs.os == 'Linux' }}
       shell: bash
       run: |
@@ -64,6 +73,13 @@ runs:
         fi
 
         sudo apt-get update -y
+
+    - name: Install Dependencies
+      if: ${{ inputs.os == 'Linux' && inputs.type == 'build' }}
+      shell: bash
+      run: |
+        set -e
+
         sudo apt-get install -y \
             autoconf \
             autoconf-archive \
@@ -105,6 +121,22 @@ runs:
         sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-${{ inputs.llvm_version }} 100
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc_version }} 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc_version }} 100
+
+    - name: Install Dependencies
+      if: ${{ inputs.os == 'Linux' && inputs.type == 'lint' }}
+      shell: bash
+      run: |
+        set -e
+
+        sudo apt-get install -y \
+            clang-format-${{ inputs.llvm_version }} \
+            generate-ninja \
+            optipng \
+            shellcheck
+
+        sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${{ inputs.llvm_version }} 100
+
+        sudo npm install -g prettier@3.8.1
 
     - name: Ensure clang-cl is available
       if: ${{ inputs.os == 'Windows' && inputs.toolchain == 'ClangCL' }}
@@ -153,6 +185,7 @@ runs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: 'Install wasm-tools'
+      if: ${{ inputs.type == 'build' }}
       shell: bash
       run: |
         VERSION=1.243.0
@@ -190,6 +223,7 @@ runs:
           core.exportVariable('VCPKG_FORCE_SYSTEM_BINARIES', '1')
 
     - name: 'Install vcpkg'
+      if: ${{ inputs.type == 'build' }}
       shell: bash
       run: ./Toolchain/BuildVcpkg.py
 

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -4,34 +4,20 @@ on: [ push, pull_request ]
 
 jobs:
   lint:
-    runs-on: macos-14
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
 
     steps:
       - uses: actions/checkout@v6.0.2
 
       - name: Set Up Environment
-        shell: bash
-        run: |
-          set -e
-
-          brew install curl llvm@21 ninja optipng ruff shellcheck unzip
-
-          # Note: gn isn't available in homebrew :(
-          # Corresponds to https://gn.googlesource.com/gn/+/225e90c5025bf74f41dbee60d9cde4512c846fe7
-          curl -L -o gn-mac-arm64.zip "https://chrome-infra-packages.appspot.com/dl/gn/gn/mac-arm64/+/786UV5-XW0Bz6QnRFxKtnzTSVq0ta5AU1KXRJs-ZNwcC"
-          unzip gn-mac-arm64.zip -d ${{ github.workspace }}/bin
-          chmod +x ${{ github.workspace }}/bin/gn
-          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-          echo -n "gn version: "
-          ${{ github.workspace}}/bin/gn --version
-
-      - name: Install JS Dependencies
-        shell: bash
-        run: npm install -g prettier@3.8.1
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: ./.github/actions/setup
+        id: 'setup'
+        with:
+          os: 'Linux'
+          arch: 'x86_64'
+          llvm_version: 21
+          type: 'lint'
 
       - name: Lint
         run: ${{ github.workspace }}/Meta/lint-ci.sh


### PR DESCRIPTION
We switched to macOS since it was easier to install swift-format in CI. With that removed, let's switch back to Linux, as macOS runners tend to have higher contention.

To do so, this makes more use of the setup action. This way, the setup action is the only place that needs to know how to install the apt repos we need (LLVM in particular).