### PR TITLE
LibHTTP: Parse token-list headers according to their ABNF

### DIFF
--- a/Tests/LibHTTP/TestHTTPUtils.cpp
+++ b/Tests/LibHTTP/TestHTTPUtils.cpp
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <LibHTTP/Cache/Utilities.h>
 #include <LibHTTP/HTTP.h>
+#include <LibHTTP/Header.h>
 
 TEST_CASE(collect_an_http_quoted_string)
 {
@@ -124,4 +125,90 @@ TEST_CASE(extract_cache_control_directive)
     EXPECT_EQ(HTTP::extract_cache_control_directive("max-age==4"sv, "max-age"sv), "=4"sv);
     EXPECT_EQ(HTTP::extract_cache_control_directive("max-age=4="sv, "max-age"sv), "4="sv);
     EXPECT(!HTTP::contains_cache_control_directive("=4"sv, "max-age"sv));
+}
+
+TEST_CASE(extract_header_values)
+{
+    struct TestHeader {
+        StringView name;
+        bool requires_at_least_one; // true = 1#token, false = #token
+    };
+
+    TestHeader const headers[] = {
+        { "Access-Control-Expose-Headers"sv, false },
+        { "access-control-expose-headers"sv, false },
+        { "Access-Control-Allow-Headers"sv, false },
+        { "Access-Control-Allow-Methods"sv, false },
+        { "Access-Control-Request-Headers"sv, true },
+        { "Accept-Ranges"sv, true },
+    };
+
+    for (auto const& [header, requires_at_least_one] : headers) {
+        // Valid single token.
+        auto result = HTTP::Header { header, "bb-8"sv }.extract_header_values();
+        EXPECT_EQ(result, (Vector<ByteString> { "bb-8" }));
+
+        // Valid multiple tokens, whitespace trimmed.
+        result = HTTP::Header { header, "bb-8, no"sv }.extract_header_values();
+        EXPECT_EQ(result, (Vector<ByteString> { "bb-8", "no" }));
+
+        // Wildcard is a valid token.
+        result = HTTP::Header { header, "*"sv }.extract_header_values();
+        EXPECT_EQ(result, (Vector<ByteString> { "*" }));
+
+        // Single-quoted tokens are valid (apostrophe is a tchar).
+        result = HTTP::Header { header, "'bb-8',bb-8"sv }.extract_header_values();
+        EXPECT_EQ(result, (Vector<ByteString> { "'bb-8'", "bb-8" }));
+
+        // Leading/trailing commas: empty parts discarded.
+        result = HTTP::Header { header, ",bb-8,"sv }.extract_header_values();
+        EXPECT_EQ(result, (Vector<ByteString> { "bb-8" }));
+
+        // Empty value and only-commas.
+        result = HTTP::Header { header, ""sv }.extract_header_values();
+        if (requires_at_least_one) {
+            EXPECT_EQ(result, OptionalNone {});
+        } else {
+            EXPECT_EQ(result, (Vector<ByteString> {}));
+        }
+
+        result = HTTP::Header { header, ",,,"sv }.extract_header_values();
+        if (requires_at_least_one) {
+            EXPECT_EQ(result, OptionalNone {});
+        } else {
+            EXPECT_EQ(result, (Vector<ByteString> {}));
+        }
+
+        // Space inside a token is invalid.
+        result = HTTP::Header { header, "no no"sv }.extract_header_values();
+        EXPECT_EQ(result, OptionalNone {});
+
+        // Double-quote is invalid.
+        result = HTTP::Header { header, "\"bb-8\",bb-8"sv }.extract_header_values();
+        EXPECT_EQ(result, OptionalNone {});
+
+        // @ is invalid.
+        result = HTTP::Header { header, "@invalid,bb-8"sv }.extract_header_values();
+        EXPECT_EQ(result, OptionalNone {});
+
+        // Vertical tab (0x0B) is invalid.
+        result = HTTP::Header { header, "bb-8\x0B"sv }.extract_header_values();
+        EXPECT_EQ(result, OptionalNone {});
+
+        // Form feed (0x0C) is invalid.
+        result = HTTP::Header { header, "bb-8\x0C"sv }.extract_header_values();
+        EXPECT_EQ(result, OptionalNone {});
+
+        // Invalid token alongside a valid one still fails.
+        result = HTTP::Header { header, "bb-8,no no"sv }.extract_header_values();
+        EXPECT_EQ(result, OptionalNone {});
+
+        // Whitespace-only item between commas fails.
+        result = HTTP::Header { header, "bb-8,  ,no"sv }.extract_header_values();
+        EXPECT_EQ(result, OptionalNone {});
+    }
+
+    // Other headers: returned as a single-element list regardless of content.
+    auto result = HTTP::Header { "Content-Type"sv, "text/html; charset=utf-8"sv }.extract_header_values();
+    EXPECT_EQ(result, (Vector<ByteString> { "text/html; charset=utf-8" }));
 }


### PR DESCRIPTION
The previous implementation did not fully align with each headers ABNF, so would not reject some headers as we should have been doing.

Fixes 6 WPT subtests for

https://wpt.live/cors/access-control-expose-headers-parsing.window.html