### PR TITLE
LibWeb: Include shadow host when checking for node event listeners

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -3409,7 +3409,7 @@ bool Node::has_inclusive_ancestor_with_display_none()
 
 bool Node::has_inclusive_ancestor_with_event_listener(FlyString const& type) const
 {
-    for (auto const* ancestor = this; ancestor; ancestor = ancestor->parent()) {
+    for (auto const* ancestor = this; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
         if (ancestor->has_event_listener(type))
             return true;
     }

--- a/Tests/LibWeb/Text/expected/UIEvents/pointer-events-shadow-dom.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/pointer-events-shadow-dom.txt
@@ -1,0 +1,6 @@
+> move pointer over shadow content
+pointerover target.id="host" relatedTarget.id="body"
+pointerenter target.id="host" relatedTarget.id="body"
+pointermove target.id="host" relatedTarget.id="null"
+> move pointer outside
+pointerout target.id="host" relatedTarget.id="body"

--- a/Tests/LibWeb/Text/input/UIEvents/pointer-events-shadow-dom.html
+++ b/Tests/LibWeb/Text/input/UIEvents/pointer-events-shadow-dom.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+    padding: 5px;
+    width: 200px;
+    height: 200px;
+}
+
+#host {
+    width: 100px;
+    height: 100px;
+    background-color: yellowgreen;
+}
+</style>
+<body id="body"><div id="host"></div></body>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const shadow = host.attachShadow({ mode: "open" });
+        shadow.innerHTML = `
+            <style>
+                #inner {
+                    width: 50px;
+                    height: 50px;
+                    background-color: magenta;
+                }
+            </style>
+            <div id="inner"></div>
+        `;
+        const inner = shadow.getElementById("inner");
+
+        function logEvent(e) {
+            println(`${e.type} target.id="${e.target.id}" relatedTarget.id="${e.relatedTarget?.id ?? 'null'}"`);
+        }
+
+        internals.mouseMove(0, 0);
+
+        const events = [
+            'pointerover',
+            'pointerout',
+            'pointerenter',
+            'pointerleave',
+            'pointermove',
+        ];
+
+        events.forEach(eventType => {
+            host.addEventListener(eventType, logEvent);
+        });
+
+        println("> move pointer over shadow content");
+        internals.mouseMove(10, 10);
+
+        println("> move pointer outside");
+        internals.mouseMove(0, 0);
+    });
+</script>


### PR DESCRIPTION
Fixes a regression in 57c9bb5 where the media controls would not show when moving the cursor over the video overlay element.