### PR TITLE
LibWeb: Allow custom properties on pseudo-elements with property lists

### DIFF
--- a/Libraries/LibWeb/CSS/PseudoElements.json
+++ b/Libraries/LibWeb/CSS/PseudoElements.json
@@ -57,7 +57,8 @@
       "#margin-properties",
       "#padding-properties",
       "#border-properties",
-      "box-shadow"
+      "box-shadow",
+      "#custom-properties"
     ]
   },
   "first-line": {
@@ -69,6 +70,7 @@
       "#background-properties",
       "#inline-typesetting-properties",
       "#text-decoration-properties",
+      "#custom-properties",
       "FIXME: ruby-position",
       "#inline-layout-properties"
     ]
@@ -90,6 +92,7 @@
       "#background-properties",
       "#inline-typesetting-properties",
       "#text-decoration-properties",
+      "#custom-properties",
       "FIXME: ruby-position"
     ]
   },

--- a/Tests/LibWeb/Text/expected/css/placeholder-custom-properties.txt
+++ b/Tests/LibWeb/Text/expected/css/placeholder-custom-properties.txt
@@ -1,0 +1,5 @@
+color: rgb(0, 0, 255)
+opacity: 0.5
+font-weight: 900
+inherited color: rgb(0, 128, 0)
+nested color: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-first-letter.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-first-letter.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	color
+Pass	font-size
+Pass	font-weight
+Pass	position
+Pass	nested color
+Pass	abspos

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-first-line.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-variables/variable-first-line.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	color
+Pass	font-size
+Pass	font-weight
+Pass	position
+Pass	nested color
+Pass	abspos

