### PR TITLE
Meta: Update curl to version 8.19.0 to handle reduced mtu

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "05442024c3fda64320bd25d2251cc9807b84fb6f",
+  "builtin-baseline": "48cfe1e0e928341709d97fc3d2eff10ad6262c96",
   "dependencies": [
     {
       "name": "angle",
@@ -235,7 +235,7 @@
     },
     {
       "name": "curl",
-      "version": "8.18.0#1"
+      "version": "8.19.0#0"
     },
     {
       "name": "dav1d",


### PR DESCRIPTION
When mtu (maximum transmission unit) on a network interface is reduced below expected level, this leads to packet fragmentation that is not always handled correctly by libcurl.

Changing the mtu is often done with VPNs, ipv6 tunnels, PPPoE, and other special situations.

fixes #8072

https://github.com/curl/curl/issues/20440
https://github.com/curl/curl/issues/20445
https://github.com/curl/curl/issues/20448