### PR TITLE
LibWeb: Fire error event at Worker when script loading fails

### DIFF
--- a/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Libraries/LibWeb/HTML/Worker.cpp
@@ -111,8 +111,10 @@ void run_a_worker(Variant<GC::Ref<Worker>, GC::Ref<SharedWorker>> worker, URL::U
     // 4. Let agent be the result of obtaining a dedicated/shared worker agent given outside settings and is shared.
     //    Run the rest of these steps in that agent.
 
+    auto event_target = worker.visit([](auto& worker) -> GC::Ref<DOM::EventTarget> { return worker; });
+
     // Note: This spawns a new process to act as the 'agent' for the worker.
-    auto agent = outside_settings.realm().create<WorkerAgentParent>(url, options, port, outside_settings, agent_type);
+    auto agent = outside_settings.realm().create<WorkerAgentParent>(url, options, port, outside_settings, event_target, agent_type);
     worker.visit([&](auto worker) { worker->set_agent(agent); });
 }
 

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -6,8 +6,14 @@
 
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Event.h>
+#include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessagePort.h>
+#include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/Worker.h>
 #include <LibWeb/HTML/WorkerAgentParent.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
@@ -16,12 +22,13 @@ namespace Web::HTML {
 
 GC_DEFINE_ALLOCATOR(WorkerAgentParent);
 
-WorkerAgentParent::WorkerAgentParent(URL::URL url, WorkerOptions const& options, GC::Ptr<MessagePort> outside_port, GC::Ref<EnvironmentSettingsObject> outside_settings, Bindings::AgentType agent_type)
+WorkerAgentParent::WorkerAgentParent(URL::URL url, WorkerOptions const& options, GC::Ptr<MessagePort> outside_port, GC::Ref<EnvironmentSettingsObject> outside_settings, GC::Ref<DOM::EventTarget> worker_event_target, Bindings::AgentType agent_type)
     : m_worker_options(options)
     , m_agent_type(agent_type)
     , m_url(move(url))
     , m_outside_port(outside_port)
     , m_outside_settings(outside_settings)
+    , m_worker_event_target(worker_event_target)
 {
 }
 
@@ -69,6 +76,17 @@ void WorkerAgentParent::setup_worker_ipc_callbacks(JS::Realm& realm)
         auto& client = Bindings::principal_host_defined_page(realm).client();
         return client.request_worker_agent(worker_type);
     };
+    m_worker_ipc->on_worker_script_load_failure = [self = GC::Weak { *this }]() {
+        if (!self)
+            return;
+        auto& outside_settings = *self->m_outside_settings;
+        auto& event_target = *self->m_worker_event_target;
+        // See: https://html.spec.whatwg.org/multipage/workers.html#worker-processing-model, onComplete handler for fetching script.
+        // 1. Queue a global task on the DOM manipulation task source given worker's relevant global object to fire an event named error at worker.
+        queue_global_task(Task::Source::DOMManipulation, outside_settings.global_object(), GC::create_function(outside_settings.heap(), [&event_target, &outside_settings]() {
+            event_target.dispatch_event(DOM::Event::create(outside_settings.realm(), EventNames::error));
+        }));
+    };
 }
 
 void WorkerAgentParent::visit_edges(Cell::Visitor& visitor)
@@ -77,6 +95,7 @@ void WorkerAgentParent::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_message_port);
     visitor.visit(m_outside_port);
     visitor.visit(m_outside_settings);
+    visitor.visit(m_worker_event_target);
 }
 
 }

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.h
@@ -26,7 +26,7 @@ class WorkerAgentParent : public JS::Cell {
     GC_DECLARE_ALLOCATOR(WorkerAgentParent);
 
 protected:
-    WorkerAgentParent(URL::URL url, WorkerOptions const& options, GC::Ptr<MessagePort> outside_port, GC::Ref<EnvironmentSettingsObject> outside_settings, Bindings::AgentType);
+    WorkerAgentParent(URL::URL url, WorkerOptions const& options, GC::Ptr<MessagePort> outside_port, GC::Ref<EnvironmentSettingsObject> outside_settings, GC::Ref<DOM::EventTarget> worker_event_target, Bindings::AgentType);
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -40,6 +40,7 @@ private:
     GC::Ptr<MessagePort> m_message_port;
     GC::Ptr<MessagePort> m_outside_port;
     GC::Ref<EnvironmentSettingsObject> m_outside_settings;
+    GC::Ref<DOM::EventTarget> m_worker_event_target;
 
     RefPtr<Web::HTML::WebWorkerClient> m_worker_ipc;
 };

