### PR TITLE
LibWebView: Restrict file requests to directories of loaded file:// URLs

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <AK/Error.h>
 #include <AK/String.h>
 #include <AK/TemporaryChange.h>
@@ -61,8 +62,25 @@ ViewImplementation::ViewImplementation()
     });
 
     on_request_file = [this](auto const& path, auto request_id) {
-        auto file = Core::File::open(path, Core::File::OpenMode::Read);
+        auto canonical = LexicalPath::canonicalized_path(path);
 
+        if (!LexicalPath::is_absolute_path(canonical)) {
+            client().async_handle_file_return(page_id(), EACCES, {}, request_id);
+            return;
+        }
+
+        LexicalPath requested { canonical };
+        auto is_allowed = any_of(m_allowed_file_directory_trees, [&](auto const& allowed_directory) {
+            return requested.is_child_of(LexicalPath { allowed_directory });
+        });
+
+        if (!is_allowed) {
+            dbgln("ViewImplementation: Rejected file request outside allowed directories: {}", path);
+            client().async_handle_file_return(page_id(), EACCES, {}, request_id);
+            return;
+        }
+
+        auto file = Core::File::open(canonical, Core::File::OpenMode::Read);
         if (file.is_error())
             client().async_handle_file_return(page_id(), file.error().code(), {}, request_id);
         else
@@ -113,6 +131,7 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
     m_backup_bitmap = nullptr;
     handle_resize();
 
+    m_allowed_file_directory_trees.clear();
     load(url);
 }
 
@@ -154,6 +173,22 @@ void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState 
 void ViewImplementation::load(URL::URL const& url)
 {
     m_url = url;
+
+    if (url.scheme() == "file"sv) {
+        auto canonical_path = LexicalPath::canonicalized_path(url.file_path());
+        auto directory = LexicalPath::dirname(canonical_path);
+        LexicalPath lexical_directory { directory };
+        if (!directory.is_empty() && !lexical_directory.is_root()) {
+            auto already_covered = any_of(m_allowed_file_directory_trees, [&](auto const& allowed) {
+                return lexical_directory.is_child_of(LexicalPath { allowed });
+            });
+            if (!already_covered)
+                m_allowed_file_directory_trees.append(directory);
+        }
+    } else {
+        m_allowed_file_directory_trees.clear();
+    }
+
     client().async_load_url(page_id(), url);
 }
 
@@ -684,6 +719,8 @@ void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_err
 
     initialize_client();
     VERIFY(m_client_state.client);
+
+    m_allowed_file_directory_trees.clear();
 
     // Don't keep a stale backup bitmap around.
     m_backup_bitmap = nullptr;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -320,6 +320,8 @@ protected:
     URL::URL m_url;
     Utf16String m_title;
 
+    Vector<ByteString> m_allowed_file_directory_trees;
+
     double m_zoom_level { 1.0 };
     double m_device_pixel_ratio { 1.0 };
     double m_maximum_frames_per_second { 60.0 };

--- a/Tests/LibWeb/test-web/TestWebView.cpp
+++ b/Tests/LibWeb/test-web/TestWebView.cpp
@@ -6,8 +6,10 @@
 
 #include "TestWebView.h"
 
+#include <LibCore/File.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ShareableBitmap.h>
+#include <LibIPC/File.h>
 
 namespace TestWeb {
 
@@ -23,6 +25,14 @@ TestWebView::TestWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewp
     : WebView::HeadlessWebView(move(theme), viewport_size)
     , m_test_promise(TestPromise::construct())
 {
+    // Allow unrestricted file access for tests, which load shared resources from sibling directories.
+    on_request_file = [this](auto const& path, auto request_id) {
+        auto file = Core::File::open(path, Core::File::OpenMode::Read);
+        if (file.is_error())
+            client().async_handle_file_return(page_id(), file.error().code(), {}, request_id);
+        else
+            client().async_handle_file_return(page_id(), 0, IPC::File::adopt_file(file.release_value()), request_id);
+    };
 }
 
 void TestWebView::clear_content_filters()

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SOURCES
+    TestWebViewFileRequestAllowlist.cpp
     TestWebViewURL.cpp
 )
 

