### PR TITLE
Add fast_is<TransientRegisteredObserver> to avoid dynamic_cast

### DIFF
--- a/Libraries/LibWeb/DOM/MutationObserver.h
+++ b/Libraries/LibWeb/DOM/MutationObserver.h
@@ -74,10 +74,15 @@ public:
     static GC::Ref<RegisteredObserver> create(MutationObserver&, MutationObserverInit const&);
     virtual ~RegisteredObserver() override;
 
+    virtual bool is_transient() const { return false; }
+
     GC::Ref<MutationObserver> observer() const { return m_observer; }
 
     MutationObserverInit const& options() const { return m_options; }
     void set_options(MutationObserverInit options) { m_options = move(options); }
+
+    template<typename T>
+    bool fast_is() const = delete;
 
 protected:
     RegisteredObserver(MutationObserver& observer, MutationObserverInit const& options);
@@ -100,6 +105,8 @@ public:
 
     GC::Ref<RegisteredObserver> source() const { return m_source; }
 
+    virtual bool is_transient() const override { return true; }
+
 private:
     TransientRegisteredObserver(MutationObserver& observer, MutationObserverInit const& options, RegisteredObserver& source);
 
@@ -107,5 +114,8 @@ private:
 
     GC::Ref<RegisteredObserver> m_source;
 };
+
+template<>
+inline bool RegisteredObserver::fast_is<TransientRegisteredObserver>() const { return is_transient(); }
 
 }


### PR DESCRIPTION
Profiling shows is<TransientRegisteredObserver> dynamic_cast consuming significant time during event dispatch.