### PR TITLE
LibWeb: Ensure execution context exists for FontFace loading task

### DIFF
--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -143,6 +143,7 @@ GC::Ref<FontFace> FontFace::construct_impl(JS::Realm& realm, String family, Font
         return font_face;
 
     HTML::queue_global_task(HTML::Task::Source::FontLoading, HTML::relevant_global_object(*font_face), GC::create_function(vm.heap(), [&realm, font_face] {
+        HTML::TemporaryExecutionContext context(font_face->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 1.  Set font face’s status attribute to "loading".
         font_face->m_status = Bindings::FontFaceLoadStatus::Loading;
 

--- a/Tests/LibWeb/Crash/CSS/font-face-set-loading-with-binary-data.html
+++ b/Tests/LibWeb/Crash/CSS/font-face-set-loading-with-binary-data.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<script>
+    document.fonts.ready.then(() => {
+        const face = new FontFace("test", new ArrayBuffer(16));
+        document.fonts.add(face);
+    });
+</script>


### PR DESCRIPTION
Fixes a crash when opening: https://mozilla.github.io/pdf.js/web/viewer.html