### PR TITLE
LibWebView: Default to http:// for bare IP addresses in URL bar

### DIFF
--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -44,6 +44,12 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
         https_scheme_was_guessed = true;
     }
 
+    // IP addresses should default to http:// since they rarely have valid TLS certificates.
+    if (https_scheme_was_guessed) {
+        if (auto const& host = url->host(); host.has_value() && (host->has<IPv4Address>() || host->has<IPv6Address>()))
+            url->set_scheme("http"_string);
+    }
+
     // FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.
     static constexpr Array SUPPORTED_SCHEMES { "about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv };
     if (!any_of(SUPPORTED_SCHEMES, [&](StringView const& scheme) { return scheme == url->scheme(); }))

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -14,6 +14,56 @@
 
 namespace WebView {
 
+static bool is_local_ip_address(URL::URL const& url)
+{
+    auto const& host = url.host();
+    if (!host.has_value())
+        return false;
+
+    if (host->has<IPv4Address>()) {
+        auto const& addr = host->get<IPv4Address>();
+        // 127.0.0.0/8
+        if (addr[0] == 127)
+            return true;
+        // 10.0.0.0/8
+        if (addr[0] == 10)
+            return true;
+        // 172.16.0.0/12
+        if (addr[0] == 172 && addr[1] >= 16 && addr[1] <= 31)
+            return true;
+        // 192.168.0.0/16
+        if (addr[0] == 192 && addr[1] == 168)
+            return true;
+        // 169.254.0.0/16 (link-local)
+        if (addr[0] == 169 && addr[1] == 254)
+            return true;
+        return false;
+    }
+
+    if (host->has<IPv6Address>()) {
+        auto const& addr = host->get<IPv6Address>().to_in6_addr_t();
+        // ::1 (loopback)
+        bool is_loopback = true;
+        for (int i = 0; i < 15; ++i) {
+            if (addr[i] != 0) {
+                is_loopback = false;
+                break;
+            }
+        }
+        if (is_loopback && addr[15] == 1)
+            return true;
+        // fe80::/10 (link-local)
+        if (addr[0] == 0xfe && (addr[1] & 0xc0) == 0x80)
+            return true;
+        // fc00::/7 (unique local)
+        if ((addr[0] & 0xfe) == 0xfc)
+            return true;
+        return false;
+    }
+
+    return false;
+}
+
 Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
 {
     auto search_url_or_error = [&]() -> Optional<URL::URL> {
@@ -41,13 +91,13 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
         if (!url.has_value())
             return search_url_or_error();
 
-        https_scheme_was_guessed = true;
-    }
-
-    // IP addresses should default to http:// since they rarely have valid TLS certificates.
-    if (https_scheme_was_guessed) {
-        if (auto const& host = url->host(); host.has_value() && (host->has<IPv4Address>() || host->has<IPv6Address>()))
+        // Local/private IP addresses should default to http:// since they rarely have valid TLS certificates.
+        // Public IPs still default to https://.
+        // However, if the user explicitly specified port 443, honor the https scheme.
+        if (is_local_ip_address(*url) && !location.contains(":443"sv))
             url->set_scheme("http"_string);
+        else
+            https_scheme_was_guessed = true;
     }
 
     // FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -189,12 +189,15 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://localhost/hello.world"sv, "localhost/hello.world"sv);
     expect_url_equals_sanitized_url("https://localhost/hello.world?query=123"sv, "localhost/hello.world?query=123"sv);
 
-    expect_url_equals_sanitized_url("http://192.168.1.1/"sv, "192.168.1.1"sv);          // IPv4: default to http.
+    expect_url_equals_sanitized_url("http://192.168.1.1/"sv, "192.168.1.1"sv);          // Local IPv4: default to http.
     expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv);              // Loopback: default to http.
-    expect_url_equals_sanitized_url("http://10.0.0.1:8080/"sv, "10.0.0.1:8080"sv);      // IPv4 with port: default to http.
+    expect_url_equals_sanitized_url("http://10.0.0.1:8080/"sv, "10.0.0.1:8080"sv);      // Local IPv4 with port: default to http.
     expect_url_equals_sanitized_url("https://192.168.1.1/"sv, "https://192.168.1.1"sv); // Explicit https: respect user.
     expect_url_equals_sanitized_url("http://192.168.1.1/"sv, "http://192.168.1.1"sv);   // Explicit http: respect user.
-    expect_url_equals_sanitized_url("http://[::1]/"sv, "[::1]"sv);                      // IPv6: default to http.
+    expect_url_equals_sanitized_url("http://[::1]/"sv, "[::1]"sv);                      // IPv6 loopback: default to http.
+    expect_url_equals_sanitized_url("https://127.0.0.1/"sv, "127.0.0.1:443"sv);         // Port 443 means https, even for local.
+    expect_url_equals_sanitized_url("https://8.8.8.8/"sv, "8.8.8.8"sv);                 // Public IPv4: default to https.
+    expect_url_equals_sanitized_url("https://[2606:4700:4700::1111]/"sv, "[2606:4700:4700::1111]"sv); // Public IPv6: default to https.
 
     expect_url_equals_sanitized_url("https://example.com/"sv, "example"sv, WebView::AppendTLD::Yes); // User holds down the Ctrl key.
     expect_url_equals_sanitized_url("https://example.def.com/"sv, "example.def"sv, WebView::AppendTLD::Yes);

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -189,6 +189,13 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://localhost/hello.world"sv, "localhost/hello.world"sv);
     expect_url_equals_sanitized_url("https://localhost/hello.world?query=123"sv, "localhost/hello.world?query=123"sv);
 
+    expect_url_equals_sanitized_url("http://192.168.1.1/"sv, "192.168.1.1"sv);          // IPv4: default to http.
+    expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv);              // Loopback: default to http.
+    expect_url_equals_sanitized_url("http://10.0.0.1:8080/"sv, "10.0.0.1:8080"sv);      // IPv4 with port: default to http.
+    expect_url_equals_sanitized_url("https://192.168.1.1/"sv, "https://192.168.1.1"sv); // Explicit https: respect user.
+    expect_url_equals_sanitized_url("http://192.168.1.1/"sv, "http://192.168.1.1"sv);   // Explicit http: respect user.
+    expect_url_equals_sanitized_url("http://[::1]/"sv, "[::1]"sv);                      // IPv6: default to http.
+
     expect_url_equals_sanitized_url("https://example.com/"sv, "example"sv, WebView::AppendTLD::Yes); // User holds down the Ctrl key.
     expect_url_equals_sanitized_url("https://example.def.com/"sv, "example.def"sv, WebView::AppendTLD::Yes);
     expect_url_equals_sanitized_url("https://com.com/"sv, "com"sv, WebView::AppendTLD::Yes);


### PR DESCRIPTION
## Summary

When entering a bare IP address (e.g. `192.168.1.1`) into the URL bar without a scheme, the browser defaults to `https://`. This causes connection failures for local network devices that do not have TLS certificates. After guessing the scheme, this checks if the host is an IPv4 or IPv6 address and switches to `http://` instead.

## Changes

- In `sanitize_url()`, after the `https_scheme_was_guessed` block, detect IP hosts using `Host::has<IPv4Address>()` / `Host::has<IPv6Address>()` and set the scheme to `http`
- Added 6 test cases in `TestWebViewURL.cpp` covering IPv4, IPv6, IPv4 with port, and explicit scheme preservation

## Testing

- Bare IPv4 (`192.168.1.1`) resolves to `http://192.168.1.1/`
- Bare IPv6 (`[::1]`) resolves to `http://[::1]/`
- IPv4 with port (`10.0.0.1:8080`) resolves to `http://10.0.0.1:8080/`
- Explicit `https://192.168.1.1` is preserved (user override respected)
- Domain names (`example.org`) still default to `https://`

Fixes #8344

This contribution was developed with AI assistance (Claude Code).