### PR TITLE
LibJS: Add Mov2/Mov3 instructions to reduce dispatch overhead

### DIFF
--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -372,6 +372,24 @@ handler Mov
     dispatch_next
 end
 
+handler Mov2
+    load_operand t1, m_src1
+    store_operand m_dst1, t1
+    load_operand t2, m_src2
+    store_operand m_dst2, t2
+    dispatch_next
+end
+
+handler Mov3
+    load_operand t1, m_src1
+    store_operand m_dst1, t1
+    load_operand t2, m_src2
+    store_operand m_dst2, t2
+    load_operand t3, m_src3
+    store_operand m_dst3, t3
+    dispatch_next
+end
+
 # ============================================================================
 # Arithmetic
 # ============================================================================

--- a/Libraries/LibJS/Bytecode/Bytecode.def
+++ b/Libraries/LibJS/Bytecode/Bytecode.def
@@ -637,6 +637,24 @@ op Mov < Instruction
     m_src: Operand
 endop
 
+op Mov2 < Instruction
+    @nothrow
+    m_dst1: Operand
+    m_src1: Operand
+    m_dst2: Operand
+    m_src2: Operand
+endop
+
+op Mov3 < Instruction
+    @nothrow
+    m_dst1: Operand
+    m_src1: Operand
+    m_dst2: Operand
+    m_src2: Operand
+    m_dst3: Operand
+    m_src3: Operand
+endop
+
 op Mul < Instruction
     m_dst: Operand
     m_lhs: Operand

--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -462,6 +462,64 @@ GC::Ref<Executable> Generator::compile(VM& vm, ASTNode const& node, FunctionKind
                 }
             }
 
+            // OPTIMIZATION: Merge consecutive Mov instructions into Mov2 or Mov3.
+            if (instruction.type() == Instruction::Type::Mov) {
+                auto& mov1 = static_cast<Op::Mov const&>(instruction);
+                auto it2 = it;
+                ++it2;
+                if (!it2.at_end() && (*it2).type() == Instruction::Type::Mov) {
+                    auto& mov2 = static_cast<Op::Mov const&>(*it2);
+                    // If the two Movs are identical, just emit a single Mov.
+                    if (mov1.dst() == mov2.dst() && mov1.src() == mov2.src()) {
+                        emit_source_map_entry(it.offset());
+                        bytecode.append(reinterpret_cast<u8 const*>(&mov1), mov1.length());
+                        ++it;
+                        ++it;
+                        continue;
+                    }
+                    auto it3 = it2;
+                    ++it3;
+                    if (!it3.at_end() && (*it3).type() == Instruction::Type::Mov) {
+                        auto& mov3 = static_cast<Op::Mov const&>(*it3);
+                        // Check for duplicates among the three Movs and reduce accordingly.
+                        bool mov2_is_dup = (mov2.dst() == mov1.dst() && mov2.src() == mov1.src());
+                        bool mov3_is_dup = (mov3.dst() == mov1.dst() && mov3.src() == mov1.src())
+                            || (mov3.dst() == mov2.dst() && mov3.src() == mov2.src());
+                        if (mov2_is_dup && mov3_is_dup) {
+                            // All three identical: emit single Mov.
+                            emit_source_map_entry(it.offset());
+                            bytecode.append(reinterpret_cast<u8 const*>(&mov1), mov1.length());
+                        } else if (mov2_is_dup) {
+                            // mov1 == mov2, mov3 is different: emit Mov2(mov1, mov3).
+                            Op::Mov2 merged(mov1.dst(), mov1.src(), mov3.dst(), mov3.src());
+                            emit_source_map_entry(it.offset());
+                            bytecode.append(reinterpret_cast<u8 const*>(&merged), merged.length());
+                        } else if (mov3_is_dup) {
+                            // mov3 is duplicate of mov1 or mov2: emit Mov2(mov1, mov2).
+                            Op::Mov2 merged(mov1.dst(), mov1.src(), mov2.dst(), mov2.src());
+                            emit_source_map_entry(it.offset());
+                            bytecode.append(reinterpret_cast<u8 const*>(&merged), merged.length());
+                        } else {
+                            // All three are unique: emit Mov3.
+                            Op::Mov3 merged(mov1.dst(), mov1.src(), mov2.dst(), mov2.src(), mov3.dst(), mov3.src());
+                            emit_source_map_entry(it.offset());
+                            bytecode.append(reinterpret_cast<u8 const*>(&merged), merged.length());
+                        }
+                        ++it;
+                        ++it;
+                        ++it;
+                        continue;
+                    }
+                    // Only two Movs: emit Mov2.
+                    Op::Mov2 merged(mov1.dst(), mov1.src(), mov2.dst(), mov2.src());
+                    emit_source_map_entry(it.offset());
+                    bytecode.append(reinterpret_cast<u8 const*>(&merged), merged.length());
+                    ++it;
+                    ++it;
+                    continue;
+                }
+            }
+
             instruction.visit_labels([&](Label& label) {
                 size_t label_offset = bytecode.size() + (bit_cast<FlatPtr>(&label) - bit_cast<FlatPtr>(&instruction));
                 label_offsets.append(label_offset);

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -492,6 +492,21 @@ void Interpreter::run_bytecode(size_t entry_point)
             DISPATCH_NEXT(Mov);
         }
 
+        handle_Mov2: {
+            auto& instruction = *reinterpret_cast<Op::Mov2 const*>(&bytecode[program_counter]);
+            set(instruction.dst1(), get(instruction.src1()));
+            set(instruction.dst2(), get(instruction.src2()));
+            DISPATCH_NEXT(Mov2);
+        }
+
+        handle_Mov3: {
+            auto& instruction = *reinterpret_cast<Op::Mov3 const*>(&bytecode[program_counter]);
+            set(instruction.dst1(), get(instruction.src1()));
+            set(instruction.dst2(), get(instruction.src2()));
+            set(instruction.dst3(), get(instruction.src3()));
+            DISPATCH_NEXT(Mov3);
+        }
+
         handle_End: {
             auto& instruction = *reinterpret_cast<Op::End const*>(&bytecode[program_counter]);
             auto value = get(instruction.value());

--- a/Libraries/LibJS/Rust/src/bytecode/generator.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/generator.rs
@@ -1318,6 +1318,96 @@ impl Generator {
             }
         }
 
+        // Phase 1b: Peephole optimization - merge consecutive Mov instructions into Mov2/Mov3.
+        for block in &mut self.basic_blocks {
+            let mut i = 0;
+            while i < block.instructions.len() {
+                if !matches!(block.instructions[i].0, Instruction::Mov { .. }) {
+                    i += 1;
+                    continue;
+                }
+                let (dst1, src1) = match &block.instructions[i].0 {
+                    Instruction::Mov { dst, src } => (*dst, *src),
+                    _ => unreachable!(),
+                };
+                // Check for a second consecutive Mov.
+                if i + 1 < block.instructions.len()
+                    && let Instruction::Mov { dst, src } = &block.instructions[i + 1].0
+                {
+                    let (dst2, src2) = (*dst, *src);
+                    // Identical Movs: deduplicate to a single Mov.
+                    if dst1 == dst2 && src1 == src2 {
+                        block.instructions.remove(i + 1);
+                        continue; // Re-check from same position.
+                    }
+                    // Check for a third consecutive Mov.
+                    if i + 2 < block.instructions.len()
+                        && let Instruction::Mov { dst, src } = &block.instructions[i + 2].0
+                    {
+                        let (dst3, src3) = (*dst, *src);
+                        let mov2_is_dup = dst2 == dst1 && src2 == src1;
+                        let mov3_is_dup =
+                            (dst3 == dst1 && src3 == src1) || (dst3 == dst2 && src3 == src2);
+                        if mov2_is_dup && mov3_is_dup {
+                            // All three identical: keep single Mov.
+                            block.instructions.remove(i + 2);
+                            block.instructions.remove(i + 1);
+                            continue;
+                        } else if mov2_is_dup {
+                            // mov1 == mov2, mov3 different: Mov2(mov1, mov3).
+                            block.instructions[i].0 = Instruction::Mov2 {
+                                dst1,
+                                src1,
+                                dst2: dst3,
+                                src2: src3,
+                            };
+                            block.instructions.remove(i + 2);
+                            block.instructions.remove(i + 1);
+                            i += 1;
+                            continue;
+                        } else if mov3_is_dup {
+                            // mov3 is dup: Mov2(mov1, mov2).
+                            block.instructions[i].0 = Instruction::Mov2 {
+                                dst1,
+                                src1,
+                                dst2,
+                                src2,
+                            };
+                            block.instructions.remove(i + 2);
+                            block.instructions.remove(i + 1);
+                            i += 1;
+                            continue;
+                        } else {
+                            // All three unique: Mov3.
+                            block.instructions[i].0 = Instruction::Mov3 {
+                                dst1,
+                                src1,
+                                dst2,
+                                src2,
+                                dst3,
+                                src3,
+                            };
+                            block.instructions.remove(i + 2);
+                            block.instructions.remove(i + 1);
+                            i += 1;
+                            continue;
+                        }
+                    }
+                    // Only two unique Movs: Mov2.
+                    block.instructions[i].0 = Instruction::Mov2 {
+                        dst1,
+                        src1,
+                        dst2,
+                        src2,
+                    };
+                    block.instructions.remove(i + 1);
+                    i += 1;
+                    continue;
+                }
+                i += 1;
+            }
+        }
+
         // Phase 2: Compute block byte offsets, applying assembly-time optimizations.
         // These match the C++ Generator.cpp:compile() optimizations:
         //   - Skip Jump-to-next-block

--- a/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
+++ b/Tests/LibJS/Bytecode/expected/arguments-with-arguments-fn.txt
@@ -8,7 +8,6 @@ JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       JumpUndefined condition:arg0, true_target:@18, false_target:@28
 [  18]    1: Mov dst:arg0, src:Int32(1)
-[  28]    2: Mov dst:reg5, src:Undefined
-[  38]       Mov dst:arguments~0, src:reg5
-[  48]       NewFunction dst:arguments~0, shared_function_data_index:0
-[  60]       End value:Undefined
+[  28]    2: Mov2 dst1:reg5, src1:Undefined, dst2:arguments~0, src2:reg5
+[  40]       NewFunction dst:arguments~0, shared_function_data_index:0
+[  58]       End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-argument-no-tdz.txt
@@ -6,6 +6,5 @@ JS bytecode executable ""
 
 JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:y~0, src:Int32(1)
-[  18]       Mov dst:arg0, src:y~0
-[  28]       Return value:arg0
+[   8]       Mov2 dst1:y~0, src1:Int32(1), dst2:arg0, src2:y~0
+[  20]       Return value:arg0

--- a/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/assign-to-let-variable-tdz.txt
@@ -16,16 +16,15 @@ JS bytecode executable "f"
 [  48]       Typeof dst:reg5, src:a~0
 [  58]       LooselyEquals dst:reg6, lhs:String("string"), rhs:reg5
 [  68]       Mov dst:reg5, src:reg6
-[  78]       JumpFalse condition:reg6, target:@108
+[  78]       JumpFalse condition:reg6, target:@100
 [  88]    1: GetGlobal dst:reg8, identifier:g
 [  a0]       ThrowIfTDZ src:a~0
 [  a8]       Mov dst:reg9, src:a~0
 [  b8]       Call dst:reg7, callee:reg8, this_value:Undefined, g, arguments:[reg9]
 [  e0]       ThrowIfTDZ src:a~0
-[  e8]       Mov dst:a~0, src:reg7
-[  f8]       Mov dst:reg5, src:reg7
-[ 108]    2: ThrowIfTDZ src:a~0
-[ 110]       Return value:a~0
+[  e8]       Mov2 dst1:a~0, src1:reg7, dst2:reg5, src2:reg7
+[ 100]    2: ThrowIfTDZ src:a~0
+[ 108]       Return value:a~0
 
 JS bytecode executable "g"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoped-function-no-tdz.txt
@@ -9,12 +9,11 @@ JS bytecode executable "test"
 [   8]       Mov dst:result~1, src:Undefined
 [  18]       CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
 [  28]       NewFunction dst:reg6, shared_function_data_index:0
-[  40]       Mov dst:foo~0, src:reg6
-[  50]       Mov dst:reg7, src:foo~0
-[  60]       Call dst:reg6, callee:reg7, this_value:Undefined, foo
-[  80]       Mov dst:result~1, src:reg6
-[  90]       SetLexicalEnvironment environment:reg4
-[  98]       Return value:result~1
+[  40]       Mov2 dst1:foo~0, src1:reg6, dst2:reg7, src2:foo~0
+[  58]       Call dst:reg6, callee:reg7, this_value:Undefined, foo
+[  78]       Mov dst:result~1, src:reg6
+[  88]       SetLexicalEnvironment environment:reg4
+[  90]       Return value:result~1
 
 JS bytecode executable "foo"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/block-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/block-scoping.txt
@@ -52,25 +52,24 @@ JS bytecode executable ""
 
 JS bytecode executable "breakThroughBlockScopes"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:result~2, src:Undefined
-[  18]       Mov dst:i~1, src:Int32(0)
-[  28]       Jump target:@c0
-[  30]    1: CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
-[  40]       CreateMutableBinding environment:reg5, identifier:x, can_be_deleted:false
-[  50]       InitializeLexicalBinding identifier:x, src:i~1
-[  68]       NewFunction dst:f~0, shared_function_data_index:0, lhs_name:f
-[  80]       GetBinding dst:reg6, identifier:x
-[  98]       JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:@110, false_target:@130
-[  b0]    2: PostfixIncrement dst:reg5, src:i~1
-[  c0]    3: JumpLessThan lhs:i~1, rhs:Int32(3), true_target:@30, false_target:@d8
-[  d8]    4: Mov dst:reg6, src:result~2
-[  e8]       Call dst:reg5, callee:reg6, this_value:Undefined, result
-[ 108]       Return value:reg5
-[ 110]    5: Mov dst:result~2, src:f~0
-[ 120]       SetLexicalEnvironment environment:reg4
-[ 128]       Jump target:@d8
-[ 130]    6: SetLexicalEnvironment environment:reg4
-[ 138]       Jump target:@b0
+[   8]       Mov2 dst1:result~2, src1:Undefined, dst2:i~1, src2:Int32(0)
+[  20]       Jump target:@b8
+[  28]    1: CreateLexicalEnvironment dst:reg5, parent:reg4, capacity:0
+[  38]       CreateMutableBinding environment:reg5, identifier:x, can_be_deleted:false
+[  48]       InitializeLexicalBinding identifier:x, src:i~1
+[  60]       NewFunction dst:f~0, shared_function_data_index:0, lhs_name:f
+[  78]       GetBinding dst:reg6, identifier:x
+[  90]       JumpGreaterThan lhs:reg6, rhs:Int32(1), true_target:@108, false_target:@128
+[  a8]    2: PostfixIncrement dst:reg5, src:i~1
+[  b8]    3: JumpLessThan lhs:i~1, rhs:Int32(3), true_target:@28, false_target:@d0
+[  d0]    4: Mov dst:reg6, src:result~2
+[  e0]       Call dst:reg5, callee:reg6, this_value:Undefined, result
+[ 100]       Return value:reg5
+[ 108]    5: Mov dst:result~2, src:f~0
+[ 118]       SetLexicalEnvironment environment:reg4
+[ 120]       Jump target:@d0
+[ 128]    6: SetLexicalEnvironment environment:reg4
+[ 130]       Jump target:@a8
 
 JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
+++ b/Tests/LibJS/Bytecode/expected/catch-scope-boundary.txt
@@ -15,23 +15,22 @@ JS bytecode executable ""
 JS bytecode executable "throwInCatch"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       Mov dst:result~2, src:String("bad")
-[  18]       Jump target:@90
+[  18]       Jump target:@88
 [  20]    1: Catch dst:reg5
 [  28]       SetLexicalEnvironment environment:reg4
 [  30]       Mov dst:e~1, src:reg5
-[  40]       Jump target:@80
+[  40]       Jump target:@78
 [  48]    2: Catch dst:reg6
 [  50]       SetLexicalEnvironment environment:reg4
-[  58]       Mov dst:e2~0, src:reg6
-[  68]       Mov dst:result~2, src:String("good")
-[  78]    3: Return value:result~2
-[  80]    4: Throw src:Int32(2)
-[  88]    5: Return value:result~2
-[  90]    6: Throw src:Int32(1)
+[  58]       Mov2 dst1:e2~0, src1:reg6, dst2:result~2, src2:String("good")
+[  70]    3: Return value:result~2
+[  78]    4: Throw src:Int32(2)
+[  80]    5: Return value:result~2
+[  88]    6: Throw src:Int32(1)
 
 Exception handlers:
-    from   80 to   88 handler   48
-    from   90 to   98 handler   20
+    from   78 to   80 handler   48
+    from   88 to   90 handler   20
 
 JS bytecode executable "throwInCatchWithLocals"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/chained-member-call.txt
+++ b/Tests/LibJS/Bytecode/expected/chained-member-call.txt
@@ -1,32 +1,28 @@
 JS bytecode executable ""
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Jump target:@48
+[   8]       Jump target:@40
 [  10]    1: Catch dst:reg5
 [  18]       SetLexicalEnvironment environment:reg4
-[  20]       Mov dst:reg6, src:Undefined
-[  30]       Mov dst:reg7, src:reg6
-[  40]    2: Jump target:@100
-[  48]    3: Mov dst:reg5, src:Undefined
-[  58]       GetGlobal dst:reg8, identifier:chained_computed_call
-[  70]       Call dst:reg6, callee:reg8, this_value:Undefined, chained_computed_call, arguments:[Int32(0), Int32(0), Int32(0)]
-[  a0]       Mov dst:reg5, src:reg6
-[  b0]       Mov dst:reg6, src:reg5
-[  c0]       Jump target:@40
-[  c8]    4: Catch dst:reg5
-[  d0]       SetLexicalEnvironment environment:reg4
-[  d8]       Mov dst:reg7, src:Undefined
-[  e8]       Mov dst:reg8, src:reg7
-[  f8]    5: End value:reg7
-[ 100]    6: Mov dst:reg5, src:Undefined
-[ 110]       GetGlobal dst:reg9, identifier:chained_dot_call
-[ 128]       Call dst:reg7, callee:reg9, this_value:Undefined, chained_dot_call, arguments:[Int32(0)]
-[ 150]       Mov dst:reg5, src:reg7
-[ 160]       Mov dst:reg7, src:reg5
-[ 170]       End value:reg7
+[  20]       Mov2 dst1:reg6, src1:Undefined, dst2:reg7, src2:reg6
+[  38]    2: Jump target:@e8
+[  40]    3: Mov dst:reg5, src:Undefined
+[  50]       GetGlobal dst:reg8, identifier:chained_computed_call
+[  68]       Call dst:reg6, callee:reg8, this_value:Undefined, chained_computed_call, arguments:[Int32(0), Int32(0), Int32(0)]
+[  98]       Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+[  b0]       Jump target:@38
+[  b8]    4: Catch dst:reg5
+[  c0]       SetLexicalEnvironment environment:reg4
+[  c8]       Mov2 dst1:reg7, src1:Undefined, dst2:reg8, src2:reg7
+[  e0]    5: End value:reg7
+[  e8]    6: Mov dst:reg5, src:Undefined
+[  f8]       GetGlobal dst:reg9, identifier:chained_dot_call
+[ 110]       Call dst:reg7, callee:reg9, this_value:Undefined, chained_dot_call, arguments:[Int32(0)]
+[ 138]       Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
+[ 150]       End value:reg7
 
 Exception handlers:
-    from   48 to   c8 handler   10
-    from  100 to  178 handler   c8
+    from   40 to   b8 handler   10
+    from   e8 to  158 handler   b8
 
 JS bytecode executable "chained_computed_call"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
+++ b/Tests/LibJS/Bytecode/expected/computed-member-compound-assign.txt
@@ -24,7 +24,6 @@ JS bytecode executable "compound_then_assign"
 [  20]       Mov dst:reg6, src:arg1
 [  30]       Add dst:reg7, lhs:reg5, rhs:Int32(0)
 [  40]       PutByValue base:arg0, property:reg6, src:reg7, kind:Normal
-[  58]       Mov dst:reg5, src:arg0
-[  68]       Mov dst:reg6, src:arg1
-[  78]       PutByValue base:reg5, property:reg6, src:arg1, kind:Normal, base_identifier:imag
-[  90]       End value:Undefined
+[  58]       Mov2 dst1:reg5, src1:arg0, dst2:reg6, src2:arg1
+[  70]       PutByValue base:reg5, property:reg6, src:arg1, kind:Normal, base_identifier:imag
+[  88]       End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/const-assignment-no-extra-tdz.txt
@@ -1,21 +1,18 @@
 JS bytecode executable ""
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Jump target:@58
+[   8]       Jump target:@48
 [  10]    1: Catch dst:reg5
 [  18]       SetLexicalEnvironment environment:reg4
-[  20]       Mov dst:e~0, src:reg5
-[  30]       Mov dst:reg6, src:Undefined
-[  40]       Mov dst:reg7, src:reg6
-[  50]    2: End value:reg6
-[  58]    3: Mov dst:reg5, src:Undefined
-[  68]       GetGlobal dst:reg8, identifier:f
-[  80]       Call dst:reg6, callee:reg8, this_value:Undefined, f
-[  a0]       Mov dst:reg5, src:reg6
-[  b0]       Mov dst:reg6, src:reg5
-[  c0]       End value:reg6
+[  20]       Mov3 dst1:e~0, src1:reg5, dst2:reg6, src2:Undefined, dst3:reg7, src3:reg6
+[  40]    2: End value:reg6
+[  48]    3: Mov dst:reg5, src:Undefined
+[  58]       GetGlobal dst:reg8, identifier:f
+[  70]       Call dst:reg6, callee:reg8, this_value:Undefined, f
+[  90]       Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+[  a8]       End value:reg6
 
 Exception handlers:
-    from   58 to   c8 handler   10
+    from   48 to   b0 handler   10
 
 JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-expression-register.txt
@@ -7,11 +7,9 @@ JS bytecode executable ""
 JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       CreateArguments dst:arguments~0, is_immutable:false
-[  18]       Mov dst:x~1, src:Undefined
-[  28]       Mov dst:x~1, src:Bool(false)
-[  38]       Mov dst:reg5, src:x~1
-[  48]       JumpTrue condition:x~1, target:@78
-[  58]    1: DeleteByValue dst:reg6, base:arguments~0, property:Int32(0)
-[  68]       Mov dst:reg5, src:reg6
-[  78]    2: Mov dst:x~1, src:reg5
-[  88]       Return value:x~1
+[  18]       Mov3 dst1:x~1, src1:Undefined, dst2:x~1, src2:Bool(false), dst3:reg5, src3:x~1
+[  38]       JumpTrue condition:x~1, target:@68
+[  48]    1: DeleteByValue dst:reg6, base:arguments~0, property:Int32(0)
+[  58]       Mov dst:reg5, src:reg6
+[  68]    2: Mov dst:x~1, src:reg5
+[  78]       Return value:x~1

--- a/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-eval-order.txt
@@ -5,23 +5,21 @@ JS bytecode executable ""
 [  28]       SetLexicalEnvironment environment:reg4
 [  30]       NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("m")]
 [  58]       InitializeLexicalBinding identifier:A, src:reg6
