### PR TITLE
LibWeb: Apply document stylesheets to SVG use element shadow trees

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -272,7 +272,8 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::AbstractE
             || (element_shadow_root && rule_root == element_shadow_root)
             || from_user_agent_or_user_stylesheet
             || rule_to_run.slotted
-            || rule_to_run.contains_part_pseudo_element;
+            || rule_to_run.contains_part_pseudo_element
+            || (shadow_root && !rule_root && shadow_root->uses_document_style_sheets());
 
         if (!rule_is_relevant_for_current_scope)
             return;

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -214,8 +214,12 @@ String AbstractElement::debug_description() const
 CSS::StyleScope const& AbstractElement::style_scope() const
 {
     auto& root = m_element->root();
-    if (root.is_shadow_root())
-        return as<DOM::ShadowRoot>(root).style_scope();
+    if (root.is_shadow_root()) {
+        auto& shadow_root = as<DOM::ShadowRoot>(root);
+        if (shadow_root.uses_document_style_sheets())
+            return root.document().style_scope();
+        return shadow_root.style_scope();
+    }
     return root.document().style_scope();
 }
 

--- a/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -49,6 +49,9 @@ public:
     [[nodiscard]] bool is_user_agent_internal() const { return m_user_agent_internal; }
     void set_user_agent_internal(bool user_agent_internal) { m_user_agent_internal = user_agent_internal; }
 
+    [[nodiscard]] bool uses_document_style_sheets() const { return m_uses_document_style_sheets; }
+    void set_uses_document_style_sheets(bool value) { m_uses_document_style_sheets = value; }
+
     // ^EventTarget
     virtual EventTarget* get_parent(Event const&) override;
 
@@ -117,6 +120,7 @@ private:
     bool m_delegates_focus { false };
     bool m_available_to_element_internals { false };
     bool m_user_agent_internal { false };
