### PR TITLE
CMake: Patch highway to work with clang-22 and possibly gcc-16

### DIFF
--- a/Meta/CMake/vcpkg/overlay-ports/highway/2695.patch
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/2695.patch
@@ -1,0 +1,25 @@
+From 21635e43996f0b4365584f69b0014655f548853a Mon Sep 17 00:00:00 2001
+From: John Platts <john_platts@hotmail.com>
+Date: Sun, 31 Aug 2025 22:08:43 -0500
+Subject: [PATCH] Fix for AVX10_2 target with Android NDK r29-beta3
+
+---
+ hwy/ops/x86_128-inl.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/hwy/ops/x86_128-inl.h b/hwy/ops/x86_128-inl.h
+index bcd08d590d..3a2820102e 100644
+--- a/hwy/ops/x86_128-inl.h
++++ b/hwy/ops/x86_128-inl.h
+@@ -71,8 +71,9 @@ namespace detail {
+ #endif
+ 
+ #undef HWY_X86_HAVE_AVX10_2_OPS
+-#if HWY_TARGET_IS_AVX10_2 && \
+-    (HWY_COMPILER_GCC_ACTUAL >= 1501 || HWY_COMPILER3_CLANG >= 200103)
++#if HWY_TARGET_IS_AVX10_2 &&            \
++    (HWY_COMPILER_GCC_ACTUAL >= 1501 || \
++     (HWY_COMPILER3_CLANG >= 200103 && HWY_COMPILER_CLANG != 2100))
+ #define HWY_X86_HAVE_AVX10_2_OPS 1
+ #else
+ #define HWY_X86_HAVE_AVX10_2_OPS 0

--- a/Meta/CMake/vcpkg/overlay-ports/highway/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/portfile.cmake
@@ -1,0 +1,36 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/highway
+    REF "${VERSION}"
+    SHA512 8b9f4fdc4fa60b6817417959853f5b55bf86aec9d35fc6664dda15179cc55e0a9940f3a46011a84b95263ba342dc47ca1cb93b04481ff4b63d724cce1815d7c6
+    HEAD_REF master
+    PATCHES
+        2695.patch
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        contrib  HWY_ENABLE_CONTRIB
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DHWY_ENABLE_INSTALL=ON
+        -DHWY_ENABLE_EXAMPLES=OFF
+        -DHWY_ENABLE_TESTS=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME hwy CONFIG_PATH lib/cmake/hwy)
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/hwy/highway_export.h" "defined(HWY_SHARED_DEFINE)" "1")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/Meta/CMake/vcpkg/overlay-ports/highway/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/portfile.cmake
@@ -6,6 +6,7 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         2695.patch
+        vcpkg-50397.diff # https://github.com/microsoft/vcpkg/issues/50397
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/Meta/CMake/vcpkg/overlay-ports/highway/usage
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/usage
@@ -1,0 +1,4 @@
+highway provides CMake targets:
+
+    find_package(hwy CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE hwy::hwy)

