### PR TITLE
LibWeb: Avoid applying viewbox transform multiple times for nested SVGs

### DIFF
--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -332,7 +332,6 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
 {
     // Layout for a nested SVG viewport.
     // https://svgwg.org/svg2-draft/coords.html#EstablishingANewSVGViewport.
-    SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, m_current_viewbox_transform);
     auto& nested_viewport_state = m_state.get_mutable(viewport);
     auto resolve_dimension = [](auto& node, auto size, auto reference_value) {
         // The value auto for width and height on the ‘svg’ element is treated as 100%.
@@ -346,11 +345,32 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
     auto nested_viewport_y = viewport.computed_values().y().to_px(viewport, m_viewport_size.height());
     auto nested_viewport_width = resolve_dimension(viewport, viewport.computed_values().width(), m_viewport_size.width());
     auto nested_viewport_height = resolve_dimension(viewport, viewport.computed_values().height(), m_viewport_size.height());
-    nested_viewport_state.set_content_offset({ nested_viewport_x, nested_viewport_y });
-    nested_viewport_state.set_content_width(nested_viewport_width);
-    nested_viewport_state.set_content_height(nested_viewport_height);
+
+    CSSPixelPoint content_offset { nested_viewport_x, nested_viewport_y };
+    auto content_width = nested_viewport_width;
+    auto content_height = nested_viewport_height;
+    auto parent_viewbox_transform = m_current_viewbox_transform;
+
+    auto* svg_element = as_if<SVG::SVGSVGElement>(*viewport.dom_node());
+    if (svg_element && svg_element->view_box().has_value()) {
+        // FIXME: Avoid converting SVG box to floats.
+        Gfx::FloatRect nested_rect {
+            { nested_viewport_x.to_float(), nested_viewport_y.to_float() },
+            { nested_viewport_width.to_float(), nested_viewport_height.to_float() }
+        };
+        auto mapped_rect = m_current_viewbox_transform.map(nested_rect);
+        content_offset = mapped_rect.location().to_type<CSSPixels>();
+        content_width = CSSPixels(mapped_rect.width());
+        content_height = CSSPixels(mapped_rect.height());
+        parent_viewbox_transform = {};
+    }
+
+    nested_viewport_state.set_content_offset(content_offset);
+    nested_viewport_state.set_content_width(content_width);
+    nested_viewport_state.set_content_height(content_height);
     nested_viewport_state.set_has_definite_width(true);
     nested_viewport_state.set_has_definite_height(true);
+    SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform);
     nested_context.run(*m_available_space);
 }
 

--- a/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
+++ b/Tests/LibWeb/Layout/expected/svg/nested-viewports.txt
@@ -10,7 +10,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
             SVGGeometryBox <rect> at [34.671875,34.671875] [0+0+0 266.671875 0+0+0] [0+0+0 266.671875 0+0+0] children: not-inline
             TextNode <#text> (not painted)
-            SVGGeometryBox <rect> at [34.671875,34.671875] [0+0+0 133.328125 0+0+0] [0+0+0 133.328125 0+0+0] children: not-inline
+            SVGGeometryBox <rect> at [34.671875,34.671875] [0+0+0 133.34375 0+0+0] [0+0+0 133.34375 0+0+0] children: not-inline
             TextNode <#text> (not painted)
           TextNode <#text> (not painted)
         TextNode <#text> (not painted)
@@ -23,7 +23,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGSVGPaintable (SVGSVGBox<svg>#b) [8,8 200x200] overflow: [8,8 266.671875x266.671875]
           SVGSVGPaintable (SVGSVGBox<svg>#c) [8,8 266.671875x266.671875] overflow: [8,8 293.34375x293.34375]
             SVGPathPaintable (SVGGeometryBox<rect>) [34.671875,34.671875 266.671875x266.671875]
-            SVGPathPaintable (SVGGeometryBox<rect>) [34.671875,34.671875 133.328125x133.328125]
+            SVGPathPaintable (SVGGeometryBox<rect>) [34.671875,34.671875 133.34375x133.34375]
 
 SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x216] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Ref/expected/svg-nested-viewport-positioning-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-nested-viewport-positioning-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 256 256">
+    <rect x="0" y="0" width="256" height="256" fill="lime" />
+    <circle cx="128" cy="128" r="32" fill="blue" />
+</svg>

--- a/Tests/LibWeb/Ref/input/svg-nested-viewport-positioning.html
+++ b/Tests/LibWeb/Ref/input/svg-nested-viewport-positioning.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-nested-viewport-positioning-ref.html" />
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 256 256">
+    <rect x="0" y="0" width="256" height="256" fill="red" />
+    <svg x="0" y="0" viewBox="0 0 256 256">
+        <rect x="0" y="0" width="256" height="256" fill="lime" />
+        <circle cx="128" cy="128" r="32" fill="blue" />
+    </svg>
+</svg>


### PR DESCRIPTION
The parent's viewBox transform includes both scaling and a centering offset. For nested <svg> elements, this transform was applied once to position the nested SVG's box, then again to position children inside it, double-counting the centering offset.

We now apply the parent's transform to the nested SVG box upfront to ensure the transform is only applied once.

Fixes #632