### PR TITLE
LibMedia: Only update durations from data providers if it increases

### DIFF
--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -168,7 +168,7 @@ void PlaybackManager::set_up_data_providers()
                 return;
             self->dispatch_error(move(error));
         });
-        video_track_data.provider->set_frame_end_time_handler([self = weak()](AK::Duration time) {
+        video_track_data.provider->set_duration_change_handler([self = weak()](AK::Duration time) {
             if (!self)
                 return;
             self->check_for_duration_change(time);
@@ -186,7 +186,7 @@ void PlaybackManager::set_up_data_providers()
                 return;
             self->dispatch_error(move(error));
         });
-        audio_track_data.provider->set_block_end_time_handler([self = weak()](AK::Duration time) {
+        audio_track_data.provider->set_duration_change_handler([self = weak()](AK::Duration time) {
             if (!self)
                 return;
             self->check_for_duration_change(time);

--- a/Libraries/LibMedia/Providers/AudioDataProvider.h
+++ b/Libraries/LibMedia/Providers/AudioDataProvider.h
@@ -42,7 +42,7 @@ public:
     ~AudioDataProvider();
 
     void set_error_handler(ErrorHandler&&);
-    void set_block_end_time_handler(BlockEndTimeHandler&&);
+    void set_duration_change_handler(BlockEndTimeHandler&&);
     void set_output_sample_specification(Audio::SampleSpecification);
 
     void start();
@@ -56,11 +56,11 @@ public:
 private:
     class ThreadData final : public AtomicRefCounted<ThreadData> {
     public:
-        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, NonnullOwnPtr<Audio::AudioConverter>&&);
+        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration, NonnullOwnPtr<Audio::AudioConverter>&&);
         ~ThreadData();
 
         void set_error_handler(ErrorHandler&&);
-        void set_block_end_time_handler(BlockEndTimeHandler&&);
+        void set_duration_change_handler(BlockEndTimeHandler&&);
         void set_output_sample_specification(Audio::SampleSpecification);
 
         void start();
@@ -112,6 +112,7 @@ private:
 
         NonnullRefPtr<Demuxer> m_demuxer;
         Track m_track;
+        AK::Duration m_duration;
         OwnPtr<AudioDecoder> m_decoder;
         bool m_decoder_needs_keyframe_next_seek { false };
         NonnullOwnPtr<Audio::AudioConverter> m_converter;
@@ -119,7 +120,7 @@ private:
 
         size_t m_queue_max_size { 8 };
         AudioQueue m_queue;
-        BlockEndTimeHandler m_frame_end_time_handler;
+        BlockEndTimeHandler m_duration_change_handler;
         ErrorHandler m_error_handler;
         bool m_is_in_error_state { false };
 

--- a/Libraries/LibMedia/Providers/VideoDataProvider.h
+++ b/Libraries/LibMedia/Providers/VideoDataProvider.h
@@ -44,7 +44,7 @@ public:
     ~VideoDataProvider();
 
     void set_error_handler(ErrorHandler&&);
-    void set_frame_end_time_handler(FrameEndTimeHandler&&);
+    void set_duration_change_handler(FrameEndTimeHandler&&);
     void set_frames_queue_is_full_handler(FramesQueueIsFullHandler&&);
 
     void start();
@@ -60,11 +60,11 @@ public:
 private:
     class ThreadData final : public AtomicRefCounted<ThreadData> {
     public:
-        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, RefPtr<MediaTimeProvider> const&);
+        ThreadData(NonnullRefPtr<Core::WeakEventLoopReference> const& main_thread_event_loop, NonnullRefPtr<Demuxer> const&, Track const&, AK::Duration, RefPtr<MediaTimeProvider> const&);
         ~ThreadData();
 
         void set_error_handler(ErrorHandler&&);
-        void set_frame_end_time_handler(FrameEndTimeHandler&&);
+        void set_duration_change_handler(FrameEndTimeHandler&&);
         void set_frames_queue_is_full_handler(FramesQueueIsFullHandler&&);
 
         void start();
@@ -115,6 +115,7 @@ private:
 
         NonnullRefPtr<Demuxer> m_demuxer;
         Track m_track;
+        AK::Duration m_duration;
         OwnPtr<VideoDecoder> m_decoder;
         bool m_decoder_needs_keyframe_next_seek { false };
 
@@ -122,7 +123,7 @@ private:
 
         size_t m_queue_max_size { 4 };
         ImageQueue m_queue;
-        FrameEndTimeHandler m_frame_end_time_handler;
+        FrameEndTimeHandler m_duration_change_handler;
         ErrorHandler m_error_handler;
         bool m_is_in_error_state { false };
         FramesQueueIsFullHandler m_frames_queue_is_full_handler;


### PR DESCRIPTION
Previously, we would call the frame end callbacks every time a frame was decoded. However, the only use case for the callback was to update the media duration. Instead, cache the duration in the data providers, and only invoke the callback (renamed to duration_change_handler) when the duration actually increases. Hopefully this will reduce wasted work, and possibly some allocations as well.