### PR TITLE
LibJS: Update spec steps for the Intl Locale info proposal

### DIFF
--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -23,8 +23,8 @@
 
 namespace JS::Intl {
 
-// 6.2.1 IsStructurallyValidLanguageTag ( locale ), https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag
-bool is_structurally_valid_language_tag(StringView locale)
+// 6.2.1 IsWellFormedLanguageTag ( locale ), https://tc39.es/ecma402/#sec-iswellformedlanguagetag
+bool is_well_formed_language_tag(StringView locale)
 {
     auto contains_duplicate_variant = [&](auto& variants) {
         if (variants.is_empty())
@@ -309,8 +309,8 @@ ThrowCompletionOr<Vector<String>> canonicalize_locale_list(VM& vm, Value locales
                 tag = TRY(key_value.to_string(vm));
             }
 
-            // v. If ! IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
-            if (!is_structurally_valid_language_tag(tag))
+            // v. If IsWellFormedLanguageTag(tag) is false, throw a RangeError exception.
+            if (!is_well_formed_language_tag(tag))
                 return vm.throw_completion<RangeError>(ErrorType::IntlInvalidLanguageTag, tag);
 
             // vi. Let canonicalizedTag be ! CanonicalizeUnicodeLocaleId(tag).

--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -63,7 +63,7 @@ AK_ENUM_BITWISE_OPERATORS(SpecialBehaviors);
 
 using StringOrBoolean = Variant<StringView, bool>;
 
-bool is_structurally_valid_language_tag(StringView locale);
+bool is_well_formed_language_tag(StringView locale);
 String canonicalize_unicode_locale_id(StringView locale);
 bool is_well_formed_currency_code(StringView currency);
 Vector<TimeZoneIdentifier> const& available_named_time_zone_identifiers();

--- a/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -101,8 +101,8 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(VM& vm, DisplayNames::
         if (!Unicode::parse_unicode_language_id(code).has_value())
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, code, "language"sv);
 
-        // b. If IsStructurallyValidLanguageTag(code) is false, throw a RangeError exception.
-        if (!is_structurally_valid_language_tag(code))
+        // b. If IsWellFormedLanguageTag(code) is false, throw a RangeError exception.
+        if (!is_well_formed_language_tag(code))
             return vm.throw_completion<RangeError>(ErrorType::IntlInvalidLanguageTag, code);
 
         // c. Return ! CanonicalizeUnicodeLocaleId(code).

--- a/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -53,109 +53,142 @@ Optional<String> get_locale_variants(Unicode::LocaleID const& locale)
 
     // 3. Let variants be the longest suffix of baseName that starts with a "-" followed by a substring that is matched
     //    by the unicode_variant_subtag Unicode locale nonterminal. If there is no such suffix, return undefined.
-    // 4. Return the substring of variants from 1.
     if (base_name.variants.is_empty())
         return {};
+
+    // 4. Return the substring of variants from 1.
     return MUST(String::join("-"sv, base_name.variants));
 }
 
-// 1.1.1 CreateArrayFromListOrRestricted ( list , restricted )
-static GC::Ref<Array> create_array_from_list_or_restricted(VM& vm, Vector<String> list, Optional<String> restricted)
+// 15.5.9 CalendarsOfLocale ( loc ), https://tc39.es/ecma402/#sec-calendarsoflocale
+GC::Ref<Array> calendars_of_locale(VM& vm, Locale const& locale_object)
 {
     auto& realm = *vm.current_realm();
 
-    // 1. If restricted is not undefined, then
-    if (restricted.has_value()) {
-        // a. Set list to « restricted ».
-        list = { restricted.release_value() };
+    // 1. If loc.[[Calendar]] is not undefined, then
+    if (locale_object.has_calendar()) {
+        // a. Return CreateArrayFromList(« loc.[[Calendar]] »).
+        return Array::create_from(realm, { PrimitiveString::create(vm, locale_object.calendar()) });
     }
 
-    // 2. Return CreateArrayFromList( list ).
-    return Array::create_from<String>(realm, list, [&vm](auto value) {
-        return PrimitiveString::create(vm, move(value));
+    // 2. Let preference be RegionPreference(loc.[[Locale]]).
+    // 3. Let region be preference.[[Region]].
+    // 4. Let regionOverride be preference.[[RegionOverride]].
+    // 5. If regionOverride is not undefined and calendar preference data for regionOverride are available, then
+    //     a. Let lookupRegion be regionOverride.
+    // 6. Else,
+    //     a. Let lookupRegion be region.
+    // 7. Let list be a List of unique calendar types in canonical form (6.9), sorted in descending preference of those
+    //    in common use for date and time formatting in lookupRegion. The list is empty if no calendar preference data
+    //    for lookupRegion is available.
+    // 8. If list is empty, set list to « "gregory" ».
+    auto list = Unicode::available_calendars(locale_object.locale());
+
+    // 9. Return CreateArrayFromList(list).
+    return Array::create_from<String>(realm, list, [&vm](auto const& value) {
+        return PrimitiveString::create(vm, value);
     });
 }
 
-// 1.1.2 CalendarsOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-calendars-of-locale
-GC::Ref<Array> calendars_of_locale(VM& vm, Locale const& locale_object)
-{
-    // 1. Let restricted be loc.[[Calendar]].
-    Optional<String> restricted = locale_object.has_calendar() ? locale_object.calendar() : Optional<String> {};
-
-    // 2. Let locale be loc.[[Locale]].
-    auto const& locale = locale_object.locale();
-
-    // 3. Let list be a List of one or more unique calendar types in canonical form (10), sorted in descending preference
-    //    of those in common use for date and time formatting in locale.
-    auto list = Unicode::available_calendars(locale);
-
-    // 4. Return CreateArrayFromListOrRestricted( list, restricted ).
-    return create_array_from_list_or_restricted(vm, move(list), move(restricted));
-}
-
-// 1.1.3 CollationsOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-collations-of-locale
+// 15.5.10 CollationsOfLocale ( loc ), https://tc39.es/ecma402/#sec-collationsoflocale
 GC::Ref<Array> collations_of_locale(VM& vm, Locale const& locale_object)
 {
-    // 1. Let restricted be loc.[[Collation]].
-    Optional<String> restricted = locale_object.has_collation() ? locale_object.collation() : Optional<String> {};
+    auto& realm = *vm.current_realm();
 
-    // 2. Let locale be loc.[[Locale]].
-    auto const& locale = locale_object.locale();
+    // 1. If loc.[[Collation]] is not undefined, then
+    if (locale_object.has_collation()) {
+        // a. Return CreateArrayFromList(« loc.[[Collation]] »).
+        return Array::create_from(realm, { PrimitiveString::create(vm, locale_object.collation()) });
+    }
 
-    // 3. Let list be a List of one or more unique collation types in canonical form (9), of those in common use for
-    //    string comparison in locale. The values "standard" and "search" must be excluded from list. The list is sorted
-    //    according to lexicographic code unit order.
-    auto list = Unicode::available_collations(locale);
+    // 2. Let language be GetLocaleLanguage(loc.[[Locale]]).
+    // 3. If language is not "und", then
+    //     a. Let r be LookupMatchingLocaleByPrefix(%Intl.Collator%.[[AvailableLocales]], « loc.[[Locale]] »).
+    //     b. If r is not undefined, then
+    //         i. Let foundLocale be r.[[locale]].
+    //     c. Else,
+    //         i. Let foundLocale be DefaultLocale().
+    //     d. Let foundLocaleData be %Intl.Collator%.[[SortLocaleData]].[[<foundLocale>]].
+    //     e. Let list be a copy of foundLocaleData.[[co]].
+    //     f. Assert: list[0] is null.
+    //     g. Remove the first element from list.
+    // 4. Else,
+    //     a. Let list be « "emoji", "eor" ».
+    // 5. Let sorted be a copy of list, sorted according to lexicographic code unit order.
+    auto list = Unicode::available_collations(locale_object.locale());
 
-    // 4. Return CreateArrayFromListOrRestricted( list, restricted ).
-    return create_array_from_list_or_restricted(vm, move(list), move(restricted));
+    // 6. Return CreateArrayFromList(sorted).
+    return Array::create_from<String>(realm, list, [&vm](auto const& value) {
+        return PrimitiveString::create(vm, value);
+    });
 }
 
-// 1.1.4 HourCyclesOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-hour-cycles-of-locale
+// 15.5.11 HourCyclesOfLocale ( loc ), https://tc39.es/ecma402/#sec-hourcyclesoflocale
 GC::Ref<Array> hour_cycles_of_locale(VM& vm, Locale const& locale_object)
 {
-    // 1. Let restricted be loc.[[HourCycle]].
-    Optional<String> restricted = locale_object.has_hour_cycle() ? locale_object.hour_cycle() : Optional<String> {};
+    auto& realm = *vm.current_realm();
 
-    // 2. Let locale be loc.[[Locale]].
-    auto const& locale = locale_object.locale();
+    // 1. If loc.[[HourCycle]] is not undefined, then
+    if (locale_object.has_hour_cycle()) {
+        // a. Return CreateArrayFromList(« loc.[[HourCycle]] »).
+        return Array::create_from(realm, { PrimitiveString::create(vm, locale_object.hour_cycle()) });
+    }
 
-    // 3. Let list be a List of one or more unique hour cycle identifiers, which must be lower case String values
-    //    indicating either the 12-hour format ("h11", "h12") or the 24-hour format ("h23", "h24"), sorted in descending
-    //    preference of those in common use for date and time formatting in locale.
-    auto list = Unicode::available_hour_cycles(locale);
+    // 2. Let preference be RegionPreference(loc.[[Locale]]).
+    // 3. Let region be preference.[[Region]].
+    // 4. Let regionOverride be preference.[[RegionOverride]].
+    // 5. If regionOverride is not undefined and time data for regionOverride are available, then
+    //     a. Let lookupRegion be regionOverride.
+    // 6. Else,
+    //     a. Let lookupRegion be region.
+    // 7. Let list be a List of unique hour cycle identifiers, which must be lower case String values indicating either the 12-hour format ("h11", "h12") or the 24-hour format ("h23", "h24"), sorted in descending preference of those in common use for date and time formatting in lookupRegion. The list is empty if no time data for lookupRegion is available.
+    // 8. If list is empty, set list to « "h23" ».
+    auto list = Unicode::available_hour_cycles(locale_object.locale());
 
-    // 4. Return CreateArrayFromListOrRestricted( list, restricted ).
-    return create_array_from_list_or_restricted(vm, move(list), move(restricted));
+    // 9. Return CreateArrayFromList(list).
+    return Array::create_from<String>(realm, list, [&vm](auto const& value) {
+        return PrimitiveString::create(vm, value);
+    });
 }
 
-// 1.1.5 NumberingSystemsOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-numbering-systems-of-locale
+// 15.5.12 NumberingSystemsOfLocale ( loc ), https://tc39.es/ecma402/#sec-numberingsystemsoflocale
 GC::Ref<Array> numbering_systems_of_locale(VM& vm, Locale const& locale_object)
 {
-    // 1. Let restricted be loc.[[NumberingSystem]].
-    Optional<String> restricted = locale_object.has_numbering_system() ? locale_object.numbering_system() : Optional<String> {};
+    auto& realm = *vm.current_realm();
 
-    // 2. Let locale be loc.[[Locale]].
-    auto const& locale = locale_object.locale();
+    // 1. If loc.[[NumberingSystem]] is not undefined, then
+    if (locale_object.has_numbering_system()) {
+        // a. Return CreateArrayFromList(« loc.[[NumberingSystem]] »).
+        return Array::create_from(realm, { PrimitiveString::create(vm, locale_object.numbering_system()) });
+    }
 
-    // 3. Let list be a List of one or more unique numbering system identifiers in canonical form (8), sorted in
-    //    descending preference of those in common use for formatting numeric values in locale.
-    auto list = Unicode::available_number_systems(locale);
+    // 2. Let r be LookupMatchingLocaleByPrefix(%Intl.NumberFormat%.[[AvailableLocales]], « loc.[[Locale]] »).
+    // 3. If r is not undefined, then
+    //     a. Let foundLocale be r.[[locale]].
+    //     b. Let foundLocaleData be %Intl.NumberFormat%.[[LocaleData]].[[<foundLocale>]].
+    //     c. Let numberingSystems be foundLocaleData.[[nu]].
+    //     d. Let list be « numberingSystems[0] ».
+    // 4. Else,
+    //     a. Let list be « "latn" ».
+    auto list = Unicode::available_number_systems(locale_object.locale());
 
-    // 4. Return CreateArrayFromListOrRestricted( list, restricted ).
-    return create_array_from_list_or_restricted(vm, move(list), move(restricted));
+    // 5. Return CreateArrayFromList(list).
+    return Array::create_from<String>(realm, list, [&vm](auto const& value) {
+        return PrimitiveString::create(vm, value);
+    });
 }
 
-// 1.1.6 TimeZonesOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-time-zones-of-locale
-GC::Ref<Array> time_zones_of_locale(VM& vm, Locale const& locale_object)
+// 15.5.13 TimeZonesOfLocale ( loc ), https://tc39.es/ecma402/#sec-timezonesoflocale
+Value time_zones_of_locale(VM& vm, Locale const& locale_object)
 {
     auto& realm = *vm.current_realm();
 
     // 1. Let region be GetLocaleRegion(loc.[[Locale]]).
     auto const& region = locale_object.locale_id().language_id.region;
 
-    // 2. Assert: region is not undefined.
-    VERIFY(region.has_value());
+    // 2. If region is undefined, return undefined.
+    if (!region.has_value())
+        return js_undefined();
 
     // 3. Let list be a List of unique canonical time zone identifiers, which must be String values indicating a
     //    canonical Zone name of the IANA Time Zone Database, of those in common use in region. The list is empty if no
@@ -163,9 +196,29 @@ GC::Ref<Array> time_zones_of_locale(VM& vm, Locale const& locale_object)
     auto list = Unicode::available_time_zones_in_region(*region);
 
     // 4. Return CreateArrayFromList( list ).
-    return Array::create_from<String>(realm, list, [&vm](auto value) {
-        return PrimitiveString::create(vm, move(value));
+    return Array::create_from<String>(realm, list, [&vm](auto const& value) {
+        return PrimitiveString::create(vm, value);
     });
+}
+
+// 15.5.14 TextDirectionOfLocale ( loc ), https://tc39.es/ecma402/#sec-textdirectionoflocale
+StringView text_direction_of_locale(Locale const& locale_object)
+{
+    // 1. Let locale be loc.[[Locale]].
+    auto const& locale = locale_object.locale();
+
+    // 2. Let script be GetLocaleScript(locale).
+    // 3. If script is undefined, then
+    //     a. Let maximal be the result of the Add Likely Subtags algorithm applied to locale. If an error is signaled, return undefined.
+    //     b. Set script to GetLocaleScript(maximal).
+    //     c. If script is undefined, return undefined.
+    // NB: ICU handles maximizing the locale if there is no script.
+
+    // 4. If the default general ordering of characters within a line in script is right-to-left, return "rtl".
+    // 5. If the default general ordering of characters within a line in script is left-to-right, return "ltr".
+    // 6. Return undefined.
+    // FIXME: ICU does not provide a method to determine if a locale is neither rtl nor ltr.
+    return Unicode::is_locale_character_ordering_right_to_left(locale) ? "rtl"sv : "ltr"sv;
 }
 
 struct FirstDayStringAndValue {
@@ -174,8 +227,8 @@ struct FirstDayStringAndValue {
     u8 value { 0 };
 };
 
-// Table 1: First Day String and Value, https://tc39.es/proposal-intl-locale-info/#table-locale-first-day-option-value
-static constexpr auto first_day_string_and_value_table = to_array<FirstDayStringAndValue>({
+// Table 26: Weekday String and Value, https://tc39.es/ecma402/#table-locale-weekday-string-value
+static constexpr auto WEEKDAY_STRING_AND_VALUE = to_array<FirstDayStringAndValue>({
     { "0"sv, "sun"sv, 7 },
     { "1"sv, "mon"sv, 1 },
     { "2"sv, "tue"sv, 2 },
@@ -186,13 +239,13 @@ static constexpr auto first_day_string_and_value_table = to_array<FirstDayString
     { "7"sv, "sun"sv, 7 },
 });
 
-// 1.1.8 WeekdayToString ( fw ), https://tc39.es/proposal-intl-locale-info/#sec-weekday-to-string
-StringView weekday_to_string(StringView weekday)
+// 15.5.15 WeekdayToUValue ( fw ), https://tc39.es/ecma402/#sec-weekdaytouvalue
+StringView weekday_to_u_value(StringView weekday)
 {
-    // 1. For each row of Table 1, except the header row, in table order, do
-    for (auto const& row : first_day_string_and_value_table) {
-        // a. Let w be the name given in the Weekday column of the current row.
-        // b. Let s be the name given in the String column of the current row.
+    // 1. For each row of Table 26, except the header row, in table order, do
+    for (auto const& row : WEEKDAY_STRING_AND_VALUE) {
+        // a. Let w be the Weekday value of the current row.
+        // b. Let s be the String value of the current row.
         // c. If fw is equal to w, return s.
         if (weekday == row.weekday)
             return row.string;
@@ -202,13 +255,13 @@ StringView weekday_to_string(StringView weekday)
     return weekday;
 }
 
-// 1.1.9 StringToWeekdayValue ( fw ), https://tc39.es/proposal-intl-locale-info/#sec-string-to-weekday-value
-Optional<u8> string_to_weekday_value(StringView weekday)
+// 15.5.16 WeekdayUValueToNumber ( fw ), https://tc39.es/ecma402/#sec-weekdayuvaluetonumber
+Optional<u8> weekday_u_value_to_number(StringView weekday)
 {
-    // 1. For each row of Table 1, except the header row, in table order, do
-    for (auto const& row : first_day_string_and_value_table) {
-        // a. Let s be the name given in the String column of the current row.
-        // b. Let v be the name given in the Value column of the current row.
+    // 1. For each row of Table 26, except the header row, in table order, do
+    for (auto const& row : WEEKDAY_STRING_AND_VALUE) {
+        // a. Let s be the String value of the current row.
+        // b. Let v be the Value value of the current row.
         // c. If fw is equal to s, return v.
         if (weekday == row.string)
             return row.value;
@@ -220,8 +273,8 @@ Optional<u8> string_to_weekday_value(StringView weekday)
 
 static u8 weekday_to_integer(Optional<Unicode::Weekday> const& weekday, Unicode::Weekday falllback)
 {
-    // NOTE: This fallback will be used if the ICU data lookup failed. Its value should be that of the
-    //       default region ("001") in the CLDR.
+    // NB: This fallback will be used if the ICU data lookup failed. Its value should be that of the default region
+    //     ("001") in the CLDR.
     switch (weekday.value_or(falllback)) {
     case Unicode::Weekday::Monday:
         return 1;
@@ -253,17 +306,16 @@ static Vector<u8> weekend_of_locale(ReadonlySpan<Unicode::Weekday> const& weeken
     return weekend;
 }
 
-// 1.1.10 WeekInfoOfLocale ( loc ), https://tc39.es/proposal-intl-locale-info/#sec-week-info-of-locale
+// 15.5.17 WeekInfoOfLocale ( loc ), https://tc39.es/ecma402/#sec-weekinfooflocale
 WeekInfo week_info_of_locale(Locale const& locale_object)
 {
     // 1. Let locale be loc.[[Locale]].
     auto const& locale = locale_object.locale();
 
-    // 2. Let r be a record whose fields are defined by Table 2, with values based on locale.
+    // 2. Let r be a Record whose fields are defined by Table 27, with values based on locale.
     auto locale_week_info = Unicode::week_info_of_locale(locale);
 
     WeekInfo week_info {};
-    week_info.minimal_days = locale_week_info.minimal_days_in_first_week;
     week_info.first_day = weekday_to_integer(locale_week_info.first_day_of_week, Unicode::Weekday::Monday);
     week_info.weekend = weekend_of_locale(locale_week_info.weekend_days);
 
@@ -273,8 +325,8 @@ WeekInfo week_info_of_locale(Locale const& locale_object)
         // 3. Let fws be loc.[[FirstDayOfWeek]].
         auto const& first_day_of_week_string = locale_object.first_day_of_week();
 
-        // 4. Let fw be StringToWeekdayValue(fws).
-        first_day_of_week = string_to_weekday_value(first_day_of_week_string);
+        // 4. Let fw be WeekdayUValueToNumber(fws).
+        first_day_of_week = weekday_u_value_to_number(first_day_of_week_string);
     }
 
     // 5. If fw is not undefined, then

--- a/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -28,9 +28,8 @@ public:
     static constexpr auto locale_extension_keys()
     {
         // 15.2.2 Internal slots, https://tc39.es/ecma402/#sec-intl.locale-internal-slots
-        // 1.3.2 Internal slots, https://tc39.es/proposal-intl-locale-info/#sec-intl.locale-internal-slots
         // The value of the [[LocaleExtensionKeys]] internal slot is a List that must include all elements of
-        // « "ca", "co", "fw"sv, "hc", "nu" », must additionally include any element of « "kf", "kn" » that is also an
+        // « "ca", "co", "fw", "hc", "nu" », must additionally include any element of « "kf", "kn" » that is also an
         // element of %Intl.Collator%.[[RelevantExtensionKeys]], and must not include any other elements.
         return AK::Array { "ca"sv, "co"sv, "fw"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
     }
@@ -84,11 +83,10 @@ private:
     mutable Optional<Unicode::LocaleID> m_cached_locale_id;
 };
 
-// Table 1: WeekInfo Record Fields, https://tc39.es/proposal-intl-locale-info/#table-locale-weekinfo-record
+// Table 27: WeekInfo Record Fields, https://tc39.es/ecma402/#sec-weekinfooflocale
 struct WeekInfo {
-    u8 minimal_days { 0 }; // [[MinimalDays]]
-    u8 first_day { 0 };    // [[FirstDay]]
-    Vector<u8> weekend;    // [[Weekend]]
+    u8 first_day { 0 }; // [[FirstDay]]
+    Vector<u8> weekend; // [[Weekend]]
 };
 
 Optional<String> get_locale_variants(Unicode::LocaleID const&);
@@ -97,9 +95,10 @@ GC::Ref<Array> calendars_of_locale(VM&, Locale const&);
 GC::Ref<Array> collations_of_locale(VM&, Locale const& locale);
 GC::Ref<Array> hour_cycles_of_locale(VM&, Locale const& locale);
 GC::Ref<Array> numbering_systems_of_locale(VM&, Locale const&);
-GC::Ref<Array> time_zones_of_locale(VM&, Locale const&);
-StringView weekday_to_string(StringView weekday);
-Optional<u8> string_to_weekday_value(StringView weekday);
+Value time_zones_of_locale(VM&, Locale const&);
+StringView text_direction_of_locale(Locale const&);
+StringView weekday_to_u_value(StringView weekday);
+Optional<u8> weekday_u_value_to_number(StringView weekday);
 WeekInfo week_info_of_locale(Locale const&);
 
 }

--- a/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -259,7 +259,6 @@ ThrowCompletionOr<Value> LocaleConstructor::call()
 }
 
 // 15.1.1 Intl.Locale ( tag [ , options ] ), https://tc39.es/ecma402/#sec-Intl.Locale
-// 1.2.3 Intl.Locale ( tag [ , options ] ), https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale
 ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -295,99 +294,103 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
     // 10. Set options to ? CoerceOptionsToObject(options).
     auto options = TRY(coerce_options_to_object(vm, options_value));
 
-    // 11. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
-    if (!is_structurally_valid_language_tag(tag))
+    // 11. If IsWellFormedLanguageTag(tag) is false, throw a RangeError exception.
+    if (!is_well_formed_language_tag(tag))
         return vm.throw_completion<RangeError>(ErrorType::IntlInvalidLanguageTag, tag);
 
-    // 12. Set tag to CanonicalizeUnicodeLocaleId(tag).
+    // 12. NOTE: Because LanguageId canonicalization can alter tag in arbitrary ways according to Alias Rules from
+    //     supplementalMetadata.xml, it is necessary to perform such canonicalization before applying overrides from
+    //     options.
+
+    // 13. Set tag to CanonicalizeUnicodeLocaleId(tag).
     tag = canonicalize_unicode_locale_id(tag);
 
-    // 13. Set tag to ? UpdateLanguageId(tag, options).
+    // 14. Set tag to ? UpdateLanguageId(tag, options).
     tag = TRY(update_language_id(vm, tag, options));
 
-    // 14. Let opt be a new Record.
+    // 15. Let opt be a new Record.
     LocaleAndKeys opt {};
 
-    // 15. Let calendar be ? GetOption(options, "calendar", STRING, EMPTY, undefined).
-    // 16. If calendar is not undefined, then
+    // 16. Let calendar be ? GetOption(options, "calendar", STRING, EMPTY, undefined).
+    // 17. If calendar is not undefined, then
     //     a. If calendar cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
-    // 17. Set opt.[[ca]] to calendar.
+    // 18. Set opt.[[ca]] to calendar.
     opt.ca = TRY(get_string_option(vm, options, vm.names.calendar, Unicode::is_type_identifier));
 
-    // 18. Let collation be ? GetOption(options, "collation", STRING, EMPTY, undefined).
-    // 19. If collation is not undefined, then
+    // 19. Let collation be ? GetOption(options, "collation", STRING, EMPTY, undefined).
+    // 20. If collation is not undefined, then
     //     a. If collation cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
-    // 20. Set opt.[[co]] to collation.
+    // 21. Set opt.[[co]] to collation.
     opt.co = TRY(get_string_option(vm, options, vm.names.collation, Unicode::is_type_identifier));
 
-    // 21. Let fw be ? GetOption(options, "firstDayOfWeek", STRING, EMPTY, undefined).
+    // 22. Let fw be ? GetOption(options, "firstDayOfWeek", STRING, EMPTY, undefined).
     auto first_day_of_week = TRY(get_string_option(vm, options, vm.names.firstDayOfWeek, nullptr));
 
-    // 22. If fw is not undefined, then
+    // 23. If fw is not undefined, then
     if (first_day_of_week.has_value()) {
-        // a. Set fw to WeekdayToString(fw).
-        first_day_of_week = MUST(String::from_utf8(weekday_to_string(*first_day_of_week)));
+        // a. Set fw to WeekdayToUValue(fw).
+        first_day_of_week = MUST(String::from_utf8(weekday_to_u_value(*first_day_of_week)));
 
         // b. If fw cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
         if (!Unicode::is_type_identifier(*first_day_of_week))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, *first_day_of_week, vm.names.firstDayOfWeek);
     }
 
-    // 23. Set opt.[[fw]] to firstDay.
+    // 24. Set opt.[[fw]] to fw.
     opt.fw = move(first_day_of_week);
 
-    // 24. Let hc be ? GetOption(options, "hourCycle", STRING, « "h11", "h12", "h23", "h24" », undefined).
-    // 25. Set opt.[[hc]] to hc.
+    // 25. Let hc be ? GetOption(options, "hourCycle", STRING, « "h11", "h12", "h23", "h24" », undefined).
+    // 26. Set opt.[[hc]] to hc.
     opt.hc = TRY(get_string_option(vm, options, vm.names.hourCycle, nullptr, AK::Array { "h11"sv, "h12"sv, "h23"sv, "h24"sv }));
 
-    // 26. Let kf be ? GetOption(options, "caseFirst", STRING, « "upper", "lower", "false" », undefined).
-    // 27. Set opt.[[kf]] to kf.
+    // 27. Let kf be ? GetOption(options, "caseFirst", STRING, « "upper", "lower", "false" », undefined).
+    // 28. Set opt.[[kf]] to kf.
     opt.kf = TRY(get_string_option(vm, options, vm.names.caseFirst, nullptr, AK::Array { "upper"sv, "lower"sv, "false"sv }));
 
-    // 28. Let kn be ? GetOption(options, "numeric", BOOLEAN, EMPTY, undefined).
+    // 29. Let kn be ? GetOption(options, "numeric", BOOLEAN, EMPTY, undefined).
     auto kn = TRY(get_option(vm, options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
 
-    // 29. If kn is not undefined, set kn to ! ToString(kn).
-    // 30. Set opt.[[kn]] to kn.
+    // 30. If kn is not undefined, set kn to ! ToString(kn).
+    // 31. Set opt.[[kn]] to kn.
     if (!kn.is_undefined())
         opt.kn = TRY(kn.to_string(vm));
 
-    // 31. Let numberingSystem be ? GetOption(options, "numberingSystem", STRING, EMPTY, undefined).
-    // 32. If numberingSystem is not undefined, then
+    // 32. Let numberingSystem be ? GetOption(options, "numberingSystem", STRING, EMPTY, undefined).
+    // 33. If numberingSystem is not undefined, then
     //     a. If numberingSystem cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
-    // 33. Set opt.[[nu]] to numberingSystem.
+    // 34. Set opt.[[nu]] to numberingSystem.
     opt.nu = TRY(get_string_option(vm, options, vm.names.numberingSystem, Unicode::is_type_identifier));
 
-    // 34. Let r be MakeLocaleRecord(tag, opt, localeExtensionKeys).
+    // 35. Let r be MakeLocaleRecord(tag, opt, localeExtensionKeys).
     auto result = make_locale_record(tag, move(opt), locale_extension_keys);
 
-    // 35. Set locale.[[Locale]] to r.[[locale]].
+    // 36. Set locale.[[Locale]] to r.[[locale]].
     locale->set_locale(move(result.locale));
 
-    // 36. Set locale.[[Calendar]] to r.[[ca]].
+    // 37. Set locale.[[Calendar]] to r.[[ca]].
     if (result.ca.has_value())
         locale->set_calendar(result.ca.release_value());
 
-    // 37. Set locale.[[Collation]] to r.[[co]].
+    // 38. Set locale.[[Collation]] to r.[[co]].
     if (result.co.has_value())
         locale->set_collation(result.co.release_value());
 
-    // 38. Set locale.[[FirstDayOfWeek]] to r.[[fw]].
+    // 39. Set locale.[[FirstDayOfWeek]] to r.[[fw]].
     if (result.fw.has_value())
         locale->set_first_day_of_week(result.fw.release_value());
 
-    // 39. Set locale.[[HourCycle]] to r.[[hc]].
+    // 40. Set locale.[[HourCycle]] to r.[[hc]].
     if (result.hc.has_value())
         locale->set_hour_cycle(result.hc.release_value());
 
-    // 40. If localeExtensionKeys contains "kf", then
+    // 41. If localeExtensionKeys contains "kf", then
     if (locale_extension_keys.span().contains_slow("kf"sv)) {
         // a. Set locale.[[CaseFirst]] to r.[[kf]].
         if (result.kf.has_value())
             locale->set_case_first(result.kf.release_value());
     }
 
-    // 41. If localeExtensionKeys contains "kn", then
+    // 42. If localeExtensionKeys contains "kn", then
     if (locale_extension_keys.span().contains_slow("kn"sv)) {
         // a. If SameValue(r.[[kn]], "true") is true or r.[[kn]] is the empty String, then
         if (result.kn.has_value() && (result.kn == "true"sv || result.kn->is_empty())) {
@@ -401,11 +404,11 @@ ThrowCompletionOr<GC::Ref<Object>> LocaleConstructor::construct(FunctionObject& 
         }
     }
 
-    // 42. Set locale.[[NumberingSystem]] to r.[[nu]].
+    // 43. Set locale.[[NumberingSystem]] to r.[[nu]].
     if (result.nu.has_value())
         locale->set_numbering_system(result.nu.release_value());
 
-    // 43. Return locale.
+    // 44. Return locale.
     return locale;
 }
 

--- a/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -78,9 +78,9 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::base_name)
 // 15.3.3 get Intl.Locale.prototype.calendar, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.calendar
 // 15.3.4 get Intl.Locale.prototype.caseFirst, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.caseFirst
 // 15.3.5 get Intl.Locale.prototype.collation, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.collation
-// 1.4.1 get Intl.Locale.prototype.firstDayOfWeek, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.firstDayOfWeek
-// 15.3.6 get Intl.Locale.prototype.hourCycle, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle
-// 15.3.10 get Intl.Locale.prototype.numberingSystem, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numberingSystem
+// 15.3.6 get Intl.Locale.prototype.firstDayOfWeek, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.firstDayOfWeek
+// 15.3.7 get Intl.Locale.prototype.hourCycle, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle
+// 15.3.11 get Intl.Locale.prototype.numberingSystem, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numberingSystem
 #define __JS_ENUMERATE(keyword)                                       \
     JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::keyword)               \
     {                                                                 \
@@ -92,7 +92,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::base_name)
 JS_ENUMERATE_LOCALE_KEYWORD_PROPERTIES
 #undef __JS_ENUMERATE
 
-// 15.3.7 get Intl.Locale.prototype.language, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.language
+// 15.3.8 get Intl.Locale.prototype.language, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.language
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::language)
 {
     // 1. Let loc be the this value.
@@ -103,7 +103,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::language)
     return PrimitiveString::create(vm, *locale_object->locale_id().language_id.language);
 }
 
-// 15.3.8 Intl.Locale.prototype.maximize ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.maximize
+// 15.3.9 Intl.Locale.prototype.maximize ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.maximize
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::maximize)
 {
     auto& realm = *vm.current_realm();
@@ -119,7 +119,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::maximize)
     return Locale::create(realm, locale_object, move(maximal));
 }
 
-// 15.3.9 Intl.Locale.prototype.minimize ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize
+// 15.3.10 Intl.Locale.prototype.minimize ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.minimize
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::minimize)
 {
     auto& realm = *vm.current_realm();
@@ -135,7 +135,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::minimize)
     return Locale::create(realm, locale_object, move(minimal));
 }
 
-// 15.3.11 get Intl.Locale.prototype.numeric, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric
+// 15.3.12 get Intl.Locale.prototype.numeric, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::numeric)
 {
     // 1. Let loc be the this value.
@@ -146,7 +146,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::numeric)
     return Value { locale_object->numeric() };
 }
 
-// 15.3.12 get Intl.Locale.prototype.region, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.region
+// 15.3.13 get Intl.Locale.prototype.region, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.region
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::region)
 {
     // 1. Let loc be the this value.
@@ -159,7 +159,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::region)
     return js_undefined();
 }
 
-// 15.3.13 get Intl.Locale.prototype.script, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.script
+// 15.3.14 get Intl.Locale.prototype.script, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.script
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::script)
 {
     // 1. Let loc be the this value.
@@ -172,7 +172,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::script)
     return js_undefined();
 }
 
-// 15.3.14 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
+// 15.3.15 Intl.Locale.prototype.toString ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::to_string)
 {
     // 1. Let loc be the this value.
@@ -183,29 +183,18 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::to_string)
     return PrimitiveString::create(vm, locale_object->locale());
 }
 
-// 15.3.15 get Intl.Locale.prototype.variants, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
-JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::variants)
-{
-    // 1. Let loc be the this value.
-    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto locale_object = TRY(typed_this_object(vm));
-
-    // 3. Return GetLocaleVariants(loc.[[Locale]]).
-    if (auto variants = get_locale_variants(locale_object->locale_id()); variants.has_value())
-        return PrimitiveString::create(vm, variants.release_value());
-    return js_undefined();
-}
-
 #define JS_ENUMERATE_LOCALE_INFO_PROPERTIES \
     __JS_ENUMERATE(calendars)               \
     __JS_ENUMERATE(collations)              \
     __JS_ENUMERATE(hour_cycles)             \
-    __JS_ENUMERATE(numbering_systems)
+    __JS_ENUMERATE(numbering_systems)       \
+    __JS_ENUMERATE(time_zones)
 
-// 1.4.2 Intl.Locale.prototype.getCalendars, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCalendars
-// 1.4.3 Intl.Locale.prototype.getCollations, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCollations
-// 1.4.4 Intl.Locale.prototype.getHourCycles, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getHourCycles
-// 1.4.5 Intl.Locale.prototype.getNumberingSystems, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getNumberingSystems
+// 15.3.16 Intl.Locale.prototype.getCalendars ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getCalendars
+// 15.3.17 Intl.Locale.prototype.getCollations ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getCollations
+// 15.3.18 Intl.Locale.prototype.getHourCycles ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getHourCycles
+// 15.3.19 Intl.Locale.prototype.getNumberingSystems ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getNumberingSystems
+// 15.3.20 Intl.Locale.prototype.getTimeZones ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getTimeZones
 #define __JS_ENUMERATE(keyword)                               \
     JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::get_##keyword) \
     {                                                         \
@@ -215,25 +204,7 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::variants)
 JS_ENUMERATE_LOCALE_INFO_PROPERTIES
 #undef __JS_ENUMERATE
 
-// 1.4.6 Intl.Locale.prototype.getTimeZones, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTimeZones
-JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::get_time_zones)
-{
-    // 1. Let loc be the this value.
-    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto locale_object = TRY(typed_this_object(vm));
-
-    // 3. Let region be GetLocaleRegion(loc.[[Locale]]).
-    auto const& region = locale_object->locale_id().language_id.region;
-
-    // 4. If region is undefined, return undefined.
-    if (!region.has_value())
-        return js_undefined();
-
-    // 5. Return TimeZonesOfLocale(loc).
-    return time_zones_of_locale(vm, locale_object);
-}
-
-// 1.4.7 Intl.Locale.prototype.getTextInfo, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTextInfo
+// 15.3.21 Intl.Locale.prototype.getTextInfo ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getTextInfo
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::get_text_info)
 {
     auto& realm = *vm.current_realm();
@@ -245,23 +216,17 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::get_text_info)
     // 3. Let info be OrdinaryObjectCreate(%Object.prototype%).
     auto info = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 4. Let dir be "ltr".
