### PR TITLE
LibWeb: Respect `box-sizing` value when getting width/height used value

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -645,6 +645,14 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         return {};
     };
 
+    auto used_size_for_property = [&layout_node, &used_value_for_property]<typename ContentBoxGetter, typename BorderBoxGetter>(ContentBoxGetter content_box_getter, BorderBoxGetter border_box_getter) -> Optional<CSSPixels> {
+        return used_value_for_property([&layout_node, content_box_getter, border_box_getter](Painting::PaintableBox const& paintable_box) {
+            if (layout_node.computed_values().box_sizing() == BoxSizing::BorderBox)
+                return border_box_getter(paintable_box);
+            return content_box_getter(paintable_box);
+        });
+    };
+
     auto& element = owner_node()->element();
     auto pseudo_element = owner_node()->pseudo_element();
 
@@ -753,7 +761,9 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
         // display property is not none or contents, then the resolved value is the used value.
         // Otherwise the resolved value is the computed value.
     case PropertyID::Height: {
-        auto maybe_used_height = used_value_for_property([](auto const& paintable_box) { return paintable_box.content_height(); });
+        auto maybe_used_height = used_size_for_property(
+            [](auto const& paintable_box) { return paintable_box.content_height(); },
+            [](auto const& paintable_box) { return paintable_box.absolute_border_box_rect().height(); });
         if (maybe_used_height.has_value())
             return style_value_for_size(Size::make_px(maybe_used_height.release_value()));
         return style_value_for_size(layout_node.computed_values().height());
@@ -791,7 +801,9 @@ RefPtr<StyleValue const> CSSStyleProperties::style_value_for_computed_property(L
             return LengthStyleValue::create(Length::make_px(maybe_used_value.release_value()));
         return style_value_for_length_percentage_or_auto(layout_node.computed_values().padding().top());
     case PropertyID::Width: {
-        auto maybe_used_width = used_value_for_property([](auto const& paintable_box) { return paintable_box.content_width(); });
+        auto maybe_used_width = used_size_for_property(
+            [](auto const& paintable_box) { return paintable_box.content_width(); },
+            [](auto const& paintable_box) { return paintable_box.absolute_border_box_rect().width(); });
         if (maybe_used_width.has_value())
             return style_value_for_size(Size::make_px(maybe_used_width.release_value()));
         return style_value_for_size(layout_node.computed_values().width());

--- a/Tests/LibWeb/Text/expected/css/computed-style-box-sizing.txt
+++ b/Tests/LibWeb/Text/expected/css/computed-style-box-sizing.txt
@@ -1,0 +1,4 @@
+border-box width: 120px
+border-box height: 80px
+content-box width: 120px
+content-box height: 80px

--- a/Tests/LibWeb/Text/input/css/computed-style-box-sizing.html
+++ b/Tests/LibWeb/Text/input/css/computed-style-box-sizing.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+    #border-box {
+        box-sizing: border-box;
+        width: 120px;
+        height: 80px;
+        border: 10px solid black;
+    }
+
+    #content-box {
+        width: 120px;
+        height: 80px;
+        border: 10px solid black;
+    }
+</style>
+<script src="../include.js"></script>
+<div id="border-box"></div>
+<div id="content-box"><div style="height: 90px;"></div></div>
+<script>
+    function dump_used_values(label, style, properties) {
+        for (let property of properties)
+            println(`${label} ${property}: ${style.getPropertyValue(property)}`);
+    }
+
+    test(() => {
+        const borderBox = document.getElementById("border-box");
+        const contentBox = document.getElementById("content-box");
+        dump_used_values("border-box", getComputedStyle(borderBox), ["width", "height"]);
+        dump_used_values("content-box", getComputedStyle(contentBox), ["width", "height"]);
+    });
+</script>


### PR DESCRIPTION
This makes the navbar flyout on https://apple.com render correctly.

Before:

<img width="1220" height="583" alt="image" src="https://github.com/user-attachments/assets/149b7b41-06af-4a5b-9ff8-4667e21c03af" />


After:

<img width="1220" height="583" alt="image" src="https://github.com/user-attachments/assets/42126668-0648-4aa1-bfd0-005fa8b024bb" />
