### PR TITLE
LibWeb: Update layout before accessing paintables in viewport scroll

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -109,6 +109,7 @@ enum class InvalidateLayoutTreeReason {
     X(HTMLInputElementWidth)               \
     X(InternalsHitTest)                    \
     X(MediaQueryListMatches)               \
+    X(NavigableViewportScroll)             \
     X(NodeNameOrDescription)               \
     X(RangeGetClientRects)                 \
     X(ResolvedCSSStyleDeclarationProperty) \

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2943,6 +2943,9 @@ GC::Ref<WebIDL::Promise> Navigable::perform_a_scroll_of_the_viewport(CSSPixelPoi
     //     Promise returned from this step.
     TemporaryExecutionContext temporary_execution_context { doc->realm() };
 
+    // NB: Must update layout before accessing paintables.
+    doc->update_layout(DOM::UpdateLayoutReason::NavigableViewportScroll);
+
     // AD-HOC: Skip scrolling unscrollable boxes.
     if (!doc->paintable_box()->could_be_scrolled_by_wheel_event())
         return WebIDL::create_resolved_promise(doc->realm(), JS::js_undefined());

--- a/Tests/LibWeb/Text/expected/viewport-scroll-after-layout-tree-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/viewport-scroll-after-layout-tree-invalidation.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/viewport-scroll-after-layout-tree-invalidation.html
+++ b/Tests/LibWeb/Text/input/viewport-scroll-after-layout-tree-invalidation.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+    div {
+        height: 5000px;
+    }
+</style>
+<div></div>
+<dialog id="d">Hello</dialog>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        // Scroll down first. This triggers update_layout and sets viewport offset.
+        window.scrollTo(0, 100);
+
+        // showModal() adds the dialog to the top layer, which calls
+        // invalidate_layout_tree(), tearing down the paintable tree
+        // (setting m_paintable to null on the Document).
+        d.showModal();
+
+        // Scroll to (0, 0). Window::scroll has an optimization that skips
+        // update_layout when scrolling to (0, 0), but since the viewport is
+        // currently at y=100, it still calls perform_a_scroll_of_the_viewport.
+        // Without the update_layout call inside perform_a_scroll_of_the_viewport,
+        // this would null-deref paintable_box().
+        window.scrollTo(0, 0);
+
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
`perform_a_scroll_of_the_viewport()` accesses `paintable_box()` without
ensuring layout is up to date. This can lead to a null dereference
if the paintable tree was torn down (e.g. by adding a dialog to the top
layer via `showModal()`) between the last layout update and the scroll.

One concrete path: `Window::scroll()` has an optimization that skips
`update_layout` when scrolling to (0, 0), but still calls `perform_a_scroll_of_the_viewport` if the viewport is at a non-zero position.

Fix by adding an update_layout call at the top of `perform_a_scroll_of_the_viewport`.

This fixes a flake I've seen on CI a bunch of times.