### PR TITLE
LibWasm: Preserve stack semantics for synthetic br(.if).nostack.

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -5130,9 +5130,17 @@ InstructionPointer BytecodeInterpreter::branch_to_label(Configuration& configura
     auto const& label = configuration.label_stack().unsafe_last();
     dbgln_if(WASM_TRACE_DEBUG, "...which is actually IP {}, and has {} result(s)", label.continuation().value(), label.arity());
 
-    if constexpr (NeedsStackAdjustment) {
-        if (actually_branching)
-            configuration.value_stack().remove(label.stack_height(), configuration.value_stack().size() - label.stack_height() - label.arity());
+    if (actually_branching) {
+        auto expected_stack_size = label.stack_height() + label.arity();
+        auto actual_stack_size = configuration.value_stack().size();
+
+        if constexpr (NeedsStackAdjustment) {
+            configuration.value_stack().remove(label.stack_height(), actual_stack_size - expected_stack_size);
+        } else if (actual_stack_size > expected_stack_size) {
+            // Synthetic *.nostack branches assume there is no stack adjustment, but if instruction metadata
+            // is stale or imprecise in complex control-flow we must still preserve correct branch semantics.
+            configuration.value_stack().remove(label.stack_height(), actual_stack_size - expected_stack_size);
+        }
     }
     return actually_branching ? label.continuation().value() - 1 : current_ip;
 }


### PR DESCRIPTION
When `br`/`br_if` has `has_stack_adjustment == false`, we rewrite it to `synthetic_br_nostack`/`synthetic_br_if_nostack` and skip value-stack trimming.

On `ratijas.me/lc`, this can leave stale values on the value stack on a taken branch path. A later load then uses a corrupted pointer (`0xffffffff`) and traps with an out-of-bounds memory access.

Add a safety correction in `branch_to_label<false>()`: for taken branches, compute `expected = label.stack_height() + label.arity()` and trim extra values when `actual > expected`.

This keeps the nostack fast path while restoring correct branch semantics when branch metadata is imprecise.

Fixes #2502