### PR TITLE
LibWeb: Store scroll frames by value in contiguous storage

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -41,6 +41,7 @@
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
@@ -350,8 +351,8 @@ int HTMLImageElement::x() const
         return 0;
 
     CSSPixels scroll_offset_x = 0;
-    if (auto enclosing_scroll = paintable_box->enclosing_scroll_frame(); enclosing_scroll)
-        scroll_offset_x = enclosing_scroll->cumulative_offset().x();
+    if (auto idx = paintable_box->enclosing_scroll_frame_index(); idx.value())
+        scroll_offset_x = paintable_box->document().paintable()->scroll_state().cumulative_offset(idx).x();
 
     return (paintable_box->absolute_border_box_rect().x() - scroll_offset_x).to_int();
 }
@@ -369,8 +370,8 @@ int HTMLImageElement::y() const
         return 0;
 
     CSSPixels scroll_offset_y = 0;
-    if (auto enclosing_scroll = paintable_box->enclosing_scroll_frame(); enclosing_scroll)
-        scroll_offset_y = enclosing_scroll->cumulative_offset().y();
+    if (auto idx = paintable_box->enclosing_scroll_frame_index(); idx.value())
+        scroll_offset_y = paintable_box->document().paintable()->scroll_state().cumulative_offset(idx).y();
 
     return (paintable_box->absolute_border_box_rect().y() - scroll_offset_y).to_int();
 }

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -21,7 +21,7 @@ NonnullRefPtr<AccumulatedVisualContextTree> AccumulatedVisualContextTree::create
 {
     auto visual_context_tree = adopt_ref(*new AccumulatedVisualContextTree());
     // Sentinel at index 0 (null context). Data type doesn't matter; it's never accessed.
-    visual_context_tree->m_nodes.append({ ScrollData { 0, false }, {}, 0, false });
+    visual_context_tree->m_nodes.append({ ScrollData { {}, false }, {}, 0, false });
     return visual_context_tree;
 }
 
@@ -91,7 +91,7 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
                 return point;
             },
             [&](ScrollData const& scroll) -> Optional<Gfx::FloatPoint> {
-                point.translate_by(-scroll_state.device_offset_for_frame_with_id(scroll.scroll_frame_id));
+                point.translate_by(-scroll_state.device_offset_for_index(scroll.scroll_frame_index));
                 return point;
             },
             [&](TransformData const& transform) -> Optional<Gfx::FloatPoint> {
@@ -186,7 +186,7 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
                 rect = affine.map(rect);
             },
             [&](ScrollData const& scroll) {
-                rect.translate_by(scroll_state.device_offset_for_frame_with_id(scroll.scroll_frame_id));
+                rect.translate_by(scroll_state.device_offset_for_index(scroll.scroll_frame_index));
             },
             [&](ClipData const&) { /* clips don't affect rect coordinates */ },
             [&](ClipPathData const&) { /* clip paths don't affect rect coordinates */ },
@@ -207,7 +207,7 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
             builder.append("perspective"sv);
         },
         [&](ScrollData const& scroll) {
-            builder.appendff("scroll_frame_id={}", scroll.scroll_frame_id);
+            builder.appendff("scroll_frame_id={}", scroll.scroll_frame_index);
             if (scroll.is_sticky)
                 builder.append(" (sticky)"sv);
         },

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -18,6 +18,7 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/WindingRule.h>
 #include <LibWeb/Painting/BorderRadiiData.h>
+#include <LibWeb/Painting/ScrollFrame.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {
@@ -27,7 +28,7 @@ class ScrollStateSnapshot;
 AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, VisualContextIndex);
 
 struct ScrollData {
-    size_t scroll_frame_id;
+    ScrollFrameIndex scroll_frame_index;
     bool is_sticky;
 };
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -89,7 +89,7 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
             },
             [&](ScrollData const& scroll) {
                 save({});
-                auto offset = scroll_state.device_offset_for_frame_with_id(scroll.scroll_frame_id);
+                auto offset = scroll_state.device_offset_for_index(scroll.scroll_frame_index);
                 if (!offset.is_zero())
                     translate({ .delta = offset.to_type<int>() });
             },
@@ -156,7 +156,7 @@ void DisplayListPlayer::execute_impl(DisplayList& display_list, ScrollStateSnaps
         if (command.has<PaintScrollBar>()) {
             auto translated_command = command;
             auto& paint_scroll_bar = translated_command.get<PaintScrollBar>();
-            auto device_offset = scroll_state.device_offset_for_frame_with_id(paint_scroll_bar.scroll_frame_id);
+            auto device_offset = scroll_state.device_offset_for_index(paint_scroll_bar.scroll_frame_index);
             if (paint_scroll_bar.vertical)
                 paint_scroll_bar.thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * paint_scroll_bar.scroll_size));
             else

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -351,7 +351,7 @@ struct PaintNestedDisplayList {
 struct PaintScrollBar {
     static constexpr StringView command_name = "PaintScrollBar"sv;
 
-    int scroll_frame_id { 0 };
+    ScrollFrameIndex scroll_frame_index;
     Gfx::IntRect gutter_rect;
     Gfx::IntRect thumb_rect;
     double scroll_size;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -401,10 +401,10 @@ void DisplayListRecorder::fill_rect_with_rounded_corners(Gfx::IntRect const& a_r
             { bottom_left_radius, bottom_left_radius } });
 }
 