-[  70]       Jump target:@b0
+[  70]       Jump target:@a8
 [  78]    1: Catch dst:reg5
 [  80]       SetLexicalEnvironment environment:reg4
-[  88]       Mov dst:reg6, src:Undefined
-[  98]       Mov dst:reg7, src:reg6
-[  a8]    2: End value:reg6
-[  b0]    3: Mov dst:reg5, src:Undefined
-[  c0]       GetGlobal dst:reg9, identifier:A
-[  d8]       CallConstruct dst:reg8, callee:reg9, A
-[  f0]       GetById dst:reg9, base:reg8, property:m
-[ 110]       Call dst:reg6, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
-[ 138]       Mov dst:reg5, src:reg6
-[ 148]       Mov dst:reg6, src:reg5
-[ 158]       End value:reg6
+[  88]       Mov2 dst1:reg6, src1:Undefined, dst2:reg7, src2:reg6
+[  a0]    2: End value:reg6
+[  a8]    3: Mov dst:reg5, src:Undefined
+[  b8]       GetGlobal dst:reg9, identifier:A
+[  d0]       CallConstruct dst:reg8, callee:reg9, A
+[  e8]       GetById dst:reg9, base:reg8, property:m
+[ 108]       Call dst:reg6, callee:reg9, this_value:reg8, <object>.m, arguments:[String("x")]
+[ 130]       Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+[ 148]       End value:reg6
 
 Exception handlers:
-    from   b0 to  160 handler   78
+    from   a8 to  150 handler   78
 
 JS bytecode executable "A"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/delete-super-property.txt
+++ b/Tests/LibJS/Bytecode/expected/delete-super-property.txt
@@ -5,39 +5,33 @@ JS bytecode executable ""
 [  28]       SetLexicalEnvironment environment:reg4
 [  30]       NewClass dst:reg6, class_environment:reg5, class_blueprint_index:0, element_keys:[element_keys:String("foo"), element_keys:String("baz")]
 [  58]       InitializeLexicalBinding identifier:A, src:reg6
-[  70]       Jump target:@c0
+[  70]       Jump target:@b0
 [  78]    1: Catch dst:reg5
 [  80]       SetLexicalEnvironment environment:reg4
-[  88]       Mov dst:e~0, src:reg5
-[  98]       Mov dst:reg6, src:Undefined
-[  a8]       Mov dst:reg7, src:reg6
-[  b8]    2: Jump target:@1b0
-[  c0]    3: Mov dst:reg5, src:Undefined
-[  d0]       GetGlobal dst:reg9, identifier:A
-[  e8]       CallConstruct dst:reg8, callee:reg9, A
-[ 100]       GetById dst:reg9, base:reg8, property:foo
-[ 120]       Call dst:reg6, callee:reg9, this_value:reg8, <object>.foo
-[ 140]       Mov dst:reg5, src:reg6
-[ 150]       Mov dst:reg6, src:reg5
-[ 160]       Jump target:@b8
-[ 168]    4: Catch dst:reg5
-[ 170]       SetLexicalEnvironment environment:reg4
-[ 178]       Mov dst:e~1, src:reg5
-[ 188]       Mov dst:reg7, src:Undefined
-[ 198]       Mov dst:reg8, src:reg7
-[ 1a8]    5: End value:reg7
-[ 1b0]    6: Mov dst:reg5, src:Undefined
-[ 1c0]       GetGlobal dst:reg10, identifier:A
-[ 1d8]       CallConstruct dst:reg9, callee:reg10, A
-[ 1f0]       GetById dst:reg10, base:reg9, property:baz
-[ 210]       Call dst:reg7, callee:reg10, this_value:reg9, <object>.baz
-[ 230]       Mov dst:reg5, src:reg7
-[ 240]       Mov dst:reg7, src:reg5
-[ 250]       End value:reg7
+[  88]       Mov3 dst1:e~0, src1:reg5, dst2:reg6, src2:Undefined, dst3:reg7, src3:reg6
+[  a8]    2: Jump target:@188
+[  b0]    3: Mov dst:reg5, src:Undefined
+[  c0]       GetGlobal dst:reg9, identifier:A
+[  d8]       CallConstruct dst:reg8, callee:reg9, A
+[  f0]       GetById dst:reg9, base:reg8, property:foo
+[ 110]       Call dst:reg6, callee:reg9, this_value:reg8, <object>.foo
+[ 130]       Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+[ 148]       Jump target:@a8
+[ 150]    4: Catch dst:reg5
+[ 158]       SetLexicalEnvironment environment:reg4
+[ 160]       Mov3 dst1:e~1, src1:reg5, dst2:reg7, src2:Undefined, dst3:reg8, src3:reg7
+[ 180]    5: End value:reg7
+[ 188]    6: Mov dst:reg5, src:Undefined
+[ 198]       GetGlobal dst:reg10, identifier:A
+[ 1b0]       CallConstruct dst:reg9, callee:reg10, A
+[ 1c8]       GetById dst:reg10, base:reg9, property:baz
+[ 1e8]       Call dst:reg7, callee:reg10, this_value:reg9, <object>.baz
+[ 208]       Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
+[ 220]       End value:reg7
 
 Exception handlers:
