### PR TITLE
Revert "LibJS: Shrink ExecutionContext by replacing ScriptOrModule …"

### DIFF
--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -641,10 +641,10 @@ i64 asm_try_get_global_env_binding(Interpreter* interp, u32 pc)
     auto& vm = Interpreter::vm();
     ThrowCompletionOr<Value> result = js_undefined();
     if (cache.in_module_environment) {
-        auto* module = as_if<Module>(vm.running_execution_context().script_or_module.ptr());
+        auto module = vm.running_execution_context().script_or_module.get_pointer<GC::Ref<Module>>();
         if (!module) [[unlikely]]
             return 1;
-        result = module->environment()->get_binding_value_direct(vm, cache.environment_binding_index);
+        result = (*module)->environment()->get_binding_value_direct(vm, cache.environment_binding_index);
     } else {
         result = interp->global_declarative_environment().get_binding_value_direct(vm, cache.environment_binding_index);
     }
@@ -672,10 +672,10 @@ i64 asm_try_set_global_env_binding(Interpreter* interp, u32 pc)
     auto src = interp->get(insn.src());
     ThrowCompletionOr<void> result;
     if (cache.in_module_environment) {
-        auto* module = as_if<Module>(vm.running_execution_context().script_or_module.ptr());
+        auto module = vm.running_execution_context().script_or_module.get_pointer<GC::Ref<Module>>();
         if (!module) [[unlikely]]
             return 1;
-        result = module->environment()->set_mutable_binding_direct(vm, cache.environment_binding_index, src, insn.strict() == Strict::Yes);
+        result = (*module)->environment()->set_mutable_binding_direct(vm, cache.environment_binding_index, src, insn.strict() == Strict::Yes);
     } else {
         result = interp->global_declarative_environment().set_mutable_binding_direct(vm, cache.environment_binding_index, src, insn.strict() == Strict::Yes);
     }

--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -149,7 +149,7 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, GC::Ptr<Environ
     script_context->realm = &script_record.realm();
 
     // 5. Set the ScriptOrModule of scriptContext to scriptRecord.
-    script_context->script_or_module = &script_record;
+    script_context->script_or_module = GC::Ref<Script>(script_record);
 
     // 6. Set the VariableEnvironment of scriptContext to globalEnv.
     script_context->variable_environment = &global_environment;
