### PR TITLE
LibWeb: Allow SVG root elements to participate in inline continuation

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1436,8 +1436,12 @@ bool NodeWithStyleAndBoxModelMetrics::should_create_inline_continuation() const
     if (is<SVG::SVGForeignObjectElement>(parent()->dom_node()))
         return false;
 
-    // SVG related boxes should never be split.
-    if (is_svg_box() || is_svg_svg_box() || is_svg_foreign_object_box())
+    // Non-root SVG elements and foreign object boxes should never be split.
+    if (is_svg_box() || is_svg_foreign_object_box())
+        return false;
+
+    // Nested SVG roots should never be split, but a top-level SVG root inside an HTML inline element should be.
+    if (is_svg_svg_box() && (parent()->is_svg_box() || parent()->is_svg_svg_box()))
         return false;
 
     // Replaced boxes with children (e.g. media elements with shadow DOM controls)

--- a/Tests/LibWeb/Ref/expected/svg-block-in-inline-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-block-in-inline-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0 }
+</style>
+<div style="width: 100px; height: 100px; background: green"></div>

--- a/Tests/LibWeb/Ref/input/svg-block-in-inline.html
+++ b/Tests/LibWeb/Ref/input/svg-block-in-inline.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-block-in-inline-ref.html" />
+<style>
+    body { margin: 0 }
+    svg { display: block }
+</style>
+<a><svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="green" /></svg></a>


### PR DESCRIPTION
This makes the logo appear on https://engadget.com

Before:

<img width="1046" height="161" alt="image" src="https://github.com/user-attachments/assets/7ca3649e-58ca-48f1-9f56-f41184f5b17c" />


After:

<img width="1046" height="161" alt="image" src="https://github.com/user-attachments/assets/406994fa-355a-4b5a-ab49-2d61f67bd749" />
