### PR TITLE
Meta+LibWeb: Use a code generator to create the media controls' DOM

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1187,7 +1187,6 @@ generate_html_implementation()
 set(GENERATED_SOURCES
     ARIA/AriaRoles.cpp
     CSS/DefaultStyleSheetSource.cpp
-    CSS/MediaControlsStyleSheetSource.cpp
     CSS/DescriptorID.cpp
     CSS/Enums.cpp
     CSS/EnvironmentVariable.cpp
@@ -1208,6 +1207,7 @@ set(GENERATED_SOURCES
     SVG/SVGStyleSheetSource.cpp
     Worker/WebWorkerClientEndpoint.h
     Worker/WebWorkerServerEndpoint.h
+    HTML/MediaControlsDOM.cpp
     HTML/Parser/NamedCharacterReferences.cpp
 )
 

--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -10,30 +10,19 @@
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/IDLEventListener.h>
 #include <LibWeb/DOM/ShadowRoot.h>
-#include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/AudioTrackList.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/MediaControls.h>
 #include <LibWeb/HTML/Window.h>
-#include <LibWeb/Namespace.h>
-#include <LibWeb/SVG/AttributeNames.h>
-#include <LibWeb/SVG/TagNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/KeyboardEvent.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 #include <LibWeb/WebIDL/CallbackType.h>
-
-namespace Web::CSS {
-
-extern String media_controls_stylesheet_source;
-
-}
 
 namespace Web::HTML {
 
@@ -51,92 +40,6 @@ MediaControls::~MediaControls()
         media_element->set_shadow_root(nullptr);
 }
 
-static GC::Ref<DOM::Element> create_html_element(DOM::Document& document, FlyString const& tag, StringView class_name = {})
-{
-    auto element = MUST(DOM::create_element(document, tag, Namespace::HTML));
-    if (!class_name.is_empty())
-        element->set_attribute_value(HTML::AttributeNames::class_, String::from_utf8(class_name).release_value());
-    return element;
-}
-
-static GC::Ref<DOM::Element> create_svg_element(DOM::Document& document, FlyString const& tag, StringView class_name = {})
-{
-    auto element = MUST(DOM::create_element(document, tag, Namespace::SVG));
-    if (!class_name.is_empty())
-        element->set_attribute_value(SVG::AttributeNames::class_, String::from_utf8(class_name).release_value());
-    return element;
-}
-
-static String s_icon_view_box = "0 0 24 24"_string;
-
-static GC::Ref<DOM::Element> create_play_icon(DOM::Document& document, StringView class_name)
-{
-    auto icon = create_svg_element(document, SVG::TagNames::svg, class_name);
-    icon->set_attribute_value(SVG::AttributeNames::viewBox, s_icon_view_box);
-
-    auto path = create_svg_element(document, SVG::TagNames::path, "play-path"sv);
-    path->set_attribute_value(SVG::AttributeNames::d, "m6 5 13 7-13 7Z"_string);
-    MUST(icon->append_child(path));
-
-    return icon;
-}
-
-static GC::Ref<DOM::Element> create_mute_icon(DOM::Document& document, StringView class_name)
-{
-    auto icon = create_svg_element(document, SVG::TagNames::svg, class_name);
-    icon->set_attribute_value(SVG::AttributeNames::viewBox, s_icon_view_box);
-
-    // Muted clipping path
-    auto defs = create_svg_element(document, SVG::TagNames::defs);
-    MUST(icon->append_child(defs));
-
-    auto muted_clip_path = create_svg_element(document, SVG::TagNames::clipPath);
-    muted_clip_path->set_attribute_value(AttributeNames::id, "muted-clip"_string);
-    MUST(defs->append_child(muted_clip_path));
-
-    auto muted_clip_path_path = create_svg_element(document, SVG::TagNames::path);
-    muted_clip_path_path->set_attribute_value(SVG::AttributeNames::d, "M3 0h21v21ZM0 0v24h24z"_string);
-    MUST(muted_clip_path->append_child(muted_clip_path_path));
-
-    // Muted cross-out line
-    auto muted_line = create_svg_element(document, SVG::TagNames::path, "muted-line"_string);
-    muted_line->set_attribute_value(SVG::AttributeNames::d, "m5 5 14 14-1.5 1.5-14-14z"_string);
-    MUST(icon->append_child(muted_line));
-
-    // High volume wave path
-    auto volume_high = create_svg_element(document, SVG::TagNames::path, "volume-high"_string);
-    volume_high->set_attribute_value(SVG::AttributeNames::d, "M14 4.08v2.04c2.23.55 4 2.9 4 5.88 0 2.97-1.77 5.33-4 5.88v2.04c3.45-.56 6-3.96 6-7.92s-2.55-7.36-6-7.92Z"_string);
-    MUST(icon->append_child(volume_high));
-
-    // Low volume wave path
-    auto volume_low = create_svg_element(document, SVG::TagNames::path, "volume-low"_string);
-    volume_low->set_attribute_value(SVG::AttributeNames::d, "M14 7.67v8.66c.35-.25.66-.55.92-.9A5.7 5.7 0 0 0 16 12c0-1.3-.39-2.5-1.08-3.43a4.24 4.24 0 0 0-.92-.9Z"_string);
-    MUST(icon->append_child(volume_low));
-
-    // Speaker path
-    auto speaker = create_svg_element(document, SVG::TagNames::path, "speaker"_string);
-    speaker->set_attribute_value(SVG::AttributeNames::d, "M4 9v6h4l4 5V4L8 9Z"_string);
-    MUST(icon->append_child(speaker));
-
-    return icon;
-}
-
-static GC::Ref<DOM::Element> create_fullscreen_icon(DOM::Document& document, StringView class_name)
-{
-    auto icon = create_svg_element(document, SVG::TagNames::svg, class_name);
-    icon->set_attribute_value(SVG::AttributeNames::viewBox, s_icon_view_box);
-
-    auto maximize_path = create_svg_element(document, SVG::TagNames::path, "fullscreen-maximize-path"sv);
-    maximize_path->set_attribute_value(SVG::AttributeNames::d, "M3 3h6v2H5v4H3Zm12 0h6v6h-2V5h-4Zm6 12v6h-6v-2h4v-4ZM3 15v6h6v-2H5v-4Z"_string);
-    MUST(icon->append_child(maximize_path));
-
-    auto minimize_path = create_svg_element(document, SVG::TagNames::path, "fullscreen-minimize-path"sv);
-    minimize_path->set_attribute_value(SVG::AttributeNames::d, "M9 3v6H3V7h4V3Zm6 0v6h6V7h-4V3ZM3 15h6v6H7v-4H3Zm12 0v6h2v-4h4v-2Z"_string);
-    MUST(icon->append_child(minimize_path));
-
-    return icon;
-}
-
 void MediaControls::create_shadow_tree()
 {
     auto& media_element = *m_media_element;
@@ -149,82 +52,14 @@ void MediaControls::create_shadow_tree()
     shadow_root->set_user_agent_internal(true);
     media_element.set_shadow_root(shadow_root);
 
-    // Scoped stylesheet
-    auto style_element = create_html_element(document, HTML::TagNames::style);
-    MUST(style_element->set_text_content(Utf16String::from_utf8(CSS::media_controls_stylesheet_source)));
-    MUST(shadow_root->append_child(style_element));
+    m_dom = MediaControlsDOM(document, *shadow_root, is_video ? MediaControlsDOM::Options::Video : MediaControlsDOM::Options::None);
 
-    // Controls container
-    auto controls_container = create_html_element(document, HTML::TagNames::div, is_video ? "container video"sv : "container audio"sv);
-    MUST(shadow_root->append_child(controls_container));
-
-    // Video overlay — covers the full video area to catch clicks for play/pause toggle.
-    // Also contains the placeholder circle shown when no video data is available.
-    if (is_video) {
-        m_video_overlay = create_html_element(document, HTML::TagNames::div, "video-overlay"sv);
-        MUST(controls_container->append_child(*m_video_overlay));
-
-        m_placeholder_circle = create_html_element(document, HTML::TagNames::div, "placeholder-circle"sv);
-        MUST(m_video_overlay->append_child(*m_placeholder_circle));
-
-        auto placeholder_icon = create_play_icon(document, "placeholder-icon"sv);
-        MUST(m_placeholder_circle->append_child(placeholder_icon));
-    }
-
-    // Control bar container
-    m_control_bar = create_html_element(document, HTML::TagNames::div, "controls"sv);
-    MUST(controls_container->append_child(*m_control_bar));
-
-    // Timeline
-    m_timeline_element = create_html_element(document, HTML::TagNames::div, "timeline"sv);
-    MUST(m_control_bar->append_child(*m_timeline_element));
-    m_timeline_fill = create_html_element(document, HTML::TagNames::div, "timeline-fill"sv);
-    MUST(m_timeline_element->append_child(*m_timeline_fill));
-
-    // Button bar
-    auto button_bar = create_html_element(document, HTML::TagNames::div, "button-bar"sv);
-    MUST(m_control_bar->append_child(button_bar));
-
-    // Play/pause button
-    m_play_button = create_html_element(document, HTML::TagNames::button, "control-button play-pause-button"sv);
-    MUST(button_bar->append_child(*m_play_button));
-
-    // Play/pause icon
-    m_play_pause_icon = create_play_icon(document, "icon play-pause-icon"sv);
-    MUST(m_play_button->append_child(*m_play_pause_icon));
-
-    auto pause_path = create_svg_element(document, SVG::TagNames::path, "pause-path"sv);
-    pause_path->set_attribute_value(SVG::AttributeNames::d, "M14 5h4v14h-4Zm-4 0H6v14h4z"_string);
-    MUST(m_play_pause_icon->append_child(pause_path));
-
-    // Timestamp
-    m_timestamp_element = create_html_element(document, HTML::TagNames::span, "timestamp"sv);
-    MUST(m_timestamp_element->set_text_content(Utf16String::from_utf8("0:00 / 0:00"sv)));
-    MUST(button_bar->append_child(*m_timestamp_element));
-
-    // Speaker button
-    m_mute_button = create_html_element(document, HTML::TagNames::button, "control-button mute-button"sv);
-    MUST(button_bar->append_child(*m_mute_button));
-
-    auto mute_icon = create_mute_icon(document, "icon"sv);
-    MUST(m_mute_button->append_child(mute_icon));
-
-    // Volume slider
-    m_volume_area = create_html_element(document, HTML::TagNames::div, "volume-area"sv);
-    MUST(button_bar->append_child(*m_volume_area));
-    m_volume_element = create_html_element(document, HTML::TagNames::div, "volume"sv);
-    MUST(m_volume_area->append_child(*m_volume_element));
-    m_volume_fill = create_html_element(document, HTML::TagNames::div, "volume-fill"sv);
-    MUST(m_volume_element->append_child(*m_volume_fill));
-
-    // Fullscreen button
-    if (is_video) {
-        m_fullscreen_button = create_html_element(document, HTML::TagNames::button, "control-button fullscreen-button"sv);
-        MUST(button_bar->append_child(*m_fullscreen_button));
-
-        m_fullscreen_icon = create_fullscreen_icon(document, "icon fullscreen-icon"sv);
-        MUST(m_fullscreen_button->append_child(*m_fullscreen_icon));
-    }
+    static Vector<String> s_video_class = { "video"_string };
+    static Vector<String> s_audio_class = { "audio"_string };
+    if (is_video)
+        MUST(m_dom->container->class_list()->add(s_video_class));
+    else
+        MUST(m_dom->container->class_list()->add(s_audio_class));
 
     // Initialize state
     update_play_pause_icon();
@@ -352,7 +187,7 @@ void MediaControls::set_up_event_listeners()
         return true;
     });
 
