### PR TITLE
LibWeb: Implement get_total_length on SVGGeometryElement.

### DIFF
--- a/Libraries/LibGfx/Path.h
+++ b/Libraries/LibGfx/Path.h
@@ -35,6 +35,7 @@ public:
     virtual void text(Utf16View const&, Font const&) = 0;
     virtual void glyph_run(GlyphRun const&) = 0;
     virtual void offset(Gfx::FloatPoint const&) = 0;
+    virtual float length() const = 0;
 
     virtual void append_path(Gfx::Path const&) = 0;
     virtual void intersect(Gfx::Path const&) = 0;
@@ -97,6 +98,7 @@ public:
     void text(Utf16View const& text, Font const& font) { impl().text(text, font); }
     void glyph_run(GlyphRun const& glyph_run) { impl().glyph_run(glyph_run); }
     void offset(Gfx::FloatPoint const& offset) { impl().offset(offset); }
+    float length() const { return impl().length(); }
 
     void horizontal_line_to(float x) { line_to({ x, last_point().y() }); }
     void vertical_line_to(float y) { line_to({ last_point().x(), y }); }

--- a/Libraries/LibGfx/PathSkia.cpp
+++ b/Libraries/LibGfx/PathSkia.cpp
@@ -129,6 +129,12 @@ void PathImplSkia::offset(Gfx::FloatPoint const& offset)
     m_path->offset(offset.x(), offset.y());
 }
 
+float PathImplSkia::length() const
+{
+    SkPathMeasure path_measure(*m_path, false);
+    return path_measure.getLength();
+}
+
 template<typename TextToGlyphs>
 static NonnullOwnPtr<PathImpl> place_text_along_impl(SkPath const& path, Font const& font, size_t length_in_code_points, TextToGlyphs&& text_to_glyphs)
 {

--- a/Libraries/LibGfx/PathSkia.h
+++ b/Libraries/LibGfx/PathSkia.h
@@ -30,6 +30,7 @@ public:
     virtual void text(Utf16View const&, Font const&) override;
     virtual void glyph_run(GlyphRun const&) override;
     virtual void offset(Gfx::FloatPoint const&) override;
+    virtual float length() const override;
 
     virtual void append_path(Gfx::Path const&) override;
     virtual void intersect(Gfx::Path const&) override;

--- a/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <LibGfx/Path.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SVGCircleElementPrototype.h>
 #include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
@@ -59,27 +61,36 @@ void SVGCircleElement::apply_presentational_hints(GC::Ref<CSS::CascadedPropertie
         cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::R, r_value.release_nonnull());
 }
 
-static CSSPixels normalized_diagonal_length(CSSPixelSize viewport_size)
+static float viewport_size_diagonal(CSSPixelSize viewport_size)
 {
-    if (viewport_size.width() == viewport_size.height())
-        return viewport_size.width();
-    return sqrt(((viewport_size.width() * viewport_size.width()) + (viewport_size.height() * viewport_size.height())) / 2);
+    float w = viewport_size.width().to_float();
+    float h = viewport_size.height().to_float();
+    if (w == h)
+        return w;
+    return AK::sqrt(((w * w) + (h * h)) / 2);
+}
+
+void SVGCircleElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    Base::attribute_changed(name, old_value, value, namespace_);
+
+    if (name == SVG::AttributeNames::cx) {
+        m_center_x = AttributeParser::parse_number_percentage(value.value_or(String {}));
+    } else if (name == SVG::AttributeNames::cy) {
+        m_center_y = AttributeParser::parse_number_percentage(value.value_or(String {}));
+    } else if (name == SVG::AttributeNames::r) {
+        m_radius = AttributeParser::parse_number_percentage(value.value_or(String {}));
+    }
 }
 
 Gfx::Path SVGCircleElement::get_path(CSSPixelSize viewport_size)
 {
-    // NB: Called during SVG layout.
-    auto node = unsafe_layout_node();
-    if (!node) {
-        dbgln("FIXME: Null layout node in SVGCircleElement::get_path");
-        return {};
-    }
+    float viewport_w = viewport_size.width().to_float();
+    float viewport_h = viewport_size.height().to_float();
 
-    auto cx = float(node->computed_values().cx().to_px(*node, viewport_size.width()));
-    auto cy = float(node->computed_values().cy().to_px(*node, viewport_size.height()));
-    // Percentages refer to the normalized diagonal of the current SVG viewport
-    // (see Units: https://svgwg.org/svg2-draft/coords.html#Units)
-    auto r = float(node->computed_values().r().to_px(*node, normalized_diagonal_length(viewport_size)));
+    float cx = m_center_x.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_w);
+    float cy = m_center_y.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_h);
+    float r = m_radius.value_or(NumberPercentage::create_number(0)).resolve_relative_to(viewport_size_diagonal(viewport_size));
 
     // A zero radius disables rendering.
     if (r == 0)

--- a/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -21,6 +21,8 @@ public:
     virtual bool is_presentational_hint(FlyString const&) const override;
     virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
 
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
     GC::Ref<SVGAnimatedLength> cx() const;
@@ -31,6 +33,10 @@ private:
     SVGCircleElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+
+    Optional<NumberPercentage> m_center_x;
+    Optional<NumberPercentage> m_center_y;
+    Optional<NumberPercentage> m_radius;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/Path.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SVGGeometryElementPrototype.h>
 #include <LibWeb/Layout/SVGGeometryBox.h>
@@ -35,7 +36,9 @@ GC::Ptr<Layout::Node> SVGGeometryElement::create_layout_node(GC::Ref<CSS::Comput
 
 float SVGGeometryElement::get_total_length()
 {
-    return 0;
+    auto viewport_size = get_viewport_size();
+    auto path = get_path(viewport_size);
+    return path.length();
 }
 
 GC::Ref<Geometry::DOMPoint> SVGGeometryElement::get_point_at_length(float distance)

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -281,7 +281,7 @@ Optional<float> SVGGraphicsElement::stroke_opacity() const
     return unsafe_layout_node()->computed_values().stroke_opacity();
 }
 
-float SVGGraphicsElement::resolve_relative_to_viewport_size(CSS::LengthPercentage const& length_percentage) const
+CSSPixelSize SVGGraphicsElement::get_viewport_size() const
 {
     // FIXME: Converting to pixels isn't really correct - values should be in "user units"
     //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
@@ -295,7 +295,13 @@ float SVGGraphicsElement::resolve_relative_to_viewport_size(CSS::LengthPercentag
             viewport_height = svg_svg_layout_node->computed_values().height().to_px(*svg_svg_layout_node, 0);
         }
     }
-    auto scaled_viewport_size = (viewport_width + viewport_height) * CSSPixels(0.5);
+    return { viewport_width, viewport_height };
+}
+
+float SVGGraphicsElement::resolve_relative_to_viewport_size(CSS::LengthPercentage const& length_percentage) const
+{
+    auto viewport_size = get_viewport_size();
+    auto scaled_viewport_size = (viewport_size.width() + viewport_size.height()) * CSSPixels(0.5);
     return length_percentage.to_px(*unsafe_layout_node(), scaled_viewport_size).to_double();
 }
 

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -99,6 +99,8 @@ protected:
         return as_if<T>(resolve_url_to_element(url).ptr());
     }
 
+    CSSPixelSize get_viewport_size() const;
+
 private:
     virtual bool is_svg_graphics_element() const final { return true; }
     float resolve_relative_to_viewport_size(CSS::LengthPercentage const& length_percentage) const;


### PR DESCRIPTION
Enable JS to get the real value for `getTotalLength()` at SVG DOM API.