-    from   c0 to  168 handler   78
-    from  1b0 to  258 handler  168
+    from   b0 to  150 handler   78
+    from  188 to  228 handler  150
 
 JS bytecode executable "A"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/destructuring-assignment-in-logical-and.txt
@@ -6,29 +6,26 @@ JS bytecode executable ""
 
 JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:a~0, src:Undefined
-[  18]       Mov dst:b~1, src:Undefined
-[  28]       Mov dst:reg5, src:arg0
-[  38]       JumpFalse condition:arg0, target:@e0
-[  48]    1: Mov dst:reg7, src:arg0
-[  58]       Mov dst:reg8, src:arg1
-[  68]       Call dst:reg6, callee:reg7, this_value:Undefined, t, arguments:[reg8]
-[  90]       Mov dst:reg7, src:Bool(false)
-[  a0]       GetIterator dst_iterator_object:reg8, dst_iterator_next:reg9, dst_iterator_done:reg10, iterable:reg6
-[  b8]       IteratorNextUnpack dst_value:reg11, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
-[  d0]       JumpIf condition:reg7, true_target:@e8, false_target:@100
-[  e0]    2: End value:Undefined
-[  e8]    3: Mov dst:reg11, src:Undefined
-[  f8]       Jump target:@100
-[ 100]    4: Mov dst:a~0, src:reg11
-[ 110]       JumpFalse condition:reg7, target:@138
-[ 120]    5: Mov dst:reg11, src:Undefined
-[ 130]       Jump target:@160
-[ 138]    6: IteratorNextUnpack dst_value:reg11, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
-[ 150]       JumpTrue condition:reg7, target:@120
-[ 160]    7: Mov dst:b~1, src:reg11
-[ 170]       JumpFalse condition:reg7, target:@198
-[ 180]    8: Mov dst:reg5, src:reg6
-[ 190]       Jump target:@e0
-[ 198]    9: IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:Undefined
-[ 1b0]       Jump target:@180
+[   8]       Mov3 dst1:a~0, src1:Undefined, dst2:b~1, src2:Undefined, dst3:reg5, src3:arg0
+[  28]       JumpFalse condition:arg0, target:@c8
+[  38]    1: Mov2 dst1:reg7, src1:arg0, dst2:reg8, src2:arg1
+[  50]       Call dst:reg6, callee:reg7, this_value:Undefined, t, arguments:[reg8]
+[  78]       Mov dst:reg7, src:Bool(false)
+[  88]       GetIterator dst_iterator_object:reg8, dst_iterator_next:reg9, dst_iterator_done:reg10, iterable:reg6
+[  a0]       IteratorNextUnpack dst_value:reg11, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
+[  b8]       JumpIf condition:reg7, true_target:@d0, false_target:@e8
+[  c8]    2: End value:Undefined
+[  d0]    3: Mov dst:reg11, src:Undefined
+[  e0]       Jump target:@e8
+[  e8]    4: Mov dst:a~0, src:reg11
+[  f8]       JumpFalse condition:reg7, target:@120
+[ 108]    5: Mov dst:reg11, src:Undefined
+[ 118]       Jump target:@148
+[ 120]    6: IteratorNextUnpack dst_value:reg11, dst_done:reg7, iterator_object:reg8, iterator_next:reg9, iterator_done:reg10
+[ 138]       JumpTrue condition:reg7, target:@108
+[ 148]    7: Mov dst:b~1, src:reg11
+[ 158]       JumpFalse condition:reg7, target:@180
+[ 168]    8: Mov dst:reg5, src:reg6
+[ 178]       Jump target:@c8
+[ 180]    9: IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg10, completion_value:Undefined
+[ 198]       Jump target:@168

--- a/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
+++ b/Tests/LibJS/Bytecode/expected/do-while-register-allocation.txt
@@ -6,17 +6,16 @@ JS bytecode executable ""
 
 JS bytecode executable "test"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:i~0, src:Undefined
-[  18]       Mov dst:i~0, src:Int32(0)
-[  28]       GetGlobal dst:reg6, identifier:foo
-[  40]       NewArray dst:reg7
-[  50]       Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
-[  78]    1: GetGlobal dst:reg7, identifier:bar
-[  90]       Mov dst:reg8, src:i~0
-[  a0]       Call dst:reg6, callee:reg7, this_value:Undefined, bar, arguments:[reg8]
-[  c8]       PostfixIncrement dst:reg6, src:i~0
-[  d8]    2: JumpLessThan lhs:i~0, rhs:Int32(7), true_target:@78, false_target:@f0
-[  f0]    3: End value:Undefined
+[   8]       Mov2 dst1:i~0, src1:Undefined, dst2:i~0, src2:Int32(0)
+[  20]       GetGlobal dst:reg6, identifier:foo
+[  38]       NewArray dst:reg7
+[  48]       Call dst:reg5, callee:reg6, this_value:Undefined, foo, arguments:[reg7]
+[  70]    1: GetGlobal dst:reg7, identifier:bar
+[  88]       Mov dst:reg8, src:i~0
+[  98]       Call dst:reg6, callee:reg7, this_value:Undefined, bar, arguments:[reg8]
+[  c0]       PostfixIncrement dst:reg6, src:i~0
+[  d0]    2: JumpLessThan lhs:i~0, rhs:Int32(7), true_target:@70, false_target:@e8
+[  e8]    3: End value:Undefined
 
 JS bytecode executable "foo"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/for-in-register-lifetime.txt
@@ -26,5 +26,4 @@ JS bytecode executable ""
 [ 1d0]       Add dst:reg12, lhs:reg11, rhs:reg13
 [ 1e0]       SetGlobal identifier:result, src:reg12
 [ 1f8]       Mov dst:reg5, src:reg12
-[ 208]       Mov dst:reg5, src:reg12
-[ 218]       Jump target:@d0
+[ 208]       Jump target:@d0

--- a/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iteration-env-capacity.txt
@@ -10,18 +10,17 @@ JS bytecode executable ""
 [  90]    3: Catch dst:reg10
 [  98]       SetLexicalEnvironment environment:reg4
 [  a0]       Mov dst:reg9, src:Int32(1)
-[  b0]    4: JumpStrictlyEquals lhs:reg9, rhs:Int32(1), true_target:@108, false_target:@128
+[  b0]    4: JumpStrictlyEquals lhs:reg9, rhs:Int32(1), true_target:@f8, false_target:@118
 [  c8]    5: Mov dst:x~0, src:reg11
 [  d8]       ThrowIfTDZ src:x~0
 [  e0]       Mov dst:reg5, src:x~0
-[  f0]       Mov dst:reg5, src:x~0
-[ 100]       Jump target:@68
-[ 108]    6: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg10
-[ 120]       Throw src:reg10
-[ 128]    7: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-[ 140]       JumpStrictlyEquals lhs:reg9, rhs:Int32(2), true_target:@158, false_target:@160
-[ 158]    8: Return value:reg10
-[ 160]    9: Throw src:reg10
+[  f0]       Jump target:@68
+[  f8]    6: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg10
+[ 110]       Throw src:reg10
+[ 118]    7: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
+[ 130]       JumpStrictlyEquals lhs:reg9, rhs:Int32(2), true_target:@148, false_target:@150
+[ 148]    8: Return value:reg10
+[ 150]    9: Throw src:reg10
 
 Exception handlers:
-    from   c8 to  108 handler   90
+    from   c8 to   f8 handler   90

--- a/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
+++ b/Tests/LibJS/Bytecode/expected/for-of-iterator-close.txt
@@ -49,21 +49,20 @@ JS bytecode executable "forOfReturn"
 [  80]    3: Catch dst:reg9
 [  88]       SetLexicalEnvironment environment:reg4
 [  90]       Mov dst:reg5, src:Int32(1)
-[  a0]    4: JumpStrictlyEquals lhs:reg5, rhs:Int32(1), true_target:@f8, false_target:@118
+[  a0]    4: JumpStrictlyEquals lhs:reg5, rhs:Int32(1), true_target:@f0, false_target:@110
 [  b8]    5: Mov dst:x~0, src:reg10
 [  c8]       ThrowIfTDZ src:x~0
-[  d0]       Mov dst:reg9, src:x~0
-[  e0]       Mov dst:reg5, src:Int32(2)
-[  f0]       Jump target:@a0
-[  f8]    6: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
-[ 110]       Throw src:reg9
-[ 118]    7: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
-[ 130]       JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@148, false_target:@150
-[ 148]    8: Return value:reg9
-[ 150]    9: Throw src:reg9
+[  d0]       Mov2 dst1:reg9, src1:x~0, dst2:reg5, src2:Int32(2)
+[  e8]       Jump target:@a0
+[  f0]    6: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:reg9
+[ 108]       Throw src:reg9
+[ 110]    7: IteratorClose iterator_object:reg6, iterator_next:reg7, iterator_done:reg8, completion_value:Undefined
+[ 128]       JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@140, false_target:@148
+[ 140]    8: Return value:reg9
+[ 148]    9: Throw src:reg9
 
 Exception handlers:
-    from   b8 to   f8 handler   80
+    from   b8 to   f0 handler   80
 
 JS bytecode executable "forAwaitOfBreak"
 [   0]    0: Yield continuation_label:@10, value:Undefined

--- a/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/for-try-finally-continue.txt
@@ -3,7 +3,7 @@ JS bytecode executable ""
 [   8]       SetGlobal identifier:i, src:Int32(0)
 [  20]       Mov dst:reg5, src:Undefined
 [  30]       Jump target:@80
-[  38]    1: Jump target:@198
+[  38]    1: Jump target:@188
 [  40]    2: GetGlobal dst:reg6, identifier:i
 [  58]       PostfixIncrement dst:reg7, src:reg6
 [  68]       SetGlobal identifier:i, src:reg6
@@ -12,33 +12,28 @@ JS bytecode executable ""
 [  b0]    4: GetGlobal dst:reg6, identifier:i
 [  c8]       StrictlyInequals dst:reg7, lhs:reg6, rhs:Int32(5)
 [  d8]       Mov dst:reg6, src:Undefined
-[  e8]       JumpIf condition:reg7, true_target:@238, false_target:@240
+[  e8]       JumpIf condition:reg7, true_target:@208, false_target:@210
 [  f8]    5: Catch dst:reg7
 [ 100]       SetLexicalEnvironment environment:reg4
 [ 108]       Mov dst:reg6, src:Int32(1)
 [ 118]    6: Mov dst:reg9, src:Undefined
-[ 128]       JumpStrictlyEquals lhs:reg6, rhs:Int32(0), true_target:@1d0, false_target:@1f8
+[ 128]       JumpStrictlyEquals lhs:reg6, rhs:Int32(0), true_target:@1b0, false_target:@1c8
 [ 140]    7: Catch dst:reg8
 [ 148]       SetLexicalEnvironment environment:reg4
-[ 150]       Mov dst:e~0, src:reg8
-[ 160]       Mov dst:reg9, src:Undefined
-[ 170]       Mov dst:reg10, src:reg9
-[ 180]       Mov dst:reg6, src:Int32(0)
-[ 190]       Jump target:@118
-[ 198]    8: Mov dst:reg8, src:Undefined
-[ 1a8]       Mov dst:reg5, src:reg8
-[ 1b8]       Mov dst:reg6, src:Int32(3)
-[ 1c8]       Jump target:@118
-[ 1d0]    9: Mov dst:reg5, src:reg10
-[ 1e0]       Mov dst:reg5, src:reg10
-[ 1f0]       Jump target:@40
-[ 1f8]   10: JumpStrictlyEquals lhs:reg6, rhs:Int32(3), true_target:@40, false_target:@210
-[ 210]   11: JumpStrictlyEquals lhs:reg6, rhs:Int32(2), true_target:@228, false_target:@230
-[ 228]   12: Return value:reg7
-[ 230]   13: Throw src:reg7
-[ 238]   14: Throw src:String("bad")
-[ 240]   15: End value:reg6
+[ 150]       Mov3 dst1:e~0, src1:reg8, dst2:reg9, src2:Undefined, dst3:reg10, src3:reg9
+[ 170]       Mov dst:reg6, src:Int32(0)
+[ 180]       Jump target:@118
+[ 188]    8: Mov3 dst1:reg8, src1:Undefined, dst2:reg5, src2:reg8, dst3:reg6, src3:Int32(3)
+[ 1a8]       Jump target:@118
+[ 1b0]    9: Mov dst:reg5, src:reg10
+[ 1c0]       Jump target:@40
+[ 1c8]   10: JumpStrictlyEquals lhs:reg6, rhs:Int32(3), true_target:@40, false_target:@1e0
+[ 1e0]   11: JumpStrictlyEquals lhs:reg6, rhs:Int32(2), true_target:@1f8, false_target:@200
+[ 1f8]   12: Return value:reg7
+[ 200]   13: Throw src:reg7
+[ 208]   14: Throw src:String("bad")
+[ 210]   15: End value:reg6
 
 Exception handlers:
-    from  140 to  198 handler   f8
-    from  198 to  1d0 handler  140
+    from  140 to  188 handler   f8
+    from  188 to  1b0 handler  140

--- a/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-finally.txt
@@ -12,39 +12,36 @@ JS bytecode executable "f"
 [  28]       SetLexicalEnvironment environment:reg4
 [  30]       Mov dst:reg5, src:Int32(1)
 [  40]    3: Mov dst:reg10, src:reg1
-[  50]       Yield continuation_label:@198, value:Int32(3)
+[  50]       Yield continuation_label:@188, value:Int32(3)
 [  60]    4: Yield continuation_label:@70, value:Int32(1)
 [  70]    5: Mov dst:reg7, src:reg0
 [  80]       GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
 [  90]       JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:@a8, false_target:@b8
-[  a8]    6: Yield continuation_label:@100, value:Int32(2)
+[  a8]    6: Yield continuation_label:@f8, value:Int32(2)
 [  b8]    7: JumpStrictlyEquals lhs:reg8, rhs:Int32(5), true_target:@d0, false_target:@d8
 [  d0]    8: Throw src:reg9
