### PR TITLE
LibJS: Return UTF16String's ASCII storage when applicable

### DIFF
--- a/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -185,8 +185,13 @@ String PrimitiveString::utf8_string() const
 
 StringView PrimitiveString::utf8_string_view() const
 {
-    if (!has_utf8_string())
+    if (!has_utf8_string()) {
+        if (has_utf16_string() && m_utf16_string->has_ascii_storage())
+            return m_utf16_string->ascii_view();
+
         (void)utf8_string();
+    }
+
     return m_utf8_string->bytes_as_string_view();
 }
 


### PR DESCRIPTION
If we have a UTF-16 string with ASCII storage, we don't need to convert the string to UTF-8 to get a `StringView`. This fast-path is hit over 76k times during `test-js`.