### PR TITLE
LibWeb: Drain microtasks after background parse completion

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -25,6 +25,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
 #include <LibWeb/HTML/PotentialCORSRequest.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
@@ -73,6 +74,10 @@ static void parse_off_thread(NonnullRefPtr<JS::SourceCode const> source_code, JS
         origin->deferred_invoke([parsed, callback]() {
             (*callback)(parsed);
             delete callback;
+            // AD-HOC: Perform a microtask checkpoint so that any microtasks queued by the callback (e.g. promise
+            //         reactions from react_to_promise during module linking) are drained. Without this, module worker
+            //         scripts would stall because their promise chains never resolve.
+            perform_a_microtask_checkpoint();
         });
     });
 }


### PR DESCRIPTION
When parse_off_thread() completes, the result callback runs inside a
deferred_invoke, which executes outside the HTML event loop's task
model. This meant that any microtasks queued by the callback (e.g.
promise reactions from react_to_promise during module linking) were
never drained, since HTML::EventLoop::process() only performs
microtask checkpoints after executing an HTML task.

Fix this by performing an explicit microtask checkpoint after the
parse result callback. This ensures that promise reactions queued
during module linking are drained immediately.

This fixes module worker scripts timing out because their loading
promise chains would stall indefinitely.