### PR TITLE
LibWeb: Implement CSS field-sizing property

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1829,6 +1829,17 @@
       "empty-cells"
     ]
   },
+  "field-sizing": {
+    "affects-layout": true,
+    "animation-type": "discrete",
+    "inherited": false,
+    "initial": "fixed",
+    "requires-computation": "never",
+    "valid-identifiers": [
+      "fixed", 
+      "content"
+    ]
+  },
   "fill": {
     "affects-layout": false,
     "animation-type": "by-computed-value",

--- a/Libraries/LibWeb/Layout/TextAreaBox.cpp
+++ b/Libraries/LibWeb/Layout/TextAreaBox.cpp
@@ -1,10 +1,16 @@
 /*
  * Copyright (c) 2025-2026, Jonathan Gamble <gamblej@gmail.com>
+ * Copyright (c) 2026, Jack Bodine <jacktaylorbodine@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Layout/TextAreaBox.h>
+#include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/SerializationMode.h>
+#include <LibWeb/CSS/StyleValues/StyleValue.h>
+#include <LibWeb/DOM/Node.h>
 
 namespace Web::Layout {
 
@@ -17,6 +23,13 @@ TextAreaBox::TextAreaBox(DOM::Document& document, GC::Ptr<DOM::Element> element,
 
 CSS::SizeWithAspectRatio TextAreaBox::compute_auto_content_box_size() const
 {
+    auto const& style_properties = dom_node().computed_properties();
+
+    // If field-sizing: content, return empty size (auto) to fit the text content.
+    if (style_properties->property(CSS::PropertyID::FieldSizing).to_string(CSS::SerializationMode::Normal) == "content") {
+        return { {}, {}, {} };
+    }
+
     auto width = CSS::Length(dom_node().cols(), CSS::LengthUnit::Ch).to_px(*this);
     auto height = CSS::Length(dom_node().rows(), CSS::LengthUnit::Lh).to_px(*this);
 


### PR DESCRIPTION
This adds support for the 'field-sizing' CSS property. It supports both the 'fixed' (default) and 'content' values.

When set to 'content', the TextAreaBox ignores its 'cols' and 'rows' attributes and instead returns an empty auto-size, allowing the layout engine to size the element based on its content.