### PR TITLE
LibJS: Treat concise methods as non-constructors 

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1186,7 +1186,7 @@ inline Value new_function(Interpreter& interpreter, u32 shared_function_data_ind
 
     if (home_object.has_value()) {
         auto home_object_value = interpreter.get(home_object.value());
-        function->set_home_object(&home_object_value.as_object());
+        function->make_method(home_object_value.as_object());
     }
 
     return function;

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -408,6 +408,7 @@ void ECMAScriptFunctionObject::make_method(Object& home_object)
 {
     // 1. Set F.[[HomeObject]] to homeObject.
     m_home_object = &home_object;
+    m_is_method = true;
 
     // 2. Return unused.
 }

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -106,7 +106,7 @@ public:
     bool has_simple_parameter_list() const { return shared_data().m_has_simple_parameter_list; }
 
     // Equivalent to absence of [[Construct]]
-    virtual bool has_constructor() const override { return kind() == FunctionKind::Normal && !shared_data().m_is_arrow_function; }
+    virtual bool has_constructor() const override { return kind() == FunctionKind::Normal && !shared_data().m_is_arrow_function && !m_is_method; }
 
     virtual Vector<LocalVariable> const& local_variables_names() const override { return shared_data().m_local_variables_names; }
 
@@ -161,6 +161,7 @@ private:
     mutable OwnPtr<ClassData> m_class_data;
 
     mutable bool m_may_need_lazy_prototype_instantiation { false };
+    bool m_is_method { false };
 };
 
 template<>