--- a/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -20,6 +20,12 @@ void WebWorkerClient::did_close_worker()
         on_worker_close();
 }
 
+void WebWorkerClient::did_fail_loading_worker_script()
+{
+    if (on_worker_script_load_failure)
+        on_worker_script_load_failure();
+}
+
 Messages::WebWorkerClient::DidRequestCookieResponse WebWorkerClient::did_request_cookie(URL::URL url, HTTP::Cookie::Source source)
 {
     if (on_request_cookie)

--- a/Libraries/LibWeb/Worker/WebWorkerClient.h
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.h
@@ -23,10 +23,12 @@ public:
     explicit WebWorkerClient(NonnullOwnPtr<IPC::Transport>);
 
     virtual void did_close_worker() override;
+    virtual void did_fail_loading_worker_script() override;
     virtual Messages::WebWorkerClient::DidRequestCookieResponse did_request_cookie(URL::URL, HTTP::Cookie::Source) override;
     virtual Messages::WebWorkerClient::RequestWorkerAgentResponse request_worker_agent(Web::Bindings::AgentType worker_type) override;
 
     Function<void()> on_worker_close;
+    Function<void()> on_worker_script_load_failure;
     Function<HTTP::Cookie::VersionedCookie(URL::URL const&, HTTP::Cookie::Source)> on_request_cookie;
     Function<IPC::File(Web::Bindings::AgentType)> on_request_worker_agent;
 

--- a/Libraries/LibWeb/Worker/WebWorkerClient.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.ipc
@@ -4,6 +4,7 @@
 
 endpoint WebWorkerClient {
     did_close_worker() =|
+    did_fail_loading_worker_script() =|
     did_request_cookie(URL::URL url, HTTP::Cookie::Source source) => (HTTP::Cookie::VersionedCookie cookie)
     request_worker_agent(Web::Bindings::AgentType worker_type) => (IPC::File socket)
 }

--- a/Services/WebWorker/PageHost.cpp
+++ b/Services/WebWorker/PageHost.cpp
@@ -102,6 +102,11 @@ IPC::File PageHost::request_worker_agent(Web::Bindings::AgentType worker_type)
     return m_client.request_worker_agent(worker_type);
 }
 
+void PageHost::did_fail_loading_worker_script()
+{
+    m_client.async_did_fail_loading_worker_script();
+}
+
 PageHost::PageHost(ConnectionFromClient& client)
     : m_client(client)
     , m_page(Web::Page::create(Web::Bindings::main_thread_vm(), *this))

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -43,6 +43,7 @@ public:
     virtual bool is_headless() const override { VERIFY_NOT_REACHED(); }
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] Web::EventResult event_was_handled) override { VERIFY_NOT_REACHED(); }
+    void did_fail_loading_worker_script();
 
 private:
     explicit PageHost(ConnectionFromClient&);

--- a/Services/WebWorker/WorkerHost.cpp
+++ b/Services/WebWorker/WorkerHost.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/HighResolutionTime/TimeOrigin.h>
 #include <LibWeb/Loader/ResourceLoader.h>
