### PR TITLE
LibWeb: Remove ViewportClient from ImagePaintable and VideoBox

### DIFF
--- a/Libraries/LibWeb/Layout/VideoBox.cpp
+++ b/Libraries/LibWeb/Layout/VideoBox.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/Layout/VideoBox.h>
 #include <LibWeb/Painting/VideoPaintable.h>
@@ -16,16 +15,6 @@ GC_DEFINE_ALLOCATOR(VideoBox);
 VideoBox::VideoBox(DOM::Document& document, DOM::Element& element, GC::Ref<CSS::ComputedProperties> style)
     : ReplacedBox(document, element, style)
 {
-    document.register_viewport_client(*this);
-}
-
-void VideoBox::finalize()
-{
-    Base::finalize();
-
-    // NOTE: We unregister from the document in finalize() to avoid trouble
-    //       in the scenario where our Document has already been swept by GC.
-    document().unregister_viewport_client(*this);
 }
 
 HTML::HTMLVideoElement& VideoBox::dom_node()
@@ -51,12 +40,6 @@ CSS::SizeWithAspectRatio VideoBox::natural_size() const
     if (width > 0 && height > 0)
         return { width, height, CSSPixelFraction(width, height) };
     return { width, height, {} };
-}
-
-void VideoBox::did_set_viewport_rect(CSSPixelRect const&)
-{
-    // FIXME: Several steps in HTMLMediaElement indicate we may optionally handle whether the media object
-    //        is in view. Implement those steps.
 }
 
 GC::Ptr<Painting::Paintable> VideoBox::create_paintable() const

--- a/Libraries/LibWeb/Layout/VideoBox.h
+++ b/Libraries/LibWeb/Layout/VideoBox.h
@@ -6,21 +6,16 @@
 
 #pragma once
 
-#include <LibWeb/DOM/ViewportClient.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 
 namespace Web::Layout {
 
-class VideoBox final
-    : public ReplacedBox
-    , public DOM::ViewportClient {
+class VideoBox final : public ReplacedBox {
     GC_CELL(VideoBox, ReplacedBox);
     GC_DECLARE_ALLOCATOR(VideoBox);
 
 public:
-    static constexpr bool OVERRIDES_FINALIZE = true;
-
     HTML::HTMLVideoElement& dom_node();
     HTML::HTMLVideoElement const& dom_node() const;
 
@@ -31,12 +26,6 @@ public:
 private:
     VideoBox(DOM::Document&, DOM::Element&, GC::Ref<CSS::ComputedProperties>);
     virtual CSS::SizeWithAspectRatio natural_size() const override;
-
-    // ^Document::ViewportClient
-    virtual void did_set_viewport_rect(CSSPixelRect const&) final;
-
-    // ^JS::Cell
-    virtual void finalize() override;
 };
 
 }

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -7,7 +7,6 @@
 
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
-#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
@@ -39,22 +38,12 @@ ImagePaintable::ImagePaintable(Layout::Box const& layout_box, Layout::ImageProvi
     , m_image_provider(image_provider)
     , m_is_svg_image(is_svg_image)
 {
-    const_cast<DOM::Document&>(layout_box.document()).register_viewport_client(*this);
 }
 
 void ImagePaintable::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     m_image_provider.image_provider_visit_edges(visitor);
-}
-
-void ImagePaintable::finalize()
-{
-    Base::finalize();
-
-    // NOTE: We unregister from the document in finalize() to avoid trouble
-    //       in the scenario where our Document has already been swept by GC.
-    document().unregister_viewport_client(*this);
 }
 
 void ImagePaintable::reset_for_relayout()
@@ -176,11 +165,6 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
                 context.display_list_recorder().fill_rect(image_rect_device_pixels.to_type<int>(), selection_background_color);
         }
     }
-}
-
-void ImagePaintable::did_set_viewport_rect(CSSPixelRect const& viewport_rect)
-{
-    const_cast<Layout::ImageProvider&>(m_image_provider).set_visible_in_viewport(viewport_rect.intersects(absolute_rect()));
 }
 
 }

