### PR TITLE
LibWeb: Use device-pixel coordinates in display list and AVC

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -100,7 +100,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         painter->clear_rect(bitmap.rect().to_type<float>(), Color::Transparent);
 
         // Paint the cursor into a bitmap.
-        auto display_list = Painting::DisplayList::create(document.page().client().device_pixels_per_css_pixel());
+        auto display_list = Painting::DisplayList::create();
         Painting::DisplayListRecorder display_list_recorder(display_list);
         DisplayListRecordingContext paint_context { display_list_recorder, document.page().palette(), document.page().client().device_pixels_per_css_pixel(), document.page().chrome_metrics() };
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7279,7 +7279,7 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     if (m_cached_display_list && m_cached_display_list_paint_config == config)
         return m_cached_display_list;
 
-    auto display_list = Painting::DisplayList::create(page().client().device_pixels_per_css_pixel());
+    auto display_list = Painting::DisplayList::create();
     Painting::DisplayListRecorder display_list_recorder(display_list);
 
     // https://drafts.csswg.org/css-color-adjust-1/#color-scheme-effect

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1434,10 +1434,10 @@ Vector<CSSPixelRect> Element::get_client_rects() const
         auto absolute_rect = paintable_box->absolute_border_box_rect();
 
         if (auto const& accumulated_visual_context = paintable_box->accumulated_visual_context()) {
-            auto const& viewport_paintable = *document().paintable();
-            auto const& scroll_state = viewport_paintable.scroll_state_snapshot();
-            auto transformed_rect = accumulated_visual_context->transform_rect_to_viewport(absolute_rect, scroll_state);
-            rects.append(transformed_rect);
+            auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
+            auto const& scroll_state = document().paintable()->scroll_state_snapshot();
+            auto result = accumulated_visual_context->transform_rect_to_viewport(absolute_rect.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+            rects.append((result * (1.f / pixel_ratio)).to_type<CSSPixels>());
         } else {
             rects.append(absolute_rect);
         }

--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/Page/AutoScrollHandler.h>
 #include <LibWeb/Page/EventHandler.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 
@@ -49,8 +50,10 @@ static Optional<CSSPixelRect> scrollport_rect_in_viewport(Painting::PaintableBox
     auto const* viewport_paintable = paintable_box.document().paintable();
     if (!viewport_paintable)
         return {};
+    auto pixel_ratio = static_cast<float>(paintable_box.document().page().client().device_pixels_per_css_pixel());
     auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
-    return accumulated_visual_context->transform_rect_to_viewport(scrollport, scroll_state);
+    auto result = accumulated_visual_context->transform_rect_to_viewport(scrollport.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+    return (result * (1.f / pixel_ratio)).to_type<CSSPixels>();
 }
 
 // Returns scroll speed in CSS pixels per second for each axis, based on how far the mouse is past the auto scroll edge.

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -206,8 +206,9 @@ static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting
         visual_context = containing_block->accumulated_visual_context();
     }
     if (visual_context) {
-        auto transformed = visual_context->inverse_transform_point(position);
-        precision_offset = { transformed.x().to_double(), transformed.y().to_double() };
+        auto pixel_ratio = static_cast<float>(paintable.document().page().client().device_pixels_per_css_pixel());
+        auto result = visual_context->inverse_transform_point(position.to_type<float>() * pixel_ratio);
+        precision_offset = result / pixel_ratio;
     }
 
     // relative to the origin of the padding edge of the target node

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -21,7 +21,7 @@ namespace Web::Painting {
 
 static RefPtr<DisplayList> compute_text_clip_paths(DisplayListRecordingContext& context, Paintable const& paintable, CSSPixelPoint containing_block_location)
 {
-    auto text_clip_paths = DisplayList::create(context.device_pixels_per_css_pixel());
+    auto text_clip_paths = DisplayList::create();
     DisplayListRecorder display_list_recorder(*text_clip_paths);
     // Remove containing block offset, so executing the display list will produce mask at (0, 0)
     display_list_recorder.translate(-context.floored_device_point(containing_block_location).to_type<int>());

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -72,9 +72,9 @@ private:
 
 class DisplayList : public AtomicRefCounted<DisplayList> {
 public:
-    static NonnullRefPtr<DisplayList> create(double device_pixels_per_css_pixel)
+    static NonnullRefPtr<DisplayList> create()
     {
-        return adopt_ref(*new DisplayList(device_pixels_per_css_pixel));
+        return adopt_ref(*new DisplayList());
     }
 
     void append(DisplayListCommand&& command, RefPtr<AccumulatedVisualContext const> context);
@@ -86,16 +86,11 @@ public:
 
     auto& commands(Badge<DisplayListRecorder>) { return m_commands; }
     auto const& commands() const { return m_commands; }
-    double device_pixels_per_css_pixel() const { return m_device_pixels_per_css_pixel; }
 
 private:
-    DisplayList(double device_pixels_per_css_pixel)
-        : m_device_pixels_per_css_pixel(device_pixels_per_css_pixel)
-    {
-    }
+    DisplayList() = default;
 
     AK::SegmentedVector<CommandListItem, 512> m_commands;
-    double m_device_pixels_per_css_pixel;
 };
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -269,7 +269,7 @@ struct ApplyBackdropFilter {
     static constexpr StringView command_name = "ApplyBackdropFilter"sv;
 
     Gfx::IntRect backdrop_region;
-    BorderRadiiData border_radii_data;
+    CornerRadii corner_radii;
     Optional<Gfx::Filter> backdrop_filter;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return backdrop_region; }
@@ -344,7 +344,7 @@ struct PaintScrollBar {
     int scroll_frame_id { 0 };
     Gfx::IntRect gutter_rect;
     Gfx::IntRect thumb_rect;
-    CSSPixelFraction scroll_size;
+    double scroll_size;
     Color thumb_color;
     Color track_color;
     bool vertical;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -285,13 +285,13 @@ void DisplayListRecorder::restore()
     APPEND(Restore {});
 }
 
-void DisplayListRecorder::apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, Gfx::Filter const& backdrop_filter)
+void DisplayListRecorder::apply_backdrop_filter(Gfx::IntRect const& backdrop_region, CornerRadii const& corner_radii, Gfx::Filter const& backdrop_filter)
 {
     if (backdrop_region.is_empty())
         return;
     APPEND(ApplyBackdropFilter {
         .backdrop_region = backdrop_region,
-        .border_radii_data = border_radii_data,
+        .corner_radii = corner_radii,
         .backdrop_filter = backdrop_filter,
     });
 }
@@ -349,7 +349,7 @@ void DisplayListRecorder::fill_rect_with_rounded_corners(Gfx::IntRect const& a_r
             { bottom_left_radius, bottom_left_radius } });
 }
 