-    auto direction = "ltr"sv;
+    // 4. Let dir be TextDirectionOfLocale(loc).
+    auto direction = text_direction_of_locale(locale_object);
 
-    // 5. If LocaleIsRightToLeft(loc) is true, then
-    if (Unicode::is_locale_character_ordering_right_to_left(locale_object->locale())) {
-        // a. Set dir to "rtl".
-        direction = "rtl"sv;
-    }
-
-    // 6. Perform ! CreateDataPropertyOrThrow(info, "direction", dir).
+    // 5. Perform ! CreateDataPropertyOrThrow(info, "direction", dir).
     MUST(info->create_data_property_or_throw(vm.names.direction, PrimitiveString::create(vm, direction)));
 
-    // 7. Return info.
+    // 6. Return info.
     return info;
 }
 
-// 1.4.8 Intl.Locale.prototype.getWeekInfo, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo
+// 15.3.22 Intl.Locale.prototype.getWeekInfo ( ), https://tc39.es/ecma402/#sec-Intl.Locale.prototype.getWeekInfo
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::get_week_info)
 {
     auto& realm = *vm.current_realm();
@@ -276,20 +241,28 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::get_week_info)
     // 4. Let wi be WeekInfoOfLocale(loc).
     auto week_info = week_info_of_locale(locale_object);
 
