### PR TITLE
LibWeb: Guard layout_node() null dereference in set_user_selection()

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -275,6 +275,17 @@ static GC::Ref<DOM::Range> find_paragraph_range(DOM::Text& text_node, WebIDL::Un
 // https://drafts.csswg.org/css-ui/#propdef-user-select
 static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_offset, GC::Ptr<DOM::Node> focus_node, size_t focus_offset, Selection::Selection* selection, CSS::UserSelect user_select)
 {
+    // Helper to safely get the user-select used value. If a node has no layout node
+    // (e.g. near shadow DOM boundaries), we walk up the tree to find the nearest ancestor
+    // that does have a layout node to inherit the correct user-select value.
+    auto safe_user_select = [](GC::Ptr<DOM::Node> node) -> CSS::UserSelect {
+        for (auto* n = node.ptr(); n; n = n->parent()) {
+            if (auto* layout = n->layout_node())
+                return layout->user_select_used_value();
+        }
+        return CSS::UserSelect::Text;
+    };
+
     // https://drafts.csswg.org/css-ui/#valdef-user-select-contain
     // NB: This is clamping the focus node to any node with user-select: contain that stands between it and the anchor node.
     if (focus_node != anchor_node) {
@@ -286,12 +297,12 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
         //     focus node, as this means they are inside the same contain element, or not in a contain element at all.
         //     This takes care of the "selection trying to escape from a contain" case.
         while (
-            (!potential_contain_node->is_element() || potential_contain_node->layout_node()->user_select_used_value() != CSS::UserSelect::Contain) && potential_contain_node->parent() && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
+            (!potential_contain_node->is_element() || safe_user_select(potential_contain_node) != CSS::UserSelect::Contain) && potential_contain_node->parent() && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
             potential_contain_node = potential_contain_node->parent();
         }
 
         if (
-            potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
+            safe_user_select(potential_contain_node) == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
             if (focus_node->is_before(*potential_contain_node)) {
                 focus_offset = 0;
             } else {
@@ -311,11 +322,11 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
             auto target_node = potential_contain_node;
             potential_contain_node = focus_node;
             while (
-                (!potential_contain_node->is_element() || potential_contain_node->layout_node()->user_select_used_value() != CSS::UserSelect::Contain) && potential_contain_node->parent() && potential_contain_node != target_node) {
+                (!potential_contain_node->is_element() || safe_user_select(potential_contain_node) != CSS::UserSelect::Contain) && potential_contain_node->parent() && potential_contain_node != target_node) {
                 potential_contain_node = potential_contain_node->parent();
             }
             if (
-                potential_contain_node->layout_node()->user_select_used_value() == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*anchor_node)) {
+                safe_user_select(potential_contain_node) == CSS::UserSelect::Contain && !potential_contain_node->is_inclusive_ancestor_of(*anchor_node)) {
                 if (potential_contain_node->is_before(*anchor_node)) {
                     focus_node = potential_contain_node->next_in_pre_order();
                     while (potential_contain_node->is_inclusive_ancestor_of(*focus_node)) {
@@ -346,7 +357,7 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
 
         // A selection started outside of this element must not end in this element. If the user attempts to create such
         // a selection, the UA must instead end the selection range at the element boundary.
-        while (focus_node->parent() && focus_node->parent()->layout_node()->user_select_used_value() == CSS::UserSelect::None) {
+        while (focus_node->parent() && safe_user_select(focus_node->parent()) == CSS::UserSelect::None) {
             focus_node = focus_node->parent();
         }
         if (focus_node->is_before(*anchor_node)) {
@@ -367,7 +378,7 @@ static void set_user_selection(GC::Ptr<DOM::Node> anchor_node, size_t anchor_off
         // then the selection must contain the entire element including all its descendants. If the element is selected
         // and the used value of 'user-select' on its parent is 'all', then the parent must be included in the selection,
         // recursively.
-        while (focus_node->parent() && focus_node->parent()->layout_node()->user_select_used_value() == CSS::UserSelect::All) {
+        while (focus_node->parent() && safe_user_select(focus_node->parent()) == CSS::UserSelect::All) {
             if (anchor_node == focus_node) {
                 anchor_node = focus_node->parent();
             }

--- a/Tests/LibWeb/Crash/HTML/selection-across-shadow-tree.html
+++ b/Tests/LibWeb/Crash/HTML/selection-across-shadow-tree.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<!-- Regression test for https://github.com/LadybirdBrowser/ladybird/issues/8205 -->
+<!-- Ensure selecting text across shadow tree boundaries does not crash. -->
+<body>
+<div id="host"></div>
+<p id="outside">Text outside the shadow tree</p>
+<script>
+    const host = document.getElementById("host");
+    const shadow = host.attachShadow({ mode: "open" });
+    shadow.innerHTML = "<span id='inside'>Text inside shadow tree</span>";
+
+    if (window.internals) {
+        const inside = shadow.getElementById("inside");
+        const outside = document.getElementById("outside");
+
+        const insideRect = inside.getBoundingClientRect();
+        const outsideRect = outside.getBoundingClientRect();
+
+        const startX = insideRect.x + insideRect.width / 2;
+        const startY = insideRect.y + insideRect.height / 2;
+
+        const endX = outsideRect.x + outsideRect.width / 2;
+        const endY = outsideRect.y + outsideRect.height / 2;
+
+        internals.mouseDown(startX, startY);
+        internals.mouseMove(endX, endY);
+        internals.mouseUp(endX, endY);
+    }
+</script>
+</body>


### PR DESCRIPTION
## What

Fixes a crash when selecting text that crosses shadow DOM boundaries.

## Why

When dragging a selection from inside a shadow tree to outside or vice versa, the selection handles nodes near the boundary. Some of these nodes may not have an associated layout node. The `set_user_selection()` function walked up the tree calling `node->layout_node()->user_select_used_value()` without checking if `layout_node()` was null, causing a crash.

## Changes

1. **`EventHandler.cpp`** — Added a `safe_user_select` helper lambda that walks up the DOM tree to find the nearest ancestor with a layout node, inheriting its `user-select` value. If no such node is found, it defaults to `CSS::UserSelect::Text`. Replaced all 6 unsafe calls with this helper.
2. **Crash test** — Added `Tests/LibWeb/Crash/HTML/selection-across-shadow-tree.html` which simulates a user selection crossing a shadow boundary using `internals.mouseDown/Move/Up`.

## Testing

All 183 tests pass, 0 failures.

Fixes #8205

cc @gmta