-void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, CSSPixelFraction scroll_size, Color thumb_color, Color track_color, bool vertical)
+void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical)
 {
     APPEND(PaintScrollBar {
         .scroll_frame_id = scroll_frame_id,

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -106,7 +106,7 @@ public:
     void begin_masks(ReadonlySpan<MaskInfo>);
     void end_masks(ReadonlySpan<MaskInfo>);
 
-    void apply_backdrop_filter(Gfx::IntRect const& backdrop_region, BorderRadiiData const& border_radii_data, Gfx::Filter const& backdrop_filter);
+    void apply_backdrop_filter(Gfx::IntRect const& backdrop_region, CornerRadii const& corner_radii, Gfx::Filter const& backdrop_filter);
 
     void paint_outer_box_shadow(PaintBoxShadowParams params);
     void paint_inner_box_shadow(PaintBoxShadowParams params);
@@ -116,7 +116,7 @@ public:
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int radius);
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
 
-    void paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, CSSPixelFraction scroll_size, Color thumb_color, Color track_color, bool vertical);
+    void paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical);
 
     void apply_effects(float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Gfx::Filter> filter = {}, Optional<Gfx::MaskKind> mask_kind = {});
 

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -75,7 +75,7 @@ static RefPtr<DisplayList> paint_mask_or_clip_to_display_list(
     bool is_clip_path)
 {
     auto mask_rect = context.enclosing_device_rect(area);
-    auto display_list = DisplayList::create(context.device_pixels_per_css_pixel());
+    auto display_list = DisplayList::create();
     DisplayListRecorder display_list_recorder(*display_list);
     display_list_recorder.translate(-mask_rect.location().to_type<int>());
     auto paint_context = context.clone(display_list_recorder);

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -8,12 +8,17 @@
 
 namespace Web::Painting {
 
-ScrollStateSnapshot ScrollStateSnapshot::create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames)
+ScrollStateSnapshot ScrollStateSnapshot::create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames, double device_pixels_per_css_pixel)
 {
     ScrollStateSnapshot snapshot;
-    snapshot.own_offsets.ensure_capacity(scroll_frames.size());
-    for (auto const& scroll_frame : scroll_frames)
-        snapshot.own_offsets.append({ scroll_frame->m_own_offset });
+    auto scale = static_cast<float>(device_pixels_per_css_pixel);
+    snapshot.m_css_offsets.ensure_capacity(scroll_frames.size());
+    snapshot.m_device_offsets.ensure_capacity(scroll_frames.size());
+    for (auto const& scroll_frame : scroll_frames) {
+        auto const& offset = scroll_frame->m_own_offset;
+        snapshot.m_css_offsets.unchecked_append(offset);
+        snapshot.m_device_offsets.unchecked_append(offset.to_type<float>() * scale);
+    }
     return snapshot;
 }
 

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -6,23 +6,27 @@
 
 #pragma once
 