--- a/Tests/LibJS/Runtime/functions/method-functions-are-not-constructors.js
+++ b/Tests/LibJS/Runtime/functions/method-functions-are-not-constructors.js
@@ -1,0 +1,28 @@
+test("object literal concise methods are not constructors", () => {
+    const object_method = { m() {} }.m;
+    expect(() => {
+        new object_method();
+    }).toThrow(TypeError);
+});
+
+test("class methods are not constructors", () => {
+    class C {
+        m() {}
+        static s() {}
+    }
+
+    expect(() => {
+        new C.prototype.m();
+    }).toThrow(TypeError);
+    expect(() => {
+        new C.s();
+    }).toThrow(TypeError);
+});
+
+test("non-method functions remain constructible", () => {
+    const plain_function = function () {};
+    const property_function = { m: function () {} }.m;
+
+    expect(new plain_function()).toBeInstanceOf(plain_function);
+    expect(new property_function()).toBeInstanceOf(property_function);
+});

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/define.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/define.txt
@@ -1,0 +1,75 @@
+Harness status: OK
+
+Found 70 tests
+
+70 Pass
+Pass	"window.customElements.define" should exists
+Pass	If no arguments, should throw a TypeError
+Pass	If one argument, should throw a TypeError
+Pass	If constructor is undefined, should throw a TypeError
+Pass	If constructor is null, should throw a TypeError
+Pass	If constructor is object, should throw a TypeError
+Pass	If constructor is string, should throw a TypeError
+Pass	If constructor is arrow function, should throw a TypeError
+Pass	If constructor is method, should throw a TypeError
+Pass	Element names: defining an element named a- should succeed
+Pass	Element names: defining an element named a-a should succeed
+Pass	Element names: defining an element named aa- should succeed
+Pass	Element names: defining an element named aa-a should succeed
+Pass	Element names: defining an element named a-.-_ should succeed
+Pass	Element names: defining an element named a-0123456789 should succeed
+Pass	Element names: defining an element named a-漢字 should succeed
+Pass	Element names: defining an element named a-𠀋 should succeed
+Pass	Element names: defining an element named a-a× should succeed
+Pass	Element names: defining an element named a-a　 should succeed
+Pass	Element names: defining an element named a-a󰀀 should succeed
+Pass	Element names: defining an element named undefined should throw a SyntaxError
+Pass	Element names: defining an element named null should throw a SyntaxError
+Pass	Element names: defining an element named  should throw a SyntaxError
+Pass	Element names: defining an element named - should throw a SyntaxError
+Pass	Element names: defining an element named a should throw a SyntaxError
+Pass	Element names: defining an element named input should throw a SyntaxError
+Pass	Element names: defining an element named mycustomelement should throw a SyntaxError
+Pass	Element names: defining an element named A should throw a SyntaxError
+Pass	Element names: defining an element named A- should throw a SyntaxError
+Pass	Element names: defining an element named 0- should throw a SyntaxError
+Pass	Element names: defining an element named a-A should throw a SyntaxError
+Pass	Element names: defining an element named a-Z should throw a SyntaxError
+Pass	Element names: defining an element named A-a should throw a SyntaxError
+Pass	Element names: defining an element named annotation-xml should throw a SyntaxError
+Pass	Element names: defining an element named color-profile should throw a SyntaxError
+Pass	Element names: defining an element named font-face should throw a SyntaxError
+Pass	Element names: defining an element named font-face-src should throw a SyntaxError
+Pass	Element names: defining an element named font-face-uri should throw a SyntaxError
+Pass	Element names: defining an element named font-face-format should throw a SyntaxError
+Pass	Element names: defining an element named font-face-name should throw a SyntaxError
+Pass	Element names: defining an element named missing-glyph should throw a SyntaxError
+Pass	If the name is already defined, should throw a NotSupportedError
+Pass	If the constructor is already defined, should throw a NotSupportedError
+Pass	If constructor.prototype throws, should rethrow
+Pass	If Type(constructor.prototype) is undefined, should throw a TypeError
+Pass	If Type(constructor.prototype) is string, should throw a TypeError
+Pass	If constructor.prototype.connectedCallback throws, should rethrow
+Pass	If constructor.prototype.connectedCallback is undefined, should succeed
+Pass	If constructor.prototype.connectedCallback is function, should succeed
+Pass	If constructor.prototype.connectedCallback is null, should throw a TypeError
+Pass	If constructor.prototype.connectedCallback is object, should throw a TypeError
+Pass	If constructor.prototype.connectedCallback is integer, should throw a TypeError
+Pass	If constructor.prototype.disconnectedCallback throws, should rethrow
+Pass	If constructor.prototype.disconnectedCallback is undefined, should succeed
+Pass	If constructor.prototype.disconnectedCallback is function, should succeed
+Pass	If constructor.prototype.disconnectedCallback is null, should throw a TypeError
+Pass	If constructor.prototype.disconnectedCallback is object, should throw a TypeError
+Pass	If constructor.prototype.disconnectedCallback is integer, should throw a TypeError
+Pass	If constructor.prototype.adoptedCallback throws, should rethrow
+Pass	If constructor.prototype.adoptedCallback is undefined, should succeed
+Pass	If constructor.prototype.adoptedCallback is function, should succeed
+Pass	If constructor.prototype.adoptedCallback is null, should throw a TypeError
+Pass	If constructor.prototype.adoptedCallback is object, should throw a TypeError
+Pass	If constructor.prototype.adoptedCallback is integer, should throw a TypeError
+Pass	If constructor.prototype.attributeChangedCallback throws, should rethrow
+Pass	If constructor.prototype.attributeChangedCallback is undefined, should succeed
+Pass	If constructor.prototype.attributeChangedCallback is function, should succeed
+Pass	If constructor.prototype.attributeChangedCallback is null, should throw a TypeError
+Pass	If constructor.prototype.attributeChangedCallback is object, should throw a TypeError
+Pass	If constructor.prototype.attributeChangedCallback is integer, should throw a TypeError

