### PR TITLE
LibWeb: Invalidate paint cache for all layout node paintables on repaint

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2703,8 +2703,10 @@ void Node::clear_paintable()
 
 void Node::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)
 {
-    if (auto* p = unsafe_paintable())
-        p->set_needs_repaint(should_invalidate_display_list);
+    if (auto* layout_node = unsafe_layout_node()) {
+        for (auto& paintable : layout_node->paintables())
+            paintable.set_needs_repaint(should_invalidate_display_list);
+    }
 }
 
 void Node::set_needs_layout_update(SetNeedsLayoutReason reason)

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
@@ -1,0 +1,32 @@
+Before:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  DrawGlyphRun@1 rect=[8,8 70x18] translation=[8,21.796875] color=rgb(0, 0, 255)
+  DrawLine@1 from=[8,24] to=[78,24] color=rgb(0, 0, 255) thickness=2
+  DrawGlyphRun@1 rect=[8,26 48x18] translation=[8,39.796875] color=rgb(0, 0, 255)
+  DrawLine@1 from=[8,42] to=[55,42] color=rgb(0, 0, 255) thickness=2
+  DrawGlyphRun@1 rect=[8,44 60x18] translation=[8,57.796875] color=rgb(0, 0, 255)
+  DrawLine@1 from=[8,60] to=[68,60] color=rgb(0, 0, 255) thickness=2
+  DrawGlyphRun@1 rect=[8,62 37x18] translation=[8,75.796875] color=rgb(0, 0, 255)
+  DrawLine@1 from=[8,78] to=[44,78] color=rgb(0, 0, 255) thickness=2
+Restore@0
+
+After:
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+
+DisplayList:
+SaveLayer@0
+  DrawGlyphRun@1 rect=[8,8 70x18] translation=[8,21.796875] color=rgb(255, 0, 0)
+  DrawLine@1 from=[8,24] to=[78,24] color=rgb(255, 0, 0) thickness=2
+  DrawGlyphRun@1 rect=[8,26 48x18] translation=[8,39.796875] color=rgb(255, 0, 0)
+  DrawLine@1 from=[8,42] to=[55,42] color=rgb(255, 0, 0) thickness=2
+  DrawGlyphRun@1 rect=[8,44 60x18] translation=[8,57.796875] color=rgb(255, 0, 0)
+  DrawLine@1 from=[8,60] to=[68,60] color=rgb(255, 0, 0) thickness=2
+  DrawGlyphRun@1 rect=[8,62 37x18] translation=[8,75.796875] color=rgb(255, 0, 0)
+  DrawLine@1 from=[8,78] to=[44,78] color=rgb(255, 0, 0) thickness=2
+Restore@0
+

--- a/Tests/LibWeb/Text/input/display_list/multiline-inline-paint-invalidation.html
+++ b/Tests/LibWeb/Text/input/display_list/multiline-inline-paint-invalidation.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    div {
+        width: 100px;
+        font-size: 16px;
+    }
+    a {
+        color: blue;
+    }
+</style>
+<div>
+    <a id="link" href="#">This link spans multiple lines</a>
+</div>
+<script>
+    test(() => {
+        const displayListBefore = internals.dumpDisplayList();
+        document.getElementById("link").style.color = "red";
+        const displayListAfter = internals.dumpDisplayList();
+
+        println("Before:");
+        println(displayListBefore);
+        println("After:");
+        println(displayListAfter);
+    });
+</script>


### PR DESCRIPTION
Previously, when clicking a href that spanned over multiple lines only part of the link was being repainted.

This was seen on multiple websites where hovering over links changed the link style in some way.