+#include <LibGfx/Point.h>
 #include <LibWeb/Painting/ScrollFrame.h>
 
 namespace Web::Painting {
 
 class ScrollStateSnapshot {
 public:
-    static ScrollStateSnapshot create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames);
+    static ScrollStateSnapshot create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames, double device_pixels_per_css_pixel);
 
-    CSSPixelPoint own_offset_for_frame_with_id(size_t id) const
+    ReadonlySpan<Gfx::FloatPoint> device_offsets() const { return m_device_offsets; }
+
+    CSSPixelPoint css_offset_for_frame_with_id(size_t id) const
     {
-        if (id >= own_offsets.size())
+        if (id >= m_css_offsets.size())
             return {};
-        return own_offsets[id];
+        return m_css_offsets[id];
     }
 
 private:
-    Vector<CSSPixelPoint> own_offsets;
+    Vector<CSSPixelPoint> m_css_offsets;
+    Vector<Gfx::FloatPoint> m_device_offsets;
 };
 
 class ScrollState {
@@ -69,9 +73,9 @@ public:
 private:
     friend class ViewportPaintable;
 
-    ScrollStateSnapshot snapshot() const
+    ScrollStateSnapshot snapshot(double device_pixels_per_css_pixel) const
     {
-        return ScrollStateSnapshot::create(m_scroll_frames);
+        return ScrollStateSnapshot::create(m_scroll_frames, device_pixels_per_css_pixel);
     }
 
     Vector<NonnullRefPtr<ScrollFrame>> m_scroll_frames;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -221,7 +221,7 @@ void PageClient::set_viewport(Web::DevicePixelSize const& size, double device_pi
 void PageClient::set_zoom_level(double zoom_level)
 {
     m_zoom_level = zoom_level;
-    page().top_level_traversable()->set_viewport_size(page().device_to_css_size(m_viewport_size));
+    page().top_level_traversable()->set_viewport_size(page().device_to_css_size(m_viewport_size), Web::InvalidateDisplayList::Yes);
 }
 
 void PageClient::set_maximum_frames_per_second(u64 maximum_frames_per_second)

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -1,9 +1,9 @@
 AccumulatedVisualContext Tree:
-  [2] clip=[23,23 91.328125x150]
+  [2] clip=[23,23 91x150]
     [3] scroll_frame_id=1 (PaintableWithLines(BlockContainer(anonymous)))
-  [4] clip=[126.328125,23 91.328125x150]
+  [4] clip=[126,23 92x150]
     [5] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
-  [6] clip=[229.65625,23 91.328125x150]
+  [6] clip=[230,23 91x150]
     [7] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:


### PR DESCRIPTION
Stop converting between CSS and device pixels as part of rendering - the display list should be as simple as possible, so convert to DevicePixels once when constructing the display list.