### PR TITLE
AK: Guard JSON parser against deep nesting

### DIFF
--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -8,6 +8,7 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonParser.h>
+#include <AK/ScopeGuard.h>
 #include <AK/StringConversions.h>
 #include <math.h>
 
@@ -17,6 +18,8 @@ constexpr bool is_space(int ch)
 {
     return ch == '\t' || ch == '\n' || ch == '\r' || ch == ' ';
 }
+
+constexpr StringView exceeded_max_nesting_depth_error = "JsonParser: Exceeded maximum nesting depth"sv;
 
 ErrorOr<JsonValue> JsonParser::parse(StringView input)
 {
@@ -137,6 +140,11 @@ ErrorOr<ByteString> JsonParser::consume_and_unescape_string()
 
 ErrorOr<JsonValue> JsonParser::parse_object()
 {
+    if (m_current_nesting_depth >= max_nesting_depth)
+        return Error::from_string_view(exceeded_max_nesting_depth_error);
+    ++m_current_nesting_depth;
+    ScopeGuard nesting_depth_guard { [this] { --m_current_nesting_depth; } };
+
     JsonObject object;
     if (!consume_specific('{'))
         return Error::from_string_literal("JsonParser: Expected '{'");
@@ -168,6 +176,11 @@ ErrorOr<JsonValue> JsonParser::parse_object()
 
 ErrorOr<JsonValue> JsonParser::parse_array()
 {
+    if (m_current_nesting_depth >= max_nesting_depth)
+        return Error::from_string_view(exceeded_max_nesting_depth_error);
+    ++m_current_nesting_depth;
+    ScopeGuard nesting_depth_guard { [this] { --m_current_nesting_depth; } };
+
     JsonArray array;
     if (!consume_specific('['))
         return Error::from_string_literal("JsonParser: Expected '['");

--- a/AK/JsonParser.h
+++ b/AK/JsonParser.h
@@ -32,6 +32,10 @@ private:
     ErrorOr<JsonValue> parse_false();
     ErrorOr<JsonValue> parse_true();
     ErrorOr<JsonValue> parse_null();
+
+    // Keep recursive parsing depth bounded so untrusted JSON cannot overflow the call stack.
+    static constexpr size_t max_nesting_depth { 512 };
+    size_t m_current_nesting_depth { 0 };
 };
 
 }

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -319,6 +319,32 @@ TEST_CASE(json_parse_fails_on_invalid_number)
 #undef EXPECT_JSON_PARSE_TO_FAIL
 }
 
+TEST_CASE(json_parse_rejects_excessive_nesting_depth)
+{
+    StringBuilder input;
+    constexpr size_t nesting_depth = 4096;
+
+    input.append_repeated('[', nesting_depth);
+    input.append('0');
+    input.append_repeated(']', nesting_depth);
+
+    auto parsed = JsonValue::from_string(input.string_view());
+    EXPECT(parsed.is_error());
+}
+
+TEST_CASE(json_parse_accepts_reasonable_nesting_depth)
+{
+    StringBuilder input;
+    constexpr size_t nesting_depth = 64;
+
+    input.append_repeated('[', nesting_depth);
+    input.append('0');
+    input.append_repeated(']', nesting_depth);
+
+    auto parsed = JsonValue::from_string(input.string_view());
+    EXPECT(!parsed.is_error());
+}
+
 struct CustomError {
 };
 


### PR DESCRIPTION
Add a maximum nesting depth check in JsonParser so deeply nested arrays/objects from untrusted input cannot blow the call stack.

Add regression tests for excessive nesting rejection and reasonable nesting acceptance.

Fuzz log:

<details>

