### PR TITLE
CI: Update rust ci to run on all targets

### DIFF
--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -52,17 +52,17 @@ else
     ((FAILURES+=1))
 fi
 
-if cargo fmt --check && git diff --exit-code -- ':*.rs'; then
+if cargo fmt --check --all && git diff --exit-code -- ':*.rs'; then
     echo -e "[${GREEN}OK${NC}]: cargo fmt --check"
 else
     echo -e "[${BOLD_RED}FAIL${NC}]: cargo fmt --check"
     ((FAILURES+=1))
 fi
 
-if cargo clippy -- -D clippy::all && git diff --exit-code -- ':*.rs'; then
-    echo -e "[${GREEN}OK${NC}]: cargo clippy -- -D clippy::all"
+if cargo clippy --all --all-targets -- -D clippy::all -D warnings && git diff --exit-code -- ':*.rs'; then
+    echo -e "[${GREEN}OK${NC}]: cargo clippy --all --all-targets -- -D clippy::all -D warnings"
 else
-    echo -e "[${BOLD_RED}FAIL${NC}]: cargo clippy -- -D clippy::all"
+    echo -e "[${BOLD_RED}FAIL${NC}]: cargo clippy --all --all-targets -- -D clippy::all -D warnings"
     ((FAILURES+=1))
 fi
 


### PR DESCRIPTION
run cargo fmt and cargo cippy on `--all` / `--all-targets`

This also denies warnings in case there might be something that clippy::all doesn't catch.