### PR TITLE
LibJS: Fix GCC build

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -433,6 +433,7 @@ NEVER_INLINE void Interpreter::pop_inline_frame(Value return_value)
         return_value = callee_frame->this_value.value();
 
     auto& ec_stack = vm().execution_context_stack();
+    VERIFY(!ec_stack.is_empty());
     ec_stack.resize(ec_stack.size() - 1);
     vm().interpreter_stack().deallocate(callee_frame);
 


### PR DESCRIPTION
GCC inlines the `ec_stack.size() - 1` subtraction and then fails to build because that operation would result in a wraparound if `size()` was zero. This fixes the build by asserting that `ec_stack` isn't empty.