### PR TITLE
Meta: Enable angled brackets in clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -4,3 +4,6 @@ CompileFlags:
 Diagnostics:
   UnusedIncludes: None
   MissingIncludes: None
+
+Style:
+  AngledHeaders: ["AK/.*", "Lib.*"]


### PR DESCRIPTION
This commit enables angled includes on completion for headers under Libraries and AK to match our coding style.