### PR TITLE
LibWeb: Add scroll-behavior CSS property

### DIFF
--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -3810,6 +3810,17 @@
     "affects-stacking-context": true,
     "requires-computation": "cascaded-value"
   },
+  "scroll-behavior": {
+    "initial": "auto",
+    "inherited": false,
+    "affects-layout": false,
+    "animation-type": "none",
+    "requires-computation": "never",
+    "valid-identifiers": [
+      "auto",
+      "smooth"
+    ]
+  },
   "scroll-timeline": {
     "affects-layout": false,
     "initial": "none block",

--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
@@ -272,6 +272,7 @@ All properties associated with getComputedStyle(document.body):
     "rx",
     "ry",
     "scale",
+    "scroll-behavior",
     "scroll-timeline-axis",
     "scroll-timeline-name",
     "scrollbar-gutter",

--- a/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
@@ -752,6 +752,8 @@ All supported properties and their default values exposed from CSSStylePropertie
 'rx': 'auto'
 'ry': 'auto'
 'scale': 'none'
+'scrollBehavior': 'auto'
+'scroll-behavior': 'auto'
 'scrollTimeline': 'none'
 'scroll-timeline': 'none'
 'scrollTimelineAxis': 'block'

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -270,6 +270,7 @@ row-gap: normal
 rx: auto
 ry: auto
 scale: none
+scroll-behavior: auto
 scroll-timeline-axis: block
 scroll-timeline-name: none
 scrollbar-gutter: auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 286 tests
+Found 287 tests
 
-282 Pass
+283 Pass
 4 Fail
 Pass	accent-color
 Pass	border-collapse
@@ -250,6 +250,7 @@ Pass	row-gap
 Pass	rx
 Pass	ry
 Pass	scale
+Pass	scroll-behavior
 Pass	scroll-timeline-axis
 Pass	scroll-timeline-name
 Pass	scrollbar-gutter

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/inheritance.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/inheritance.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	Property scroll-behavior has initial value auto
+Pass	Property scroll-behavior does not inherit

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/parsing/scroll-behavior-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/parsing/scroll-behavior-computed.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	Property scroll-behavior value 'auto'
+Pass	Property scroll-behavior value 'smooth'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/parsing/scroll-behavior-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/parsing/scroll-behavior-valid.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	e.style['scroll-behavior'] = "auto" should set the property value
+Pass	e.style['scroll-behavior'] = "smooth" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-default-css.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-default-css.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+2 Pass
+1 Fail
+Pass	Make sure the page is ready for animation.
+Pass	Instant scrolling of an element with default scroll-behavior
+Fail	Smooth scrolling of an element with default scroll-behavior

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/inheritance.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/inheritance.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Inheritance of CSSOM View properties</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#property-index">
+<meta name="assert" content="Properties inherit or not according to the spec.">
+<meta name="assert" content="Properties have initial values according to the spec.">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/support/inheritance-testcommon.js"></script>
+</head>
+<body>
+<div id="container">
+  <div id="target"></div>
+</div>
+<script>
+assert_not_inherited('scroll-behavior', 'auto', 'smooth');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/parsing/scroll-behavior-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/parsing/scroll-behavior-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSSOM View: getComputedStyle().scrollBehavior</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#propdef-scroll-behavior">
+<meta name="assert" content="scroll-behavior computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("scroll-behavior", 'auto');
+test_computed_value("scroll-behavior", 'smooth');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/parsing/scroll-behavior-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/parsing/scroll-behavior-valid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSSOM View: parsing scroll-behavior with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#propdef-scroll-behavior">
+<meta name="assert" content="scroll-behavior supports the full grammar 'auto | smooth'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("scroll-behavior", 'auto');
+test_valid_value("scroll-behavior", 'smooth');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-default-css.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scroll-behavior-default-css.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<title>Testing default value of scroll-behavior</title>
+<meta name="timeout" content="long"/>
+<link rel="author" title="Frédéric Wang" href="mailto:fwang@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#propdef-scroll-behavior">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-box">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../dom/events/scrolling/scroll_support.js"></script>
+<script src="support/scroll-behavior.js"></script>
+<style>
+  .scrollable {
+    overflow: auto;
+    width: 400px;
+    height: 200px;
+  }
+</style>
+<div id="log">
+</div>
+<div id="overflowNode" class="scrollable">
+  <div style="width: 2000px; height: 1000px; background: linear-gradient(135deg, red, green);">
+    <span style="display: inline-block; width: 500px; height: 250px;"></span><span id="elementToReveal" style="display: inline-block; vertical-align: -15px; width: 10px; height: 15px; background: black;"></span>
+  </div>
+</div>
+<script>
+  var scrollingElement = overflowNode;
+  var elementToRevealLeft = 500;
+  var elementToRevealTop = 250;
+  var scrollFunction = "scroll";
+
+  promise_test(async () => {
+    await waitForCompositorReady();
+  }, "Make sure the page is ready for animation.");
+
+  promise_test(() => {
+    resetScroll(scrollingElement);
+    assert_equals(scrollingElement.scrollLeft, 0);
+    assert_equals(scrollingElement.scrollTop, 0);
+    scrollNode(scrollingElement, "scroll", "instant", elementToRevealLeft, elementToRevealTop);
+    assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Should set scrollLeft immediately");
+    assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Should set scrollTop immediately");
+    return new Promise((resolve) => { resolve(); });
+  }, "Instant scrolling of an element with default scroll-behavior");
+
+  promise_test(() => {
+    resetScroll(scrollingElement);
+    assert_equals(scrollingElement.scrollLeft, 0);
+    assert_equals(scrollingElement.scrollTop, 0);
+    scrollNode(scrollingElement, "scroll", "smooth", elementToRevealLeft, elementToRevealTop);
+    assert_less_than(scrollingElement.scrollLeft, elementToRevealLeft, "Should not set scrollLeft immediately");
+    assert_less_than(scrollingElement.scrollTop, elementToRevealTop, "Should not set scrollTop immediately");
+    return waitForScrollEnd(scrollingElement).then(() => {
+      assert_equals(scrollingElement.scrollLeft, elementToRevealLeft, "Final value of scrollLeft");
+      assert_equals(scrollingElement.scrollTop, elementToRevealTop, "Final value of scrollTop");
+    });
+  }, "Smooth scrolling of an element with default scroll-behavior");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/support/scroll-behavior.js
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/support/scroll-behavior.js
@@ -1,0 +1,92 @@
+// TODO(crbug.com/888443): It would be better to listen to the scrollend event
+// instead of polling the scroll position.
+function observeScrolling(elements, callback) {
+  if (!Array.isArray(elements))
+      elements = [elements];
+  var lastChangedFrame = 0;
+  var lastLeft = new Map();
+  var lastTop = new Map();
+  elements.forEach((element) => {
+    lastLeft.set(element, element.scrollLeft);
+    lastTop.set(element, element.scrollTop);
+  });
+  function tick(frames) {
+    // We requestAnimationFrame either for 5000 frames or until 20 frames with
+    // no change have been observed. (In Chromium, frames may run as frequently
+    // as once per millisecond when threaded compositing is disabled. The limit
+    // of 5000 frames is chosen to be high enough to reasonably ensure any
+    // scroll animation will run to completion.)
+    if (frames >= 5000 || frames - lastChangedFrame > 20) {
+      callback(true);
+    } else {
+      var scrollHappened = elements.some((element) => {
+        return element.scrollLeft != lastLeft.get(element) || element.scrollTop != lastTop.get(element);
+      });
+      if (scrollHappened) {
+        lastChangedFrame = frames;
+        elements.forEach((element) => {
+          lastLeft.set(element, element.scrollLeft);
+          lastTop.set(element, element.scrollTop);
+        });
+        callback(false);
+      }
+      requestAnimationFrame(tick.bind(null, frames + 1));
+    }
+  }
+  tick(0);
+}
+
+function waitForScrollEnd(elements) {
+  return new Promise((resolve) => {
+    observeScrolling(elements, (done) => {
+      if (done)
+        resolve();
+    });
+  });
+}
+
+function resetScroll(scrollingElement) {
+  // Try various methods to ensure the element position is reset immediately.
+  scrollingElement.scrollLeft = 0;
+  scrollingElement.scrollTop = 0;
+  scrollingElement.scroll({left: 0, top: 0, behavior: "instant"});
+}
+
+function resetScrollForWindow(scrollingWindow) {
+  // Try various methods to ensure the element position is reset immediately.
+  scrollingWindow.document.scrollingElement.scrollLeft = 0;
+  scrollingWindow.document.scrollingElement.scrollTop = 0;
+  scrollingWindow.scroll({left: 0, top: 0, behavior: "instant"});
+}
+
+function setScrollBehavior(styledElement, className) {
+  styledElement.classList.remove("autoBehavior", "smoothBehavior");
+  styledElement.classList.add(className);
+}
+
+function scrollNode(scrollingElement, scrollFunction, behavior, elementToRevealLeft, elementToRevealTop) {
+  var args = {};
+  if (behavior)
+    args.behavior = behavior;
+  switch (scrollFunction) {
+    case "scrollIntoView":
+      args.inline = "start";
+      args.block = "start";
+      elementToReveal.scrollIntoView(args);
+      break;
+    default:
+      args.left = elementToRevealLeft;
+      args.top = elementToRevealTop;
+      scrollingElement[scrollFunction](args);
+      break;
+  }
+}
+
+function scrollWindow(scrollingWindow, scrollFunction, behavior, elementToRevealLeft, elementToRevealTop) {
+  var args = {};
+  if (behavior)
+    args.behavior = behavior;
+  args.left = elementToRevealLeft;
+  args.top = elementToRevealTop;
+  scrollingWindow[scrollFunction](args);
+}


### PR DESCRIPTION
To quote [the spec](https://drafts.csswg.org/css-overflow/#smooth-scrolling):
"User agents may ignore this property."
So that is what we do.