### PR TITLE
WebContent: Exit after the crash signal handler dumps a backtrace

### DIFF
--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -80,8 +80,7 @@ static void crash_signal_handler(int signo)
     }
     warnln("\n\033[31;1mCRASH\033[0m: Received signal {} ({})", name, signo);
     dump_backtrace(2, 100);
-    signal(signo, SIG_DFL);
-    raise(signo);
+    exit(128 + signo);
 }
 
 static void install_crash_signal_handlers()


### PR DESCRIPTION
I'm unsure exactly why this is possible, but using a freed GC pointer on macOS was causing a segmentation violation to reach our signal handler, but instead of exiting, the process would get stuck.

To solve this, when terminal signals are received, just exit() instead of trying to let it get to the default handler. This allows test-web to get unstuck in cases like this, and instead of timing out and leaving a zombie, count the test as a crash.

In particular, the issue was caused by calling top_level_traversable() on a null Navigable. Since GC::Ptr's null checks are debug-only, it was trying to access garbage m_parent fields. With or without the signal handlers, this would result in an (unsurprising) EXC_BAD_ACCESS, as observed by attaching lldb. Regardless of debuggers being attached, or signal handlers being enabled, after the signal, the process would get stuck and refuse to exit, even after a SIGKILL. Sampling the stuck processes didn't seem to indicate that the program counter was moving in this state, so I'm unsure what causes it to get stuck.