### PR TITLE
LibJS: harden Rust parser against deep nesting stack overflows

### DIFF
--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -638,6 +638,10 @@ impl<'a> Parser<'a> {
     where
         F: FnOnce(&mut Self) -> T,
     {
+        if self.should_abort_parsing() {
+            return None;
+        }
+
         self.parse_recursion_depth += 1;
         if self.parse_recursion_depth > MAX_PARSER_RECURSION_DEPTH {
             self.parse_recursion_depth -= 1;

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -62,6 +62,7 @@ pub(crate) const PRECEDENCE_UNARY: i32 = 17;
 pub(crate) const PRECEDENCE_MEMBER: i32 = 19;
 // Conservative until we benchmark actual parser stack usage across targets.
 const MAX_PARSER_RECURSION_DEPTH: u32 = 1024;
+const RECURSION_LIMIT_ERROR_MESSAGE: &str = "Maximum parser recursion depth exceeded";
 
 /// Result of parsing a function's formal parameter list.
 pub struct ParsedParameters {
@@ -303,6 +304,7 @@ pub struct Parser<'a> {
     /// Recursive-descent parser nesting depth.
     parse_recursion_depth: u32,
     recursion_limit_exceeded: bool,
+    recursion_limit_error_position: Option<(u32, u32)>,
 }
 
 impl<'a> Parser<'a> {
@@ -349,6 +351,7 @@ impl<'a> Parser<'a> {
             arrow_function_failed_positions: HashSet::new(),
             parse_recursion_depth: 0,
             recursion_limit_exceeded: false,
+            recursion_limit_error_position: None,
         }
     }
 
@@ -640,8 +643,10 @@ impl<'a> Parser<'a> {
             self.parse_recursion_depth -= 1;
             if !self.recursion_limit_exceeded {
                 self.recursion_limit_exceeded = true;
+                self.recursion_limit_error_position =
+                    Some((self.current_token.line_number, self.current_token.line_column));
                 self.errors.push(ParseError {
-                    message: "Maximum parser recursion depth exceeded".to_string(),
+                    message: RECURSION_LIMIT_ERROR_MESSAGE.to_string(),
                     line: self.current_token.line_number,
                     column: self.current_token.line_column,
                 });
@@ -767,6 +772,7 @@ impl<'a> Parser<'a> {
         let state = self.saved_states.pop().expect("No saved state to restore");
         self.current_token = state.token;
         self.errors.truncate(state.errors_len);
+        self.ensure_recursion_limit_diagnostic_present();
         self.flags = state.flags;
         self.scope_collector.load_state(state.scope_collector_state);
         self.lexer.load_state();
@@ -775,6 +781,27 @@ impl<'a> Parser<'a> {
     pub(crate) fn discard_saved_state(&mut self) {
         self.saved_states.pop();
         self.lexer.discard_saved_state();
+    }
+
+    fn ensure_recursion_limit_diagnostic_present(&mut self) {
+        if !self.recursion_limit_exceeded {
+            return;
+        }
+        if self
+            .errors
+            .iter()
+            .any(|error| error.message == RECURSION_LIMIT_ERROR_MESSAGE)
+        {
+            return;
+        }
+        let (line, column) = self
+            .recursion_limit_error_position
+            .unwrap_or((self.current_token.line_number, self.current_token.line_column));
+        self.errors.push(ParseError {
+            message: RECURSION_LIMIT_ERROR_MESSAGE.to_string(),
+            line,
+            column,
+        });
     }
 
     // === Token matching helpers ===
@@ -1360,6 +1387,44 @@ impl<'a> Parser<'a> {
             | TokenType::Comma => Associativity::Left,
             _ => Associativity::Right,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recursion_limit_error_survives_state_rollback() {
+        let source: Vec<u16> = Vec::new();
+        let mut parser = Parser::new(&source, ProgramType::Script);
+
+        parser.save_state();
+        parser.parse_recursion_depth = MAX_PARSER_RECURSION_DEPTH;
+
+        let result = parser.with_parser_recursion_guard(|_| ());
+        assert!(result.is_none());
+        assert!(parser.recursion_limit_exceeded);
+        assert_eq!(
+            parser
+                .errors
+                .iter()
+                .filter(|error| error.message == RECURSION_LIMIT_ERROR_MESSAGE)
+                .count(),
+            1
+        );
+
+        parser.load_state();
+
+        assert!(parser.recursion_limit_exceeded);
+        assert_eq!(
+            parser
+                .errors
+                .iter()
+                .filter(|error| error.message == RECURSION_LIMIT_ERROR_MESSAGE)
+                .count(),
+            1
+        );
     }
 }
 

--- a/Libraries/LibJS/Rust/src/parser.rs
+++ b/Libraries/LibJS/Rust/src/parser.rs
@@ -60,6 +60,8 @@ pub(crate) const PRECEDENCE_COMMA: i32 = 0;
 pub(crate) const PRECEDENCE_ASSIGNMENT: i32 = 2;
 pub(crate) const PRECEDENCE_UNARY: i32 = 17;
 pub(crate) const PRECEDENCE_MEMBER: i32 = 19;
+// Conservative until we benchmark actual parser stack usage across targets.
+const MAX_PARSER_RECURSION_DEPTH: u32 = 1024;
 
 /// Result of parsing a function's formal parameter list.
 pub struct ParsedParameters {
@@ -298,6 +300,9 @@ pub struct Parser<'a> {
     /// `(a=(b=(c=0)))` where each failed arrow attempt would otherwise
     /// re-attempt inner positions during grouping expression re-parse.
     arrow_function_failed_positions: HashSet<usize>,
+    /// Recursive-descent parser nesting depth.
+    parse_recursion_depth: u32,
+    recursion_limit_exceeded: bool,
 }
 
 impl<'a> Parser<'a> {
@@ -342,6 +347,8 @@ impl<'a> Parser<'a> {
             exported_names: HashSet::new(),
             function_table: FunctionTable::new(),
             arrow_function_failed_positions: HashSet::new(),
+            parse_recursion_depth: 0,
+            recursion_limit_exceeded: false,
         }
     }
 
@@ -599,6 +606,9 @@ impl<'a> Parser<'a> {
     // === Error reporting ===
 
     pub(crate) fn syntax_error(&mut self, message: &str) {
+        if self.recursion_limit_exceeded {
+            return;
+        }
         self.errors.push(ParseError {
             message: message.to_string(),
             line: self.current_token.line_number,
@@ -607,6 +617,9 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn syntax_error_at(&mut self, message: &str, line: u32, column: u32) {
+        if self.recursion_limit_exceeded {
+            return;
+        }
         self.errors.push(ParseError {
             message: message.to_string(),
             line,
@@ -616,6 +629,34 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn syntax_error_at_position(&mut self, message: &str, pos: Position) {
         self.syntax_error_at(message, pos.line, pos.column);
+    }
+
+    pub(crate) fn with_parser_recursion_guard<T, F>(&mut self, f: F) -> Option<T>
+    where
+        F: FnOnce(&mut Self) -> T,
+    {
+        self.parse_recursion_depth += 1;
+        if self.parse_recursion_depth > MAX_PARSER_RECURSION_DEPTH {
+            self.parse_recursion_depth -= 1;
+            if !self.recursion_limit_exceeded {
+                self.recursion_limit_exceeded = true;
+                self.errors.push(ParseError {
+                    message: "Maximum parser recursion depth exceeded".to_string(),
+                    line: self.current_token.line_number,
+                    column: self.current_token.line_column,
+                });
+            }
+            return None;
+        }
+
+        let result = f(self);
+        debug_assert!(self.parse_recursion_depth > 0);
+        self.parse_recursion_depth -= 1;
+        Some(result)
+    }
+
+    pub(crate) fn should_abort_parsing(&self) -> bool {
+        self.recursion_limit_exceeded
     }
 
     /// Register a referenced private name. Returns true if we're inside a class
@@ -1002,7 +1043,7 @@ impl<'a> Parser<'a> {
         }
 
         children.extend(self.parse_statement_list(true));
-        if !self.done() {
+        if !self.done() && !self.should_abort_parsing() {
             if self.flags.in_function_context {
                 self.expected("CurlyClose");
             } else {
@@ -1030,9 +1071,12 @@ impl<'a> Parser<'a> {
         let mut children = Vec::new();
 
         while !self.done() {
+            if self.should_abort_parsing() {
+                break;
+            }
             children.extend(self.parse_statement_list(true));
 
-            if self.done() {
+            if self.done() || self.should_abort_parsing() {
                 break;
             }
 
@@ -1049,7 +1093,9 @@ impl<'a> Parser<'a> {
         }
 
         // Check that all exported bindings are declared in the module.
-        self.check_undeclared_exports(&children);
+        if !self.should_abort_parsing() {
+            self.check_undeclared_exports(&children);
+        }
 
         self.flags.strict_mode = strict_before;
         self.flags.await_expression_is_valid = await_before;
@@ -1103,7 +1149,7 @@ impl<'a> Parser<'a> {
     pub(crate) fn parse_directive(&mut self) -> (bool, Vec<Statement>) {
         let mut found_use_strict = false;
         let mut statements = Vec::new();
-        while !self.done() && self.match_token(TokenType::StringLiteral) {
+        while !self.done() && !self.should_abort_parsing() && self.match_token(TokenType::StringLiteral) {
             let raw_value = self.token_original_value(&self.current_token);
             let statement = self.parse_statement(false);
             statements.push(statement);
@@ -1121,20 +1167,26 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn parse_statement_list(&mut self, allow_labelled_functions: bool) -> Vec<Statement> {
-        let mut statements = Vec::new();
-        while !self.done() {
-            if self.match_export_or_import() {
-                break;
+        self.with_parser_recursion_guard(|parser| {
+            let mut statements = Vec::new();
+            while !parser.done() {
+                if parser.should_abort_parsing() {
+                    break;
+                }
+                if parser.match_export_or_import() {
+                    break;
+                }
+                if parser.match_declaration() {
+                    statements.push(parser.parse_declaration());
+                } else if parser.match_statement() {
+                    statements.push(parser.parse_statement(allow_labelled_functions));
+                } else {
+                    break;
+                }
             }
-            if self.match_declaration() {
-                statements.push(self.parse_declaration());
-            } else if self.match_statement() {
-                statements.push(self.parse_statement(allow_labelled_functions));
-            } else {
-                break;
-            }
-        }
-        statements
+            statements
+        })
+        .unwrap_or_default()
     }
 
     pub(crate) fn match_statement(&mut self) -> bool {

--- a/Libraries/LibJS/Rust/src/parser/declarations.rs
+++ b/Libraries/LibJS/Rust/src/parser/declarations.rs
@@ -1368,6 +1368,19 @@ impl Parser<'_> {
     //                      | `[` BindingElementList `]`
     //                      | `[` BindingElementList `,` Elision? BindingRestElement? `]`
     pub(crate) fn parse_binding_pattern(&mut self) -> BindingPattern {
+        let fallback_kind = if self.match_token(TokenType::BracketOpen) {
+            BindingPatternKind::Array
+        } else {
+            BindingPatternKind::Object
+        };
+        self.with_parser_recursion_guard(|parser| parser.parse_binding_pattern_impl())
+            .unwrap_or_else(|| BindingPattern {
+                kind: fallback_kind,
+                entries: Vec::new(),
+            })
+    }
+
+    fn parse_binding_pattern_impl(&mut self) -> BindingPattern {
         let is_object = self.match_token(TokenType::CurlyOpen);
         let is_array = self.match_token(TokenType::BracketOpen);
         if !is_object && !is_array {
@@ -1396,7 +1409,7 @@ impl Parser<'_> {
         };
         let mut entries: Vec<BindingEntry> = Vec::new();
 
-        while !self.match_token(closing_token) && !self.done() {
+        while !self.match_token(closing_token) && !self.done() && !self.should_abort_parsing() {
             // Array elision: bare comma.
             if !is_object && self.match_token(TokenType::Comma) {
                 self.consume();
@@ -1617,7 +1630,9 @@ impl Parser<'_> {
             }
         }
 
-        self.consume_token(closing_token);
+        if !self.should_abort_parsing() {
+            self.consume_token(closing_token);
+        }
         self.binding_pattern_start = outer_pattern_start;
         BindingPattern { kind, entries }
     }

--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -152,6 +152,18 @@ impl Parser<'_> {
         associativity: Associativity,
         forbidden: ForbiddenTokens,
     ) -> Expression {
+        self.with_parser_recursion_guard(|parser| {
+            parser.parse_expression_inner(min_precedence, associativity, forbidden)
+        })
+        .unwrap_or_else(|| self.expression(self.position(), ExpressionKind::Error))
+    }
+
+    fn parse_expression_inner(
+        &mut self,
+        min_precedence: i32,
+        associativity: Associativity,
+        forbidden: ForbiddenTokens,
+    ) -> Expression {
         if self.match_unary_prefixed_expression() {
             let start = self.position();
             let expression = self.parse_unary_prefixed_expression();

--- a/Libraries/LibJS/Rust/src/parser/statements.rs
+++ b/Libraries/LibJS/Rust/src/parser/statements.rs
@@ -22,6 +22,16 @@ enum LocalForInit {
 impl Parser<'_> {
     pub(crate) fn parse_statement(&mut self, allow_labelled_function: bool) -> Statement {
         let start = self.position();
+        if self.should_abort_parsing() {
+            return self.statement(start, StatementKind::Empty);
+        }
+
+        self.with_parser_recursion_guard(|parser| parser.parse_statement_impl(allow_labelled_function))
+            .unwrap_or_else(|| self.statement(start, StatementKind::Empty))
+    }
+
+    fn parse_statement_impl(&mut self, allow_labelled_function: bool) -> Statement {
+        let start = self.position();
         let tt = self.current_token_type();
 
         match tt {
@@ -82,6 +92,9 @@ impl Parser<'_> {
         let mut children = Vec::new();
 
         while !self.match_token(TokenType::CurlyClose) && !self.done() {
+            if self.should_abort_parsing() {
+                break;
+            }
             if self.match_declaration() {
                 children.push(self.parse_declaration());
             } else {
@@ -598,6 +611,9 @@ impl Parser<'_> {
         let mut cases = Vec::new();
         let mut has_default = false;
         while !self.match_token(TokenType::CurlyClose) && !self.done() {
+            if self.should_abort_parsing() {
+                break;
+            }
             let case = self.parse_switch_case();
             if case.test.is_none() {
                 if has_default {
@@ -647,6 +663,9 @@ impl Parser<'_> {
             && !self.match_token(TokenType::Default)
             && !self.done()
         {
+            if self.should_abort_parsing() {
+                break;
+            }
             if self.match_declaration() {
                 children.push(self.parse_declaration());
             } else {

--- a/Tests/LibJS/Runtime/regress/deep-array-binding-pattern-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-array-binding-pattern-nesting.js
@@ -1,0 +1,12 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+function makeDeepArrayBindingPattern(depth) {
+    let pattern = "x";
+    for (let i = 0; i < depth; ++i) pattern = `[${pattern}]`;
+    return pattern;
+}
+
+test("deep array binding pattern nesting does not crash parser", () => {
+    const source = `let ${makeDeepArrayBindingPattern(DEEP_NESTING_DEPTH)} = 0;`;
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-array-literal-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-array-literal-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep array literal nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `[${source}]`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-arrow-function-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-arrow-function-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep arrow function nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `(x${i}) => (${source})`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-block-statement-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-block-statement-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep block statement nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `{ ${source} }`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-call-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-call-expression-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep call expression nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `f(${source})`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-catch-parameter-binding-pattern-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-catch-parameter-binding-pattern-nesting.js
@@ -1,0 +1,12 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+function makeDeepArrayBindingPattern(depth) {
+    let pattern = "x";
+    for (let i = 0; i < depth; ++i) pattern = `[${pattern}]`;
+    return pattern;
+}
+
+test("deep catch parameter binding pattern nesting does not crash parser", () => {
+    const source = `try {} catch (${makeDeepArrayBindingPattern(DEEP_NESTING_DEPTH)}) {}`;
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-class-declaration-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-class-declaration-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep class declaration nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `class C${i} { m() { ${source} } }`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-conditional-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-conditional-expression-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep conditional expression nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `(true ? ${source} : 0)`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-function-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-function-nesting.js
@@ -1,0 +1,10 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep function nesting does not crash parser", () => {
+    let source = "";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += `function f${i}(){`;
+    source += "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += "}";
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-function-parameter-binding-pattern-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-function-parameter-binding-pattern-nesting.js
@@ -1,0 +1,12 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+function makeDeepObjectBindingPattern(depth) {
+    let pattern = "x";
+    for (let i = 0; i < depth; ++i) pattern = `{a:${pattern}}`;
+    return pattern;
+}
+
+test("deep function parameter binding pattern nesting does not crash parser", () => {
+    const source = `function f(${makeDeepObjectBindingPattern(DEEP_NESTING_DEPTH)}) {}`;
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-grouping-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-grouping-expression-nesting.js
@@ -1,0 +1,10 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep grouping expression nesting does not crash parser", () => {
+    let source = "";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += "(";
+    source += "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source += ")";
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-if-statement-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-if-statement-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep if statement nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `if (true) { ${source} }`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-object-binding-pattern-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-object-binding-pattern-nesting.js
@@ -1,0 +1,12 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+function makeDeepObjectBindingPattern(depth) {
+    let pattern = "x";
+    for (let i = 0; i < depth; ++i) pattern = `{a:${pattern}}`;
+    return pattern;
+}
+
+test("deep object binding pattern nesting does not crash parser", () => {
+    const source = `let ${makeDeepObjectBindingPattern(DEEP_NESTING_DEPTH)} = 0;`;
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-object-literal-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-object-literal-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep object literal nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `({ a: ${source} })`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-speculative-arrow-rollback-recursion-error.js
+++ b/Tests/LibJS/Runtime/regress/deep-speculative-arrow-rollback-recursion-error.js
@@ -1,0 +1,19 @@
+const DEEP_NESTING_DEPTH = 5000;
+
+function makeDeepGroupingExpression(depth) {
+    let value = "0";
+    for (let i = 0; i < depth; ++i) value = `(${value})`;
+    return value;
+}
+
+test("deep speculative arrow rollback preserves recursion-limit error", () => {
+    // `(` triggers speculative arrow parsing first. This source is *not* an
+    // arrow function, so parser state is rolled back via load_state().
+    //
+    // Without preserving recursion-limit diagnostics across rollback, the
+    // overflow error from the speculative branch can get truncated.
+    const source = `(a = ${makeDeepGroupingExpression(DEEP_NESTING_DEPTH)});`;
+    expect(() => {
+        evaluateSource(source);
+    }).toThrowWithMessage(SyntaxError, "Maximum parser recursion depth exceeded");
+});

--- a/Tests/LibJS/Runtime/regress/deep-template-literal-expression-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-template-literal-expression-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep template literal expression nesting does not crash parser", () => {
+    let source = "0";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = "`${" + source + "}`";
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});

--- a/Tests/LibJS/Runtime/regress/deep-try-catch-statement-nesting.js
+++ b/Tests/LibJS/Runtime/regress/deep-try-catch-statement-nesting.js
@@ -1,0 +1,8 @@
+const DEEP_NESTING_DEPTH = 100000;
+
+test("deep try-catch statement nesting does not crash parser", () => {
+    let source = "0;";
+    for (let i = 0; i < DEEP_NESTING_DEPTH; ++i) source = `try { ${source} } catch (e) {}`;
+
+    expect(typeof canParseSource(source)).toBe("boolean");
+});


### PR DESCRIPTION
Add guards to prevent that stack overflows and tests to proof that the guards work. This prevents  untrusted inputs from using deliberately deep nesting language elements to crash the parser. Scope is the Rust parser. The C++ parser has the same vulnerability, but is skipped with the tests for now to keep the scope of this PR small.

As requested in #8415 all commits lead to a successful test (if applied on top of #8415).

Build/Test log:

<details>

```
❯ git cherry-pick 28ff7c4740 && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && git cherry-pick b32f39a375 && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && git cherry-pick 67bcdbd8db && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && git cherry-pick cd63bcadff && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && git cherry-pick 967db8fd7d && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && git cherry-pick 78bb6e634a && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && git cherry-pick ac942dd934 && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && git cherry-pick 011e2beef0 && ninja -C Build/release -j2 test-js test-js-bytecode test-js-ast && ctest --test-dir Build/release -R '^(test-js|test-js-cpp|test-js-bytecode|test-js-ast)$' --output-on-failure && echo "FINSIH!"
Auto-merging Libraries/LibJS/Rust/src/parser/expressions.rs
[temp_test_libjs-rust-parser-nesting-guard c7b3566196] LibJS: Guard Rust expression and statement-list parsing depth
 Date: Sat Mar 14 22:09:20 2026 +0100
 2 files changed, 82 insertions(+), 17 deletions(-)
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[0/1] Re-running CMake...
-- Running vcpkg install
Detecting compiler hash for triplet x64-linux-dynamic...
Compiler found: /usr/bin/c++
The following packages are already installed:
  * abseil:x64-linux-dynamic@20260107.1
    angle:x64-linux-dynamic@chromium_7258 -- /home/ruben/dev/ladybird_rust_js_parser/Meta/CMake/vcpkg/overlay-ports/angle
  * brotli:x64-linux-dynamic@1.2.0
  * bzip2[core,tool]:x64-linux-dynamic@1.0.8#6
    cpptrace:x64-linux-dynamic@1.0.2 -- /home/ruben/dev/ladybird_rust_js_parser/Meta/CMake/vcpkg/overlay-ports/cpptrace
    curl[brotli,core,http2,http3,non-http,openssl,ssl,websockets,zstd]:x64-linux-dynamic@8.19.0
  * dav1d:x64-linux-dynamic@1.5.1
    dbus:x64-linux-dynamic@1.16.2#2
  * dirent:x64-linux-dynamic@1.26
  * egl-registry:x64-linux-dynamic@2025-05-27
  * expat:x64-linux-dynamic@2.7.4
    fast-float:x64-linux-dynamic@8.1.0
    ffmpeg[avcodec,avdevice,avfilter,avformat,core,dav1d,openh264,opus,swresample,swscale,theora,vorbis,vpx,webp,zlib]:x64-linux-dynamic@7.1.1#5
    fmt:x64-linux-dynamic@12.1.0
    fontconfig:x64-linux-dynamic@2.15.0#4
  * freetype[brotli,bzip2,core,png,zlib]:x64-linux-dynamic@2.13.3
  * giflib:x64-linux-dynamic@5.2.2#2
  * gperf:x64-linux-dynamic@3.3
    harfbuzz[core,freetype,icu]:x64-linux-dynamic@10.2.0
  * highway:x64-linux-dynamic@1.3.0#1
    icu[core,tools]:x64-linux-dynamic@78.2
  * lcms:x64-linux-dynamic@2.18
    libavif[core,dav1d]:x64-linux-dynamic@1.3.0#1
    libdwarf:x64-linux-dynamic@2.3.0
  * libiconv:x64-linux-dynamic@1.18#3
    libjpeg-turbo:x64-linux-dynamic@3.1.1
    libjxl:x64-linux-dynamic@0.11.1#3
  * liblzma:x64-linux-dynamic@5.8.2#1
  * libogg:x64-linux-dynamic@1.3.6#1
    libpng[apng,core]:x64-linux-dynamic@1.6.50
    libproxy:x64-linux-dynamic@0.4.18#3
  * libtheora:x64-linux-dynamic@1.2.0
    libtommath:x64-linux-dynamic@1.3.0#2 -- /home/ruben/dev/ladybird_rust_js_parser/Meta/CMake/vcpkg/overlay-ports/libtommath
  * libuuid:x64-linux-dynamic@1.0.3#16
  * libvorbis:x64-linux-dynamic@1.3.7#4
  * libvpx:x64-linux-dynamic@1.16.0
    libwebp[anim,core,img2webp,libwebpmux,mux,nearlossless,simd]:x64-linux-dynamic@1.6.0#1
    libxml2[core,iconv,zlib]:x64-linux-dynamic@2.13.8#1
  * libyuv:x64-linux-dynamic@1916
  * nghttp2:x64-linux-dynamic@1.68.0#1 -- /home/ruben/dev/ladybird_rust_js_parser/Meta/CMake/vcpkg/overlay-ports/nghttp2
  * nghttp3:x64-linux-dynamic@1.15.0
  * ngtcp2[core,openssl]:x64-linux-dynamic@1.21.0
  * opengl-registry:x64-linux-dynamic@2026-01-26
  * openh264:x64-linux-dynamic@2.6.0#4
    openssl:x64-linux-dynamic@3.5.3
  * opus:x64-linux-dynamic@1.5.2#1
  * pkgconf:x64-linux-dynamic@2.5.1#4
  * pthread:x64-linux-dynamic@3.0.0#2
  * pthreads:x64-linux-dynamic@3.0.0#14
    sdl3:x64-linux-dynamic@3.2.28
    simdjson[core,deprecated,exceptions,threads,utf8-validation]:x64-linux-dynamic@4.2.4
    simdutf:x64-linux-dynamic@7.4.0
    skia[core,fontconfig,freetype,harfbuzz,icu,vulkan]:x64-linux-dynamic@144
    sqlite3[core,json1]:x64-linux-dynamic@3.50.4
    tiff[core,jpeg,lzma,zip,zstd]:x64-linux-dynamic@4.7.1
  * vcpkg-cmake:x64-linux-dynamic@2024-04-23
  * vcpkg-cmake-config:x64-linux-dynamic@2024-05-23
  * vcpkg-cmake-get-vars:x64-linux-dynamic@2025-05-29
  * vcpkg-get-python-packages:x64-linux-dynamic@2025-04-05
  * vcpkg-gn:x64-linux-dynamic@2025-08-05
  * vcpkg-make:x64-linux-dynamic@2026-01-01
  * vcpkg-pkgconfig-get-modules:x64-linux-dynamic@2024-04-03
  * vcpkg-tool-gn:x64-linux-dynamic@2025-08-05#1
  * vcpkg-tool-meson:x64-linux-dynamic@1.9.0#3
    vulkan:x64-linux-dynamic@2023-12-17 -- /home/ruben/dev/ladybird_rust_js_parser/Meta/CMake/vcpkg/overlay-ports/vulkan
    vulkan-headers:x64-linux-dynamic@1.4.335.0
  * vulkan-memory-allocator:x64-linux-dynamic@3.3.0
    woff2:x64-linux-dynamic@1.0.2#5
    zlib:x64-linux-dynamic@1.3.1
  * zstd:x64-linux-dynamic@1.5.7
All requested installations completed successfully in: 3.42 ms
-- Running vcpkg install - done
-- Found ZLIB: /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libz.so (found version "1.3.1")
-- Found ICU: /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/include (found suitable exact version "78.2") found components: data i18n uc
-- Found the following WebP libraries:
--  WebP (required): /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libwebp.so
--  webpdemux (optional): /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libwebpdemux.so
--  mux (optional): /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libwebpmux.so
--  decoder (optional): /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libwebpdecoder.so
-- Found ICU: /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/include (found suitable version "78.2", minimum required is "61") found components: uc
-- Found OpenSSL: /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libcrypto.so (found suitable version "3.5.3", minimum required is "3")
-- Found ZLIB: /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libz.so (found suitable version "1.3.1", minimum required is "1")
-- Found OpenSSL: /home/ruben/dev/ladybird_rust_js_parser/Build/release/vcpkg_installed/x64-linux-dynamic/lib/libcrypto.so (found version "3.5.3")
-- Configuring done (21.1s)
-- Generating done (9.6s)
-- Build files have been written to: /home/ruben/dev/ladybird_rust_js_parser/Build/release
ninja: warning: premature end of file; recovering
[36/483] Building Rust crate libunicode_rust
    Finished `release` profile [optimized] target(s) in 0.20s
[182/483] Building Rust crate libjs_rust
   Compiling libjs_rust v0.1.0 (/home/ruben/dev/ladybird_rust_js_parser/Libraries/LibJS/Rust)
    Finished `release` profile [optimized] target(s) in 1m 26s
[199/483] Building asmintgen
   Compiling asmintgen v0.1.0 (/home/ruben/dev/ladybird_rust_js_parser/Libraries/LibJS/AsmIntGen)
    Finished `release` profile [optimized] target(s) in 14.28s
[482/483] Linking CXX executable bin/js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   23.86 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.46 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    1.01 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.69 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  38.05 sec
Auto-merging Libraries/LibJS/Rust/src/parser/statements.rs
[temp_test_libjs-rust-parser-nesting-guard 5c474370a4] LibJS: Guard Rust statement recursion and abort statement loops
 Date: Sat Mar 14 23:09:19 2026 +0100
 1 file changed, 21 insertions(+)
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[181/480] Building Rust crate libjs_rust
   Compiling libjs_rust v0.1.0 (/home/ruben/dev/ladybird_rust_js_parser/Libraries/LibJS/Rust)
    Finished `release` profile [optimized] target(s) in 26.79s
[480/480] Linking CXX executable bin/js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   11.88 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.10 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    0.90 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.66 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  25.56 sec
Auto-merging Tests/LibJS/test-js.cpp
[temp_test_libjs-rust-parser-nesting-guard 08b5aa86df] LibJS: Add deep nesting parser conformance tests
 Date: Sat Mar 14 22:21:11 2026 +0100
 13 files changed, 177 insertions(+)
 create mode 100644 Tests/LibJS/Runtime/regress/deep-array-literal-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-arrow-function-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-block-statement-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-call-expression-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-class-declaration-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-conditional-expression-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-function-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-grouping-expression-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-if-statement-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-object-literal-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-template-literal-expression-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-try-catch-statement-nesting.js
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[181/480] Building Rust crate libjs_rust
    Finished `release` profile [optimized] target(s) in 0.03s
[480/480] Linking CXX executable bin/test-js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   15.34 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.10 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    0.94 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.69 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  29.08 sec
[temp_test_libjs-rust-parser-nesting-guard 6eec668fbd] LibJS: Preserve recursion-limit diagnostics across rollback
 Date: Mon Mar 16 02:40:40 2026 +0100
 1 file changed, 66 insertions(+), 1 deletion(-)
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[181/480] Building Rust crate libjs_rust
   Compiling libjs_rust v0.1.0 (/home/ruben/dev/ladybird_rust_js_parser/Libraries/LibJS/Rust)
    Finished `release` profile [optimized] target(s) in 26.55s
[480/480] Linking CXX executable bin/js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   15.63 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.26 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    0.93 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.69 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  29.53 sec
[temp_test_libjs-rust-parser-nesting-guard 39ce5f96d5] LibJS: Short-circuit recursion guard after abort
 Date: Mon Mar 16 02:52:29 2026 +0100
 1 file changed, 4 insertions(+)
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[181/480] Building Rust crate libjs_rust
   Compiling libjs_rust v0.1.0 (/home/ruben/dev/ladybird_rust_js_parser/Libraries/LibJS/Rust)
    Finished `release` profile [optimized] target(s) in 26.76s
[480/480] Linking CXX executable bin/js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   13.78 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.09 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    0.91 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.80 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  27.59 sec
[temp_test_libjs-rust-parser-nesting-guard 9d9674dc97] LibJS: Add rollback recursion-limit regression test
 Date: Mon Mar 16 04:01:53 2026 +0100
 1 file changed, 19 insertions(+)
 create mode 100644 Tests/LibJS/Runtime/regress/deep-speculative-arrow-rollback-recursion-error.js
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[181/480] Building Rust crate libjs_rust
    Finished `release` profile [optimized] target(s) in 0.03s
[480/480] Linking CXX executable bin/js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   14.42 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.12 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    0.99 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.73 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  28.28 sec
Auto-merging Libraries/LibJS/Rust/src/parser/declarations.rs
[temp_test_libjs-rust-parser-nesting-guard 2637a2d6cb] LibJS: Guard binding-pattern parser recursion depth
 Date: Mon Mar 16 13:59:06 2026 +0100
 1 file changed, 17 insertions(+), 2 deletions(-)
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[181/480] Building Rust crate libjs_rust
   Compiling libjs_rust v0.1.0 (/home/ruben/dev/ladybird_rust_js_parser/Libraries/LibJS/Rust)
    Finished `release` profile [optimized] target(s) in 26.77s
[480/480] Linking CXX executable bin/test-js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   13.78 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.23 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    0.93 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.70 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  27.65 sec
[temp_test_libjs-rust-parser-nesting-guard 1edebc3f10] LibJS: Add deep nesting tests for binding-pattern paths
 Date: Mon Mar 16 02:58:19 2026 +0100
 4 files changed, 72 insertions(+)
 create mode 100644 Tests/LibJS/Runtime/regress/deep-array-binding-pattern-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-catch-parameter-binding-pattern-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-function-parameter-binding-pattern-nesting.js
 create mode 100644 Tests/LibJS/Runtime/regress/deep-object-binding-pattern-nesting.js
ninja: Entering directory `Build/release'
ninja: warning: premature end of file; recovering
[181/480] Building Rust crate libjs_rust
    Finished `release` profile [optimized] target(s) in 0.03s
[480/480] Linking CXX executable bin/test-js
Test project /home/ruben/dev/ladybird_rust_js_parser/Build/release
    Start 123: test-js
1/4 Test #123: test-js ..........................   Passed   14.12 sec
    Start 124: test-js-cpp
2/4 Test #124: test-js-cpp ......................   Passed   12.30 sec
    Start 125: test-js-bytecode
3/4 Test #125: test-js-bytecode .................   Passed    0.93 sec
    Start 126: test-js-ast
4/4 Test #126: test-js-ast ......................   Passed    0.69 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =  28.05 sec
FINSIH!
```

</details>

Limitations:

I did not check the exact limit which the parser can handle for all platforms, so I choose a "low and safe" limit of 1024, to make sure we don't crash on different platforms earlier than under x86_64.

<strike>(Contains compatibility patch at the end to make the CI here "green" which needs to be removed before merging it, after PR #8415 has been successfully merged.)</strike>

