### PR TITLE
LibWeb: Replace is<T> + as<T> with as_if<T>

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2730,7 +2730,7 @@ WebIDL::ExceptionOr<GC::Ref<Node>> Document::adopt_node_binding(GC::Ref<Node> no
     if (is<ShadowRoot>(*node))
         return WebIDL::HierarchyRequestError::create(realm(), "Cannot adopt a shadow root into a document"_utf16);
 
-    if (is<DocumentFragment>(*node) && as<DocumentFragment>(*node).host())
+    if (auto* fragment = as_if<DocumentFragment>(*node); fragment && fragment->host())
         return node;
 
     adopt_node(*node);

--- a/Libraries/LibWeb/DOM/MutationObserver.cpp
+++ b/Libraries/LibWeb/DOM/MutationObserver.cpp
@@ -92,7 +92,8 @@ WebIDL::ExceptionOr<void> MutationObserver::observe(Node& target, MutationObserv
 
                 if (node->registered_observer_list()) {
                     node->registered_observer_list()->remove_all_matching([&registered_observer](RegisteredObserver& observer) {
-                        return is<TransientRegisteredObserver>(observer) && as<TransientRegisteredObserver>(observer).source().ptr() == registered_observer;
+                        auto* transient = as_if<TransientRegisteredObserver>(observer);
+                        return transient && transient->source().ptr() == registered_observer;
                     });
                 }
             }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1680,7 +1680,8 @@ bool Node::is_editing_host() const
     }
 
     // or a child HTML element of a Document whose design mode enabled is true.
-    return is<Document>(parent()) && as<Document>(*parent()).design_mode_enabled_state();
+    auto* doc = as_if<Document>(parent());
+    return doc && doc->design_mode_enabled_state();
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#editing-host-of

--- a/Libraries/LibWeb/DOM/Utils.cpp
+++ b/Libraries/LibWeb/DOM/Utils.cpp
@@ -19,17 +19,17 @@ EventTarget* retarget(EventTarget* a, EventTarget* b)
     for (;;) {
         // 1. If one of the following is true then return A.
         // - A is not a node
-        if (!is<Node>(a))
+        auto* a_node = as_if<Node>(a);
+        if (!a_node)
             return a;
 
         // - A’s root is not a shadow root
-        auto* a_node = as<Node>(a);
         auto& a_root = a_node->root();
         if (!is<ShadowRoot>(a_root))
             return a;
 
         // - B is a node and A’s root is a shadow-including inclusive ancestor of B
-        if (is<Node>(b) && a_root.is_shadow_including_inclusive_ancestor_of(as<Node>(*b)))
+        if (auto* b_node = as_if<Node>(b); b_node && a_root.is_shadow_including_inclusive_ancestor_of(*b_node))
             return a;
 
         // 2. Set A to A’s root’s host.

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -1507,10 +1507,11 @@ bool command_insert_paragraph_action(DOM::Document& document, Utf16String const&
 
         // 2. While outer container is not a dd or dt or li, and outer container's parent is editable, set outer
         //    container to its parent.
-        auto is_li_dt_or_dd = [](DOM::Element const& node) {
-            return node.local_name().is_one_of(HTML::TagNames::li, HTML::TagNames::dt, HTML::TagNames::dd);
+        auto is_li_dt_or_dd = [](DOM::Node const& node) {
+            auto* element = as_if<DOM::Element>(node);
+            return element && element->local_name().is_one_of(HTML::TagNames::li, HTML::TagNames::dt, HTML::TagNames::dd);
         };
-        while (!is<DOM::Element>(*outer_container) || !is_li_dt_or_dd(as<DOM::Element>(*outer_container))) {
+        while (!is_li_dt_or_dd(*outer_container)) {
             auto outer_container_parent = outer_container->parent();
             if (!outer_container_parent->is_editable())
                 break;
@@ -1518,7 +1519,7 @@ bool command_insert_paragraph_action(DOM::Document& document, Utf16String const&
         }
 
         // 3. If outer container is a dd or dt or li, set container to outer container.
-        if (is<DOM::Element>(*outer_container) && is_li_dt_or_dd(as<DOM::Element>(*outer_container)))
+        if (is_li_dt_or_dd(*outer_container))
             container = outer_container;
     }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -715,7 +715,8 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         }
     }
 
-    auto shadow_root = is<DOM::Element>(dom_node) ? as<DOM::Element>(dom_node).shadow_root() : nullptr;
+    auto* dom_element = as_if<DOM::Element>(dom_node);
+    auto shadow_root = dom_element ? dom_element->shadow_root() : nullptr;
 
     auto element_has_content_visibility_hidden = [&dom_node]() {
         if (is<DOM::Element>(dom_node)) {

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -164,7 +164,9 @@ StackingContext* Paintable::enclosing_stacking_context()
 void Paintable::paint_inspector_overlay(DisplayListRecordingContext& context) const
 {
     auto& display_list_recorder = context.display_list_recorder();
-    auto const* paintable_box = is<PaintableBox>(this) ? as<PaintableBox>(this) : this->first_ancestor_of_type<PaintableBox>();
+    auto const* paintable_box = as_if<PaintableBox>(this);
+    if (!paintable_box)
+        paintable_box = first_ancestor_of_type<PaintableBox>();
 
     if (paintable_box) {
         Vector<RefPtr<AccumulatedVisualContext const>> relevant_contexts;
@@ -286,7 +288,9 @@ Paintable::SelectionStyle Paintable::selection_style() const
     if (!node)
         return default_style;
 
-    auto element = is<DOM::Element>(*node) ? as<DOM::Element>(*node) : node->parent_element();
+    DOM::Element const* element = as_if<DOM::Element>(*node);
+    if (!element)
+        element = node->parent_element();
     if (!element)
         return default_style;
 


### PR DESCRIPTION
Doing so results in a single fast_if\<T\> or dynamic_cast\<T\> call instead of two. No functional changes.