### PR TITLE
LibGfx+LibWeb: Implement `CanvasTextDrawingStyles.letterSpacing`

### DIFF
--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -94,7 +94,7 @@ SkTextBlob* GlyphRun::cached_skia_text_blob() const
     return m_cached_text_blob->blob.get();
 }
 
-Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View const& string, FontCascadeList const& font_cascade_list)
+Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View const& string, FontCascadeList const& font_cascade_list, float letter_spacing)
 {
     if (string.is_empty())
         return {};
@@ -106,8 +106,8 @@ Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View 
     Font const* last_font = &font_cascade_list.font_for_code_point(*it);
     FloatPoint last_position = baseline_start;
 
-    auto add_run = [&runs, &last_position](Utf16View const& string, Font const& font) {
-        auto run = shape_text(last_position, 0, string, font, GlyphRun::TextType::Common);
+    auto add_run = [&runs, &last_position, letter_spacing](Utf16View const& string, Font const& font) {
+        auto run = shape_text(last_position, letter_spacing, string, font, GlyphRun::TextType::Common);
         last_position.translate_by(run->width(), 0);
         runs.append(*run);
     };

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -68,7 +68,7 @@ private:
 };
 
 NonnullRefPtr<GlyphRun> shape_text(FloatPoint baseline_start, float letter_spacing, Utf16View const&, Gfx::Font const& font, GlyphRun::TextType);
-Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View const&, FontCascadeList const&);
+Vector<NonnullRefPtr<GlyphRun>> shape_text(FloatPoint baseline_start, Utf16View const&, FontCascadeList const&, float letter_spacing = 0.f);
 float measure_text_width(Utf16View const&, Font const& font, float letter_spacing = 0.f);
 
 }

--- a/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -16,6 +16,7 @@
 #include <LibGfx/FontCascadeList.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibWeb/Bindings/CanvasRenderingContext2DPrototype.h>
+#include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 #include <LibWeb/HTML/CanvasGradient.h>
 #include <LibWeb/HTML/CanvasPattern.h>
@@ -110,6 +111,7 @@ public:
         Bindings::CanvasTextAlign text_align { Bindings::CanvasTextAlign::Start };
         Bindings::CanvasTextBaseline text_baseline { Bindings::CanvasTextBaseline::Alphabetic };
         Bindings::CanvasDirection direction { Bindings::CanvasDirection::Inherit };
+        CSS::Length letter_spacing { CSS::Length::make_px(0) };
 
         void visit_edges(GC::Cell::Visitor& visitor)
         {

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
@@ -158,6 +158,31 @@ void CanvasTextDrawingStyles<IncludingClass, CanvasType>::set_font(StringView fo
     my_drawing_state().current_font_cascade_list = font_list;
 }
 
+// https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-letterspacing
+template<typename IncludingClass, typename CanvasType>
+String CanvasTextDrawingStyles<IncludingClass, CanvasType>::letter_spacing() const
+{
+    // The letterSpacing getter steps are to return the serialized form of this's letter spacing.
+    StringBuilder builder;
+    my_drawing_state().letter_spacing.serialize(builder);
+    return MUST(builder.to_string());
+}
+
+// https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-letterspacing
+template<typename IncludingClass, typename CanvasType>
+void CanvasTextDrawingStyles<IncludingClass, CanvasType>::set_letter_spacing(StringView letter_spacing)
+{
+    // 1. Let parsed be the result of parsing the given value as a CSS <length>.
+    auto parsed = parse_css_type(CSS::Parser::ParsingParams {}, letter_spacing, CSS::ValueType::Length);
+
+    // 2. If parsed is failure, then return.
+    if (!parsed || !parsed->is_length())
+        return;
+
+    // 3. Set this's letter spacing to parsed.
+    my_drawing_state().letter_spacing = parsed->as_length().length();
+}
+
 template class CanvasTextDrawingStyles<CanvasRenderingContext2D, HTMLCanvasElement>;
 template class CanvasTextDrawingStyles<OffscreenCanvasRenderingContext2D, HTML::OffscreenCanvas>;
 

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -30,6 +30,9 @@ public:
     Bindings::CanvasDirection direction() const { return my_drawing_state().direction; }
     void set_direction(Bindings::CanvasDirection direction) { my_drawing_state().direction = direction; }
 
+    String letter_spacing() const;
+    void set_letter_spacing(StringView);
+
 protected:
     CanvasTextDrawingStyles() = default;
 

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.idl
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.idl
@@ -17,7 +17,7 @@ interface mixin CanvasTextDrawingStyles {
     attribute CanvasTextAlign textAlign; // (default: "start")
     attribute CanvasTextBaseline textBaseline; // (default: "alphabetic")
     attribute CanvasDirection direction; // (default: "inherit")
-    [FIXME] attribute DOMString letterSpacing; // (default: "0px")
+    attribute DOMString letterSpacing; // (default: "0px")
     [FIXME] attribute CanvasFontKerning fontKerning; // (default: "auto")
     [FIXME] attribute CanvasFontStretch fontStretch; // (default: "normal")
     [FIXME] attribute CanvasFontVariantCaps fontVariantCaps; // (default: "normal")

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -261,6 +261,16 @@ void CanvasRenderingContext2D::allocate_painting_surface_if_needed()
     }
 }
 