-    // 5. Let we be CreateArrayFromList(wi.[[Weekend]]).
-    auto weekend = Array::create_from<u8>(realm, week_info.weekend, [](auto day) { return Value { day }; });
-
-    // 6. Perform ! CreateDataPropertyOrThrow(info, "firstDay", wi.[[FirstDay]]).
+    // 5. Perform ! CreateDataPropertyOrThrow(info, "firstDay", wi.[[FirstDay]]).
     MUST(info->create_data_property_or_throw(vm.names.firstDay, Value { week_info.first_day }));
 
-    // 7. Perform ! CreateDataPropertyOrThrow(info, "weekend", we).
+    // 6. Perform ! CreateDataPropertyOrThrow(info, "weekend", CreateArrayFromList(wi.[[Weekend]])).
+    auto weekend = Array::create_from<u8>(realm, week_info.weekend, [](auto day) { return Value { day }; });
     MUST(info->create_data_property_or_throw(vm.names.weekend, weekend));
 
-    // 8. Perform ! CreateDataPropertyOrThrow(info, "minimalDays", wi.[[MinimalDays]]).
-    MUST(info->create_data_property_or_throw(vm.names.minimalDays, Value { week_info.minimal_days }));
-
-    // 9. Return info.
+    // 7. Return info.
     return info;
