### PR TITLE
CI: Move the flatpak build steps to their own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,23 +74,3 @@ jobs:
       arch: ${{ matrix.arch }}
       build_preset: ${{ matrix.build_preset }}
       clang_plugins: ${{ matrix.clang_plugins }}
-
-  Flatpak:
-    if: github.repository == 'LadybirdBrowser/ladybird'
-    name: Flatpak ${{ matrix.arch }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['x86_64']
-        runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
-
-        include:
-          - arch: 'aarch64'
-            runner_labels: '["blacksmith-16vcpu-ubuntu-2404-arm"]'
-
-    secrets: inherit
-    uses: ./.github/workflows/flatpak-template.yml
-    with:
-      arch: ${{ matrix.arch }}
-      runner_labels: ${{ matrix.runner_labels }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,28 @@
+name: Flatpak
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
+  cancel-in-progress: true
+
+jobs:
+  Flatpak:
+    if: github.repository == 'LadybirdBrowser/ladybird'
+    name: Flatpak ${{ matrix.arch }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['x86_64']
+        runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
+
+        include:
+          - arch: 'aarch64'
+            runner_labels: '["blacksmith-16vcpu-ubuntu-2404-arm"]'
+
+    secrets: inherit
+    uses: ./.github/workflows/flatpak-template.yml
+    with:
+      arch: ${{ matrix.arch }}
+      runner_labels: ${{ matrix.runner_labels }}


### PR DESCRIPTION
This is entirely a GitHub limitation. But I have found myself wanting to rerun flaky CI tests, but have to wait some time for the flatpak builder to complete. Moving this to its own job means we don't need to wait to restart other CI jobs.

edit: was already able to make use of this change in this PR :sweat_smile: 