### PR TITLE
Documentation: Clarify Rust installation note

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -4,8 +4,7 @@
 
 Qt6 development packages, nasm, additional build tools, and a C++23 capable compiler are required.
 
-A Rust toolchain is also required for building the JavaScript engine. You can install it via
-[rustup](https://rustup.rs/) or your system's package manager.
+A Rust toolchain is also required. You can install it via [rustup](https://rustup.rs/).
 
 We currently use gcc-14 and clang-21 in our CI pipeline. If these versions are not available on your system, see
 [`Meta/find_compiler.py`](../Meta/find_compiler.py) for the minimum compatible version.


### PR DESCRIPTION
* It is required for more than LibJS, so let's just remove that note.
* Only recommend using rustup to install the toolchain. System package managers have been found to be too out of date.