### PR TITLE
LibWeb: Update layout after dispatching initial mouse events

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -733,6 +733,9 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint visual_viewport_position,
                 //        then step 8 of this algorithm needs to be implemented in Navigable::choose_a_navigable:
                 //        https://html.spec.whatwg.org/multipage/document-sequences.html#the-rules-for-choosing-a-navigable
 
+                // NOTE: Event dispatches above may have run JS that invalidated layout.
+                m_navigable->active_document()->update_layout(DOM::UpdateLayoutReason::EventHandlerHandleMouseUp);
+
                 auto top_level_viewport_position = m_navigable->to_top_level_position(viewport_position);
                 if (GC::Ptr<HTML::HTMLAnchorElement const> link = node->enclosing_link_element()) {
                     GC::Ref<DOM::Document> document = *m_navigable->active_document();

--- a/Tests/LibWeb/Crash/UIEvents/iframe-click-invalidating-parent-layout.html
+++ b/Tests/LibWeb/Crash/UIEvents/iframe-click-invalidating-parent-layout.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<iframe id="frame" srcdoc="
+    <!DOCTYPE html>
+    <div style='width: 100px; height: 100px'
+         onclick='parent.document.body.insertBefore(parent.document.createElement(&quot;div&quot;), parent.document.getElementById(&quot;frame&quot;))'></div>
+"></iframe>
+<script>
+frame.onload = () => {
+    internals.click(50, 50);
+    document.documentElement.classList.remove("test-wait");
+};
+</script>
+</html>


### PR DESCRIPTION
Since #8182, we've been verifying "is the layout up to date" in more places. After dispatching mouseup/pointerup, the layout could have been changed again and we need to update it before trying to run activation behaviors.

Fixes opening/closing an email's details in Roundcube webmail.

CC @awesomekling 