### PR TITLE
LibWeb: Implement CSS `inherit()` function

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.cpp
@@ -69,6 +69,8 @@ Optional<ArbitrarySubstitutionFunction> to_arbitrary_substitution_function(FlySt
         return ArbitrarySubstitutionFunction::Env;
     if (name.equals_ignoring_ascii_case("if"sv))
         return ArbitrarySubstitutionFunction::If;
+    if (name.equals_ignoring_ascii_case("inherit"sv))
+        return ArbitrarySubstitutionFunction::Inherit;
     if (name.equals_ignoring_ascii_case("var"sv))
         return ArbitrarySubstitutionFunction::Var;
     return {};
@@ -345,6 +347,44 @@ static Vector<ComponentValue> replace_an_if_function(DOM::AbstractElement& eleme
     return {};
 }
 
+// https://drafts.csswg.org/css-values-5/#replace-an-inherit-function
+static Vector<ComponentValue> replace_an_inherit_function(DOM::AbstractElement& element, GuardedSubstitutionContexts& guarded_contexts, ArbitrarySubstitutionFunctionArguments const& arguments)
+{
+    // To replace an inherit() function, given a list of arguments:
+    auto declaration_value_list = arguments.get<DeclarationValueList>();
+    auto const& first_argument = declaration_value_list.first();
+    auto const second_argument = declaration_value_list.get(1);
+
+    // 1. Substitute arbitrary substitution functions in the first <declaration-value> of arguments, then parse it as a
+    //    <custom-property-name>.
+    auto substituted_first_argument = substitute_arbitrary_substitution_functions(element, guarded_contexts, first_argument);
+
+    TokenStream first_argument_tokens { substituted_first_argument };
+    first_argument_tokens.discard_whitespace();
+    auto const& name_token = first_argument_tokens.consume_a_token();
+    first_argument_tokens.discard_whitespace();
+
+    // 2. If parsing returned a <custom-property-name>, and the inherited value of that custom property on the element
+    //    does not contain the guaranteed-invalid value, return that inherited value.
+    if (name_token.is(Token::Type::Ident) && is_a_custom_property_name_string(name_token.token().ident()) && first_argument_tokens.is_empty()) {
+        if (auto element_to_inherit_style_from = element.element_to_inherit_style_from(); element_to_inherit_style_from.has_value()) {
+            if (auto const& inherited_value = element_to_inherit_style_from->get_custom_property(name_token.token().ident())) {
+                auto inherited_value_tokens = inherited_value->tokenize();
+                if (!contains_guaranteed_invalid_value(inherited_value_tokens))
+                    return inherited_value_tokens;
+            }
+        }
+    }
+
+    // 3. Otherwise, if a second <declaration-value>? was passed in arguments, substitute arbitrary substitution
+    //    functions in that argument, and return the result.
+    if (second_argument.has_value())
+        return substitute_arbitrary_substitution_functions(element, guarded_contexts, second_argument.value());
+
+    // 4. Otherwise, return the guaranteed-invalid value.
+    return { ComponentValue { GuaranteedInvalidValue {} } };
+}
+
 // https://drafts.csswg.org/css-variables-1/#replace-a-var-function
 static Vector<ComponentValue> replace_a_var_function(DOM::AbstractElement& element, GuardedSubstitutionContexts& guarded_contexts, ArbitrarySubstitutionFunctionArguments const& arguments)
 {
@@ -571,6 +611,10 @@ Optional<ArbitrarySubstitutionFunctionArguments> parse_according_to_argument_gra
 
         return return_if_no_remaining_tokens(args);
     }
+    case ArbitrarySubstitutionFunction::Inherit:
+        // https://drafts.csswg.org/css-values-5/#inherit-notation
+        // <inherit-args> = inherit( <declaration-value>, <declaration-value>? )
+        return return_if_no_remaining_tokens(parse_declaration_value_then_optional_declaration_value(tokens, Token::Type::Comma).map([](DeclarationValueList const& list) -> ArbitrarySubstitutionFunctionArguments { return list; }));
     case ArbitrarySubstitutionFunction::Var:
         // https://drafts.csswg.org/css-variables/#funcdef-var
         // <var-args> = var( <declaration-value> , <declaration-value>? )
@@ -589,6 +633,8 @@ Vector<ComponentValue> replace_an_arbitrary_substitution_function(DOM::AbstractE
         return replace_an_env_function(element, guarded_contexts, arguments);
     case ArbitrarySubstitutionFunction::If:
         return replace_an_if_function(element, guarded_contexts, arguments);
+    case ArbitrarySubstitutionFunction::Inherit:
+        return replace_an_inherit_function(element, guarded_contexts, arguments);
     case ArbitrarySubstitutionFunction::Var:
         return replace_a_var_function(element, guarded_contexts, arguments);
     }

--- a/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.h
+++ b/Libraries/LibWeb/CSS/Parser/ArbitrarySubstitutionFunctions.h
@@ -41,6 +41,7 @@ enum class ArbitrarySubstitutionFunction : u8 {
     Attr,
     Env,
     If,
+    Inherit,
     Var,
 };
 [[nodiscard]] Optional<ArbitrarySubstitutionFunction> to_arbitrary_substitution_function(FlyString const& name);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -485,6 +485,7 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_css_value(Pr
             return ParseError::SyntaxError;
         }
 
+        // FIXME: We should validate ASF grammar syntax at parse time
         if (token.is_function())
             token.function().contains_arbitrary_substitution_function(substitution_presence);
         else if (token.is_block())

--- a/Libraries/LibWeb/CSS/Parser/Types.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Types.cpp
@@ -76,6 +76,8 @@ void Function::contains_arbitrary_substitution_function(SubstitutionFunctionsPre
         presence.env = true;
     else if (name.equals_ignoring_ascii_case("if"sv))
         presence.if_ = true;
+    else if (name.equals_ignoring_ascii_case("inherit"sv))
+        presence.inherit = true;
     else if (name.equals_ignoring_ascii_case("var"sv))
         presence.var = true;
     for (auto const& component_value : value) {

--- a/Libraries/LibWeb/CSS/Parser/Types.h
+++ b/Libraries/LibWeb/CSS/Parser/Types.h
@@ -64,9 +64,10 @@ struct SubstitutionFunctionsPresence {
     bool attr { false };
     bool env { false };
     bool if_ { false };
+    bool inherit { false };
     bool var { false };
 
-    bool has_any() const { return attr || env || if_ || var; }
+    bool has_any() const { return attr || env || if_ || inherit || var; }
 };
 
 // https://drafts.csswg.org/css-syntax/#simple-block

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -5842,6 +5842,8 @@ NonnullRefPtr<StyleValue const> Parser::resolve_unresolved_style_value(DOM::Abst
         element.element().set_style_uses_attr_css_function();
     if (unresolved.includes_if_function())
         element.element().set_style_uses_if_css_function();
+    if (unresolved.includes_inherit_function())
+        element.element().set_style_uses_inherit_css_function();
     if (unresolved.includes_var_function())
         element.element().set_style_uses_var_css_function();
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2196,6 +2196,7 @@ void StyleComputer::compute_custom_properties(ComputedProperties&, DOM::Abstract
         return;
     }
 
+    // FIXME: We should update in place so that non-recomputed children aren't left pointing at stale data
     abstract_element.set_custom_property_data(
         CustomPropertyData::create(move(resolved_own), parent_data ? move(parent_data) : data->parent()));
 }

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
@@ -26,6 +26,7 @@ public:
     Vector<Parser::ComponentValue> const& values() const { return m_values; }
     bool contains_arbitrary_substitution_function() const { return m_substitution_functions_presence.has_any(); }
     bool includes_attr_function() const { return m_substitution_functions_presence.attr; }
+    bool includes_inherit_function() const { return m_substitution_functions_presence.inherit; }
     bool includes_if_function() const { return m_substitution_functions_presence.if_; }
     bool includes_var_function() const { return m_substitution_functions_presence.var; }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1664,7 +1664,7 @@ bool Document::layout_is_up_to_date() const
         //        include media conditions, or b) the data used to resolve media queries hasn't changed.
         bool const needs_style_update_due_to_if_media = element.style_uses_if_css_function();
 
-        if (needs_full_style_update || node.needs_style_update() || parent_display_changed || (recompute_elements_depending_on_custom_properties && element.style_uses_var_css_function()) || needs_style_update_due_to_if_media) {
+        if (needs_full_style_update || node.needs_style_update() || parent_display_changed || (recompute_elements_depending_on_custom_properties && (element.style_uses_var_css_function() || element.style_uses_inherit_css_function())) || needs_style_update_due_to_if_media) {
             node_invalidation = element.recompute_style(did_change_custom_properties);
         } else if (needs_inherited_style_update) {
             node_invalidation = element.recompute_inherited_style();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -858,6 +858,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style(bool& did_cha
     m_style_uses_var_css_function = false;
     m_style_uses_tree_counting_function = false;
     m_style_uses_if_css_function = false;
+    m_style_uses_inherit_css_function = false;
     m_affected_by_has_pseudo_class_in_subject_position = false;
     m_affected_by_has_pseudo_class_in_non_subject_position = false;
     m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator = false;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -310,6 +310,8 @@ public:
     }
     bool style_uses_if_css_function() const { return m_style_uses_if_css_function; }
     void set_style_uses_if_css_function() { m_style_uses_if_css_function = true; }
+    bool style_uses_inherit_css_function() const { return m_style_uses_inherit_css_function; }
+    void set_style_uses_inherit_css_function() { m_style_uses_inherit_css_function = true; }
 
     bool child_style_uses_tree_counting_function() const { return m_child_style_uses_tree_counting_function; }
     void set_child_style_uses_tree_counting_function() { m_child_style_uses_tree_counting_function = true; }
@@ -688,6 +690,7 @@ private:
     bool m_style_uses_var_css_function : 1 { false };
     bool m_style_uses_tree_counting_function : 1 { false };
     bool m_style_uses_if_css_function : 1 { false };
+    bool m_style_uses_inherit_css_function : 1 { false };
     bool m_child_style_uses_tree_counting_function : 1 { false };
     bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
     bool m_affected_by_has_pseudo_class_in_non_subject_position : 1 { false };

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/inherit-function-basic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/inherit-function-basic.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 6 tests
+
+4 Pass
+2 Fail
+Pass	inherit() on value set on parent
+Pass	inherit() on value set on ancestor
+Pass	inherit(), no value set on parent
+Pass	inherit(), accumulating values
+Fail	inherit(), accumulating font-size
+Fail	inherit() can be used within if()

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/inherit-function-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/inherit-function-invalidation.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+1 Pass
+2 Fail
+Pass	inherit() invalidates when values changes on parent element, inherited
+Fail	inherit() invalidates when values changes on parent element, inherited, deeper
+Fail	inherit() invalidates when values changes on parent element, non-inherited

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-values/inherit-function-parsing.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-values/inherit-function-parsing.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 8 tests
+
+6 Pass
+2 Fail
+Pass	e.style['left'] = "inherit(--x)" should set the property value
+Pass	e.style['left'] = "calc(inherit(--x) + 1px)" should set the property value
+Pass	e.style['left'] = "inherit(--x,)" should set the property value
+Pass	e.style['left'] = "inherit(--x, )" should set the property value
+Pass	e.style['left'] = "inherit(--x , )" should set the property value
+Pass	e.style['left'] = "inherit(--x, foo)" should set the property value
+Fail	e.style['left'] = "inherit(!!, foo)" should not set the property value
+Fail	e.style['left'] = "inherit(, foo)" should not set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/inherit-function-basic.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/inherit-function-basic.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<title>CSS Values: The inherit() function (basic behavior)</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#inherit-notation">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<main id=main>
+</main>
+
+<template id=inherit_immediate_parent>
+  <style>
+    #parent {
+      --z: 2;
+    }
+    #target {
+      --z: 13;
+      z-index: inherit(--z);
+    }
+  </style>
+  <div id=parent>
+    <div id=target>
+    </div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(inherit_immediate_parent.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(target).zIndex, '2');
+  }, 'inherit() on value set on parent');
+</script>
+
+<template id=inherit_ancestor>
+  <style>
+    :root {
+      --z: 2;
+    }
+    #foo {
+      --z: 13;
+      z-index: inherit(--z);
+    }
+  </style>
+  <div id=foo>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(inherit_ancestor.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(foo).zIndex, '2');
+  }, 'inherit() on value set on ancestor');
+</script>
+
+<template id=inherit_fallback>
+  <style>
+    #foo {
+      --z: 13;
+      z-index: inherit(--z, 4);
+    }
+  </style>
+  <div id=foo>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(inherit_fallback.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(foo).zIndex, '4');
+  }, 'inherit(), no value set on parent');
+</script>
+
+<template id=inherit_accumulate_values>
+  <style>
+    #e1 { --v: e1; }
+    #e2 { --v: e2 inherit(--v); }
+    #e3 { --v: e3 inherit(--v); }
+  </style>
+  <div id=e1>
+    <div id=e2>
+      <div id=e3>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(inherit_accumulate_values.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(e3).getPropertyValue('--v'), 'e3 e2 e1');
+  }, 'inherit(), accumulating values');
+</script>
+
+<template id=inherit_accumulate_font_size>
+  <style>
+    @property --f {
+      syntax: "<length>";
+      inherits: false;
+      initial-value: 0px;
+    }
+    #e1 { font-size: 3px; --f: 1em; }
+    #e2 { font-size: 5px; --f: calc(1em + inherit(--f)); }
+    #e3 { font-size: 7px; --f: calc(1em + inherit(--f)); }
+  </style>
+  <div id=e1>
+    <div id=e2>
+      <div id=e3>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(inherit_accumulate_font_size.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(e3).getPropertyValue('--f'), '15px');
+  }, 'inherit(), accumulating font-size');
+</script>
+
+<template id=inherit_within_if>
+  <style>
+    #parent {
+      --z: 2;
+    }
+    #target {
+      --z: 13;
+      z-index: if(style(--z > inherit(--z)):4; else:7);
+    }
+  </style>
+  <div id=parent>
+    <div id=target>
+    </div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(inherit_within_if.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(target).zIndex, '4');
+  }, 'inherit() can be used within if()');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/inherit-function-invalidation.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/inherit-function-invalidation.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<title>CSS Values: The inherit() function (invalidation)</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#inherit-notation">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<main id=main>
+</main>
+
+<template id=parent_change_unregistered>
+  <style>
+    #outer {
+      --z: 2;
+    }
+    #target {
+      z-index: inherit(--z);
+    }
+  </style>
+  <div id=outer>
+    <div id=target>
+    </div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(parent_change_unregistered.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(target).zIndex, '2');
+    assert_equals(getComputedStyle(target).getPropertyValue('--z'), '2');
+    outer.style.setProperty('--z', '4');
+    assert_equals(getComputedStyle(target).zIndex, '4');
+    assert_equals(getComputedStyle(target).getPropertyValue('--z'), '4');
+  }, 'inherit() invalidates when values changes on parent element, inherited');
+</script>
+
+<!-- Like the previous test, but #target is buried deeper. -->
+<template id=parent_change_unregistered_deep>
+  <style>
+    #outer {
+      --z: 2;
+    }
+    #target {
+      z-index: inherit(--z, 7);
+    }
+  </style>
+  <div id=outer>
+    <div>
+      <div>
+        <div>
+          <div id=target></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(parent_change_unregistered_deep.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(target).zIndex, '2');
+    outer.style.setProperty('--z', '4');
+    assert_equals(getComputedStyle(target).zIndex, '4');
+  }, 'inherit() invalidates when values changes on parent element, inherited, deeper');
+</script>
+
+<template id=parent_change_registered>
+  <style>
+    @property --z {
+      syntax: "<integer>";
+      inherits: false;
+      initial-value: 0;
+    }
+    #outer {
+      --z: 2;
+    }
+    #target {
+      z-index: inherit(--z, 7);
+    }
+  </style>
+  <div id=outer>
+    <div id=target>
+    </div>
+  </div>
+</template>
+<script>
+  test((t) => {
+    main.append(parent_change_registered.content.cloneNode(true));
+    t.add_cleanup(() => { main.replaceChildren(); });
+    assert_equals(getComputedStyle(target).zIndex, '2');
+    assert_equals(getComputedStyle(target).getPropertyValue('--z'), '0');
+    outer.style.setProperty('--z', '4');
+    assert_equals(getComputedStyle(target).zIndex, '4');
+    assert_equals(getComputedStyle(target).getPropertyValue('--z'), '0');
+  }, 'inherit() invalidates when values changes on parent element, non-inherited');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-values/inherit-function-parsing.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-values/inherit-function-parsing.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Values: The inherit() function (parsing)</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#inherit-notation">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/support/parsing-testcommon.js"></script>
+<script>
+  // 'left' chosen arbitrarily:
+  test_valid_value('left', 'inherit(--x)');
+  test_valid_value('left', 'calc(inherit(--x) + 1px)');
+  test_valid_value('left', 'inherit(--x,)');
+  test_valid_value('left', 'inherit(--x, )');
+  test_valid_value('left', 'inherit(--x , )');
+  test_valid_value('left', 'inherit(--x, foo)');
+  test_invalid_value('left', 'inherit(!!, foo)');
+  test_invalid_value('left', 'inherit(, foo)');
+</script>


### PR DESCRIPTION
The remaining failing imported tests are due to wider issues which are covered by FIXMEs (both existing and added in this PR)