### PR TITLE
RequestServer: Increase RequestPipe socket buffer sizes

### DIFF
--- a/Services/RequestServer/RequestPipe.cpp
+++ b/Services/RequestServer/RequestPipe.cpp
@@ -48,6 +48,14 @@ ErrorOr<RequestPipe> RequestPipe::create()
     int option = 1;
     TRY(Core::System::ioctl(socket_fds[0], FIONBIO, &option));
     TRY(Core::System::ioctl(socket_fds[1], FIONBIO, &option));
+
+    // Increase socket buffer sizes from OS default (~8KB on macOS) to allow
+    // larger writes/reads per syscall, significantly improving throughput for
+    // large response bodies.
+    static constexpr int buffer_size = 512 * KiB;
+    (void)Core::System::setsockopt(socket_fds[0], SOL_SOCKET, SO_RCVBUF, &buffer_size, sizeof(buffer_size));
+    (void)Core::System::setsockopt(socket_fds[1], SOL_SOCKET, SO_SNDBUF, &buffer_size, sizeof(buffer_size));
+
     return RequestPipe(socket_fds[0], socket_fds[1]);
 }
 


### PR DESCRIPTION
The RequestPipe uses a socketpair for streaming response body data from RequestServer to WebContent. On macOS, the default socket buffer size for AF_LOCAL sockets is only ~8KB, which meant every read/write syscall could only transfer ~8KB at a time. For large responses, this resulted in thousands of tiny reads with significant per-read overhead.

Increase the send and receive buffer sizes to 512KB, matching the approach already used by IPC::TransportSocket. This dramatically improves throughput for large response bodies -- for example, fetching a 25MB file from localhost went from ~850ms to ~25ms in testing.