### PR TITLE
LibWeb: Reinitialize TextNode chunk state after collapsing whitespace

### DIFF
--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -727,10 +727,11 @@ Optional<TextNode::Chunk> TextNode::ChunkIterator::next_without_peek()
 
             while (m_current_index < m_view.length_in_code_units() && is_collapsible(current_code_point()))
                 m_current_index = next_grapheme_boundary();
-            can_break_at_current_position = is_at_line_break_opportunity();
 
             if (result.has_value())
                 return result.release_value();
+
+            return next_without_peek();
         }
 
         if (m_should_wrap_lines) {

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/white-space/reference/white-space-vs-joiners-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/white-space/reference/white-space-vs-joiners-001-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+
+<title>CSS Text reference</title>
+<link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com">
+
+<style>
+p {
+  width: fit-content;
+  border: 2px solid green;
+  font: 24px monospace;
+}
+</style>
+
+<body>
+</body>
+
+<script>
+for (i = 0x200b; i <= 0x200f; ++i) {
+  txt = "This should have no leading or trailing ["
+    + i.toString(16)
+    + "]";
+  p = document.createElement("p");
+  p.textContent = txt;
+  document.body.appendChild(p);
+}
+</script>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/white-space/reference/white-space-vs-joiners-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-text/white-space/reference/white-space-vs-joiners-002-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+
+<title>CSS Text reference</title>
+<link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com">
+
+<style>
+p {
+  width: min-content;
+  border: 2px solid green;
+  font: 24px monospace;
+}
+</style>
+
+<body>
+  <p>
+    This
+    is
+    a
+    simple
+    test
+  </p>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/white-space/white-space-vs-joiners-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/white-space/white-space-vs-joiners-001.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+
+<title>CSS Text Test: join controls do not disrupt white-space processing</title>
+<link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules">
+<!-- NB: The spec doesn't explicitly discuss join controls in this context,
+     but it is self-evident that they should not have any effect on the white-space processing.
+     Their only effect should be on the shaping (if any) of the adjacent characters. -->
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/white-space/reference/white-space-vs-joiners-001-ref.html">
+<meta name="assert" content="The presence of join controls (ZWJ/ZWNJ) at word edges should not affect white-space processing">
+
+<style>
+p {
+  width: fit-content;
+  border: 2px solid green;
+  font: 24px monospace;
+}
+</style>
+
+<body>
+</body>
+
+<script>
+for (i = 0x200b; i <= 0x200f; ++i) {
+  txt = "  "
+    + String.fromCharCode(i)
+    + "This should have no leading or trailing ["
+    + i.toString(16)
+    + "]"
+    + String.fromCharCode(i)
+    + "  ";
+  p = document.createElement("p");
+  p.textContent = txt;
+  document.body.appendChild(p);
+}
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-text/white-space/white-space-vs-joiners-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-text/white-space/white-space-vs-joiners-002.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+
+<title>CSS Text Test: join controls do not disrupt white-space processing</title>
+<link rel="author" title="Jonathan Kew" href="mailto:jkew@mozilla.com">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-rules">
+<!-- NB: The spec doesn't explicitly discuss join controls in this context,
+     but it is self-evident that they should not have any effect on the white-space processing.
+     Their only effect should be on the shaping (if any) of the adjacent characters. -->
+<link rel="match" href="../../../../../expected/wpt-import/css/css-text/white-space/reference/white-space-vs-joiners-002-ref.html">
+<meta name="assert" content="The presence of join controls (ZWJ/ZWNJ) at word edges should not affect white-space processing">
+
+<style>
+p {
+  width: min-content;
+  border: 2px solid green;
+  font: 24px monospace;
+}
+</style>
+
+<body>
+  <p>
+    &#x200d;This&#x200d;
+    &#x200d;is&#x200d;
+    &#x200d;a&#x200d;
+    &#x200d;simple&#x200d;
+    &#x200d;test&#x200d;
+  </p>
+</body>


### PR DESCRIPTION
When collapsible whitespace is skipped without committing a prior chunk, the loop would fall through and continue with font information derived from the last whitespace code point rather than the next non-whitespace character. Restart the function via recursion so that these values are reinitialized from the correct code point.

Found while debugging something that turned out to be entirely unrelated.