### PR TITLE
Update build instructions to include Rust for macOS

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -155,7 +155,7 @@ Xcode 15 or clang from homebrew is required to successfully build ladybird.
 
 ```
 xcode-select --install
-brew install autoconf autoconf-archive automake ccache cmake libtool nasm ninja pkg-config
+brew install autoconf autoconf-archive automake ccache cmake libtool nasm ninja pkg-config rust
 ```
 
 If you wish to use clang from homebrew instead:


### PR DESCRIPTION
Added rust to the list of dependencies for building Ladybird for macOS