+}
+
+// 15.3.23 get Intl.Locale.prototype.variants, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.variants
+JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::variants)
+{
+    // 1. Let loc be the this value.
+    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
+    auto locale_object = TRY(typed_this_object(vm));
+
+    // 3. Return GetLocaleVariants(loc.[[Locale]]).
+    if (auto variants = get_locale_variants(locale_object->locale_id()); variants.has_value())
+        return PrimitiveString::create(vm, variants.release_value());
+    return js_undefined();
 }
 
 }

--- a/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
+++ b/Libraries/LibJS/Runtime/Intl/LocalePrototype.h
@@ -22,10 +22,6 @@ public:
 private:
     explicit LocalePrototype(Realm&);
 
-    JS_DECLARE_NATIVE_FUNCTION(maximize);
-    JS_DECLARE_NATIVE_FUNCTION(minimize);
-    JS_DECLARE_NATIVE_FUNCTION(to_string);
-
     JS_DECLARE_NATIVE_FUNCTION(base_name);
     JS_DECLARE_NATIVE_FUNCTION(calendar);
     JS_DECLARE_NATIVE_FUNCTION(case_first);
@@ -33,18 +29,21 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(first_day_of_week);
     JS_DECLARE_NATIVE_FUNCTION(hour_cycle);
     JS_DECLARE_NATIVE_FUNCTION(language);
