### PR TITLE
LibIPC+LibWeb+LibWebView: Remove clone_from_transport() API

### DIFF
--- a/Libraries/LibIPC/TransportHandle.cpp
+++ b/Libraries/LibIPC/TransportHandle.cpp
@@ -24,12 +24,6 @@ ErrorOr<TransportHandle> TransportHandle::from_transport(Transport& transport)
     return TransportHandle { File::adopt_fd(fd) };
 }
 
-ErrorOr<TransportHandle> TransportHandle::clone_from_transport(Transport& transport)
-{
-    auto file = TRY(transport.clone_for_transfer());
-    return TransportHandle { move(file) };
-}
-
 ErrorOr<NonnullOwnPtr<Transport>> TransportHandle::create_transport() const
 {
     auto socket = TRY(Core::LocalSocket::adopt_fd(m_file.take_fd()));

--- a/Libraries/LibIPC/TransportHandle.h
+++ b/Libraries/LibIPC/TransportHandle.h
@@ -32,7 +32,6 @@ public:
     TransportHandle& operator=(TransportHandle&&) = default;
 
     static ErrorOr<TransportHandle> from_transport(Transport& transport);
-    static ErrorOr<TransportHandle> clone_from_transport(Transport& transport);
 
     ErrorOr<NonnullOwnPtr<Transport>> create_transport() const;
 

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -509,9 +509,4 @@ ErrorOr<int> TransportSocket::release_underlying_transport_for_transfer()
     return m_socket->release_fd();
 }
 
-ErrorOr<IPC::File> TransportSocket::clone_for_transfer()
-{
-    return IPC::File::clone_fd(m_socket->fd().value());
-}
-
 }

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -72,8 +72,6 @@ public:
     // Obnoxious name to make it clear that this is a dangerous operation.
     ErrorOr<int> release_underlying_transport_for_transfer();
 
-    ErrorOr<IPC::File> clone_for_transfer();
-
 private:
     enum class TransferState {
         Continue,

--- a/Libraries/LibIPC/TransportSocketWindows.cpp
+++ b/Libraries/LibIPC/TransportSocketWindows.cpp
@@ -277,9 +277,4 @@ ErrorOr<int> TransportSocketWindows::release_underlying_transport_for_transfer()
     return m_socket->release_fd();
 }
 
-ErrorOr<IPC::File> TransportSocketWindows::clone_for_transfer()
-{
-    return IPC::File::clone_fd(m_socket->fd().value());
-}
-
 }

--- a/Libraries/LibIPC/TransportSocketWindows.h
+++ b/Libraries/LibIPC/TransportSocketWindows.h
@@ -49,8 +49,6 @@ public:
     // Obnoxious name to make it clear that this is a dangerous operation.
     ErrorOr<int> release_underlying_transport_for_transfer();
 
-    ErrorOr<IPC::File> clone_for_transfer();
-
 private:
     ErrorOr<void> duplicate_handles(Bytes, Vector<size_t> const& handle_offsets);
     ErrorOr<void> transfer(ReadonlyBytes);

--- a/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/System.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 
 namespace Web::HTML {
@@ -43,11 +42,6 @@ Messages::WebWorkerClient::RequestWorkerAgentResponse WebWorkerClient::request_w
 WebWorkerClient::WebWorkerClient(NonnullOwnPtr<IPC::Transport> transport)
     : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport))
 {
-}
-
-IPC::TransportHandle WebWorkerClient::clone_transport()
-{
-    return MUST(IPC::TransportHandle::clone_from_transport(*m_transport));
 }
 
 }

--- a/Libraries/LibWeb/Worker/WebWorkerClient.h
+++ b/Libraries/LibWeb/Worker/WebWorkerClient.h
@@ -33,8 +33,6 @@ public:
     Function<HTTP::Cookie::VersionedCookie(URL::URL const&, HTTP::Cookie::Source)> on_request_cookie;
     Function<Messages::WebWorkerClient::RequestWorkerAgentResponse(Web::Bindings::AgentType)> on_request_worker_agent;
 
-    IPC::TransportHandle clone_transport();
-
 private:
     virtual void die() override;
 };

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -791,7 +791,8 @@ Messages::WebContentClient::RequestWorkerAgentResponse WebContentClient::request
         auto request_server_handle = MUST(connect_new_request_server_client());
         auto image_decoder_handle = MUST(connect_new_image_decoder_client());
         auto worker_client = MUST(WebView::launch_web_worker_process(worker_type));
-        return { worker_client->clone_transport(), move(request_server_handle), move(image_decoder_handle) };
+        auto worker_handle = MUST(IPC::TransportHandle::from_transport(worker_client->transport()));
+        return { move(worker_handle), move(request_server_handle), move(image_decoder_handle) };
     }
 
     return { IPC::TransportHandle {}, IPC::TransportHandle {}, IPC::TransportHandle {} };


### PR DESCRIPTION
Replace clone_from_transport() (which dup()s the FD) with from_transport() (which releases the FD) in the WebWorkerClient call site. The UI process never uses the WebWorkerClient connection after spawning — it only passes the transport to WebContent — so releasing instead of cloning is safe and simpler.

This removes clone_from_transport() from TransportHandle, and clone_for_transfer() from TransportSocket/TransportSocketWindows, as they no longer have any callers.