### PR TITLE
LibWeb: Remove CSS pixel offsets from ScrollState

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1436,7 +1436,7 @@ Vector<CSSPixelRect> Element::get_client_rects() const
         if (auto const& accumulated_visual_context = paintable_box->accumulated_visual_context()) {
             auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
             auto const& scroll_state = document().paintable()->scroll_state_snapshot();
-            auto result = accumulated_visual_context->transform_rect_to_viewport(absolute_rect.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+            auto result = accumulated_visual_context->transform_rect_to_viewport(absolute_rect.to_type<float>() * pixel_ratio, scroll_state);
             rects.append((result * (1.f / pixel_ratio)).to_type<CSSPixels>());
         } else {
             rects.append(absolute_rect);

--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -52,7 +52,7 @@ static Optional<CSSPixelRect> scrollport_rect_in_viewport(Painting::PaintableBox
         return {};
     auto pixel_ratio = static_cast<float>(paintable_box.document().page().client().device_pixels_per_css_pixel());
     auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
-    auto result = accumulated_visual_context->transform_rect_to_viewport(scrollport.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+    auto result = accumulated_visual_context->transform_rect_to_viewport(scrollport.to_type<float>() * pixel_ratio, scroll_state);
     return (result * (1.f / pixel_ratio)).to_type<CSSPixels>();
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -20,6 +20,8 @@
 
 namespace Web::Painting {
 
+class ScrollStateSnapshot;
+
 struct ScrollData {
     size_t scroll_frame_id;
     bool is_sticky;
@@ -83,9 +85,9 @@ public:
 
     void dump(StringBuilder&) const;
 
-    Optional<Gfx::FloatPoint> transform_point_for_hit_test(Gfx::FloatPoint, ReadonlySpan<Gfx::FloatPoint> scroll_offsets) const;
+    Optional<Gfx::FloatPoint> transform_point_for_hit_test(Gfx::FloatPoint, ScrollStateSnapshot const&) const;
     Gfx::FloatPoint inverse_transform_point(Gfx::FloatPoint) const;
-    Gfx::FloatRect transform_rect_to_viewport(Gfx::FloatRect const&, ReadonlySpan<Gfx::FloatPoint> scroll_offsets) const;
+    Gfx::FloatRect transform_rect_to_viewport(Gfx::FloatRect const&, ScrollStateSnapshot const&) const;
 
 private:
     AccumulatedVisualContext(size_t id, VisualContextData data, RefPtr<AccumulatedVisualContext const> parent)

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -97,12 +97,9 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
             },
             [&](ScrollData const& scroll) {
                 save({});
-                auto const& offsets = scroll_state.device_offsets();
-                if (scroll.scroll_frame_id < offsets.size()) {
-                    auto const& offset = offsets[scroll.scroll_frame_id];
-                    if (!offset.is_zero())
-                        translate({ .delta = offset.to_type<int>() });
-                }
+                auto offset = scroll_state.device_offset_for_frame_with_id(scroll.scroll_frame_id);
+                if (!offset.is_zero())
+                    translate({ .delta = offset.to_type<int>() });
             },
             [&](TransformData const& transform) {
                 save({});
@@ -167,14 +164,11 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
         if (command.has<PaintScrollBar>()) {
             auto translated_command = command;
             auto& paint_scroll_bar = translated_command.get<PaintScrollBar>();
-            auto const& offsets = scroll_state.device_offsets();
-            if (paint_scroll_bar.scroll_frame_id < static_cast<int>(offsets.size())) {
-                auto const& device_offset = offsets[paint_scroll_bar.scroll_frame_id];
-                if (paint_scroll_bar.vertical)
-                    paint_scroll_bar.thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * paint_scroll_bar.scroll_size));
-                else
-                    paint_scroll_bar.thumb_rect.translate_by(static_cast<int>(-device_offset.x() * paint_scroll_bar.scroll_size), 0);
-            }
+            auto device_offset = scroll_state.device_offset_for_frame_with_id(paint_scroll_bar.scroll_frame_id);
+            if (paint_scroll_bar.vertical)
+                paint_scroll_bar.thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * paint_scroll_bar.scroll_size));
+            else
+                paint_scroll_bar.thumb_rect.translate_by(static_cast<int>(-device_offset.x() * paint_scroll_bar.scroll_size), 0);
             paint_scrollbar(paint_scroll_bar);
             continue;
         }

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -88,7 +88,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
             return;
 
         if (auto state = accumulated_visual_context()) {
-            auto result = state->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+            auto result = state->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state);
             if (result.has_value())
                 local_position = (*result / pixel_ratio).to_type<CSSPixels>();
         } else {
@@ -144,7 +144,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
     auto avc_for_descendants = accumulated_visual_context_for_descendants();
     Optional<CSSPixelPoint> local_position_for_fragments;
     if (avc_for_descendants) {
-        auto result = avc_for_descendants->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+        auto result = avc_for_descendants->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state);
         if (result.has_value())
             local_position_for_fragments = (*result / pixel_ratio).to_type<CSSPixels>();
     } else {

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -12,11 +12,9 @@ ScrollStateSnapshot ScrollStateSnapshot::create(Vector<NonnullRefPtr<ScrollFrame
 {
     ScrollStateSnapshot snapshot;
     auto scale = static_cast<float>(device_pixels_per_css_pixel);
-    snapshot.m_css_offsets.ensure_capacity(scroll_frames.size());
     snapshot.m_device_offsets.ensure_capacity(scroll_frames.size());
     for (auto const& scroll_frame : scroll_frames) {
         auto const& offset = scroll_frame->m_own_offset;
-        snapshot.m_css_offsets.unchecked_append(offset);
         snapshot.m_device_offsets.unchecked_append(offset.to_type<float>() * scale);
     }
     return snapshot;

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -15,17 +15,14 @@ class ScrollStateSnapshot {
 public:
     static ScrollStateSnapshot create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames, double device_pixels_per_css_pixel);
 
-    ReadonlySpan<Gfx::FloatPoint> device_offsets() const { return m_device_offsets; }
-
-    CSSPixelPoint css_offset_for_frame_with_id(size_t id) const
+    Gfx::FloatPoint device_offset_for_frame_with_id(size_t id) const
     {
-        if (id >= m_css_offsets.size())
+        if (id >= m_device_offsets.size())
             return {};
-        return m_css_offsets[id];
+        return m_device_offsets[id];
     }
 
 private:
-    Vector<CSSPixelPoint> m_css_offsets;
     Vector<Gfx::FloatPoint> m_device_offsets;
 };
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -396,7 +396,7 @@ TraversalDecision StackingContext::hit_test(CSSPixelPoint position, HitTestType 
             auto const& scroll_state = paintable_box().document().paintable()->scroll_state_snapshot();
             Optional<CSSPixelPoint> local_position;
             if (auto state = paintable_box().accumulated_visual_context()) {
-                auto result = state->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+                auto result = state->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state);
                 if (result.has_value())
                     local_position = (*result / pixel_ratio).to_type<CSSPixels>();
             } else {
@@ -447,7 +447,7 @@ TraversalDecision StackingContext::hit_test(CSSPixelPoint position, HitTestType 
     auto const& scroll_state = paintable_box().document().paintable()->scroll_state_snapshot();
     Optional<CSSPixelPoint> local_position;
     if (auto state = paintable_box().accumulated_visual_context()) {
-        auto result = state->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state.device_offsets());
+        auto result = state->transform_point_for_hit_test(position.to_type<float>() * pixel_ratio, scroll_state);
         if (result.has_value())
             local_position = (*result / pixel_ratio).to_type<CSSPixels>();
     } else {


### PR DESCRIPTION
This was arguably put in a worse place by #8162; we mostly need the device pixel offsets from the scroll state so keep track of those and convert back to CSS pixels when necessary (i.e. scrollbar data).