### PR TITLE
LibWeb: Treat percentage insets as auto for indefinite containing blocks

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1618,9 +1618,22 @@ void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
+    // NOTE: Percentage heights resolve against the containing block's used height. If the containing block's height is
+    //       indefinite, percentage insets behave as auto.
+    auto treat_percentage_as_auto = [&](CSS::LengthPercentageOrAuto const& value) -> CSS::LengthPercentageOrAuto {
+        if (value.contains_percentage()) {
+            auto containing_block = box.containing_block();
+            while (containing_block && containing_block->is_anonymous())
+                containing_block = containing_block->containing_block();
+            if (containing_block && !m_state.get(*containing_block).has_definite_height())
+                return CSS::LengthPercentageOrAuto::make_auto();
+        }
+        return value;
+    };
+
     // FIXME: Respect the containing block's writing-mode.
     resolve_two_opposing_insets(computed_values.inset().left(), computed_values.inset().right(), box_state.inset_left, box_state.inset_right, containing_block_size.width());
-    resolve_two_opposing_insets(computed_values.inset().top(), computed_values.inset().bottom(), box_state.inset_top, box_state.inset_bottom, containing_block_size.height());
+    resolve_two_opposing_insets(treat_percentage_as_auto(computed_values.inset().top()), treat_percentage_as_auto(computed_values.inset().bottom()), box_state.inset_top, box_state.inset_bottom, containing_block_size.height());
 }
 
 // https://drafts.csswg.org/css-sizing-3/#fit-content-size

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-position/position-relative-007.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-position/position-relative-007.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta name="assert" content="This ensures that a relative-positioned element inset doesn't resolve against an indefinite size.">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#relpos-insets">
+<link rel="match" href="../../../../expected/wpt-import/css/css-position/../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 100px; min-height: 100px; background: red;">
+  <div style="width: 100px; height: 100px; background: green; top: calc(10px + 10%); position: relative;"></div>
+</div>


### PR DESCRIPTION
A similar approach is used in 492629e3d8d when resolving the `height` property.

This fixes the position of the top nav bar on https://tuananh.net/ 

Before:

<img width="1068" height="183" alt="image" src="https://github.com/user-attachments/assets/c2a493c5-7627-4eb5-87ed-23ef8133a530" />


After:

<img width="1057" height="183" alt="image" src="https://github.com/user-attachments/assets/ef3bc4a2-e848-43ba-93ad-6a6938927f6f" />




