### PR TITLE
LibWeb: Add vendor-specific aliases for the `placeholder` pseudoelement

### DIFF
--- a/Libraries/LibWeb/CSS/PseudoElements.json
+++ b/Libraries/LibWeb/CSS/PseudoElements.json
@@ -2,6 +2,9 @@
   "-moz-meter-bar": {
     "alias-for": "slider-fill"
   },
+  "-moz-placeholder": {
+    "alias-for": "placeholder"
+  },
   "-moz-progress-bar": {
     "alias-for": "slider-fill"
   },
@@ -13,6 +16,9 @@
   },
   "-moz-range-thumb": {
     "alias-for": "slider-thumb"
+  },
+  "-webkit-input-placeholder": {
+    "alias-for": "placeholder"
   },
   "-webkit-meter-bar": {
     "alias-for": "slider-track"

--- a/Tests/LibWeb/Ref/expected/css-legacy-placeholder-pseudo-element-ref.html
+++ b/Tests/LibWeb/Ref/expected/css-legacy-placeholder-pseudo-element-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+input::placeholder {
+    color: green;
+}
+textarea::placeholder {
+    color: green;
+}
+</style>
+<input type="text" placeholder="This should be green">
+<textarea placeholder="This should be green"></textarea>

--- a/Tests/LibWeb/Ref/input/css-legacy-placeholder-pseudo-element.html
+++ b/Tests/LibWeb/Ref/input/css-legacy-placeholder-pseudo-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/css-legacy-placeholder-pseudo-element-ref.html" />
+<style>
+input::-webkit-input-placeholder {
+    color: green;
+}
+textarea::-moz-placeholder {
+    color: green;
+}
+</style>
+<input type="text" placeholder="This should be green">
+<textarea placeholder="This should be green"></textarea>

--- a/Tests/LibWeb/Text/expected/css/supports.txt
+++ b/Tests/LibWeb/Text/expected/css/supports.txt
@@ -13,5 +13,5 @@ These should all fail:
 @supports (width: yellow) or (height: green): FAIL
 @supports (flogwizzle: purple): FAIL
 @supports selector(.....nope): FAIL
-@supports selector(::-webkit-input-placeholder): FAIL
+@supports selector(::-webkit-input-placeholder): PASS
 @supports selector(32) or selector(thing[foo??????bar]): FAIL


### PR DESCRIPTION
This adds both the `-moz-placeholder` and `-webkit-input-placeholder` as an alias for the `placeholder` pseudoelement.

This ensures the placeholder remains hidden on: https://employ.remote.com/sign-in/

Before:
<img width="549" height="584" alt="image" src="https://github.com/user-attachments/assets/cfc601ff-b638-4f42-902a-cb68194af85b" />


After:

<img width="544" height="581" alt="image" src="https://github.com/user-attachments/assets/b187ee8b-48a6-4284-81d5-d7060cfc1300" />

