### PR TITLE
LibGfx: Make Font atomically ref-counted

### DIFF
--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AK/AtomicRefCounted.h>
 #include <AK/FlyString.h>
 #include <AK/RefPtr.h>
 #include <AK/Utf16String.h>
@@ -54,7 +55,7 @@ enum FontWidth {
 
 constexpr float text_shaping_resolution = 64;
 
-class Font : public RefCounted<Font> {
+class Font : public AtomicRefCounted<Font> {
 public:
     Font(NonnullRefPtr<Typeface const>, float point_width, float point_height, unsigned dpi_x, unsigned dpi_y, FontVariationSettings const variations, ShapeFeatures const& features);
     ScaledFontMetrics metrics() const;


### PR DESCRIPTION
Font objects are cached per-Typeface with non-atomic RefCounted, but GlyphRun (which is AtomicRefCounted) holds a NonnullRefPtr<Font const> and can be destroyed on the rendering thread when tearing down display lists. This created a data race on the Font refcount, leading to use-after-free crashes in Typeface::font() where the cache's NonnullRefPtr would point to memory already freed by a concurrent unref.