-[  d8]    9: Mov dst:reg6, src:reg9
-[  e8]       Mov dst:reg5, src:Int32(2)
-[  f8]       Jump target:@40
-[ 100]   10: Mov dst:reg7, src:reg0
-[ 110]       GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
-[ 120]       JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:@138, false_target:@150
-[ 138]   11: Mov dst:reg5, src:Int32(0)
-[ 148]       Jump target:@40
-[ 150]   12: JumpStrictlyEquals lhs:reg8, rhs:Int32(5), true_target:@168, false_target:@170
-[ 168]   13: Throw src:reg9
-[ 170]   14: Mov dst:reg6, src:reg9
-[ 180]       Mov dst:reg5, src:Int32(2)
-[ 190]       Jump target:@40
-[ 198]   15: Mov dst:reg1, src:reg10
-[ 1a8]       Mov dst:reg7, src:reg0
-[ 1b8]       GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
-[ 1c8]       JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:@1e0, false_target:@1f8
-[ 1e0]   16: JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@228, false_target:@238
-[ 1f8]   17: JumpStrictlyEquals lhs:reg8, rhs:Int32(5), true_target:@210, false_target:@218
-[ 210]   18: Throw src:reg9
-[ 218]   19: Yield value:reg9
-[ 228]   20: Yield value:Undefined
-[ 238]   21: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@250, false_target:@260
-[ 250]   22: Yield value:reg6
-[ 260]   23: Throw src:reg6
+[  d8]    9: Mov2 dst1:reg6, src1:reg9, dst2:reg5, src2:Int32(2)
+[  f0]       Jump target:@40
+[  f8]   10: Mov dst:reg7, src:reg0
+[ 108]       GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
+[ 118]       JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:@130, false_target:@148
+[ 130]   11: Mov dst:reg5, src:Int32(0)
+[ 140]       Jump target:@40
+[ 148]   12: JumpStrictlyEquals lhs:reg8, rhs:Int32(5), true_target:@160, false_target:@168
+[ 160]   13: Throw src:reg9
+[ 168]   14: Mov2 dst1:reg6, src1:reg9, dst2:reg5, src2:Int32(2)
+[ 180]       Jump target:@40
+[ 188]   15: Mov2 dst1:reg1, src1:reg10, dst2:reg7, src2:reg0
+[ 1a0]       GetCompletionFields type_dst:reg8, value_dst:reg9, completion:reg7
+[ 1b0]       JumpStrictlyEquals lhs:reg8, rhs:Int32(1), true_target:@1c8, false_target:@1e0
+[ 1c8]   16: JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@210, false_target:@220
+[ 1e0]   17: JumpStrictlyEquals lhs:reg8, rhs:Int32(5), true_target:@1f8, false_target:@200
+[ 1f8]   18: Throw src:reg9
+[ 200]   19: Yield value:reg9
+[ 210]   20: Yield value:Undefined
+[ 220]   21: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@238, false_target:@248
+[ 238]   22: Yield value:reg6
+[ 248]   23: Throw src:reg6
 
 Exception handlers:
-    from   60 to  198 handler   20
+    from   60 to  188 handler   20

--- a/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
+++ b/Tests/LibJS/Bytecode/expected/generator-yield-star.txt
@@ -9,43 +9,42 @@ JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       Yield continuation_label:@18, value:Undefined
 [  18]    1: GetIterator dst_iterator_object:reg8, dst_iterator_next:reg9, dst_iterator_done:reg10, iterable:arg0
-[  30]       Mov dst:reg6, src:Int32(1)
-[  40]       Mov dst:reg7, src:Undefined
-[  50]    2: JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:@a0, false_target:@100
-[  68]    3: Mov dst:reg5, src:reg0
-[  78]       GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
-[  88]       Jump target:@50
-[  90]    4: Yield value:Undefined
-[  a0]    5: Call dst:reg12, callee:reg9, this_value:reg8, arguments:[reg7]
-[  c8]       ThrowIfNotObject src:reg12
-[  d0]       GetById dst:reg13, base:reg12, property:done
-[  f0]       JumpIf condition:reg13, true_target:@118, false_target:@140
-[ 100]    6: JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:@170, false_target:@190
-[ 118]    7: GetById dst:reg14, base:reg12, property:value
-[ 138]       Jump target:@90
-[ 140]    8: GetById dst:reg15, base:reg12, property:value
-[ 160]       Yield continuation_label:@68, value:reg15
-[ 170]    9: GetMethod dst:reg16, object:reg8, property:throw
-[ 180]       JumpUndefined condition:reg16, true_target:@210, false_target:@1b0
-[ 190]   10: GetMethod dst:reg18, object:reg8, property:return
-[ 1a0]       JumpUndefined condition:reg18, true_target:@298, false_target:@2a8
-[ 1b0]   11: Call dst:reg12, callee:reg16, this_value:reg8, arguments:[reg7]
-[ 1d8]       ThrowIfNotObject src:reg12
-[ 1e0]       GetById dst:reg13, base:reg12, property:done
-[ 200]       JumpIf condition:reg13, true_target:@240, false_target:@268
-[ 210]   12: IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg13, completion_value:Undefined
-[ 228]       NewTypeError dst:reg17, yield* protocol violation: iterator must have a throw method
-[ 238]       Throw src:reg17
-[ 240]   13: GetById dst:reg14, base:reg12, property:value
-[ 260]       Jump target:@90
-[ 268]   14: GetById dst:reg17, base:reg12, property:value
-[ 288]       Yield continuation_label:@68, value:reg17
-[ 298]   15: Yield value:reg7
-[ 2a8]   16: Call dst:reg19, callee:reg18, this_value:reg8, arguments:[reg7]
-[ 2d0]       ThrowIfNotObject src:reg19
-[ 2d8]       GetById dst:reg13, base:reg19, property:done
-[ 2f8]       JumpFalse condition:reg13, target:@338
-[ 308]   17: GetById dst:reg20, base:reg19, property:value
-[ 328]       Yield value:reg20
-[ 338]   18: GetById dst:reg21, base:reg19, property:value
-[ 358]       Yield continuation_label:@68, value:reg21
+[  30]       Mov2 dst1:reg6, src1:Int32(1), dst2:reg7, src2:Undefined
+[  48]    2: JumpStrictlyEquals lhs:reg6, rhs:Int32(1), true_target:@98, false_target:@f8
+[  60]    3: Mov dst:reg5, src:reg0
+[  70]       GetCompletionFields type_dst:reg6, value_dst:reg7, completion:reg5
+[  80]       Jump target:@48
+[  88]    4: Yield value:Undefined
+[  98]    5: Call dst:reg12, callee:reg9, this_value:reg8, arguments:[reg7]
+[  c0]       ThrowIfNotObject src:reg12
+[  c8]       GetById dst:reg13, base:reg12, property:done
+[  e8]       JumpIf condition:reg13, true_target:@110, false_target:@138
+[  f8]    6: JumpStrictlyEquals lhs:reg6, rhs:Int32(5), true_target:@168, false_target:@188
+[ 110]    7: GetById dst:reg14, base:reg12, property:value
+[ 130]       Jump target:@88
+[ 138]    8: GetById dst:reg15, base:reg12, property:value
+[ 158]       Yield continuation_label:@60, value:reg15
+[ 168]    9: GetMethod dst:reg16, object:reg8, property:throw
+[ 178]       JumpUndefined condition:reg16, true_target:@208, false_target:@1a8
+[ 188]   10: GetMethod dst:reg18, object:reg8, property:return
+[ 198]       JumpUndefined condition:reg18, true_target:@290, false_target:@2a0
+[ 1a8]   11: Call dst:reg12, callee:reg16, this_value:reg8, arguments:[reg7]
+[ 1d0]       ThrowIfNotObject src:reg12
+[ 1d8]       GetById dst:reg13, base:reg12, property:done
+[ 1f8]       JumpIf condition:reg13, true_target:@238, false_target:@260
+[ 208]   12: IteratorClose iterator_object:reg8, iterator_next:reg9, iterator_done:reg13, completion_value:Undefined
+[ 220]       NewTypeError dst:reg17, yield* protocol violation: iterator must have a throw method
+[ 230]       Throw src:reg17
+[ 238]   13: GetById dst:reg14, base:reg12, property:value
+[ 258]       Jump target:@88
+[ 260]   14: GetById dst:reg17, base:reg12, property:value
+[ 280]       Yield continuation_label:@60, value:reg17
+[ 290]   15: Yield value:reg7
+[ 2a0]   16: Call dst:reg19, callee:reg18, this_value:reg8, arguments:[reg7]
+[ 2c8]       ThrowIfNotObject src:reg19
+[ 2d0]       GetById dst:reg13, base:reg19, property:done
+[ 2f0]       JumpFalse condition:reg13, target:@330
+[ 300]   17: GetById dst:reg20, base:reg19, property:value
+[ 320]       Yield value:reg20
+[ 330]   18: GetById dst:reg21, base:reg19, property:value
+[ 350]       Yield continuation_label:@60, value:reg21

--- a/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
+++ b/Tests/LibJS/Bytecode/expected/if-else-register-lifetime.txt
@@ -7,35 +7,30 @@ JS bytecode executable ""
 
 JS bytecode executable "test"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:a~0, src:Undefined
-[  18]       Mov dst:i~1, src:Undefined
-[  28]       Mov dst:j~2, src:Undefined
-[  38]       Mov dst:a~0, src:Int32(1)
-[  48]       Mov dst:i~1, src:Int32(0)
-[  58]       Jump target:@88
-[  60]    1: Mov dst:j~2, src:Int32(0)
-[  70]       Jump target:@120
-[  78]    2: PostfixIncrement dst:reg5, src:i~1
-[  88]    3: JumpLessThan lhs:i~1, rhs:Int32(10), true_target:@60, false_target:@a0
-[  a0]    4: GetGlobal dst:reg6, identifier:parseInt
-[  b8]       Mov dst:reg7, src:a~0
-[  c8]       Call dst:reg5, callee:reg6, this_value:Undefined, parseInt, arguments:[reg7]
-[  f0]       Return value:reg5
-[  f8]    5: JumpLessThan lhs:j~2, rhs:Int32(5), true_target:@140, false_target:@1a8
-[ 110]    6: PostfixIncrement dst:reg5, src:j~2
-[ 120]    7: JumpLessThan lhs:j~2, rhs:Int32(10), true_target:@f8, false_target:@138
-[ 138]    8: Jump target:@78
-[ 140]    9: Mov dst:reg6, src:arg0
-[ 150]       Mov dst:reg7, src:j~2
-[ 160]       Add dst:reg8, lhs:i~1, rhs:j~2
-[ 170]       GetByValue dst:reg9, base:arg0, property:reg8, base_identifier:x
-[ 188]       PutByValue base:reg6, property:reg7, src:reg9, kind:Normal, base_identifier:x
-[ 1a0]       Jump target:@248
-[ 1a8]   10: Mov dst:reg6, src:arg0
-[ 1b8]       Mov dst:reg7, src:j~2
-[ 1c8]       GetGlobal dst:reg9, identifier:parseInt
-[ 1e0]       Sub dst:reg10, lhs:j~2, rhs:Int32(3)
-[ 1f0]       GetByValue dst:reg11, base:arg0, property:reg10, base_identifier:x
-[ 208]       Call dst:reg8, callee:reg9, this_value:Undefined, parseInt, arguments:[reg11, Int32(1)]
-[ 230]       PutByValue base:reg6, property:reg7, src:reg8, kind:Normal, base_identifier:x
-[ 248]   11: Jump target:@110
+[   8]       Mov3 dst1:a~0, src1:Undefined, dst2:i~1, src2:Undefined, dst3:j~2, src3:Undefined
+[  28]       Mov2 dst1:a~0, src1:Int32(1), dst2:i~1, src2:Int32(0)
+[  40]       Jump target:@70
+[  48]    1: Mov dst:j~2, src:Int32(0)
+[  58]       Jump target:@108
+[  60]    2: PostfixIncrement dst:reg5, src:i~1
+[  70]    3: JumpLessThan lhs:i~1, rhs:Int32(10), true_target:@48, false_target:@88
+[  88]    4: GetGlobal dst:reg6, identifier:parseInt
+[  a0]       Mov dst:reg7, src:a~0
+[  b0]       Call dst:reg5, callee:reg6, this_value:Undefined, parseInt, arguments:[reg7]
+[  d8]       Return value:reg5
+[  e0]    5: JumpLessThan lhs:j~2, rhs:Int32(5), true_target:@128, false_target:@188
+[  f8]    6: PostfixIncrement dst:reg5, src:j~2
+[ 108]    7: JumpLessThan lhs:j~2, rhs:Int32(10), true_target:@e0, false_target:@120
+[ 120]    8: Jump target:@60
+[ 128]    9: Mov2 dst1:reg6, src1:arg0, dst2:reg7, src2:j~2
+[ 140]       Add dst:reg8, lhs:i~1, rhs:j~2
+[ 150]       GetByValue dst:reg9, base:arg0, property:reg8, base_identifier:x
+[ 168]       PutByValue base:reg6, property:reg7, src:reg9, kind:Normal, base_identifier:x
+[ 180]       Jump target:@220
+[ 188]   10: Mov2 dst1:reg6, src1:arg0, dst2:reg7, src2:j~2
+[ 1a0]       GetGlobal dst:reg9, identifier:parseInt
+[ 1b8]       Sub dst:reg10, lhs:j~2, rhs:Int32(3)
+[ 1c8]       GetByValue dst:reg11, base:arg0, property:reg10, base_identifier:x
+[ 1e0]       Call dst:reg8, callee:reg9, this_value:Undefined, parseInt, arguments:[reg11, Int32(1)]
+[ 208]       PutByValue base:reg6, property:reg7, src:reg8, kind:Normal, base_identifier:x
+[ 220]   11: Jump target:@f8

--- a/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
+++ b/Tests/LibJS/Bytecode/expected/invalid-lhs-assignment-no-dead-code.txt
@@ -1,21 +1,19 @@
 JS bytecode executable ""
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Jump target:@48
+[   8]       Jump target:@40
 [  10]    1: Catch dst:reg5
 [  18]       SetLexicalEnvironment environment:reg4
