### PR TITLE
LibWeb/IndexedDB: Avoid GC allocation in cleanup function

### DIFF
--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -131,7 +131,7 @@ void open_a_database_connection(JS::Realm& realm, StorageAPI::StorageKey storage
             dbgln_if(IDB_DEBUG, "open_a_database_connection: Upgrading database from version {} to {}", db->version(), version);
 
             // 1. Let openConnections be the set of all connections, except connection, associated with db.
-            auto open_connections = db->associated_connections_except(connection);
+            auto open_connections = db->associated_connections_as_heap_vector_except(connection);
 
             // 2. For each entry of openConnections that does not have its close pending flag set to true,
             //    queue a database task to fire a version change event named versionchange at entry with db’s version and version.
@@ -503,7 +503,7 @@ void delete_a_database(JS::Realm& realm, StorageAPI::StorageKey storage_key, Str
         GC::Ref db = maybe_db.value();
 
         // 5. Let openConnections be the set of all connections associated with db.
-        auto open_connections = db->associated_connections();
+        auto open_connections = db->associated_connections_as_heap_vector();
 
         // 6. For each entry of openConnections that does not have its close pending flag set to true,
         //    queue a database task to fire a version change event named versionchange at entry with db’s version and null.
@@ -2197,7 +2197,7 @@ bool cleanup_indexed_database_transactions(GC::Ref<HTML::EventLoop> event_loop)
     bool has_matching_event_loop = false;
 
     Database::for_each_database([&has_matching_event_loop, event_loop](Database& database) {
-        for (auto const& connection : database.associated_connections()->elements()) {
+        for (auto const& connection : database.associated_connections_as_root_vector()) {
             for (auto const& transaction : connection->transactions()) {
                 // 2. For each transaction transaction with cleanup event loop matching the current event loop:
                 if (transaction->cleanup_event_loop() == event_loop) {

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
@@ -130,7 +130,7 @@ ErrorOr<void> Database::delete_for_key_and_name(StorageAPI::StorageKey const& ke
     return {};
 }
 
-GC::Ref<Database::AssociatedConnections> Database::associated_connections()
+GC::Ref<Database::AssociatedConnections> Database::associated_connections_as_heap_vector()
 {
     auto connections = realm().heap().allocate<AssociatedConnections>();
     connections->elements().ensure_capacity(m_associated_connections.size());
@@ -140,7 +140,16 @@ GC::Ref<Database::AssociatedConnections> Database::associated_connections()
     return connections;
 }
 
-GC::Ref<Database::AssociatedConnections> Database::associated_connections_except(IDBDatabase& connection)
+GC::RootVector<GC::Ref<IDBDatabase>> Database::associated_connections_as_root_vector()
+{
+    GC::RootVector<GC::Ref<IDBDatabase>> connections(realm().heap());
+    connections.ensure_capacity(m_associated_connections.size());
+    for (auto& connection : m_associated_connections)
+        connections.unchecked_append(connection);
+    return connections;
+}
+
+GC::Ref<Database::AssociatedConnections> Database::associated_connections_as_heap_vector_except(IDBDatabase& connection)
 {
     auto connections = realm().heap().allocate<AssociatedConnections>();
     for (auto& associated_connection : m_associated_connections) {

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.h
@@ -8,6 +8,7 @@
 
 #include <LibGC/HeapVector.h>
 #include <LibGC/Ptr.h>
+#include <LibGC/RootVector.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/IndexedDB/Internal/ObjectStore.h>
 #include <LibWeb/StorageAPI/StorageKey.h>
@@ -29,8 +30,9 @@ public:
 
     void associate(GC::Ref<IDBDatabase> connection) { m_associated_connections.append(connection); }
     using AssociatedConnections = GC::HeapVector<GC::Ref<IDBDatabase>>;
-    GC::Ref<AssociatedConnections> associated_connections();
-    GC::Ref<AssociatedConnections> associated_connections_except(IDBDatabase& connection);
+    GC::Ref<AssociatedConnections> associated_connections_as_heap_vector();
+    GC::Ref<AssociatedConnections> associated_connections_as_heap_vector_except(IDBDatabase& connection);
+    GC::RootVector<GC::Ref<IDBDatabase>> associated_connections_as_root_vector();
 
     ReadonlySpan<GC::Ref<ObjectStore>> object_stores() { return m_object_stores; }
     GC::Ptr<ObjectStore> object_store_with_name(String const& name) const;


### PR DESCRIPTION
cleanup_indexed_database_transactions() is called on every event loop spin. It was calling associated_connections() which allocates a GC::HeapVector every time, creating massive GC pressure on JS-heavy sites (217K allocations observed on x.com).

Switch the hot path to use a GC::RootVector instead, which lives on the stack and avoids GC heap allocation while still being visible to the garbage collector.

Rename the existing methods to make the return type explicit:
- associated_connections_as_heap_vector() for callers that capture the result in GC::Function lambdas
- associated_connections_as_root_vector() for callers that just iterate safely within a single scope