### PR TITLE
RequestServer: Prioritize immediate fetch connection startup

### DIFF
--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -530,7 +530,11 @@ void Request::handle_fetch_state()
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());
     set_option(CURLOPT_PORT, m_url.port_or_default());
     set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
-    set_option(CURLOPT_PIPEWAIT, 1L);
+    // Do not delay a transfer while waiting for a potentially reusable connection.
+    // Prioritizing immediate connection establishment improves page load latency.
+    set_option(CURLOPT_PIPEWAIT, 0L);
+    set_option(CURLOPT_TCP_FASTOPEN, 1L);
+    set_option(CURLOPT_TCP_NODELAY, 1L);
     set_option(CURLOPT_ALTSVC, m_alt_svc_cache_path.characters());
 
     set_option(CURLOPT_CUSTOMREQUEST, m_method.characters());


### PR DESCRIPTION
Fetch startup can be delayed when libcurl waits for a potentially reusable
connection. This can increase latency on navigation and subresource loads.
Description

    Set CURLOPT_PIPEWAIT to 0 in the fetch path so transfers begin
    immediately instead of waiting for connection reuse.

    Enable CURLOPT_TCP_FASTOPEN and CURLOPT_TCP_NODELAY on fetch handles to
    reduce connection and request transmission latency where supported.

    Keep the change scoped to RequestServer fetch configuration.
