### PR TITLE
LibWeb: Queue a task when setting IDBRequest as processed

### DIFF
--- a/Libraries/LibWeb/IndexedDB/IDBRequest.cpp
+++ b/Libraries/LibWeb/IndexedDB/IDBRequest.cpp
@@ -7,8 +7,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGC/Cell.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/IndexedDB/IDBCursor.h>
 #include <LibWeb/IndexedDB/IDBIndex.h>
@@ -127,9 +129,17 @@ void IDBRequest::unregister_request_observer(Badge<IDBRequestObserver>, IDBReque
 void IDBRequest::set_processed(bool processed)
 {
     m_processed = processed;
-    notify_each_request_observer([](IDBRequestObserver const& request_observer) {
-        return request_observer.request_processed_changed_observer();
-    });
+
+    // Queue a task to notify observers to prevent synchronous recursion
+    // when processing a large queue of database requests.
+    HTML::queue_global_task(HTML::Task::Source::DatabaseAccess, realm().global_object(), GC::create_function(realm().heap(), [this_request = GC::Ref { *this }]() {
+        if (this_request->realm().global_object().state() == GC::Cell::State::Dead)
+            return;
+
+        this_request->notify_each_request_observer([](IDBRequestObserver const& request_observer) {
+            return request_observer.request_processed_changed_observer();
+        });
+    }));
 }
 
 }

--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -96,18 +96,14 @@ void open_a_database_connection(JS::Realm& realm, StorageAPI::StorageKey storage
 
     queue.all_previous_requests_processed(realm.heap(), request, GC::create_function(realm.heap(), [&realm, storage_key = move(storage_key), name = move(name), maybe_version = move(maybe_version), request, on_complete] -> void {
         // 4. Let db be the database named name in storageKey, or null otherwise.
-        GC::Ptr<Database> db;
-        auto maybe_db = Database::for_key_and_name(storage_key, name);
-        if (maybe_db.has_value()) {
-            db = &maybe_db.value();
-        }
+        auto db = Database::for_key_and_name(storage_key, name);
 
         // 5. If version is undefined, let version be 1 if db is null, or db’s version otherwise.
-        auto version = maybe_version.value_or(maybe_db.has_value() ? maybe_db.value().version() : 1);
+        auto version = maybe_version.value_or(db ? db->version() : 1);
 
         // 6. If db is null, let db be a new database with name name, version 0 (zero), and with no object stores.
         // If this fails for any reason, return an appropriate error (e.g. a "QuotaExceededError" or "UnknownError" DOMException).
-        if (!maybe_db.has_value()) {
+        if (!db) {
             auto maybe_database = Database::create_for_key_and_name(realm, storage_key, name);
 
             if (maybe_database.is_error()) {
@@ -500,13 +496,11 @@ void delete_a_database(JS::Realm& realm, StorageAPI::StorageKey storage_key, Str
 
     queue.all_previous_requests_processed(realm.heap(), request, GC::create_function(realm.heap(), [&realm, storage_key = move(storage_key), name = move(name), on_complete] -> void {
         // 4. Let db be the database named name in storageKey, if one exists. Otherwise, return 0 (zero).
-        auto maybe_db = Database::for_key_and_name(storage_key, name);
-        if (!maybe_db.has_value()) {
+        auto db = Database::for_key_and_name(storage_key, name);
+        if (!db) {
             on_complete->function()(0);
             return;
         }
-
-        GC::Ref db = maybe_db.value();
 
         // 5. Let openConnections be the set of all connections associated with db.
         auto open_connections = db->associated_connections();

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
@@ -80,12 +80,17 @@ RequestList& ConnectionQueueHandler::for_key_and_name(StorageAPI::StorageKey con
     return new_connection->request_list;
 }
 
-Optional<Database&> Database::for_key_and_name(StorageAPI::StorageKey const& key, String const& name)
+GC::Ptr<Database> Database::for_key_and_name(StorageAPI::StorageKey const& key, String const& name)
 {
-    auto database_mapping = m_databases.ensure(key, [] { return HashMap<String, GC::Weak<Database>>(); });
-    if (auto maybe_database = database_mapping.get(name); maybe_database.has_value())
-        return *maybe_database.value();
-    return {};
+    auto maybe_database_mapping = m_databases.get(key);
+    if (!maybe_database_mapping.has_value())
+        return nullptr;
+
+    auto maybe_database = maybe_database_mapping.value().get(name);
+    if (!maybe_database.has_value())
+        return nullptr;
+
+    return maybe_database.value().ptr();
 }
 
 ErrorOr<GC::Root<Database>> Database::create_for_key_and_name(JS::Realm& realm, StorageAPI::StorageKey const& key, String const& name)

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.h
@@ -41,7 +41,7 @@ public:
     }
 
     [[nodiscard]] static Vector<GC::Weak<Database>> for_key(StorageAPI::StorageKey const&);
-    [[nodiscard]] static Optional<Database&> for_key_and_name(StorageAPI::StorageKey const&, String const&);
+    [[nodiscard]] static GC::Ptr<Database> for_key_and_name(StorageAPI::StorageKey const&, String const&);
     [[nodiscard]] static ErrorOr<GC::Root<Database>> create_for_key_and_name(JS::Realm&, StorageAPI::StorageKey const&, String const&);
     [[nodiscard]] static ErrorOr<void> delete_for_key_and_name(StorageAPI::StorageKey const&, String const&);
 

--- a/Tests/LibWeb/Crash/IndexedDB/mulitple-open.html
+++ b/Tests/LibWeb/Crash/IndexedDB/mulitple-open.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<script>
+for (var i = 0; i < 10; i++) {
+    var request = indexedDB.open("multiple-open-test", 1);
+}
+</script>


### PR DESCRIPTION
This prevents a synchronous recursive loop that leads to an assertion
failure when many database requests are opened at the same time.

By queuing a task on the HTML event loop, the call stack is allowed
to unwind before the next request is processed.

Fixes #7512