### PR TITLE
LibWeb+UI/AppKit: Complain when search engine isn't configured

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1475,7 +1475,7 @@ void Navigable::populate_session_history_entry_document(
                 // 1. Set entry's document state's document to the result of creating a document for inline content that doesn't have a DOM, given navigable, null, navTimingType, and userInvolvement. The inline content should indicate to the user the sort of error that occurred.
                 auto error_message = received_navigation_params.has<NullOrError>() ? received_navigation_params.get<NullOrError>().value_or("Unknown error"_string) : "The request was denied."_string;
 
-                auto error_html = load_error_page(entry->url(), error_message).release_value_but_fixme_should_propagate_errors();
+                auto error_html = load_error_page(entry->url().to_byte_string(), error_message).release_value_but_fixme_should_propagate_errors();
                 entry->document_state()->set_document(create_document_for_inline_content(this, navigation_id, user_involvement, [this, error_html](auto& document) {
                     auto parser = HTML::HTMLParser::create(document, error_html, "utf-8"sv);
                     document.set_url(URL::about_error());

--- a/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -30,14 +30,14 @@ void set_browser_process_executable_path(StringView executable_path)
     s_browser_process_executable_path = MUST(String::from_utf8(executable_path));
 }
 
-ErrorOr<String> load_error_page(URL::URL const& url, StringView error_message)
+ErrorOr<String> load_error_page(StringView location, StringView error_message)
 {
     // Generate HTML error page from error template file
     // FIXME: Use an actual templating engine (our own one when it's built, preferably with a way to check these usages at compile time)
     auto template_file = TRY(Core::Resource::load_from_uri("resource://ladybird/templates/error.html"sv));
     StringBuilder builder;
     SourceGenerator generator { builder, '%', '%' };
-    generator.set("failed_url", escape_html_entities(url.to_byte_string()));
+    generator.set("failed_url", escape_html_entities(location));
     generator.set("error_message", escape_html_entities(error_message));
     generator.append(template_file->data());
     return TRY(String::from_utf8(generator.as_string_view()));

--- a/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
+++ b/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
@@ -14,7 +14,7 @@ namespace Web {
 WEB_API void set_browser_process_command_line(StringView command_line);
 WEB_API void set_browser_process_executable_path(StringView executable_path);
 
-ErrorOr<String> load_error_page(URL::URL const&, StringView error_message);
+WEB_API ErrorOr<String> load_error_page(StringView, StringView error_message);
 
 ErrorOr<String> load_file_directory_page(URL::URL const&);
 

--- a/UI/AppKit/Interface/LadybirdWebView.h
+++ b/UI/AppKit/Interface/LadybirdWebView.h
@@ -49,6 +49,7 @@
                   pageIndex:(u64)page_index;
 
 - (void)loadURL:(URL::URL const&)url;
+- (void)loadHTML:(StringView)html;
 
 - (WebView::ViewImplementation&)view;
 - (String const&)handle;

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -164,6 +164,11 @@ struct HideCursor {
     m_web_view_bridge->load(url);
 }
 
+- (void)loadHTML:(StringView)html
+{
+    m_web_view_bridge->load_html(html);
+}
+
 - (WebView::ViewImplementation&)view
 {
     return *m_web_view_bridge;

--- a/UI/AppKit/Interface/TabController.h
+++ b/UI/AppKit/Interface/TabController.h
@@ -20,6 +20,7 @@
                   pageIndex:(u64)page_index;
 
 - (void)loadURL:(URL::URL const&)url;
+- (void)loadHTML:(StringView)html;
 
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect;
 

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/Autocomplete.h>
 #include <LibWebView/URL.h>
@@ -147,6 +148,11 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     [[self tab].web_view loadURL:url];
 }
 
+- (void)loadHTML:(StringView)html
+{
+    [[self tab].web_view loadHTML:html];
+}
+
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)isRedirect
 {
     [self setLocationFieldText:url.serialize()];
@@ -251,6 +257,13 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 {
     if (auto url = WebView::sanitize_url(location, WebView::Application::settings().search_engine()); url.has_value()) {
         [self loadURL:*url];
+    } else {
+        if (!WebView::Application::settings().search_engine().has_value()) {
+            auto errorPage = Web::load_error_page(location, "You can configure a search engine in the settings menu. Otherwise, the location bar will only accept URLs."sv);
+            if (!errorPage.is_error()) {
+                [self loadHTML:errorPage.value()];
+            }
+        }
     }
 
     [self.window makeFirstResponder:nil];


### PR DESCRIPTION
When you first start Ladybird with no search engine configured, nothing happens when you type something into the location/address bar and press Enter.

This adds a small error page letting you know that Ladybird at least tried to do something.
Using `GeneratedPagesLoader` as an external interface feels a little dirty, I think this would be better replaced by a more generic templating method or just copied directly through to get rid of the new `WEB_API`. Let me know what you think.

Before:
<img width="844" height="537" alt="image" src="https://github.com/user-attachments/assets/b97e374b-9b00-4bf7-852c-a45c02acd3ed" />

After:
<img width="844" height="537" alt="image" src="https://github.com/user-attachments/assets/20804dfc-8c61-49fa-80d6-35de462557f7" />
