### PR TITLE
Everywhere: Add initial support for the Tracy profiler

### DIFF
--- a/AK/StringData.h
+++ b/AK/StringData.h
@@ -26,7 +26,7 @@ public:
         VERIFY(byte_count);
 
         auto capacity = allocation_size_for_string_data(byte_count);
-        void* slot = malloc(capacity);
+        void* slot = kmalloc(capacity);
         if (!slot)
             return Error::from_errno(ENOMEM);
 
@@ -52,7 +52,7 @@ public:
         VERIFY(byte_count > MAX_SHORT_STRING_BYTE_COUNT);
 
         auto capacity = sizeof(StringData) + sizeof(StringData::SubstringData);
-        void* slot = malloc(capacity);
+        void* slot = kmalloc(capacity);
         if (!slot)
             return Error::from_errno(ENOMEM);
 
@@ -66,7 +66,7 @@ public:
 
     void operator delete(void* ptr)
     {
-        free(ptr);
+        kfree(ptr);
     }
 
     ~StringData()

--- a/AK/Tracy.h
+++ b/AK/Tracy.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#if defined(TRACY_ENABLE)
+#    include <tracy/Tracy.hpp>
+#    define TRACY_ZONE_SCOPED() ZoneScoped
+#    define TRACY_ZONE_SCOPED_NAMED(name) ZoneScopedN(name)
+#    define TRACY_SET_ZONE_NAME(name, length) ZoneName(name, length)
+#    define TRACY_FRAME_MARK() FrameMark
+#    define TRACY_FRAME_MARK_NAMED(name) FrameMarkNamed(name)
+#    define TRACY_SET_PROGRAM_NAME(name) TracySetProgramName(name)
+#    define TRACY_PLOT(name, value) TracyPlot(name, value)
+#    if defined(TRACY_ENABLE_MEMORY)
+#        define TRACY_ALLOCATED_MEMORY(ptr, size) TracyAlloc(ptr, size)
+#        define TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, name) TracyAllocN(ptr, size, name)
+#        define TRACY_FREED_MEMORY(ptr) TracyFree(ptr)
+#        define TRACY_FREED_MEMORY_NAMED(ptr, name) TracyFreeN(ptr, name)
+#    else
+#        define TRACY_ALLOCATED_MEMORY(ptr, size)
+#        define TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, name)
+#        define TRACY_FREED_MEMORY(ptr)
+#        define TRACY_FREED_MEMORY_NAMED(ptr, name)
+#    endif
+#else
+#    define TRACY_ZONE_SCOPED()
+#    define TRACY_ZONE_SCOPED_NAMED(name)
+#    define TRACY_SET_ZONE_NAME(name, length)
+#    define TRACY_FRAME_MARK()
+#    define TRACY_FRAME_MARK_NAMED(name)
+#    define TRACY_SET_PROGRAM_NAME(name)
+#    define TRACY_PLOT(name, value)
+#    define TRACY_ALLOCATED_MEMORY(ptr, size)
+#    define TRACY_ALLOCATED_MEMORY_NAMED(ptr, size, name)
+#    define TRACY_FREED_MEMORY(ptr)
+#    define TRACY_FREED_MEMORY_NAMED(ptr, name)
+#endif

