### PR TITLE
LibJS: Wrap CompiledRegex in Rc to allow AST cloning

### DIFF
--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -656,7 +656,7 @@ impl<'a> Parser<'a> {
             ExpressionKind::RegExpLiteral(RegExpLiteralData {
                 pattern: pattern.into(),
                 flags: flags.into(),
-                compiled_regex: CompiledRegex::new(compiled_regex),
+                compiled_regex: Rc::new(CompiledRegex::new(compiled_regex)),
             }),
         )
     }

--- a/Tests/LibJS/Runtime/classes/class-public-fields.js
+++ b/Tests/LibJS/Runtime/classes/class-public-fields.js
@@ -155,6 +155,21 @@ test("using 'arguments' via indirect eval throws at runtime instead of parse tim
     }).toThrowWithMessage(ReferenceError, "'arguments' is not defined");
 });
 
+test("regex field initializer", () => {
+    class A {
+        pattern = /hello/;
+        flags = /world/gi;
+        static s_pattern = /static/m;
+    }
+
+    const a = new A();
+    expect(a.pattern).toBeInstanceOf(RegExp);
+    expect(a.pattern.source).toBe("hello");
+    expect(a.flags.flags).toBe("gi");
+    expect(A.s_pattern.source).toBe("static");
+    expect(A.s_pattern.flags).toBe("m");
+});
+
 describe("class fields with a 'special' name", () => {
     test("static", () => {
         class A {


### PR DESCRIPTION
`CompiledRegex` held an FFI handle with unique ownership and panicked on clone. This caused a crash when a class field initializer contained a regex literal, since the codegen wraps field initializers in a synthetic function body by cloning the expression.

Wrapping `CompiledRegex` in `Rc` makes the clone a cheap refcount bump. The `take()` semantics are preserved: the first codegen path to call `take()` gets the handle, and `Drop` frees it if nobody took it.

Fixes a panic on https://fangamer.com/