### PR TITLE
LibWeb: Reduce noise from <img>'s `decoding` attribute

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -185,8 +185,8 @@ void HTMLImageElement::form_associated_element_attribute_changed(FlyString const
     }
 
     if (name == HTML::AttributeNames::decoding) {
-        if (value.has_value() && (value->equals_ignoring_ascii_case("sync"sv) || value->equals_ignoring_ascii_case("async"sv)))
-            dbgln("FIXME: HTMLImageElement.decoding = '{}' is not implemented yet", value->to_ascii_lowercase());
+        if (value.has_value() && value->equals_ignoring_ascii_case("sync"sv))
+            dbgln("FIXME: HTMLImageElement.decoding = 'sync' is not implemented yet");
     }
 }
 


### PR DESCRIPTION
Our implementation of image decoding and its effect on presenting/rendering the DOM is already effectively "async". The value "auto" is implementation-defined, but should likely default to async behavior as well. That leaves us with `decoding="sync"`, for which we should still show a FIXME.

Makes the stderr output a bit more palatable for sites like Google Maps.