--- a/AK/Utf16StringData.cpp
+++ b/AK/Utf16StringData.cpp
@@ -24,7 +24,7 @@ NonnullRefPtr<Utf16StringData> Utf16StringData::create_uninitialized(StorageType
         ? sizeof(Utf16StringData) + (sizeof(char) * code_unit_length)
         : sizeof(Utf16StringData) + (sizeof(char16_t) * code_unit_length);
 
-    void* slot = malloc(allocation_size);
+    void* slot = kmalloc(allocation_size);
     VERIFY(slot);
 
     return adopt_ref(*new (slot) Utf16StringData(storage_type, code_unit_length));

--- a/AK/Utf16StringData.h
+++ b/AK/Utf16StringData.h
@@ -52,7 +52,7 @@ public:
 
     void operator delete(void* ptr)
     {
-        free(ptr);
+        kfree(ptr);
     }
 
     [[nodiscard]] ALWAYS_INLINE bool operator==(Utf16StringData const& other) const

--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <AK/kmalloc.h>
 
-#if defined(AK_OS_SERENITY)
+#if defined(TRACY_ENABLE_MEMORY)
 
 #    include <AK/Assertions.h>
 
@@ -20,21 +21,26 @@ void* operator new(size_t size)
 {
     void* ptr = malloc(size);
     VERIFY(ptr);
+    TRACY_ALLOCATED_MEMORY(ptr, size);
     return ptr;
 }
 
 void* operator new(size_t size, std::nothrow_t const&) noexcept
 {
-    return malloc(size);
+    auto* ptr = malloc(size);
+    TRACY_ALLOCATED_MEMORY(ptr, size);
+    return ptr;
 }
 
 void operator delete(void* ptr) noexcept
 {
+    TRACY_FREED_MEMORY(ptr);
     return free(ptr);
 }
 
 void operator delete(void* ptr, size_t) noexcept
 {
+    TRACY_FREED_MEMORY(ptr);
     return free(ptr);
 }
 
@@ -42,30 +48,27 @@ void* operator new[](size_t size)
 {
     void* ptr = malloc(size);
     VERIFY(ptr);
+    TRACY_ALLOCATED_MEMORY(ptr, size);
     return ptr;
 }
 
 void* operator new[](size_t size, std::nothrow_t const&) noexcept
 {
-    return malloc(size);
+    auto* ptr = malloc(size);
+    TRACY_ALLOCATED_MEMORY(ptr, size);
+    return ptr;
 }
 
 void operator delete[](void* ptr) noexcept
 {
+    TRACY_FREED_MEMORY(ptr);
     return free(ptr);
 }
 
 void operator delete[](void* ptr, size_t) noexcept
 {
+    TRACY_FREED_MEMORY(ptr);
     return free(ptr);
-}
-
-// This is usually provided by libstdc++ in most cases, and the kernel has its own definition in
-// Kernel/Heap/kmalloc.cpp. If neither of those apply, the following should suffice to not fail during linking.
-namespace AK_REPLACED_STD_NAMESPACE {
-
-nothrow_t const nothrow;
-
 }
 
 #endif

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -9,15 +9,47 @@
 
 #include <AK/Checked.h>
 #include <AK/Platform.h>
+
+#if defined(TRACY_ENABLE_MEMORY)
+#    include <AK/Tracy.h>
+#endif
+
 #include <new>
 #include <stdlib.h>
 
-#define kcalloc calloc
-#define kmalloc malloc
-#define kmalloc_good_size malloc_good_size
+#if !defined(TRACY_ENABLE_MEMORY)
+#    define kcalloc(count, size) calloc(count, size)
+#    define kmalloc(size) malloc(size)
+#    define kfree(ptr) free(ptr)
+#else
+#    define kcalloc(count, size)               \
+        ({                                     \
+            auto* ptr = calloc(count, size);   \
+            TRACY_ALLOCATED_MEMORY(ptr, size); \
+            ptr;                               \
+        })
+
+#    define kmalloc(size)                      \
+        ({                                     \
+            auto* ptr = malloc(size);          \
+            TRACY_ALLOCATED_MEMORY(ptr, size); \
+            ptr;                               \
+        })
+
+#    define kfree(ptr)               \
+        ({                           \
+            TRACY_FREED_MEMORY(ptr); \
+            free(ptr);               \
+        })
+#endif
+
+#define kmalloc_good_size(size) malloc_good_size(size)
 
 inline void kfree_sized(void* ptr, size_t)
 {
+#if defined(TRACY_ENABLE_MEMORY)
+    TRACY_FREED_MEMORY(ptr);
+#endif
     free(ptr);
 }
 

--- a/Libraries/LibCore/EventLoop.cpp
+++ b/Libraries/LibCore/EventLoop.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Badge.h>
+#include <AK/Tracy.h>
 #include <AK/Vector.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/EventLoopImplementation.h>
@@ -109,6 +110,7 @@ void EventLoop::spin_until(Function<bool()> goal_condition)
 
 size_t EventLoop::pump(WaitMode mode)
 {
+    TRACY_ZONE_SCOPED_NAMED("EventLoop::pump");
     return m_impl->pump(mode == WaitMode::WaitForEvents ? EventLoopImplementation::PumpMode::WaitForEvents : EventLoopImplementation::PumpMode::DontWaitForEvents);
 }
 

--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/Platform.h>
 #include <AK/Random.h>
+#include <AK/Tracy.h>
 #include <AK/Vector.h>
 #include <LibGC/BlockAllocator.h>
 #include <LibGC/HeapBlock.h>
@@ -34,6 +35,7 @@ BlockAllocator::~BlockAllocator()
 {
     for (auto* block : m_blocks) {
         ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
+        TRACY_FREED_MEMORY_NAMED(block, "GC Blocks");
 #if defined(AK_OS_MACOS)
         kern_return_t kr = mach_vm_deallocate(mach_task_self(), reinterpret_cast<mach_vm_address_t>(block), HeapBlock::BLOCK_SIZE);
         VERIFY(kr == KERN_SUCCESS);
@@ -56,6 +58,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
         auto* block = m_blocks.unstable_take(random_index);
         ASAN_UNPOISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
         LSAN_REGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+        TRACY_ALLOCATED_MEMORY_NAMED(block, HeapBlock::BLOCK_SIZE, "GC Blocks");
 #if defined(MADV_FREE_REUSE) && defined(MADV_FREE_REUSABLE)
         if (madvise(block, HeapBlock::BLOCK_SIZE, MADV_FREE_REUSE) < 0) {
             perror("madvise(MADV_FREE_REUSE)");
@@ -90,6 +93,7 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
     VERIFY(rc == 0);
 #endif
     LSAN_REGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+    TRACY_ALLOCATED_MEMORY_NAMED(block, HeapBlock::BLOCK_SIZE, "GC Blocks");
     return block;
 }
 
@@ -122,6 +126,7 @@ void BlockAllocator::deallocate_block(void* block)
 
     ASAN_POISON_MEMORY_REGION(block, HeapBlock::BLOCK_SIZE);
     LSAN_UNREGISTER_ROOT_REGION(block, HeapBlock::BLOCK_SIZE);
+    TRACY_FREED_MEMORY_NAMED(block, "GC Blocks");
     m_blocks.append(block);
 }
 

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -14,6 +14,7 @@
 #include <AK/Platform.h>
 #include <AK/StackInfo.h>
 #include <AK/TemporaryChange.h>
+#include <AK/Tracy.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibGC/CellAllocator.h>
 #include <LibGC/Heap.h>
@@ -66,6 +67,11 @@ void Heap::will_allocate(size_t size)
     }
 
     m_allocated_bytes_since_last_gc += size;
+
+#if defined(TRACY_ENABLE_MEMORY)
+    m_live_heap_size += size;
+    TRACY_PLOT("Live GC Heap Size", static_cast<i64>(m_live_heap_size));
+#endif
 }
 
 static void add_possible_value(HashMap<FlatPtr, HeapRoot>& possible_pointers, FlatPtr data, HeapRoot origin, FlatPtr min_block_address, FlatPtr max_block_address)
