### PR TITLE
LibGC: Add missing & in Weak assignment

### DIFF
--- a/Libraries/LibGC/WeakInlines.h
+++ b/Libraries/LibGC/WeakInlines.h
@@ -49,7 +49,7 @@ template<typename U>
 Weak<T>& Weak<T>::operator=(U const& other)
 requires(IsConvertible<U*, T*>)
 {
-    if (ptr() != other) {
+    if (ptr() != &other) {
         m_impl = *other.heap().create_weak_impl(const_cast<void*>(static_cast<void const*>(&other)));
     }
     return *this;


### PR DESCRIPTION
The Weak<T>::operator=(U const&) template incorrectly compares the internal pointer directly against the `other` reference. If this template is instantiated, it causes a compilation error because a Ptr<T> cannot be compared directly to a U const&