-[  20]       Mov dst:reg6, src:Undefined
-[  30]       Mov dst:reg7, src:reg6
-[  40]    2: End value:reg6
-[  48]    3: Mov dst:reg5, src:Undefined
-[  58]       GetGlobal dst:reg8, identifier:f
-[  70]       NewFunction dst:reg9, shared_function_data_index:0
-[  88]       Call dst:reg6, callee:reg8, this_value:Undefined, f, arguments:[reg9]
-[  b0]       Mov dst:reg5, src:reg6
-[  c0]       Mov dst:reg6, src:reg5
-[  d0]       End value:reg6
+[  20]       Mov2 dst1:reg6, src1:Undefined, dst2:reg7, src2:reg6
+[  38]    2: End value:reg6
+[  40]    3: Mov dst:reg5, src:Undefined
+[  50]       GetGlobal dst:reg8, identifier:f
+[  68]       NewFunction dst:reg9, shared_function_data_index:0
+[  80]       Call dst:reg6, callee:reg8, this_value:Undefined, f, arguments:[reg9]
+[  a8]       Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+[  c0]       End value:reg6
 
 Exception handlers:
-    from   48 to   d8 handler   10
+    from   40 to   c8 handler   10
 
 JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
+++ b/Tests/LibJS/Bytecode/expected/lexical-env-teardown.txt
@@ -56,9 +56,8 @@ JS bytecode executable "withTeardown"
 
 JS bytecode executable "blockTeardown"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:outer~1, src:Int32(2)
-[  18]       Mov dst:inner~0, src:Int32(3)
-[  28]       Return value:outer~1
+[   8]       Mov2 dst1:outer~1, src1:Int32(2), dst2:inner~0, src2:Int32(3)
+[  20]       Return value:outer~1
 
 JS bytecode executable "forInTeardown"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/local-variables.txt
+++ b/Tests/LibJS/Bytecode/expected/local-variables.txt
@@ -20,7 +20,6 @@ JS bytecode executable "simple_const"
 
 JS bytecode executable "multiple_locals"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:a~0, src:Int32(1)
-[  18]       Mov dst:b~1, src:Int32(2)
-[  28]       Add dst:reg5, lhs:a~0, rhs:b~1
-[  38]       Return value:reg5
+[   8]       Mov2 dst1:a~0, src1:Int32(1), dst2:b~1, src2:Int32(2)
+[  20]       Add dst:reg5, lhs:a~0, rhs:b~1
+[  30]       Return value:reg5

--- a/Tests/LibJS/Bytecode/expected/mov-merging.txt
+++ b/Tests/LibJS/Bytecode/expected/mov-merging.txt
@@ -1,0 +1,29 @@
+JS bytecode executable ""
+[   0]    0: GetLexicalEnvironment dst:reg4
+[   8]       GetGlobal dst:reg6, identifier:console
+[  20]       GetById dst:reg7, base:reg6, property:log, base_identifier:console
+[  40]       GetGlobal dst:reg9, identifier:twoLocals
+[  58]       Call dst:reg8, callee:reg9, this_value:Undefined, twoLocals
+[  78]       Call dst:reg5, callee:reg7, this_value:reg6, console.log, arguments:[reg8]
+[  a0]       GetGlobal dst:reg7, identifier:console
+[  b8]       GetById dst:reg8, base:reg7, property:log, base_identifier:console
+[  d8]       GetGlobal dst:reg10, identifier:threeLocals
+[  f0]       Call dst:reg9, callee:reg10, this_value:Undefined, threeLocals
+[ 110]       Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg9]
+[ 138]       End value:reg6
+
+JS bytecode executable "twoLocals"
+[   0]    0: GetLexicalEnvironment dst:reg4
+[   8]       Mov2 dst1:a~0, src1:Int32(1), dst2:b~1, src2:Int32(2)
+[  20]       Add dst:reg5, lhs:a~0, rhs:b~1
+[  30]       Return value:reg5
+
+JS bytecode executable "threeLocals"
+[   0]    0: GetLexicalEnvironment dst:reg4
+[   8]       Mov3 dst1:a~0, src1:Int32(1), dst2:b~1, src2:Int32(2), dst3:c~2, src3:Int32(3)
+[  28]       Add dst:reg5, lhs:a~0, rhs:b~1
+[  38]       Add dst:reg6, lhs:reg5, rhs:c~2
+[  48]       Return value:reg6
+
+3
+6

--- a/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-for-loop-completion.txt
@@ -18,5 +18,4 @@ JS bytecode executable ""
 [ 120]    6: GetGlobal dst:reg7, identifier:depth
 [ 138]       JumpLessThanEquals lhs:reg7, rhs:Int32(0), true_target:@e0, false_target:@150
 [ 150]    7: Mov dst:reg5, src:reg6
-[ 160]       Mov dst:reg5, src:reg6
-[ 170]       Jump target:@68
+[ 160]       Jump target:@68

--- a/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/nested-try-finally-continue.txt
@@ -19,7 +19,7 @@ JS bytecode executable "nestedTryFinallyContinue"
 [  90]       GetById dst:reg9, base:reg8, property:log, base_identifier:console
 [  b0]       Mov dst:reg10, src:i~0
 [  c0]       Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer"), reg10]
-[  e8]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@288, false_target:@290
+[  e8]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@280, false_target:@288
 [ 100]    7: Jump target:@1b0
 [ 108]    8: Catch dst:reg8
 [ 110]       SetLexicalEnvironment environment:reg4
@@ -39,21 +39,20 @@ JS bytecode executable "nestedTryFinallyContinue"
 [ 210]   14: Mov dst:reg5, src:Int32(0)
 [ 220]       Jump target:@78
 [ 228]   15: JumpStrictlyEquals lhs:reg7, rhs:Int32(3), true_target:@1f8, false_target:@240
-[ 240]   16: JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:@258, false_target:@280
-[ 258]   17: Mov dst:reg5, src:reg7
-[ 268]       Mov dst:reg6, src:reg8
-[ 278]       Jump target:@78
-[ 280]   18: Throw src:reg8
-[ 288]   19: Jump target:@28
-[ 290]   20: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@28, false_target:@2a8
-[ 2a8]   21: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@2c0, false_target:@2c8
-[ 2c0]   22: Return value:reg6
-[ 2c8]   23: Throw src:reg6
+[ 240]   16: JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:@258, false_target:@278
+[ 258]   17: Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
+[ 270]       Jump target:@78
+[ 278]   18: Throw src:reg8
+[ 280]   19: Jump target:@28
+[ 288]   20: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@28, false_target:@2a0
+[ 2a0]   21: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@2b8, false_target:@2c0
+[ 2b8]   22: Return value:reg6
+[ 2c0]   23: Throw src:reg6
 
 Exception handlers:
     from  100 to  1b0 handler   58
     from  1b0 to  210 handler  108
-    from  210 to  288 handler   58
+    from  210 to  280 handler   58
 
 "inner" 0
 "outer" 0

--- a/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain-base-identifier.txt
@@ -10,11 +10,10 @@ JS bytecode executable ""
 [  90]       Mov dst:reg5, src:Undefined
 [  a0]       GetGlobal dst:reg7, identifier:obj
 [  b8]       GetById dst:reg8, base:reg7, property:a, base_identifier:obj
-[  d8]       Mov dst:reg5, src:reg7
-[  e8]       Mov dst:reg6, src:reg8
-[  f8]       JumpNullish condition:reg6, true_target:@108, false_target:@120
-[ 108]    1: Mov dst:reg6, src:Undefined
-[ 118]    2: End value:reg6
-[ 120]    3: Mov dst:reg5, src:reg6
-[ 130]       GetById dst:reg6, base:reg6, property:b
-[ 150]       End value:reg6
+[  d8]       Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
+[  f0]       JumpNullish condition:reg6, true_target:@100, false_target:@118
+[ 100]    1: Mov dst:reg6, src:Undefined
+[ 110]    2: End value:reg6
+[ 118]    3: Mov dst:reg5, src:reg6
+[ 128]       GetById dst:reg6, base:reg6, property:b
+[ 148]       End value:reg6

--- a/Tests/LibJS/Bytecode/expected/optional-chain.txt
+++ b/Tests/LibJS/Bytecode/expected/optional-chain.txt
@@ -16,83 +16,75 @@ JS bytecode executable ""
 
 JS bytecode executable "member"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:reg5, src:Undefined
-[  18]       Mov dst:reg6, src:arg0
-[  28]       JumpNullish condition:reg6, true_target:@38, false_target:@50
-[  38]    1: Mov dst:reg6, src:Undefined
-[  48]    2: Return value:reg6
-[  50]    3: Mov dst:reg5, src:reg6
-[  60]       GetById dst:reg6, base:reg6, property:x
-[  80]       Return value:reg6
+[   8]       Mov2 dst1:reg5, src1:Undefined, dst2:reg6, src2:arg0
+[  20]       JumpNullish condition:reg6, true_target:@30, false_target:@48
+[  30]    1: Mov dst:reg6, src:Undefined
+[  40]    2: Return value:reg6
+[  48]    3: Mov dst:reg5, src:reg6
+[  58]       GetById dst:reg6, base:reg6, property:x
+[  78]       Return value:reg6
 
 JS bytecode executable "nested_member"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:reg5, src:Undefined
-[  18]       Mov dst:reg6, src:arg0
-[  28]       JumpNullish condition:reg6, true_target:@38, false_target:@50
-[  38]    1: Mov dst:reg6, src:Undefined
-[  48]    2: Return value:reg6
-[  50]    3: Mov dst:reg5, src:reg6
-[  60]       GetById dst:reg6, base:reg6, property:x
-[  80]       JumpNullish condition:reg6, true_target:@38, false_target:@90
-[  90]    4: Mov dst:reg5, src:reg6
-[  a0]       GetById dst:reg6, base:reg6, property:y
-[  c0]       Return value:reg6
+[   8]       Mov2 dst1:reg5, src1:Undefined, dst2:reg6, src2:arg0
+[  20]       JumpNullish condition:reg6, true_target:@30, false_target:@48
+[  30]    1: Mov dst:reg6, src:Undefined
+[  40]    2: Return value:reg6
+[  48]    3: Mov dst:reg5, src:reg6
+[  58]       GetById dst:reg6, base:reg6, property:x
+[  78]       JumpNullish condition:reg6, true_target:@30, false_target:@88
+[  88]    4: Mov dst:reg5, src:reg6
+[  98]       GetById dst:reg6, base:reg6, property:y
+[  b8]       Return value:reg6
 
 JS bytecode executable "call_no_args"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:reg5, src:Undefined
-[  18]       Mov dst:reg6, src:arg0
-[  28]       JumpNullish condition:reg6, true_target:@38, false_target:@50
-[  38]    1: Mov dst:reg6, src:Undefined
-[  48]    2: Return value:reg6
-[  50]    3: Mov dst:reg5, src:reg6
-[  60]       GetById dst:reg6, base:reg6, property:foo
-[  80]       NewArray dst:reg7
-[  90]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-[  a8]       Mov dst:reg5, src:Undefined
-[  b8]       Return value:reg6
+[   8]       Mov2 dst1:reg5, src1:Undefined, dst2:reg6, src2:arg0
+[  20]       JumpNullish condition:reg6, true_target:@30, false_target:@48
+[  30]    1: Mov dst:reg6, src:Undefined
+[  40]    2: Return value:reg6
+[  48]    3: Mov dst:reg5, src:reg6
+[  58]       GetById dst:reg6, base:reg6, property:foo
+[  78]       NewArray dst:reg7
+[  88]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+[  a0]       Mov dst:reg5, src:Undefined
+[  b0]       Return value:reg6
 
 JS bytecode executable "call_with_args"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:reg5, src:Undefined
-[  18]       Mov dst:reg6, src:arg0
-[  28]       JumpNullish condition:reg6, true_target:@38, false_target:@50
-[  38]    1: Mov dst:reg6, src:Undefined
-[  48]    2: Return value:reg6
-[  50]    3: Mov dst:reg5, src:reg6
-[  60]       GetById dst:reg6, base:reg6, property:foo
-[  80]       Mov dst:reg8, src:Int32(1)
-[  90]       Mov dst:reg9, src:Int32(2)
-[  a0]       Mov dst:reg10, src:Int32(3)
-[  b0]       NewArray dst:reg7, elements:[reg8, reg9, reg10]
-[  d0]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-[  e8]       Mov dst:reg5, src:Undefined
-[  f8]       Return value:reg6
+[   8]       Mov2 dst1:reg5, src1:Undefined, dst2:reg6, src2:arg0
+[  20]       JumpNullish condition:reg6, true_target:@30, false_target:@48
+[  30]    1: Mov dst:reg6, src:Undefined
+[  40]    2: Return value:reg6
+[  48]    3: Mov dst:reg5, src:reg6
+[  58]       GetById dst:reg6, base:reg6, property:foo
+[  78]       Mov3 dst1:reg8, src1:Int32(1), dst2:reg9, src2:Int32(2), dst3:reg10, src3:Int32(3)
+[  98]       NewArray dst:reg7, elements:[reg8, reg9, reg10]
+[  b8]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+[  d0]       Mov dst:reg5, src:Undefined
+[  e0]       Return value:reg6
 
 JS bytecode executable "computed"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:reg5, src:Undefined
-[  18]       Mov dst:reg6, src:arg0
-[  28]       JumpNullish condition:reg6, true_target:@38, false_target:@50
-[  38]    1: Mov dst:reg6, src:Undefined
-[  48]    2: Return value:reg6
-[  50]    3: Mov dst:reg5, src:reg6
-[  60]       GetById dst:reg6, base:reg6, property:hello
-[  80]       Return value:reg6
+[   8]       Mov2 dst1:reg5, src1:Undefined, dst2:reg6, src2:arg0
+[  20]       JumpNullish condition:reg6, true_target:@30, false_target:@48
+[  30]    1: Mov dst:reg6, src:Undefined
+[  40]    2: Return value:reg6
+[  48]    3: Mov dst:reg5, src:reg6
+[  58]       GetById dst:reg6, base:reg6, property:hello
+[  78]       Return value:reg6
 
 JS bytecode executable "member_then_call"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:reg5, src:Undefined
