### PR TITLE
LibWeb: Invalidate paint cache for input/textarea on focus change

### DIFF
--- a/Libraries/LibWeb/DOM/StyleInvalidationReason.h
+++ b/Libraries/LibWeb/DOM/StyleInvalidationReason.h
@@ -19,8 +19,6 @@ namespace Web::DOM {
     X(CSSStylePropertiesTextChange)                 \
     X(CustomElementStateChange)                     \
     X(CustomStateSetChange)                         \
-    X(DidLoseFocus)                                 \
-    X(DidReceiveFocus)                              \
     X(EditingInsertion)                             \
     X(EditingDeletion)                              \
     X(ElementAttributeChange)                       \

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1472,10 +1472,10 @@ void HTMLInputElement::did_receive_focus()
 {
     if (!m_text_node)
         return;
-    m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
+    m_text_node->set_needs_repaint();
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
+        m_placeholder_text_node->set_needs_repaint();
 
     if (has_selectable_text()) {
         if (document().last_focus_trigger() == FocusTrigger::Key)
@@ -1487,12 +1487,11 @@ void HTMLInputElement::did_receive_focus()
 
 void HTMLInputElement::did_lose_focus()
 {
-    if (m_text_node) {
-        m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);
-    }
+    if (m_text_node)
+        m_text_node->set_needs_repaint();
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);
+        m_placeholder_text_node->set_needs_repaint();
 
     commit_pending_changes();
 }

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -72,10 +72,10 @@ void HTMLTextAreaElement::did_receive_focus()
 {
     if (!m_text_node)
         return;
-    m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
+    m_text_node->set_needs_repaint();
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
+        m_placeholder_text_node->set_needs_repaint();
 
     document().get_selection()->remove_all_ranges();
 }
@@ -83,10 +83,10 @@ void HTMLTextAreaElement::did_receive_focus()
 void HTMLTextAreaElement::did_lose_focus()
 {
     if (m_text_node)
-        m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);
+        m_text_node->set_needs_repaint();
 
     if (m_placeholder_text_node)
-        m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);
+        m_placeholder_text_node->set_needs_repaint();
 
     // The change event fires when the value is committed, if that makes sense for the control,
     // or else when the control loses focus

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -1,0 +1,20 @@
+AccumulatedVisualContext Tree:
+  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+    [2] clip=[9,9 200x20] (PaintableWithLines(BlockContainer<DIV>))
+      [3] clip=[11,10 196x18]
+    [4] clip=[219,9 200x20] (PaintableWithLines(BlockContainer<DIV>))
+      [5] clip=[221,10 196x18]
+
+DisplayList:
+SaveLayer@0
+  FillRect@1 rect=[8,8 202x22] color=rgb(255, 255, 255)
+  FillPath@1 path_bounding_rect=[8,8 202x22]
+  FillRect@1 rect=[218,8 202x22] color=rgb(255, 255, 255)
+  FillPath@1 path_bounding_rect=[218,8 202x22]
+  DrawGlyphRun@1 rect=[210,14 8x18] translation=[210,27.796875] color=rgb(0, 0, 0)
+  DrawGlyphRun@3 rect=[11,10 28x18] translation=[11,23.796875] color=rgb(0, 0, 0)
+  DrawGlyphRun@5 rect=[221,10 28x18] translation=[221,23.796875] color=rgb(0, 0, 0)
+  FillRect@5 rect=[221,10 1x18] color=rgb(0, 0, 0)
+  FillPath@1 path_bounding_rect=[216,6 206x26]
+Restore@0
+

--- a/Tests/LibWeb/Text/input/display_list/input-focus-switch-selection-and-caret.html
+++ b/Tests/LibWeb/Text/input/display_list/input-focus-switch-selection-and-caret.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<input id="foo" value="foo">
+<input id="bar" value="bar">
+<script>
+asyncTest(done => {
+    foo.select();
+    foo.focus();
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            bar.focus();
+            println(internals.dumpDisplayList());
+            done();
+        });
+    });
+});
+</script>


### PR DESCRIPTION
The invalidate_style() calls on text nodes in did_receive_focus() and did_lose_focus() were no-ops since Node::invalidate_style() returns early for character data nodes. Replace them with set_needs_repaint() which properly invalidates the containing PaintableWithLines' paint cache, ensuring selection highlights are cleared and the caret is repainted when switching focus between text controls.

Fixes #8363