### PR TITLE
LibWeb: Match nth-child pseudo-classes on elements without a parent

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -679,8 +679,6 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     case CSS::PseudoClass::NthOfType:
     case CSS::PseudoClass::NthLastOfType: {
         auto const* parent = element.parent();
-        if (!parent)
-            return false;
 
         if (context.collect_per_element_selector_involvement_metadata) {
             auto& mutable_element = const_cast<DOM::Element&>(element);
@@ -704,6 +702,9 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
             return list.contains([&](auto const& selector) { return matches(selector, element, shadow_host, context); });
         };
 
+        // https://drafts.csswg.org/selectors-4/#child-index
+        // The pseudo-classes defined in this section select elements based on their index amongst their inclusive siblings.
+        // NB: An element without a parent has no siblings, so its index is 1.
         int index = 1;
         switch (pseudo_class.type) {
         case CSS::PseudoClass::__Count:
@@ -711,6 +712,8 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         case CSS::PseudoClass::NthChild: {
             if (!matches_selector_list(pseudo_class.argument_selector_list, element))
                 return false;
+            if (!parent)
+                break;
             for (auto* child = parent->first_child_of_type<DOM::Element>(); child && child != &element; child = child->next_element_sibling()) {
                 if (matches_selector_list(pseudo_class.argument_selector_list, *child))
                     ++index;
@@ -720,6 +723,8 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         case CSS::PseudoClass::NthLastChild: {
             if (!matches_selector_list(pseudo_class.argument_selector_list, element))
                 return false;
+            if (!parent)
+                break;
             for (auto* child = parent->last_child_of_type<DOM::Element>(); child && child != &element; child = child->previous_element_sibling()) {
                 if (matches_selector_list(pseudo_class.argument_selector_list, *child))
                     ++index;

--- a/Tests/LibWeb/Text/expected/wpt-import/css/selectors/child-indexed-pseudo-class.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/selectors/child-indexed-pseudo-class.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 54 tests
 
-46 Pass
-8 Fail
+54 Pass
 Pass	Expected HTML element to match :first-child with matches, querySelector(), and querySelectorAll()
 Pass	Expected HTML element to match :last-child with matches, querySelector(), and querySelectorAll()
 Pass	Expected HTML element to match :only-child with matches, querySelector(), and querySelectorAll()
@@ -28,14 +27,14 @@ Pass	Expected DIV element to match :only-child with matches
 Pass	Expected DIV element to match :first-of-type with matches
 Pass	Expected DIV element to match :last-of-type with matches
 Pass	Expected DIV element to match :only-of-type with matches
-Fail	Expected DIV element to match :nth-child(1) with matches
-Fail	Expected DIV element to match :nth-child(n) with matches
-Fail	Expected DIV element to match :nth-last-child(1) with matches
-Fail	Expected DIV element to match :nth-last-child(n) with matches
-Fail	Expected DIV element to match :nth-of-type(1) with matches
-Fail	Expected DIV element to match :nth-of-type(n) with matches
-Fail	Expected DIV element to match :nth-last-of-type(1) with matches
-Fail	Expected DIV element to match :nth-last-of-type(n) with matches
+Pass	Expected DIV element to match :nth-child(1) with matches
+Pass	Expected DIV element to match :nth-child(n) with matches
+Pass	Expected DIV element to match :nth-last-child(1) with matches
+Pass	Expected DIV element to match :nth-last-child(n) with matches
+Pass	Expected DIV element to match :nth-of-type(1) with matches
+Pass	Expected DIV element to match :nth-of-type(n) with matches
+Pass	Expected DIV element to match :nth-last-of-type(1) with matches
+Pass	Expected DIV element to match :nth-last-of-type(n) with matches
 Pass	Expected DIV element to not match :nth-child(2) with matches
 Pass	Expected DIV element to not match :nth-last-child(2) with matches
 Pass	Expected DIV element to not match :nth-of-type(2) with matches


### PR DESCRIPTION
## Summary

The `:nth-child()`, `:nth-last-child()`, `:nth-of-type()`, and `:nth-last-of-type()` pseudo-classes were returning`false` when matched against elements that have no parent node (for example, a standalone element created via `document.createElement()`). Per the [Selectors Level 4 child-index definition](https://drafts.csswg.org/selectors-4/#child-index), an element with no siblings should be at index 1. The simpler child-indexed pseudo-classes (`:first-child`, `:last-child`, `:only-child`, etc.) already handle this case.

<img width="854" height="242" alt="Screenshot 2026-03-07 at 11 58 26" src="https://github.com/user-attachments/assets/d21264b8-37b3-4b24-9744-e88328f55be9" />

## Implementation Approach

The nth-* matching code in `SelectorEngine.cpp` had an early `return false` when `element.parent()` was null. Removing this check allows the index to remain at 1 (no siblings to count) and lets the `An+B` pattern check determine the result.

Since parent is no longer guaranteed to be non-null, the `NthChild` and `NthLastChild` cases now have a guard against that before we start iterating over the siblings. The `NthOfType` and `NthLastOfType` cases use sibling traversal functions that naturally return `nullptr` for parentless elements, so they needed no changes.

```cpp
// Before: early return prevented matching on parentless elements
auto const* parent = element.parent();
if (!parent)
    return false;

// After: guard only the loops that dereference parent
auto const* parent = element.parent();
// ...
if (!parent)
    break;
for (auto* child = parent->first_child_of_type<DOM::Element>(); ...) { ... }
```

## Testing

This fixes 8 subtests in the `css/selectors/child-indexed-pseudo-class.html` WPT test, bringing it from 46/54 to 54/54.

## Changes

- `Libraries/LibWeb/CSS/SelectorEngine.cpp`
- `Tests/LibWeb/Text/expected/wpt-import/css/selectors/child-indexed-pseudo-class.txt`
