### PR TITLE
UI/AppKit: Hide the location bar when elements are fullscreened

### DIFF
--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2023-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -32,6 +32,9 @@
 - (void)onTitleChange:(Utf16String const&)title;
 - (void)onFaviconChange:(Gfx::Bitmap const&)bitmap;
 - (void)onAudioPlayStateChange:(Web::HTML::AudioPlayState)play_state;
+
+- (void)onEnterFullscreenWindow;
+- (void)onExitFullscreenWindow;
 
 - (void)onFindInPageResult:(size_t)current_match_index
            totalMatchCount:(Optional<size_t> const&)total_match_count;

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2023-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -853,10 +853,7 @@ struct HideCursor {
             return;
         }
 
-        if (([[self window] styleMask] & NSWindowStyleMaskFullScreen) == 0) {
-            [[self window] toggleFullScreen:nil];
-        }
-
+        [self.observer onEnterFullscreenWindow];
         m_web_view_bridge->did_update_window_rect();
     };
 
@@ -866,10 +863,7 @@ struct HideCursor {
             return;
         }
 
-        if (([[self window] styleMask] & NSWindowStyleMaskFullScreen) != 0) {
-            [[self window] toggleFullScreen:nil];
-        }
-
+        [self.observer onExitFullscreenWindow];
         m_web_view_bridge->did_update_window_rect();
     };
 

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2023-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -298,6 +298,16 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
         [[self tab] setAccessoryView:button];
         break;
     }
+}
+
+- (void)onEnterFullscreenWindow
+{
+    [[self tabController] onEnterFullscreenWindow];
+}
+
+- (void)onExitFullscreenWindow
+{
+    [[self tabController] onExitFullscreenWindow];
 }
 
 - (void)onFindInPageResult:(size_t)current_match_index

--- a/UI/AppKit/Interface/TabController.h
+++ b/UI/AppKit/Interface/TabController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +24,9 @@
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect;
 
 - (void)onURLChange:(URL::URL const&)url;
+
+- (void)onEnterFullscreenWindow;
+- (void)onExitFullscreenWindow;
 
 - (void)clearHistory;
 

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2023-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,6 +53,9 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     u64 m_page_index;
 
     OwnPtr<WebView::Autocomplete> m_autocomplete;
+
+    bool m_fullscreen_requested_for_web_content;
+    bool m_fullscreen_should_restore_tab_bar;
 }
 
 @property (nonatomic, assign) BOOL already_requested_close;
@@ -104,6 +107,8 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [self.toolbar setSizeMode:NSToolbarSizeModeRegular];
 
         m_page_index = 0;
+        m_fullscreen_requested_for_web_content = false;
+        m_fullscreen_should_restore_tab_bar = false;
 
         self.autocomplete = [[Autocomplete alloc] init:self withToolbarItem:self.location_toolbar_item];
         m_autocomplete = make<WebView::Autocomplete>();
@@ -126,7 +131,10 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 {
     if (self = [self init]) {
         self.parent = parent;
+
         m_page_index = page_index;
+        m_fullscreen_requested_for_web_content = false;
+        m_fullscreen_should_restore_tab_bar = false;
     }
 
     return self;
@@ -151,6 +159,22 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     // Don't steal focus from the location bar when loading the new tab page
     if (url != WebView::Application::settings().new_tab_page_url()) {
         [self.window makeFirstResponder:[self tab].web_view];
+    }
+}
+
+- (void)onEnterFullscreenWindow
+{
+    m_fullscreen_requested_for_web_content = true;
+
+    if (([self.window styleMask] & NSWindowStyleMaskFullScreen) == 0) {
+        [self.window toggleFullScreen:nil];
+    }
+}
+
+- (void)onExitFullscreenWindow
+{
+    if (([self.window styleMask] & NSWindowStyleMaskFullScreen) != 0) {
+        [self.window toggleFullScreen:nil];
     }
 }
 
@@ -453,9 +477,42 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     [[[self tab] web_view] handleDisplayRefreshRateChange];
 }
 
+- (void)windowWillEnterFullScreen:(NSNotification*)notification
+{
+    if (m_fullscreen_requested_for_web_content) {
+        [self.toolbar setVisible:NO];
+
+        m_fullscreen_should_restore_tab_bar = [[self.window tabGroup] isTabBarVisible];
+        if (m_fullscreen_should_restore_tab_bar) {
+            [self.window toggleTabBar:nil];
+        }
+    }
+}
+
 - (void)windowDidExitFullScreen:(NSNotification*)notification
 {
+    if (exchange(m_fullscreen_requested_for_web_content, false)) {
+        [self.toolbar setVisible:YES];
+
+        if (m_fullscreen_should_restore_tab_bar && ![[self.window tabGroup] isTabBarVisible]) {
+            [self.window toggleTabBar:nil];
+        }
+    }
+
     [[[self tab] web_view] handleExitFullScreen];
+}
+
+- (NSApplicationPresentationOptions)window:(NSWindow*)window
+      willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposed_options
+{
+    if (m_fullscreen_requested_for_web_content) {
+        return NSApplicationPresentationAutoHideDock
+            | NSApplicationPresentationAutoHideToolbar
+            | NSApplicationPresentationAutoHideMenuBar
+            | NSApplicationPresentationFullScreen;
+    }
+
+    return proposed_options;
 }
 
 #pragma mark - NSToolbarDelegate


### PR DESCRIPTION
When an element is fullscreened, we now hide the application menu and location bar. The user can hover over the top of the window to make them show. When fullscreen is requested for the application directly from the UI, we do not hide the location bar. This matches Safari's behavior.

[fullscreen.webm](https://github.com/user-attachments/assets/89c4b43a-a2c5-4eaa-a21f-da3c68874bd9)