+    bool m_uses_document_style_sheets { false };
 
     // https://dom.spec.whatwg.org/#shadowroot-declarative
     bool m_declarative { false };

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -182,6 +182,11 @@ void SVGUseElement::clone_element_tree_as_our_shadow_tree(Element* to_clone)
 {
     shadow_root()->remove_all_children();
 
+    // https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance
+    // When the referenced element is from the same document as the ‘use’ element, the same document stylesheets will
+    // apply in both the original document and the shadow tree document fragment.
+    shadow_root()->set_uses_document_style_sheets(to_clone && is_referenced_element_same_document());
+
     if (to_clone && is_valid_reference_element(*to_clone)) {
         // The ‘use’ element references another element, a copy of which is rendered in place of the ‘use’ in the document.
         auto cloned_reference_node = MUST(to_clone->clone_node(nullptr, true));

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/linking/reftests/use-descendant-combinator-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/linking/reftests/use-descendant-combinator-ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS Test reference</title>
+<p>
+  You should see a green square, and no red.
+</p>
+<svg
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/green-100x100.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/green-100x100.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="green"/>
+</svg>

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/styling/use-element-selector-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/styling/use-element-selector-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>SVG Test Reference</title>
+<svg>
+  <rect width="100" height="100" fill="green"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/styling/use-element-transitions-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/styling/use-element-transitions-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Test Reference</title>
+<style>
+  use { font-size: 60px; }
+  g { font-size: 100px; }
+</style>
+<svg>
+  <use id="use_elm" xlink:href="#tmpl" />
+  <g id="g_elm">
+    <text id="tmpl" x="10" y="100">Hello!</text>
+  </g>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/linking/reftests/use-descendant-combinator-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/linking/reftests/use-descendant-combinator-002.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS Test: use element doesn't cross shadow tree boundaries in selector-matching</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../../expected/wpt-import//svg/linking/reftests/use-descendant-combinator-ref.html">
+<style>
+#test rect {
+  stroke: red;
+  stroke-width: 10px;
+}
+.inside-use rect {
+  fill: green;
+}
+</style>
+<p>
+  You should see a green square, and no red.
+</p>
+<svg
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <g id="square">
+      <g class="inside-use">
+        <rect width="100" height="100"/>
+      </g>
+    </g>
+  </defs>
+  <g id="test">
+    <use xlink:href="#square" />
+  </g>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/linking/reftests/use-descendant-combinator-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/linking/reftests/use-descendant-combinator-003.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSS Test: use element doesn't cross shadow tree boundaries in selector-matching, and is invalidated properly</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../../expected/wpt-import//svg/linking/reftests/use-descendant-combinator-ref.html">
+<style>
+#test rect {
+  stroke: red;
+  stroke-width: 10px;
+}
+.inside-use rect {
+  fill: red;
+}
+defs .inside-use rect {
+  fill: red;
+}
+</style>
+<p>
+  You should see a green square, and no red.
+</p>
+<svg>
+  <defs>
+    <g id="square">
+      <g class="inside-use">
+        <rect width="100" height="100"/>
+      </g>
+    </g>
+  </defs>
+  <g id="test">
+    <use href="#square" />
+  </g>
+</svg>
+<script>
+  document.body.offsetTop;
+  document.styleSheets[0].cssRules[1].style.fill = 'green';
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/use-inheritance-001.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/use-inheritance-001.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Use property inheritance in SVG2</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance"/>
+    <h:link rel="match" href="../../../../../expected/wpt-import/svg/struct/reftests/reference/green-100x100.svg"/>
+    <h:link rel="author" title="Mike Bremford" href="http://bfo.com"/>
+  </metadata>
+  <style>
+  use rect { stroke: red }
+  .container rect { fill: red; stroke: red }
+  rect { stroke-width: 40px; stroke: green }
+  rect:root { opacity: 0 }
+  </style>
+  <defs>
+    <g class="container">
+      <rect id="r" x="20" y="20" width="60" height="60" style="fill-opacity:1"/>
+    </g>
+  </defs>
+  <g>
+    <use href="#r" xlink:href="#r" style="fill: green; fill-opacity:0"/>
+  </g>
+  <!--
+  This presume the SVG2 use inheritance rules, in SVG1 it will display as red.
+
+  1. The "rect" cloned by the "use" element is in a shadow DOM, so it DOES NOT
+     inherit the stroke from the "use rect" or ".container rect" style rules.
+  2. The cloned "rect" DOES get the rules set by the "rect" style rule, as that
+     still matches elements in the shadow DOM.
+  3. The "rect" DOES inherit "fill: green" from the <use>
+  4. The "rect"'s own "fill-opacity: 1" overrides the "fill-opacity: 0" inherited
+     from the "use" element.
+  5. Even though "rect" is considered to have no parent, it is not a root element
+     so does not match the rect:root style rule
+  -->
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/use-inheritance-nth-child-of.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/use-inheritance-nth-child-of.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Use property inheritance with :nth-child(... of &lt;selector list&gt;) in SVG2</title>
+  <metadata>
+    <h:link rel="match" href="../../../../../expected/wpt-import/svg/struct/reftests/reference/green-100x100.svg"/>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance"/>
+    <h:link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1821258"/>
+    <h:link rel="author" title="Zach Hoffman" href="mailto:zach@zrhoffman.net"/>
+  </metadata>
+  <style>
+  :nth-child(n of use rect) { stroke: red }
+  :nth-child(n of .container rect) { fill: red; stroke: red }
+  rect { stroke-width: 40px; stroke: green }
+  rect:root { opacity: 0 }
+  </style>
+  <defs>
+    <g class="container">
+      <rect id="r" x="20" y="20" width="60" height="60" style="fill-opacity:1"/>
+    </g>
+  </defs>
+  <g>
+    <use href="#r" xlink:href="#r" style="fill: green; fill-opacity:0"/>
+  </g>
+  <!--
+  This presumes the SVG2 use inheritance rules, in SVG1 it will display as red.
+
+  1. The "rect" cloned by the "use" element is in a shadow DOM, so it DOES NOT
+     inherit the stroke from the ":nth-child(n of use rect)" or
+     ":nth-child(n of .container rect)" style rules.
+  2. The cloned "rect" DOES get the rules set by the "rect" style rule, as that
+     still matches elements in the shadow DOM.
+  3. The "rect" DOES inherit "fill: green" from the <use>
+  4. The "rect"'s own "fill-opacity: 1" overrides the "fill-opacity: 0" inherited
+     from the "use" element.
+  5. Even though "rect" is considered to have no parent, it is not a root element
+     so does not match the rect:root style rule
+  -->
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/use-inheritance-nth-last-child-of.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/use-inheritance-nth-last-child-of.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Use property inheritance with :nth-last-child(... of &lt;selector list&gt;) in SVG2</title>
+  <metadata>
+    <h:link rel="match" href="../../../../../expected/wpt-import/svg/struct/reftests/reference/green-100x100.svg"/>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseStyleInheritance"/>
+    <h:link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1821258"/>
+    <h:link rel="author" title="Zach Hoffman" href="mailto:zach@zrhoffman.net"/>
+  </metadata>
+  <style>
+  :nth-last-child(n of use rect) { stroke: red }
+  :nth-last-child(n of .container rect) { fill: red; stroke: red }
+  rect { stroke-width: 40px; stroke: green }
+  rect:root { opacity: 0 }
+  </style>
+  <defs>
+    <g class="container">
+      <rect id="r" x="20" y="20" width="60" height="60" style="fill-opacity:1"/>
+    </g>
+  </defs>
+  <g>
+    <use href="#r" xlink:href="#r" style="fill: green; fill-opacity:0"/>
+  </g>
+  <!--
+  This presumes the SVG2 use inheritance rules, in SVG1 it will display as red.
+
+  1. The "rect" cloned by the "use" element is in a shadow DOM, so it DOES NOT
+     inherit the stroke from the ":nth-last-child(n of use rect)" or
+     ":nth-last-child(n of .container rect)" style rules.
+  2. The cloned "rect" DOES get the rules set by the "rect" style rule, as that
+     still matches elements in the shadow DOM.
+  3. The "rect" DOES inherit "fill: green" from the <use>
+  4. The "rect"'s own "fill-opacity: 1" overrides the "fill-opacity: 0" inherited
+     from the "use" element.
+  5. Even though "rect" is considered to have no parent, it is not a root element
+     so does not match the rect:root style rule
+  -->
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-animations.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-animations.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<title>SVG Test: Independent CSS animations on svg:use instantiation and corresponding element</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../expected/wpt-import/svg/styling/use-element-transitions-ref.html">
+<style>
+  use {
+    font-size: 40px;
+  }
+  g {
+    font-size: 120px;
+  }
+  @keyframes font-anim {
+    0% { /* starts from computed font-size */ }
+    100% { font-size: 80px; }
+  }
+  text {
+    animation: font-anim 100s steps(2, start);
+  }
+</style>
+<svg>
+  <use id="use_elm" xlink:href="#tmpl" />
+  <g id="g_elm">
+    <text id="tmpl" x="10" y="100">Hello!</text>
+  </g>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-attr-selector.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-attr-selector.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>SVG Test: Attribute change in template affects attribute selector matching in &lt;use&gt; element tree</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../expected/wpt-import/svg/styling/use-element-selector-ref.html">
+<style>
+  [attr] > #rect { fill: green; }
+</style>
+<svg>
+  <use id="use_elm" xlink:href="#tmpl" />
+  <defs>
+    <g id="tmpl">
+      <rect id="rect" width="100" height="100"></rect>
+    </g>
+  </defs>
+</svg>
+<script>
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      tmpl.setAttribute("attr", "val");
+      document.documentElement.classList.remove('reftest-wait');
+    });
+  });
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-class-selector.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-class-selector.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>SVG Test: Class change in template affects class selector matching in &lt;use&gt; element tree</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../expected/wpt-import/svg/styling/use-element-selector-ref.html">
+<style>
+  .class > #rect { fill: green; }
+</style>
+<svg>
+  <use id="use_elm" xlink:href="#tmpl" />
+  <defs>
+    <g id="tmpl">
+      <rect id="rect" width="100" height="100"></rect>
+    </g>
+  </defs>
+</svg>
+<script>
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      tmpl.setAttribute("class", "class");
+      document.documentElement.classList.remove('reftest-wait');
+    });
+  });
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-id-selector.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-id-selector.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>SVG Test: Id change in template affects id selector matching in &lt;use&gt; element tree</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../expected/wpt-import/svg/styling/use-element-selector-ref.html">
+<style>
+  #id > #rect { fill: green; }
+</style>
+<svg>
+  <use id="use_elm" xlink:href="#tmpl" />
+  <defs>
+    <g id="tmpl">
+      <g id="no_id">
+        <rect id="rect" width="100" height="100"></rect>
+      </g>
+    </g>
+  </defs>
+</svg>
+<script>
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      no_id.setAttribute("id", "id");
+      document.documentElement.classList.remove('reftest-wait');
+    });
+  });
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-non-rendered-has-selector.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-non-rendered-has-selector.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>SVG Test: CSS selector matching non-rendered descendant with :has() in &lt;use&gt; element tree</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../expected/wpt-import/svg/styling/use-element-selector-ref.html">
+<style>
+  #rect:has(defs) { fill: green; }
+</style>
+<svg>
+  <use id="use_elm" xlink:href="#group" />
+  <defs>
+    <g id="group">
+      <rect id="rect" width="100" height="100">
+        <defs></defs>
+      </rect>
+    </g>
+  </defs>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-non-rendered-sibling-selector.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/styling/use-element-non-rendered-sibling-selector.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>SVG Test: CSS selector matching non-rendered sibling in &lt;use&gt; element tree</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/struct.html#UseElement">
+<link rel="match" href="../../../../expected/wpt-import/svg/styling/use-element-selector-ref.html">
+<style>
+  defs + #rect { fill: green; }
+</style>
+<svg>
+  <use id="use_elm" xlink:href="#group" />
+  <defs>
+    <g id="group">
+      <defs></defs>
+      <rect id="rect" width="100" height="100"></rect>
+    </g>
+  </defs>
+</svg>


### PR DESCRIPTION
The SVG spec says document stylesheets should apply inside `<use>` element shadow trees if the referenced element is from the same document.

Improves the reddit logo on https://redditinc.com/:

Before:

<img width="1025" height="453" alt="image" src="https://github.com/user-attachments/assets/40a3ca6f-d0f4-4710-aa0c-776409ac0e5f" />


After:

<img width="1025" height="453" alt="image" src="https://github.com/user-attachments/assets/820a95fa-4dff-48c0-8d6c-897dd7e1988a" />