+    JS_DECLARE_NATIVE_FUNCTION(maximize);
+    JS_DECLARE_NATIVE_FUNCTION(minimize);
     JS_DECLARE_NATIVE_FUNCTION(numbering_system);
     JS_DECLARE_NATIVE_FUNCTION(numeric);
     JS_DECLARE_NATIVE_FUNCTION(region);
     JS_DECLARE_NATIVE_FUNCTION(script);
-    JS_DECLARE_NATIVE_FUNCTION(variants);
+    JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(get_calendars);
     JS_DECLARE_NATIVE_FUNCTION(get_collations);
     JS_DECLARE_NATIVE_FUNCTION(get_hour_cycles);
     JS_DECLARE_NATIVE_FUNCTION(get_numbering_systems);
-    JS_DECLARE_NATIVE_FUNCTION(get_time_zones);
     JS_DECLARE_NATIVE_FUNCTION(get_text_info);
+    JS_DECLARE_NATIVE_FUNCTION(get_time_zones);
     JS_DECLARE_NATIVE_FUNCTION(get_week_info);
+    JS_DECLARE_NATIVE_FUNCTION(variants);
 };
 
 }

--- a/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -53,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::resolved_options)
     // 4. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 5. For each row of Table 26, except the header row, in table order, do
+    // 5. For each row of Table 28, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of nf's internal slot whose name is the Internal Slot value of the current row.
     //     c. If v is not undefined, then

