### PR TITLE
LibCore+LibWeb: Add ScopedAutoreleasePool and use it on macOS

### DIFF
--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -87,6 +87,7 @@ endif()
 
 if (APPLE)
     list(APPEND SOURCES IOSurface.cpp)
+    list(APPEND SOURCES Platform/ScopedAutoreleasePoolMacOS.mm)
 endif()
 
 ladybird_lib(LibCore core EXPLICIT_SYMBOL_EXPORT)

--- a/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -14,6 +14,7 @@
 #include <LibCore/EventLoopImplementationUnix.h>
 #include <LibCore/EventReceiver.h>
 #include <LibCore/Notifier.h>
+#include <LibCore/Platform/ScopedAutoreleasePool.h>
 #include <LibCore/System.h>
 #include <LibCore/ThreadEventQueue.h>
 #include <LibThreading/Mutex.h>
@@ -308,6 +309,7 @@ int EventLoopImplementationUnix::exec()
 
 size_t EventLoopImplementationUnix::pump(PumpMode mode)
 {
+    ScopedAutoreleasePool autorelease_pool;
     static_cast<EventLoopManagerUnix&>(EventLoopManager::the()).wait_for_events(mode);
     return ThreadEventQueue::current().process();
 }

--- a/Libraries/LibCore/Platform/ScopedAutoreleasePool.h
+++ b/Libraries/LibCore/Platform/ScopedAutoreleasePool.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/Platform.h>
+#include <LibCore/Export.h>
+
+namespace Core {
+
+#ifdef AK_OS_MACOS
+
+class CORE_API ScopedAutoreleasePool {
+    AK_MAKE_NONCOPYABLE(ScopedAutoreleasePool);
+    AK_MAKE_NONMOVABLE(ScopedAutoreleasePool);
+
+public:
+    ScopedAutoreleasePool();
+    ~ScopedAutoreleasePool();
+
+private:
+    void* m_pool;
+};
+
+#else
+
+class ScopedAutoreleasePool {
+public:
+    ScopedAutoreleasePool() = default;
+    ~ScopedAutoreleasePool() { }
+};
+
+#endif
+
+}

--- a/Libraries/LibCore/Platform/ScopedAutoreleasePoolMacOS.mm
+++ b/Libraries/LibCore/Platform/ScopedAutoreleasePoolMacOS.mm
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Platform/ScopedAutoreleasePool.h>
+
+extern "C" void* objc_autoreleasePoolPush(void);
+extern "C" void objc_autoreleasePoolPop(void* pool);
+
+namespace Core {
+
+ScopedAutoreleasePool::ScopedAutoreleasePool()
+    : m_pool(objc_autoreleasePoolPush())
+{
+}
+
+ScopedAutoreleasePool::~ScopedAutoreleasePool()
+{
+    objc_autoreleasePoolPop(m_pool);
+}
+
+}

--- a/Libraries/LibWeb/HTML/RenderingThread.cpp
+++ b/Libraries/LibWeb/HTML/RenderingThread.cpp
@@ -11,6 +11,8 @@
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 
+#include <LibCore/Platform/ScopedAutoreleasePool.h>
+
 namespace Web::HTML {
 
 struct BackingStoreState {
@@ -98,6 +100,10 @@ public:
                 if (m_exit)
                     break;
             }
+
+            // Drain autoreleased Objective-C objects created by Metal/Skia each iteration,
+            // since this background thread has no autorelease pool.
+            Core::ScopedAutoreleasePool autorelease_pool;
 
             while (true) {
                 auto command = [this]() -> Optional<CompositorCommand> {


### PR DESCRIPTION
On macOS, Objective-C methods frequently return autoreleased objects that accumulate until an autorelease pool is drained. Our event loop (Core::EventLoop) and rendering thread both lacked autorelease pools, causing unbounded accumulation of autoreleased objects.

The rendering thread was the worst offender: every Skia flush triggers Metal resource allocation which sets labels on GPU textures via -[IOGPUMetalResource setLabel:], creating autoreleased CFData objects. With ~1M+ such objects at 112 bytes each, this leaked ~121MB. Metal command buffer objects (_MTLCommandBufferEncoderInfo, etc.) also accumulated, adding another ~128MB.

Add Core::ScopedAutoreleasePool, a RAII wrapper around the ObjC runtime autorelease pool (no-op on non-macOS), and drain it:
- Every event loop pump (like NSRunLoop does)
- Every compositor loop iteration on the rendering thread