### PR TITLE
LibJS: Widen binary operation fast path to include doubles

### DIFF
--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -291,21 +291,37 @@ macro jump_binary_epilogue(slow_path_func)
     goto_handler t0
 end
 
-# Fast path for bitwise binary operations on int32/boolean operands.
+# Coerce two operands (already in t1/t2) to int32 for bitwise operations.
+# On success: t3 = lhs as int32, t4 = rhs as int32. Falls through.
+# If either operand is not a number (int32, boolean, or double): jumps to fail.
+# Clobbers t1 (on x86_64, js_to_int32 clobbers rcx=t1), t3, t4.
+macro coerce_to_int32s(fail)
+    extract_tag t3, t1
+    branch_any_eq t3, INT32_TAG, BOOLEAN_TAG, .lhs_is_int
+    check_tag_is_double t3, fail
+    fp_mov ft0, t1
+    js_to_int32 t3, ft0, fail
+    jmp .lhs_done
+.lhs_is_int:
+    unbox_int32 t3, t1
+.lhs_done:
+    extract_tag t4, t2
+    branch_any_eq t4, INT32_TAG, BOOLEAN_TAG, .rhs_is_int
+    check_tag_is_double t4, fail
+    fp_mov ft0, t2
+    js_to_int32 t4, ft0, fail
+    jmp .rhs_done
+.rhs_is_int:
+    unbox_int32 t4, t2
+.rhs_done:
+end
+
+# Fast path for bitwise binary operations on int32/boolean/double operands.
 # op_insn: the bitwise instruction to apply (xor, and, or).
 macro bitwise_op(op_insn, slow_path_func)
     load_operand t1, m_lhs
     load_operand t2, m_rhs
-    extract_tag t3, t1
-    branch_any_eq t3, INT32_TAG, BOOLEAN_TAG, .lhs_ok
-    jmp .slow
-.lhs_ok:
-    extract_tag t4, t2
-    branch_any_eq t4, INT32_TAG, BOOLEAN_TAG, .rhs_ok
-    jmp .slow
-.rhs_ok:
-    unbox_int32 t3, t1
-    unbox_int32 t4, t2
+    coerce_to_int32s .slow
     op_insn t3, t4
     box_int32 t4, t3
     store_operand m_dst, t4


### PR DESCRIPTION
Improves the performance of bitwise ops (&,^,|) with doubles by ~3x on x86.

Makes the animation noticeably smoother on: https://theintraclinic.com/archive/minecraft4k-js/. 

Tested with the following benchmark:

```html
<!DOCTYPE html>
<pre id="output"></pre>
<script>
const output = document.getElementById("output");

const SIZE = 1024;
const PASSES = 4000;
const SAMPLES = 5;

function log(line = "") {
    output.textContent += `${line}\n`;
}

function median(values) {
    const sorted = values.slice().sort((a, b) => a - b);
    return sorted[Math.floor(sorted.length / 2)];
}

function make_values(mapper) {
    const values = new Array(SIZE);
    for (let i = 0; i < SIZE; i++)
        values[i] = mapper(i);
    return values;
}

function benchmark(lhs, rhs) {
    let acc_and = 0;
    let acc_or = 1;
    let acc_xor = 2;
    const start = performance.now();

    for (let pass = 0; pass < PASSES; pass++) {
        for (let i = 0; i < SIZE; i++) {
            const a = lhs[i];
            const b = rhs[i];
            acc_and ^= a & b;
            acc_or ^= a | b;
            acc_xor ^= a ^ b;
        }
    }

    return performance.now() - start;
}

function run_case(name, lhs, rhs) {
    benchmark(lhs, rhs);

    const samples = [];
    for (let sample = 0; sample < SAMPLES; sample++)
        samples.push(benchmark(lhs, rhs));

    const time = median(samples);
    const ops = SIZE * PASSES * 3;
    const ns_per_op = time * 1000000 / ops;
    log(`${name}: ${time.toFixed(2)} ms median (${ns_per_op.toFixed(2)} ns/op)`);
}

const int32_lhs = make_values(i => (i * 1103515245) | 0);
const int32_rhs = make_values(i => ((i * 12345) ^ 0x5a5a5a5a) | 0);
const double_lhs = make_values(i => i + 0.75);
const double_rhs = make_values(i => i * 3 + 0.25);

run_case("int32 / int32", int32_lhs, int32_rhs);
run_case("double / double", double_lhs, double_rhs);
</script>
```

Results:

Before:

```
int32 / int32: 67.10 ms median (5.46 ns/op)
double / double: 200.00 ms median (16.28 ns/op)
```

After:

```
int32 / int32: 66.40 ms median (5.40 ns/op)
double / double: 66.70 ms median (5.43 ns/op)
```

No test262 diff

No appreciable difference in `js-benchmarks` on x86.
