### PR TITLE
LibWeb: Clamp saturated CSSPixels values before make_definite()

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -26,7 +26,7 @@ CSSPixels FlexFormattingContext::get_pixel_height(FlexItem const& item, CSS::Siz
     if (is_row_layout() && size.is_intrinsic_sizing_constraint()) {
         // NOTE: In a row layout, after we've determined the main size, we use that as the available width for any
         //       intrinsic sizing layout needed to resolve the height.
-        auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(item.main_size.value()) : AvailableSize::make_indefinite();
+        auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
         auto available_height = AvailableSize::make_indefinite();
         auto available_space = AvailableSpace { available_width, available_height };
         return calculate_inner_height(item.box, available_space, size);
@@ -1203,7 +1203,7 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
     // "... treating auto as fit-content"
     CSSPixels fit_content_cross_size;
     if (is_row_layout()) {
-        auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(item.main_size.value()) : AvailableSize::make_indefinite();
+        auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
         auto available_height = AvailableSize::make_indefinite();
         fit_content_cross_size = calculate_fit_content_height(item.box, AvailableSpace(available_width, available_height));
     } else {

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1373,7 +1373,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Abs
         VERIFY_NOT_REACHED();
     }
 
-    auto const available_space = AvailableSpace(AvailableSize::make_definite(containing_block_info.rect.width()), AvailableSize::make_definite(containing_block_info.rect.height()));
+    auto const available_space = AvailableSpace(AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_info.rect.width())), AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_info.rect.height())));
 
     auto& containing_block_state = m_state.get_mutable(*box.containing_block());
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1704,8 +1704,8 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
         };
 
         AvailableSpace available_space {
-            AvailableSize::make_definite(containing_block_size_for_item(item, GridDimension::Column)),
-            AvailableSize::make_definite(containing_block_size_for_item(item, GridDimension::Row))
+            AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Column))),
+            AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)))
         };
 
         auto calculate_inner_size = [this, &item, dimension, available_space](CSS::Size const& size) {
@@ -2443,9 +2443,9 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
     }
 
     auto resolve_size = [&] {
-        auto available_width = AvailableSize::make_definite(containing_block_size_for_item(item, GridDimension::Column));
+        auto available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Column)));
         if (dimension == GridDimension::Row) {
-            auto available_height = AvailableSize::make_definite(containing_block_size_for_item(item, GridDimension::Row));
+            auto available_height = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)));
             AvailableSpace item_available_space { available_width, available_height };
             return calculate_inner_height(item.box, item_available_space, preferred_size);
         }

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1740,7 +1740,7 @@ void TableFormattingContext::run(AvailableSpace const& available_space)
 
     auto const& table_state = m_state.get(table_box());
     auto caption_available_space = AvailableSpace(
-        AvailableSize::make_definite(table_state.border_box_width()),
+        AvailableSize::make_definite(clamp_to_max_dimension_value(table_state.border_box_width())),
         available_space.height);
 
     auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);

--- a/Tests/LibWeb/Crash/CSS/large-value-abspos-font-size.html
+++ b/Tests/LibWeb/Crash/CSS/large-value-abspos-font-size.html
@@ -1,0 +1,3 @@
+<div style="padding: 12em; position: absolute; font-size: 10000000px">
+  <div style="position: absolute"></div>
+</div>

--- a/Tests/LibWeb/Crash/CSS/large-value-abspos-padding.html
+++ b/Tests/LibWeb/Crash/CSS/large-value-abspos-padding.html
@@ -1,0 +1,6 @@
+<style>
+  * {
+    padding-top: calc(439804in);
+    position: absolute;
+  }
+</style>

--- a/Tests/LibWeb/Crash/CSS/large-value-abspos-transform.html
+++ b/Tests/LibWeb/Crash/CSS/large-value-abspos-transform.html
@@ -1,0 +1,3 @@
+<body style="padding: 810520769306363pt; transform: translate(50%)">
+  <div style="position: absolute"></div>
+</body>

--- a/Tests/LibWeb/Crash/CSS/large-value-flex-margin.html
+++ b/Tests/LibWeb/Crash/CSS/large-value-flex-margin.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<div style="display: flex">
+  <div style="margin: -3642924795px; flex-grow: 1"></div>
+</div>

--- a/Tests/LibWeb/Crash/CSS/large-value-grid-padding.html
+++ b/Tests/LibWeb/Crash/CSS/large-value-grid-padding.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html style="display: grid">
+  <body style="padding-right: 56030668px"></body>
+</html>

--- a/Tests/LibWeb/Crash/CSS/large-value-grid-spanning-tracks.html
+++ b/Tests/LibWeb/Crash/CSS/large-value-grid-spanning-tracks.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<div style="display: grid; grid-template-columns: 17000000px 17000000px;">
+  <div style="grid-column: 1 / -1;">content</div>
+</div>

--- a/Tests/LibWeb/Crash/CSS/large-value-table-border-box.html
+++ b/Tests/LibWeb/Crash/CSS/large-value-table-border-box.html
@@ -1,0 +1,2 @@
+<table border="2026722966"><tbody><tr><td>
+</td></tr></tbody></table>


### PR DESCRIPTION
Fixes #7971                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                         
Added clamping at the call sites to `make_definite()` to avoid crashing on large numbers. Tried finding different ways to crash but these were the only test cases I found.                                                                                                                                                                                                             

I am not 100% sure if this is the best option compared to clamping inside `make_definite()`, but from what I saw, in most cases the values were already clamped before call to `make_definite()` happens.

(This is my first PR to a FOSS project so apologies if I made any mistakes in my commits or pr description)