-[  18]       Mov dst:reg6, src:arg0
-[  28]       JumpNullish condition:reg6, true_target:@38, false_target:@50
-[  38]    1: Mov dst:reg6, src:Undefined
-[  48]    2: Return value:reg6
-[  50]    3: Mov dst:reg5, src:reg6
-[  60]       GetById dst:reg6, base:reg6, property:x
-[  80]       Mov dst:reg5, src:reg6
-[  90]       GetById dst:reg6, base:reg6, property:foo
-[  b0]       NewArray dst:reg7
-[  c0]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-[  d8]       Mov dst:reg5, src:Undefined
-[  e8]       Return value:reg6
+[   8]       Mov2 dst1:reg5, src1:Undefined, dst2:reg6, src2:arg0
+[  20]       JumpNullish condition:reg6, true_target:@30, false_target:@48
+[  30]    1: Mov dst:reg6, src:Undefined
+[  40]    2: Return value:reg6
+[  48]    3: Mov dst:reg5, src:reg6
+[  58]       GetById dst:reg6, base:reg6, property:x
+[  78]       Mov dst:reg5, src:reg6
+[  88]       GetById dst:reg6, base:reg6, property:foo
+[  a8]       NewArray dst:reg7
+[  b8]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+[  d0]       Mov dst:reg5, src:Undefined
+[  e0]       Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
+++ b/Tests/LibJS/Bytecode/expected/parameter-createvariable-order.txt
@@ -14,10 +14,9 @@ JS bytecode executable "f"
 [  68]       InitializeLexicalBinding identifier:c, src:arg2
 [  80]       Mov dst:inner~0, src:Undefined
 [  90]       NewFunction dst:reg5, shared_function_data_index:0, lhs_name:inner
-[  a8]       Mov dst:inner~0, src:reg5
-[  b8]       Mov dst:reg6, src:inner~0
-[  c8]       Call dst:reg5, callee:reg6, this_value:Undefined, inner
-[  e8]       Return value:reg5
+[  a8]       Mov2 dst1:inner~0, src1:reg5, dst2:reg6, src2:inner~0
+[  c0]       Call dst:reg5, callee:reg6, this_value:Undefined, inner
+[  e0]       Return value:reg5
 
 JS bytecode executable "inner"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
+++ b/Tests/LibJS/Bytecode/expected/postfix-update-in-logical-and.txt
@@ -8,8 +8,7 @@ JS bytecode executable "postfixInLogicalAnd"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       GreaterThan dst:reg5, lhs:arg0, rhs:Int32(0)
 [  18]       Mov dst:reg6, src:reg5
-[  28]       JumpFalse condition:reg5, target:@68
+[  28]       JumpFalse condition:reg5, target:@60
 [  38]    1: PostfixDecrement dst:reg7, src:arg0
-[  48]       Mov dst:arg0, src:arg0
-[  58]       Mov dst:reg6, src:reg7
-[  68]    2: Return value:reg6
+[  48]       Mov2 dst1:arg0, src1:arg0, dst2:reg6, src2:reg7
+[  60]    2: Return value:reg6

--- a/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
+++ b/Tests/LibJS/Bytecode/expected/sequential-try-blocks.txt
@@ -10,32 +10,30 @@ JS bytecode executable ""
 JS bytecode executable "sequentialTryCatch"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       Mov dst:result~2, src:String("")
-[  18]       Jump target:@78
+[  18]       Jump target:@70
 [  20]    1: Catch dst:reg5
 [  28]       SetLexicalEnvironment environment:reg4
-[  30]       Mov dst:e~0, src:reg5
-[  40]       Mov dst:reg6, src:result~2
-[  50]       Add dst:reg7, lhs:reg6, rhs:String("b")
-[  60]       Mov dst:result~2, src:reg7
-[  70]    2: Jump target:@108
-[  78]    3: Mov dst:reg5, src:result~2
-[  88]       Add dst:reg6, lhs:reg5, rhs:String("a")
-[  98]       Mov dst:result~2, src:reg6
-[  a8]       Throw src:Int32(1)
-[  b0]    4: Catch dst:reg5
-[  b8]       SetLexicalEnvironment environment:reg4
-[  c0]       Mov dst:e~1, src:reg5
-[  d0]       Mov dst:reg6, src:result~2
-[  e0]       Add dst:reg7, lhs:reg6, rhs:String("d")
-[  f0]       Mov dst:result~2, src:reg7
-[ 100]    5: Return value:result~2
-[ 108]    6: Mov dst:reg5, src:result~2
-[ 118]       Add dst:reg6, lhs:reg5, rhs:String("c")
-[ 128]       Mov dst:result~2, src:reg6
-[ 138]       Throw src:Int32(2)
+[  30]       Mov2 dst1:e~0, src1:reg5, dst2:reg6, src2:result~2
+[  48]       Add dst:reg7, lhs:reg6, rhs:String("b")
+[  58]       Mov dst:result~2, src:reg7
+[  68]    2: Jump target:@f8
+[  70]    3: Mov dst:reg5, src:result~2
+[  80]       Add dst:reg6, lhs:reg5, rhs:String("a")
+[  90]       Mov dst:result~2, src:reg6
+[  a0]       Throw src:Int32(1)
+[  a8]    4: Catch dst:reg5
+[  b0]       SetLexicalEnvironment environment:reg4
+[  b8]       Mov2 dst1:e~1, src1:reg5, dst2:reg6, src2:result~2
+[  d0]       Add dst:reg7, lhs:reg6, rhs:String("d")
+[  e0]       Mov dst:result~2, src:reg7
+[  f0]    5: Return value:result~2
+[  f8]    6: Mov dst:reg5, src:result~2
+[ 108]       Add dst:reg6, lhs:reg5, rhs:String("c")
+[ 118]       Mov dst:result~2, src:reg6
+[ 128]       Throw src:Int32(2)
 
 Exception handlers:
-    from   78 to   b0 handler   20
-    from  108 to  140 handler   b0
+    from   70 to   a8 handler   20
+    from   f8 to  130 handler   a8
 
 "abcd"

--- a/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
+++ b/Tests/LibJS/Bytecode/expected/super-optional-call-this.txt
@@ -36,15 +36,14 @@ JS bytecode executable "method"
 [  18]       ResolveThisBinding
 [  20]       ResolveSuperBase dst:reg7
 [  28]       GetByIdWithThis dst:reg8, base:reg7, property:method, this_value:this
-[  48]       Mov dst:reg5, src:this
-[  58]       Mov dst:reg6, src:reg8
-[  68]       JumpNullish condition:reg6, true_target:@78, false_target:@90
-[  78]    1: Mov dst:reg6, src:Undefined
-[  88]    2: Return value:reg6
-[  90]    3: NewArray dst:reg7
-[  a0]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
-[  b8]       Mov dst:reg5, src:Undefined
-[  c8]       Return value:reg6
+[  48]       Mov2 dst1:reg5, src1:this, dst2:reg6, src2:reg8
+[  60]       JumpNullish condition:reg6, true_target:@70, false_target:@88
+[  70]    1: Mov dst:reg6, src:Undefined
+[  80]    2: Return value:reg6
+[  88]    3: NewArray dst:reg7
+[  98]       CallWithArgumentArray dst:reg6, callee:reg6, this_value:reg5, arguments:reg7
+[  b0]       Mov dst:reg5, src:Undefined
+[  c0]       Return value:reg6
 
 JS bytecode executable "method"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
+++ b/Tests/LibJS/Bytecode/expected/switch-completion-value.txt
@@ -22,18 +22,16 @@ JS bytecode executable "eval"
 [   8]       Mov dst:reg5, src:Undefined
 [  18]    1: JumpStrictlyEquals lhs:Int32(1), rhs:Int32(1), true_target:@38, false_target:@30
 [  30]    2: End value:reg5
-[  38]    3: Mov dst:reg5, src:String("hello")
-[  48]       Mov dst:x~0, src:Int32(1)
-[  58]    4: End value:reg5
+[  38]    3: Mov2 dst1:reg5, src1:String("hello"), dst2:x~0, src2:Int32(1)
+[  50]    4: End value:reg5
 
 JS bytecode executable "eval"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       Mov dst:reg5, src:Undefined
 [  18]    1: JumpStrictlyEquals lhs:Int32(1), rhs:Int32(1), true_target:@38, false_target:@30
 [  30]    2: End value:reg5
-[  38]    3: Mov dst:reg5, src:String("first")
-[  48]       Mov dst:reg5, src:String("second")
-[  58]    4: End value:reg5
+[  38]    3: Mov2 dst1:reg5, src1:String("first"), dst2:reg5, src2:String("second")
+[  50]    4: End value:reg5
 
 JS bytecode executable "eval"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
+++ b/Tests/LibJS/Bytecode/expected/tagged-template-if-register-order.txt
@@ -9,11 +9,10 @@ JS bytecode executable ""
 [  b8]       GetGlobal dst:reg5, identifier:x
 [  d0]       StrictlyEquals dst:reg6, lhs:reg5, rhs:String("hello")
 [  e0]       Mov dst:reg5, src:Undefined
-[  f0]       JumpFalse condition:reg6, target:@190
+[  f0]       JumpFalse condition:reg6, target:@180
 [ 100]    1: GetGlobal dst:reg8, identifier:x
 [ 118]       GetById dst:reg9, base:reg8, property:toUpperCase, base_identifier:x
 [ 138]       Call dst:reg7, callee:reg9, this_value:reg8, x.toUpperCase
 [ 158]       SetGlobal identifier:y, src:reg7
 [ 170]       Mov dst:reg5, src:reg7
-[ 180]       Mov dst:reg5, src:reg7
-[ 190]    2: End value:reg5
+[ 180]    2: End value:reg5

--- a/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
+++ b/Tests/LibJS/Bytecode/expected/this-base-identifier.txt
@@ -4,21 +4,19 @@ JS bytecode executable ""
 [  20]       Call dst:reg5, callee:reg6, this_value:Undefined, get_from_this
 [  40]       GetGlobal dst:reg7, identifier:set_on_this
 [  58]       Call dst:reg6, callee:reg7, this_value:Undefined, set_on_this
-[  78]       Jump target:@b8
+[  78]       Jump target:@b0
 [  80]    1: Catch dst:reg5
 [  88]       SetLexicalEnvironment environment:reg4
-[  90]       Mov dst:reg7, src:Undefined
-[  a0]       Mov dst:reg8, src:reg7
-[  b0]    2: End value:reg7
-[  b8]    3: Mov dst:reg5, src:Undefined
-[  c8]       GetGlobal dst:reg9, identifier:chained_this_access
-[  e0]       Call dst:reg7, callee:reg9, this_value:Undefined, chained_this_access
-[ 100]       Mov dst:reg5, src:reg7
-[ 110]       Mov dst:reg7, src:reg5
-[ 120]       End value:reg7
+[  90]       Mov2 dst1:reg7, src1:Undefined, dst2:reg8, src2:reg7
+[  a8]    2: End value:reg7
+[  b0]    3: Mov dst:reg5, src:Undefined
+[  c0]       GetGlobal dst:reg9, identifier:chained_this_access
+[  d8]       Call dst:reg7, callee:reg9, this_value:Undefined, chained_this_access
+[  f8]       Mov2 dst1:reg5, src1:reg7, dst2:reg7, src2:reg5
+[ 110]       End value:reg7
 
 Exception handlers:
-    from   b8 to  128 handler   80
+    from   b0 to  118 handler   80
 
 JS bytecode executable "get_from_this"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/try-catch-completion-ordering.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-completion-ordering.txt
@@ -1,15 +1,13 @@
 JS bytecode executable ""
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Jump target:@68
+[   8]       Jump target:@58
 [  10]    1: Catch dst:reg5
 [  18]       SetLexicalEnvironment environment:reg4
-[  20]       Mov dst:e~0, src:reg5
-[  30]       Mov dst:reg6, src:Undefined
-[  40]       Mov dst:reg6, src:Int32(42)
-[  50]       Mov dst:reg7, src:reg6
-[  60]    2: End value:reg7
-[  68]    3: Mov dst:reg5, src:Undefined
-[  78]       Throw src:Null
+[  20]       Mov3 dst1:e~0, src1:reg5, dst2:reg6, src2:Undefined, dst3:reg6, src3:Int32(42)
+[  40]       Mov dst:reg7, src:reg6
+[  50]    2: End value:reg7
+[  58]    3: Mov dst:reg5, src:Undefined
+[  68]       Throw src:Null
 
 Exception handlers:
-    from   68 to   80 handler   10
+    from   58 to   70 handler   10

--- a/Tests/LibJS/Bytecode/expected/try-catch-finally-register.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-finally-register.txt
@@ -1,30 +1,24 @@
 JS bytecode executable ""
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Jump target:@d0
+[   8]       Jump target:@b0
 [  10]    1: Catch dst:reg6
 [  18]       SetLexicalEnvironment environment:reg4
 [  20]       Mov dst:reg5, src:Int32(1)
-[  30]    2: Mov dst:reg9, src:Undefined
-[  40]       Mov dst:reg9, src:Int32(3)
-[  50]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@118, false_target:@120
-[  68]    3: Catch dst:reg7
-[  70]       SetLexicalEnvironment environment:reg4
-[  78]       Mov dst:e~0, src:reg7
-[  88]       Mov dst:reg8, src:Undefined
-[  98]       Mov dst:reg8, src:Int32(2)
-[  a8]       Mov dst:reg9, src:reg8
-[  b8]       Mov dst:reg5, src:Int32(0)
-[  c8]       Jump target:@30
-[  d0]    4: Mov dst:reg7, src:Undefined
-[  e0]       Mov dst:reg7, src:Int32(1)
-[  f0]       Mov dst:reg8, src:reg7
-[ 100]       Mov dst:reg5, src:Int32(0)
-[ 110]       Jump target:@30
-[ 118]    5: End value:reg8
-[ 120]    6: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@138, false_target:@140
-[ 138]    7: Return value:reg6
-[ 140]    8: Throw src:reg6
+[  30]    2: Mov2 dst1:reg9, src1:Undefined, dst2:reg9, src2:Int32(3)
+[  48]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@e8, false_target:@f0
+[  60]    3: Catch dst:reg7
+[  68]       SetLexicalEnvironment environment:reg4
+[  70]       Mov3 dst1:e~0, src1:reg7, dst2:reg8, src2:Undefined, dst3:reg8, src3:Int32(2)
+[  90]       Mov2 dst1:reg9, src1:reg8, dst2:reg5, src2:Int32(0)
+[  a8]       Jump target:@30
+[  b0]    4: Mov3 dst1:reg7, src1:Undefined, dst2:reg7, src2:Int32(1), dst3:reg8, src3:reg7
+[  d0]       Mov dst:reg5, src:Int32(0)
+[  e0]       Jump target:@30
+[  e8]    5: End value:reg8
+[  f0]    6: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@108, false_target:@110
+[ 108]    7: Return value:reg6
+[ 110]    8: Throw src:reg6
 
 Exception handlers:
