### PR TITLE
LibJS: Two Rust pipeline fixes

### DIFF
--- a/Libraries/LibJS/SourceCode.cpp
+++ b/Libraries/LibJS/SourceCode.cpp
@@ -25,6 +25,20 @@ SourceCode::SourceCode(String filename, Utf16String code)
 {
 }
 
+u16 const* SourceCode::utf16_data() const
+{
+    if (!m_code_view.has_ascii_storage())
+        return reinterpret_cast<u16 const*>(m_code_view.utf16_span().data());
+
+    if (m_utf16_data_cache.is_empty() && m_length_in_code_units > 0) {
+        auto ascii = m_code_view.ascii_span();
+        m_utf16_data_cache.ensure_capacity(m_length_in_code_units);
+        for (size_t i = 0; i < m_length_in_code_units; ++i)
+            m_utf16_data_cache.unchecked_append(static_cast<u16>(ascii[i]));
+    }
+    return m_utf16_data_cache.data();
+}
+
 void SourceCode::fill_position_cache() const
 {
     constexpr size_t predicted_minimum_cached_positions = 8;

--- a/Libraries/LibJS/SourceCode.h
+++ b/Libraries/LibJS/SourceCode.h
@@ -24,6 +24,8 @@ public:
     Utf16View const& code_view() const { return m_code_view; }
     size_t length_in_code_units() const { return m_length_in_code_units; }
 
+    u16 const* utf16_data() const;
+
     SourceRange range_from_offsets(u32 start_offset, u32 end_offset) const;
 
 private:
@@ -39,6 +41,10 @@ private:
     // line:column they map to. This can then be binary-searched.
     void fill_position_cache() const;
     Vector<Position> mutable m_cached_positions;
+
+    // Cached UTF-16 widening of ASCII source data, lazily populated by
+    // utf16_data() for use by the Rust compilation pipeline.
+    Vector<u16> mutable m_utf16_data_cache;
 };
 
 }


### PR DESCRIPTION
Fixing two mistakes:

1. We were not suppressing GC while parsing modules or built-in functions. This meant that objects allocated in the process could potentially be unrooted and get garbage-collected.
2. For all-ASCII scripts, we were re-converting to UTF-16 every single time a function was lazily compiled. This caused huge slowdown on content with large scripts.