--- a/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -56,7 +56,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
         return PrimitiveString::create(vm, Unicode::plural_category_to_string(category));
     });
 
-    // 5. For each row of Table 30, except the header row, in table order, do
+    // 5. For each row of Table 32, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. If p is "pluralCategories", then
     //         i. Let v be CreateArrayFromList(pluralCategories).

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
@@ -46,7 +46,7 @@ JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::resolved_options)
     // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 4. For each row of Table 31, except the header row, in table order, do
+    // 4. For each row of Table 33, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of relativeTimeFormat's internal slot whose name is the Internal Slot value of the current row.
     //     c. Assert: v is not undefined.

--- a/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
@@ -45,7 +45,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmenterPrototype::resolved_options)
     // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 4. For each row of Table 32, except the header row, in table order, do
+    // 4. For each row of Table 34, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of segmenter's internal slot whose name is the Internal Slot value of the current row.
     //     c. Assert: v is not undefined.

--- a/Tests/LibJS/Runtime/builtins/Intl/Locale/Locale.prototype.getWeekInfo.js
+++ b/Tests/LibJS/Runtime/builtins/Intl/Locale/Locale.prototype.getWeekInfo.js
@@ -20,10 +20,6 @@ describe("normal behavior", () => {
         expect(weekInfo.weekend).toBeDefined();
         expect(Array.isArray(weekInfo.weekend)).toBeTrue();
         expect(weekInfo.weekend).toEqual([6, 7]);
-
-        expect(weekInfo.minimalDays).toBeDefined();
-        expect(Object.getPrototypeOf(weekInfo.minimalDays)).toBe(Number.prototype);
-        expect(weekInfo.minimalDays).toBe(1);
     });
 
     test("regions with CLDR-specified firstDay", () => {
@@ -44,15 +40,6 @@ describe("normal behavior", () => {
 
     test("weekend falls back to default region 001", () => {
         expect(new Intl.Locale("en-AC").getWeekInfo().weekend).toEqual([6, 7]);
-    });
-
-    test("regions with CLDR-specified minimalDays", () => {
-        expect(new Intl.Locale("en-AD").getWeekInfo().minimalDays).toBe(4);
-        expect(new Intl.Locale("en-CZ").getWeekInfo().minimalDays).toBe(4);
-    });
-
-    test("minimalDays falls back to default region 001", () => {
-        expect(new Intl.Locale("en-AC").getWeekInfo().minimalDays).toBe(1);
     });
 
     test("likely regional subtags are added to locales without a region", () => {


### PR DESCRIPTION
This proposal has reached stage 4 and was merged into ECMA-402. See: 
https://github.com/tc39/ecma402/commit/70b0ecc

test262 diff:
```
test/intl402/Locale/prototype/getWeekInfo/output-object-keys.js  ❌ -> ✅
```