-    from   68 to   d0 handler   10
-    from   d0 to  118 handler   68
+    from   60 to   b0 handler   10
+    from   b0 to   e8 handler   60

--- a/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
+++ b/Tests/LibJS/Bytecode/expected/try-catch-scoping.txt
@@ -9,22 +9,21 @@ JS bytecode executable ""
 JS bytecode executable "tryCatchWithBlocks"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       Mov dst:x~3, src:Int32(1)
-[  18]       Jump target:@d8
+[  18]       Jump target:@d0
 [  20]    1: Catch dst:reg5
 [  28]       SetLexicalEnvironment environment:reg4
-[  30]       Mov dst:e~2, src:reg5
-[  40]       Mov dst:z~1, src:Int32(3)
-[  50]       GetGlobal dst:reg7, identifier:console
-[  68]       GetById dst:reg8, base:reg7, property:log, base_identifier:console
-[  88]       Add dst:reg9, lhs:x~3, rhs:e~2
-[  98]       Add dst:reg10, lhs:reg9, rhs:z~1
-[  a8]       Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg10]
-[  d0]    2: End value:Undefined
-[  d8]    3: Mov dst:y~0, src:Int32(2)
-[  e8]       Throw src:y~0
+[  30]       Mov2 dst1:e~2, src1:reg5, dst2:z~1, src2:Int32(3)
+[  48]       GetGlobal dst:reg7, identifier:console
+[  60]       GetById dst:reg8, base:reg7, property:log, base_identifier:console
+[  80]       Add dst:reg9, lhs:x~3, rhs:e~2
+[  90]       Add dst:reg10, lhs:reg9, rhs:z~1
+[  a0]       Call dst:reg6, callee:reg8, this_value:reg7, console.log, arguments:[reg10]
+[  c8]    2: End value:Undefined
+[  d0]    3: Mov dst:y~0, src:Int32(2)
+[  e0]       Throw src:y~0
 
 Exception handlers:
-    from   d8 to   f0 handler   20
+    from   d0 to   e8 handler   20
 
 JS bytecode executable "tryCatchFinallyWithBlocks"
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally-continue.txt
@@ -14,69 +14,65 @@ JS bytecode executable ""
 
 JS bytecode executable "continueThroughFinally"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:result~1, src:Int32(0)
-[  18]       Mov dst:i~0, src:Int32(0)
-[  28]       Jump target:@48
-[  30]    1: Jump target:@d0
-[  38]    2: PostfixIncrement dst:reg5, src:i~0
-[  48]    3: JumpLessThan lhs:i~0, rhs:Int32(3), true_target:@30, false_target:@60
-[  60]    4: Return value:result~1
-[  68]    5: Catch dst:reg6
-[  70]       SetLexicalEnvironment environment:reg4
-[  78]       Mov dst:reg5, src:Int32(1)
-[  88]    6: Mov dst:reg7, src:result~1
-[  98]       Add dst:reg8, lhs:reg7, rhs:Int32(10)
-[  a8]       Mov dst:result~1, src:reg8
-[  b8]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@148, false_target:@150
-[  d0]    7: JumpStrictlyEquals lhs:i~0, rhs:Int32(1), true_target:@e8, false_target:@100
-[  e8]    8: Mov dst:reg5, src:Int32(3)
-[  f8]       Jump target:@88
-[ 100]    9: Mov dst:reg7, src:result~1
-[ 110]       Add dst:reg8, lhs:reg7, rhs:i~0
-[ 120]       Mov dst:result~1, src:reg8
-[ 130]       Mov dst:reg5, src:Int32(0)
-[ 140]       Jump target:@88
-[ 148]   10: Jump target:@38
-[ 150]   11: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@38, false_target:@168
-[ 168]   12: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@180, false_target:@188
-[ 180]   13: Return value:reg6
-[ 188]   14: Throw src:reg6
+[   8]       Mov2 dst1:result~1, src1:Int32(0), dst2:i~0, src2:Int32(0)
+[  20]       Jump target:@40
+[  28]    1: Jump target:@c8
+[  30]    2: PostfixIncrement dst:reg5, src:i~0
+[  40]    3: JumpLessThan lhs:i~0, rhs:Int32(3), true_target:@28, false_target:@58
+[  58]    4: Return value:result~1
+[  60]    5: Catch dst:reg6
+[  68]       SetLexicalEnvironment environment:reg4
+[  70]       Mov dst:reg5, src:Int32(1)
+[  80]    6: Mov dst:reg7, src:result~1
+[  90]       Add dst:reg8, lhs:reg7, rhs:Int32(10)
+[  a0]       Mov dst:result~1, src:reg8
+[  b0]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@138, false_target:@140
+[  c8]    7: JumpStrictlyEquals lhs:i~0, rhs:Int32(1), true_target:@e0, false_target:@f8
+[  e0]    8: Mov dst:reg5, src:Int32(3)
+[  f0]       Jump target:@80
+[  f8]    9: Mov dst:reg7, src:result~1
+[ 108]       Add dst:reg8, lhs:reg7, rhs:i~0
+[ 118]       Mov2 dst1:result~1, src1:reg8, dst2:reg5, src2:Int32(0)
+[ 130]       Jump target:@80
+[ 138]   10: Jump target:@30
+[ 140]   11: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@30, false_target:@158
+[ 158]   12: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@170, false_target:@178
+[ 170]   13: Return value:reg6
+[ 178]   14: Throw src:reg6
 
 Exception handlers:
-    from   d0 to  148 handler   68
+    from   c8 to  138 handler   60
 
 JS bytecode executable "breakThroughFinally"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:result~1, src:Int32(0)
-[  18]       Mov dst:i~0, src:Int32(0)
-[  28]       Jump target:@48
-[  30]    1: Jump target:@d0
-[  38]    2: PostfixIncrement dst:reg5, src:i~0
-[  48]    3: JumpLessThan lhs:i~0, rhs:Int32(10), true_target:@30, false_target:@60
-[  60]    4: Return value:result~1
-[  68]    5: Catch dst:reg6
-[  70]       SetLexicalEnvironment environment:reg4
-[  78]       Mov dst:reg5, src:Int32(1)
-[  88]    6: Mov dst:reg7, src:result~1
-[  98]       Add dst:reg8, lhs:reg7, rhs:Int32(100)
-[  a8]       Mov dst:result~1, src:reg8
-[  b8]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@148, false_target:@150
-[  d0]    7: JumpStrictlyEquals lhs:i~0, rhs:Int32(2), true_target:@e8, false_target:@100
-[  e8]    8: Mov dst:reg5, src:Int32(3)
-[  f8]       Jump target:@88
-[ 100]    9: Mov dst:reg7, src:result~1
-[ 110]       Add dst:reg8, lhs:reg7, rhs:i~0
-[ 120]       Mov dst:result~1, src:reg8
-[ 130]       Mov dst:reg5, src:Int32(0)
-[ 140]       Jump target:@88
-[ 148]   10: Jump target:@38
-[ 150]   11: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@60, false_target:@168
-[ 168]   12: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@180, false_target:@188
-[ 180]   13: Return value:reg6
-[ 188]   14: Throw src:reg6
+[   8]       Mov2 dst1:result~1, src1:Int32(0), dst2:i~0, src2:Int32(0)
+[  20]       Jump target:@40
+[  28]    1: Jump target:@c8
+[  30]    2: PostfixIncrement dst:reg5, src:i~0
+[  40]    3: JumpLessThan lhs:i~0, rhs:Int32(10), true_target:@28, false_target:@58
+[  58]    4: Return value:result~1
+[  60]    5: Catch dst:reg6
+[  68]       SetLexicalEnvironment environment:reg4
+[  70]       Mov dst:reg5, src:Int32(1)
+[  80]    6: Mov dst:reg7, src:result~1
+[  90]       Add dst:reg8, lhs:reg7, rhs:Int32(100)
+[  a0]       Mov dst:result~1, src:reg8
+[  b0]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@138, false_target:@140
+[  c8]    7: JumpStrictlyEquals lhs:i~0, rhs:Int32(2), true_target:@e0, false_target:@f8
+[  e0]    8: Mov dst:reg5, src:Int32(3)
+[  f0]       Jump target:@80
+[  f8]    9: Mov dst:reg7, src:result~1
+[ 108]       Add dst:reg8, lhs:reg7, rhs:i~0
+[ 118]       Mov2 dst1:result~1, src1:reg8, dst2:reg5, src2:Int32(0)
+[ 130]       Jump target:@80
+[ 138]   10: Jump target:@30
+[ 140]   11: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@58, false_target:@158
+[ 158]   12: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@170, false_target:@178
+[ 170]   13: Return value:reg6
+[ 178]   14: Throw src:reg6
 
 Exception handlers:
-    from   d0 to  148 handler   68
+    from   c8 to  138 handler   60
 
 32
 301

--- a/Tests/LibJS/Bytecode/expected/try-finally.txt
+++ b/Tests/LibJS/Bytecode/expected/try-finally.txt
@@ -17,17 +17,16 @@ JS bytecode executable "basicTryFinally"
 [  30]    2: GetGlobal dst:reg8, identifier:console
 [  48]       GetById dst:reg9, base:reg8, property:log, base_identifier:console
 [  68]       Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("finally")]
-[  90]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@d0, false_target:@d8
-[  a8]    3: Mov dst:reg6, src:Int32(1)
-[  b8]       Mov dst:reg5, src:Int32(2)
-[  c8]       Jump target:@30
-[  d0]    4: End value:Undefined
-[  d8]    5: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@f0, false_target:@f8
-[  f0]    6: Return value:reg6
-[  f8]    7: Throw src:reg6
+[  90]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@c8, false_target:@d0
+[  a8]    3: Mov2 dst1:reg6, src1:Int32(1), dst2:reg5, src2:Int32(2)
+[  c0]       Jump target:@30
+[  c8]    4: End value:Undefined
+[  d0]    5: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@e8, false_target:@f0
+[  e8]    6: Return value:reg6
+[  f0]    7: Throw src:reg6
 
 Exception handlers:
-    from   a8 to   d0 handler   10
+    from   a8 to   c8 handler   10
 
 JS bytecode executable "breakThroughFinally"
 [   0]    0: GetLexicalEnvironment dst:reg4
@@ -72,7 +71,7 @@ JS bytecode executable "nestedTryFinallyWithBreak"
 [  60]    5: GetGlobal dst:reg8, identifier:console
 [  78]       GetById dst:reg9, base:reg8, property:log, base_identifier:console
 [  98]       Call dst:reg7, callee:reg9, this_value:reg8, console.log, arguments:[String("outer")]
-[  c0]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@220, false_target:@228
+[  c0]       JumpStrictlyEquals lhs:reg5, rhs:Int32(0), true_target:@218, false_target:@220
 [  d8]    6: Jump target:@178
 [  e0]    7: Catch dst:reg8
 [  e8]       SetLexicalEnvironment environment:reg4
@@ -88,21 +87,20 @@ JS bytecode executable "nestedTryFinallyWithBreak"
 [ 1a8]   11: Mov dst:reg5, src:Int32(0)
 [ 1b8]       Jump target:@60
 [ 1c0]   12: JumpStrictlyEquals lhs:reg7, rhs:Int32(3), true_target:@190, false_target:@1d8
-[ 1d8]   13: JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:@1f0, false_target:@218
-[ 1f0]   14: Mov dst:reg5, src:reg7
-[ 200]       Mov dst:reg6, src:reg8
-[ 210]       Jump target:@60
-[ 218]   15: Throw src:reg8
-[ 220]   16: Jump target:@20
-[ 228]   17: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@38, false_target:@240
-[ 240]   18: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@258, false_target:@260
-[ 258]   19: Return value:reg6
-[ 260]   20: Throw src:reg6
+[ 1d8]   13: JumpStrictlyEquals lhs:reg7, rhs:Int32(2), true_target:@1f0, false_target:@210
+[ 1f0]   14: Mov2 dst1:reg5, src1:reg7, dst2:reg6, src2:reg8
+[ 208]       Jump target:@60
+[ 210]   15: Throw src:reg8
+[ 218]   16: Jump target:@20
+[ 220]   17: JumpStrictlyEquals lhs:reg5, rhs:Int32(3), true_target:@38, false_target:@238
+[ 238]   18: JumpStrictlyEquals lhs:reg5, rhs:Int32(2), true_target:@250, false_target:@258
+[ 250]   19: Return value:reg6
+[ 258]   20: Throw src:reg6
 
 Exception handlers:
     from   d8 to  178 handler   40
     from  178 to  1a8 handler   e0
-    from  1a8 to  220 handler   40
+    from  1a8 to  218 handler   40
 
 "finally"
 0

--- a/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
+++ b/Tests/LibJS/Bytecode/expected/using-declaration-non-local-env.txt
@@ -1,21 +1,18 @@
 JS bytecode executable ""
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Jump target:@58
+[   8]       Jump target:@48
 [  10]    1: Catch dst:reg5
 [  18]       SetLexicalEnvironment environment:reg4