--- a/Tests/LibWebView/TestWebViewFileRequestAllowlist.cpp
+++ b/Tests/LibWebView/TestWebViewFileRequestAllowlist.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/AnyOf.h>
+#include <AK/ByteString.h>
+#include <AK/LexicalPath.h>
+#include <AK/Vector.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibURL/URL.h>
+
+static void populate_allowlist_for_url(Vector<ByteString>& allowlist, URL::URL const& url)
+{
+    if (url.scheme() == "file"sv) {
+        auto canonical_path = LexicalPath::canonicalized_path(url.file_path());
+        auto directory = LexicalPath::dirname(canonical_path);
+        LexicalPath lexical_directory { directory };
+        if (!directory.is_empty() && !lexical_directory.is_root()) {
+            auto already_covered = any_of(allowlist, [&](auto const& allowed) {
+                return lexical_directory.is_child_of(LexicalPath { allowed });
+            });
+            if (!already_covered)
+                allowlist.append(directory);
+        }
+    } else {
+        allowlist.clear();
+    }
+}
+
+static bool is_file_request_allowed(Vector<ByteString> const& allowlist, StringView path)
+{
+    auto canonical = LexicalPath::canonicalized_path(path);
+
+    if (!LexicalPath::is_absolute_path(canonical))
+        return false;
+
+    LexicalPath requested { canonical };
+    return any_of(allowlist, [&](auto const& allowed_directory) {
+        return requested.is_child_of(LexicalPath { allowed_directory });
+    });
+}
+
+TEST_CASE(file_in_same_directory_is_allowed)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(is_file_request_allowed(allowlist, "/home/user/docs/style.css"sv));
+    EXPECT(is_file_request_allowed(allowlist, "/home/user/docs/image.png"sv));
+}
+
+TEST_CASE(file_in_subdirectory_is_allowed)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(is_file_request_allowed(allowlist, "/home/user/docs/images/logo.png"sv));
+    EXPECT(is_file_request_allowed(allowlist, "/home/user/docs/sub/deep/file.js"sv));
+}
+
+TEST_CASE(file_outside_directory_is_rejected)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/other/secret.txt"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/etc/passwd"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/.ssh/id_rsa"sv));
+}
+
+TEST_CASE(path_traversal_is_neutralized)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs/../../../etc/passwd"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs/../../.ssh/id_rsa"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs/../other/secret.txt"sv));
+}
+
+TEST_CASE(sibling_directory_is_rejected)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/home/user/docs/input/test.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs/data/image.png"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs/expected/output.txt"sv));
+}
+
+TEST_CASE(empty_allowlist_rejects_everything)
+{
+    Vector<ByteString> allowlist;
+
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs/page.html"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/tmp/file.txt"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/etc/passwd"sv));
+}
+
+TEST_CASE(non_file_navigation_clears_allowlist)
+{
+    Vector<ByteString> allowlist;
+    auto file_url = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, file_url);
+    EXPECT(is_file_request_allowed(allowlist, "/home/user/docs/style.css"sv));
+
+    auto http_url = URL::Parser::basic_parse("http://example.com"sv).release_value();
+    populate_allowlist_for_url(allowlist, http_url);
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs/style.css"sv));
+    EXPECT(allowlist.is_empty());
+}
+
+TEST_CASE(root_directory_is_excluded)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/vmlinuz"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(allowlist.is_empty());
+    EXPECT(!is_file_request_allowed(allowlist, "/etc/passwd"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "/vmlinuz"sv));
+}
+
+TEST_CASE(relative_path_is_rejected)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(!is_file_request_allowed(allowlist, "relative/path.txt"sv));
+    EXPECT(!is_file_request_allowed(allowlist, "./local.txt"sv));
+    EXPECT(!is_file_request_allowed(allowlist, ""sv));
+}
+
+TEST_CASE(multiple_file_navigations_accumulate)
+{
+    Vector<ByteString> allowlist;
+    auto url1 = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url1);
+
+    auto url2 = URL::create_with_file_scheme("/home/user/images/gallery.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url2);
+
+    EXPECT(is_file_request_allowed(allowlist, "/home/user/docs/style.css"sv));
+    EXPECT(is_file_request_allowed(allowlist, "/home/user/images/photo.jpg"sv));
+    EXPECT_EQ(allowlist.size(), 2u);
+}
+
+TEST_CASE(duplicate_directory_is_not_added)
+{
+    Vector<ByteString> allowlist;
+    auto url1 = URL::create_with_file_scheme("/home/user/docs/page1.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url1);
+
+    auto url2 = URL::create_with_file_scheme("/home/user/docs/page2.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url2);
+
+    EXPECT_EQ(allowlist.size(), 1u);
+}
+
+TEST_CASE(child_directory_is_not_added_when_parent_exists)
+{
+    Vector<ByteString> allowlist;
+    auto url1 = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url1);
+
+    auto url2 = URL::create_with_file_scheme("/home/user/docs/sub/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url2);
+
+    EXPECT_EQ(allowlist.size(), 1u);
+}
+
+TEST_CASE(prefix_confusion_is_prevented)
+{
+    Vector<ByteString> allowlist;
+    auto url = URL::create_with_file_scheme("/home/user/docs/page.html"sv).release_value();
+    populate_allowlist_for_url(allowlist, url);
+
+    EXPECT(!is_file_request_allowed(allowlist, "/home/user/docs-secret/passwords.txt"sv));
+}


### PR DESCRIPTION
The on_request_file callback in ViewImplementation opened any renderer-supplied file path without validation, allowing a compromised WebContent process to read arbitrary files accessible to the browser user.

This makes it so that a per-view allowlist of permitted directory trees is now populated when the UI process initiates file:// navigations. Requested paths are canonicalized and checked against this allowlist via LexicalPath::is_child_of before opening. The allowlist is cleared on non-file:// navigation and on WebContent process crash. The root directory is excluded to prevent a root-level file:// navigation from granting full filesystem access.

TestWebView has also been added (a dedicated unit test to cover the allowlist validation logic).

Known limitations: symlink traversal within allowed directories is not resolved (requires realpath or openat2, tracked separately), and back/forward navigation to file:// pages does not repopulate the allowlist.