### PR TITLE
Tests/LibWeb: Skip flaky WPT tests

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -682,6 +682,7 @@ Text/input/wpt-import/fullscreen/api/document-fullscreen-enabled-setting-allowfu
 Text/input/wpt-import/fullscreen/api/document-fullscreen-enabled-cross-origin.sub.html
 Text/input/wpt-import/fullscreen/api/document-fullscreen-enabled-removing-allowfullscreen.sub.html
 Text/input/wpt-import/fullscreen/api/element-request-fullscreen-and-remove-iframe.html
+Text/input/wpt-import/fullscreen/api/element-request-fullscreen-timing.html
 Text/input/wpt-import/fullscreen/api/document-fullscreen-enabled-setting-allowfullscreen.sub.html
 Ref/input/wpt-import/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html
 Ref/input/wpt-import/fullscreen/rendering/fullscreen-root-fills-page.html
@@ -691,3 +692,6 @@ Ref/input/wpt-import/fullscreen/rendering/backdrop-inherit.html
 Ref/input/wpt-import/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html
 Crash/wpt-import/fullscreen/crashtests/chrome-1312699.html
 Crash/wpt-import/fullscreen/crashtests/content-visibility-crash.html
+
+; Times out
+Text/input/wpt-import/css/css-color/parsing/color-computed-hsl.html


### PR DESCRIPTION
## Summary
- Skip `color-computed-hsl.html` which times out
- Skip `element-request-fullscreen-timing.html` which fails

During the past days these fail more often than passing on Sanitizer build Linux.