@@ -263,6 +269,7 @@ AK::JsonObject Heap::dump_graph()
 
 void Heap::collect_garbage(CollectionType collection_type, bool print_report)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::collect_garbage");
     VERIFY(!m_collecting_garbage);
 
     {
@@ -375,6 +382,7 @@ void Heap::enqueue_post_gc_task(AK::Function<void()> task)
 
 void Heap::gather_roots(HashMap<Cell*, HeapRoot>& roots, HashTable<HeapBlock*>& all_live_heap_blocks)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::gather_roots");
     for_each_block([&](auto& block) {
         all_live_heap_blocks.set(&block);
 
@@ -547,6 +555,7 @@ private:
 
 void Heap::mark_live_cells(HashMap<Cell*, HeapRoot> const& roots, HashTable<HeapBlock*> const& all_live_heap_blocks)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::mark_live_cells");
     dbgln_if(HEAP_DEBUG, "mark_live_cells:");
 
     MarkingVisitor visitor(*this, roots, all_live_heap_blocks);
@@ -589,6 +598,7 @@ void Heap::sweep_weak_blocks()
 
 void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measurement_timer)
 {
+    TRACY_ZONE_SCOPED_NAMED("GC::Heap::sweep_dead_cells");
     dbgln_if(HEAP_DEBUG, "sweep_dead_cells:");
     Vector<HeapBlock*, 32> empty_blocks;
     Vector<HeapBlock*, 32> full_blocks_that_became_usable;
@@ -642,6 +652,11 @@ void Heap::sweep_dead_cells(bool print_report, Core::ElapsedTimer const& measure
     }
 
     m_gc_bytes_threshold = live_cell_bytes > GC_MIN_BYTES_THRESHOLD ? live_cell_bytes : GC_MIN_BYTES_THRESHOLD;
+
+#if defined(TRACY_ENABLE_MEMORY)
+    m_live_heap_size = live_cell_bytes;
+    TRACY_PLOT("Live GC Heap Size", static_cast<i64>(m_live_heap_size));
+#endif
 
     if (print_report) {
         AK::Duration const time_spent = measurement_timer.elapsed_time();

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -151,6 +151,10 @@ private:
     size_t m_gc_bytes_threshold { GC_MIN_BYTES_THRESHOLD };
     size_t m_allocated_bytes_since_last_gc { 0 };
 
+#if defined(TRACY_ENABLE_MEMORY)
+    size_t m_live_heap_size { 0 };
+#endif
+
     bool m_should_collect_on_every_allocation { false };
 
     Vector<NonnullOwnPtr<CellAllocator>> m_size_based_cell_allocators;

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -8,6 +8,7 @@
 #include <AK/Debug.h>
 #include <AK/HashTable.h>
 #include <AK/TemporaryChange.h>
+#include <AK/Tracy.h>
 #include <LibGC/RootHashMap.h>
 #include <LibJS/AST.h>
 #include <LibJS/Bytecode/BasicBlock.h>
@@ -232,13 +233,26 @@ Interpreter::HandleExceptionResponse Interpreter::handle_exception(u32& program_
 
 void Interpreter::run_bytecode(size_t entry_point)
 {
+    auto& executable = current_executable();
+    TRACY_ZONE_SCOPED();
+
+#if defined(TRACY_ENABLE)
+    if (executable.name.is_ascii()) {
+        auto name_view = executable.name.view();
+        auto name_span = name_view.ascii_span();
+        TRACY_SET_ZONE_NAME(name_span.data(), name_span.size());
+    } else {
+        constexpr auto FunctionName = "JS::Interpreter::run_bytecode()"sv;
+        TRACY_SET_ZONE_NAME(FunctionName.characters_without_null_termination(), FunctionName.length());
+    }
+#endif
+
     if (vm().did_reach_stack_space_limit()) [[unlikely]] {
         reg(Register::exception()) = vm().throw_completion<InternalError>(ErrorType::CallStackSizeExceeded).value();
         return;
     }
 
     auto& running_execution_context = this->running_execution_context();
-    auto& executable = current_executable();
     auto const* bytecode = executable.bytecode.data();
 
     u32& program_counter = running_execution_context.program_counter;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -20,6 +20,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/TemporaryChange.h>
 #include <AK/Time.h>
+#include <AK/Tracy.h>
 #include <AK/Utf8View.h>
 #include <LibCore/Timer.h>
 #include <LibGC/RootVector.h>
@@ -1459,6 +1460,7 @@ static void propagate_overflow_to_viewport(Element& root_element, Layout::Viewpo
 
 void Document::update_layout(UpdateLayoutReason reason)
 {
+    TRACY_ZONE_SCOPED_NAMED("Document::update_layout");
     auto navigable = this->navigable();
     if (!navigable || navigable->active_document() != this)
         return;

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <LibCore/EventLoop.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -157,6 +158,7 @@ void EventLoop::spin_processing_tasks_with_source_until(Task::Source source, GC:
 // https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model
 void EventLoop::process()
 {
+    TRACY_ZONE_SCOPED_NAMED("HTML::EventLoop::process");
     if (m_skip_event_loop_processing_steps)
         return;
 
@@ -347,6 +349,7 @@ void EventLoop::process_input_events() const
 // https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering
 void EventLoop::update_the_rendering()
 {
+    TRACY_ZONE_SCOPED_NAMED("EventLoop::update_the_rendering");
     VERIFY(!m_running_rendering_task);
     m_running_rendering_task = true;
     ScopeGuard const guard = [this] {
@@ -540,6 +543,8 @@ void EventLoop::update_the_rendering()
         TemporaryExecutionContext context(document->realm(), TemporaryExecutionContext::CallbacksEnabled::Yes);
         document->fonts()->set_is_pending_on_the_environment(document->readiness() == DocumentReadyState::Loading);
     }
+
+    TRACY_FRAME_MARK();
 }
 
 void run_when_event_loop_reaches_step_1(GC::Ref<GC::Function<void()>> steps)
@@ -617,6 +622,7 @@ void perform_a_microtask_checkpoint()
 // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint
 void EventLoop::perform_a_microtask_checkpoint()
 {
+    TRACY_ZONE_SCOPED_NAMED("EventLoop::perform_a_microtask_checkpoint");
     if (execution_paused())
         return;
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/TemporaryChange.h>
+#include <AK/Tracy.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibWeb/Painting/DisplayList.h>
 
@@ -41,6 +42,7 @@ static bool command_is_clip(DisplayListCommand const& command)
 
 void DisplayListPlayer::execute(DisplayList& display_list, ScrollStateSnapshotByDisplayList&& scroll_state_snapshot_by_display_list, RefPtr<Gfx::PaintingSurface> surface)
 {
+    TRACY_ZONE_SCOPED_NAMED("DisplayListPlayer::execute");
     TemporaryChange change { m_scroll_state_snapshots_by_display_list, move(scroll_state_snapshot_by_display_list) };
     if (surface) {
         surface->lock_context();

--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -179,3 +179,4 @@ elseif (MSVC)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/sanitizers.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/tracy.cmake)

--- a/Meta/CMake/lagom_options.cmake
+++ b/Meta/CMake/lagom_options.cmake
@@ -24,6 +24,9 @@ ladybird_option(LAGOM_USE_LINKER "" CACHE STRING "The linker to use (e.g. lld, m
 ladybird_option(LAGOM_LINK_POOL_SIZE "" CACHE STRING "The maximum number of parallel jobs to use for linking")
 ladybird_option(ENABLE_LTO_FOR_RELEASE ${RELEASE_LTO_DEFAULT} CACHE BOOL "Enable link-time optimization for release builds")
 ladybird_option(ENABLE_LAGOM_COVERAGE_COLLECTION OFF CACHE STRING "Enable code coverage instrumentation for lagom binaries in clang")
+ladybird_option(ENABLE_TRACY OFF CACHE BOOL "Enable Tracy profiler instrumentation")
+ladybird_option(ENABLE_TRACY_MEMORY OFF CACHE BOOL "Enable Tracy profiler memory instrumentation")
+ladybird_option(TRACY_CALLSTACK_DEPTH 0 CACHE STRING "Tracy call stack capture depth on zones (0 = disabled, 16+ recommended)")
 
 if (ANDROID OR APPLE)
     ladybird_option(ENABLE_QT OFF CACHE BOOL "Build ladybird application using Qt GUI")

--- a/Meta/CMake/tracy.cmake
+++ b/Meta/CMake/tracy.cmake
@@ -1,0 +1,18 @@
+if (ENABLE_TRACY OR ENABLE_TRACY_MEMORY)
+    find_package(Tracy CONFIG REQUIRED)
+    add_compile_definitions(TRACY_ENABLE)
+    if (ENABLE_TRACY_MEMORY)
+        add_compile_definitions(TRACY_ENABLE_MEMORY)
+    endif()
+    if (TRACY_CALLSTACK_DEPTH GREATER 0)
+        add_compile_definitions(TRACY_CALLSTACK=${TRACY_CALLSTACK_DEPTH})
+    endif()
+    add_cxx_compile_options(-fno-omit-frame-pointer)
+    # Tracy needs full debug info to resolve call stack symbols.
+    add_cxx_compile_options(-g2)
+    if (NOT APPLE)
+        # Export symbols from executables so Tracy can resolve call stack addresses.
+        add_link_options(-rdynamic)
+    endif()
+    link_libraries(Tracy::TracyClient)
+endif()

--- a/Services/ImageDecoder/main.cpp
+++ b/Services/ImageDecoder/main.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <ImageDecoder/ConnectionFromClient.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
@@ -19,6 +20,7 @@
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("ImageDecoder");
     AK::set_rich_debug_enabled(true);
 
     Core::ArgsParser args_parser;

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -8,6 +8,7 @@
 #include <AK/ByteString.h>
 #include <AK/Format.h>
 #include <AK/StringView.h>
+#include <AK/Tracy.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
@@ -40,6 +41,7 @@ static void handle_signal(int signal)
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("RequestServer");
     AK::set_rich_debug_enabled(true);
 
     Vector<ByteString> certificates;

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/LexicalPath.h>
+#include <AK/Tracy.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
@@ -62,6 +63,7 @@ static ErrorOr<void> reinitialize_image_decoder(IPC::File const& image_decoder_s
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("WebContent");
     AK::set_rich_debug_enabled(true);
 
 #if defined(AK_OS_WINDOWS)

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Platform.h>
+#include <AK/Tracy.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Directory.h>
 #include <LibCore/EventLoop.h>
@@ -73,6 +74,7 @@ static Vector<ByteString> create_arguments(ByteString const& socket_path, bool h
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("WebDriver");
     AK::set_rich_debug_enabled(true);
 
     auto listen_address = "0.0.0.0"sv;

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
@@ -44,6 +45,7 @@ static ErrorOr<Web::Bindings::AgentType> agent_type_from_string(StringView type)
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("WebWorker");
     AK::set_rich_debug_enabled(true);
 
     int request_server_socket { -1 };

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Enumerate.h>
+#include <AK/Tracy.h>
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/BrowserProcess.h>
@@ -37,6 +38,7 @@ static void open_urls_from_client(Vector<URL::URL> const& urls, WebView::NewWind
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("Ladybird");
     AK::set_rich_debug_enabled(true);
 
     auto app = TRY(Ladybird::Application::create(arguments));

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Tracy.h>
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/BrowserProcess.h>
@@ -41,6 +42,7 @@ bool is_using_dark_system_theme(QWidget& widget)
 
 ErrorOr<int> ladybird_main(Main::Arguments arguments)
 {
+    TRACY_SET_PROGRAM_NAME("Ladybird");
     AK::set_rich_debug_enabled(true);
 
     auto app = TRY(Ladybird::Application::create(arguments));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -214,6 +214,12 @@
     },
     "sqlite3",
     {
+      "name": "tracy",
+      "features": [
+        "on-demand"
+      ]
+    },
+    {
       "name": "tiff",
       "features": [
         "zstd"
@@ -352,6 +358,10 @@
     {
       "name": "tiff",
       "version": "4.7.1#0"
+    },
+    {
+      "name": "tracy",
+      "version": "0.13.1"
     },
     {
       "name": "vulkan",


### PR DESCRIPTION
This allows us to get explicit zones (complimented with full call stacks on Linux and Windows) plus plot graphs such as memory usage (including GC blocks and live GC heap size), in per-frame boundaries or across the capture lifetime.

Demos:
- Loading a Ladybird newsletter and finding memory allocation churn when playing a video:

https://github.com/user-attachments/assets/12baba31-7a7e-41b8-ade3-1c28a78ff41d

- Loading Google and investigating a long frame, seeing layout update takes a long time and allocates ~1 MB of memory

https://github.com/user-attachments/assets/45716822-4fb4-439d-a5e6-12151d302e15

- Long JS execution frame on Google:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 15 47 29" src="https://github.com/user-attachments/assets/5c706943-55fb-427d-8b81-2ee068970082" />

- Ghost frames (i.e. stack traces) from a remote Linux machine with perf_event_paranoid=1:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 16 41 06" src="https://github.com/user-attachments/assets/f188b281-6420-4a4c-963d-54cd07570ca5" />

- Active allocations with stack traces:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 16 42 55" src="https://github.com/user-attachments/assets/8d8ffc46-1271-4974-8af7-691d2ed141bf" />

- Memory pool categorisation:
<img width="2672" height="1522" alt="Screenshot 2026-02-26 at 16 47 25" src="https://github.com/user-attachments/assets/bb3aa923-4914-4502-ae62-4cd5ed63289b" />
