### PR TITLE
Tests/LibWeb: Dump stack trace on test timeout

### DIFF
--- a/Tests/LibWeb/test-web/CMakeLists.txt
+++ b/Tests/LibWeb/test-web/CMakeLists.txt
@@ -30,7 +30,7 @@ if (BUILD_TESTING)
 
     add_test(
         NAME LibWeb
-        COMMAND $<TARGET_FILE:test-web> --python-executable ${Python3_EXECUTABLE} --per-test-timeout 120 -v -v
+        COMMAND $<TARGET_FILE:test-web> --python-executable ${Python3_EXECUTABLE} --per-test-timeout 90 --debug-timeouts -v -v
     )
 
     set_tests_properties(LibWeb PROPERTIES


### PR DESCRIPTION
Hopefully this provides us with useful data on tests that are timing out in CI.

Also reduce the test timeout from 120 to 90 seconds. This was originally set to accommodate "the slow GCC CI" in
be03002780d3b7d2e3e0e38c2139361aa5fb718a, let's see if it's still necessary.