### PR TITLE
LibWeb: Ensure inline abspos containing blocks contain a fragment

### DIFF
--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/InlineFormattingContext.h>
 #include <LibWeb/Layout/InlineLevelIterator.h>
 #include <LibWeb/Layout/LineBuilder.h>
@@ -329,6 +330,12 @@ void InlineFormattingContext::generate_line_boxes()
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
                 parent().layout_floating_box(*box, containing_block(), *m_available_space, 0, &line_builder);
+            }
+            break;
+
+        case InlineLevelIterator::Item::Type::AbsolutePositioningInlineContainingElement:
+            if (auto* inline_node = as_if<InlineNode>(*item.node)) {
+                line_builder.append_inline(*inline_node, item.margin_start, item.margin_end);
             }
             break;
 

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -387,6 +387,28 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         return generate_next_item();
     }
 
+    if (auto const* node = as_if<Layout::InlineNode>(*m_current_node)) {
+        if (!node->computed_values().contain().is_empty() || !node->computed_values().transformations().is_empty() || node->is_body() || node->is_generated_for_pseudo_element() || !node->computed_values_establish_absolute_positioning_containing_block()) {
+            skip_to_next();
+            return generate_next_item();
+        }
+
+        auto const& node_state = m_layout_state.get(*node);
+        skip_to_next();
+        Item item = Item {
+            .type = Item::Type::AbsolutePositioningInlineContainingElement,
+            .node = node,
+            .offset_in_node = 0,
+            .length_in_node = 0,
+            .margin_start = node_state.margin_left,
+            .margin_end = node_state.margin_right,
+        };
+
+        add_extra_box_model_metrics_to_item(item, true, true);
+
+        return item;
+    }
+
     if (!is<Layout::Box>(*m_current_node)) {
         skip_to_next();
         return generate_next_item();

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -28,6 +28,7 @@ public:
             ForcedBreak,
             AbsolutelyPositionedElement,
             FloatingElement,
+            AbsolutePositioningInlineContainingElement,
         };
         Type type {};
         GC::Ptr<Layout::Node const> node {};

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/LineBuilder.h>
+#include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/TextNode.h>
 
 namespace Web::Layout {
@@ -103,6 +104,12 @@ void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels t
         .line_box_index = m_containing_block_used_values.line_boxes.size() - 1,
         .fragment_index = line_box.fragments().size() - 1,
     };
+}
+
+void LineBuilder::append_inline(InlineNode const& inline_node, CSSPixels leading_margin, CSSPixels trailing_margin)
+{
+    auto& line_box = ensure_last_line_box();
+    line_box.add_fragment(inline_node, 0, 0, 0, 0, leading_margin, trailing_margin, 0, 0, 0, 0);
 }
 
 void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun> glyph_run)
@@ -280,7 +287,7 @@ void LineBuilder::update_last_line()
             // The CSS specification calls this AD (A+D, Ascent + Descent).
 
             CSSPixels fragment_baseline = 0;
