### PR TITLE
LibWeb: Use requestAnimationFrame to update media controls timeline

### DIFF
--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -136,6 +136,7 @@ void MediaControls::set_up_event_listeners()
 {
     auto& media_element = *m_media_element;
     auto& realm = media_element.realm();
+    auto& window = as<HTML::Window>(realm.global_object());
 
     // Media element state events
     add_event_listener(realm, media_element, HTML::EventNames::play, [this]() {
@@ -408,6 +409,21 @@ void MediaControls::set_up_event_listeners()
 
         return true;
     });
+
+    // Use requestAnimationFrame to update the timeline, since timeupdate only fires every 250ms.
+    auto request_animation_frame_callback_function = JS::NativeFunction::create(
+        realm, [this](JS::VM&) {
+            update_timeline();
+
+            auto& realm = m_media_element->realm();
+            auto& window = as<HTML::Window>(realm.global_object());
+            window.request_animation_frame(*m_request_animation_frame_callback);
+
+            return JS::js_undefined();
+        },
+        0, Utf16FlyString {}, &realm);
+    m_request_animation_frame_callback = realm.heap().allocate<WebIDL::CallbackType>(request_animation_frame_callback_function, realm);
+    window.request_animation_frame(*m_request_animation_frame_callback);
 }
 
 void MediaControls::toggle_playback()

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -73,6 +73,7 @@ private:
         GC::Weak<DOM::IDLEventListener> listener;
     };
     Vector<RegisteredEventListener> m_registered_event_listeners;
+    GC::Weak<WebIDL::CallbackType> m_request_animation_frame_callback;
 
     enum class Scrubbing : u8 {
         No,


### PR DESCRIPTION
The media element's timeupdate event only fires every 250ms. To make the timeline update more smoothly, poll currentTime to update the timeline every frame.