@@ -1086,8 +1086,8 @@ inline ThrowCompletionOr<Value> get_global(Interpreter& interpreter, IdentifierT
         //               we can use the cached environment binding index.
         if (cache.has_environment_binding_index) {
             if (cache.in_module_environment) {
-                auto* module = as_if<Module>(vm.running_execution_context().script_or_module.ptr());
-                return module->environment()->get_binding_value_direct(vm, cache.environment_binding_index);
+                auto module = vm.running_execution_context().script_or_module.get_pointer<GC::Ref<Module>>();
+                return (*module)->environment()->get_binding_value_direct(vm, cache.environment_binding_index);
             }
             return declarative_record.get_binding_value_direct(vm, cache.environment_binding_index);
         }
@@ -1097,10 +1097,10 @@ inline ThrowCompletionOr<Value> get_global(Interpreter& interpreter, IdentifierT
 
     auto& identifier = interpreter.get_identifier(identifier_index);
 
-    if (auto* module = as_if<Module>(vm.running_execution_context().script_or_module.ptr())) {
+    if (auto* module = vm.running_execution_context().script_or_module.get_pointer<GC::Ref<Module>>()) {
         // NOTE: GetGlobal is used to access variables stored in the module environment and global environment.
         //       The module environment is checked first since it precedes the global environment in the environment chain.
-        auto& module_environment = *module->environment();
+        auto& module_environment = *(*module)->environment();
         Optional<size_t> index;
         if (TRY(module_environment.has_binding(identifier, &index))) {
             if (index.has_value()) {
@@ -2317,8 +2317,8 @@ ThrowCompletionOr<void> SetGlobal::execute_impl(Bytecode::Interpreter& interpret
         //               we can use the cached environment binding index.
         if (cache.has_environment_binding_index) {
             if (cache.in_module_environment) {
-                auto* module = as_if<Module>(vm.running_execution_context().script_or_module.ptr());
-                TRY(module->environment()->set_mutable_binding_direct(vm, cache.environment_binding_index, src, strict() == Strict::Yes));
+                auto module = vm.running_execution_context().script_or_module.get_pointer<GC::Ref<Module>>();
+                TRY((*module)->environment()->set_mutable_binding_direct(vm, cache.environment_binding_index, src, strict() == Strict::Yes));
             } else {
                 TRY(declarative_record.set_mutable_binding_direct(vm, cache.environment_binding_index, src, strict() == Strict::Yes));
             }
@@ -2330,10 +2330,10 @@ ThrowCompletionOr<void> SetGlobal::execute_impl(Bytecode::Interpreter& interpret
 
     auto& identifier = interpreter.get_identifier(m_identifier);
 
-    if (auto* module = as_if<Module>(vm.running_execution_context().script_or_module.ptr())) {
+    if (auto* module = vm.running_execution_context().script_or_module.get_pointer<GC::Ref<Module>>()) {
         // NOTE: GetGlobal is used to access variables stored in the module environment and global environment.
         //       The module environment is checked first since it precedes the global environment in the environment chain.
-        auto& module_environment = *module->environment();
+        auto& module_environment = *(*module)->environment();
         Optional<size_t> index;
         if (TRY(module_environment.has_binding(identifier, &index))) {
             if (index.has_value()) {

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -167,9 +167,7 @@ ECMAScriptFunctionObject::ECMAScriptFunctionObject(
         unsafe_set_shape(realm()->intrinsics().normal_function_shape());
 
     // 15. Set F.[[ScriptOrModule]] to GetActiveScriptOrModule().
-    vm().get_active_script_or_module().visit(
-        [](Empty) {},
-        [&](auto& ref) { m_script_or_module = ref.ptr(); });
+    m_script_or_module = vm().get_active_script_or_module();
 }
 
 void ECMAScriptFunctionObject::initialize(Realm& realm)
@@ -398,7 +396,11 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
             visitor.visit(private_element.value);
     }
 
-    visitor.visit(m_script_or_module);
+    m_script_or_module.visit(
+        [](Empty) {},
+        [&](auto& script_or_module) {
+            visitor.visit(script_or_module);
+        });
 }
 
 // 10.2.7 MakeMethod ( F, homeObject ), https://tc39.es/ecma262/#sec-makemethod

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -114,7 +114,7 @@ public:
 
     // This is used by LibWeb to disassociate event handler attribute callback functions from the nearest script on the call stack.
     // https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler Step 3.11
-    void set_script_or_module(GC::Ptr<Cell> script_or_module) { m_script_or_module = script_or_module; }
+    void set_script_or_module(ScriptOrModule script_or_module) { m_script_or_module = move(script_or_module); }
 
     Variant<PropertyKey, PrivateName, Empty> const& class_field_initializer_name() const { return shared_data().m_class_field_initializer_name; }
 
@@ -151,7 +151,7 @@ private:
     // Internal Slots of ECMAScript Function Objects, https://tc39.es/ecma262/#table-internal-slots-of-ecmascript-function-objects
     GC::Ptr<Environment> m_environment;                // [[Environment]]
     GC::Ptr<PrivateEnvironment> m_private_environment; // [[PrivateEnvironment]]
-    GC::Ptr<Cell> m_script_or_module;                  // [[ScriptOrModule]]
+    ScriptOrModule m_script_or_module;                 // [[ScriptOrModule]]
     GC::Ptr<Object> m_home_object;                     // [[HomeObject]]
     struct ClassData {
         Vector<ClassFieldDefinition> fields;    // [[Fields]]

--- a/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -9,22 +9,11 @@
 
 #include <LibGC/Heap.h>
 #include <LibJS/Bytecode/Executable.h>
-#include <LibJS/Module.h>
 #include <LibJS/Runtime/DeclarativeEnvironment.h>
 #include <LibJS/Runtime/ExecutionContext.h>
 #include <LibJS/Runtime/FunctionObject.h>
-#include <LibJS/Script.h>
 
 namespace JS {
-
-ScriptOrModule script_or_module_from_cell(GC::Ptr<Cell> cell)
-{
-    if (!cell)
-        return Empty {};
-    if (auto* script = as_if<Script>(*cell))
-        return GC::Ref<Script> { *script };
-    return GC::Ref<Module> { as<Module>(*cell) };
-}
 
 class ExecutionContextAllocator {
 public:
@@ -141,9 +130,13 @@ void ExecutionContext::visit_edges(Cell::Visitor& visitor)
     visitor.visit(lexical_environment);
     visitor.visit(private_environment);
     visitor.visit(this_value);
-    visitor.visit(script_or_module);
     visitor.visit(executable);
     visitor.visit(registers_and_constants_and_locals_and_arguments_span());
+    script_or_module.visit(
+        [](Empty) {},
+        [&](auto& script_or_module) {
+            visitor.visit(script_or_module);
+        });
 }
 
 }

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -22,8 +22,6 @@ namespace JS {
 
 using ScriptOrModule = Variant<Empty, GC::Ref<Script>, GC::Ref<Module>>;
 
-[[nodiscard]] JS_API ScriptOrModule script_or_module_from_cell(GC::Ptr<Cell>);
-
 // 9.4 Execution Contexts, https://tc39.es/ecma262/#sec-execution-contexts
 struct JS_API ExecutionContext {
     static NonnullOwnPtr<ExecutionContext> create(u32 registers_and_locals_count, u32 constants_count, u32 arguments_count);
@@ -53,7 +51,7 @@ public:
 
     GC::Ptr<FunctionObject> function;                // [[Function]]
     GC::Ptr<Realm> realm;                            // [[Realm]]
-    GC::Ptr<Cell> script_or_module;                  // [[ScriptOrModule]] — points to Script or Module
+    ScriptOrModule script_or_module;                 // [[ScriptOrModule]]
     GC::Ptr<Environment> lexical_environment;        // [[LexicalEnvironment]]
     GC::Ptr<Environment> variable_environment;       // [[VariableEnvironment]]
     GC::Ptr<PrivateEnvironment> private_environment; // [[PrivateEnvironment]]

--- a/Libraries/LibJS/Runtime/Realm.cpp
+++ b/Libraries/LibJS/Runtime/Realm.cpp
@@ -47,7 +47,7 @@ ThrowCompletionOr<NonnullOwnPtr<ExecutionContext>> Realm::initialize_host_define
     new_context->realm = realm;
 
     // 10. Set the ScriptOrModule of newContext to null.
-    new_context->script_or_module = nullptr;
+    new_context->script_or_module = {};
 
     // 11. Push newContext onto the execution context stack; newContext is now the running execution context.
     vm.push_execution_context(*new_context);

--- a/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -346,7 +346,7 @@ NonnullOwnPtr<ExecutionContext> get_shadow_realm_context(Realm& shadow_realm, bo
     context->realm = &shadow_realm;
 
     // 7. Set context's ScriptOrModule to null.
-    context->script_or_module = nullptr;
+    context->script_or_module = {};
 
     // 8. Set context's VariableEnvironment to varEnv.
     context->variable_environment = variable_environment;

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -561,14 +561,14 @@ ScriptOrModule VM::get_active_script_or_module() const
 
     // 2. Let ec be the topmost execution context on the execution context stack whose ScriptOrModule component is not null.
     for (auto i = m_execution_context_stack.size() - 1; i > 0; i--) {
-        if (m_execution_context_stack[i]->script_or_module)
-            return script_or_module_from_cell(m_execution_context_stack[i]->script_or_module);
+        if (!m_execution_context_stack[i]->script_or_module.has<Empty>())
+            return m_execution_context_stack[i]->script_or_module;
     }
 
     // 3. If no such execution context exists, return null. Otherwise, return ec's ScriptOrModule.
     // Note: Since it is not empty we have 0 and since we got here all the
     //       above contexts don't have a non-null ScriptOrModule
-    return script_or_module_from_cell(m_execution_context_stack[0]->script_or_module);
+    return m_execution_context_stack[0]->script_or_module;
 }
 
 VM::StoredModule* VM::get_stored_module(ImportedModuleReferrer const&, ByteString const& filename, Utf16String const&)

--- a/Libraries/LibJS/Runtime/WrappedFunction.cpp
+++ b/Libraries/LibJS/Runtime/WrappedFunction.cpp
@@ -159,7 +159,7 @@ void prepare_for_wrapped_function_call(WrappedFunction& function, ExecutionConte
     callee_context.realm = callee_realm;
 
     // 6. Set the ScriptOrModule of calleeContext to null.
-    callee_context.script_or_module = nullptr;
+    callee_context.script_or_module = {};
 
     // 7. If callerContext is not already suspended, suspend callerContext.
     // NOTE: We don't support this concept yet.

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -548,7 +548,7 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
     m_execution_context->realm = &this->realm();
 
     // 12. Set the ScriptOrModule of moduleContext to module.
-    m_execution_context->script_or_module = this;
+    m_execution_context->script_or_module = GC::Ref<Module>(*this);
 
     // 13. Set the VariableEnvironment of moduleContext to module.[[Environment]].
     m_execution_context->variable_environment = environment;
@@ -801,7 +801,7 @@ ThrowCompletionOr<void> SourceTextModule::execute_module(VM& vm, GC::Ptr<Promise
     module_context->realm = &realm();
 
     // 4. Set the ScriptOrModule of moduleContext to module.
-    module_context->script_or_module = this;
+    module_context->script_or_module = GC::Ref<Module>(*this);
 
     // 5. Assert: module has been linked and declarations in its module environment have been instantiated.
     VERIFY(m_status != ModuleStatus::New);

--- a/Libraries/LibJS/SyntheticModule.cpp
+++ b/Libraries/LibJS/SyntheticModule.cpp
@@ -159,7 +159,7 @@ ThrowCompletionOr<GC::Ref<Promise>> SyntheticModule::evaluate(VM& vm)
     module_context->realm = &realm;
 
     // 4. Set the ScriptOrModule of moduleContext to module.
-    module_context->script_or_module = this;
+    module_context->script_or_module = GC::Ref<Module>(*this);
 
     // 5. Set the VariableEnvironment of moduleContext to module.[[Environment]].
     module_context->variable_environment = environment();

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -142,15 +142,15 @@ void initialize_main_thread_vm(AgentType type)
         // 1. Let script be the running script.
         //    The running script is the script in the [[HostDefined]] field in the ScriptOrModule component of the running JavaScript execution context.
         HTML::Script* script { nullptr };
-        auto script_or_module = JS::script_or_module_from_cell(vm.running_execution_context().script_or_module);
-        script_or_module.visit(
+        vm.running_execution_context().script_or_module.visit(
             [&script](GC::Ref<JS::Script>& js_script) {
                 script = as<HTML::ClassicScript>(js_script->host_defined());
             },
             [&script](GC::Ref<JS::Module>& js_module) {
                 script = as<HTML::ModuleScript>(js_module->host_defined());
             },
-            [](Empty) {});
+            [](Empty) {
+            });
 
         // 2. If script is a classic script and script's muted errors is true, then return.
         // NOTE: is<T>() returns false if nullptr is passed.
@@ -277,10 +277,7 @@ void initialize_main_thread_vm(AgentType type)
         // IMPLEMENTATION DEFINED: The JS spec says we must take implementation defined steps to make the currently active script or module at the time of HostEnqueuePromiseJob being invoked
         //                         also be the active script or module of the job at the time of its invocation.
         //                         This means taking it here now and passing it through to the lambda.
-        GC::Ptr<JS::Cell> active_script_or_module_cell;
-        vm.get_active_script_or_module().visit(
-            [](Empty) {},
-            [&](auto& ref) { active_script_or_module_cell = ref.ptr(); });
+        auto script_or_module = vm.get_active_script_or_module();
 
         // 1. Queue a microtask to perform the following steps:
         // This instance of "queue a microtask" uses the "implied document". The best fit for "implied document" here is "If the task is being queued by or for a script, then return the script's settings object's responsible document."
@@ -288,7 +285,7 @@ void initialize_main_thread_vm(AgentType type)
         auto* script = active_script();
 
         auto& heap = realm ? realm->heap() : vm.heap();
-        HTML::queue_a_microtask(script ? script->settings_object().responsible_document().ptr() : nullptr, GC::create_function(heap, [&vm, realm, job = move(job), active_script_or_module_cell] {
+        HTML::queue_a_microtask(script ? script->settings_object().responsible_document().ptr() : nullptr, GC::create_function(heap, [&vm, realm, job = move(job), script_or_module = move(script_or_module)] {
             // The dummy execution context has to be kept up here to keep it alive for the duration of the function.
             OwnPtr<JS::ExecutionContext> dummy_execution_context;
 
@@ -303,13 +300,13 @@ void initialize_main_thread_vm(AgentType type)
 
                 // IMPLEMENTATION DEFINED: Per the previous "implementation defined" comment, we must now make the script or module the active script or module.
                 //                         Since the only active execution context currently is the realm execution context of job settings, lets attach it here.
-                HTML::execution_context_of_realm(*realm).script_or_module = active_script_or_module_cell;
+                HTML::execution_context_of_realm(*realm).script_or_module = script_or_module;
             } else {
                 // FIXME: We need to setup a dummy execution context in case a JS::NativeFunction is called when processing the job.
                 //        This is because JS::NativeFunction::call excepts something to be on the execution context stack to be able to get the caller context to initialize the environment.
                 //        Do note that the JS spec gives _no_ guarantee that the execution context stack has something on it if HostEnqueuePromiseJob was called with a null realm: https://tc39.es/ecma262/#job-preparedtoevaluatecode
                 dummy_execution_context = JS::ExecutionContext::create(0, 0, 0);
-                dummy_execution_context->script_or_module = active_script_or_module_cell;
+                dummy_execution_context->script_or_module = script_or_module;
                 vm.push_execution_context(*dummy_execution_context);
             }
 
@@ -319,7 +316,7 @@ void initialize_main_thread_vm(AgentType type)
             // 3. If realm is not null, then clean up after running script with job settings.
             if (realm) {
                 // IMPLEMENTATION DEFINED: Disassociate the realm execution context from the script or module.
-                HTML::execution_context_of_realm(*realm).script_or_module = nullptr;
+                HTML::execution_context_of_realm(*realm).script_or_module = Empty {};
 
                 // IMPLEMENTATION DEFINED: See comment above, we need to clean up the non-standard prepare_to_run_callback() call.
                 HTML::clean_up_after_running_callback(*realm);
@@ -355,10 +352,10 @@ void initialize_main_thread_vm(AgentType type)
             script_execution_context->function = nullptr;
             script_execution_context->realm = &script->realm();
             if (is<HTML::ClassicScript>(script)) {
-                script_execution_context->script_or_module = as<HTML::ClassicScript>(script)->script_record();
+                script_execution_context->script_or_module = GC::Ref<JS::Script>(*as<HTML::ClassicScript>(script)->script_record());
             } else if (is<HTML::ModuleScript>(script)) {
                 if (is<HTML::JavaScriptModuleScript>(script)) {
-                    script_execution_context->script_or_module = as<HTML::JavaScriptModuleScript>(script)->record();
+                    script_execution_context->script_or_module = GC::Ref<JS::Module>(*as<HTML::JavaScriptModuleScript>(script)->record());
                 } else {
                     // NOTE: Handle CSS and JSON module scripts once we have those.
                     VERIFY_NOT_REACHED();
@@ -634,7 +631,7 @@ void initialize_main_thread_vm(AgentType type)
             VERIFY(module_execution_context);
             module_execution_context->realm = realm;
             if (module)
-                module_execution_context->script_or_module = module;
+                module_execution_context->script_or_module = GC::Ref { *module };
             vm.push_execution_context(*module_execution_context);
 
             JS::finish_loading_imported_module(referrer, module_request, payload, completion);

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -518,7 +518,7 @@ WebIDL::CallbackType* EventTarget::get_current_value_of_event_handler(FlyString 
         vm.pop_execution_context();
 
         // 11. Set function.[[ScriptOrModule]] to null.
-        function->set_script_or_module(nullptr);
+        function->set_script_or_module({});
 
         // 12. Set eventHandler's value to the result of creating a Web IDL EventHandler callback function object whose object reference is function and whose callback context is settings object.
         // FIXME: Update this comment once the ShadowRealm proposal is merged to pass realm.

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -192,7 +192,7 @@ static JS::ExecutionContext* top_most_script_having_execution_context(JS::VM& vm
     // Here, the topmost script-having execution context is the topmost entry of the JavaScript execution context stack that has a non-null ScriptOrModule component,
     // or null if there is no such entry in the JavaScript execution context stack.
     auto execution_context = vm.execution_context_stack().last_matching([&](JS::ExecutionContext* context) {
-        return context->script_or_module != nullptr;
+        return !context->script_or_module.has<Empty>();
     });
 
     if (!execution_context.has_value())

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -128,7 +128,7 @@ JS::Promise* JavaScriptModuleScript::run(PreventErrorReporting)
         auto* module_execution_context = stack.allocate(0, 0, 0);
         VERIFY(module_execution_context);
         module_execution_context->realm = &realm;
-        module_execution_context->script_or_module = record;
+        module_execution_context->script_or_module = GC::Ref<JS::Module> { *record };
         vm().push_execution_context(*module_execution_context);
 
         // 2. Set evaluationPromise to record.Evaluate().


### PR DESCRIPTION
… with Cell*.

This reverts commit d3495c62a728b097392c85f6275cdf2c0f66d04a.

This change introduced [some new WPT crashes](<https://wpt.fyi/results/css/css-text/i18n?q=ladybird%3Acrash&run_id=5987129781125120>) in the `css/css-text/i18n` directory.