### PR TITLE
LibIPC: Do not allocate for unprocessed bytes

### DIFF
--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -453,13 +453,9 @@ void TransportSocket::read_incoming_messages()
     }
 
     if (index < m_unprocessed_bytes.size()) {
-        auto remaining_bytes_or_error = ByteBuffer::copy(m_unprocessed_bytes.span().slice(index));
-        if (remaining_bytes_or_error.is_error()) {
-            dbgln("TransportSocket: Failed to copy remaining bytes");
-            m_peer_eof = true;
-        } else {
-            m_unprocessed_bytes = remaining_bytes_or_error.release_value();
-        }
+        auto remaining = m_unprocessed_bytes.size() - index;
+        m_unprocessed_bytes.overwrite(0, m_unprocessed_bytes.data() + index, remaining);
+        m_unprocessed_bytes.resize(remaining);
     } else {
         m_unprocessed_bytes.clear();
     }


### PR DESCRIPTION
While we're processing received messages, we can end up with unprocessed bytes after the last message. Instead of copying the data into a new ByteBuffer, just move the bytes inside the existing buffer and resize it.

This does mean that as long as there are unprocessed bytes after reading incoming messages, the buffer does not shrink. But as soon as there's nothing left, we clear this buffer again.