```
#486593 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15746 exec/s: 106 rss: 625Mb L: 43/14457 MS: 1 EraseBytes-
#487136 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15746 exec/s: 106 rss: 625Mb L: 145/14457 MS: 3 ChangeByte-CopyPart-EraseBytes-
#487513 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15746 exec/s: 107 rss: 625Mb L: 12/14457 MS: 2 ChangeBinInt-EraseBytes-
#490059 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15759 exec/s: 107 rss: 625Mb L: 80/14457 MS: 1 EraseBytes-
#490270 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15759 exec/s: 107 rss: 625Mb L: 28/14457 MS: 1 EraseBytes-
#490391 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15759 exec/s: 107 rss: 625Mb L: 85/14457 MS: 1 EraseBytes-
#492652 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 146/14457 MS: 1 EraseBytes-
#492828 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 36/14457 MS: 1 EraseBytes-
#493017 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 59/14457 MS: 4 CMP-CopyPart-ChangeBit-EraseBytes- DE: "\003\000"-
#493185 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 16/14457 MS: 3 CopyPart-ChangeBit-EraseBytes-
#494092 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 21/14457 MS: 2 InsertByte-EraseBytes-
#494823 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 18/14457 MS: 1 EraseBytes-
#495057 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 213/14457 MS: 4 InsertByte-ShuffleBytes-ChangeByte-EraseBytes-
#495858 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 45/14457 MS: 1 EraseBytes-
#496504 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 232/14457 MS: 1 EraseBytes-
#497450 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 147/14457 MS: 1 EraseBytes-
#497471 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15772 exec/s: 107 rss: 625Mb L: 36/14457 MS: 1 EraseBytes-
#503332 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15824 exec/s: 107 rss: 625Mb L: 410/14457 MS: 1 EraseBytes-
#503824 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15824 exec/s: 107 rss: 625Mb L: 10/14457 MS: 2 CopyPart-EraseBytes-
#504043 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15824 exec/s: 107 rss: 625Mb L: 23/14457 MS: 4 CopyPart-ChangeBit-ShuffleBytes-EraseBytes-
#504730 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15824 exec/s: 107 rss: 625Mb L: 13/14457 MS: 2 InsertByte-EraseBytes-
#505501 REDUCE cov: 3839 ft: 21928 corp: 1935/587Kb lim: 15824 exec/s: 107 rss: 625Mb L: 62/14457 MS: 1 EraseBytes-
AddressSanitizer:DEADLYSIGNAL
=================================================================
==3162547==ERROR: AddressSanitizer: stack-overflow on address 0x7ffc4f42cff8 (pc 0x55e8e871aad2 bp 0x7ffc4f42d110 sp 0x7ffc4f42d000 T0)
    #0 0x55e8e871aad2 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:170
    #1 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #2 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #3 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #4 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #5 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #6 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #7 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #8 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #9 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #10 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #11 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #12 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #13 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #14 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #15 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #16 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #17 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #18 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #19 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #20 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #21 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #22 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #23 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #24 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #25 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #26 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #27 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #28 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #29 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #30 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #31 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #32 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #33 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #34 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #35 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #36 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #37 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #38 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #39 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #40 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #41 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #42 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #43 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #44 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #45 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #46 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #47 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #48 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #49 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #50 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #51 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #52 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #53 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #54 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #55 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #56 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #57 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #58 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #59 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #60 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #61 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #62 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #63 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #64 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #65 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #66 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #67 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #68 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #69 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #70 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #71 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #72 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #73 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #74 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #75 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #76 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #77 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #78 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #79 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #80 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #81 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #82 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #83 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #84 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #85 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #86 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #87 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #88 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #89 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #90 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #91 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #92 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #93 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #94 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #95 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #96 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #97 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #98 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #99 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #100 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #101 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #102 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #103 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #104 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #105 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #106 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #107 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #108 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #109 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #110 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #111 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #112 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #113 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #114 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #115 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #116 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #117 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #118 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #119 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #120 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #121 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #122 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #123 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #124 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #125 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #126 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #127 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #128 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #129 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #130 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #131 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #132 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #133 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #134 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #135 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #136 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #137 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #138 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #139 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #140 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #141 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #142 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #143 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #144 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #145 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #146 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #147 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #148 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #149 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #150 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #151 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #152 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #153 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #154 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #155 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #156 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #157 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #158 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #159 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #160 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #161 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #162 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #163 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #164 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #165 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #166 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #167 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #168 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #169 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #170 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #171 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #172 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #173 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #174 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #175 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #176 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #177 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #178 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #179 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #180 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #181 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #182 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #183 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #184 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #185 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #186 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #187 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #188 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #189 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #190 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #191 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #192 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #193 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #194 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #195 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #196 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #197 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #198 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #199 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #200 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #201 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #202 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #203 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #204 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #205 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #206 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #207 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #208 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #209 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #210 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #211 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #212 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #213 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #214 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #215 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #216 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #217 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #218 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #219 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #220 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #221 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #222 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #223 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #224 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #225 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #226 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #227 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #228 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #229 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #230 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #231 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #232 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #233 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #234 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #235 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #236 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #237 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #238 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #239 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #240 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #241 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #242 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #243 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #244 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24
    #245 0x55e8e871a87f in AK::JsonParser::parse_helper() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:314:16
    #246 0x55e8e871ae54 in AK::JsonParser::parse_array() /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:178:24

SUMMARY: AddressSanitizer: stack-overflow /home/ruben/dev/LadybirdBrowser_ladybird/AK/JsonParser.cpp:170 in AK::JsonParser::parse_array()
==3162547==ABORTING
```

</details>