### PR TITLE
LibWeb: Update layout before accessing paintable in label activation

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -107,6 +107,7 @@ enum class InvalidateLayoutTreeReason {
     X(HTMLImageElementY)                   \
     X(HTMLInputElementHeight)              \
     X(HTMLInputElementWidth)               \
+    X(HTMLLabelElementActivationBehavior)  \
     X(InspectDOMTree)                      \
     X(InternalsHitTest)                    \
     X(MediaQueryListMatches)               \

--- a/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -71,6 +71,9 @@ void HTMLLabelElement::activation_behavior(DOM::Event const& event)
         auto const& mouse_event = as<UIEvents::MouseEvent>(event);
         auto click_event = mouse_event.clone();
 
+        // NB: Ensure layout is up to date before accessing the control's paintable.
+        document().update_layout(DOM::UpdateLayoutReason::HTMLLabelElementActivationBehavior);
+
         // Recompute offsetX/offsetY relative to the control element, since the original values are relative to the label.
         if (auto const* paintable = control_element->paintable(); paintable && document().navigable()) {
             auto scroll_offset = document().navigable()->viewport_scroll_offset();

--- a/Tests/LibWeb/Crash/HTML/label-click-dirty-layout.html
+++ b/Tests/LibWeb/Crash/HTML/label-click-dirty-layout.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<label id="label" for="input">Test</label>
+<input id="input">
+<script>
+    document.getElementById("input").offsetWidth;
+    document.body.appendChild(document.createElement("div"));
+    document.getElementById("label").click();
+</script>


### PR DESCRIPTION
Another stale layout bug uncovered by #8182.

Found while browsing: https://employ.remote.com/sign-in/