### PR TITLE
LibWeb: Increment fetch generation counter on fetching process cancel

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -197,6 +197,7 @@ void HTMLMediaElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 
 void HTMLMediaElement::cancel_the_fetching_process()
 {
+    m_current_fetch_generation++;
     m_fetch_data.clear();
 }
 


### PR DESCRIPTION
This workaround avoids a crash that occurs when various fetching processes are quickly started and canceled. Although a better solution would be to atually remove the body callbacks when the fetch is stopped, this works for now.