### PR TITLE
LibJS: Fix AssignmentTargetType for NewExpression and strict mode

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -1222,7 +1222,9 @@ Parser::PrimaryExpressionParseResult Parser::parse_primary_expression()
             if (function.kind() == FunctionKind::Async && function.name() == "await"sv)
                 syntax_error("function is not allowed to be called 'await' in this context"_string, function.source_range().start);
         }
-        return { move(expression) };
+        auto result = PrimaryExpressionParseResult { move(expression) };
+        result.was_parenthesized = true;
+        return result;
     }
     case TokenType::This: {
         if (scope_collector().has_current_scope())
@@ -1372,9 +1374,20 @@ NonnullRefPtr<RegExpLiteral const> Parser::parse_regexp_literal()
     return literal;
 }
 
-static bool is_simple_assignment_target(Expression const& expression, bool allow_web_reality_call_expression = true)
+static bool is_simple_assignment_target(Expression const& expression, bool allow_web_reality_call_expression = true, bool strict_mode = false)
 {
-    return is<Identifier>(expression) || is<MemberExpression>(expression) || (allow_web_reality_call_expression && is<CallExpression>(expression));
+    if (is<Identifier>(expression) || is<MemberExpression>(expression))
+        return true;
+    // https://tc39.es/ecma262/#sec-static-semantics-assignmenttargettype
+    // CallExpression : CoverCallExpressionAndAsyncArrowHead | CallExpression Arguments
+    //   1. If the host supports Runtime Errors for Function Call Assignment Targets, then
+    //      a. If IsStrict(this CallExpression) is false, return ~web-compat~.
+    //   2. Return ~invalid~.
+    // NB: NewExpression inherits from CallExpression in our AST, but `new` expressions
+    //     are always ~invalid~ as assignment targets, so we explicitly exclude them.
+    if (allow_web_reality_call_expression && !strict_mode && is<CallExpression>(expression) && !is<NewExpression>(expression))
+        return true;
+    return false;
 }
 
 NonnullRefPtr<Expression const> Parser::parse_unary_prefixed_expression()
@@ -1394,7 +1407,7 @@ NonnullRefPtr<Expression const> Parser::parse_unary_prefixed_expression()
         consume();
         auto rhs_start = position();
         auto rhs = parse_expression(precedence, associativity);
