### PR TITLE
LibWeb: Distribute grid track free space among unfrozen tracks only

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1144,13 +1144,25 @@ void GridFormattingContext::maximize_tracks_using_available_size(AvailableSpace 
 
     // If the free space is positive, distribute it equally to the base sizes of all tracks, freezing
     // tracks as they reach their growth limits (and continuing to grow the unfrozen tracks as needed).
-    while (free_space_px > 0) {
-        auto free_space_to_distribute_per_track = free_space_px / tracks.size();
+    size_t growable_track_count = 0;
+    for (auto& track : tracks) {
+        if (track.base_size_frozen)
+            continue;
+        VERIFY(track.growth_limit.has_value());
+        if (track.base_size < track.growth_limit.value())
+            growable_track_count++;
+    }
+    while (free_space_px > 0 && growable_track_count > 0) {
+        auto free_space_to_distribute_per_track = free_space_px / growable_track_count;
         for (auto& track : tracks) {
             if (track.base_size_frozen)
                 continue;
-            VERIFY(track.growth_limit.has_value());
-            track.base_size = min(track.growth_limit.value(), track.base_size + free_space_to_distribute_per_track);
+            if (track.base_size >= track.growth_limit.value())
+                continue;
+            auto new_base_size = min(track.growth_limit.value(), track.base_size + free_space_to_distribute_per_track);
+            if (new_base_size >= track.growth_limit.value())
+                --growable_track_count;
+            track.base_size = new_base_size;
         }
         if (get_free_space_px() == free_space_px)
             break;

--- a/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/image-in-grid.txt
@@ -4,10 +4,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       Box <div.grid-container> at [8,8] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.wrapper> at [8,8] [0+0+0 64.03125 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
-          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64.03125x24] baseline: 24
+        BlockContainer <div.wrapper> at [8,8] [0+0+0 64 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 64x24] baseline: 24
           TextNode <#text> (not painted)
-          ImageBox <img> at [8,8] [0+0+0 64.03125 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+          ImageBox <img> at [8,8] [0+0+0 64 0+0+0] [0+0+0 24 0+0+0] children: not-inline
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
@@ -16,8 +16,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x40]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
       PaintableBox (Box<DIV>.grid-container) [8,8 784x24]
-        PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 64.03125x24]
-          ImagePaintable (ImageBox<IMG>) [8,8 64.03125x24]
+        PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 64x24]
+          ImagePaintable (ImageBox<IMG>) [8,8 64x24]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x40] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/item-column-span-2.txt
@@ -7,10 +7,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         BlockContainer <div.item-left> at [8,8] [0+0+0 100 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <div.item-right> at [108.03125,8] [0+0+0 683.96875 0+0+0] [0+0+0 36 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 77, rect: [108.03125,8 625.953125x18] baseline: 13.796875
+        BlockContainer <div.item-right> at [108,8] [0+0+0 684 0+0+0] [0+0+0 36 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 77, rect: [108,8 625.953125x18] baseline: 13.796875
               "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut iaculis venenatis"
-          frag 1 from TextNode start: 78, length: 39, rect: [108.03125,26 304.0625x18] baseline: 13.796875
+          frag 1 from TextNode start: 78, length: 39, rect: [108,26 304.0625x18] baseline: 13.796875
               "purus, eget blandit velit venenatis at."
           TextNode <#text> (not painted)
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -23,7 +23,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
       PaintableBox (Box<DIV>.container) [8,8 784x36]
         PaintableWithLines (BlockContainer<DIV>.item-left) [8,8 100x36]
-        PaintableWithLines (BlockContainer<DIV>.item-right) [108.03125,8 683.96875x36]
+        PaintableWithLines (BlockContainer<DIV>.item-right) [108,8 684x36]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,44 784x0]
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/grid-model/grid-gutters-and-tracks-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/grid-model/grid-gutters-and-tracks-001.txt
@@ -1,0 +1,23 @@
+Harness status: OK
+
+Found 17 tests
+
+11 Pass
+6 Fail
+Fail	.grid 1
+Pass	.grid 2
+Fail	.grid 3
+Pass	.grid 4
+Fail	.grid 5
+Pass	.grid 6
+Pass	.grid 7
+Fail	.grid 8
+Pass	.grid 9
+Pass	.grid 10
+Pass	.grid 11
+Fail	.grid 12
+Pass	.grid 13
+Pass	.grid 14
+Pass	.grid 15
+Pass	.grid 16
+Fail	.grid 17

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-grid/grid-model/grid-gutters-and-tracks-001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-grid/grid-model/grid-gutters-and-tracks-001.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<title>CSS Grid: grid gutters and tracks.</title>
+<link rel="author" title="Sergio Villar" href="mailto:svillar@igalia.com"/>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#gutters"/>
+<meta name="assert" content="Check that gutters contribute to the size of the grid containers and spanning items, and do not alter grid items positioning, margin computation and track sizing."/>
+<link rel="stylesheet" href="../../../css/support/grid.css"/>
+<link rel="stylesheet" href="../../../css/support/width-keyword-classes.css"/>
+<link rel="stylesheet" href="../../../fonts/ahem.css" type="text/css"/>
+<style>
+body { margin: 0px; }
+
+.grid { padding: 3px 7px 5px 1px; border: solid yellow 1px; }
+
+.normalGap { grid-gap: normal; }
+
+.gridGap { grid-gap: 16px; }
+
+.gridRowColumnGaps {
+    grid-row-gap: 12px;
+    grid-column-gap: 23px;
+}
+
+.gridMultipleCols { grid-template-columns: 30px minmax(10px, 50px) 80px; }
+.gridMultipleRows { grid-template-rows: 90px 70px min-content; }
+.gridAutoAuto { grid-template: auto auto / auto auto; }
+.gridMultipleFixed { grid-template: [first] 37px [foo] 57px [bar] 77px [last] / [first] 15px [foo] 25px [bar] 35px [last]; }
+.gridFixed100 { grid-template: repeat(2, 100px) / repeat(2, 100px); }
+.gridWithPercent { grid-template-columns: 10px 20% repeat(2, 30px); }
+.gridWithDoublePercent { grid-template-columns: 60% 40%; }
+.gridWithRowPercent { grid-template: 10px 20% 30px / 20px; }
+.gridWithRowDoublePercent { grid-template: 60% 40% / 20px; }
+
+.width220 { width: 220px; }
+.height100 { height: 100px; }
+.gridAutoRows20 { grid-auto-rows: 20px; }
+
+.thirdRowThirdColumn { grid-area: 3 / 3; }
+.firstRowThirdColumn { grid-area: 1 / 3; }
+
+div.grid > div { font: 10px/1 Ahem; }
+
+.gridItemMargins {
+    margin: 20px 30px 40px 50px;
+    width: 20px;
+    height: 40px;
+}
+
+</style>
+
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../resources/check-layout-th.js"></script>
+<script type="text/javascript">
+    setup({ explicit_done: true });
+</script>
+
+<body onload="document.fonts.ready.then(() => { checkLayout('.grid'); })">
+
+<!-- Check that gutters contribute to the size of the grid containers. -->
+
+<div style="position: relative;">
+    <div class="grid normalGap gridMultipleCols fit-content" data-expected-width="170" data-expected-height="10"></div>
+    <div class="grid normalGap gridMultipleRows" style="width: 400px" data-expected-width="410" data-expected-height="170"></div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridRowColumnGaps fit-content" data-expected-width="103" data-expected-height="62">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="20" data-expected-height="10">XX</div>
+        <div class="secondRowSecondColumn" data-offset-x="45" data-offset-y="26" data-expected-width="50" data-expected-height="30">XX<br>X<br>XX XX</div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridMultipleCols gridRowColumnGaps fit-content" data-expected-width="216" data-expected-height="94">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="30" data-expected-height="10">XX</div>
+        <div class="secondRowSecondColumn" data-offset-x="55" data-offset-y="26" data-expected-width="50" data-expected-height="20">XX<br>XX XX</div>
+        <div class="thirdRowThirdColumn" data-offset-x="128" data-offset-y="58" data-expected-width="80" data-expected-height="30">XXXX XX<br>X<br>XX XX</div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridMultipleRows gridRowColumnGaps fit-content" data-expected-width="196" data-expected-height="224">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="20" data-expected-height="90">XX</div>
+        <div class="secondRowSecondColumn" data-offset-x="45" data-offset-y="106" data-expected-width="50" data-expected-height="70">XX<br>XX XX</div>
+        <div class="thirdRowThirdColumn" data-offset-x="118" data-offset-y="188" data-expected-width="70" data-expected-height="30">XXXX XX<br>X<br>XX XX</div>
+    </div>
+</div>
+
+<!-- Check that gutters do not alter grid items positioning. -->
+<div style="position: relative">
+    <div class="grid gridMultipleFixed gridRowColumnGaps">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="15" data-expected-height="37">X X X</div>
+        <div class="secondRowSecondColumn" data-offset-x="40" data-offset-y="53" data-expected-width="25" data-expected-height="57">X X</div>
+        <div class="thirdRowThirdColumn" data-offset-x="88" data-offset-y="122" data-expected-width="35" data-expected-height="77">XXX XX X XX XX</div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridMultipleFixed gridRowColumnGaps">
+        <div style="grid-row: 2; grid-column: -2 / -1;" data-offset-x="88" data-offset-y="53" data-expected-width="35" data-expected-height="57">X X X</div>
+        <div style="grid-row: 1 / bar; grid-column: bar" data-offset-x="88" data-offset-y="4" data-expected-width="35" data-expected-height="106">X XX X XX XX XX X</div>
+        <div style="grid-row: -2; grid-column-end: foo" data-offset-x="2" data-offset-y="122" data-expected-width="15" data-expected-height="77">X X</div>
+    </div>
+</div>
+
+<!-- Check that gutters do not alter track sizing. -->
+<div style="position: relative">
+    <div class="grid gridRowColumnGaps fit-content" data-expected-width="166" data-expected-height="94">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="20" data-expected-height="10">XX</div>
+        <div class="secondRowSecondColumn" data-offset-x="45" data-offset-y="26" data-expected-width="30" data-expected-height="20">X X<br>X X</div>
+        <div class="thirdRowThirdColumn" data-offset-x="98" data-offset-y="58" data-expected-width="60" data-expected-height="30">XXX XX<br>X<br>XX XX</div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridRowColumnGaps gridMultipleCols gridMultipleRows fit-content" data-expected-width="216" data-expected-height="224">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="30" data-expected-height="90">XX</div>
+        <div class="secondRowSecondColumn" data-offset-x="55" data-offset-y="106" data-expected-width="50" data-expected-height="70">X X<br>X X</div>
+        <div class="thirdRowThirdColumn" data-offset-x="128" data-offset-y="188" data-expected-width="80" data-expected-height="30">XXX XX<br>X<br>XX XX</div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridWithPercent width220 gridRowColumnGaps gridAutoRows20" data-expected-width="230" data-expected-height="94">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="10" data-expected-height="20"></div>
+        <div class="secondRowSecondColumn" data-offset-x="35" data-offset-y="36" data-expected-width="44" data-expected-height="20"></div>
+        <div class="thirdRowThirdColumn" data-offset-x="102" data-offset-y="68" data-expected-width="30" data-expected-height="20"></div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridWithRowPercent gridRowColumnGaps width220 height100" data-expected-width="230" data-expected-height="110">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="20" data-expected-height="10"></div>
+        <div class="secondRowFirstColumn" data-offset-x="2" data-offset-y="26" data-expected-width="20" data-expected-height="20"></div>
+        <div class="thirdRowAutoColumn" data-offset-x="2" data-offset-y="58" data-expected-width="20" data-expected-height="30"></div>
+    </div>
+</div>
+
+<!-- Check that gutters contribute to the size of spanning items. -->
+<div style="position: relative">
+    <div class="grid gridGap gridAutoAuto constrainedContainer">
+        <div class="secondRowBothColumn" data-offset-x="2" data-offset-y="30" data-expected-width="50" data-expected-height="10">XXXXX</div>
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="17" data-expected-height="10">X</div>
+        <div class="firstRowSecondColumn" data-offset-x="35" data-offset-y="4" data-expected-width="17" data-expected-height="10">X</div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridMultipleFixed gridRowColumnGaps">
+        <div style="grid-row: 2; grid-column: 1 / -1;" data-offset-x="2" data-offset-y="53" data-expected-width="121" data-expected-height="57">XXXX X XXXX</div>
+        <div style="grid-row: first / last; grid-column-start: 2" data-offset-x="40" data-offset-y="4" data-expected-width="25" data-expected-height="195">X XX X XX X</div>
+        <div style="grid-row: 1 / 3; grid-column: first / bar" data-offset-x="2" data-offset-y="4" data-expected-width="63" data-expected-height="106">XXX XX<br>XX<br>XXXXX</div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridWithDoublePercent width220 gridRowColumnGaps gridAutoRows20" data-expected-width="230" data-expected-height="62">
+        <div class="firstRowFirstColumn sizedToGridArea" data-offset-x="2" data-offset-y="4" data-expected-width="132" data-expected-height="20"></div>
+        <div class="secondRowSecondColumn sizedToGridArea" data-offset-x="157" data-offset-y="36" data-expected-width="88" data-expected-height="20"></div>
+        <div class="secondRowBothColumn sizedToGridArea" data-offset-x="2" data-offset-y="36" data-expected-width="243" data-expected-height="20"></div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridWithRowDoublePercent gridRowColumnGaps width220 height100" data-expected-width="230" data-expected-height="110">
+        <div class="firstRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="20" data-expected-height="60"></div>
+        <div class="secondRowFirstColumn" data-offset-x="2" data-offset-y="76" data-expected-width="20" data-expected-height="40"></div>
+        <div class="bothRowFirstColumn" data-offset-x="2" data-offset-y="4" data-expected-width="20" data-expected-height="112"></div>
+    </div>
+</div>
+
+<!-- Check that gutters do not interfere with margins computation. -->
+<div style="position: relative">
+    <div class="grid gridFixed100 gridGap">
+        <div class="gridItemMargins firstRowFirstColumn" data-offset-x="52" data-offset-y="24" data-expected-width="20" data-expected-height="40"></div>
+        <div class="gridItemMargins firstRowSecondColumn" data-offset-x="168" data-offset-y="24" data-expected-width="20" data-expected-height="40"></div>
+        <div class="gridItemMargins secondRowFirstColumn" data-offset-x="52" data-offset-y="140" data-expected-width="20" data-expected-height="40"></div>
+        <div class="gridItemMargins secondRowSecondColumn" data-offset-x="168" data-offset-y="140" data-expected-width="20" data-expected-height="40"></div>
+    </div>
+</div>
+
+<div style="position: relative">
+    <div class="grid gridFixed100 verticalRL directionRTL gridGap">
+        <div class="gridItemMargins firstRowFirstColumn" data-offset-x="168" data-offset-y="140" data-expected-width="20" data-expected-height="40"></div>
+        <div class="gridItemMargins firstRowSecondColumn" data-offset-x="168" data-offset-y="24" data-expected-width="20" data-expected-height="40"></div>
+        <div class="gridItemMargins secondRowFirstColumn" data-offset-x="52" data-offset-y="140" data-expected-width="20" data-expected-height="40"></div>
+        <div class="gridItemMargins secondRowSecondColumn" data-offset-x="52" data-offset-y="24" data-expected-width="20" data-expected-height="40"></div>
+    </div>
+</div>
+
+</body>


### PR DESCRIPTION
Previously, during grid track maximization we used the total number of grid tracks as the denominator when distributing the available free space. Using a larger denominator than expected meant that the algorithm needed a larger number of iterations than necessary to converge leading to rounding errors in the final track sizes.

Gains us +12 WPT subtests in `css/css-grid`.

Improves rendering of the "Newsroom" nav bar on https://www.apple.com/newsroom/2026/03/say-hello-to-macbook-neo/:

Before:
<img width="1184" height="281" alt="image" src="https://github.com/user-attachments/assets/36b5190a-5dac-444a-8ef8-fb2f4800d5be" />


After:
<img width="1184" height="281" alt="image" src="https://github.com/user-attachments/assets/c21b527e-817b-4f25-8cbb-1a09afdc2a89" />

