### PR TITLE
LibCore+LibWeb+UI+Services: Send notifications on linux

### DIFF
--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -83,6 +83,12 @@ else()
     list(APPEND SOURCES TimeZoneWatcherUnimplemented.cpp)
 endif()
 
+if(LINUX OR BSD)
+    list(APPEND SOURCES NotificationUnix.cpp)
+else()
+    list(APPEND SOURCES NotificationUnimplemented.cpp)
+endif()
+
 if (APPLE OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
     list(APPEND SOURCES MachPort.cpp)
 endif()
@@ -123,4 +129,10 @@ endif()
 
 if (ANDROID)
     target_link_libraries(LibCore PRIVATE log)
+endif()
+
+if (LINUX OR BSD)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(dbus REQUIRED IMPORTED_TARGET dbus-1)
+    target_link_libraries(LibCore PRIVATE PkgConfig::dbus)
 endif()

--- a/Libraries/LibCore/Notification.h
+++ b/Libraries/LibCore/Notification.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Niccolo Antonelli-Dziri <niccolo.antonelli-dziri@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/String.h>
+#include <LibCore/Export.h>
+
+namespace Core {
+
+class CORE_API PlatformNotification {
+    AK_MAKE_NONCOPYABLE(PlatformNotification);
+
+public:
+    static ErrorOr<NonnullOwnPtr<PlatformNotification>> create();
+
+    virtual ~PlatformNotification() = default;
+
+    virtual ErrorOr<void> show_notification(String const& title) = 0;
+
+protected:
+    PlatformNotification() = default;
+};
+
+}

--- a/Libraries/LibCore/NotificationUnimplemented.cpp
+++ b/Libraries/LibCore/NotificationUnimplemented.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025, Niccolo Antonelli-Dziri <niccolo.antonelli-dziri@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <LibCore/Notification.h>
+
+namespace Core {
+
+ErrorOr<NonnullOwnPtr<PlatformNotification>> PlatformNotification::create()
+{
+    return Error::from_errno(ENOTSUP);
+}
+
+}

--- a/Libraries/LibCore/NotificationUnix.cpp
+++ b/Libraries/LibCore/NotificationUnix.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025, Niccolo Antonelli-Dziri <niccolo.antonelli-dziri@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/Format.h>
+#include <AK/String.h>
+#include <LibCore/Notification.h>
+#include <LibCore/System.h>
+#include <dbus/dbus.h>
+
+namespace Core {
+
+class PlatformNotificationImpl final : public PlatformNotification {
+public:
+    static ErrorOr<NonnullOwnPtr<PlatformNotificationImpl>> create()
+    {
+        DBusError error;
+        dbus_error_init(&error);
+
+        DBusConnection* connection = dbus_bus_get(DBUS_BUS_SESSION, &error);
+
+        if (dbus_error_is_set(&error)) {
+            dbus_error_free(&error);
+            return Error::from_string_literal("Failed to connect to DBus session bus");
+        }
+
+        return adopt_own(*new PlatformNotificationImpl(connection));
+    }
+
+    ErrorOr<void> show_notification(String const& title) override
+    {
+        // Create notification message
+        DBusMessage* message = dbus_message_new_method_call(
+            m_destination,
+            m_path,
+            m_interface,
+            "Notify" // method
+        );
+
+        if (!message) {
+            return Error::from_string_literal("Failed to create D-Bus notification message");
+        }
+        // Add arguments
+        char const* app_name = "Ladybird";
+        dbus_uint32_t replaces_id = 0;
+        char const* icon = "";
+        auto title_bytes = title.to_byte_string();
+        char const* summary = title_bytes.characters();
+        char const* body_text = "";
+        dbus_int32_t timeout = 5000;
+
+        DBusMessageIter args;
+        dbus_message_iter_init_append(message, &args);
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &app_name);
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_UINT32, &replaces_id);
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &icon);
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &summary);
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &body_text);
+
+        // Empty actions array
+        DBusMessageIter actions;
+        dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "s", &actions);
+        dbus_message_iter_close_container(&args, &actions);
+
+        // Empty hints dict
+        DBusMessageIter hints;
+        dbus_message_iter_open_container(&args, DBUS_TYPE_ARRAY, "{sv}", &hints);
+        dbus_message_iter_close_container(&args, &hints);
+
+        dbus_message_iter_append_basic(&args, DBUS_TYPE_INT32, &timeout);
+
+        // Send message
+        dbus_connection_send(m_connection, message, nullptr);
+        dbus_connection_flush(m_connection);
+
+        // Cleanup
+        dbus_message_unref(message);
+        return {};
+    }
+
+private:
+    explicit PlatformNotificationImpl(DBusConnection* connection)
+        : m_connection(connection)
+        , m_destination("org.freedesktop.Notifications")
+        , m_path("/org/freedesktop/Notifications")
+        , m_interface("org.freedesktop.Notifications")
+    {
+    }
+
+    DBusConnection* m_connection { nullptr };
+
+    char const* m_destination;
+    char const* m_path;
+    char const* m_interface;
+};
+
+ErrorOr<NonnullOwnPtr<PlatformNotification>> PlatformNotification::create()
+{
+    return PlatformNotificationImpl::create();
+}
+
+}

