### PR TITLE
AppKit: Fix NSToolbarItem warning about ambiguous view dimensions

### DIFF
--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -338,6 +338,9 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 
         _location_toolbar_item = [[NSToolbarItem alloc] initWithItemIdentifier:TOOLBAR_LOCATION_IDENTIFIER];
         [_location_toolbar_item setView:location_search_field];
+
+        self.location_toolbar_item_width = [[location_search_field widthAnchor] constraintEqualToConstant:600];
+        self.location_toolbar_item_width.active = YES;
     }
 
     return _location_toolbar_item;


### PR DESCRIPTION
## Summary
- Fix the NSToolbarItem warning logged on every window open:
  `WARNING <NSToolbarItem> -> view was automatically measured but had an ambiguous height or width and the view's frame size had a zero height or width`
- The location search field was created with `[[LocationSearchField alloc] init]` (zero frame) and only received its width constraint in `windowDidResize:`, which fires after the toolbar's initial layout pass
- Set an initial width constraint (600pt) at creation time; `windowDidResize:` replaces it with the proper proportional width immediately after


🤖 Generated with [Claude Code](https://claude.com/claude-code)