### PR TITLE
LibJS: Add deep nesting parser conformance tests

### DIFF
--- a/Tests/LibJS/Runtime/regress/deep-array-literal-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-array-literal-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep array literal nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `[${source}]`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-arrow-function-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-arrow-function-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep arrow function nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `(x${i}) => (${source})`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-block-statement-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-block-statement-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep block statement nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `{ ${source} }`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-call-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-call-expression-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep call expression nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `f(${source})`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-class-declaration-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-class-declaration-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep class declaration nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `class C${i} { m() { ${source} } }`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-conditional-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-conditional-expression-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep conditional expression nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `(true ? ${source} : 0)`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-function-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-function-nesting.js
@@ -1,0 +1,10 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep function nesting does not crash parser", () => {
+    let source = "";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += `function f${i}(){`;
+    source += "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += "}";
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-grouping-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-grouping-expression-nesting.js
@@ -1,0 +1,10 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep grouping expression nesting does not crash parser", () => {
+    let source = "";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += "(";
+    source += "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += ")";
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-if-statement-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-if-statement-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep if statement nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `if (true) { ${source} }`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-object-literal-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-object-literal-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep object literal nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `({ a: ${source} })`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-template-literal-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-template-literal-expression-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep template literal expression nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = "`${" + source + "}`";
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-try-catch-statement-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-try-catch-statement-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep try-catch statement nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `try { ${source} } catch (e) {}`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});


### PR DESCRIPTION
This PR adds 12 tests which currently crash both parsers reliably with SIGSEGV. PR #8415 allows to check both parsers - without it will check only the C++ parser.

**The expected result is at the moment is, that this tests is failing on the C++ and the Rust parser.**

Fix for the Rust parser is filed in the separate PR #8421.