### PR TITLE
LibWeb: Propagate paint invalidation to anonymous child nodes

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1230,8 +1230,16 @@ TraversalDecision PaintableBox::hit_test_children(CSSPixelPoint position, HitTes
 
 void PaintableBox::set_needs_repaint(InvalidateDisplayList should_invalidate_display_list)
 {
-    if (should_invalidate_display_list == InvalidateDisplayList::Yes)
+    if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
         invalidate_paint_cache();
+
+        // Recurse into anonymous child nodes so we properly invalidate nested contents of e.g. <button>s.
+        for_each_child_of_type<PaintableBox>([&](auto& child) {
+            if (child.layout_node().is_anonymous())
+                child.set_needs_repaint(should_invalidate_display_list);
+            return IterationDecision::Continue;
+        });
+    }
     Paintable::set_needs_repaint(should_invalidate_display_list);
 }
 

--- a/Tests/LibWeb/Ref/expected/paint-invalidation-in-anonymous-wrapper-ref.html
+++ b/Tests/LibWeb/Ref/expected/paint-invalidation-in-anonymous-wrapper-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<button style="background: blue; color: white">Button</button>
+<fieldset style="background: blue; color: white"><legend>Legend</legend>Content</fieldset>

--- a/Tests/LibWeb/Ref/input/paint-invalidation-in-anonymous-wrapper.html
+++ b/Tests/LibWeb/Ref/input/paint-invalidation-in-anonymous-wrapper.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/paint-invalidation-in-anonymous-wrapper-ref.html" />
+<style>
+.white { color: white; }
+</style>
+<button id="btn" style="background: blue">Button</button>
+<fieldset id="fs" style="background: blue"><legend>Legend</legend>Content</fieldset>
+<script>
+requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+        document.getElementById("btn").classList.add("white");
+        document.getElementById("fs").classList.add("white");
+    });
+});
+</script>


### PR DESCRIPTION
Elements that generate anonymous boxes such as `<button>` and `<fieldset>` need to propagate paint invalidation to them in order to properly invalidate the style of their inner contents.

Fixes #8347