### PR TITLE
LibUnicode: Preserve original ICU pattern in CalendarPattern

### DIFF
--- a/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2021-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -358,7 +358,7 @@ String CalendarPattern::to_pattern() const
 }
 
 // https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
-CalendarPattern CalendarPattern::create_from_pattern(StringView pattern)
+CalendarPattern CalendarPattern::create_from_pattern(String pattern)
 {
     GenericLexer lexer { pattern };
     CalendarPattern format {};
@@ -494,6 +494,7 @@ CalendarPattern CalendarPattern::create_from_pattern(StringView pattern)
         }
     }
 
+    format.pattern = move(pattern);
     return format;
 }
 
@@ -919,9 +920,15 @@ NonnullOwnPtr<DateTimeFormat> DateTimeFormat::create_for_pattern_options(
     auto locale_data = LocaleData::for_locale(locale);
     VERIFY(locale_data.has_value());
 
-    auto skeleton = icu_string(options.to_pattern());
-    auto pattern = locale_data->date_time_pattern_generator().getBestPattern(skeleton, UDATPG_MATCH_ALL_FIELDS_LENGTH, status);
-    verify_icu_success(status);
+    icu::UnicodeString pattern;
+
+    if (options.pattern.has_value()) {
+        pattern = icu_string(*options.pattern);
+    } else {
+        auto skeleton = icu_string(options.to_pattern());
+        pattern = locale_data->date_time_pattern_generator().getBestPattern(skeleton, UDATPG_MATCH_ALL_FIELDS_LENGTH, status);
+        verify_icu_success(status);
+    }
 
     apply_hour_cycle_to_skeleton(pattern, options.hour_cycle, {});
 

--- a/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Libraries/LibUnicode/DateTimeFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2021-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +8,7 @@
 
 #include <AK/IterationDecision.h>
 #include <AK/Optional.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
@@ -75,7 +76,7 @@ struct CalendarPattern {
         TimeZoneName,
     };
 
-    static CalendarPattern create_from_pattern(StringView);
+    static CalendarPattern create_from_pattern(String);
     String to_pattern() const;
 
     template<typename Callback>
@@ -130,6 +131,8 @@ struct CalendarPattern {
     Optional<CalendarPatternStyle> second;
     Optional<u8> fractional_second_digits;
     Optional<CalendarPatternStyle> time_zone_name;
+
+    Optional<String> pattern;
 };
 
 class DateTimeFormat {

--- a/Tests/LibJS/Runtime/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.toLocaleString.js
+++ b/Tests/LibJS/Runtime/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.toLocaleString.js
@@ -18,6 +18,15 @@ describe("correct behavior", () => {
         expect(result1).toBe(result2);
         expect(result1).toBe(result3);
     });
+
+    test("same result as Date.toLocaleString", () => {
+        const date = new Date(0);
+        const plainDateTime = new Temporal.PlainDateTime(1970, 1, 1);
+
+        const result1 = date.toLocaleString("ja", { dateStyle: "full", timeZone: "UTC" });
+        const result2 = plainDateTime.toLocaleString("ja", { dateStyle: "full", timeZone: "UTC" });
+        expect(result1).toBe(result2);
+    });
 });
 
 describe("errors", () => {

--- a/Tests/LibJS/Runtime/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toLocaleString.js
+++ b/Tests/LibJS/Runtime/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.toLocaleString.js
@@ -8,6 +8,15 @@ describe("correct behavior", () => {
         const zonedDateTime = plainDateTime.toZonedDateTime("UTC");
         expect(zonedDateTime.toLocaleString()).toBe("11/3/2021, 1:33:05 AM UTC");
     });
+
+    test("same result as Date.toLocaleString", () => {
+        const date = new Date(0);
+        const zonedDateTime = new Temporal.ZonedDateTime(0n, "UTC");
+
+        const result1 = date.toLocaleString("ja", { dateStyle: "full", timeZone: "UTC" });
+        const result2 = zonedDateTime.toLocaleString("ja", { dateStyle: "full" });
+        expect(result1).toBe(result2);
+    });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
When `AdjustDateTimeStyleFormat` determines that no adjustment is needed (no conflicting fields), the original date/time style pattern should be used as-is for Temporal type formatting. Previously, the `CalendarPattern` was round-tripped through ICU, which apparently can produce a different pattern than the original result.

test262 diff:
```
test/intl402/Temporal/Instant/prototype/toLocaleString/datestyle-not-adjusted-when-no-conflicting-options.js       ❌ -> ✅
test/intl402/Temporal/PlainDate/prototype/toLocaleString/datestyle-not-adjusted-when-no-conflicting-options.js     ❌ -> ✅
test/intl402/Temporal/PlainDateTime/prototype/toLocaleString/datestyle-not-adjusted-when-no-conflicting-options.js ❌ -> ✅
test/intl402/Temporal/ZonedDateTime/prototype/toLocaleString/datestyle-not-adjusted-when-no-conflicting-options.js ❌ -> ✅
```