-            if (fragment.layout_node().is_text_node()) {
+            if (fragment.layout_node().is_text_node() || fragment.layout_node().is_inline_node()) {
                 fragment_baseline = CSSPixels::nearest_value_for(font_metrics.ascent) + half_leading;
             } else {
                 auto const& box = as<Layout::Box>(fragment.layout_node());

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -24,6 +24,7 @@ public:
 
     void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
+    void append_inline(InlineNode const&, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
 
     // Returns whether a line break occurred.

--- a/Tests/LibWeb/Layout/expected/abspos-element-with-inline-as-abspos-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-element-with-inline-as-abspos-containing-block.txt
@@ -1,6 +1,7 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] positioned [8+0+0 300 0+0+8] [8+0+0 300 0+0+8] [BFC] children: inline
+      frag 0 from InlineNode start: 0, length: 0, rect: [8,8 0x0] baseline: 13.796875
       InlineNode <span.span1> at [8,8] [0+0+0 74.125 16+0+0] [0+0+0 18 0+0+0]
         frag 0 from TextNode start: 0, length: 8, rect: [8,8 74.125x18] baseline: 13.796875
             "Features"

--- a/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-empty-inline-as-abspos-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-empty-inline-as-abspos-containing-block.txt
@@ -1,0 +1,201 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 740.34375 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 653.953125 0+0+78.390625] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [356.625,8] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [356.625,8 8.890625x18] baseline: 13.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 43, rect: [8,8 348.625x18] baseline: 13.796875
+              "green "c" should be written on top of "b": "
+          frag 1 from InlineNode start: 0, length: 0, rect: [356.625,8 0x0] baseline: 13.796875
+          frag 2 from TextNode start: 0, length: 1, rect: [356.625,8 9.46875x18] baseline: 13.796875
+              "b"
+          TextNode <#text> (not painted)
+          InlineNode <span.with-pseudo> at [8,8] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,26] [0+0+0 784 0+0+0] [0+0+0 36 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,44] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,44 8.890625x18] baseline: 13.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 42, rect: [8,26 340.625x18] baseline: 13.796875
+              "green "c" should be written on top of "b":"
+          TextNode <#text> (not painted)
+        BlockContainer <div> at [8,44] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from InlineNode start: 0, length: 0, rect: [8,44 0x0] baseline: 13.796875
+          frag 1 from TextNode start: 0, length: 1, rect: [8,44 9.46875x18] baseline: 13.796875
+              "b"
+          InlineNode <span.with-pseudo> at [8,44] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,62] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,62] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [356.625,62] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [356.625,62 8.890625x18] baseline: 13.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,62] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 43, rect: [8,62 348.625x18] baseline: 13.796875
+              "green "c" should be written on top of "b": "
+          frag 1 from BlockContainer start: 0, length: 0, rect: [356.625,75 0x0] baseline: 0
+          frag 2 from InlineNode start: 0, length: 0, rect: [356.625,62 0x0] baseline: 13.796875
+          frag 3 from TextNode start: 0, length: 1, rect: [356.625,62 9.46875x18] baseline: 13.796875
+              "b"
+          TextNode <#text> (not painted)
+          BlockContainer <div.inline-block> at [356.625,75] inline-block [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+          InlineNode <span.with-pseudo> at [8,62] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,80] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,80] [0+0+0 784 0+0+0] [0+0+0 160.390625 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [513.40625,222] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [513.40625,222 8.890625x18] baseline: 13.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,80] [0+0+0 784 0+0+0] [0+0+0 160.390625 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 43, rect: [8,222 348.625x18] baseline: 13.796875
+              "green "c" should be written on top of "b": "
+          frag 1 from BlockContainer start: 0, length: 0, rect: [435.015625,158 0x0] baseline: 156.78125
+          frag 2 from InlineNode start: 0, length: 0, rect: [513.40625,222 0x0] baseline: 13.796875
+          frag 3 from TextNode start: 0, length: 1, rect: [513.40625,222 9.46875x18] baseline: 13.796875
+              "b"
+          TextNode <#text> (not painted)
+          BlockContainer <div.inline-block.with-margin> at [435.015625,158] inline-block [78.390625+0+0 0 0+0+78.390625] [78.390625+0+0 0 0+0+78.390625] [BFC] children: not-inline
+          InlineNode <span.with-pseudo> at [8,80] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,240.390625] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div> at [8,240.390625] [0+0+0 784 0+0+0] [0+0+0 174.78125 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [522.75,318.390625] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [522.75,318.390625 8.890625x18] baseline: 13.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,240.390625] [0+0+0 784 0+0+0] [0+0+0 174.78125 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 43, rect: [8,318.390625 348.625x18] baseline: 13.796875
+              "green "c" should be written on top of "b": "
+          frag 1 from BlockContainer start: 0, length: 0, rect: [435.015625,318.390625 9.34375x18] baseline: 92.1875
+          frag 2 from InlineNode start: 0, length: 0, rect: [522.75,318.390625 0x0] baseline: 13.796875
+          frag 3 from TextNode start: 0, length: 1, rect: [522.75,318.390625 9.46875x18] baseline: 13.796875
+              "b"
+          TextNode <#text> (not painted)
+          BlockContainer <div.inline-block.with-margin> at [435.015625,318.390625] inline-block [78.390625+0+0 9.34375 0+0+78.390625] [78.390625+0+0 18 0+0+78.390625] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 1, rect: [435.015625,318.390625 9.34375x18] baseline: 13.796875
+                "a"
+            TextNode <#text> (not painted)
+          InlineNode <span.with-pseudo> at [8,240.390625] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,415.171875] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.with-margin> at [86.390625,493.5625] [78.390625+0+0 627.21875 0+0+78.390625] [78.390625+0+0 18 0+0+78.390625] children: not-inline
+        BlockContainer <(anonymous)> at [435.015625,493.5625] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [435.015625,493.5625 8.890625x18] baseline: 13.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [86.390625,493.5625] [0+0+0 627.21875 0+0+0] [0+0+0 18 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 43, rect: [86.390625,493.5625 348.625x18] baseline: 13.796875
+              "green "c" should be written on top of "b": "
+          frag 1 from InlineNode start: 0, length: 0, rect: [435.015625,493.5625 0x0] baseline: 13.796875
+          frag 2 from TextNode start: 0, length: 1, rect: [435.015625,493.5625 9.46875x18] baseline: 13.796875
+              "b"
+          TextNode <#text> (not painted)
+          InlineNode <span.with-pseudo> at [86.390625,493.5625] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,589.953125] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.with-margin.with-max-width> at [86.390625,589.953125] [78.390625+0+0 100 0+0+605.609375] [78.390625+0+0 72 0+0+78.390625] children: not-inline
+        BlockContainer <(anonymous)> at [178.046875,643.953125] positioned [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [178.046875,643.953125 8.890625x18] baseline: 13.796875
+              "c"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [86.390625,589.953125] [0+0+0 100 0+0+0] [0+0+0 72 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 9, rect: [86.390625,589.953125 71.296875x18] baseline: 13.796875
+              "green "c""
+          frag 1 from TextNode start: 10, length: 9, rect: [86.390625,607.953125 77.046875x18] baseline: 13.796875
+              "should be"
+          frag 2 from TextNode start: 20, length: 10, rect: [86.390625,625.953125 84.625x18] baseline: 13.796875
+              "written on"
+          frag 3 from TextNode start: 31, length: 12, rect: [86.390625,643.953125 91.65625x18] baseline: 13.796875
+              "top of "b": "
+          frag 4 from InlineNode start: 0, length: 0, rect: [178.046875,643.953125 0x0] baseline: 13.796875
+          frag 5 from TextNode start: 0, length: 1, rect: [178.046875,643.953125 9.46875x18] baseline: 13.796875
+              "b"
+          TextNode <#text> (not painted)
+          InlineNode <span.with-pseudo> at [86.390625,589.953125] [0+0+0 0 0+0+0] [0+0+0 18 0+0+0]
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,740.34375] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x740.34375]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x740.34375]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x653.953125]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x18]
+        PaintableWithLines (BlockContainer(anonymous)) [356.625,8 0x0]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
+          TextPaintable (TextNode<#text>)
+          PaintableWithLines (InlineNode<SPAN>.with-pseudo) [8,8 0x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,26 784x36]
+        PaintableWithLines (BlockContainer(anonymous)) [8,44 0x0]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,26 784x18]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [8,44 784x0]
+        PaintableWithLines (BlockContainer(anonymous)) [8,44 784x18]
+          PaintableWithLines (InlineNode<SPAN>.with-pseudo) [8,44 0x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,62 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,62 784x18]
+        PaintableWithLines (BlockContainer(anonymous)) [356.625,62 0x0]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,62 784x18]
+          TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.inline-block) [356.625,75 0x0]
+          PaintableWithLines (InlineNode<SPAN>.with-pseudo) [8,62 0x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,80 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,80 784x160.390625]
+        PaintableWithLines (BlockContainer(anonymous)) [513.40625,222 0x0]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,80 784x160.390625]
+          TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.inline-block.with-margin) [435.015625,158 0x0]
+          PaintableWithLines (InlineNode<SPAN>.with-pseudo) [8,80 0x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,240.390625 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,240.390625 784x174.78125]
+        PaintableWithLines (BlockContainer(anonymous)) [522.75,318.390625 0x0]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,240.390625 784x174.78125]
+          TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.inline-block.with-margin) [435.015625,318.390625 9.34375x18]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (InlineNode<SPAN>.with-pseudo) [8,240.390625 0x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,415.171875 784x0]
+      PaintableWithLines (BlockContainer<DIV>.with-margin) [86.390625,493.5625 627.21875x18]
+        PaintableWithLines (BlockContainer(anonymous)) [435.015625,493.5625 0x0]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [86.390625,493.5625 627.21875x18]
+          TextPaintable (TextNode<#text>)
+          PaintableWithLines (InlineNode<SPAN>.with-pseudo) [86.390625,493.5625 0x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,589.953125 784x0]
+      PaintableWithLines (BlockContainer<DIV>.with-margin.with-max-width) [86.390625,589.953125 100x72]
+        PaintableWithLines (BlockContainer(anonymous)) [178.046875,643.953125 0x0]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [86.390625,589.953125 100x72]
+          TextPaintable (TextNode<#text>)
+          PaintableWithLines (InlineNode<SPAN>.with-pseudo) [86.390625,589.953125 0x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,740.34375 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x740.34375] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-inline-as-abspos-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-inline-as-abspos-containing-block.txt
@@ -2,6 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+        frag 0 from InlineNode start: 0, length: 0, rect: [8,8 0x0] baseline: 13.796875
         InlineNode <span> at [8,8] [0+0+0 74.125 16+0+0] [0+0+0 18 0+0+0]
           frag 0 from TextNode start: 0, length: 8, rect: [8,8 74.125x18] baseline: 13.796875
               "Features"

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -5,10 +5,12 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         InlineNode <span> at [8,8] [0+0+0 136.609375 0+0+0] [0+0+0 18 0+0+0]
           frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x18] baseline: 13.796875
               "well "
+          frag 1 from InlineNode start: 0, length: 0, rect: [44.40625,8 0x0] baseline: 13.796875
           TextNode <#text> (not painted)
           InlineNode <b> at [44.40625,33] [0+0+0 100.203125 0+0+0] [0+0+0 18 0+0+0]
             frag 0 from TextNode start: 0, length: 6, rect: [44.40625,33 44.84375x18] baseline: 13.796875
                 "hello "
+            frag 1 from InlineNode start: 0, length: 0, rect: [89.25,33 0x0] baseline: 13.796875
             TextNode <#text> (not painted)
             InlineNode <i> at [89.25,58] [0+0+0 55.359375 0+0+0] [0+0+0 18 0+0+0]
               frag 0 from TextNode start: 0, length: 7, rect: [89.25,58 55.359375x18] baseline: 13.796875

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-elements.txt
@@ -3,15 +3,18 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: inline
       frag 0 from TextNode start: 0, length: 4, rect: [8,8 35.15625x18] baseline: 13.796875
           "foo "
-      frag 1 from TextNode start: 0, length: 1, rect: [70.796875,8 8x18] baseline: 13.796875
+      frag 1 from InlineNode start: 0, length: 0, rect: [43.15625,8 0x0] baseline: 13.796875
+      frag 2 from TextNode start: 0, length: 1, rect: [70.796875,8 8x18] baseline: 13.796875
           " "
+      frag 3 from InlineNode start: 0, length: 0, rect: [78.796875,8 0x0] baseline: 13.796875
       TextNode <#text> (not painted)
       InlineNode <b> at [43.15625,33] [0+0+0 27.640625 0+0+0] [0+0+0 18 0+0+0]
         frag 0 from TextNode start: 0, length: 3, rect: [43.15625,33 27.640625x18] baseline: 13.796875
             "bar"
         TextNode <#text> (not painted)
       TextNode <#text> (not painted)
-      InlineNode <b> at [53.796875,58] [0+0+0 27.203125 0+0+0] [0+0+0 18 0+0+0]
+      InlineNode <b> at [53.796875,33] [0+0+0 27.203125 0+0+0] [0+0+0 0 0+0+0]
+        frag 0 from InlineNode start: 0, length: 0, rect: [78.796875,33 0x0] baseline: 13.796875
         InlineNode <i> at [53.796875,58] [0+0+0 27.203125 0+0+0] [0+0+0 18 0+0+0]
           frag 0 from TextNode start: 0, length: 3, rect: [53.796875,58 27.203125x18] baseline: 13.796875
               "baz"
@@ -25,7 +28,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (InlineNode<B>) [43.15625,33 27.640625x18]
         TextPaintable (TextNode<#text>)
       TextPaintable (TextNode<#text>)
-      PaintableWithLines (InlineNode<B>) [53.796875,58 27.203125x18]
+      PaintableWithLines (InlineNode<B>) [53.796875,33 27.203125x0]
         PaintableWithLines (InlineNode<I>) [53.796875,58 27.203125x18]
           TextPaintable (TextNode<#text>)
 

--- a/Tests/LibWeb/Layout/input/abspos-pseudo-element-with-empty-inline-as-abspos-containing-block.html
+++ b/Tests/LibWeb/Layout/input/abspos-pseudo-element-with-empty-inline-as-abspos-containing-block.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<style>
+    .with-pseudo {
+        position: relative;
+    }
+    .with-pseudo::before {
+        display: block;
+        width: 100%;
+        height: 100%;
+        color: green;
+        content: "c";
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+    .with-margin {
+        margin: 10%;
+    }
+    .with-max-width {
+        max-width: 100px;
+    }
+    .inline-block {
+        display: inline-block;
+    }
+</style>
+<div>green "c" should be written on top of "b": <span class="with-pseudo"></span>b</div>
+<div>green "c" should be written on top of "b": <div></div><span class="with-pseudo"></span>b</div>
+<div>green "c" should be written on top of "b": <div class="inline-block"></div><span class="with-pseudo"></span>b</div>
+<div>green "c" should be written on top of "b": <div class="inline-block with-margin"></div><span class="with-pseudo"></span>b</div>
+<div>green "c" should be written on top of "b": <div class="inline-block with-margin">a</div><span class="with-pseudo"></span>b</div>
+<div class="with-margin">green "c" should be written on top of "b": <span class="with-pseudo"></span>b</div>
+<div class="with-margin with-max-width">green "c" should be written on top of "b": <span class="with-pseudo"></span>b</div>


### PR DESCRIPTION
Creates a fragment for inline nodes that establish an absolute positioning containing block (`position: relative`, etc).
This ensures we always have a fragment to reference when computing an abspos containing rect for an inline node.

Fixes #8302

Ladybird before:
<img width="2176" height="1184" alt="ladybird-before" src="https://github.com/user-attachments/assets/009418f3-739d-4598-9681-2fe5a1e4504a" />
Ladybird after:
<img width="1920" height="927" alt="ladybird-after" src="https://github.com/user-attachments/assets/3f2f112f-4c28-4d11-86d8-ce270af96cc6" />
Firefox for reference:
<img width="1920" height="950" alt="firefox" src="https://github.com/user-attachments/assets/bf606406-25da-46b6-9f89-bbc3e55d5688" />

