### PR TITLE
LibWeb: Apply contain constraint in default image sizing algorithm

### DIFF
--- a/Tests/LibWeb/Ref/expected/background-size-auto-svg-no-intrinsic-size-ref.html
+++ b/Tests/LibWeb/Ref/expected/background-size-auto-svg-no-intrinsic-size-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+div {
+    width: 100px;
+    height: 50px;
+    background: url(../data/50x50-green.svg) no-repeat;
+    background-size: 50px 50px;
+}
+</style>
+<div></div>
+<!-- FIXME: Workaround to ensure CSS background-image is loaded before taking screenshot: https://github.com/LadybirdBrowser/ladybird/issues/3448 -->
+<img style="display: none" src="../data/50x50-green.svg">

--- a/Tests/LibWeb/Ref/input/background-size-auto-svg-no-intrinsic-size.html
+++ b/Tests/LibWeb/Ref/input/background-size-auto-svg-no-intrinsic-size.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/background-size-auto-svg-no-intrinsic-size-ref.html">
+<style>
+div {
+    width: 100px;
+    height: 50px;
+    background: url(../data/50x50-green.svg) no-repeat;
+}
+</style>
+<div></div>
+<!-- FIXME: Workaround to ensure CSS background-image is loaded before taking screenshot: https://github.com/LadybirdBrowser/ladybird/issues/3448 -->
+<img style="display: none" src="../data/50x50-green.svg">


### PR DESCRIPTION
When an image has no intrinsic dimensions but has an intrinsic aspect ratio, the CSS default sizing algorithm should resolve its size as a contain constraint against the default object size. Previously, we returned the default size directly, which caused such images to stretch to fill the entire background positioning area. The SVG's default `preserveAspectRatio` would then center the content within that oversized viewport, making the image appear horizontally mispositioned.

Fixes the logo positioning on https://webkit.org:

Before:

<img width="611" height="279" alt="image" src="https://github.com/user-attachments/assets/29601497-44e6-448b-8082-adee7040392e" />

After:

<img width="611" height="279" alt="image" src="https://github.com/user-attachments/assets/57e28434-d21e-4f04-b251-d044bd219f22" />