--- a/Meta/CMake/vcpkg/overlay-ports/highway/vcpkg-50397.diff
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/vcpkg-50397.diff
@@ -1,0 +1,554 @@
+diff --git a/hwy/ops/set_macros-inl.h b/hwy/ops/set_macros-inl.h
+index 852aa13c..deb63101 100644
+--- a/hwy/ops/set_macros-inl.h
++++ b/hwy/ops/set_macros-inl.h
+@@ -1,5 +1,6 @@
+ // Copyright 2020 Google LLC
+-// Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
++// Copyright 2024-2025 Arm Limited and/or its affiliates
++// <open-source-office@arm.com>
+ // SPDX-License-Identifier: Apache-2.0
+ // SPDX-License-Identifier: BSD-3-Clause
+ //
+@@ -34,7 +35,7 @@
+ #undef HWY_NAMESPACE
+ #undef HWY_ALIGN
+ #undef HWY_MAX_BYTES
+-#undef HWY_LANES
++#undef HWY_MIN_BYTES
+ 
+ #undef HWY_HAVE_SCALABLE
+ #undef HWY_HAVE_TUPLE
+@@ -44,8 +45,19 @@
+ #undef HWY_MEM_OPS_MIGHT_FAULT
+ #undef HWY_NATIVE_FMA
+ #undef HWY_NATIVE_DOT_BF16
+-#undef HWY_CAP_GE256
+-#undef HWY_CAP_GE512
++#undef HWY_NATIVE_MASK
++#undef HWY_NATIVE_INTERLEAVE_WHOLE
++
++#ifndef HWY_CAP_GE256
++#define HWY_CAP_GE256 (HWY_MIN_BYTES >= 32)
++#endif
++#ifndef HWY_CAP_GE512
++#define HWY_CAP_GE512 (HWY_MIN_BYTES >= 64)
++#endif
++
++// Almost all targets (except RVV and SCALAR) use this definition.
++#undef HWY_LANES
++#define HWY_LANES(T) (HWY_MAX_BYTES / sizeof(T))
+ 
+ #undef HWY_TARGET_IS_SVE
+ #if HWY_TARGET & HWY_ALL_SVE
+@@ -141,57 +153,65 @@
+ #define HWY_TARGET_STR_AVX2 \
+   HWY_TARGET_STR_SSE4 ",avx,avx2" HWY_TARGET_STR_BMI2_FMA HWY_TARGET_STR_F16C
+ 
+-#if (HWY_COMPILER_GCC_ACTUAL >= 1400 && HWY_COMPILER_GCC_ACTUAL < 1600) || \
+-    HWY_COMPILER_CLANG >= 1800
++#ifndef HWY_HAVE_EVEX512  // allow override
++// evex512 has been removed from clang 22, see
++// https://github.com/llvm/llvm-project/pull/157034
++#if (1400 <= HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1600) || \
++    (1800 <= HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 2200)
++#define HWY_HAVE_EVEX512 1
++#else
++#define HWY_HAVE_EVEX512 0
++#endif
++#endif
++
++#if (HWY_HAVE_EVEX512 == 1)
+ #define HWY_TARGET_STR_AVX3_VL512 ",evex512"
+ #else
+ #define HWY_TARGET_STR_AVX3_VL512
+ #endif
+ 
+-#define HWY_TARGET_STR_AVX3_256 \
+-  HWY_TARGET_STR_AVX2           \
++#define HWY_TARGET_STR_AVX3 \
++  HWY_TARGET_STR_AVX2       \
+   ",avx512f,avx512cd,avx512vl,avx512dq,avx512bw" HWY_TARGET_STR_AVX3_VL512
+ 
+-#define HWY_TARGET_STR_AVX3 HWY_TARGET_STR_AVX3_256 HWY_TARGET_STR_AVX3_VL512
+-
+-#define HWY_TARGET_STR_AVX3_DL_256                                   \
+-  HWY_TARGET_STR_AVX3_256                                            \
++#define HWY_TARGET_STR_AVX3_DL                                       \
++  HWY_TARGET_STR_AVX3                                                \
+   ",vpclmulqdq,avx512vbmi,avx512vbmi2,vaes,avx512vnni,avx512bitalg," \
+   "avx512vpopcntdq,gfni"
+ 
+-#define HWY_TARGET_STR_AVX3_DL \
+-  HWY_TARGET_STR_AVX3_DL_256 HWY_TARGET_STR_AVX3_VL512
+-
+-// Force-disable for compilers that do not properly support avx512bf16.
+-#if !defined(HWY_AVX3_DISABLE_AVX512BF16) &&                        \
++// Opt-out for compilers that do not properly support avx512bf16.
++#ifndef HWY_AVX3_ENABLE_AVX512BF16  // allow override
++// Default is to disable if the DISABLE macro is defined, or if old compiler.
++// clang-cl 21.1.4 reportedly works; feel free to define this to 1 there.
++#if defined(HWY_AVX3_DISABLE_AVX512BF16) ||                         \
+     (HWY_COMPILER_CLANGCL ||                                        \
+      (HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1000) || \
+      (HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 900))
+-#define HWY_AVX3_DISABLE_AVX512BF16
++#define HWY_AVX3_ENABLE_AVX512BF16 0
++#else
++#define HWY_AVX3_ENABLE_AVX512BF16 1
+ #endif
++#endif  // HWY_AVX3_ENABLE_AVX512BF16
+ 
+-#if !defined(HWY_AVX3_DISABLE_AVX512BF16)
+-#define HWY_TARGET_STR_AVX3_ZEN4_256 HWY_TARGET_STR_AVX3_DL ",avx512bf16"
++#if HWY_AVX3_ENABLE_AVX512BF16
++#define HWY_TARGET_STR_AVX3_ZEN4 HWY_TARGET_STR_AVX3_DL ",avx512bf16"
+ #else
+-#define HWY_TARGET_STR_AVX3_ZEN4_256 HWY_TARGET_STR_AVX3_DL
++#define HWY_TARGET_STR_AVX3_ZEN4 HWY_TARGET_STR_AVX3_DL
+ #endif
+ 
+-#define HWY_TARGET_STR_AVX3_ZEN4 \
+-  HWY_TARGET_STR_AVX3_ZEN4_256 HWY_TARGET_STR_AVX3_VL512
+-
+ #if HWY_COMPILER_GCC_ACTUAL >= 1200 || HWY_COMPILER_CLANG >= 1400
+-#define HWY_TARGET_STR_AVX3_SPR_256 HWY_TARGET_STR_AVX3_ZEN4_256 ",avx512fp16"
++#define HWY_TARGET_STR_AVX3_SPR HWY_TARGET_STR_AVX3_ZEN4 ",avx512fp16"
+ #else
+-#define HWY_TARGET_STR_AVX3_SPR_256 HWY_TARGET_STR_AVX3_ZEN4_256
++#define HWY_TARGET_STR_AVX3_SPR HWY_TARGET_STR_AVX3_ZEN4
+ #endif
+ 
+-#define HWY_TARGET_STR_AVX3_SPR \
+-  HWY_TARGET_STR_AVX3_SPR_256 HWY_TARGET_STR_AVX3_VL512
+-
+-#if HWY_COMPILER_GCC_ACTUAL >= 1500
+-#define HWY_TARGET_STR_AVX10_2 HWY_TARGET_STR_AVX3_SPR ",avx10.2"
+-#elif HWY_COMPILER_CLANG >= 2000
++// Support for avx10.2-512 was removed between clang 22 and 23 without a
++// feature test macro.
++#if HWY_COMPILER_CLANG >= 2200 && HWY_HAVE_EVEX512
+ #define HWY_TARGET_STR_AVX10_2 HWY_TARGET_STR_AVX3_SPR ",avx10.2-512"
++// Recent compilers drop the -512 suffix because 512 bits are always available.
++#elif HWY_COMPILER_GCC_ACTUAL >= 1500 || HWY_COMPILER_CLANG >= 2200
++#define HWY_TARGET_STR_AVX10_2 HWY_TARGET_STR_AVX3_SPR ",avx10.2"
+ #else
+ #define HWY_TARGET_STR_AVX10_2 HWY_TARGET_STR_AVX3_SPR
+ #endif
+@@ -234,7 +254,7 @@
+ #define HWY_NAMESPACE N_SSE2
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -243,8 +263,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 0
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0  // a few actually are
+ 
+ #define HWY_TARGET_STR HWY_TARGET_STR_SSE2
+ //-----------------------------------------------------------------------------
+@@ -254,7 +273,7 @@
+ #define HWY_NAMESPACE N_SSSE3
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -263,8 +282,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 0
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0  // a few actually are
+ 
+ #define HWY_TARGET_STR HWY_TARGET_STR_SSSE3
+ 
+@@ -275,7 +293,7 @@
+ #define HWY_NAMESPACE N_SSE4
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -284,8 +302,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 0
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0  // a few actually are
+ 
+ #define HWY_TARGET_STR HWY_TARGET_STR_SSE4
+ 
+@@ -296,7 +313,7 @@
+ #define HWY_NAMESPACE N_AVX2
+ #define HWY_ALIGN alignas(32)
+ #define HWY_MAX_BYTES 32
+-#define HWY_LANES(T) (32 / sizeof(T))
++#define HWY_MIN_BYTES 32
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -310,26 +327,22 @@
+ #define HWY_NATIVE_FMA 1
+ #endif
+ #define HWY_NATIVE_DOT_BF16 0
+-
+-#define HWY_CAP_GE256 1
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0  // a few actually are
+ 
+ #define HWY_TARGET_STR HWY_TARGET_STR_AVX2
+ 
+ //-----------------------------------------------------------------------------
+-// AVX3[_DL]/AVX10
+-#elif HWY_TARGET == HWY_AVX3 || HWY_TARGET == HWY_AVX3_DL ||     \
+-    HWY_TARGET == HWY_AVX3_ZEN4 || HWY_TARGET == HWY_AVX3_SPR || \
+-    HWY_TARGET == HWY_AVX10_2
++// AVX3[_DL/ZEN4/SPR]/AVX10
++#elif HWY_TARGET <= HWY_AVX3
+ 
+ #define HWY_ALIGN alignas(64)
+ #define HWY_MAX_BYTES 64
+-#define HWY_LANES(T) (64 / sizeof(T))
++#define HWY_MIN_BYTES 64
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+ #if HWY_TARGET <= HWY_AVX3_SPR &&                              \
+-    (HWY_COMPILER_GCC_ACTUAL || HWY_COMPILER_CLANG >= 1901) && \
++    (HWY_COMPILER_GCC_ACTUAL || HWY_COMPILER_CLANG >= 2200) && \
+     HWY_HAVE_SCALAR_F16_TYPE
+ #define HWY_HAVE_FLOAT16 1
+ #else
+@@ -338,18 +351,12 @@
+ #define HWY_HAVE_FLOAT64 1
+ #define HWY_MEM_OPS_MIGHT_FAULT 0
+ #define HWY_NATIVE_FMA 1
+-#if (HWY_TARGET <= HWY_AVX3_ZEN4) && !defined(HWY_AVX3_DISABLE_AVX512BF16)
++#if (HWY_TARGET <= HWY_AVX3_ZEN4) && HWY_AVX3_ENABLE_AVX512BF16
+ #define HWY_NATIVE_DOT_BF16 1
+ #else
+ #define HWY_NATIVE_DOT_BF16 0
+ #endif
+-#define HWY_CAP_GE256 1
+-
+-#if HWY_MAX_BYTES >= 64
+-#define HWY_CAP_GE512 1
+-#else
+-#define HWY_CAP_GE512 0
+-#endif
++#define HWY_NATIVE_MASK 1
+ 
+ #if HWY_TARGET == HWY_AVX3
+ 
+@@ -386,7 +393,7 @@
+ 
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -395,8 +402,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 1
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #if HWY_TARGET == HWY_PPC8
+ 
+@@ -423,7 +429,7 @@
+ 
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -432,8 +438,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 1
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #if HWY_TARGET == HWY_Z14
+ 
+@@ -478,7 +483,7 @@
+ 
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -508,8 +513,7 @@
+ #define HWY_NATIVE_DOT_BF16 0
+ #endif
+ 
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #if HWY_TARGET == HWY_NEON_WITHOUT_AES
+ #define HWY_NAMESPACE N_NEON_WITHOUT_AES
+@@ -553,12 +557,27 @@
+ #define HWY_TARGET_STR_FP16 "+fp16"
+ #endif
+ 
++#if HWY_OS_APPLE
++// Enable i8mm for the NEON_BF16 target if compiling for macOS, iOS, or iPadOS
++// as all Apple Silicon CPU's that support BF16 have support for I8MM.
++#define HWY_TARGET_STR_NEON_BF16_EXTRA "+i8mm"
++#else
++#define HWY_TARGET_STR_NEON_BF16_EXTRA ""
++#endif
++
+ #if HWY_TARGET == HWY_NEON_WITHOUT_AES
++#if HWY_COMPILER_GCC_ACTUAL && HWY_COMPILER_GCC_ACTUAL < 1400
++// Prevents inadvertent use of SVE by GCC 13.4 and earlier, see #2689.
++#define HWY_TARGET_STR "+nosve"
++#else
+ // Do not define HWY_TARGET_STR (no pragma).
++#endif  // HWY_COMPILER_GCC_ACTUAL
+ #elif HWY_TARGET == HWY_NEON
+ #define HWY_TARGET_STR HWY_TARGET_STR_NEON
+ #elif HWY_TARGET == HWY_NEON_BF16
+-#define HWY_TARGET_STR HWY_TARGET_STR_FP16 "+bf16+dotprod" HWY_TARGET_STR_NEON
++#define HWY_TARGET_STR \
++  HWY_TARGET_STR_FP16  \
++      "+bf16+dotprod" HWY_TARGET_STR_NEON_BF16_EXTRA HWY_TARGET_STR_NEON
+ #else
+ #error "Logic error, missing case"
+ #endif  // HWY_TARGET
+@@ -575,10 +594,6 @@
+ // SVE only requires lane alignment, not natural alignment of the entire vector.
+ #define HWY_ALIGN alignas(8)
+ 
+-// Value ensures MaxLanes() is the tightest possible upper bound to reduce
+-// overallocation.
+-#define HWY_LANES(T) ((HWY_MAX_BYTES) / sizeof(T))
+-
+ #define HWY_HAVE_INTEGER64 1
+ #define HWY_HAVE_FLOAT16 1
+ #define HWY_HAVE_FLOAT64 1
+@@ -589,24 +604,27 @@
+ #else
+ #define HWY_NATIVE_DOT_BF16 0
+ #endif
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 1
+ 
+ #if HWY_TARGET == HWY_SVE2
+ #define HWY_NAMESPACE N_SVE2
+ #define HWY_MAX_BYTES 256
++#define HWY_MIN_BYTES 16
+ #define HWY_HAVE_SCALABLE 1
+ #elif HWY_TARGET == HWY_SVE_256
+ #define HWY_NAMESPACE N_SVE_256
+ #define HWY_MAX_BYTES 32
++#define HWY_MIN_BYTES 32
+ #define HWY_HAVE_SCALABLE 0
+ #elif HWY_TARGET == HWY_SVE2_128
+ #define HWY_NAMESPACE N_SVE2_128
+ #define HWY_MAX_BYTES 16
++#define HWY_MIN_BYTES 16
+ #define HWY_HAVE_SCALABLE 0
+ #else
+ #define HWY_NAMESPACE N_SVE
+ #define HWY_MAX_BYTES 256
++#define HWY_MIN_BYTES 16
+ #define HWY_HAVE_SCALABLE 1
+ #endif
+ 
+@@ -633,7 +651,7 @@
+ 
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -642,8 +660,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 0
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #define HWY_NAMESPACE N_WASM
+ 
+@@ -655,7 +672,7 @@
+ 
+ #define HWY_ALIGN alignas(32)
+ #define HWY_MAX_BYTES 32
+-#define HWY_LANES(T) (32 / sizeof(T))
++#define HWY_MIN_BYTES 32
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -664,8 +681,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 0
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 1
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #define HWY_NAMESPACE N_WASM_EMU256
+ 
+@@ -681,9 +697,11 @@
+ 
+ // The spec requires VLEN <= 2^16 bits, so the limit is 2^16 bytes (LMUL=8).
+ #define HWY_MAX_BYTES 65536
++#define HWY_MIN_BYTES 16
+ 
+ // = HWY_MAX_BYTES divided by max LMUL=8 because MaxLanes includes the actual
+ // LMUL. This is the tightest possible upper bound.
++#undef HWY_LANES
+ #define HWY_LANES(T) (8192 / sizeof(T))
+ 
+ #define HWY_HAVE_SCALABLE 1
+@@ -692,8 +710,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 0
+ #define HWY_NATIVE_FMA 1
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 1
+ 
+ #if HWY_RVV_HAVE_F16_VEC
+ #define HWY_HAVE_FLOAT16 1
+@@ -717,12 +734,18 @@
+ #if HWY_TARGET == HWY_LSX
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
++#define HWY_MIN_BYTES 16
++#ifndef __loongarch_sx
++#define HWY_TARGET_STR "lsx"
++#endif
+ #else
+ #define HWY_ALIGN alignas(32)
+ #define HWY_MAX_BYTES 32
++#define HWY_MIN_BYTES 32
++#ifndef __loongarch_asx
++#define HWY_TARGET_STR "lsx,lasx"
++#endif
+ #endif
+-
+-#define HWY_LANES(T) (HWY_MAX_BYTES / sizeof(T))
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -731,14 +754,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 1
+ #define HWY_NATIVE_DOT_BF16 0
+-
+-#if HWY_TARGET == HWY_LSX
+-#define HWY_CAP_GE256 0
+-#else
+-#define HWY_CAP_GE256 1
+-#endif
+-
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #if HWY_TARGET == HWY_LSX
+ #define HWY_NAMESPACE N_LSX
+@@ -754,7 +770,7 @@
+ 
+ #define HWY_ALIGN alignas(16)
+ #define HWY_MAX_BYTES 16
+-#define HWY_LANES(T) (16 / sizeof(T))
++#define HWY_MIN_BYTES 16
+ 
+ #define HWY_HAVE_SCALABLE 0
+ #define HWY_HAVE_INTEGER64 1
+@@ -763,8 +779,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 1
+ #define HWY_NATIVE_FMA 0
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #define HWY_NAMESPACE N_EMU128
+ 
+@@ -776,6 +791,8 @@
+ 
+ #define HWY_ALIGN
+ #define HWY_MAX_BYTES 8
++#define HWY_MIN_BYTES 8
++#undef HWY_LANES
+ #define HWY_LANES(T) 1
+ 
+ #define HWY_HAVE_SCALABLE 0
+@@ -785,8 +802,7 @@
+ #define HWY_MEM_OPS_MIGHT_FAULT 0
+ #define HWY_NATIVE_FMA 0
+ #define HWY_NATIVE_DOT_BF16 0
+-#define HWY_CAP_GE256 0
+-#define HWY_CAP_GE512 0
++#define HWY_NATIVE_MASK 0
+ 
+ #define HWY_NAMESPACE N_SCALAR
+ 
+@@ -812,7 +828,7 @@
+ 
+ // Clang <9 requires this be invoked at file scope, before any namespace.
+ #undef HWY_BEFORE_NAMESPACE
+-#if defined(HWY_TARGET_STR)
++#if defined(HWY_TARGET_STR) && !defined(HWY_DISABLE_ATTR)
+ #define HWY_BEFORE_NAMESPACE()        \
+   HWY_PUSH_ATTRIBUTES(HWY_TARGET_STR) \
+   static_assert(true, "For requiring trailing semicolon")
+@@ -824,7 +840,7 @@
+ 
+ // Clang <9 requires any namespaces be closed before this macro.
+ #undef HWY_AFTER_NAMESPACE
+-#if defined(HWY_TARGET_STR)
++#if defined(HWY_TARGET_STR) && !defined(HWY_DISABLE_ATTR)
+ #define HWY_AFTER_NAMESPACE() \
+   HWY_POP_ATTRIBUTES          \
+   static_assert(true, "For requiring trailing semicolon")
+@@ -835,8 +851,16 @@
+ #endif
+ 
+ #undef HWY_ATTR
+-#if defined(HWY_TARGET_STR) && HWY_HAS_ATTRIBUTE(target)
++#if defined(HWY_TARGET_STR) && HWY_HAS_ATTRIBUTE(target) && \
++    !defined(HWY_DISABLE_ATTR)
+ #define HWY_ATTR __attribute__((target(HWY_TARGET_STR)))
+ #else
+ #define HWY_ATTR
+ #endif
++
++#if (HWY_MAX_BYTES <= 16) || HWY_TARGET_IS_SVE || (HWY_TARGET == HWY_RVV) || \
++    (HWY_TARGET == HWY_WASM_EMU256)
++#define HWY_NATIVE_INTERLEAVE_WHOLE 1
++#else
++#define HWY_NATIVE_INTERLEAVE_WHOLE 0
++#endif

--- a/Meta/CMake/vcpkg/overlay-ports/highway/vcpkg.json
+++ b/Meta/CMake/vcpkg/overlay-ports/highway/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "highway",
+  "version": "1.3.0",
+  "port-version": 1,
+  "description": "Performance-portable, length-agnostic SIMD with runtime dispatch",
+  "homepage": "https://github.com/google/highway",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "contrib": {
+      "description": "SIMD related utility functions",
+      "supports": "!uwp"
+    }
+  }
+}


### PR DESCRIPTION
According to the relevant patches since highway 1.3.0, this should also
fix the build with gcc-16.

The attached diff is the difference between highway at
aa0f7f7a2593c770d54982fca63ac53ea5ebe632 and the 1.3.0 release.

Tested with clang-22 on Ubuntu 24.04.

cf.
https://github.com/microsoft/vcpkg/issues/50397
https://github.com/google/highway/issues/2697
https://github.com/google/highway/issues/2577
https://github.com/llvm/llvm-project/pull/157034

Presumably vcpkg maintainers or highway maintainers will have a better fix than this (such as a new patch release), but this works in the meantime.