-[  20]       Mov dst:e~0, src:reg5
-[  30]       Mov dst:reg6, src:Undefined
-[  40]       Mov dst:reg7, src:reg6
-[  50]    2: End value:reg6
-[  58]    3: Mov dst:reg5, src:Undefined
-[  68]       NewFunction dst:reg8, shared_function_data_index:0
-[  80]       Call dst:reg6, callee:reg8, this_value:Undefined
-[  a0]       Mov dst:reg5, src:reg6
-[  b0]       Mov dst:reg6, src:reg5
-[  c0]       End value:reg6
+[  20]       Mov3 dst1:e~0, src1:reg5, dst2:reg6, src2:Undefined, dst3:reg7, src3:reg6
+[  40]    2: End value:reg6
+[  48]    3: Mov dst:reg5, src:Undefined
+[  58]       NewFunction dst:reg8, shared_function_data_index:0
+[  70]       Call dst:reg6, callee:reg8, this_value:Undefined
+[  90]       Mov2 dst1:reg5, src1:reg6, dst2:reg6, src2:reg5
+[  a8]       End value:reg6
 
 Exception handlers:
-    from   58 to   c8 handler   10
+    from   48 to   b0 handler   10
 
 JS bytecode executable ""
 [   0]    0: GetLexicalEnvironment dst:reg4

--- a/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
+++ b/Tests/LibJS/Bytecode/expected/var-hoisting-tdz.txt
@@ -6,13 +6,12 @@ JS bytecode executable ""
 
 JS bytecode executable "isect"
 [   0]    0: GetLexicalEnvironment dst:reg4
-[   8]       Mov dst:i~0, src:Undefined
-[  18]       Mov dst:i~0, src:Int32(0)
-[  28]       Jump target:@40
-[  30]    1: PostfixIncrement dst:reg5, src:i~0
-[  40]    2: JumpLessThan lhs:i~0, rhs:Int32(3), true_target:@30, false_target:@58
-[  58]    3: Mov dst:i~0, src:Int32(0)
-[  68]       Jump target:@80
-[  70]    4: PostfixIncrement dst:reg5, src:i~0
-[  80]    5: JumpLessThan lhs:i~0, rhs:Int32(3), true_target:@70, false_target:@98
-[  98]    6: End value:Undefined
+[   8]       Mov2 dst1:i~0, src1:Undefined, dst2:i~0, src2:Int32(0)
+[  20]       Jump target:@38
+[  28]    1: PostfixIncrement dst:reg5, src:i~0
+[  38]    2: JumpLessThan lhs:i~0, rhs:Int32(3), true_target:@28, false_target:@50
+[  50]    3: Mov dst:i~0, src:Int32(0)
+[  60]       Jump target:@78
+[  68]    4: PostfixIncrement dst:reg5, src:i~0
+[  78]    5: JumpLessThan lhs:i~0, rhs:Int32(3), true_target:@68, false_target:@90
+[  90]    6: End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
+++ b/Tests/LibJS/Bytecode/expected/var-init-in-param-body-scope.txt
@@ -8,7 +8,5 @@ JS bytecode executable "f"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       JumpUndefined condition:arg0, true_target:@18, false_target:@28
 [  18]    1: Mov dst:arg0, src:Int32(1)
-[  28]    2: Mov dst:reg5, src:Undefined
-[  38]       Mov dst:x~0, src:reg5
-[  48]       Mov dst:x~0, src:String("inside")
-[  58]       End value:Undefined
+[  28]    2: Mov3 dst1:reg5, src1:Undefined, dst2:x~0, src2:reg5, dst3:x~0, src3:String("inside")
+[  48]       End value:Undefined

--- a/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
+++ b/Tests/LibJS/Bytecode/expected/var-shadow-in-default-param.txt
@@ -24,7 +24,5 @@ JS bytecode executable "no_conflict"
 [   0]    0: GetLexicalEnvironment dst:reg4
 [   8]       JumpUndefined condition:arg0, true_target:@18, false_target:@28
 [  18]    1: Mov dst:arg0, src:Int32(1)
-[  28]    2: Mov dst:reg5, src:Undefined
-[  38]       Mov dst:y~0, src:reg5
-[  48]       Mov dst:y~0, src:Int32(2)
-[  58]       Return value:y~0
+[  28]    2: Mov3 dst1:reg5, src1:Undefined, dst2:y~0, src2:reg5, dst3:y~0, src3:Int32(2)
+[  48]       Return value:y~0

--- a/Tests/LibJS/Bytecode/input/mov-merging.js
+++ b/Tests/LibJS/Bytecode/input/mov-merging.js
@@ -1,0 +1,15 @@
+function twoLocals() {
+    let a = 1;
+    let b = 2;
+    return a + b;
+}
+
+function threeLocals() {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    return a + b + c;
+}
+
+console.log(twoLocals());
+console.log(threeLocals());


### PR DESCRIPTION
Add `Mov2` and `Mov3` bytecode instructions that perform 2 or 3 register moves in a single dispatch. A peephole optimization pass during bytecode assembly merges consecutive Mov instructions within each basic block into these combined instructions.

When merging, identical `Mov`s are deduplicated (e.g. two identical `Mov`s become a single `Mov`, not a `Mov2`). This optimization is implemented in both the C++ and Rust codegen pipelines.

The goal is to reduce the per-instruction dispatch overhead, which is significant compared to the actual cost of moving a value.

This isn't fancy or elegant, but provides a real speed-up on many workloads. As an example, Kraken/imaging-desaturate.js improves by ~1.07x on my laptop.

```
Suite       Test                                   Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  -----------------------------------  ---------  ---------------------------------  ---------------------------------
SunSpider   3d-cube.js                               0.976  0.014 ± 0.014 … 0.014              0.014 ± 0.014 … 0.014
SunSpider   3d-morph.js                              0.938  0.016 ± 0.015 … 0.016              0.017 ± 0.017 … 0.017
SunSpider   3d-raytrace.js                           0.985  0.015 ± 0.015 … 0.015              0.016 ± 0.015 … 0.016
SunSpider   access-binary-trees.js                   0.973  0.012 ± 0.012 … 0.012              0.012 ± 0.012 … 0.013
SunSpider   access-fannkuch.js                       1.054  0.017 ± 0.017 … 0.018              0.017 ± 0.016 … 0.017
SunSpider   access-nbody.js                          0.956  0.012 ± 0.012 … 0.013              0.013 ± 0.013 … 0.013
SunSpider   access-nsieve.js                         1.056  0.012 ± 0.012 … 0.012              0.011 ± 0.011 … 0.011
SunSpider   bitops-3bit-bits-in-byte.js              1.023  0.010 ± 0.009 … 0.010              0.009 ± 0.009 … 0.009
SunSpider   bitops-bits-in-byte.js                   1.01   0.014 ± 0.014 … 0.014              0.013 ± 0.013 … 0.014
SunSpider   bitops-bitwise-and.js                    1      0.012 ± 0.012 … 0.012              0.012 ± 0.012 … 0.012
SunSpider   bitops-nsieve-bits.js                    0.953  0.011 ± 0.011 … 0.011              0.011 ± 0.011 … 0.011
SunSpider   controlflow-recursive.js                 0.982  0.010 ± 0.010 … 0.010              0.010 ± 0.010 … 0.010
SunSpider   crypto-aes.js                            0.976  0.015 ± 0.015 … 0.015              0.015 ± 0.015 … 0.016
SunSpider   crypto-md5.js                            1.014  0.010 ± 0.010 … 0.010              0.010 ± 0.010 … 0.010
SunSpider   crypto-sha1.js                           0.956  0.009 ± 0.009 … 0.010              0.010 ± 0.010 … 0.010
SunSpider   date-format-tofte.js                     0.966  0.037 ± 0.037 … 0.037              0.039 ± 0.038 … 0.039
SunSpider   date-format-xparb.js                     0.978  0.024 ± 0.024 … 0.024              0.025 ± 0.025 … 0.025
SunSpider   math-cordic.js                           1.086  0.015 ± 0.015 … 0.016              0.014 ± 0.014 … 0.014
SunSpider   math-partial-sums.js                     0.981  0.010 ± 0.010 … 0.010              0.011 ± 0.011 … 0.011
SunSpider   math-spectral-norm.js                    0.993  0.011 ± 0.011 … 0.011              0.011 ± 0.011 … 0.011
SunSpider   regexp-dna.js                            0.997  0.332 ± 0.331 … 0.334              0.333 ± 0.332 … 0.335
SunSpider   string-base64.js                         0.978  0.014 ± 0.014 … 0.015              0.015 ± 0.014 … 0.015
SunSpider   string-fasta.js                          0.963  0.051 ± 0.051 … 0.051              0.053 ± 0.052 … 0.054
SunSpider   string-tagcloud.js                       0.977  0.067 ± 0.067 … 0.068              0.069 ± 0.069 … 0.069
SunSpider   string-unpack-code.js                    0.976  0.062 ± 0.062 … 0.062              0.063 ± 0.063 … 0.063
SunSpider   string-validate-input.js                 0.983  0.019 ± 0.019 … 0.019              0.019 ± 0.019 … 0.020
Kraken      ai-astar.js                              1      0.508 ± 0.506 … 0.511              0.509 ± 0.506 … 0.511
Kraken      audio-beat-detection.js                  0.979  0.412 ± 0.411 … 0.413              0.421 ± 0.417 … 0.424
Kraken      audio-dft.js                             1.02   0.307 ± 0.305 … 0.308              0.301 ± 0.301 … 0.301
Kraken      audio-fft.js                             0.991  0.352 ± 0.352 … 0.352              0.355 ± 0.354 … 0.356
Kraken      audio-oscillator.js                      0.991  0.371 ± 0.368 … 0.375              0.375 ± 0.372 … 0.378
Kraken      imaging-darkroom.js                      0.981  0.521 ± 0.517 … 0.525              0.531 ± 0.528 … 0.533
Kraken      imaging-desaturate.js                    1.074  0.515 ± 0.515 … 0.515              0.479 ± 0.478 … 0.480
Kraken      imaging-gaussian-blur.js                 0.997  2.401 ± 2.391 … 2.412              2.409 ± 2.395 … 2.424
Kraken      json-parse-financial.js                  1.005  0.055 ± 0.055 … 0.055              0.055 ± 0.055 … 0.055
Kraken      json-stringify-tinderbox.js              1.003  0.054 ± 0.053 … 0.055              0.054 ± 0.054 … 0.054
Kraken      stanford-crypto-aes.js                   1.042  0.195 ± 0.194 … 0.195              0.187 ± 0.185 … 0.189
Kraken      stanford-crypto-ccm.js                   1.021  0.204 ± 0.203 … 0.205              0.200 ± 0.200 … 0.200
Kraken      stanford-crypto-pbkdf2.js                1.039  0.369 ± 0.369 … 0.370              0.356 ± 0.354 … 0.357
Kraken      stanford-crypto-sha256-iterative.js      1.009  0.147 ± 0.147 … 0.147              0.146 ± 0.145 … 0.147
Octane      box2d.js                                 1      9673.000 ± 9654.000 … 9692.000     9677.500 ± 9663.000 … 9692.000
Octane      code-load.js                             0.991  16552.000 ± 16267.000 … 16837.000  16402.500 ± 16400.000 … 16405.000
Octane      crypto.js                                1.027  3304.000 ± 3298.000 … 3310.000     3394.000 ± 3389.000 … 3399.000
Octane      deltablue.js                             1.004  1997.500 ± 1978.000 … 2017.000     2004.500 ± 1955.000 … 2054.000
Octane      earley-boyer.js                          1.019  4343.000 ± 4338.000 … 4348.000     4426.000 ± 4409.000 … 4443.000
Octane      gbemu.js                                 1.009  18711.000 ± 18711.000 … 18711.000  18870.500 ± 18828.000 … 18913.000
Octane      mandreel.js                              1.006  15292.500 ± 15199.000 … 15386.000  15386.000 ± 15386.000 … 15386.000
Octane      navier-stokes.js                         0.98   4956.500 ± 4952.000 … 4961.000     4858.500 ± 4830.000 … 4887.000
Octane      pdfjs.js                                 1.019  6844.500 ± 6821.000 … 6868.000     6972.500 ± 6962.000 … 6983.000
Octane      raytrace.js                              1.03   2780.000 ± 2722.000 … 2838.000     2863.000 ± 2787.000 … 2939.000
Octane      regexp.js                                1.005  194.500 ± 194.000 … 195.000        195.500 ± 195.000 … 196.000
Octane      richards.js                              1.023  2290.000 ± 2285.000 … 2295.000     2342.500 ± 2341.000 … 2344.000
Octane      splay.js                                 1.005  6035.000 ± 6019.000 … 6051.000     6062.500 ± 6061.000 … 6064.000
Octane      typescript.js                            1.007  21464.000 ± 21372.000 … 21556.000  21617.500 ± 21513.000 … 21722.000
Octane      zlib.js                                  1.016  6625.500 ± 6615.000 … 6636.000     6734.500 ± 6734.000 … 6735.000
JetStream   bigfib.cpp.js                            1.004  4.097 ± 4.095 … 4.099              4.080 ± 4.071 … 4.090
JetStream   cdjs.js                                  0.997  2.158 ± 2.150 … 2.166              2.163 ± 2.139 … 2.188
JetStream   container.cpp.js                         1.03   20.100 ± 20.097 … 20.103           19.511 ± 19.457 … 19.565
JetStream   dry.c.js                                 1      9.950 ± 9.932 … 9.968              9.954 ± 9.904 … 10.003
JetStream   float-mm.c.js                            0.985  14.381 ± 14.033 … 14.730           14.600 ± 14.399 … 14.801
JetStream   gcc-loops.cpp.js                         1.008  59.671 ± 59.638 … 59.705           59.181 ± 59.041 … 59.320
JetStream   hash-map.js                              1.012  0.941 ± 0.937 … 0.944              0.929 ± 0.925 … 0.933
JetStream   n-body.c.js                              1.003  15.670 ± 15.611 … 15.730           15.621 ± 15.530 … 15.712
JetStream   quicksort.c.js                           0.991  2.740 ± 2.687 … 2.793              2.766 ± 2.748 … 2.783
JetStream   towers.c.js                              1.034  3.107 ± 3.101 … 3.112              3.006 ± 2.978 … 3.033
SunSpider   Total                                    0.989  0.833                              0.842
Kraken      Total                                    1.006  6.411                              6.376
Octane      Total                                    1.006  121063.000                         121807.500
JetStream   Total                                    1.008  132.816                            131.810
All Suites  Total                                    1.008  208.751                            207.043
```