### PR TITLE
LibWeb: Use margin box for vertical overlap checks in float placement

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1082,7 +1082,7 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
 
     if ((!m_left_floats.current_boxes.is_empty() || !m_right_floats.current_boxes.is_empty())
         && box_should_avoid_floats_because_it_establishes_fc(child_box)) {
-        auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_state, root());
+        auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
         auto space_and_containing_margin = space_used_and_containing_margin_for_floats(box_in_root_rect.y());
         available_width_within_containing_block -= space_and_containing_margin.left_used_space + space_and_containing_margin.right_used_space;
 
@@ -1178,7 +1178,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
                 offset_from_edge = box_state.content_width() + box_state.margin_box_right();
         };
 
-        auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(box_state, root());
+        auto box_in_root_rect = margin_box_rect_in_ancestor_coordinate_space(box_state, root());
         CSSPixels y_in_root = box_in_root_rect.y();
         CSSPixels y = box_state.offset.y();
 
@@ -1248,7 +1248,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
                     lowest_margin_edge = max(lowest_margin_edge, current_rect.bottom());
                 }
 
-                side_data.y_offset += max<CSSPixels>(0, lowest_margin_edge - y_in_root + box_state.margin_box_top());
+                side_data.y_offset += max<CSSPixels>(0, lowest_margin_edge - y_in_root);
 
                 // Also, forget all previous boxes floated to this side while since they're no longer relevant.
                 side_data.clear();

--- a/Tests/LibWeb/Layout/expected/float-with-padding-top-beside-short-float.txt
+++ b/Tests/LibWeb/Layout/expected/float-with-padding-top-beside-short-float.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 58 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: inline
+      BlockContainer <div.a> at [8,8] floating [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+      BlockContainer <div.b> at [108,48] floating [0+0+0 100 0+0+0] [0+0+40 10 0+0+0] [BFC] children: not-inline
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.a) [8,8 100x20]
+      PaintableWithLines (BlockContainer<DIV>.b) [108,8 100x50]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x58] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/float-with-padding-top-beside-short-float.html
+++ b/Tests/LibWeb/Layout/input/float-with-padding-top-beside-short-float.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+.a {
+    float: left;
+    width: 100px;
+    height: 20px;
+    background: green;
+}
+.b {
+    float: left;
+    width: 100px;
+    height: 10px;
+    padding-top: 40px;
+    background: blue;
+}
+</style>
+<div class="a"></div>
+<div class="b"></div>


### PR DESCRIPTION
Previously, a float with `padding-top` would overlap a preceding float instead of being placed beside it. The vertical overlap check was comparing the new float's content box Y,which includes the padding offset, against preceding floats' margin box rects, causing the check to incorrectly conclude the floats do not overlap.

FIxes #8114