### PR TITLE
LibWeb: Restrict throwaway layout states to their subtree

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1358,8 +1358,7 @@ void Document::mark_svg_root_as_needing_relayout(Layout::SVGSVGBox& svg_root)
 
 static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
 {
-    Layout::LayoutState layout_state;
-    layout_state.set_subtree_root(svg_root);
+    Layout::LayoutState layout_state(svg_root);
 
     // Pre-populate the svg_root itself.
     if (auto const* paintable = svg_root.paintable_box())

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -278,12 +278,12 @@ struct LayoutState {
         Optional<StaticPositionRect> m_static_position_rect;
     };
 
+    LayoutState() = default;
+    explicit LayoutState(NodeWithStyle const& subtree_root);
     ~LayoutState();
 
     // Commits the used values produced by layout and builds a paintable tree.
     void commit(Box& root);
-
-    void set_subtree_root(NodeWithStyle const& node) { m_subtree_root = &node; }
 
     void ensure_capacity(u32 node_count);
 
@@ -291,6 +291,7 @@ struct LayoutState {
     UsedValues const& get(NodeWithStyle const&) const;
 
     UsedValues& populate_from_paintable(NodeWithStyle const&, Painting::PaintableBox const&);
+    UsedValues& populate_node_from(LayoutState const& source, NodeWithStyle const& node);
 
     UsedValues const* try_get(NodeWithStyle const&) const;
     UsedValues* try_get_mutable(NodeWithStyle const&);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -78,6 +78,9 @@ private:
 
     bool use_fixed_mode_layout() const;
 
+    CSSPixels table_wrapper_containing_block_width() const;
+    CSSPixels table_wrapper_containing_block_height() const;
+
     CSSPixels m_table_height { 0 };
     CSSPixels m_automatic_content_height { 0 };
 

--- a/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-max-content.txt
@@ -4,20 +4,20 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       Box <div.grid-container> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.grid-item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+        BlockContainer <div.grid-item> at [8,8] [0+0+0 98 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 11, rect: [8,8 93.765625x18] baseline: 13.796875
               "min-content"
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.grid-item> at [208,8] [0+0+0 98.640625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 11, rect: [208,8 98.640625x18] baseline: 13.796875
+        BlockContainer <div.grid-item> at [204,8] [0+0+0 98.640625 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [204,8 98.640625x18] baseline: 13.796875
               "max-content"
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.grid-item> at [306.640625,8] [0+0+0 485.359375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [306.640625,8 21.609375x18] baseline: 13.796875
+        BlockContainer <div.grid-item> at [302.640625,8] [0+0+0 489.359375 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [302.640625,8 21.609375x18] baseline: 13.796875
               "1fr"
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -27,11 +27,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x18]
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 100x18]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 98x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [208,8 98.640625x18]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [204,8 98.640625x18]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<DIV>.grid-item) [306.640625,8 485.359375x18]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [302.640625,8 489.359375x18]
           TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -7,7 +7,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       TextNode <#text> (not painted)
       TableWrapper <(anonymous)> at [125.59375,8] floating [0+0+0 478.234375 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
-        Box <table.middle> at [125.59375,8] table-box [0+0+0 478.234375 0+0+190.328125] [0+0+0 24 0+0+0] [TFC] children: not-inline
+        Box <table.middle> at [125.59375,8] table-box [0+0+0 478.234375 0+0+186.515625] [0+0+0 24 0+0+0] [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
           Box <tbody> at [127.59375,10] table-row-group [0+0+0 474.234375 0+0+0] [0+0+0 20 0+0+0] children: not-inline


### PR DESCRIPTION
Throwaway LayoutState instances used for intrinsic sizing should not access nodes outside the laid-out subtree. Make this explicit by setting a subtree root on each throwaway state, pre-populating only the immediate containing block, and using try_get() for any ancestor lookups — treating unavailable ancestors as indefinite rather than silently populating them with incorrectly-resolved values.