### PR TITLE
LibJS/Rust: Change manual matching to pattern matching

### DIFF
--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -991,26 +991,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn is_object_expression(expression: &Expression) -> bool {
-        matches!(&expression.inner, ExpressionKind::Object(_))
-    }
-
-    fn is_array_expression(expression: &Expression) -> bool {
-        matches!(&expression.inner, ExpressionKind::Array(_))
-    }
-
-    fn is_identifier(expression: &Expression) -> bool {
-        matches!(&expression.inner, ExpressionKind::Identifier(_))
-    }
-
-    fn is_member_expression(expression: &Expression) -> bool {
-        matches!(&expression.inner, ExpressionKind::Member(_))
-    }
-
-    fn is_update_expression(expression: &Expression) -> bool {
-        matches!(&expression.inner, ExpressionKind::Update(_))
-    }
-
     // === Main entry point ===
 
     pub fn parse_program(&mut self, starts_in_strict_mode: bool) -> Statement {

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -1482,13 +1482,19 @@ impl Parser<'_> {
                         Associativity::Right,
                         ForbiddenTokens::none().forbid(&[TokenType::Equals]),
                     );
-                    if Self::is_member_expression(&expression) {
-                        entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
-                    } else if Self::is_identifier(&expression) {
-                        entry_name = Some(BindingEntryName::Identifier(expression_into_identifier(expression)));
-                    } else {
-                        self.syntax_error("Invalid destructuring assignment target");
-                        break;
+
+                    match &expression.inner {
+                        ExpressionKind::Member { .. } => {
+                            entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
+                        }
+                        ExpressionKind::Identifier(_) => {
+                            entry_name = Some(BindingEntryName::Identifier(expression_into_identifier(expression)));
+                        }
+
+                        _ => {
+                            self.syntax_error("Invalid destructuring assignment target");
+                            break;
+                        }
                     }
                 } else {
                     let mut needs_alias = false;
@@ -1582,17 +1588,23 @@ impl Parser<'_> {
                                 Associativity::Right,
                                 ForbiddenTokens::none().forbid(&[TokenType::Equals]),
                             );
-                            if Self::is_object_expression(&expression) || Self::is_array_expression(&expression) {
-                                let pattern = self.synthesize_binding_pattern(expression_start);
-                                entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(pattern)));
-                            } else if Self::is_member_expression(&expression) {
-                                entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
-                            } else if Self::is_identifier(&expression) {
-                                entry_alias =
-                                    Some(BindingEntryAlias::Identifier(expression_into_identifier(expression)));
-                            } else {
-                                self.syntax_error("Invalid destructuring assignment target");
-                                break;
+
+                            match &expression.inner {
+                                ExpressionKind::Object(_) | ExpressionKind::Array(_) => {
+                                    let pattern = self.synthesize_binding_pattern(expression_start);
+                                    entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(pattern)));
+                                }
+                                ExpressionKind::Member { .. } => {
+                                    entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
+                                }
+                                ExpressionKind::Identifier(_) => {
+                                    entry_alias =
+                                        Some(BindingEntryAlias::Identifier(expression_into_identifier(expression)));
+                                }
+                                _ => {
+                                    self.syntax_error("Invalid destructuring assignment target");
+                                    break;
+                                }
                             }
                         } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                             let nested = self.parse_binding_pattern();
@@ -1628,19 +1640,25 @@ impl Parser<'_> {
                     Associativity::Right,
                     ForbiddenTokens::none().forbid(&[TokenType::Equals]),
                 );
