### PR TITLE
LibWeb: Use IntrinsicSizing mode for min-height measurement in BFC

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -877,7 +877,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // min-height. If so, we run layout with min-height as the available height.
         if (should_treat_height_as_auto(box, available_space) && !box.computed_values().min_height().is_auto()) {
             LayoutState throwaway_state;
-            auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box);
+            auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
             measuring_context->run(inner_available_space);
             auto content_height = measuring_context->automatic_content_height();
             auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height());


### PR DESCRIPTION
When measuring content height to compare against min-height, a throwaway formatting context was created with m_layout_mode (the parent's layout mode, which could be Normal). This is a measurement operation and should use LayoutMode::IntrinsicSizing instead, consistent with the similar measurement in FormattingContext.cpp.