### PR TITLE
WebDriver: Cleanup argument handling and process launch logic

### DIFF
--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -23,17 +23,25 @@ static ErrorOr<Core::Process> launch_process(StringView application, ReadonlySpa
 {
     auto paths = TRY(WebView::get_paths_for_helper_process(application));
 
-    ErrorOr<Core::Process> result = Error::from_string_literal("All paths failed to launch");
+    ErrorOr<Core::Process> last_error = Error::from_string_literal("All paths failed to launch");
+
     for (auto const& path : paths) {
-        auto path_view = path.view();
-        result = Core::Process::spawn(path_view, arguments);
+        auto result = Core::Process::spawn(path.view(), arguments);
         if (!result.is_error())
-            break;
+            return result;
+        last_error = result.release_error();
     }
-    return result;
+
+    return last_error;
 }
 
-static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint, bool headless, bool expose_experimental_interfaces, bool force_cpu_painting, Optional<StringView> debug_process, Optional<StringView> default_time_zone)
+static Vector<ByteString> create_arguments(
+    ByteString const& webdriver_endpoint,
+    bool headless,
+    bool expose_experimental_interfaces,
+    bool force_cpu_painting,
+    Optional<StringView> debug_process,
+    Optional<StringView> default_time_zone)
 {
     Vector<ByteString> arguments;
 #if defined(AK_OS_MACOS)
@@ -43,23 +51,23 @@ static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint,
 #endif
     arguments.append(webdriver_endpoint);
 
-    Vector<ByteString> certificate_args;
-    for (auto const& certificate : certificates) {
-        certificate_args.append(ByteString::formatted("--certificate={}", certificate));
-        arguments.append(certificate_args.last().view().characters_without_null_termination());
-    }
+    for (auto const& certificate : certificates)
+        arguments.append(ByteString::formatted("--certificate={}", certificate));
 
-    if (headless)
-        arguments.append("--headless"sv);
+    auto append_if = [&](bool condition, StringView arg) {
+        if (condition)
+            arguments.append(arg);
+    };
+
+    append_if(headless, "--headless"sv);
 
     arguments.append("--allow-popups"sv);
     arguments.append("--force-new-process"sv);
     arguments.append("--enable-autoplay"sv);
     arguments.append("--disable-scrollbar-painting"sv);
-    if (expose_experimental_interfaces)
-        arguments.append("--expose-experimental-interfaces"sv);
-    if (force_cpu_painting)
-        arguments.append("--force-cpu-painting"sv);
+
+    append_if(expose_experimental_interfaces, "--expose-experimental-interfaces"sv);
+    append_if(force_cpu_painting, "--force-cpu-painting"sv);
 
     if (debug_process.has_value())
         arguments.append(ByteString::formatted("--debug-process={}", debug_process.value()));
@@ -103,16 +111,22 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         return 1;
     }
 
-    if ((u16)port != port) {
+    if (port < 0 || port > NumericLimits<u16>::max()) {
         warnln("Invalid port number: {}", port);
         return 1;
     }
 
+    auto address = ipv4_address.release_value();
+
     WebView::platform_init();
 
-    Web::WebDriver::set_default_interface_mode(headless ? Web::WebDriver::InterfaceMode::Headless : Web::WebDriver::InterfaceMode::Graphical);
+    Web::WebDriver::set_default_interface_mode(
+        headless
+            ? Web::WebDriver::InterfaceMode::Headless
+            : Web::WebDriver::InterfaceMode::Graphical);
 
-    auto webdriver_socket_path = ByteString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
+    auto webdriver_socket_path =
+        ByteString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
     TRY(Core::Directory::create(webdriver_socket_path, Core::Directory::CreateDirectories::Yes));
 
     Core::EventLoop loop;
@@ -120,7 +134,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     HashTable<NonnullRefPtr<WebDriver::Client>> clients;
 
-    // FIXME: Propagate errors
     server->on_ready_to_accept = [&] {
         auto maybe_client_socket = server->accept();
         if (maybe_client_socket.is_error()) {
@@ -128,32 +141,43 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
             return;
         }
 
-        auto maybe_buffered_socket = Core::BufferedTCPSocket::create(maybe_client_socket.release_value());
+        auto maybe_buffered_socket =
+            Core::BufferedTCPSocket::create(maybe_client_socket.release_value());
         if (maybe_buffered_socket.is_error()) {
             warnln("Could not obtain a buffered socket for the client: {}", maybe_buffered_socket.error());
             return;
         }
 
-        auto launch_browser_callback = [&](ByteString const& webdriver_endpoint, bool headless) {
-            auto arguments = create_arguments(webdriver_endpoint, headless, expose_experimental_interfaces, force_cpu_painting, debug_process, default_time_zone);
-            return launch_process("Ladybird"sv, arguments.span());
-        };
+        auto launch_browser_callback =
+            [&](ByteString const& webdriver_endpoint, bool headless) {
+                auto arguments = create_arguments(
+                    webdriver_endpoint,
+                    headless,
+                    expose_experimental_interfaces,
+                    force_cpu_painting,
+                    debug_process,
+                    default_time_zone);
+                return launch_process("Ladybird"sv, arguments.span());
+            };
 
-        auto maybe_client = WebDriver::Client::try_create(maybe_buffered_socket.release_value(), move(launch_browser_callback));
+        auto maybe_client = WebDriver::Client::try_create(
+            maybe_buffered_socket.release_value(),
+            move(launch_browser_callback));
+
         if (maybe_client.is_error()) {
             warnln("Could not create a WebDriver client: {}", maybe_client.error());
             return;
         }
 
         auto client = maybe_client.release_value();
-        client->on_death = [&clients, client] {
-            clients.remove(client);
+        client->on_death = [&clients, weak_client = client] {
+            clients.remove(weak_client);
         };
         clients.set(client);
     };
 
-    TRY(server->listen(ipv4_address.value(), port, Core::TCPServer::AllowAddressReuse::Yes));
-    outln("Listening on {}:{}", ipv4_address.value(), port);
+    TRY(server->listen(address, port, Core::TCPServer::AllowAddressReuse::Yes));
+    outln("Listening on {}:{}", address, port);
 
     return loop.exec();
 }


### PR DESCRIPTION
WebDriver: Cleanup argument handling and process launch logic

Simplify internal implementation details in the WebDriver entry
point without changing behavior.

- Remove an unnecessary temporary vector used when constructing
  certificate arguments and append formatted arguments directly.

- Simplify the process launch loop by returning immediately on
  successful spawn and explicitly preserving the last error.

- Replace a narrowing cast in port validation with an explicit
  bounds check to avoid implicit truncation.

- Extract the validated IPv4 address once instead of repeatedly
  accessing Optional::value().

- Make lambda captures more explicit to clarify ownership and
  lifetime expectations.

- Apply minor consistency and readability improvements.

No functional changes intended.