-void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical)
+void DisplayListRecorder::paint_scrollbar(ScrollFrameIndex scroll_frame_index, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical)
 {
     APPEND(PaintScrollBar {
-        .scroll_frame_id = scroll_frame_id,
+        .scroll_frame_index = scroll_frame_index,
         .gutter_rect = gutter_rect,
         .thumb_rect = thumb_rect,
         .scroll_size = scroll_size,

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -137,7 +137,7 @@ public:
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int radius);
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
 
-    void paint_scrollbar(int scroll_frame_id, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical);
+    void paint_scrollbar(ScrollFrameIndex scroll_frame_index, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical);
 
     void apply_effects(float opacity = 1.0f, Gfx::CompositingAndBlendingOperator = Gfx::CompositingAndBlendingOperator::Normal, Optional<Gfx::Filter> filter = {}, Optional<Gfx::MaskKind> mask_kind = {});
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -164,8 +164,8 @@ void PaintableBox::reset_for_relayout()
     m_absolute_padding_box_rect.clear();
     m_absolute_border_box_rect.clear();
 
-    m_enclosing_scroll_frame = nullptr;
-    m_own_scroll_frame = nullptr;
+    m_enclosing_scroll_frame_index = {};
+    m_own_scroll_frame_index = {};
     m_accumulated_visual_context_index = {};
     m_accumulated_visual_context_for_descendants_index = {};
 
@@ -451,7 +451,7 @@ Optional<CSSPixelRect> PaintableBox::get_clip_rect() const
 
 bool PaintableBox::wants_mouse_events() const
 {
-    return (m_own_scroll_frame && could_be_scrolled_by_wheel_event()) || has_resizer();
+    return (m_own_scroll_frame_index.value() && could_be_scrolled_by_wheel_event()) || has_resizer();
 }
 
 bool PaintableBox::could_be_scrolled_by_wheel_event(ScrollDirection direction) const
@@ -561,7 +561,7 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
     if (overflow != CSS::Overflow::Scroll && !could_be_scrolled_by_wheel_event(direction))
         return {};
 
-    if (!own_scroll_frame_id().has_value())
+    if (!m_own_scroll_frame_index.value())
         return {};
 
     CSSPixelRect scrollable_overflow_rect = this->scrollable_overflow_rect().value();
@@ -599,7 +599,7 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
         scrollbar_data.thumb_travel_to_scroll_ratio = (usable_scrollbar_length - thumb_length) / (scrollable_overflow_length - scrollport_size);
 
     if (scroll_state_snapshot) {
-        auto own_offset = scroll_state_snapshot->device_offset_for_frame_with_id(own_scroll_frame_id().value());
+        auto own_offset = scroll_state_snapshot->device_offset_for_index(m_own_scroll_frame_index);
         auto device_scroll_offset = is_horizontal ? -own_offset.x() : -own_offset.y();
         auto device_pixels_per_css_pixel = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
         CSSPixels thumb_offset = CSSPixels::nearest_value_for(device_scroll_offset / device_pixels_per_css_pixel) * scrollbar_data.thumb_travel_to_scroll_ratio;
@@ -672,7 +672,7 @@ void PaintableBox::paint(DisplayListRecordingContext& context, PaintPhase phase)
                 if (!scrollbar_data.has_value())
                     continue;
                 context.display_list_recorder().paint_scrollbar(
-                    own_scroll_frame_id().value(),
+                    m_own_scroll_frame_index,
                     context.rounded_device_rect(scrollbar_data->gutter_rect).to_type<int>(),
                     context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
                     scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
@@ -872,20 +872,6 @@ BorderRadiiData PaintableBox::normalized_border_radii_data(ShrinkRadiiForBorders
     if (shrink == ShrinkRadiiForBorders::Yes)
         border_radii_data.shrink(computed_values().border_top().width, computed_values().border_right().width, computed_values().border_bottom().width, computed_values().border_left().width);
     return border_radii_data;
-}
-
-Optional<int> PaintableBox::own_scroll_frame_id() const
-{
-    if (m_own_scroll_frame)
-        return m_own_scroll_frame->id();
-    return {};
-}
-
-Optional<int> PaintableBox::scroll_frame_id() const
-{
-    if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->id();
-    return {};
 }
 
 Optional<CSSPixelPoint> PaintableBox::transform_point_to_local(CSSPixelPoint screen_position) const
@@ -1361,21 +1347,21 @@ CSSPixels PaintableBox::outline_offset() const
     return computed_values().outline_offset().to_px(layout_node());
 }
 
-RefPtr<ScrollFrame const> PaintableBox::nearest_scroll_frame() const
+ScrollFrameIndex PaintableBox::nearest_scroll_frame_index() const
 {
     if (is_fixed_position())
-        return nullptr;
+        return {};
     auto const* paintable = this->containing_block();
     while (paintable) {
-        if (paintable->own_scroll_frame())
-            return paintable->own_scroll_frame();
+        if (paintable->own_scroll_frame_index().value())
+            return paintable->own_scroll_frame_index();
         // Sticky elements need to find a scroll container even through fixed-position ancestors,
         // because they must reference a scrollport for their sticky offset computation.
         if (paintable->is_fixed_position() && !is_sticky_position())
-            return nullptr;
+            return {};
         paintable = paintable->containing_block();
     }
-    return nullptr;
+    return {};
 }
 
 PaintableBox const* PaintableBox::nearest_scrollable_ancestor() const

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -211,7 +211,7 @@ public:
 
     CSSPixelRect transform_reference_box() const;
 
-    RefPtr<ScrollFrame const> nearest_scroll_frame() const;
+    ScrollFrameIndex nearest_scroll_frame_index() const;
 
     PaintableBox const* nearest_scrollable_ancestor() const;
 
@@ -227,8 +227,8 @@ public:
     void set_used_values_for_grid_template_rows(RefPtr<CSS::GridTrackSizeListStyleValue const> style_value) { m_used_values_for_grid_template_rows = move(style_value); }
     RefPtr<CSS::GridTrackSizeListStyleValue const> const& used_values_for_grid_template_rows() const { return m_used_values_for_grid_template_rows; }
 
-    void set_enclosing_scroll_frame(RefPtr<ScrollFrame const> const& scroll_frame) { m_enclosing_scroll_frame = scroll_frame; }
-    void set_own_scroll_frame(RefPtr<ScrollFrame> const& scroll_frame) { m_own_scroll_frame = scroll_frame; }
+    void set_enclosing_scroll_frame_index(ScrollFrameIndex index) { m_enclosing_scroll_frame_index = index; }
+    void set_own_scroll_frame_index(ScrollFrameIndex index) { m_own_scroll_frame_index = index; }
 
     void set_accumulated_visual_context(VisualContextIndex index) { m_accumulated_visual_context_index = index; }
     [[nodiscard]] VisualContextIndex accumulated_visual_context_index() const { return m_accumulated_visual_context_index; }
@@ -259,11 +259,9 @@ public:
         m_cached_phase_commands[to_underlying(phase)] = move(commands);
     }
 
-    [[nodiscard]] RefPtr<ScrollFrame const> enclosing_scroll_frame() const { return m_enclosing_scroll_frame; }
-    [[nodiscard]] Optional<int> scroll_frame_id() const;
+    [[nodiscard]] ScrollFrameIndex enclosing_scroll_frame_index() const { return m_enclosing_scroll_frame_index; }
 
-    [[nodiscard]] RefPtr<ScrollFrame const> own_scroll_frame() const { return m_own_scroll_frame; }
-    [[nodiscard]] Optional<int> own_scroll_frame_id() const;
+    [[nodiscard]] ScrollFrameIndex own_scroll_frame_index() const { return m_own_scroll_frame_index; }
 
 protected:
     explicit PaintableBox(Layout::Box const&);
@@ -327,8 +325,8 @@ private:
     Optional<CSSPixelRect> mutable m_absolute_padding_box_rect;
     Optional<CSSPixelRect> mutable m_absolute_border_box_rect;
 
-    RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
-    RefPtr<ScrollFrame const> m_own_scroll_frame;
+    ScrollFrameIndex m_enclosing_scroll_frame_index {};
+    ScrollFrameIndex m_own_scroll_frame_index {};
     VisualContextIndex m_accumulated_visual_context_index {};
     VisualContextIndex m_accumulated_visual_context_for_descendants_index {};
 

--- a/Libraries/LibWeb/Painting/ScrollFrame.cpp
+++ b/Libraries/LibWeb/Painting/ScrollFrame.cpp
@@ -11,21 +11,11 @@
 
 namespace Web::Painting {
 
-ScrollFrame::ScrollFrame(PaintableBox const& paintable_box, size_t id, bool sticky, RefPtr<ScrollFrame const> parent)
+ScrollFrame::ScrollFrame(PaintableBox const& paintable_box, bool sticky, ScrollFrameIndex parent_index)
     : m_paintable_box(paintable_box)
-    , m_id(id)
     , m_sticky(sticky)
-    , m_parent(move(parent))
+    , m_parent_index(parent_index)
 {
-}
-
-RefPtr<ScrollFrame const> ScrollFrame::nearest_scrolling_ancestor() const
-{
-    for (auto ancestor = m_parent; ancestor; ancestor = ancestor->parent()) {
-        if (!ancestor->is_sticky())
-            return ancestor;
-    }
-    return nullptr;
 }
 
 }

--- a/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -6,12 +6,14 @@
 
 #pragma once
 
-#include <AK/RefCounted.h>
+#include <AK/DistinctNumeric.h>
 #include <LibGC/Weak.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {
+
+AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, ScrollFrameIndex);
 
 struct StickyInsets {
     Optional<CSSPixels> top;
@@ -29,52 +31,37 @@ struct StickyConstraints {
     StickyInsets insets;
 };
 
-class ScrollFrame : public RefCounted<ScrollFrame> {
+class ScrollFrame {
 public:
-    ScrollFrame(PaintableBox const& paintable_box, size_t id, bool sticky, RefPtr<ScrollFrame const> parent);
+    ScrollFrame() = default;
+    ScrollFrame(PaintableBox const& paintable_box, bool sticky, ScrollFrameIndex parent_index);
 
     PaintableBox const& paintable_box() const { return *m_paintable_box; }
 
-    size_t id() const { return m_id; }
-
     bool is_sticky() const { return m_sticky; }
 
-    CSSPixelPoint cumulative_offset() const
-    {
-        return m_cached_cumulative_offset.ensure([&] {
-            auto offset = m_own_offset;
-            if (m_parent)
-                offset += m_parent->cumulative_offset();
-            return offset;
-        });
-    }
+    CSSPixelPoint own_offset() const { return m_own_offset; }
 
     void set_own_offset(CSSPixelPoint offset)
     {
-        m_cached_cumulative_offset.clear();
         m_own_offset = offset;
     }
 
-    RefPtr<ScrollFrame const> parent() const { return m_parent; }
-    RefPtr<ScrollFrame const> nearest_scrolling_ancestor() const;
+    ScrollFrameIndex parent_index() const { return m_parent_index; }
 
     void set_sticky_constraints(StickyConstraints constraints) { m_sticky_constraints = constraints; }
     bool has_sticky_constraints() const { return m_sticky_constraints.has_value(); }
     StickyConstraints const& sticky_constraints() const { return m_sticky_constraints.value(); }
 
 private:
+    friend class ScrollState;
     friend class ScrollStateSnapshot;
 
     GC::Weak<PaintableBox> m_paintable_box;
-    size_t m_id { 0 };
     bool m_sticky { false };
-    RefPtr<ScrollFrame const> m_parent;
+    ScrollFrameIndex m_parent_index;
     CSSPixelPoint m_own_offset;
     Optional<StickyConstraints> m_sticky_constraints;
-
-    // Caching here relies on the fact that offsets of all scroll frames are invalidated when any of them changes,
-    // so we don't need to worry about invalidating the cache when the parent's offset changes.
-    mutable Optional<CSSPixelPoint> m_cached_cumulative_offset;
 };
 
 }

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -8,13 +8,13 @@
 
 namespace Web::Painting {
 
-ScrollStateSnapshot ScrollStateSnapshot::create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames, double device_pixels_per_css_pixel)
+ScrollStateSnapshot ScrollStateSnapshot::create(Vector<ScrollFrame> const& scroll_frames, double device_pixels_per_css_pixel)
 {
     ScrollStateSnapshot snapshot;
     auto scale = static_cast<float>(device_pixels_per_css_pixel);
     snapshot.m_device_offsets.ensure_capacity(scroll_frames.size());
     for (auto const& scroll_frame : scroll_frames) {
-        auto const& offset = scroll_frame->m_own_offset;
+        auto const& offset = scroll_frame.own_offset();
         snapshot.m_device_offsets.unchecked_append(offset.to_type<float>() * scale);
     }
     return snapshot;

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -13,13 +13,13 @@ namespace Web::Painting {
 
 class ScrollStateSnapshot {
 public:
-    static ScrollStateSnapshot create(Vector<NonnullRefPtr<ScrollFrame>> const& scroll_frames, double device_pixels_per_css_pixel);
+    static ScrollStateSnapshot create(Vector<ScrollFrame> const& scroll_frames, double device_pixels_per_css_pixel);
 
-    Gfx::FloatPoint device_offset_for_frame_with_id(size_t id) const
+    Gfx::FloatPoint device_offset_for_index(ScrollFrameIndex index) const
     {
-        if (id >= m_device_offsets.size())
+        if (index.value() >= m_device_offsets.size())
             return {};
-        return m_device_offsets[id];
+        return m_device_offsets[index.value()];
     }
 
 private:
@@ -28,43 +28,75 @@ private:
 
 class ScrollState {
 public:
-    NonnullRefPtr<ScrollFrame> create_scroll_frame_for(PaintableBox const& paintable_box, RefPtr<ScrollFrame const> parent)
+    // ScrollFrameIndex is 1-based: value 0 means "no frame".
+    // Index 0 in m_scroll_frames is a sentinel (never accessed by callers).
+    // Value N maps directly to m_scroll_frames[N].
+    ScrollState()
     {
-        auto scroll_frame = adopt_ref(*new ScrollFrame(paintable_box, m_scroll_frames.size(), false, move(parent)));
-        m_scroll_frames.append(scroll_frame);
-        return scroll_frame;
+        m_scroll_frames.empend(); // Sentinel at index 0
     }
 
-    NonnullRefPtr<ScrollFrame> create_sticky_frame_for(PaintableBox const& paintable_box, RefPtr<ScrollFrame const> parent)
+    ScrollFrameIndex create_scroll_frame_for(PaintableBox const& paintable_box, ScrollFrameIndex parent)
     {
-        auto scroll_frame = adopt_ref(*new ScrollFrame(paintable_box, m_scroll_frames.size(), true, move(parent)));
-        m_scroll_frames.append(scroll_frame);
-        return scroll_frame;
+        auto index = ScrollFrameIndex { m_scroll_frames.size() };
+        m_scroll_frames.empend(paintable_box, false, parent);
+        return index;
+    }
+
+    ScrollFrameIndex create_sticky_frame_for(PaintableBox const& paintable_box, ScrollFrameIndex parent)
+    {
+        auto index = ScrollFrameIndex { m_scroll_frames.size() };
+        m_scroll_frames.empend(paintable_box, true, parent);
+        return index;
+    }
+
+    ScrollFrame const& frame_at(ScrollFrameIndex index) const { return m_scroll_frames[index.value()]; }
+    ScrollFrame& frame_at(ScrollFrameIndex index) { return m_scroll_frames[index.value()]; }
+
+    CSSPixelPoint cumulative_offset(ScrollFrameIndex index) const
+    {
+        CSSPixelPoint offset;
+        while (index.value()) {
+            offset += frame_at(index).own_offset();
+            index = frame_at(index).parent_index();
+        }
+        return offset;
+    }
+
+    ScrollFrameIndex nearest_scrolling_ancestor(ScrollFrameIndex index) const
+    {
+        auto ancestor = frame_at(index).parent_index();
+        while (ancestor.value()) {
+            if (!frame_at(ancestor).is_sticky())
+                return ancestor;
+            ancestor = frame_at(ancestor).parent_index();
+        }
+        return {};
     }
 
     template<typename Callback>
-    void for_each_scroll_frame(Callback callback) const
+    void for_each_scroll_frame(Callback callback)
     {
-        for (auto const& scroll_frame : m_scroll_frames) {
-            if (scroll_frame->is_sticky())
+        for (size_t i = 1; i < m_scroll_frames.size(); ++i) {
+            if (m_scroll_frames[i].is_sticky())
                 continue;
-            callback(scroll_frame);
+            callback(ScrollFrameIndex { i }, m_scroll_frames[i]);
         }
     }
 
     template<typename Callback>
-    void for_each_sticky_frame(Callback callback) const
+    void for_each_sticky_frame(Callback callback)
     {
-        for (auto const& scroll_frame : m_scroll_frames) {
-            if (!scroll_frame->is_sticky())
+        for (size_t i = 1; i < m_scroll_frames.size(); ++i) {
+            if (!m_scroll_frames[i].is_sticky())
                 continue;
-            callback(scroll_frame);
+            callback(ScrollFrameIndex { i }, m_scroll_frames[i]);
         }
     }
 
     void clear()
     {
-        m_scroll_frames.clear();
+        m_scroll_frames.resize_and_keep_capacity(1); // Keep sentinel at index 0
     }
 
 private:
@@ -75,7 +107,7 @@ private:
         return ScrollStateSnapshot::create(m_scroll_frames, device_pixels_per_css_pixel);
     }
 
-    Vector<NonnullRefPtr<ScrollFrame>> m_scroll_frames;
+    Vector<ScrollFrame> m_scroll_frames;
 };
 
 }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -91,12 +91,12 @@ void ViewportPaintable::paint_all_phases(DisplayListRecordingContext& context)
 
 void ViewportPaintable::assign_scroll_frames()
 {
-    auto precompute_sticky_constraints = [](ScrollFrame& sticky_frame, PaintableBox const& paintable_box) {
-        auto nearest_scrolling_ancestor_frame = sticky_frame.nearest_scrolling_ancestor();
-        if (!nearest_scrolling_ancestor_frame)
+    auto precompute_sticky_constraints = [&](ScrollFrameIndex sticky_frame_index, PaintableBox const& paintable_box) {
+        auto nearest_scrolling_ancestor_index = m_scroll_state.nearest_scrolling_ancestor(sticky_frame_index);
+        if (!nearest_scrolling_ancestor_index.value())
             return;
 
-        auto const& scroll_ancestor_paintable = nearest_scrolling_ancestor_frame->paintable_box();
+        auto const& scroll_ancestor_paintable = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box();
         auto sticky_border_box_rect = paintable_box.absolute_border_box_rect();
         auto const* containing_block_of_sticky = paintable_box.containing_block();
 
@@ -110,7 +110,7 @@ void ViewportPaintable::assign_scroll_frames()
             needs_parent_offset_adjustment = true;
         }
 
-        sticky_frame.set_sticky_constraints({
+        m_scroll_state.frame_at(sticky_frame_index).set_sticky_constraints({
             .position_relative_to_scroll_ancestor = sticky_border_box_rect.top_left() - scroll_ancestor_paintable.absolute_rect().top_left(),
             .border_box_size = sticky_border_box_rect.size(),
             .scrollport_size = scroll_ancestor_paintable.absolute_rect().size(),
@@ -121,24 +121,24 @@ void ViewportPaintable::assign_scroll_frames()
     };
 
     for_each_in_inclusive_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
-        RefPtr<ScrollFrame> sticky_scroll_frame;
+        ScrollFrameIndex sticky_scroll_frame_index;
         if (paintable_box.is_sticky_position()) {
-            auto parent_scroll_frame = paintable_box.nearest_scroll_frame();
-            sticky_scroll_frame = m_scroll_state.create_sticky_frame_for(paintable_box, parent_scroll_frame);
-            precompute_sticky_constraints(*sticky_scroll_frame, paintable_box);
-            paintable_box.set_enclosing_scroll_frame(sticky_scroll_frame);
-            paintable_box.set_own_scroll_frame(sticky_scroll_frame);
+            auto parent_index = paintable_box.nearest_scroll_frame_index();
+            sticky_scroll_frame_index = m_scroll_state.create_sticky_frame_for(paintable_box, parent_index);
+            precompute_sticky_constraints(sticky_scroll_frame_index, paintable_box);
+            paintable_box.set_enclosing_scroll_frame_index(sticky_scroll_frame_index);
+            paintable_box.set_own_scroll_frame_index(sticky_scroll_frame_index);
         }
 
         if (paintable_box.has_scrollable_overflow() || is<ViewportPaintable>(paintable_box)) {
-            RefPtr<ScrollFrame const> parent_scroll_frame;
-            if (sticky_scroll_frame) {
-                parent_scroll_frame = sticky_scroll_frame;
+            ScrollFrameIndex parent_index;
+            if (sticky_scroll_frame_index.value()) {
+                parent_index = sticky_scroll_frame_index;
             } else {
-                parent_scroll_frame = paintable_box.nearest_scroll_frame();
+                parent_index = paintable_box.nearest_scroll_frame_index();
             }
-            auto scroll_frame = m_scroll_state.create_scroll_frame_for(paintable_box, parent_scroll_frame);
-            paintable_box.set_own_scroll_frame(scroll_frame);
+            auto scroll_frame_index = m_scroll_state.create_scroll_frame_for(paintable_box, parent_index);
+            paintable_box.set_own_scroll_frame_index(scroll_frame_index);
         }
 
         return TraversalDecision::Continue;
@@ -149,9 +149,9 @@ void ViewportPaintable::assign_scroll_frames()
             return TraversalDecision::Continue;
 
         for (auto block = paintable.containing_block(); block; block = block->containing_block()) {
-            if (auto scroll_frame = block->own_scroll_frame(); scroll_frame) {
+            if (auto index = block->own_scroll_frame_index(); index.value()) {
                 if (auto* paintable_box = as_if<PaintableBox>(paintable))
-                    paintable_box->set_enclosing_scroll_frame(*scroll_frame);
+                    paintable_box->set_enclosing_scroll_frame_index(index);
 
                 return TraversalDecision::Continue;
             }
@@ -336,8 +336,8 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
     }
 
     VisualContextIndex viewport_state_for_descendants = m_visual_viewport_context_index;
-    if (own_scroll_frame())
-        viewport_state_for_descendants = append_node(m_visual_viewport_context_index, ScrollData { own_scroll_frame()->id(), false });
+    if (own_scroll_frame_index().value())
+        viewport_state_for_descendants = append_node(m_visual_viewport_context_index, ScrollData { own_scroll_frame_index(), false });
     set_accumulated_visual_context({});
     set_accumulated_visual_context_for_descendants(viewport_state_for_descendants);
 
@@ -391,8 +391,8 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
         if (paintable_box.is_sticky_position()) {
             // For sticky elements, use enclosing_scroll_frame which holds the sticky frame.
             // own_scroll_frame may be a different scroll frame if the sticky element also has scrollable overflow.
-            if (auto sticky_frame = paintable_box.enclosing_scroll_frame(); sticky_frame && sticky_frame->is_sticky())
-                own_state = append_node(own_state, ScrollData { sticky_frame->id(), true });
+            if (auto sticky_idx = paintable_box.enclosing_scroll_frame_index(); sticky_idx.value() && m_scroll_state.frame_at(sticky_idx).is_sticky())
+                own_state = append_node(own_state, ScrollData { sticky_idx, true });
         }
 
         auto const& computed_values = paintable_box.computed_values();
@@ -441,10 +441,10 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
         if (auto clip_data = compute_clip_data(paintable_box, computed_values, converter); clip_data.has_value())
             state_for_descendants = append_node(state_for_descendants, clip_data.value());
 
-        if (paintable_box.own_scroll_frame()) {
-            auto is_sticky_without_scrollable_overflow = paintable_box.is_sticky_position() && paintable_box.enclosing_scroll_frame() == paintable_box.own_scroll_frame();
+        if (paintable_box.own_scroll_frame_index().value()) {
+            auto is_sticky_without_scrollable_overflow = paintable_box.is_sticky_position() && paintable_box.enclosing_scroll_frame_index() == paintable_box.own_scroll_frame_index();
             if (!is_sticky_without_scrollable_overflow)
-                state_for_descendants = append_node(state_for_descendants, ScrollData { paintable_box.own_scroll_frame()->id(), false });
+                state_for_descendants = append_node(state_for_descendants, ScrollData { paintable_box.own_scroll_frame_index(), false });
         }
 
         paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
@@ -459,21 +459,21 @@ void ViewportPaintable::refresh_scroll_state()
         return;
     m_needs_to_refresh_scroll_state = false;
 
-    m_scroll_state.for_each_sticky_frame([&](auto& scroll_frame) {
-        auto nearest_scrolling_ancestor_frame = scroll_frame->nearest_scrolling_ancestor();
-        if (!nearest_scrolling_ancestor_frame || !scroll_frame->has_sticky_constraints())
+    m_scroll_state.for_each_sticky_frame([&](auto idx, auto& frame) {
+        auto nearest_scrolling_ancestor_index = m_scroll_state.nearest_scrolling_ancestor(idx);
+        if (!nearest_scrolling_ancestor_index.value() || !frame.has_sticky_constraints())
             return;
 
-        auto const& sticky_data = scroll_frame->sticky_constraints();
+        auto const& sticky_data = frame.sticky_constraints();
         auto const& sticky_insets = sticky_data.insets;
-        auto const& scroll_ancestor_paintable = nearest_scrolling_ancestor_frame->paintable_box();
+        auto const& scroll_ancestor_paintable = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box();
 
         // For nested sticky elements, the parent sticky's offset is applied via cumulative_offset.
         // We need to adjust all position calculations to account for this, so we work in the
         // coordinate space where the parent sticky is at its current (offset) position.
         CSSPixelPoint parent_sticky_offset;
-        if (auto parent = scroll_frame->parent(); parent && parent->is_sticky())
-            parent_sticky_offset = parent->cumulative_offset();
+        if (auto parent_idx = frame.parent_index(); parent_idx.value() && m_scroll_state.frame_at(parent_idx).is_sticky())
+            parent_sticky_offset = m_scroll_state.cumulative_offset(parent_idx);
 
         auto sticky_position_in_ancestor = sticky_data.position_relative_to_scroll_ancestor + parent_sticky_offset;
 
@@ -506,11 +506,11 @@ void ViewportPaintable::refresh_scroll_state()
                 sticky_offset.set_x(max(scrollport_rect.right() - sticky_data.border_box_size.width() - *sticky_insets.right, min_offset_within_containing_block.x()) - sticky_position_in_ancestor.x());
         }
 
-        scroll_frame->set_own_offset(sticky_offset);
+        frame.set_own_offset(sticky_offset);
     });
 
-    m_scroll_state.for_each_scroll_frame([&](auto& scroll_frame) {
-        scroll_frame->set_own_offset(-scroll_frame->paintable_box().scroll_offset());
+    m_scroll_state.for_each_scroll_frame([&](auto, auto& frame) {
+        frame.set_own_offset(-frame.paintable_box().scroll_offset());
     });
 
     m_scroll_state_snapshot = m_scroll_state.snapshot(document().page().client().device_pixels_per_css_pixel());

--- a/Tests/LibWeb/Text/expected/css/text-underline-position.txt
+++ b/Tests/LibWeb/Text/expected/css/text-underline-position.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
       [5] effects=[opacity=0.5]
         [6] effects=[opacity=0.3] (PaintableWithLines(BlockContainer<DIV>.abspos))

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
       [4] effects=[opacity=0.5] (PaintableWithLines(BlockContainer<DIV>.abspos))
 

--- a/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
+++ b/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
@@ -1,6 +1,6 @@
 Before clip change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[8,13 100x100] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
@@ -11,7 +11,7 @@ Restore@0
 
 After clip change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[18,23 80x80] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
@@ -1,6 +1,6 @@
 Before clip-path change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
@@ -11,7 +11,7 @@ Restore@0
 
 After clip-path change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip_path=[bounds: 8,8 100x100, path: M58 8L108 58L58 108L8 58L58 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
+++ b/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[28,23 80x70] (PaintableWithLines(BlockContainer<DIV>.clipped))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
+++ b/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[10,10 400x200] (PaintableWithLines(BlockContainer<DIV>.branch))
       [3] clip=[11,11 193x198] (PaintableWithLines(BlockContainer(anonymous)))
         [4] transform=[0.9961947,-0.08715574,0.08715574,0.9961947,0,0] origin=(91,56) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-a))

--- a/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[8,8 200x100] (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
+++ b/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/input-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-caret.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[9,9 100x20] (PaintableWithLines(BlockContainer<DIV>))
       [3] clip=[11,10 96x18]
 

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[9,9 200x20] (PaintableWithLines(BlockContainer<DIV>))
       [3] clip=[11,10 196x18]
     [4] clip=[219,9 200x20] (PaintableWithLines(BlockContainer<DIV>))

--- a/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
@@ -1,7 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [3] clip=[119,9 100x100]
-      [4] scroll_frame_id=1 (PaintableWithLines(BlockContainer(anonymous)))
+      [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
     [2] transform=[1,0,0,1,5,5] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.transformed))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
@@ -1,6 +1,6 @@
 Before:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
@@ -16,7 +16,7 @@ Restore@0
 
 After:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[10,10 320x270] (PaintableWithLines(BlockContainer<DIV>.level2))
       [3] clip=[21,21 143x248] (PaintableWithLines(BlockContainer(anonymous)))
         [4] transform=[0.9986295,-0.05233596,0.05233596,0.9986295,0,0] origin=(92.5,46) (PaintableWithLines(BlockContainer<DIV>.level3.t1))

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -1,9 +1,9 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[10,10 200x150]
-      [3] scroll_frame_id=1 (PaintableWithLines(BlockContainer(anonymous)))
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
         [4] clip=[11,11 300x100]
-          [5] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+          [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] perspective (PaintableWithLines(BlockContainer(anonymous)))
       [3] transform=[0.8660254,0,0,1,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.rotated))
 

--- a/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] transform=[1,0,0,1,10,10] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
+++ b/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(58,58) (PaintableWithLines(InlineNode<SPAN>.inline-transformed))
       [3] perspective (PaintableWithLines(BlockContainer<SPAN>.relative-child))
 

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -1,6 +1,6 @@
 AccumulatedVisualContext Tree:
   [2] clip=[33,33 180x100]
-    [3] scroll_frame_id=1 (PaintableWithLines(BlockContainer(anonymous)))
+    [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -1,9 +1,9 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[9,9 100x80]
-      [3] scroll_frame_id=1 (PaintableWithLines(BlockContainer(anonymous)))
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
     [4] clip=[131,9 100x80]
-      [5] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+      [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -1,10 +1,10 @@
 AccumulatedVisualContext Tree:
   [2] clip=[23,23 91x150]
-    [3] scroll_frame_id=1 (PaintableWithLines(BlockContainer(anonymous)))
+    [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
   [4] clip=[126,23 92x150]
-    [5] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+    [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
   [6] clip=[230,23 91x150]
-    [7] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
+    [7] scroll_frame_id=4 (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(48,48) (PaintableWithLines(BlockContainer<DIV>.box.left))
     [3] transform=[0.8,0,0,0.8,0,0] origin=(138,48) (PaintableWithLines(BlockContainer<DIV>.box.right))
 

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -1,7 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[10,10 200x100]
-      [3] scroll_frame_id=1 (PaintableWithLines(BlockContainer<DIV>.inner-box))
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>.inner-box))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
+++ b/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [6] clip=[8,108 100x100] (PaintableWithLines(BlockContainer<DIV>.child))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[8,8 100x100] (SVGForeignObjectPaintable(SVGForeignObjectBox<foreignObject>#fo))
       [3] clip=[8,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (ImagePaintable(ImageBox<IMG>))
+  [1] scroll_frame_id=1 (ImagePaintable(ImageBox<IMG>))
 
 DisplayList:
 SaveLayer@0

--- a/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[0,0 200x200] (SVGPathPaintable(SVGGeometryBox<rect>))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[8,8 200x200]
       [3] effects=[opacity=0.5]
         [4] transform=[1,0,0,1,20,20] origin=(8,8) (SVGPathPaintable(SVGGeometryBox<rect>))

--- a/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[9,9 104x34] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
+++ b/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] transform=[0.9659258,-0.25881904,0.25881904,0.9659258,0,0] origin=(38,38) (PaintableWithLines(BlockContainer<DIV>.box.a))
     [3] transform=[1.1,0,0,1.1,0,0] origin=(103,38) (PaintableWithLines(BlockContainer<DIV>.box.b))
     [4] transform=[1,0.17632698,0,1,0,0] origin=(168,38) (PaintableWithLines(BlockContainer<DIV>.box.c))

--- a/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] transform=[1,0,0,1,50,30] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.box))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
@@ -1,5 +1,5 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] transform=[0.70710677,-0.70710677,0.70710677,0.70710677,0,0] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
       [3] transform=[0.5,0,0,0.5,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.inner))
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
@@ -1,7 +1,7 @@
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[10,10 150x150]
-      [3] scroll_frame_id=1 (PaintableWithLines(BlockContainer(anonymous)))
+      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
         [4] transform=[1,0,0,1,20,20] origin=(110,110) (PaintableWithLines(BlockContainer<DIV>.transformed))
 
 DisplayList:

--- a/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
+++ b/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
@@ -1,6 +1,6 @@
 Before z-index change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
@@ -9,7 +9,7 @@ Restore@0
 
 After z-index change:
 AccumulatedVisualContext Tree:
-  [1] scroll_frame_id=0 (PaintableWithLines(BlockContainer<PRE>#out))
+  [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0


### PR DESCRIPTION
Replace per-frame heap-allocated RefCounted ScrollFrame objects with a single contiguous Vector<ScrollFrame> inside ScrollState. All frames for a viewport are now stored in one allocation, using type-safe ScrollFrameIndex instead of RefPtr pointers.

This reduces allocation churn, improves cache locality, and moves parent-chain traversal (cumulative offset, nearest scrolling ancestor) into ScrollState — similar to how visual context nodes were recently consolidated into AccumulatedVisualContextTree.