### PR TITLE
LibWeb: Synchronously resize viewport on fullscreen transitions

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3711,6 +3711,14 @@ void Document::update_the_visibility_state(HTML::VisibilityState visibility_stat
     dispatch_event(event);
 }
 
+void Document::record_current_viewport_size()
+{
+    // Update last viewport state so that run_the_resize_steps() sees no change and does not fire a resize event.
+    m_last_viewport_size = viewport_rect().size().to_type<int>();
+    auto& viewport = *visual_viewport();
+    m_last_visual_viewport_state = { viewport.scale(), { viewport.width(), viewport.height() } };
+}
+
 // https://drafts.csswg.org/cssom-view/#run-the-resize-steps
 void Document::run_the_resize_steps()
 {
@@ -7017,8 +7025,24 @@ GC::Ref<WebIDL::Promise> Document::exit_fullscreen()
 
         // 10. If resize is true, resize doc’s viewport to its "normal" dimensions.
         // NB: Fullscreen API is affected by site-isolation and will require additional work once site-isolation is implemented.
-        if (resize)
-            document_to_unfullscreen->page().client().page_did_request_exit_fullscreen();
+        if (resize) {
+            auto& page = document_to_unfullscreen->page();
+            page.client().page_did_request_exit_fullscreen();
+
+            // NB: We synchronously restore the viewport to its pre-fullscreen dimensions so that the later async IPC
+            //     from the UI process is a no-op. This prevents a spurious resize event from firing before fullscreenchange.
+            if (auto saved_size = page.pre_fullscreen_window_size(); saved_size.has_value()) {
+                auto navigable = document_to_unfullscreen->navigable();
+                if (navigable && navigable->top_level_traversable()) {
+                    auto traversable = navigable->top_level_traversable();
+                    traversable->set_viewport_size(page.device_to_css_size(saved_size.value()));
+                    page.clear_pre_fullscreen_window_size();
+
+                    if (auto doc = traversable->active_document())
+                        doc->record_current_viewport_size();
+                }
+            }
+        }
 
         // 11. If doc’s fullscreen element is null, then resolve promise with undefined and terminate these steps.
         if (!document_to_unfullscreen->fullscreen_element()) {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -580,6 +580,7 @@ public:
     void update_the_visibility_state(HTML::VisibilityState);
 
     void run_the_resize_steps();
+    void record_current_viewport_size();
     void run_the_scroll_steps();
 
     void evaluate_media_queries_and_report_changes();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2463,8 +2463,22 @@ GC::Ref<WebIDL::Promise> Element::request_fullscreen(FullscreenRequester fullscr
 
         // 8. If error is false, then resize pendingDoc’s node navigable’s top-level traversable’s active document’s
         //    viewport’s dimensions FIXME: optionally taking into account options["navigationUI"]:
-        if (error == RequestFullscreenError::False)
-            pending_doc->page().client().page_did_request_fullscreen_window();
+        if (error == RequestFullscreenError::False) {
+            auto& page = pending_doc->page();
+            page.client().page_did_request_fullscreen_window();
+
+            // NB: We resize the viewport to screen dimensions so that the later async IPC from the
+            //     UI process is a no-op. This prevents a spurious resize event from firing before fullscreenchange.
+            if (auto navigable = pending_doc->navigable(); navigable && navigable->top_level_traversable()) {
+                auto traversable = navigable->top_level_traversable();
+                auto screen_size = page.client().screen_rect().size();
+                page.set_pre_fullscreen_window_size(page.window_size());
+                traversable->set_viewport_size(page.device_to_css_size(screen_size));
+
+                if (auto doc = traversable->active_document())
+                    doc->record_current_viewport_size();
+            }
+        }
 
         // 9. If any of the following conditions are false, then set error to true:
         //    * This’s node document is pendingDoc.

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -144,6 +144,10 @@ public:
     DevicePixelSize window_size() const { return m_window_size; }
     void set_window_size(DevicePixelSize size) { m_window_size = size; }
 
+    void set_pre_fullscreen_window_size(DevicePixelSize size) { m_pre_fullscreen_window_size = size; }
+    Optional<DevicePixelSize> pre_fullscreen_window_size() const { return m_pre_fullscreen_window_size; }
+    void clear_pre_fullscreen_window_size() { m_pre_fullscreen_window_size.clear(); }
+
     void did_update_window_rect();
     void set_window_rect_observer(GC::Ptr<GC::Function<void(DevicePixelRect)>> window_rect_observer) { m_window_rect_observer = window_rect_observer; }
 
@@ -289,6 +293,7 @@ private:
 
     DevicePixelPoint m_window_position {};
     DevicePixelSize m_window_size {};
+    Optional<DevicePixelSize> m_pre_fullscreen_window_size;
     GC::Ptr<GC::Function<void(DevicePixelRect)>> m_window_rect_observer;
 
     PendingDialog m_pending_dialog { PendingDialog::None };


### PR DESCRIPTION
Previously, `requestFullscreen()` and `exit_fullscreen()` relied entirely on async IPC to resize the viewport. The UI process would respond with an async viewport resize that could arrive before the next rendering update, causing run_the_resize_steps to fire a spurious resize event before fullscreenchange. We now update the viewport state in the WebContent process on fullscreen transitions, so that we can't cause resize events to be fired on the next rendering update.

This fixes a CI flake in,  `Text/input/wpt-import/fullscreen/api/element-request-fullscreen-timing.html`. Tested by running `Meta/ladybird.py run test-web --shuffle --repeat 100 -f Text/input/wpt-import/fullscreen/` locally.