-        if (!is_simple_assignment_target(*rhs))
+        if (!is_simple_assignment_target(*rhs, true, m_state.strict_mode))
             syntax_error(MUST(String::formatted("Right-hand side of prefix increment operator must be identifier or member expression, got {}", rhs->class_name())), rhs_start);
 
         if (m_state.strict_mode && is<Identifier>(*rhs)) {
@@ -1409,7 +1422,7 @@ NonnullRefPtr<Expression const> Parser::parse_unary_prefixed_expression()
         consume();
         auto rhs_start = position();
         auto rhs = parse_expression(precedence, associativity);
-        if (!is_simple_assignment_target(*rhs))
+        if (!is_simple_assignment_target(*rhs, true, m_state.strict_mode))
             syntax_error(MUST(String::formatted("Right-hand side of prefix decrement operator must be identifier or member expression, got {}", rhs->class_name())), rhs_start);
 
         if (m_state.strict_mode && is<Identifier>(*rhs)) {
@@ -1815,6 +1828,7 @@ NonnullRefPtr<Expression const> Parser::parse_expression(int min_precedence, Ass
     }
     if (should_continue_parsing) {
         auto original_forbidden = forbidden;
+        auto lhs_is_parenthesized = primary.was_parenthesized;
         while (match_secondary_expression(forbidden)) {
             int new_precedence = g_operator_precedence.get(m_state.current_token().type());
             if (new_precedence < min_precedence)
@@ -1824,7 +1838,8 @@ NonnullRefPtr<Expression const> Parser::parse_expression(int min_precedence, Ass
             check_for_invalid_object_property(expression);
 
             Associativity new_associativity = operator_associativity(m_state.current_token().type());
-            auto result = parse_secondary_expression(move(expression), new_precedence, new_associativity, original_forbidden);
+            auto result = parse_secondary_expression(move(expression), new_precedence, new_associativity, original_forbidden, lhs_is_parenthesized);
+            lhs_is_parenthesized = false;
             expression = result.expression;
             forbidden = forbidden.merge(result.forbidden);
             while (match(TokenType::TemplateLiteralStart) && !is<UpdateExpression>(*expression)) {
@@ -1852,7 +1867,7 @@ NonnullRefPtr<Expression const> Parser::parse_expression(int min_precedence, Ass
     return expression;
 }
 
-Parser::ExpressionResult Parser::parse_secondary_expression(NonnullRefPtr<Expression const> lhs, int min_precedence, Associativity associativity, ForbiddenTokens forbidden)
+Parser::ExpressionResult Parser::parse_secondary_expression(NonnullRefPtr<Expression const> lhs, int min_precedence, Associativity associativity, ForbiddenTokens forbidden, bool lhs_is_parenthesized)
 {
     auto rule_start = push_start();
     switch (m_state.current_token().type()) {
@@ -1949,7 +1964,7 @@ Parser::ExpressionResult Parser::parse_secondary_expression(NonnullRefPtr<Expres
     case TokenType::ParenOpen:
         return parse_call_expression(move(lhs));
     case TokenType::Equals:
-        return parse_assignment_expression(AssignmentOp::Assignment, move(lhs), min_precedence, associativity, forbidden);
+        return parse_assignment_expression(AssignmentOp::Assignment, move(lhs), min_precedence, associativity, forbidden, lhs_is_parenthesized);
     case TokenType::Period:
         consume();
         if (match(TokenType::PrivateIdentifier)) {
@@ -1971,7 +1986,7 @@ Parser::ExpressionResult Parser::parse_secondary_expression(NonnullRefPtr<Expres
         return expression;
     }
     case TokenType::PlusPlus:
-        if (!is_simple_assignment_target(*lhs))
+        if (!is_simple_assignment_target(*lhs, true, m_state.strict_mode))
             syntax_error(MUST(String::formatted("Left-hand side of postfix increment operator must be identifier or member expression, got {}", lhs->class_name())));
 
         if (m_state.strict_mode && is<Identifier>(*lhs)) {
@@ -1983,7 +1998,7 @@ Parser::ExpressionResult Parser::parse_secondary_expression(NonnullRefPtr<Expres
         consume();
         return create_ast_node<UpdateExpression>({ m_source_code, rule_start.position(), position() }, UpdateOp::Increment, move(lhs));
     case TokenType::MinusMinus:
-        if (!is_simple_assignment_target(*lhs))
+        if (!is_simple_assignment_target(*lhs, true, m_state.strict_mode))
             syntax_error(MUST(String::formatted("Left-hand side of postfix increment operator must be identifier or member expression, got {}", lhs->class_name())));
 
         if (m_state.strict_mode && is<Identifier>(*lhs)) {
@@ -2086,7 +2101,7 @@ RefPtr<BindingPattern const> Parser::synthesize_binding_pattern(Expression const
     return result;
 }
 
-NonnullRefPtr<AssignmentExpression const> Parser::parse_assignment_expression(AssignmentOp assignment_op, NonnullRefPtr<Expression const> lhs, int min_precedence, Associativity associativity, ForbiddenTokens forbidden)
+NonnullRefPtr<AssignmentExpression const> Parser::parse_assignment_expression(AssignmentOp assignment_op, NonnullRefPtr<Expression const> lhs, int min_precedence, Associativity associativity, ForbiddenTokens forbidden, bool lhs_is_parenthesized)
 {
     auto rule_start = push_start();
     VERIFY(match(TokenType::Equals)
@@ -2108,7 +2123,9 @@ NonnullRefPtr<AssignmentExpression const> Parser::parse_assignment_expression(As
     consume();
 
     if (assignment_op == AssignmentOp::Assignment) {
-        if (is<ArrayExpression>(*lhs) || is<ObjectExpression>(*lhs)) {
+        // https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors
+        // A parenthesized ObjectLiteral or ArrayLiteral is NOT an AssignmentPattern.
+        if (!lhs_is_parenthesized && (is<ArrayExpression>(*lhs) || is<ObjectExpression>(*lhs))) {
             auto binding_pattern = synthesize_binding_pattern(*lhs);
             if (binding_pattern) {
                 auto rhs = parse_expression(min_precedence, associativity);
@@ -2127,7 +2144,7 @@ NonnullRefPtr<AssignmentExpression const> Parser::parse_assignment_expression(As
         && assignment_op != AssignmentOp::OrAssignment
         && assignment_op != AssignmentOp::NullishAssignment;
 
-    if (!is_simple_assignment_target(*lhs, has_web_reality_assignment_target_exceptions)) {
+    if (!is_simple_assignment_target(*lhs, has_web_reality_assignment_target_exceptions, m_state.strict_mode)) {
         syntax_error("Invalid left-hand side in assignment"_string);
     } else if (m_state.strict_mode && is<Identifier>(*lhs)) {
         auto const& name = static_cast<Identifier const&>(*lhs).string();
@@ -3554,7 +3571,8 @@ NonnullRefPtr<Statement const> Parser::parse_for_in_of_statement(NonnullRefPtr<A
                     has_annexB_for_in_init_extension = true;
             }
         }
-    } else if (!lhs->is_identifier() && !is<MemberExpression>(*lhs) && !is<CallExpression>(*lhs) && !is<UsingDeclaration>(*lhs)) {
+    } else if (!lhs->is_identifier() && !is<MemberExpression>(*lhs) && !is<UsingDeclaration>(*lhs)
+        && !(is<CallExpression>(*lhs) && !is<NewExpression>(*lhs) && !m_state.strict_mode)) {
         bool valid = false;
         if (is<ObjectExpression>(*lhs) || is<ArrayExpression>(*lhs)) {
             auto synthesized_binding_pattern = synthesize_binding_pattern(static_cast<Expression const&>(*lhs));

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -81,6 +81,7 @@ public:
 
         NonnullRefPtr<Expression const> result;
         bool should_continue_parsing_as_expression { true };
+        bool was_parenthesized { false };
         Optional<Position> invalid_object_property_range;
     };
 
@@ -175,7 +176,7 @@ public:
 
     NonnullRefPtr<StringLiteral const> parse_string_literal(Token const& token, StringLiteralType string_literal_type = StringLiteralType::Normal, bool* contains_invalid_escape = nullptr);
     NonnullRefPtr<TemplateLiteral const> parse_template_literal(bool is_tagged);
-    ExpressionResult parse_secondary_expression(NonnullRefPtr<Expression const>, int min_precedence, Associativity associate = Associativity::Right, ForbiddenTokens forbidden = {});
+    ExpressionResult parse_secondary_expression(NonnullRefPtr<Expression const>, int min_precedence, Associativity associate = Associativity::Right, ForbiddenTokens forbidden = {}, bool lhs_is_parenthesized = false);
     NonnullRefPtr<Expression const> parse_call_expression(NonnullRefPtr<Expression const>);
     NonnullRefPtr<NewExpression const> parse_new_expression();
     NonnullRefPtr<ClassDeclaration const> parse_class_declaration();
@@ -183,7 +184,7 @@ public:
     NonnullRefPtr<YieldExpression const> parse_yield_expression();
     NonnullRefPtr<AwaitExpression const> parse_await_expression();
     NonnullRefPtr<Expression const> parse_property_key();
-    NonnullRefPtr<AssignmentExpression const> parse_assignment_expression(AssignmentOp, NonnullRefPtr<Expression const> lhs, int min_precedence, Associativity, ForbiddenTokens forbidden = {});
+    NonnullRefPtr<AssignmentExpression const> parse_assignment_expression(AssignmentOp, NonnullRefPtr<Expression const> lhs, int min_precedence, Associativity, ForbiddenTokens forbidden = {}, bool lhs_is_parenthesized = false);
     NonnullRefPtr<Identifier const> parse_identifier();
     NonnullRefPtr<ImportStatement const> parse_import_statement(Program& program);
     NonnullRefPtr<ExportStatement const> parse_export_statement(Program& program);

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -250,6 +250,10 @@ pub struct Parser<'a> {
     /// through nested labels (e.g., `a: b: for(...)`).
     last_inner_label_is_iteration: bool,
 
+    /// Set by parse_primary_expression when it parses a parenthesized expression.
+    /// Consumed by parse_secondary_expression to prevent treating (obj) as destructuring.
+    pub(crate) last_primary_was_parenthesized: bool,
+
     last_function_name: Utf16String,
     last_function_kind: FunctionKind,
     last_class_name: Utf16String,
@@ -333,6 +337,7 @@ impl<'a> Parser<'a> {
             in_eval_function_context: false,
             labels_in_scope: HashMap::new(),
             last_inner_label_is_iteration: false,
+            last_primary_was_parenthesized: false,
             last_function_name: Utf16String::default(),
             last_function_kind: FunctionKind::Normal,
             last_class_name: Utf16String::default(),
@@ -955,14 +960,20 @@ impl<'a> Parser<'a> {
         Some(pattern)
     }
 
+    // https://tc39.es/ecma262/#sec-static-semantics-assignmenttargettype
     pub(crate) fn is_simple_assignment_target(
         expression: &Expression,
         allow_call_expression: bool,
+        strict_mode: bool,
     ) -> bool {
-        matches!(
-            &expression.inner,
-            ExpressionKind::Identifier(_) | ExpressionKind::Member { .. }
-        ) || (allow_call_expression && matches!(&expression.inner, ExpressionKind::Call(_)))
+        match &expression.inner {
+            ExpressionKind::Identifier(_) | ExpressionKind::Member { .. } => true,
+            // CallExpression: In strict mode, call expressions are always ~invalid~ as
+            // assignment targets. In non-strict mode, they are ~web-compat~ (runtime error).
+            // NewExpression is always ~invalid~.
+            ExpressionKind::Call(_) if allow_call_expression && !strict_mode => true,
+            _ => false,
+        }
     }
 
     fn is_object_expression(expression: &Expression) -> bool {
@@ -979,10 +990,6 @@ impl<'a> Parser<'a> {
 
     fn is_member_expression(expression: &Expression) -> bool {
         matches!(&expression.inner, ExpressionKind::Member { .. })
-    }
-
-    fn is_call_expression(expression: &Expression) -> bool {
-        matches!(&expression.inner, ExpressionKind::Call(_))
     }
 
     fn is_update_expression(expression: &Expression) -> bool {

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -194,6 +194,7 @@ impl<'a> Parser<'a> {
         }
 
         let lhs_start = self.position();
+        self.last_primary_was_parenthesized = false;
         let (expression, should_continue) = self.parse_primary_expression(min_precedence);
 
         // C++ checks for freestanding `arguments` references here (after
@@ -237,6 +238,8 @@ impl<'a> Parser<'a> {
         mut forbidden: ForbiddenTokens,
     ) -> Expression {
         let original_forbidden = forbidden;
+        let mut lhs_is_parenthesized = self.last_primary_was_parenthesized;
+        self.last_primary_was_parenthesized = false;
         while self.match_secondary_expression(&forbidden) {
             let new_precedence = Self::operator_precedence(self.current_token_type());
             if new_precedence < min_precedence {
@@ -251,7 +254,9 @@ impl<'a> Parser<'a> {
                 expression,
                 new_precedence,
                 original_forbidden,
+                lhs_is_parenthesized,
             );
+            lhs_is_parenthesized = false;
             expression = result.0;
             forbidden = forbidden.merge(result.1);
 
@@ -310,6 +315,7 @@ impl<'a> Parser<'a> {
                 }
                 let expression = self.parse_expression_any();
                 self.consume_token(TokenType::ParenClose);
+                self.last_primary_was_parenthesized = true;
                 (expression, true)
             }
 
@@ -674,6 +680,7 @@ impl<'a> Parser<'a> {
         lhs: Expression,
         min_precedence: i32,
         forbidden: ForbiddenTokens,
+        lhs_is_parenthesized: bool,
     ) -> (Expression, ForbiddenTokens) {
         let start = self.position();
         let tt = self.current_token_type();
@@ -796,6 +803,7 @@ impl<'a> Parser<'a> {
             | TokenType::DoubleQuestionMarkEquals => {
                 let op = token_to_assignment_op(tt);
                 if op == AssignmentOp::Assignment
+                    && !lhs_is_parenthesized
                     && (Self::is_object_expression(&lhs) || Self::is_array_expression(&lhs))
                 {
                     // Save pattern_bound_names so that an outer binding
@@ -842,7 +850,7 @@ impl<'a> Parser<'a> {
                         | TokenType::DoublePipeEquals
                         | TokenType::DoubleQuestionMarkEquals
                 );
-                if !Self::is_simple_assignment_target(&lhs, allow_call) {
+                if !Self::is_simple_assignment_target(&lhs, allow_call, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in assignment");
                 }
                 if let ExpressionKind::Identifier(ref id) = lhs.inner {
@@ -963,7 +971,7 @@ impl<'a> Parser<'a> {
             // NB: The [no LineTerminator here] is enforced by match_secondary_expression
             // which checks trivia_has_line_terminator for PlusPlus/MinusMinus.
             TokenType::PlusPlus => {
-                if !Self::is_simple_assignment_target(&lhs, true) {
+                if !Self::is_simple_assignment_target(&lhs, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = lhs.inner {
@@ -983,7 +991,7 @@ impl<'a> Parser<'a> {
                 )
             }
             TokenType::MinusMinus => {
-                if !Self::is_simple_assignment_target(&lhs, true) {
+                if !Self::is_simple_assignment_target(&lhs, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in postfix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = lhs.inner {
@@ -1022,7 +1030,7 @@ impl<'a> Parser<'a> {
                     Associativity::Right,
                     ForbiddenTokens::none(),
                 );
-                if !Self::is_simple_assignment_target(&expression, true) {
+                if !Self::is_simple_assignment_target(&expression, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = expression.inner {
@@ -1044,7 +1052,7 @@ impl<'a> Parser<'a> {
                     Associativity::Right,
                     ForbiddenTokens::none(),
                 );
-                if !Self::is_simple_assignment_target(&expression, true) {
+                if !Self::is_simple_assignment_target(&expression, true, self.flags.strict_mode) {
                     self.syntax_error("Invalid left-hand side in prefix operation");
                 }
                 if let ExpressionKind::Identifier(ref id) = expression.inner {

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -911,14 +911,25 @@ impl<'a> Parser<'a> {
 
     /// Validate that an expression-form LHS is valid for for-in/for-of.
     fn validate_for_in_of_lhs(&mut self, init: &LocalForInit) {
-        if let LocalForInit::Expression(ref expression) = *init
-            && !Self::is_identifier(expression)
-            && !Self::is_member_expression(expression)
-            && !Self::is_call_expression(expression)
-            && !Self::is_object_expression(expression)
-            && !Self::is_array_expression(expression)
-        {
-            self.syntax_error("Invalid left-hand side in for-loop");
+        if let LocalForInit::Expression(ref expression) = *init {
+            match &expression.inner {
+                // NewExpression is never a valid assignment target.
+                ExpressionKind::New(_) => {
+                    self.syntax_error("Invalid left-hand side in for-loop");
+                }
+                // CallExpression is a valid assignment target only in non-strict mode (web compat).
+                ExpressionKind::Call(_) if self.flags.strict_mode => {
+                    self.syntax_error("Invalid left-hand side in for-loop");
+                }
+                ExpressionKind::Identifier(_)
+                | ExpressionKind::Member { .. }
+                | ExpressionKind::Call(_)
+                | ExpressionKind::Object(_)
+                | ExpressionKind::Array(_) => {}
+                _ => {
+                    self.syntax_error("Invalid left-hand side in for-loop");
+                }
+            }
         }
     }
 

--- a/Tests/LibJS/Runtime/assignment-target-type.js
+++ b/Tests/LibJS/Runtime/assignment-target-type.js
@@ -1,0 +1,38 @@
+test("NewExpression is never a valid assignment target", () => {
+    expect("new f() = 1").not.toEval();
+    expect("new f() += 1").not.toEval();
+    expect("new f()++").not.toEval();
+    expect("++new f()").not.toEval();
+    expect("for (new f() in x) {}").not.toEval();
+    expect("for (new f() of x) {}").not.toEval();
+});
+
+test("CallExpression is not a valid assignment target in strict mode", () => {
+    expect("'use strict'; f() = 1").not.toEval();
+    expect("'use strict'; f() += 1").not.toEval();
+    expect("'use strict'; f()++").not.toEval();
+    expect("'use strict'; ++f()").not.toEval();
+    expect("'use strict'; for (f() in x) {}").not.toEval();
+    expect("'use strict'; for (f() of x) {}").not.toEval();
+});
+
+test("CallExpression is accepted as assignment target in non-strict mode (web compat)", () => {
+    expect("f() = 1").toEval();
+    expect("f() += 1").toEval();
+    expect("f()++").toEval();
+    expect("++f()").toEval();
+    expect("for (f() in x) {}").toEval();
+    expect("for (f() of x) {}").toEval();
+});
+
+test("Parenthesized object/array literals are not valid destructuring targets", () => {
+    expect("({}) = 1").not.toEval();
+    expect("([]) = 1").not.toEval();
+    expect("({a: b}) = {a: 1}").not.toEval();
+    expect("([a]) = [1]").not.toEval();
+});
+
+test("Non-parenthesized destructuring assignment still works", () => {
+    expect("var a, b; ({a: b} = {a: 1})").toEval();
+    expect("var a; [a] = [1]").toEval();
+});

--- a/Tests/LibJS/Runtime/invalid-lhs-in-assignment.js
+++ b/Tests/LibJS/Runtime/invalid-lhs-in-assignment.js
@@ -12,8 +12,8 @@ test("Postfix operator after function call", () => {
     }).toThrow(ReferenceError);
 });
 
-test("assignment to function call in strict mode", () => {
-    expect("'use strict'; foo() = 'foo'").toEval();
+test("assignment to function call in strict mode is a SyntaxError", () => {
+    expect("'use strict'; foo() = 'foo'").not.toEval();
 });
 
 test("assignment to inline function call", () => {

--- a/Tests/LibJS/Runtime/loops/for-in-basic.js
+++ b/Tests/LibJS/Runtime/loops/for-in-basic.js
@@ -86,22 +86,15 @@ describe("special left hand sides", () => {
         expect(b.a).toBe("2");
     });
 
-    test("call function is allowed in parsing but fails in runtime", () => {
-        var fCalled = false;
-        function f() {
-            fCalled = true;
-            return {};
-        }
+    test("call expression as for-in LHS is valid in non-strict mode", () => {
+        // In non-strict mode, call expressions are allowed as for-in LHS
+        // (web compat), but they fail at runtime with ReferenceError.
+        expect("for (f() in []);").toEval();
+        expect("for (f() in {a: 1}) {}").toEval();
+    });
 
-        // Does not fail since it does not iterate (no keys in [])
-        expect("for (f() in []);").toEvalTo(undefined);
-
-        // f() is evaluated as the LHS, then ReferenceError is thrown
-        // because the result of a call is not a valid assignment target.
-        expect(() => {
-            eval("for (f() in { a: 1 }) {}");
-        }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
-        expect(fCalled).toBeTrue();
+    test("call expression as for-in LHS is SyntaxError in strict mode", () => {
+        expect("'use strict'; for (f() in []);").not.toEval();
     });
 
     test("Cannot change constant declaration in body", () => {

--- a/Tests/LibJS/Runtime/loops/for-of-basic.js
+++ b/Tests/LibJS/Runtime/loops/for-of-basic.js
@@ -130,22 +130,15 @@ describe("special left hand sides", () => {
         expect(f().a).toBe("c");
     });
 
-    test("call function is allowed in parsing but fails in runtime", () => {
-        var fCalled = false;
-        function f() {
-            fCalled = true;
-            return {};
-        }
+    test("call expression as for-of LHS is valid in non-strict mode", () => {
+        // In non-strict mode, call expressions are allowed as for-of LHS
+        // (web compat), but they fail at runtime with ReferenceError.
+        expect("for (f() of []);").toEval();
+        expect("for (f() of [0]) {}").toEval();
+    });
 
-        // Does not fail since it does not iterate but prettier does not like it so we use eval.
-        expect("for (f() of []);").toEvalTo(undefined);
-
-        // f() is evaluated as the LHS, then ReferenceError is thrown
-        // because the result of a call is not a valid assignment target.
-        expect(() => {
-            eval("for (f() of [0]) {}");
-        }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
-        expect(fCalled).toBeTrue();
+    test("call expression as for-of LHS is SyntaxError in strict mode", () => {
+        expect("'use strict'; for (f() of []);").not.toEval();
     });
 
     test("Cannot change constant declaration in body", () => {


### PR DESCRIPTION
Fix the static semantics for AssignmentTargetType in both the C++ and Rust parsers:

- NewExpression is never a valid assignment target. Previously, the C++ parser's is<CallExpression> check matched NewExpression since it inherits from CallExpression in our AST. Add explicit !is<NewExpression> guards everywhere.

- CallExpression as assignment target is only valid in non-strict mode (web-compat "runtime error for function call assignment targets"). Pass strict_mode to is_simple_assignment_target and reject call expressions in strict mode for assignment, compound assignment, prefix/postfix update, and for-in/of LHS positions.

- Parenthesized ObjectLiteral/ArrayLiteral (e.g. `({}) = 1`) must not be treated as destructuring patterns. Track whether the primary expression was parenthesized and skip binding pattern synthesis.

Update existing tests that were testing incorrect behavior:
- `'use strict'; foo() = 'foo'` is now correctly a SyntaxError
- for-in/of with call expression LHS: use toEval() instead of toEvalTo() (which runs eval inside a class method, i.e. strict mode)

test262 looks happy:
```
Summary:
    Diff Tests:
        +15 ✅    -15 ❌

Diff Tests:
    test/language/expressions/assignmenttargettype/direct-arrowfunction-1.js                              ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-asyncarrowfunction-1.js                         ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-callexpression-as-for-in-lhs.js                 ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-callexpression-as-for-of-lhs.js                 ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-callexpression-in-compound-assignment.js        ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-callexpression-in-postfix-update.js             ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-callexpression-in-prefix-update.js              ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-callexpression.js                               ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-new-memberexpression-arguments.js               ❌ -> ✅
    test/language/expressions/assignmenttargettype/direct-new-newexpression.js                            ❌ -> ✅
    test/language/expressions/assignmenttargettype/parenthesized-callexpression-in-compound-assignment.js ❌ -> ✅
    test/language/expressions/assignmenttargettype/parenthesized-callexpression.js                        ❌ -> ✅
    test/language/expressions/assignmenttargettype/parenthesized-new-memberexpression-arguments.js        ❌ -> ✅
    test/language/expressions/assignmenttargettype/parenthesized-new-newexpression.js                     ❌ -> ✅
    test/language/expressions/assignmenttargettype/parenthesized-primaryexpression-objectliteral.js       ❌ -> ✅
```