-                if Self::is_object_expression(&expression) || Self::is_array_expression(&expression) {
-                    let pattern = self.synthesize_binding_pattern(expression_start);
-                    entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(pattern)));
-                } else if Self::is_member_expression(&expression) {
-                    entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
-                } else if Self::is_identifier(&expression) {
-                    let id = expression_into_identifier(expression);
-                    let name = self.arena.identifiers[id].name;
-                    self.pattern_bound_names.push((name, id));
-                    entry_alias = Some(BindingEntryAlias::Identifier(id));
-                } else {
-                    self.syntax_error("Invalid destructuring assignment target");
-                    break;
+
+                match &expression.inner {
+                    ExpressionKind::Object(_) | ExpressionKind::Array(_) => {
+                        let pattern = self.synthesize_binding_pattern(expression_start);
+                        entry_alias = Some(BindingEntryAlias::BindingPattern(Box::new(pattern)));
+                    }
+                    ExpressionKind::Member { .. } => {
+                        entry_alias = Some(BindingEntryAlias::MemberExpression(Box::new(expression)));
+                    }
+                    ExpressionKind::Identifier(_) => {
+                        let id = expression_into_identifier(expression);
+                        let name = self.arena.identifiers[id].name;
+                        self.pattern_bound_names.push((name, id));
+                        entry_alias = Some(BindingEntryAlias::Identifier(id));
+                    }
+                    _ => {
+                        self.syntax_error("Invalid destructuring assignment target");
+                        break;
+                    }
                 }
             } else if self.match_token(TokenType::CurlyOpen) || self.match_token(TokenType::BracketOpen) {
                 let nested = self.parse_binding_pattern();

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -163,7 +163,9 @@ impl Parser<'_> {
             // NB: UnaryExpression cannot be the base of `**`, only UpdateExpression can.
             // This prevents ambiguity like `-x ** y` (is it `(-x) ** y` or `-(x ** y)`?).
             // ++x ** y and --x ** y are valid (they're UpdateExpressions, not UnaryExpressions).
-            if self.match_token(TokenType::DoubleAsterisk) && !Self::is_update_expression(&expression) {
+            if self.match_token(TokenType::DoubleAsterisk)
+                && !matches!(&expression.inner, ExpressionKind::Update { .. })
+            {
                 self.syntax_error("Unparenthesized unary expression can't appear on the left-hand side of '**'");
             }
 
@@ -241,7 +243,7 @@ impl Parser<'_> {
             // Tagged template literals bind tighter than any operator, so we
             // consume them eagerly after each secondary expression — but NOT
             // after update expressions (x++`template` is not valid).
-            if !Self::is_update_expression(&expression) {
+            if !matches!(&expression.inner, ExpressionKind::Update { .. }) {
                 expression = self.parse_tagged_template_literals(lhs_start, expression);
             }
         }
@@ -818,7 +820,7 @@ impl Parser<'_> {
                 let op = token_to_assignment_op(tt);
                 if op == AssignmentOp::Assignment
                     && !lhs_is_parenthesized
-                    && (Self::is_object_expression(&lhs) || Self::is_array_expression(&lhs))
+                    && matches!(&lhs.inner, ExpressionKind::Object(_) | ExpressionKind::Array(_))
                 {
                     // Save pattern_bound_names so that an outer binding
                     // pattern parse in progress doesn't lose its entries.
@@ -1134,7 +1136,7 @@ impl Parser<'_> {
                 let rhs_start = self.position();
                 let expression = self.parse_expression(PRECEDENCE_UNARY, Associativity::Right, ForbiddenTokens::none());
                 self.report_invalid_private_identifier_usage(&expression);
-                if self.flags.strict_mode && Self::is_identifier(&expression) {
+                if self.flags.strict_mode && matches!(&expression.inner, ExpressionKind::Identifier(_)) {
                     self.syntax_error_at(
                         "Delete of an unqualified identifier in strict mode.",
                         rhs_start.line,

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -1008,7 +1008,7 @@ impl Parser<'_> {
         match init {
             LocalForInit::Declaration(declaration) => ForInOfLhs::Declaration(Box::new(declaration)),
             LocalForInit::Expression(expression) => {
-                if Self::is_array_expression(&expression) || Self::is_object_expression(&expression) {
+                if matches!(&expression.inner, ExpressionKind::Array(_) | ExpressionKind::Object(_)) {
                     let pattern = self.synthesize_binding_pattern(init_start);
 
                     let bound_names: Vec<_> = self.pattern_bound_names.drain(..).collect();


### PR DESCRIPTION
I found a weird pattern of implementing match manually and changed it to use pattern matching