### PR TITLE
LibIPC: Add Transport::create_paired()

### DIFF
--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Checked.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/ScopeGuard.h>
 #include <AK/Types.h>
 #include <LibCore/Socket.h>
 #include <LibCore/System.h>
@@ -15,6 +16,30 @@
 #include <LibThreading/Thread.h>
 
 namespace IPC {
+
+ErrorOr<TransportSocket::Paired> TransportSocket::create_paired()
+{
+    int fds[2] {};
+    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
+
+    ArmedScopeGuard guard_fd_0 { [&] { MUST(Core::System::close(fds[0])); } };
+    ArmedScopeGuard guard_fd_1 { [&] { MUST(Core::System::close(fds[1])); } };
+
+    auto socket0 = TRY(Core::LocalSocket::adopt_fd(fds[0]));
+    guard_fd_0.disarm();
+    TRY(socket0->set_close_on_exec(true));
+    TRY(socket0->set_blocking(false));
+
+    auto socket1 = TRY(Core::LocalSocket::adopt_fd(fds[1]));
+    guard_fd_1.disarm();
+    TRY(socket1->set_close_on_exec(true));
+    TRY(socket1->set_blocking(false));
+
+    return Paired {
+        make<TransportSocket>(move(socket0)),
+        make<TransportSocket>(move(socket1)),
+    };
+}
 
 void SendQueue::enqueue_message(ReadonlyBytes header, ReadonlyBytes payload, Vector<int>&& fds)
 {

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -40,6 +40,12 @@ class TransportSocket {
 public:
     static constexpr socklen_t SOCKET_BUFFER_SIZE = 128 * KiB;
 
+    struct Paired {
+        NonnullOwnPtr<TransportSocket> local;
+        NonnullOwnPtr<TransportSocket> remote;
+    };
+    static ErrorOr<Paired> create_paired();
+
     explicit TransportSocket(NonnullOwnPtr<Core::LocalSocket> socket);
     ~TransportSocket();
 

--- a/Libraries/LibIPC/TransportSocketWindows.cpp
+++ b/Libraries/LibIPC/TransportSocketWindows.cpp
@@ -7,7 +7,9 @@
 
 #include <AK/ByteReader.h>
 #include <AK/Checked.h>
+#include <AK/ScopeGuard.h>
 #include <AK/Types.h>
+#include <LibCore/System.h>
 #include <LibIPC/HandleType.h>
 #include <LibIPC/Limits.h>
 #include <LibIPC/TransportSocketWindows.h>
@@ -15,6 +17,30 @@
 #include <AK/Windows.h>
 
 namespace IPC {
+
+ErrorOr<TransportSocketWindows::Paired> TransportSocketWindows::create_paired()
+{
+    int fds[2] {};
+    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
+
+    ArmedScopeGuard guard_fd_0 { [&] { MUST(Core::System::close(fds[0])); } };
+    ArmedScopeGuard guard_fd_1 { [&] { MUST(Core::System::close(fds[1])); } };
+
+    auto socket0 = TRY(Core::LocalSocket::adopt_fd(fds[0]));
+    guard_fd_0.disarm();
+    TRY(socket0->set_close_on_exec(true));
+    TRY(socket0->set_blocking(false));
+
+    auto socket1 = TRY(Core::LocalSocket::adopt_fd(fds[1]));
+    guard_fd_1.disarm();
+    TRY(socket1->set_close_on_exec(true));
+    TRY(socket1->set_blocking(false));
+
+    return Paired {
+        make<TransportSocketWindows>(move(socket0)),
+        make<TransportSocketWindows>(move(socket1)),
+    };
+}
 
 TransportSocketWindows::TransportSocketWindows(NonnullOwnPtr<Core::LocalSocket> socket)
     : m_socket(move(socket))

--- a/Libraries/LibIPC/TransportSocketWindows.h
+++ b/Libraries/LibIPC/TransportSocketWindows.h
@@ -18,6 +18,12 @@ class TransportSocketWindows {
     AK_MAKE_DEFAULT_MOVABLE(TransportSocketWindows);
 
 public:
+    struct Paired {
+        NonnullOwnPtr<TransportSocketWindows> local;
+        NonnullOwnPtr<TransportSocketWindows> remote;
+    };
+    static ErrorOr<Paired> create_paired();
+
     explicit TransportSocketWindows(NonnullOwnPtr<Core::LocalSocket> socket);
 
     void set_peer_pid(int pid);

--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -183,23 +183,9 @@ void MessagePort::entangle_with(MessagePort& remote_port)
     remote_port.m_remote_port = this;
     m_remote_port = &remote_port;
 
-    // FIXME: Abstract such that we can entangle different transport types
-    auto create_paired_sockets = []() -> Array<NonnullOwnPtr<Core::LocalSocket>, 2> {
-        int fds[2] = {};
-        MUST(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
-        auto socket0 = MUST(Core::LocalSocket::adopt_fd(fds[0]));
-        MUST(socket0->set_blocking(false));
-        MUST(socket0->set_close_on_exec(true));
-        auto socket1 = MUST(Core::LocalSocket::adopt_fd(fds[1]));
-        MUST(socket1->set_blocking(false));
-        MUST(socket1->set_close_on_exec(true));
-
-        return Array { move(socket0), move(socket1) };
-    };
-
-    auto sockets = create_paired_sockets();
-    m_transport = make<IPC::Transport>(move(sockets[0]));
-    m_remote_port->m_transport = make<IPC::Transport>(move(sockets[1]));
+    auto paired = MUST(IPC::Transport::create_paired());
+    m_transport = move(paired.local);
+    m_remote_port->m_transport = move(paired.remote);
 
     m_transport->set_up_read_hook([strong_this = GC::make_root(this)]() {
         if (strong_this->m_enabled)

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/Socket.h>
-#include <LibCore/System.h>
+#include <LibIPC/Transport.h>
 #include <LibWebView/WebContentClient.h>
 #include <LibWebView/WebUI.h>
 #include <LibWebView/WebUI/ProcessesUI.h>
@@ -16,19 +15,11 @@ namespace WebView {
 template<typename WebUIType>
 static ErrorOr<NonnullRefPtr<WebUIType>> create_web_ui(WebContentClient& client, String host)
 {
-    Array<int, 2> socket_fds { 0, 0 };
-    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds.data()));
+    auto paired = TRY(IPC::Transport::create_paired());
+    auto peer_fd = TRY(paired.remote->release_underlying_transport_for_transfer());
 
-    auto client_socket = Core::LocalSocket::adopt_fd(socket_fds[0]);
-    if (client_socket.is_error()) {
-        close(socket_fds[0]);
-        close(socket_fds[1]);
-
-        return client_socket.release_error();
-    }
-
-    auto web_ui = WebUIType::create(client, make<IPC::Transport>(client_socket.release_value()), move(host));
-    client.async_connect_to_web_ui(0, IPC::File::adopt_fd(socket_fds[1]));
+    auto web_ui = WebUIType::create(client, move(paired.local), move(host));
+    client.async_connect_to_web_ui(0, IPC::File::adopt_fd(peer_fd));
 
     return web_ui;
 }

--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -56,22 +56,13 @@ Messages::ImageDecoderServer::InitTransportResponse ConnectionFromClient::init_t
 
 ErrorOr<IPC::File> ConnectionFromClient::connect_new_client()
 {
-    int socket_fds[2] {};
-    if (auto err = Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds); err.is_error())
-        return err.release_error();
+    auto paired = TRY(IPC::Transport::create_paired());
+    auto peer_fd = TRY(paired.remote->release_underlying_transport_for_transfer());
 
-    auto client_socket_or_error = Core::LocalSocket::adopt_fd(socket_fds[0]);
-    if (client_socket_or_error.is_error()) {
-        (void)Core::System::close(socket_fds[0]);
-        (void)Core::System::close(socket_fds[1]);
-        return client_socket_or_error.release_error();
-    }
-
-    auto client_socket = client_socket_or_error.release_value();
     // Note: A ref is stored in the static s_connections map
-    auto client = adopt_ref(*new ConnectionFromClient(make<IPC::Transport>(move(client_socket))));
+    auto client = adopt_ref(*new ConnectionFromClient(move(paired.local)));
 
-    return IPC::File::adopt_fd(socket_fds[1]);
+    return IPC::File::adopt_fd(peer_fd);
 }
 
 Messages::ImageDecoderServer::ConnectNewClientsResponse ConnectionFromClient::connect_new_clients(size_t count)

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -139,22 +139,13 @@ Messages::RequestServer::ConnectNewClientsResponse ConnectionFromClient::connect
 
 ErrorOr<IPC::File> ConnectionFromClient::create_client_socket()
 {
-    // TODO: Mach IPC
-
-    int socket_fds[2] {};
-    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
-
-    auto client_socket = Core::LocalSocket::adopt_fd(socket_fds[0]);
-    if (client_socket.is_error()) {
-        close(socket_fds[0]);
-        close(socket_fds[1]);
-        return client_socket.release_error();
-    }
+    auto paired = TRY(IPC::Transport::create_paired());
+    auto peer_fd = TRY(paired.remote->release_underlying_transport_for_transfer());
 
     // Note: A ref is stored in the m_connections map
-    auto client = adopt_ref(*new ConnectionFromClient(make<IPC::Transport>(client_socket.release_value()), IsPrimaryConnection::No, m_connections, m_disk_cache));
+    auto client = adopt_ref(*new ConnectionFromClient(move(paired.local), IsPrimaryConnection::No, m_connections, m_disk_cache));
 
-    return IPC::File::adopt_fd(socket_fds[1]);
+    return IPC::File::adopt_fd(peer_fd);
 }
 
 void ConnectionFromClient::set_disk_cache_settings(HTTP::DiskCacheSettings disk_cache_settings)


### PR DESCRIPTION
Consolidate the repeated socketpair + adopt + configure pattern from 4 call sites into a single Transport::create_paired() factory method. This fixes inconsistent error handling and socket configuration across call sites, and prepares for future mach port support on macOS.