### PR TITLE
LibWeb: Skip shorthand serialization for `var()` longhands

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -75,6 +75,12 @@ void ShorthandStyleValue::serialize(StringBuilder& builder, SerializationMode mo
                 return;
         }
 
+        // If any non-reset-only longhand is not a value list, we can't serialize as a coordinating-list shorthand.
+        for (auto sub_property : m_properties.sub_properties) {
+            if (!reset_only_longhands.contains_slow(sub_property) && !longhand(sub_property)->is_value_list())
+                return;
+        }
+
         auto entry_count = longhand(m_properties.sub_properties[0])->as_value_list().size();
 
         // If we don't have the same number of values for each non-reset-only longhand, we can't serialize this shorthand.

--- a/Tests/LibWeb/Text/expected/css/transition-longhand-var-serialization.txt
+++ b/Tests/LibWeb/Text/expected/css/transition-longhand-var-serialization.txt
@@ -1,0 +1,1 @@
+.a { transition-property: var(--a); transition-duration: var(--b); transition-timing-function: var(--c); transition-delay: var(--d); transition-behavior: var(--e); }

--- a/Tests/LibWeb/Text/input/css/transition-longhand-var-serialization.html
+++ b/Tests/LibWeb/Text/input/css/transition-longhand-var-serialization.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+.a {
+    transition-property: var(--a);
+    transition-duration: var(--b);
+    transition-timing-function: var(--c);
+    transition-delay: var(--d);
+    transition-behavior: var(--e);
+}
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(document.styleSheets[0].cssRules[0].cssText);
+    });
+</script>


### PR DESCRIPTION
When CSSRule.cssText is accessed, shorthands are recomposed from individual longhand declarations. For coordinating-list shorthands, the `serialize()` function always assumed that each  sub-property was a value list. This caused a  crash for longhands containing `var()`. We now fall back to serializing properties individually if any sub property contains `var()`. This matches the behavior of other engines.

This fixes a crash on https://polymarket.com