### PR TITLE
Tests: Fix race condition in `iframe-click-after-parent-scroll` test

### DIFF
--- a/Tests/LibWeb/Text/input/iframe-click-after-parent-scroll.html
+++ b/Tests/LibWeb/Text/input/iframe-click-after-parent-scroll.html
@@ -10,12 +10,6 @@
         border: none;
     }
 </style>
-<iframe srcdoc="
-    <!DOCTYPE html>
-    <style>body { margin: 0; }</style>
-    <div style='width: 100px; height: 100px'
-         onclick='parent.reportClick(event.clientX, event.clientY)'></div>
-"></iframe>
 <script src="include.js"></script>
 <script>
     asyncTest((done) => {
@@ -23,9 +17,17 @@
             println(`click at (${x}, ${y})`);
             done();
         };
-        document.querySelector("iframe").onload = () => {
+        const iframe = document.createElement("iframe");
+        iframe.onload = () => {
             window.scrollTo(0, 50);
             internals.click(60, 60);
         };
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>body { margin: 0; }</style>
+            <div style='width: 100px; height: 100px'
+                 onclick='parent.reportClick(event.clientX, event.clientY)'></div>
+        `;
+        document.body.appendChild(iframe);
     });
 </script>


### PR DESCRIPTION
Previously, the iframe's load event could fire during HTML parsing, before the test had started running. We now create the iframe in JS and append it to the document so that callbacks are executed in the correct order.