--- a/Tests/LibWeb/Text/input/css/placeholder-custom-properties.html
+++ b/Tests/LibWeb/Text/input/css/placeholder-custom-properties.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-variables-1/#defining-variables">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#placeholder-pseudo">
+<style>
+    #input1::placeholder {
+        color: var(--my-color);
+        --my-color: rgb(0, 0, 255);
+    }
+
+    #input2::placeholder {
+        opacity: var(--my-opacity);
+        --my-opacity: 0.5;
+    }
+
+    #input3::placeholder {
+        font-weight: var(--my-font-weight);
+        --my-font-weight: 900;
+    }
+
+    #input4 {
+        --my-color: rgb(0, 128, 0);
+    }
+    #input4::placeholder {
+        color: var(--my-color);
+    }
+
+    #input5::placeholder {
+        color: var(--my-color1);
+        --my-color1: var(--my-color2);
+        --my-color2: rgb(0, 0, 255);
+    }
+</style>
+<input id="input1" placeholder="test">
+<input id="input2" placeholder="test">
+<input id="input3" placeholder="test">
+<input id="input4" placeholder="test">
+<input id="input5" placeholder="test">
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const s1 = getComputedStyle(document.getElementById("input1"), "::placeholder");
+        println(`color: ${s1.color}`);
+
+        const s2 = getComputedStyle(document.getElementById("input2"), "::placeholder");
+        println(`opacity: ${s2.opacity}`);
+
+        const s3 = getComputedStyle(document.getElementById("input3"), "::placeholder");
+        println(`font-weight: ${s3.fontWeight}`);
+
+        const s4 = getComputedStyle(document.getElementById("input4"), "::placeholder");
+        println(`inherited color: ${s4.color}`);
+
+        const s5 = getComputedStyle(document.getElementById("input5"), "::placeholder");
+        println(`nested color: ${s5.color}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-first-letter.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-first-letter.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Variables with ::first-letter pseudo-element.</title>
+
+    <meta rel="author" title="Kevin Babbitt">
+    <meta rel="author" title="Greg Whitworth">
+    <link rel="author" title="Microsoft Corporation" href="http://microsoft.com" />
+    <!-- This is not directly specified in the spec but should work -->
+    <link rel="help" href="http://www.w3.org/TR/css-variables-1/#defining-variables">
+
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <style>
+        #div1::first-letter {
+            color: var(--my-color);
+            --my-color: rgb(0, 0, 255);
+        }
+
+        #div2::first-letter {
+            font-size: var(--my-font-size);
+            --my-font-size: 25px;
+        }
+
+        #div3::first-letter {
+            font-weight: var(--my-font-weight);
+            --my-font-weight: 900;
+        }
+
+        #div4::first-letter {
+            position: var(--my-position);
+            --my-position: absolute;
+        }
+
+        #div5::first-letter {
+            color: var(--my-color1);
+            --my-color1: var(--my-color2);
+            --my-color2: rgb(0, 0, 255);
+        }
+
+        #div6::first-letter {
+            position: var(--my-position1);
+            --my-position1: var(--my-position2);
+            --my-position2: absolute;
+        }
+    </style>
+</head>
+<body>
+    <div id="div1">CSS variable defining 'color' property should be applied to ::first-letter and its color should be blue.</div>
+    <div id="div2">CSS variable defining 'font-size' property should be applied to ::first-letter and its font-size should be 25px.</div>
+    <div id="div3">CSS variable defining 'font-weight' property should be applied to ::first-letter and its font-weight should be 900.</div>
+    <div id="div4">CSS variable defining 'position' property should not be applied to ::first-letter and its position should be static.</div>
+    <div id="div5">CSS variable referencing another CSS variable that defines 'color' property should be applied to ::first-letter and its color should be blue.</div>
+    <div id="div6">CSS variable referencing another CSS variable that defines 'position' property should not be applied to ::first-letter and its position should be static.</div>
+
+    <script>
+        "use strict";
+        var testcases = [
+            { elementId: "div1", property: "color", expectedValue: "rgb(0, 0, 255)", testName: "color" },
+            { elementId: "div2", property: "font-size", expectedValue: "25px", testName: "font-size" },
+            { elementId: "div3", property: "font-weight", expectedValue: "900", testName: "font-weight" },
+            { elementId: "div4", property: "position", expectedValue: "static", testName: "position" },
+            { elementId: "div5", property: "color", expectedValue: "rgb(0, 0, 255)", testName: "nested color" },
+            { elementId: "div6", property: "position", expectedValue: "static", testName: "abspos" },
+        ];
+
+        testcases.forEach(function (tc) {
+            test( function () {
+                var elem = document.getElementById(tc.elementId);
+                var actualValue = window.getComputedStyle(elem, ':first-letter').getPropertyValue(tc.property);
+                assert_equals(tc.expectedValue, actualValue);
+            }, tc.testName);
+        });
+    </script>
+</body>
+</html>
+

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-first-line.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-variables/variable-first-line.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Variables with ::first-line pseudo-element.</title>
+
+    <meta rel="author" title="Kevin Babbitt">
+    <meta rel="author" title="Greg Whitworth">
+    <link rel="author" title="Microsoft Corporation" href="http://microsoft.com" />
+    <!-- This is not directly specified in the spec but should work -->
+    <link rel="help" href="http://www.w3.org/TR/css-variables-1/#defining-variables">
+
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <style>
+        div {
+            width: 500px;
+        }
+
+        #div1::first-line {
+            color: var(--my-color);
+            --my-color: rgb(0, 0, 255);
+        }
+
+        #div2::first-line {
+            font-size: var(--my-font-size);
+            --my-font-size: 25px;
+        }
+
+        #div3::first-line {
+            font-weight: var(--my-font-weight);
+            --my-font-weight: 900;
+        }
+
+        #div4::first-line {
+            position: var(--my-position);
+            --my-position: absolute;
+        }
+
+        #div5::first-line {
+            color: var(--my-color1);
+            --my-color1: var(--my-color2);
+            --my-color2: rgb(0, 0, 255);
+        }
+
+        #div6::first-line {
+            position: var(--my-position1);
+            --my-position1: var(--my-position2);
+            --my-position2: absolute;
+        }
+    </style>
+</head>
+<body>
+    <div id="div1">CSS variable defining 'color' property should be applied to ::first-line and its color should be blue.</div>
+    <br />
+    <div id="div2">CSS variable defining 'font-size' property should be applied to ::first-line and its font-size should be 25px.</div>
+    <br />
+    <div id="div3">CSS variable defining 'font-weight' property should be applied to ::first-line and its font-weight should be 900.</div>
+    <br />
+    <div id="div4">CSS variable defining 'position' property should not be applied to ::first-line and its position should be static.</div>
+    <br />
+    <div id="div5">CSS variable referencing another CSS variable that defines 'color' property should be applied to ::first-line and its color should be blue.</div>
+    <br />
+    <div id="div6">CSS variable referencing another CSS variable that defines 'position' property should not be applied to ::first-line and its position should be static.</div>
+
+    <script>
+        "use strict";
+
+        let templates = [
+            { elementId: "div1", property: "color", expectedValue: "rgb(0, 0, 255)", testName: "color" },
+            { elementId: "div2", property: "font-size", expectedValue: "25px", testName: "font-size" },
+            { elementId: "div3", property: "font-weight", expectedValue: "900", testName: "font-weight" },
+            { elementId: "div4", property: "position", expectedValue: "static", testName: "position" },
+            { elementId: "div5", property: "color", expectedValue: "rgb(0, 0, 255)", testName: "nested color" },
+            { elementId: "div6", property: "position", expectedValue: "static", testName: "abspos" },
+        ];
+
+        templates.forEach(function (template) {
+            test( function () {
+                var elem = document.getElementById(template.elementId);
+                var actualValue = window.getComputedStyle(elem, ':first-line').getPropertyValue(template.property);
+                assert_equals(template.expectedValue, actualValue);
+            }, template.testName);
+        });
+    </script>
+</body>
+</html>
+


### PR DESCRIPTION
Previously, custom properties were not being applied to pseudo-elements when they should have been.

Found while debugging a related issue.