### PR TITLE
LibWeb: Take namespace into account when matching `*-of-type` selectors

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -427,19 +427,19 @@ static inline bool matches_attribute(CSS::Selector::SimpleSelector::Attribute co
     return found_matching_attribute;
 }
 
-static inline DOM::Element const* previous_sibling_with_same_tag_name(DOM::Element const& element)
+static inline DOM::Element const* previous_sibling_with_same_type(DOM::Element const& element)
 {
     for (auto const* sibling = element.previous_element_sibling(); sibling; sibling = sibling->previous_element_sibling()) {
-        if (sibling->tag_name() == element.tag_name())
+        if (sibling->local_name() == element.local_name() && sibling->namespace_uri() == element.namespace_uri())
             return sibling;
     }
     return nullptr;
 }
 
-static inline DOM::Element const* next_sibling_with_same_tag_name(DOM::Element const& element)
+static inline DOM::Element const* next_sibling_with_same_type(DOM::Element const& element)
 {
     for (auto const* sibling = element.next_element_sibling(); sibling; sibling = sibling->next_element_sibling()) {
-        if (sibling->tag_name() == element.tag_name())
+        if (sibling->local_name() == element.local_name() && sibling->namespace_uri() == element.namespace_uri())
             return sibling;
     }
     return nullptr;
@@ -604,18 +604,18 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         if (context.collect_per_element_selector_involvement_metadata) {
             const_cast<DOM::Element&>(element).set_affected_by_forward_positional_pseudo_class(true);
         }
-        return !previous_sibling_with_same_tag_name(element);
+        return !previous_sibling_with_same_type(element);
     case CSS::PseudoClass::LastOfType:
         if (context.collect_per_element_selector_involvement_metadata) {
             const_cast<DOM::Element&>(element).set_affected_by_backward_positional_pseudo_class(true);
         }
-        return !next_sibling_with_same_tag_name(element);
+        return !next_sibling_with_same_type(element);
     case CSS::PseudoClass::OnlyOfType:
         if (context.collect_per_element_selector_involvement_metadata) {
             const_cast<DOM::Element&>(element).set_affected_by_forward_positional_pseudo_class(true);
             const_cast<DOM::Element&>(element).set_affected_by_backward_positional_pseudo_class(true);
         }
-        return !previous_sibling_with_same_tag_name(element) && !next_sibling_with_same_tag_name(element);
+        return !previous_sibling_with_same_type(element) && !next_sibling_with_same_type(element);
     case CSS::PseudoClass::Lang:
         return matches_lang_pseudo_class(element, pseudo_class.languages);
     case CSS::PseudoClass::Disabled:
@@ -727,12 +727,12 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
             break;
         }
         case CSS::PseudoClass::NthOfType: {
-            for (auto* child = previous_sibling_with_same_tag_name(element); child; child = previous_sibling_with_same_tag_name(*child))
+            for (auto* child = previous_sibling_with_same_type(element); child; child = previous_sibling_with_same_type(*child))
                 ++index;
             break;
         }
         case CSS::PseudoClass::NthLastOfType: {
-            for (auto* child = next_sibling_with_same_tag_name(element); child; child = next_sibling_with_same_tag_name(*child))
+            for (auto* child = next_sibling_with_same_type(element); child; child = next_sibling_with_same_type(*child))
                 ++index;
             break;
         }

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/selectors/of-type-selectors-ref.xhtml
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/selectors/of-type-selectors-ref.xhtml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Selectors Level 4: :first-of-type</title>
+<link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com"/>
+<style type="text/css">
+div > *|* {
+  display: block;
+  color: black;
+  border: thin solid;
+  margin: 1em;
+}
+.yellow {
+  background: yellow;
+}
+.green {
+  background: lime;
+}
+</style>
+</head>
+<body>
+<div>
+<p class="green">This line should have a green background.</p>
+<p class="yellow">This line should have a yellow background.</p>
+<p class="yellow">This line should have a yellow background.</p>
+<p class="green">This line should have a green background.</p>
+<p class="green">This line should have a green background.</p>
+</div>
+<div>
+<p class="green">This line should have a green background.</p>
+<p class="yellow">This line should have a yellow background.</p>
+<p class="yellow">This line should have a yellow background.</p>
+<p class="green">This line should have a green background.</p>
+<p class="green">This line should have a green background.</p>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/selectors/of-type-selectors.xhtml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/selectors/of-type-selectors.xhtml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:html="http://www.w3.org/1999/xhtml">
+<head>
+<title>Selectors Level 4: :first-of-type</title>
+<meta name="flags" content="namespace nonHTML"/>
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact"/>
+<link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com"/>
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#the-first-of-type-pseudo"/>
+<link rel="match" href="../../../../expected/wpt-import/css/selectors/of-type-selectors-ref.xhtml"/>
+<style type="text/css">
+div > *|* {
+  display: block;
+  color: black;
+  background: yellow;
+  border: thin solid;
+  margin: 1em;
+}
+.first-of-type > *|*:first-of-type {
+  background: lime;
+}
+.nth-of-type > *|*:nth-of-type(1) {
+  background: lime;
+}
+</style>
+</head>
+<body>
+<div class="first-of-type">
+<p>This line should have a green background.</p>
+<p>This line should have a yellow background.</p>
+<html:p>This line should have a yellow background.</html:p>
+<p xmlns="http://www.example.com/ns">This line should have a green background.</p>
+<p xmlns="">This line should have a green background.</p>
+</div>
+<div class="nth-of-type">
+<p>This line should have a green background.</p>
+<p>This line should have a yellow background.</p>
+<html:p>This line should have a yellow background.</html:p>
+<p xmlns="http://www.example.com/ns">This line should have a green background.</p>
+<p xmlns="">This line should have a green background.</p>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/selectors/nth-of-type-namespace.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/selectors/nth-of-type-namespace.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	:nth-of-type selectors matching takes element namespace into account (http://www.w3.org/1999/xhtml)
 Pass	:nth-of-type selectors matching takes element namespace into account (http://dummy1/)
-Fail	:nth-of-type selectors matching takes element namespace into account (http://dummy2/)
+Pass	:nth-of-type selectors matching takes element namespace into account (http://dummy2/)


### PR DESCRIPTION
Found while debugging something unrelated.