### PR TITLE
LibJs/Rust: Add aggressive release target optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,12 @@ members = [
     "Libraries/LibJS/Rust",
 ]
 resolver = "2"
+
+[profile.release]
+panic = "abort"
+
+[profile.distribution]
+inherits = "release"
+incremental = false
+codegen-units = 1
+lto = true


### PR DESCRIPTION
These are:

- changing `lto` to fat (perform optimizations across all crates within the dependency graph), for instance cross crate inlining
- setting `codegen-units` to 1, this reduces parallelism, but enables better optimisations due to larger context
- setting `opt-level` to 3 (all optimizations)
- setting `panic` to abort (Terminate the process upon panic.), this results in us losing the ability to recover from panics

Since release builds use some optimisations by default, the impact on build times is a bit higher, but not too high. For general build time info, see [Rust compiler performance](https://perf.rust-lang.org/dashboard.html)

There are a lot more options available, for instance omitting integer overflow checks, see [Profiles](https://doc.rust-lang.org/cargo/reference/profiles.html).