--- a/Libraries/LibWeb/NotificationsAPI/Notification.cpp
+++ b/Libraries/LibWeb/NotificationsAPI/Notification.cpp
@@ -10,7 +10,9 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/Notification.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/NotificationsAPI/Notification.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/ServiceWorker/ServiceWorkerGlobalScope.h>
 
 namespace Web::NotificationsAPI {
@@ -188,7 +190,10 @@ WebIDL::ExceptionOr<GC::Ref<Notification>> Notification::construct_impl(
     // FIXME: 1. If the result of getting the notifications permission state is not "granted",
     // then queue a task to fire an event named error on this, and abort these steps.
 
-    // FIXME: 2. Run the notification show steps for notification.
+    // 2. Run the notification show steps for notification.
+    if (auto* window = as_if<HTML::Window>(relevant_global_object)) {
+        window->page().client().show_notification(notification.title);
+    }
 
     return this_notification;
 }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -547,6 +547,8 @@ public:
     virtual Compositor::CompositorHost* compositor_host() { return nullptr; }
     virtual Compositor::CompositorHost const* compositor_host() const { return nullptr; }
 
+    virtual void show_notification(String const&) { }
+
 protected:
     virtual ~PageClient() = default;
 };

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -280,6 +280,7 @@ public:
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;
     Function<void()> on_web_content_crashed;
     Function<void()> on_web_content_process_change_for_cross_site_navigation;
+    Function<void(String)> on_request_show_notification;
 
     Menu& page_context_menu() { return *m_page_context_menu; }
     Menu& link_context_menu() { return *m_link_context_menu; }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1232,4 +1232,12 @@ Optional<ViewImplementation&> WebContentClient::view_for_page_id(u64 page_id, So
     return {};
 }
 
+void WebContentClient::did_request_show_notification(u64 page_id, String title)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_request_show_notification)
+            view->on_request_show_notification(move(title));
+    }
+}
+
 }

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -187,6 +187,7 @@ private:
     virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
     virtual void did_request_primary_paste(u64 page_id) override;
     virtual void did_update_primary_selection(u64 page_id, String) override;
+    virtual void did_request_show_notification(u64 page_id, String title) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
     virtual Messages::WebContentClient::StartWorkerAgentResponse start_worker_agent(u64 page_id, Web::HTML::WorkerAgentStartRequest request) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1115,4 +1115,9 @@ void PageClient::queue_screenshot_task(Optional<Web::UniqueNodeID> node_id)
     page().top_level_traversable()->queue_screenshot_task(node_id);
 }
 
+void PageClient::show_notification(String const& title)
+{
+    client().async_did_request_show_notification(m_id, title);
+}
+
 }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -216,6 +216,7 @@ private:
     virtual void page_did_receive_network_response_body(u64 request_id, ReadonlyBytes) override;
     virtual void page_did_finish_network_request(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&) override;
     virtual void page_did_post_broadcast_channel_message(Web::HTML::BroadcastChannelMessage const&) override;
+    virtual void show_notification(String const& title) override;
 
     void setup_palette();
     ConnectionFromClient& client() const;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -149,4 +149,6 @@ endpoint WebContentClient
 
     start_worker_agent(u64 page_id, Web::HTML::WorkerAgentStartRequest request) => (Web::HTML::WorkerAgentId agent_id)
     close_worker_agent(u64 page_id, Web::HTML::WorkerAgentId agent_id, Web::HTML::WorkerAgentOwnerToken owner_token) =|
+
+    did_request_show_notification(u64 page_id, String title) =|
 }

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibCore/EventLoop.h>
+#include <LibCore/Notification.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
@@ -310,6 +311,19 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     view().on_request_dismiss_dialog = [this]() {
         if (m_dialog)
             m_dialog->reject();
+    };
+
+    view().on_request_show_notification = [](String const& title) {
+        auto notification = Core::PlatformNotification::create();
+        if (notification.is_error()) {
+            warnln("Notification error: {}", notification.error());
+            return;
+        }
+        auto result = notification.value()->show_notification(title);
+        if (result.is_error()) {
+            warnln("Notification error: {}", notification.error());
+            return;
+        }
     };
 
     view().on_request_color_picker = [this](Color current_color) {


### PR DESCRIPTION
Add a PlatformNotification abstraction and a Linux implementation that sends desktop notifications over the session D‑Bus (org.freedesktop.Notifications).

Uses IPC calls and the Dbus logic to send only the title.

The structure of the `PlatformNotificationImpl` and `PlatformNotification` classes are inspired by the `TimeZoneWatcher ` classes, for the cross-platform implementation.

Some explanations for the choices that I made:
- Using dbus/dbus.h instead of a dbus library does not add a new dependency since dbus/dbus.h was already used in the project.
- The platform-implementation of notifications resides in its entirety inside of LibCore to centralize the different platforms.
- LibCore instead of directly in the UI folders because Qt is used for both Linux and Windows and they handle notifications differently. Having it in centralized way simplifies the cross-platform logic.

Everything is up for debate of course and everything can change.