--- a/Tests/LibWeb/Text/input/wpt-import/custom-elements/registries/define.html
+++ b/Tests/LibWeb/Text/input/wpt-import/custom-elements/registries/define.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<title>Custom Elements: Element definition</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<body>
+<div id="log"></div>
+<iframe id="iframe"></iframe>
+<script>
+'use strict';
+(() =>  {
+  // Element definition
+  // https://html.spec.whatwg.org/multipage/scripting.html#element-definition
+
+  // Use window from iframe to isolate the test.
+  const iframe = document.getElementById("iframe");
+  const testWindow = iframe.contentDocument.defaultView;
+  const customElements = testWindow.customElements;
+
+  let testable = false;
+  test(() =>  {
+    assert_true('customElements' in testWindow, '"window.customElements" exists');
+    assert_true('define' in customElements, '"window.customElements.define" exists');
+    testable = true;
+  }, '"window.customElements.define" should exists');
+  if (!testable)
+    return;
+
+  const expectTypeError = testWindow.TypeError;
+  // Following errors are DOMException, not JavaScript errors.
+  const expectSyntaxError = 'SYNTAX_ERR';
+  const expectNotSupportedError = 'NOT_SUPPORTED_ERR';
+
+  // 1. If IsConstructor(constructor) is false,
+  // then throw a TypeError and abort these steps.
+  test(() =>  {
+    assert_throws_js(expectTypeError, () =>  {
+      customElements.define();
+    });
+  }, 'If no arguments, should throw a TypeError');
+  test(() =>  {
+    assert_throws_js(expectTypeError, () =>  {
+      customElements.define('test-define-one-arg');
+    });
+  }, 'If one argument, should throw a TypeError');
+  [
+    [ 'undefined', undefined ],
+    [ 'null', null ],
+    [ 'object', {} ],
+    [ 'string', 'string' ],
+    [ 'arrow function', () => {} ], // IsConstructor returns false for arrow functions
+    [ 'method', ({ m() { } }).m ], // IsConstructor returns false for methods
+  ].forEach(t =>  {
+    test(() =>  {
+      assert_throws_js(expectTypeError, () =>  {
+        customElements.define(`test-define-constructor-${t[0]}`, t[1]);
+      });
+    }, `If constructor is ${t[0]}, should throw a TypeError`);
+  });
+
+  // 2. If name is not a valid custom element name,
+  // then throw a SyntaxError and abort these steps.
+  let validCustomElementNames = [
+    // [a-z] (PCENChar)* '-' (PCENChar)*
+    // https://html.spec.whatwg.org/multipage/scripting.html#valid-custom-element-name
+    'a-',
+    'a-a',
+    'aa-',
+    'aa-a',
+    'a-.-_',
+    'a-0123456789',
+    'a-\u6F22\u5B57', // Two CJK Unified Ideographs
+    'a-\uD840\uDC0B', // Surrogate pair U+2000B
+    'a-a\u00D7',
+    'a-a\u3000',
+    'a-a\uDB80\uDC00', // Surrogate pair U+F0000
+  ];
+  let invalidCustomElementNames = [
+    undefined,
+    null,
+    '',
+    '-',
+    'a',
+    'input',
+    'mycustomelement',
+    'A',
+    'A-',
+    '0-',
+    'a-A',
+    'a-Z',
+    'A-a',
+    // name must not be any of the hyphen-containing element names.
+    'annotation-xml',
+    'color-profile',
+    'font-face',
+    'font-face-src',
+    'font-face-uri',
+    'font-face-format',
+    'font-face-name',
+    'missing-glyph',
+  ];
+  validCustomElementNames.forEach(name =>  {
+    test(() =>  {
+      customElements.define(name, class {});
+    }, `Element names: defining an element named ${name} should succeed`);
+  });
+  invalidCustomElementNames.forEach(name =>  {
+    test(() =>  {
+      assert_throws_dom(expectSyntaxError, testWindow.DOMException, () =>  {
+        customElements.define(name, class {});
+      });
+    }, `Element names: defining an element named ${name} should throw a SyntaxError`);
+  });
+
+  // 3. If this CustomElementRegistry contains an entry with name name,
+  // then throw a NotSupportedError and abort these steps.
+  test(() =>  {
+    customElements.define('test-define-dup-name', class {});
+    assert_throws_dom(expectNotSupportedError, testWindow.DOMException, () =>  {
+      customElements.define('test-define-dup-name', class {});
+    });
+  }, 'If the name is already defined, should throw a NotSupportedError');
+
+  // 5. If this CustomElementRegistry contains an entry with constructor constructor,
+  // then throw a NotSupportedError and abort these steps.
+  test(() =>  {
+    class TestDupConstructor {};
+    customElements.define('test-define-dup-constructor', TestDupConstructor);
+    assert_throws_dom(expectNotSupportedError, testWindow.DOMException, () =>  {
+      customElements.define('test-define-dup-ctor2', TestDupConstructor);
+    });
+  }, 'If the constructor is already defined, should throw a NotSupportedError');
+
+  // 12.1. Let prototype be Get(constructor, "prototype"). Rethrow any exceptions.
+  const err = new Error('check this is rethrown');
+  err.name = 'rethrown';
+  function assert_rethrown(func, description) {
+    assert_throws_exactly(err, func, description);
+  }
+  function throw_rethrown_error() {
+    throw err;
+  }
+  test(() =>  {
+    // Hack for prototype to throw while IsConstructor is true.
+    const BadConstructor = (function () { }).bind({});
+    Object.defineProperty(BadConstructor, 'prototype', {
+      get() { throw_rethrown_error(); }
+    });
+    assert_rethrown(() =>  {
+      customElements.define('test-define-constructor-prototype-rethrow', BadConstructor);
+    });
+  }, 'If constructor.prototype throws, should rethrow');
+
+  // 12.2. If Type(prototype) is not Object,
+  // then throw a TypeError exception.
+  test(() =>  {
+    const c = (function () { }).bind({}); // prototype is undefined.
+    assert_throws_js(expectTypeError, () =>  {
+      customElements.define('test-define-constructor-prototype-undefined', c);
+    });
+  }, 'If Type(constructor.prototype) is undefined, should throw a TypeError');
+  test(() =>  {
+    function c() {};
+    c.prototype = 'string';
+    assert_throws_js(expectTypeError, () =>  {
+      customElements.define('test-define-constructor-prototype-string', c);
+    });
+  }, 'If Type(constructor.prototype) is string, should throw a TypeError');
+
+  // 12.3. Let lifecycleCallbacks be a map with the four keys "connectedCallback",
+  // "disconnectedCallback", "adoptedCallback", and "attributeChangedCallback",
+  // each of which belongs to an entry whose value is null.
+  // 12.4. For each of the four keys callbackName in lifecycleCallbacks:
+  // 12.4.1. Let callbackValue be Get(prototype, callbackName). Rethrow any exceptions.
+  // 12.4.2. If callbackValue is not undefined, then set the value of the entry in
+  // lifecycleCallbacks with key callbackName to the result of converting callbackValue
+  // to the Web IDL Function callback type. Rethrow any exceptions from the conversion.
+  [
+    'connectedCallback',
+    'disconnectedCallback',
+    'adoptedCallback',
+    'attributeChangedCallback',
+  ].forEach(name => {
+    test(() => {
+      class C {
+        get [name]() { throw_rethrown_error(); }
+      }
+      assert_rethrown(() => {
+        customElements.define(`test-define-${name.toLowerCase()}-rethrow`, C);
+      });
+    }, `If constructor.prototype.${name} throws, should rethrow`);
+
+    [
+      { name: 'undefined', value: undefined, success: true },
+      { name: 'function', value: function () { }, success: true },
+      { name: 'null', value: null, success: false },
+      { name: 'object', value: {}, success: false },
+      { name: 'integer', value: 1, success: false },
+    ].forEach(data => {
+      test(() => {
+        class C { };
+        C.prototype[name] = data.value;
+        if (data.success) {
+          customElements.define(`test-define-${name.toLowerCase()}-${data.name}`, C);
+        } else {
+          assert_throws_js(expectTypeError, () => {
+            customElements.define(`test-define-${name.toLowerCase()}-${data.name}`, C);
+          });
+        }
+      }, `If constructor.prototype.${name} is ${data.name}, should ${data.success ? 'succeed' : 'throw a TypeError'}`);
+    });
+  });
+})();
+</script>
+</body>


### PR DESCRIPTION
Fixes customElements.define WPT. 

Concise methods were incorrectly treated as constructors, so customElements.define() accepted method-valued constructors instead of throwing a TypeError.

This fixes the last failing case here: https://wpt.fyi/results/custom-elements/registries/define.html?label=master&product=ladybird