-    if (m_fullscreen_button) {
+    if (m_dom->fullscreen_button) {
         add_event_listener(realm, media_element.document(), HTML::EventNames::fullscreenchange, [this] {
             update_fullscreen_icon();
             return true;
@@ -360,14 +195,14 @@ void MediaControls::set_up_event_listeners()
     }
 
     // Play/pause button
-    add_event_listener(realm, *m_play_button, UIEvents::EventNames::click, [this] {
+    add_event_listener(realm, *m_dom->play_button, UIEvents::EventNames::click, [this] {
         toggle_playback();
         return true;
     });
 
     // Video overlay click — toggle playback when clicking outside the controls
-    if (m_video_overlay) {
-        add_event_listener(realm, *m_video_overlay, UIEvents::EventNames::click, [this] {
+    if (m_dom->video_overlay) {
+        add_event_listener(realm, *m_dom->video_overlay, UIEvents::EventNames::click, [this] {
             toggle_playback();
             return true;
         });
@@ -382,11 +217,11 @@ void MediaControls::set_up_event_listeners()
         return fraction * duration;
     };
 
-    add_event_listener(realm, *m_timeline_element, UIEvents::EventNames::mousedown, [this](UIEvents::MouseEvent const& event) {
+    add_event_listener(realm, *m_dom->timeline_element, UIEvents::EventNames::mousedown, [this](UIEvents::MouseEvent const& event) {
         VERIFY(m_media_element);
-        VERIFY(m_timeline_element);
+        VERIFY(m_dom->timeline_element);
 
-        auto position = compute_timeline_position(event, *m_timeline_element, m_media_element->duration());
+        auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
         if (!position.has_value())
             return false;
 
@@ -403,9 +238,9 @@ void MediaControls::set_up_event_listeners()
 
         auto mousemove_listener = add_event_listener(realm, window, UIEvents::EventNames::mousemove, [this](UIEvents::MouseEvent const& event) {
             VERIFY(m_media_element);
-            VERIFY(m_timeline_element);
+            VERIFY(m_dom->timeline_element);
 
-            auto position = compute_timeline_position(event, *m_timeline_element, m_media_element->duration());
+            auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
             if (!position.has_value())
                 return false;
 
@@ -415,12 +250,12 @@ void MediaControls::set_up_event_listeners()
 
         add_event_listener(realm, window, UIEvents::EventNames::mouseup, ListenOnce::Yes, [this, mousemove_listener](UIEvents::MouseEvent const& event) {
             VERIFY(m_media_element);
-            VERIFY(m_timeline_element);
+            VERIFY(m_dom->timeline_element);
 
             auto was_playing = m_scrubbing_timeline == Scrubbing::WhilePlaying;
             m_scrubbing_timeline = Scrubbing::No;
 
-            auto position = compute_timeline_position(event, *m_timeline_element, m_media_element->duration());
+            auto position = compute_timeline_position(event, *m_dom->timeline_element, m_media_element->duration());
             if (position.has_value())
                 set_current_time(*position);
 
@@ -445,7 +280,7 @@ void MediaControls::set_up_event_listeners()
     });
 
     // Speaker button
-    add_event_listener(realm, *m_mute_button, UIEvents::EventNames::click, [this] {
+    add_event_listener(realm, *m_dom->mute_button, UIEvents::EventNames::click, [this] {
         VERIFY(m_media_element);
         m_media_element->set_muted(!m_media_element->muted());
         return true;
@@ -457,11 +292,11 @@ void MediaControls::set_up_event_listeners()
         return clamp((event.client_x() - rect.left().to_double()) / rect.width().to_double(), 0.0, 1.0);
     };
 
-    add_event_listener(realm, *m_volume_area, UIEvents::EventNames::mousedown, [this](UIEvents::MouseEvent const& event) {
+    add_event_listener(realm, *m_dom->volume_area, UIEvents::EventNames::mousedown, [this](UIEvents::MouseEvent const& event) {
         VERIFY(m_media_element);
-        VERIFY(m_volume_element);
+        VERIFY(m_dom->volume_element);
 
-        auto volume = compute_volume(event, *m_volume_element);
+        auto volume = compute_volume(event, *m_dom->volume_element);
         if (!volume.has_value())
             return false;
 
@@ -474,9 +309,9 @@ void MediaControls::set_up_event_listeners()
 
         auto mousemove_listener = add_event_listener(realm, window, UIEvents::EventNames::mousemove, [this](UIEvents::MouseEvent const& event) {
             VERIFY(m_media_element);
-            VERIFY(m_volume_element);
+            VERIFY(m_dom->volume_element);
 
-            auto volume = compute_volume(event, *m_volume_element);
+            auto volume = compute_volume(event, *m_dom->volume_element);
             if (!volume.has_value())
                 return false;
 
@@ -486,11 +321,11 @@ void MediaControls::set_up_event_listeners()
 
         add_event_listener(realm, window, UIEvents::EventNames::mouseup, ListenOnce::Yes, [this, mousemove_listener](UIEvents::MouseEvent const& event) {
             VERIFY(m_media_element);
-            VERIFY(m_volume_element);
+            VERIFY(m_dom->volume_element);
 
             m_scrubbing_volume = false;
 
-            auto volume = compute_volume(event, *m_volume_element);
+            auto volume = compute_volume(event, *m_dom->volume_element);
             if (volume.has_value())
                 set_volume(*volume);
 
@@ -503,18 +338,17 @@ void MediaControls::set_up_event_listeners()
     });
 
     // Fullscreen button
-    if (m_fullscreen_button) {
-        add_event_listener(realm, *m_fullscreen_button, UIEvents::EventNames::click, [this] {
+    if (m_dom->fullscreen_button) {
+        add_event_listener(realm, *m_dom->fullscreen_button, UIEvents::EventNames::click, [this] {
             toggle_fullscreen();
             return true;
         });
 
-        if (m_video_overlay) {
-            add_event_listener(realm, *m_video_overlay, UIEvents::EventNames::dblclick, [this] {
-                toggle_fullscreen();
-                return true;
-            });
-        }
+        VERIFY(m_dom->video_overlay);
+        add_event_listener(realm, *m_dom->video_overlay, UIEvents::EventNames::dblclick, [this] {
+            toggle_fullscreen();
+            return true;
+        });
     }
 
     // Hover detection for video controls visibility
@@ -531,12 +365,12 @@ void MediaControls::set_up_event_listeners()
             hide_controls();
             return true;
         });
-        add_event_listener(realm, *m_control_bar, UIEvents::EventNames::mouseenter, [this] {
+        add_event_listener(realm, *m_dom->control_bar, UIEvents::EventNames::mouseenter, [this] {
             m_hovering_controls = true;
             show_controls();
             return true;
         });
-        add_event_listener(realm, *m_control_bar, UIEvents::EventNames::mouseleave, [this] {
+        add_event_listener(realm, *m_dom->control_bar, UIEvents::EventNames::mouseleave, [this] {
             m_hovering_controls = false;
             show_controls();
             return true;
@@ -615,7 +449,7 @@ void MediaControls::toggle_fullscreen()
 void MediaControls::update_play_pause_icon()
 {
     VERIFY(m_media_element);
-    VERIFY(m_play_pause_icon);
+    VERIFY(m_dom->play_pause_icon);
 
     auto paused = [&] {
         if (m_scrubbing_timeline != Scrubbing::No)
@@ -624,49 +458,49 @@ void MediaControls::update_play_pause_icon()
     }();
 
     static String s_playing_class = "playing"_string;
-    MUST(m_play_pause_icon->class_list()->toggle(s_playing_class, !paused));
+    MUST(m_dom->play_pause_icon->class_list()->toggle(s_playing_class, !paused));
 }
 
 void MediaControls::update_timeline()
 {
     VERIFY(m_media_element);
-    VERIFY(m_timeline_fill);
+    VERIFY(m_dom->timeline_fill);
 
     auto duration = m_media_element->duration();
     double percentage = 0.0;
     if (!isnan(duration) && duration > 0.0)
         percentage = (m_media_element->current_time() / duration) * 100.0;
 
-    MUST(m_timeline_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", percentage))));
+    MUST(m_dom->timeline_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", percentage))));
 }
 
 void MediaControls::update_timestamp()
 {
     VERIFY(m_media_element);
-    VERIFY(m_timestamp_element);
+    VERIFY(m_dom->timestamp_element);
 
     auto current = human_readable_digital_time(round_to<i64>(m_media_element->current_time()));
     auto duration = m_media_element->duration();
     auto total = human_readable_digital_time(isnan(duration) ? 0 : round_to<i64>(duration));
 
-    MUST(m_timestamp_element->set_text_content(Utf16String::formatted("{} / {}", current, total)));
+    MUST(m_dom->timestamp_element->set_text_content(Utf16String::formatted("{} / {}", current, total)));
 }
 
 void MediaControls::update_volume_and_mute_indicator()
 {
     VERIFY(m_media_element);
-    VERIFY(m_volume_fill);
-    VERIFY(m_mute_button);
+    VERIFY(m_dom->volume_fill);
+    VERIFY(m_dom->mute_button);
 
     auto volume = m_media_element->volume();
     auto has_audio = m_media_element->audio_tracks()->length() > 0;
     auto muted = !has_audio || m_media_element->muted();
 
     if (muted) {
-        MUST(m_volume_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, "0"sv));
+        MUST(m_dom->volume_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, "0"sv));
     } else {
         auto percentage = volume * 100.0;
-        MUST(m_volume_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", percentage))));
+        MUST(m_dom->volume_fill->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", percentage))));
     }
 
     auto new_volume_icon_state = [&] {
@@ -694,27 +528,27 @@ void MediaControls::update_volume_and_mute_indicator()
     };
 
     if (new_volume_icon_state != m_mute_icon_state) {
-        MUST(m_mute_button->class_list()->remove(icon_class(m_mute_icon_state)));
-        MUST(m_mute_button->class_list()->add(icon_class(new_volume_icon_state)));
+        MUST(m_dom->mute_button->class_list()->remove(icon_class(m_mute_icon_state)));
+        MUST(m_dom->mute_button->class_list()->add(icon_class(new_volume_icon_state)));
         m_mute_icon_state = new_volume_icon_state;
     }
 
     static Vector<String> s_muted_class = { "muted"_string };
     if (muted != m_was_muted) {
-        MUST(m_mute_button->class_list()->toggle("muted"_string, muted));
+        MUST(m_dom->mute_button->class_list()->toggle("muted"_string, muted));
         m_was_muted = muted;
     }
 
     static Vector<String> s_hidden_class = { "hidden"_string };
     if (has_audio != m_had_audio) {
-        MUST(m_volume_area->class_list()->toggle("hidden"_string, !has_audio));
+        MUST(m_dom->volume_area->class_list()->toggle("hidden"_string, !has_audio));
         m_had_audio = has_audio;
     }
 }
 
 void MediaControls::update_fullscreen_icon()
 {
-    if (!m_fullscreen_icon)
+    if (!m_dom->fullscreen_icon)
         return;
 
     static auto s_fullscreen_class = "fullscreen"_string;
@@ -722,24 +556,24 @@ void MediaControls::update_fullscreen_icon()
     VERIFY(m_media_element);
 
     auto is_fullscreen_element = m_media_element->document().fullscreen_element() == m_media_element;
-    MUST(m_fullscreen_icon->class_list()->toggle(s_fullscreen_class, is_fullscreen_element));
+    MUST(m_dom->fullscreen_icon->class_list()->toggle(s_fullscreen_class, is_fullscreen_element));
 }
 
 void MediaControls::update_placeholder_visibility()
 {
     VERIFY(m_media_element);
 
-    if (!m_placeholder_circle)
+    if (!m_dom->placeholder_circle)
         return;
 
     auto display = should_show_placeholder() ? "flex"sv : "none"sv;
-    MUST(m_placeholder_circle->style_for_bindings()->set_property(CSS::PropertyID::Display, display));
+    MUST(m_dom->placeholder_circle->style_for_bindings()->set_property(CSS::PropertyID::Display, display));
 }
 
 bool MediaControls::should_show_placeholder() const
 {
     VERIFY(m_media_element);
-    VERIFY(m_placeholder_circle);
+    VERIFY(m_dom->placeholder_circle);
 
     auto const& video_element = as<HTMLVideoElement>(*m_media_element);
     return video_element.current_representation() != HTMLVideoElement::Representation::VideoFrame;
@@ -749,9 +583,9 @@ static Vector<String> s_visible_class = { "visible"_string };
 
 void MediaControls::show_controls()
 {
-    VERIFY(m_control_bar);
+    VERIFY(m_dom->control_bar);
 
-    MUST(m_control_bar->class_list()->add(s_visible_class));
+    MUST(m_dom->control_bar->class_list()->add(s_visible_class));
 
     if (!m_hover_timer) {
         constexpr int hover_timeout_ms = 1000;
@@ -766,14 +600,14 @@ void MediaControls::show_controls()
 
 void MediaControls::hide_controls()
 {
-    VERIFY(m_control_bar);
+    VERIFY(m_dom->control_bar);
 
     if (m_scrubbing_timeline != Scrubbing::No || m_scrubbing_volume || m_hovering_controls)
         return;
-    if (m_placeholder_circle && should_show_placeholder())
+    if (m_dom->placeholder_circle && should_show_placeholder())
         return;
 
-    MUST(m_control_bar->class_list()->remove(s_visible_class));
+    MUST(m_dom->control_bar->class_list()->remove(s_visible_class));
     m_hover_timer.clear();
 }
 

--- a/Libraries/LibWeb/HTML/MediaControls.css
+++ b/Libraries/LibWeb/HTML/MediaControls.css
@@ -107,16 +107,6 @@
     display: inline;
 }
 
-.fullscreen-icon path {
-    display: none;
-}
-.fullscreen-icon:not(.fullscreen) .fullscreen-maximize-path {
-    display: inline;
-}
-.fullscreen-icon.fullscreen .fullscreen-minimize-path {
-    display: inline;
-}
-
 .mute-button {
     margin-left: auto;
 }
@@ -177,6 +167,16 @@
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.fullscreen-icon path {
+    display: none;
+}
+.fullscreen-icon:not(.fullscreen) .fullscreen-maximize-path {
+    display: inline;
+}
+.fullscreen-icon.fullscreen .fullscreen-minimize-path {
+    display: inline;
 }
 
 .placeholder-circle {

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -7,10 +7,12 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibCore/Timer.h>
 #include <LibGC/Weak.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/MediaControlsDOM.h>
 
 namespace Web::HTML {
 
@@ -63,20 +65,7 @@ private:
 
     GC::Weak<HTMLMediaElement> m_media_element;
 
-    GC::Weak<DOM::Element> m_control_bar;
-    GC::Weak<DOM::Element> m_timeline_element;
-    GC::Weak<DOM::Element> m_timeline_fill;
-    GC::Weak<DOM::Element> m_play_button;
-    GC::Weak<DOM::Element> m_play_pause_icon;
-    GC::Weak<DOM::Element> m_timestamp_element;
-    GC::Weak<DOM::Element> m_mute_button;
-    GC::Weak<DOM::Element> m_volume_area;
-    GC::Weak<DOM::Element> m_volume_element;
-    GC::Weak<DOM::Element> m_volume_fill;
-    GC::Weak<DOM::Element> m_fullscreen_button;
-    GC::Weak<DOM::Element> m_fullscreen_icon;
-    GC::Weak<DOM::Element> m_video_overlay;
-    GC::Weak<DOM::Element> m_placeholder_circle;
+    Optional<MediaControlsDOM> m_dom;
 
     struct RegisteredEventListener {
         GC::Weak<DOM::EventTarget> target;

--- a/Libraries/LibWeb/HTML/MediaControls.html
+++ b/Libraries/LibWeb/HTML/MediaControls.html
@@ -1,0 +1,46 @@
+<link rel="stylesheet" href="MediaControls.css">
+<div data-name="container" class="container">
+    <div data-name="video-overlay" data-option="video" class="video-overlay">
+        <div data-name="placeholder-circle" class="placeholder-circle">
+            <svg class="placeholder-icon" viewBox="0 0 24 24">
+                <path class="play-path" d="m6 5 13 7-13 7Z"/>
+            </svg>
+        </div>
+    </div>
+    <div data-name="control-bar" class="controls">
+        <div data-name="timeline-element" class="timeline">
+            <div data-name="timeline-fill" class="timeline-fill"></div>
+        </div>
+        <div class="button-bar">
+            <button data-name="play-button" class="control-button play-pause-button">
+                <svg data-name="play-pause-icon" class="icon play-pause-icon" viewBox="0 0 24 24">
+                    <path class="play-path" d="m6 5 13 7-13 7Z"/>
+                    <path class="pause-path" d="M14 5h4v14h-4Zm-4 0H6v14h4z"/>
+                </svg>
+            </button>
+            <span data-name="timestamp-element" class="timestamp">0:00 / 0:00</span>
+            <button data-name="mute-button" class="control-button mute-button">
+                <svg class="icon" viewBox="0 0 24 24">
+                    <defs><clipPath id="muted-clip">
+                        <path d="M3 0h21v21ZM0 0v24h24z"/>
+                    </clipPath></defs>
+                    <path class="muted-line" d="m5 5 14 14-1.5 1.5-14-14z"/>
+                    <path class="volume-high" d="M14 4.08v2.04c2.23.55 4 2.9 4 5.88 0 2.97-1.77 5.33-4 5.88v2.04c3.45-.56 6-3.96 6-7.92s-2.55-7.36-6-7.92Z"/>
+                    <path class="volume-low" d="M14 7.67v8.66c.35-.25.66-.55.92-.9A5.7 5.7 0 0 0 16 12c0-1.3-.39-2.5-1.08-3.43a4.24 4.24 0 0 0-.92-.9Z"/>
+                    <path class="speaker" d="M4 9v6h4l4 5V4L8 9Z"/>
+                </svg>
+            </button>
+            <div data-name="volume-area" class="volume-area">
+                <div data-name="volume-element" class="volume">
+                    <div data-name="volume-fill" class="volume-fill"></div>
+                </div>
+            </div>
+            <div data-name="fullscreen-button" data-option="video" class="control-button fullscreen-button">
+                <svg data-name="fullscreen-icon" class="icon fullscreen-icon" viewBox="0 0 24 24">
+                    <path class="fullscreen-maximize-path" d="M3 3h6v2H5v4H3Zm12 0h6v6h-2V5h-4Zm6 12v6h-6v-2h4v-4ZM3 15v6h6v-2H5v-4Z"/>
+                    <path class="fullscreen-minimize-path" d="M9 3v6H3V7h4V3Zm6 0v6h6V7h-4V3ZM3 15h6v6H7v-4H3Zm12 0v6h2v-4h4v-2Z"/>
+                </svg>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -158,14 +158,6 @@ function (generate_css_implementation)
         NAMESPACE "Web::CSS"
     )
 
-    embed_as_string(
-        "MediaControlsStyleSheetSource.cpp"
-        "${LIBWEB_INPUT_FOLDER}/HTML/MediaControls.css"
-        "CSS/MediaControlsStyleSheetSource.cpp"
-        "media_controls_stylesheet_source"
-        NAMESPACE "Web::CSS"
-    )
-
     set(CSS_GENERATED_HEADERS
        "CSS/Enums.h"
        "CSS/EnvironmentVariable.h"
@@ -206,8 +198,29 @@ function (generate_html_implementation)
         arguments -j "${LIBWEB_INPUT_FOLDER}/HTML/Parser/Entities.json"
     )
 
+    invoke_py_generator(
+        "MediaControlsDOM.cpp"
+        "generate-dom-tree.py"
+        "${LIBWEB_INPUT_FOLDER}/HTML/MediaControls.html"
+        "HTML/MediaControlsDOM.h"
+        "HTML/MediaControlsDOM.cpp"
+        arguments -i "${LIBWEB_INPUT_FOLDER}/HTML/MediaControls.html"
+                  -s MediaControlsDOM
+                  -n "Web::HTML"
+                  --html-tags "${LIBWEB_INPUT_FOLDER}/HTML/TagNames.h"
+                  --html-attributes "${LIBWEB_INPUT_FOLDER}/HTML/AttributeNames.h"
+                  --svg-tags "${LIBWEB_INPUT_FOLDER}/SVG/TagNames.h"
+                  --svg-attributes "${LIBWEB_INPUT_FOLDER}/SVG/AttributeNames.h"
+        dependencies "${LIBWEB_INPUT_FOLDER}/HTML/TagNames.h"
+                     "${LIBWEB_INPUT_FOLDER}/HTML/AttributeNames.h"
+                     "${LIBWEB_INPUT_FOLDER}/SVG/TagNames.h"
+                     "${LIBWEB_INPUT_FOLDER}/SVG/AttributeNames.h"
+                     "${LIBWEB_INPUT_FOLDER}/HTML/MediaControls.css"
+    )
+
     set(HTML_GENERATED_HEADERS
        "HTML/Parser/NamedCharacterReferences.h"
+       "HTML/MediaControlsDOM.h"
     )
     list(TRANSFORM HTML_GENERATED_HEADERS PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
     if (ENABLE_INSTALL_HEADERS)

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -92,7 +92,7 @@ function(invoke_cpp_generator name generator primary_source header implementatio
 endfunction()
 
 function(invoke_py_generator name script primary_source header implementation)
-    cmake_parse_arguments(invoke_py_generator "" "EXTRA_HEADER" "arguments" ${ARGN})
+    cmake_parse_arguments(invoke_py_generator "" "EXTRA_HEADER" "arguments;dependencies" ${ARGN})
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
     set(py_generator_arguments ${invoke_py_generator_arguments})
@@ -109,6 +109,7 @@ function(invoke_py_generator name script primary_source header implementation)
         ${implementation}
         command ${Python3_EXECUTABLE}
         arguments ${py_generator_arguments}
+        dependencies ${invoke_py_generator_dependencies}
         extra_header "${invoke_py_generator_EXTRA_HEADER}"
     )
 endfunction()

--- a/Meta/generate-dom-tree.py
+++ b/Meta/generate-dom-tree.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+
+from html.parser import HTMLParser
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+
+# HTML void elements that cannot have children
+HTML_VOID_ELEMENTS = frozenset(
+    [
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    ]
+)
+
+
+def parse_html_tag_header(path: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    pattern = re.compile(r'__ENUMERATE_HTML_TAG\(\s*(\w+)\s*,\s*"([^"]+)"\s*\)')
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                result[m.group(2)] = m.group(1)
+    return result
+
+
+def parse_html_attribute_header(path: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    pattern = re.compile(r'__ENUMERATE_HTML_ATTRIBUTE\(\s*(\w+)\s*,\s*"([^"]+)"\s*\)')
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                result[m.group(2)] = m.group(1)
+    return result
+
+
+def parse_svg_tag_header(path: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    pattern = re.compile(r"__ENUMERATE_SVG_TAG\(\s*(\w+)\s*\)")
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                result[m.group(1).lower()] = m.group(1)
+    return result
+
+
+def parse_svg_attribute_header(path: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    pattern = re.compile(r'__ENUMERATE_SVG_ATTRIBUTE\(\s*(\w+)\s*,\s*"([^"]+)"\s*\)')
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            m = pattern.search(line)
+            if m:
+                result[m.group(2).lower()] = m.group(1)
+    return result
+
+
+non_identifier_character_regex = re.compile(r"\W+")
+
+
+def to_snake_case(string: str) -> str:
+    return non_identifier_character_regex.sub("_", string)
+
+
+def to_pascal_case(string: str) -> str:
+    return non_identifier_character_regex.sub(" ", string).title().replace(" ", "")
+
+
+def resolve_tag(tag_name: str, in_svg: bool, html_tags: Dict[str, str], svg_tags: Dict[str, str]) -> Tuple[str, str]:
+    if in_svg and tag_name in svg_tags:
+        return "Namespace::SVG", f"SVG::TagNames::{svg_tags[tag_name]}"
+
+    assert tag_name in html_tags
+    return "Namespace::HTML", f"HTML::TagNames::{html_tags[tag_name]}"
+
+
+def resolve_attribute(
+    attribute_name: str, in_svg: bool, html_attributes: Dict[str, str], svg_attributes: Dict[str, str]
+) -> str:
+    if in_svg and attribute_name in svg_attributes:
+        return f"SVG::AttributeNames::{svg_attributes[attribute_name]}"
+
+    assert attribute_name in html_attributes
+    return f"HTML::AttributeNames::{html_attributes[attribute_name]}"
+
+
+def bits_for_count(count: int) -> int:
+    bits = 8
+    while bits < 64:
+        if count < 2 ^ bits:
+            return bits
+        bits <<= 1
+    return bits
+
+
+class DOMElement:
+    def __init__(self, var_name: str, tag: str, option: str | None):
+        self.var_name = var_name
+        self.tag = tag
+        self.option = option
+
+
+class DOMTreeParser(HTMLParser):
+    def __init__(
+        self,
+        struct_name: str,
+        html_tags: Dict[str, str],
+        html_attributes: Dict[str, str],
+        svg_tags: Dict[str, str],
+        svg_attributes: Dict[str, str],
+        input_dir: str,
+    ):
+        super().__init__(convert_charrefs=False)
+        self.struct_name = struct_name
+        self.html_tags = html_tags
+        self.html_attributes = html_attributes
+        self.svg_tags = svg_tags
+        self.svg_attributes = svg_attributes
+        self.input_dir = input_dir
+
+        self.lines: List[str] = []
+        self.named_fields: List[str] = []
+        self.unnamed_element_counter = 0
+        self.indentation = 0
+        self.svg_depth = 0
+        self.element_stack: List[DOMElement] = []
+        self.has_svg = False
+        self.stylesheet_sources: List[Tuple[str, str]] = []  # (var_name, css_content)
+        self.options: Set[str] = set()
+
+    def _next_var(self) -> str:
+        self.unnamed_element_counter += 1
+        return f"element_{self.unnamed_element_counter}"
+
+    def _current_parent(self) -> str:
+        if self.element_stack:
+            return self.element_stack[-1].var_name
+        return "parent"
+
+    def _deref_parent(self) -> str:
+        current_parent = self._current_parent()
+        if len(self.element_stack) > 0:
+            return f"{current_parent}->"
+        return f"{current_parent}."
+
+    def _add_line(self, line: str) -> None:
+        if not line.strip():
+            self.lines.append("")
+            return
+        self.lines.append(("    " * self.indentation) + line)
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        self._handle_tag(tag, attrs, self_closing=False)
+
+    def handle_startendtag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        self._handle_tag(tag, attrs, self_closing=True)
+
+    def _handle_tag(self, tag: str, attrs: List[Tuple[str, Optional[str]]], self_closing: bool) -> None:
+        attribute_dict = dict(attrs)
+
+        # Wrap optional nodes in if statements
+        option = attribute_dict.pop("data-option", None)
+        if option:
+            option = to_pascal_case(option)
+            self._add_line(f"if (has_flag(options, {self.struct_name}::Options::{option})) {{")
+            self.indentation += 1
+            self.options.add(option)
+        else:
+            option = None
+
+        # Handle SVG contexts
+        in_svg = self.svg_depth > 0
+        if tag == "svg":
+            self.svg_depth += 1
+            in_svg = True
+            self.has_svg = True
+
+        # Handle <link rel="stylesheet"> specially
+        if tag == "link":
+            assert attribute_dict.get("rel") is not None
+            assert "href" in attribute_dict
+            self._handle_stylesheet_link(attribute_dict)
+            return
+
+        # Determine variable name
+        data_name = attribute_dict.pop("data-name", None)
+        if data_name:
+            var_name = to_snake_case(data_name)
+            self.named_fields.append(var_name)
+            is_named = True
+        else:
+            var_name = self._next_var()
+            is_named = False
+
+        namespace_expr, tag_expr = resolve_tag(tag, in_svg, self.html_tags, self.svg_tags)
+        deref_parent = self._deref_parent()
+
+        self._add_line(f"auto {var_name} = MUST(DOM::create_element(document, {tag_expr}, {namespace_expr}));")
+        if is_named:
+            self._add_line(f"this->{var_name} = {var_name};")
+
+        # Set attributes (skip data-name)
+        for attribute_name, attribute_value in attribute_dict.items():
+            if attribute_value is None:
+                attribute_value = ""
+            attribute_expr = resolve_attribute(attribute_name, in_svg, self.html_attributes, self.svg_attributes)
+            self._add_line(f'{var_name}->set_attribute_value({attribute_expr}, "{attribute_value}"_string);')
+
+        self._add_line(f"MUST({deref_parent}append_child({var_name}));")
+
+        self._add_line("")
+
+        self.element_stack.append(DOMElement(var_name, tag, option))
+
+        if self_closing or (tag in HTML_VOID_ELEMENTS and not in_svg):
+            self.handle_endtag(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.element_stack and self.element_stack[-1].tag == tag:
+            node = self.element_stack.pop()
+
+            if tag == "svg":
+                self.svg_depth -= 1
+            if node.option:
+                self.indentation -= 1
+                if not self.lines[-1]:
+                    self.lines.pop()
+                self._add_line(f"}} // Options::{node.option}")
+                self._add_line("")
+
+    def handle_data(self, data: str) -> None:
+        if data.strip():
+            deref_parent = self._deref_parent()
+            self._add_line(f'MUST({deref_parent}set_text_content(R"~~~({data})~~~"_utf16));')
+            self._add_line("")
+
+    def handle_comment(self, data: str) -> None:
+        pass
+
+    def _handle_stylesheet_link(self, attribute_dict: Dict[str, Optional[str]]) -> None:
+        href = attribute_dict["href"]
+        assert href is not None
+        css_path = os.path.join(self.input_dir, href)
+        with open(css_path, "r", encoding="utf-8") as f:
+            css_content = f.read()
+
+        assert attribute_dict.get("data-name") is None
+        var_name = self._next_var()
+
+        source_var = f"s_stylesheet_source_{len(self.stylesheet_sources) + 1}"
+        self.stylesheet_sources.append((source_var, css_content))
+
+        deref_parent = self._deref_parent()
+
+        self._add_line(
+            f"auto {var_name} = MUST(DOM::create_element(document, HTML::TagNames::style, Namespace::HTML));"
+        )
+        self._add_line(f"MUST({var_name}->set_text_content(Utf16String::from_utf8({source_var})));")
+        self._add_line(f"MUST({deref_parent}append_child({var_name}));")
+
+        self._add_line("")
+
+
+def generate(
+    input_html: str,
+    struct_name: str,
+    namespace: str,
+    header_path: str,
+    html_tags_path: str,
+    html_attributes_path: str,
+    svg_tags_path: str,
+    svg_attributes_path: str,
+) -> Tuple[str, str]:
+    html_tags = parse_html_tag_header(html_tags_path)
+    html_attributes = parse_html_attribute_header(html_attributes_path)
+    svg_tags = parse_svg_tag_header(svg_tags_path)
+    svg_attributes = parse_svg_attribute_header(svg_attributes_path)
+
+    input_dir = os.path.dirname(os.path.abspath(input_html))
+    with open(input_html, "r", encoding="utf-8") as f:
+        html_content = f.read()
+
+    parser = DOMTreeParser(struct_name, html_tags, html_attributes, svg_tags, svg_attributes, input_dir)
+    parser.feed(html_content)
+
+    if not parser.lines[-1]:
+        parser.lines.pop()
+
+    # Generate header
+    header_lines: List[str] = []
+    header_lines.append("#pragma once")
+    header_lines.append("")
+    if parser.options:
+        header_lines.append("#include <AK/EnumBits.h>")
+    header_lines.append("#include <LibGC/Weak.h>")
+    header_lines.append("#include <LibWeb/Forward.h>")
+    header_lines.append("")
+    header_lines.append(f"namespace {namespace} {{")
+    header_lines.append("")
+    header_lines.append(f"struct {struct_name} {{")
+
+    if parser.options:
+        header_lines.append(f"    enum class Options : u{bits_for_count(len(parser.options))} {{")
+        header_lines.append("        None = 0,")
+        option_bit = 0
+        for option in parser.options:
+            header_lines.append(f"        {option} = 1 << {option_bit},")
+            option_bit += 1
+        header_lines.append("    };")
+        header_lines.append("")
+
+    header_lines.append(
+        f"    {struct_name}(DOM::Document&, DOM::Node& parent{(', Options = Options::None' if parser.options else '')});"
+    )
+    header_lines.append("")
+    for field in parser.named_fields:
+        header_lines.append(f"    GC::Weak<DOM::Element> {field};")
+    header_lines.append("};")
+    header_lines.append("")
+    if parser.options:
+        header_lines.append(f"AK_ENUM_BITWISE_OPERATORS({struct_name}::Options);")
+        header_lines.append("")
+    header_lines.append(f"}} // namespace {namespace}")
+    header_lines.append("")
+
+    # Generate implementation
+    impl_lines: List[str] = []
+
+    impl_lines.append("#include <LibWeb/DOM/Document.h>")
+    impl_lines.append("#include <LibWeb/DOM/ElementFactory.h>")
+    impl_lines.append("#include <LibWeb/HTML/AttributeNames.h>")
+    impl_lines.append("#include <LibWeb/HTML/TagNames.h>")
+    impl_lines.append("#include <LibWeb/Namespace.h>")
+    if parser.has_svg:
+        impl_lines.append("#include <LibWeb/SVG/AttributeNames.h>")
+        impl_lines.append("#include <LibWeb/SVG/TagNames.h>")
+    impl_lines.append("")
+
+    impl_lines.append(f'#include "{header_path}"')
+    impl_lines.append("")
+
+    impl_lines.append(f"namespace {namespace} {{")
+    impl_lines.append("")
+
+    # Static stylesheet sources
+    for source_var, css_content in parser.stylesheet_sources:
+        impl_lines.append(f'static String {source_var} = R"~~~(')
+        impl_lines.append(css_content.strip())
+        impl_lines.append(')~~~"_string;')
+        impl_lines.append("")
+
+    # Constructor
+    impl_lines.append(
+        f"{struct_name}::{struct_name}(DOM::Document& document, DOM::Node& parent{', Options options' if parser.options else ''})"
+    )
+    impl_lines.append("{")
+    for line in parser.lines:
+        if line:
+            impl_lines.append(f"    {line}")
+        else:
+            impl_lines.append("")
+    impl_lines.append("}")
+    impl_lines.append("")
+    impl_lines.append(f"}} // namespace {namespace}")
+    impl_lines.append("")
+
+    return "\n".join(header_lines), "\n".join(impl_lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate C++ DOM tree from HTML template", add_help=False)
+    parser.add_argument("-h", required=True, dest="header_output")
+    parser.add_argument("-c", required=True, dest="impl_output")
+    parser.add_argument("-i", required=True, dest="input_html")
+    parser.add_argument("-s", required=True, dest="struct_name")
+    parser.add_argument("-n", required=True, dest="namespace")
+    parser.add_argument("--html-tags", required=True)
+    parser.add_argument("--html-attributes", required=True)
+    parser.add_argument("--svg-tags", required=True)
+    parser.add_argument("--svg-attributes", required=True)
+    args = parser.parse_args()
+
+    header_path = os.path.relpath(args.header_output, os.path.dirname(str(args.impl_output)))
+    if header_path.endswith(".tmp"):
+        header_path = header_path[:-4]
+
+    header, impl = generate(
+        args.input_html,
+        args.struct_name,
+        args.namespace,
+        header_path,
+        args.html_tags,
+        args.html_attributes,
+        args.svg_tags,
+        args.svg_attributes,
+    )
+
+    with open(args.header_output, "w", encoding="utf-8") as f:
+        f.write(header)
+
+    with open(args.impl_output, "w", encoding="utf-8") as f:
+        f.write(impl)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Instead of manually writing code to instantiate DOM elements in MediaControls.cpp, use a Python script to generate a separate C++ struct to create and store the DOM elements.

The generator reads an HTML file and the HTML/SVG tags/attributes headers to create C++ source that instantiates the DOM elements. To enable embedding of stylesheets in shadow DOM, the generator replaces `<link rel="stylesheet">` elements with plain `<style>` elements containing the source from the linked stylesheet.

The MediaControls class remains to wrap the generated MediaControlsDOM struct and set up interaction events.