### PR TITLE
LibIPC: Reduce stack usage in IPC dispatch functions

### DIFF
--- a/Libraries/LibIPC/Connection.cpp
+++ b/Libraries/LibIPC/Connection.cpp
@@ -34,10 +34,11 @@ bool ConnectionBase::is_open() const
 
 ErrorOr<void> ConnectionBase::post_message(Message const& message)
 {
-    return post_message(TRY(message.encode()));
+    auto buffer = TRY(message.encode());
+    return post_message(buffer);
 }
 
-ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
+ErrorOr<void> ConnectionBase::post_message(MessageBuffer& buffer)
 {
     // NOTE: If this connection is being shut down, but has not yet been destroyed,
     //       the socket will be closed. Don't try to send more messages.

--- a/Libraries/LibIPC/Connection.h
+++ b/Libraries/LibIPC/Connection.h
@@ -26,7 +26,7 @@ public:
 
     [[nodiscard]] bool is_open() const;
     ErrorOr<void> post_message(Message const&);
-    ErrorOr<void> post_message(MessageBuffer);
+    ErrorOr<void> post_message(MessageBuffer&);
 
     void shutdown();
     virtual void die() { }

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -658,7 +658,7 @@ void generate_proxy_method(SourceGenerator& message_generator, Endpoint const& e
     } else {
         // Async messages silently ignore send failures (e.g. peer disconnected).
         message_generator.append(R"~~~());
-        (void)m_connection.post_message(move(message_buffer)); )~~~");
+        (void)m_connection.post_message(message_buffer); )~~~");
     }
 
     message_generator.appendln(R"~~~(


### PR DESCRIPTION
Since IPC dispatch often sits at the base of the stack, excessive stack usage means more potentially-bogus values going into our conservative GC stack scan.

By refactoring slightly, we remove almost 4 KiB of potentially uninitialized stack values for the GC to worry about.