+#include <WebWorker/PageHost.h>
 #include <WebWorker/WorkerHost.h>
 
 namespace WebWorker {
@@ -199,13 +200,13 @@ void WorkerHost::run(GC::Ref<Web::Page> page, Web::HTML::TransferDataEncoder mes
     auto perform_fetch = Web::HTML::create_perform_the_fetch_hook(inside_settings->heap(), move(perform_fetch_function));
 
     // In both cases, let onComplete given script be the following steps:
-    auto on_complete_function = [inside_settings, worker_global_scope, message_port_data = move(message_port_data), url = m_url, is_shared](GC::Ptr<Web::HTML::Script> script) mutable {
+    auto on_complete_function = [page, inside_settings, worker_global_scope, message_port_data = move(message_port_data), url = m_url, is_shared](GC::Ptr<Web::HTML::Script> script) mutable {
         auto& realm = inside_settings->realm();
 
         // 1. If script is null or if script's error to rethrow is non-null, then:
         if (!script || !script->error_to_rethrow().is_null()) {
-            // FIXME: 1. Queue a global task on the DOM manipulation task source given worker's relevant global object to fire an event named error at worker.
-            // FIXME: Notify Worker parent through IPC to fire an error event at Worker
+            // 1. Queue a global task on the DOM manipulation task source given worker's relevant global object to fire an event named error at worker.
+            as<WebWorker::PageHost>(page->client()).did_fail_loading_worker_script();
 
             // 2. Run the environment discarding steps for inside settings.
             inside_settings->discard_environment();

--- a/Tests/LibWeb/Text/expected/wpt-import/workers/data-url.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/workers/data-url.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 9 tests
+
+9 Pass
+Pass	application/javascript MIME allowed
+Pass	text/plain MIME allowed
+Pass	empty MIME allowed
+Pass	communication goes both ways
+Pass	indexedDB is present
+Pass	indexedDB is inaccessible
+Pass	cross-origin worker
+Pass	worker has opaque origin
+Pass	invalid javascript produces error

--- a/Tests/LibWeb/Text/expected/wpt-import/workers/semantics/run-a-worker/003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/workers/semantics/run-a-worker/003.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	worker
+Pass	shared

--- a/Tests/LibWeb/Text/input/wpt-import/workers/data-url.html
+++ b/Tests/LibWeb/Text/input/wpt-import/workers/data-url.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<title>data URL dedicated workers</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script>
+// Helper assert functions -START-
+function assert_worker_sends_pass(test_desc, mime_type, worker_code) {
+  async_test(function(t) {
+    var w = new Worker(`data:${mime_type},${worker_code}`);
+    w.onmessage = t.step_func_done(function(e) {
+      assert_equals(e.data, 'PASS');
+    });
+    w.postMessage('SEND_PASS');
+  }, test_desc);
+}
+
+function assert_worker_throws(test_desc, worker_code) {
+  assert_worker_sends_pass(test_desc, '', `try { ${worker_code}; self.postMessage("FAIL"); } catch (e) { self.postMessage("PASS"); }`);
+}
+
+function assert_worker_construction_fails(test_desc, mime_type, worker_code) {
+  async_test(function(t) {
+    var w = new Worker(`data:${mime_type},${worker_code};postMessage("PASS")`);
+    w.onmessage = t.step_func_done(function(e) {
+      assert_unreached('Should not receive any message back.');
+    });
+    w.onerror = t.step_func_done(function(e) {
+      assert_true(true, 'Should throw ' + e.message);
+      // Stop the error from being propagated to the WPT test harness
+      e.preventDefault();
+    });
+  }, test_desc);
+}
+// Helper assert functions -END-
+
+// Actual tests -START-
+
+// Any MIME type allowed
+assert_worker_sends_pass('application/javascript MIME allowed', 'application/javascript', 'self.postMessage("PASS")');
+assert_worker_sends_pass('text/plain MIME allowed', 'text/plain', 'self.postMessage("PASS")');
+assert_worker_sends_pass('empty MIME allowed', '', 'self.postMessage("PASS")');
+
+// Communications goes both ways
+assert_worker_sends_pass('communication goes both ways', 'application/javascript', 'onmessage = function(e) { self.postMessage("PASS"); }');
+
+// test access to storage APIs
+
+// https://w3c.github.io/IndexedDB/#dom-idbfactory-open
+assert_worker_sends_pass('indexedDB is present', '', 'self.postMessage("indexedDB" in self ? "PASS" : "FAIL")');
+assert_worker_throws('indexedDB is inaccessible', 'self.indexedDB.open("someDBName")');
+
+// Other standardized storage APIs are either not exposed to workers
+// (e.g. window.localStorage, window.sessionStorage), or are [SecureContext]
+// (e.g. self.caches).
+
+// 'data:' workers are cross-origin
+assert_worker_sends_pass('cross-origin worker', '', 'fetch("../").then(() => self.postMessage("FAIL"), () => self.postMessage("PASS"))');
+
+// 'data:' workers have opaque origin
+assert_worker_sends_pass('worker has opaque origin', 'application/javascript', 'if (self.location.origin == "null") {postMessage("PASS");} else {postMessage("FAIL");}');
+
+setup({allow_uncaught_exception:true});
+// invalid javascript will trigger an ErrorEvent
+assert_worker_construction_fails('invalid javascript produces error', 'application/javascript', '}x=3');
+
+// Actual tests -END-
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/workers/semantics/run-a-worker/003.html
+++ b/Tests/LibWeb/Text/input/wpt-import/workers/semantics/run-a-worker/003.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>handling for 404 response</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+async_test(t => {
+  const worker = new Worker('404_worker');
+  worker.onerror = e => t.done();
+}, 'worker');
+
+async_test(t => {
+  const shared = new SharedWorker('404_shared');
+  shared.onerror = e => t.done();
+}, 'shared');
+</script>


### PR DESCRIPTION
This fixes a whole bunch of WPT timeouts for Workers which wait for this event to arrive.