### PR TITLE
Meta: Add an option to generate dSYM files for line numbers on macOS

### DIFF
--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -34,6 +34,7 @@ ladybird_option(ENABLE_GUI_TARGETS ON CACHE BOOL "Enable building GUI targets")
 ladybird_option(ENABLE_INSTALL_HEADERS ON CACHE BOOL "Enable installing headers")
 ladybird_option(ENABLE_INSTALL_FREEDESKTOP_FILES ${freedesktop_files_default} CACHE BOOL "Enable installing .desktop and .service files")
 ladybird_option(LADYBIRD_ENABLE_CPPTRACE ON CACHE BOOL "Enable use of cpptrace as the default library for stacktraces. If not available falls back to backtrace.h")
+ladybird_option(LADYBIRD_GENERATE_DSYM OFF CACHE BOOL "Generate dSYM bundles for binaries and libraries (macOS only)")
 ladybird_option(ENABLE_CI_BASELINE_CPU OFF CACHE BOOL "Use a baseline CPU target for improved ccache sharing")
 
 ladybird_option(ENABLE_RUST ON CACHE BOOL "Build Rust components")


### PR DESCRIPTION
This allows cpptrace to produce a file and line number instead of only a function, binary path and offset.