--- a/Libraries/LibWeb/Painting/ImagePaintable.h
+++ b/Libraries/LibWeb/Painting/ImagePaintable.h
@@ -6,22 +6,17 @@
 
 #pragma once
 
-#include <LibWeb/DOM/ViewportClient.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/SVGImageBox.h>
 #include <LibWeb/Painting/PaintableBox.h>
 
 namespace Web::Painting {
 
-class ImagePaintable final
-    : public PaintableBox
-    , public DOM::ViewportClient {
+class ImagePaintable final : public PaintableBox {
     GC_CELL(ImagePaintable, PaintableBox);
     GC_DECLARE_ALLOCATOR(ImagePaintable);
 
 public:
-    static constexpr bool OVERRIDES_FINALIZE = true;
-
     static GC::Ref<ImagePaintable> create(Layout::ImageBox const& layout_box);
     static GC::Ref<ImagePaintable> create(Layout::SVGImageBox const& layout_box);
 
@@ -31,10 +26,6 @@ public:
 private:
     // ^JS::Cell
     virtual void visit_edges(Visitor&) override;
-    virtual void finalize() override;
-
-    // ^Document::ViewportClient
-    virtual void did_set_viewport_rect(CSSPixelRect const&) final;
 
     ImagePaintable(Layout::Box const& layout_box, Layout::ImageProvider const& image_provider, bool renders_as_alt_text, String alt_text, bool is_svg_image);
 

--- a/Tests/LibWeb/Crash/HTML/viewport-client-gc-after-adopt-node.html
+++ b/Tests/LibWeb/Crash/HTML/viewport-client-gc-after-adopt-node.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<!-- Test: Create an image in an iframe (which creates an ImagePaintable registered
+     as a ViewportClient with the iframe's document), then adopt the image into the
+     main document. Force the iframe to re-layout so the old ImagePaintable becomes
+     unreachable. When GC runs, the old ImagePaintable's finalize() must not crash
+     trying to unregister from the wrong document. -->
+<html class="test-wait">
+<body>
+<script>
+    const iframe = document.createElement("iframe");
+    iframe.src = "../../Assets/blank.html";
+    iframe.onload = () => {
+        const img = iframe.contentDocument.createElement("img");
+        img.src = new URL("../../Assets/120.png", document.baseURI).href;
+        iframe.contentDocument.body.appendChild(img);
+
+        img.onload = () => {
+            // Force layout so an ImagePaintable is created and registered
+            // as a ViewportClient with the iframe's document.
+            img.offsetWidth;
+
+            // Adopt the image into the main document.
+            document.adoptNode(img);
+            document.body.appendChild(img);
+
+            // Force the iframe's document to re-layout. This rebuilds its
+            // layout/paintable tree without the adopted image, making the
+            // old ImagePaintable unreachable.
+            iframe.contentDocument.body.offsetHeight;
+
+            // Trigger GC to finalize the old ImagePaintable.
+            if (window.internals !== undefined)
+                internals.gc();
+
+            document.documentElement.classList.remove("test-wait");
+        };
+    };
+    document.body.appendChild(iframe);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Neither of these classes did anything useful as ViewportClients:

- ImagePaintable called set_visible_in_viewport() which is a FIXME no-op in every ImageProvider implementation.
- VideoBox had an empty did_set_viewport_rect() with a FIXME comment.

More importantly, they caused a crash when a DOM node was adopted into a different document: the old ImagePaintable/VideoBox would still be registered with the old document, but their document() accessor (which goes through the DOM node) would return the new document. During GC finalization, unregister_viewport_client() would fail because it was trying to unregister from the wrong document.

The only meaningful ViewportClient is HTMLImageElement (for responsive image source selection), which already handles document adoption correctly in adopted_from().

Fixes crash when loading https://msn.com/