+static float resolved_letter_spacing(CanvasState::DrawingState const& drawing_state, HTMLCanvasElement& canvas_element)
+{
+    CSS::Length::ResolutionContext context = [&] {
+        if (canvas_element.computed_properties())
+            return CSS::Length::ResolutionContext::for_element(DOM::AbstractElement { canvas_element });
+        return CSS::Length::ResolutionContext::for_document(canvas_element.document());
+    }();
+    return static_cast<float>(drawing_state.letter_spacing.to_px(context).to_double());
+}
+
 Gfx::Path CanvasRenderingContext2D::text_path(Utf16String const& text, float x, float y, Optional<double> max_width)
 {
     if (max_width.has_value() && max_width.value() <= 0)
@@ -270,7 +280,8 @@ Gfx::Path CanvasRenderingContext2D::text_path(Utf16String const& text, float x, 
 
     auto const& font_cascade_list = this->font_cascade_list();
     auto const& font = font_cascade_list->first();
-    auto glyph_runs = Gfx::shape_text({ x, y }, text.utf16_view(), *font_cascade_list);
+    auto glyph_runs = Gfx::shape_text({ x, y }, text.utf16_view(), *font_cascade_list,
+        resolved_letter_spacing(drawing_state, canvas_element()));
     Gfx::Path path;
     for (auto const& glyph_run : glyph_runs) {
         path.glyph_run(glyph_run);
@@ -780,7 +791,8 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(Ut
     auto replaced_text = builder.to_utf16_string();
 
     // 3. Let font be the current font of target, as given by that object's font attribute.
-    auto glyph_runs = Gfx::shape_text({ 0, 0 }, replaced_text.utf16_view(), *font_cascade_list());
+    auto glyph_runs = Gfx::shape_text({ 0, 0 }, replaced_text.utf16_view(), *font_cascade_list(),
+        resolved_letter_spacing(drawing_state(), canvas_element()));
 
     // FIXME: 4. Let language be the target's language.
     // FIXME: 5. If language is "inherit":

--- a/Tests/LibWeb/Ref/expected/canvas-letter-spacing-ref.html
+++ b/Tests/LibWeb/Ref/expected/canvas-letter-spacing-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<canvas id="c" width="400" height="200"></canvas>
+<script>
+    const ctx = c.getContext("2d");
+    ctx.font = "20px SerenitySans";
+
+    function fillTextWithSpacing(text, x, y, spacing) {
+        for (const char of text) {
+            ctx.fillText(char, x, y);
+            x += ctx.measureText(char).width + spacing;
+        }
+    }
+
+    fillTextWithSpacing("Hello", 10, 30, 0);
+    fillTextWithSpacing("Hello", 10, 70, 5);
+    fillTextWithSpacing("Hello", 10, 110, 10);
+    fillTextWithSpacing("Hello", 10, 150, -2);
+</script>

--- a/Tests/LibWeb/Ref/input/canvas-letter-spacing.html
+++ b/Tests/LibWeb/Ref/input/canvas-letter-spacing.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/canvas-letter-spacing-ref.html" />
+<meta name="fuzzy" content="maxDifference=0-7;totalPixels=0-500" />
+<canvas id="c" width="400" height="200"></canvas>
+<script>
+    const ctx = c.getContext("2d");
+    ctx.font = "20px SerenitySans";
+
+    ctx.letterSpacing = "0px";
+    ctx.fillText("Hello", 10, 30);
+
+    ctx.letterSpacing = "5px";
+    ctx.fillText("Hello", 10, 70);
+
+    ctx.letterSpacing = "10px";
+    ctx.fillText("Hello", 10, 110);
+
+    ctx.letterSpacing = "-2px";
+    ctx.fillText("Hello", 10, 150);
+</script>

--- a/Tests/LibWeb/Text/expected/canvas/letter-spacing.txt
+++ b/Tests/LibWeb/Text/expected/canvas/letter-spacing.txt
@@ -1,0 +1,9 @@
+default: 0px
+after set 5px: 5px
+after set 2em: 2em
+after set invalid: 2em
+after set empty: 2em
+after set 10px: 10px
+after save+set 20px: 20px
+after restore: 10px
+spacing affects measureText: true

--- a/Tests/LibWeb/Text/input/canvas/letter-spacing.html
+++ b/Tests/LibWeb/Text/input/canvas/letter-spacing.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
+
+        println(`default: ${ctx.letterSpacing}`);
+
+        ctx.letterSpacing = "5px";
+        println(`after set 5px: ${ctx.letterSpacing}`);
+
+        ctx.letterSpacing = "2em";
+        println(`after set 2em: ${ctx.letterSpacing}`);
+
+        ctx.letterSpacing = "invalid";
+        println(`after set invalid: ${ctx.letterSpacing}`);
+
+        ctx.letterSpacing = "";
+        println(`after set empty: ${ctx.letterSpacing}`);
+
+        ctx.letterSpacing = "10px";
+        println(`after set 10px: ${ctx.letterSpacing}`);
+
+        ctx.save();
+        ctx.letterSpacing = "20px";
+        println(`after save+set 20px: ${ctx.letterSpacing}`);
+        ctx.restore();
+        println(`after restore: ${ctx.letterSpacing}`);
+
+        ctx.letterSpacing = "3px";
+        const width_with_spacing = ctx.measureText("hello").width;
+        ctx.letterSpacing = "0px";
+        const width_without_spacing = ctx.measureText("hello").width;
+        println(`spacing affects measureText: ${width_with_spacing > width_without_spacing}`);
+    });
+</script>


### PR DESCRIPTION
| Before | After |
|--|--|
| <img width="78" height="165" alt="image" src="https://github.com/user-attachments/assets/0340b57a-ee5e-46f9-a968-c108032cd912" /> | <img width="119" height="166" alt="image" src="https://github.com/user-attachments/assets/e53d9e12-2876-4591-9f21-8320373b6dad" /> |
