### PR TITLE
LibWeb: Apply transform attribute to inner `<svg>` elements

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1554,6 +1554,10 @@ static void relayout_svg_root(Layout::SVGSVGBox& svg_root)
             if (auto paintable = svg_graphics_ancestor->paintable_box())
                 layout_state.populate_from_paintable(*svg_graphics_ancestor, *paintable);
         }
+        if (auto const* svg_svg_ancestor = as_if<Layout::SVGSVGBox>(*ancestor)) {
+            if (auto paintable = svg_svg_ancestor->paintable_box())
+                layout_state.populate_from_paintable(*svg_svg_ancestor, *paintable);
+        }
     }
 
     // Pre-populate the viewport for position:fixed elements inside <foreignObject>.

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -219,6 +219,23 @@ void SVGFormattingContext::run(AvailableSpace const& available_space)
         }
     }
 
+    if (auto const* svg_svg_box = as_if<SVGSVGBox>(context_box()); svg_svg_box && !svg_box_state.computed_svg_transforms().has_value()) {
+        bool has_svg_ancestor = false;
+        for (auto const* ancestor = svg_svg_box->parent(); ancestor; ancestor = ancestor->parent()) {
+            if (is<SVGSVGBox>(*ancestor) || is<SVGGraphicsBox>(*ancestor)) {
+                has_svg_ancestor = true;
+                break;
+            }
+        }
+        if (has_svg_ancestor) {
+            auto const& svg_graphics_element = as<SVG::SVGGraphicsElement>(*dom_node);
+            auto parent_svg_transform = get_parent_svg_transform(*svg_svg_box);
+            auto svg_transform = parent_svg_transform.multiply(svg_graphics_element.element_transform());
+            svg_box_state.set_computed_svg_transforms(
+                Painting::SVGGraphicsPaintable::ComputedTransforms(m_parent_viewbox_transform, svg_transform));
+        }
+    }
+
     m_current_viewbox_transform = m_parent_viewbox_transform;
     if (active_view_box.has_value()) {
         // FIXME: This should allow just one of width or height to be specified.
@@ -297,8 +314,8 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
 {
     if (is<SVG::SVGFitToViewBox>(child.dom_node())) {
         layout_nested_viewport(child);
-    } else if (is<SVG::SVGForeignObjectElement>(child.dom_node()) && is<BlockContainer>(child)) {
-        Layout::BlockFormattingContext bfc(m_state, m_layout_mode, static_cast<BlockContainer const&>(child), this);
+    } else if (auto* foreign_object_element = as_if<SVG::SVGForeignObjectElement>(child.dom_node()); foreign_object_element && is<BlockContainer>(child)) {
+        Layout::BlockFormattingContext bfc(m_state, m_layout_mode, as<BlockContainer>(child), this);
         auto& child_state = m_state.get_mutable(child);
         CSSPixelRect rect {
             {
@@ -310,7 +327,10 @@ void SVGFormattingContext::layout_svg_element(Box const& child)
                 child.computed_values().height().to_px(child, m_available_space->height.to_px_or_zero()),
             }
         };
-        auto transformed_rect = m_current_viewbox_transform.map(rect.to_type<float>()).to_type<CSSPixels>();
+        auto parent_svg_transform = get_parent_svg_transform(child);
+        auto svg_transform = parent_svg_transform.multiply(foreign_object_element->element_transform());
+        auto to_css_pixels_transform = Gfx::AffineTransform {}.multiply(m_current_viewbox_transform).multiply(svg_transform);
+        auto transformed_rect = to_css_pixels_transform.map(rect.to_type<float>()).to_type<CSSPixels>();
         child_state.set_content_offset(transformed_rect.location());
         child_state.set_content_width(transformed_rect.width());
         child_state.set_content_height(transformed_rect.height());
@@ -474,14 +494,21 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
     graphics_box_state.set_computed_svg_path(move(path));
 }
 
-Gfx::AffineTransform SVGFormattingContext::get_parent_svg_transform(SVGGraphicsBox const& box) const
+Gfx::AffineTransform SVGFormattingContext::get_parent_svg_transform(Box const& box) const
 {
     // Mask/clip boxes are transform boundaries — the target's transform is applied separately at paint time.
     for (auto* ancestor = box.parent(); ancestor; ancestor = ancestor->parent()) {
         if (is<SVGMaskBox>(*ancestor) || is<SVGClipBox>(*ancestor) || is<SVGPatternBox>(*ancestor))
             return {};
-        if (auto const* svg_graphics_ancestor = as_if<SVGGraphicsBox>(*ancestor)) {
-            auto const& ancestor_state = m_state.get(*svg_graphics_ancestor);
+        if (auto const* svg_svg_box = as_if<SVGSVGBox>(*ancestor)) {
+            if (auto const* ancestor_state = m_state.try_get(*svg_svg_box)) {
+                if (ancestor_state->computed_svg_transforms().has_value())
+                    return ancestor_state->computed_svg_transforms()->svg_transform();
+            }
+            continue;
+        }
+        if (auto const* svg_graphics_box = as_if<SVGGraphicsBox>(*ancestor)) {
+            auto const& ancestor_state = m_state.get(*svg_graphics_box);
             if (ancestor_state.computed_svg_transforms().has_value())
                 return ancestor_state.computed_svg_transforms()->svg_transform();
         }

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -36,7 +36,7 @@ private:
     [[nodiscard]] Gfx::Path compute_path_for_text(SVGTextBox const&) const;
     [[nodiscard]] Gfx::Path compute_path_for_text_path(SVGTextPathBox const&) const;
 
-    [[nodiscard]] Gfx::AffineTransform get_parent_svg_transform(SVGGraphicsBox const&) const;
+    [[nodiscard]] Gfx::AffineTransform get_parent_svg_transform(Box const&) const;
 
     Gfx::AffineTransform m_parent_viewbox_transform {};
 

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/inner-svg-rotate-transform-ref.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/inner-svg-rotate-transform-ref.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g transform="rotate(45)">
+    <svg width="50" height="50">
+      <rect width="50" height="50" fill="green"/>
+    </svg>
+  </g>
+</svg>

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/inner-svg-transform-and-viewbox-ref.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/inner-svg-transform-and-viewbox-ref.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(100,50)">
+    <svg width="50" height="50" viewBox="0 0 40 40">
+      <rect width="50" height="50" fill="green"/>
+      <circle cx="25" cy="25" r="6"/>
+    </svg>
+  </g>
+</svg>

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/inner-svg-transform-ref.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/struct/reftests/reference/inner-svg-transform-ref.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(100,50) scale(2)">
+    <svg width="50" height="50">
+      <rect width="50" height="50" fill="green"/>
+    </svg>
+  </g>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/inner-svg-rotate-transform.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/inner-svg-rotate-transform.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="help" href="https://www.w3.org/TR/SVG2/struct.html#SVGElement"/>
+  <html:link rel="help" href="https://www.w3.org/TR/SVG2/coords.html#TransformProperty"/>
+  <html:link rel="match" href="../../../../../expected/wpt-import/svg/struct/reftests/reference/inner-svg-rotate-transform-ref.svg"/>
+  <title>Test that rotates the inner svg element</title>
+  <svg width="50" height="50" transform="rotate(45)">
+    <rect width="50" height="50" fill="green"/>
+  </svg>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/inner-svg-transform-and-viewbox.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/inner-svg-transform-and-viewbox.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="help" href="https://www.w3.org/TR/SVG2/struct.html#SVGElement"/>
+  <html:link rel="help" href="https://www.w3.org/TR/SVG2/coords.html#TransformProperty"/>
+  <html:link rel="help" href="https://www.w3.org/TR/SVG2/coords.html#ViewBoxAttribute"/>
+  <html:link rel="match" href="../../../../../expected/wpt-import/svg/struct/reftests/reference/inner-svg-transform-and-viewbox-ref.svg"/>
+  <title>Test that transforms the inner svg element with viewBox specified</title>
+  <svg width="50" height="50" transform="translate(100,50)" viewBox="0 0 40 40">
+    <rect width="50" height="50" fill="green"/>
+    <circle cx="25" cy="25" r="6"/>
+  </svg>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/inner-svg-transform.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/struct/reftests/inner-svg-transform.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="help" href="https://www.w3.org/TR/SVG2/struct.html#SVGElement"/>
+  <html:link rel="help" href="https://www.w3.org/TR/SVG2/coords.html#TransformProperty"/>
+  <html:link rel="match" href="../../../../../expected/wpt-import/svg/struct/reftests/reference/inner-svg-transform-ref.svg"/>
+  <title>Test that transforms the inner svg element</title>
+  <svg width="50" height="50" transform="translate(100,50) scale(2)">
+    <rect width="50" height="50" fill="green"/>
+  </svg>
+</svg>

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -1,7 +1,7 @@
 AccumulatedVisualContext Tree:
   [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[8,8 100x100] (SVGForeignObjectPaintable(SVGForeignObjectBox<foreignObject>#fo))
-      [3] clip=[8,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
+      [3] clip=[9,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
@@ -23,9 +23,9 @@ SaveLayer@0
   Save@2
     AddClipRect@2 rect=[-2,-2 119x119]
     SaveLayer@2
-      CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
-      CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[8,8 100x100]
-      FillRect@3 rect=[8,8 100x100] color=rgb(0, 0, 0)
+      CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[9,8 100x100]
+      CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[9,8 100x100]
+      FillRect@3 rect=[9,8 100x100] color=rgb(0, 0, 0)
       ApplyEffects@2 opacity=1 has_filter=false
         PaintNestedDisplayList@2 rect=[-2,-2 119x119]
           Translate@0 delta=[2,2]


### PR DESCRIPTION
Previously, transforms were ignored for SVGSVGElements.