### PR TITLE
LibWeb: Skip IFC abspos static position in intrinsic sizing

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -452,9 +452,11 @@ void InlineFormattingContext::generate_line_boxes()
 
     line_builder.update_last_line();
 
-    for (auto* box : absolute_boxes) {
-        auto& box_state = m_state.get_mutable(*box);
-        box_state.set_static_position_rect(calculate_static_position_rect(*box));
+    if (m_layout_mode == LayoutMode::Normal) {
+        for (auto* box : absolute_boxes) {
+            auto& box_state = m_state.get_mutable(*box);
+            box_state.set_static_position_rect(calculate_static_position_rect(*box));
+        }
     }
 }
 


### PR DESCRIPTION
BFC, TFC, GFC, and FFC all skip absolutely positioned element handling during intrinsic sizing. IFC was the only formatting context that unconditionally calculated static positions for abspos elements.

This is unnecessary during intrinsic sizing because the positions are based on intermediate state and will be recalculated during normal layout. It also avoids creating UsedValues entries for abspos boxes that serve no purpose during intrinsic sizing.