### PR TITLE
LibWeb: Handle abspos element auto x margin that would end up negative.

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -772,11 +772,21 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         if (!computed_left.is_auto() && !width.is_auto() && !computed_right.is_auto()) {
             // If both margin-left and margin-right are auto,
             // solve the equation under the extra constraint that the two margins get equal values
-            // FIXME: unless this would make them negative, in which case when direction of the containing block is ltr (rtl), set margin-left (margin-right) to 0 and solve for margin-right (margin-left).
+            // unless this would make them negative, in which case when direction of the containing block is ltr (rtl), set margin-left (margin-right) to 0 and solve for margin-right (margin-left).
             auto size_available_for_margins = width_of_containing_block - border_left - padding_left - width.to_px_or_zero(box) - padding_right - border_right - left - right;
             if (margin_left.is_auto() && margin_right.is_auto()) {
-                margin_left = CSS::Length::make_px(size_available_for_margins / 2);
-                margin_right = CSS::Length::make_px(size_available_for_margins / 2);
+                if (size_available_for_margins >= 0) {
+                    margin_left = CSS::Length::make_px(size_available_for_margins / 2);
+                    margin_right = CSS::Length::make_px(size_available_for_margins / 2);
+                }
+                else if (computed_values.direction() == CSS::Direction::Ltr) {
+                    margin_left = CSS::Length::make_px(0);
+                    margin_right = CSS::Length::make_px(solve_for_right());
+                } 
+                else {
+                    margin_left = CSS::Length::make_px(solve_for_left());
+                    margin_right = CSS::Length::make_px(0);
+                }
                 return width;
             }
 

--- a/Tests/LibWeb/Layout/expected/abspos-auto-margin-overflow.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-auto-margin-overflow.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: inline
+      TextNode <#text> (not painted)
+      BlockContainer <div.centered> at [400,8] positioned [0+0+0 1600 0+0+-1200] [0+0+0 50 0+0+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+      BlockContainer <div.centered.tmp> at [400,100] positioned [0+0+0 1000 0+0+-600] [0+0+0 50 0+0+0] [BFC] children: inline
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 2000x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.centered) [400,8 1600x50]
+      PaintableWithLines (BlockContainer<DIV>.centered.tmp) [400,100 1000x50]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x16] [children: 2] (z-index: auto)
+  SC for BlockContainer<DIV>.centered [400,8 1600x50] [children: 0] (z-index: auto), has_transform
+  SC for BlockContainer<DIV>.centered.tmp [400,100 1000x50] [children: 0] (z-index: auto), has_transform

--- a/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-insets-and-auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/abspos-with-insets-and-auto-margins.txt
@@ -2,8 +2,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 418 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 402 0+0+8] children: not-inline
       BlockContainer <div.features-list> at [9,9] positioned [0+1+0 400 0+1+382] [0+1+0 400 0+1+0] children: not-inline
-        BlockContainer <div.feature> at [109,10] positioned [-1+1+0 200 0+1+-1] [0+1+0 200 0+1+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 11, rect: [109,10 102.625x18] baseline: 13.796875
+        BlockContainer <div.feature> at [110,10] positioned [0+1+0 200 0+1+98] [0+1+0 200 0+1+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [110,10 102.625x18] baseline: 13.796875
               "Autocorrect"
           TextNode <#text> (not painted)
 
@@ -11,7 +11,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x418]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x402]
       PaintableWithLines (BlockContainer<DIV>.features-list) [8,8 402x402]
-        PaintableWithLines (BlockContainer<DIV>.feature) [108,9 202x202]
+        PaintableWithLines (BlockContainer<DIV>.feature) [109,9 202x202]
           TextPaintable (TextNode<#text>)
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/abspos-auto-margin-overflow.html
+++ b/Tests/LibWeb/Layout/input/abspos-auto-margin-overflow.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<head>
+<style>
+    .centered {
+      inset-inline: 0;
+      background: red;
+      height: 50px;
+      left: 50%;
+      margin-inline: auto;
+      position: absolute;
+      translate: -50% 0;
+      width: 1600px;
+    }
+
+
+    .tmp {
+        background: green;
+        top: 100px;
+        width: 1000px !important;
+    }
+</style>
+</head>
+<body>
+  <div class="centered">
+  </div>
+
+  <div class="centered tmp">
+  </div>
+</body>


### PR DESCRIPTION
Addresses a fixme in `FormattingContext.cpp`.

Auto margins on absolutely positioned elements that would end up negative are now handled like in other browsers.

Ladybird before:
<img width="1920" height="928" alt="ladybird-before" src="https://github.com/user-attachments/assets/7b6279c5-6f08-4853-a09b-3da980facc0c" />
Ladybird after:
<img width="1920" height="928" alt="ladybird-after" src="https://github.com/user-attachments/assets/ff6b5222-3645-4f27-ae07-f7c73b858e37" />
Firefox:
<img width="1920" height="950" alt="Screenshot 2026-03-15 at 22-22-41 " src="https://github.com/user-attachments/assets/b9e0d455-532d-43e6-89e3-124fbe22316f" />

