### PR TITLE
LibWeb: Bump Chrome version in SAD_COMPATIBILITY_HACK

### DIFF
--- a/Libraries/LibWeb/Loader/UserAgent.h
+++ b/Libraries/LibWeb/Loader/UserAgent.h
@@ -65,7 +65,7 @@ namespace Web {
 // NB: Some web servers treat us very badly unless we pretend to be one of the major browsers.
 //     This token is appended to the User-Agent string to improve compatibility.
 //     We will need to update this periodically to match a somewhat recent version.
-#define SAD_COMPATIBILITY_HACK "Chrome/140.0.0.0 AppleWebKit/537.36 Safari/537.36"
+#define SAD_COMPATIBILITY_HACK "Chrome/146.0.0.0 AppleWebKit/537.36 Safari/537.36"
 
 constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") " BROWSER_NAME "/" BROWSER_VERSION " " SAD_COMPATIBILITY_HACK ""sv;
 constexpr auto default_platform = OS_STRING " " CPU_STRING ""sv;


### PR DESCRIPTION
Some web servers (like azure.com) are throttling us unless we claim to be a more recent version of Chrome.

Before this change, every HTTP request would take up to 30 seconds before receiving a response. After the change, azure.com responds instantly.

This is very silly, but it's the game we have to play.