### PR TITLE
Meta: Add a rust-toolchain toml file to pin required rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+


### PR DESCRIPTION
Some developers might have interesting rust versions installed and set as their default via `rustup default`, but we want to make sure that everyone is using the same version as CI.

https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file