### PR TITLE
LibJS: Add fast path in async function await for non-thenable values

### DIFF
--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -46,6 +46,37 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
     if (!m_suspended_execution_context)
         m_suspended_execution_context = vm.running_execution_context().copy();
 
+    // OPTIMIZATION: Fast path for non-thenable values.
+    //
+    // Per spec, PromiseResolve wraps non-Promise values in a new resolved promise,
+    // then PerformPromiseThen attaches reaction handlers and schedules a microtask.
+    // This creates 10+ GC objects per await.
+    //
+    // Since primitives can never have a "then" property, and already-settled native
+    // Promises with the %Promise% constructor don't need wrapping, we can skip all
+    // of that machinery and directly schedule the async function's continuation.
+    //
+    // For pending promises, or promises with a non-standard constructor, we fall
+    // through to the spec-compliant slow path.
+    if (!value.is_object()) {
+        // Primitive values are never thenable -- schedule resume directly.
+        schedule_resume(value, true);
+        return {};
+    }
+
+    if (auto promise = value.as_if<Promise>()) {
+        // Already-settled native Promises whose constructor is the intrinsic %Promise%.
+        auto* promise_prototype = realm.intrinsics().promise_prototype().ptr();
+        if (promise->state() != Promise::State::Pending
+            && promise->shape().property_count() == 0
+            && promise->shape().prototype() == promise_prototype
+            && promise_prototype->get_without_side_effects(vm.names.constructor) == Value(realm.intrinsics().promise_constructor())) {
+            schedule_resume(promise->result(), promise->state() == Promise::State::Fulfilled);
+            promise->set_is_handled();
+            return {};
+        }
+    }
+
     // 2. Let promise be ? PromiseResolve(%Promise%, value).
     auto* promise_object = TRY(promise_resolve(vm, realm.intrinsics().promise_constructor(), value));
 
@@ -119,6 +150,19 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
     // 11. Assert: If control reaches here, then asyncContext is the running execution context again.
     // 12. Return completion.
     return {};
+}
+
+void AsyncFunctionDriverWrapper::schedule_resume(Value value, bool is_fulfilled)
+{
+    auto& vm = this->vm();
+    vm.host_enqueue_promise_job(
+        GC::create_function(vm.heap(), [this, value, is_fulfilled, &vm]() -> ThrowCompletionOr<Value> {
+            TRY(vm.push_execution_context(*m_suspended_execution_context, {}));
+            continue_async_execution(vm, value, is_fulfilled);
+            vm.pop_execution_context();
+            return js_undefined();
+        }),
+        vm.current_realm());
 }
 
 void AsyncFunctionDriverWrapper::continue_async_execution(VM& vm, Value value, bool is_successful)

--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -25,6 +25,7 @@ public:
     void visit_edges(Cell::Visitor&) override;
 
     void continue_async_execution(VM&, Value, bool is_successful);
+    void schedule_resume(Value, bool is_fulfilled);
 
 private:
     AsyncFunctionDriverWrapper(Realm&, GC::Ref<GeneratorObject>, GC::Ref<Promise> top_level_promise);

--- a/Tests/LibJS/Runtime/syntax/async-await.js
+++ b/Tests/LibJS/Runtime/syntax/async-await.js
@@ -256,6 +256,380 @@ describe("await thenables", () => {
     });
 });
 
+describe("await primitive values", () => {
+    test("await number", () => {
+        let result;
+        async function f() {
+            result = await 42;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe(42);
+    });
+
+    test("await string", () => {
+        let result;
+        async function f() {
+            result = await "hello";
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe("hello");
+    });
+
+    test("await boolean", () => {
+        let result;
+        async function f() {
+            result = await true;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBeTrue();
+    });
+
+    test("await null", () => {
+        let result = "not null";
+        async function f() {
+            result = await null;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBeNull();
+    });
+
+    test("await undefined", () => {
+        let result = "not undefined";
+        async function f() {
+            result = await undefined;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBeUndefined();
+    });
+
+    test("await symbol", () => {
+        const sym = Symbol("test");
+        let result;
+        async function f() {
+            result = await sym;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe(sym);
+    });
+
+    test("await bigint", () => {
+        let result;
+        async function f() {
+            result = await 123n;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe(123n);
+    });
+
+    test("multiple primitive awaits in sequence", () => {
+        const results = [];
+        async function f() {
+            results.push(await 1);
+            results.push(await "two");
+            results.push(await true);
+            results.push(await null);
+            results.push(await undefined);
+            results.push(await 42n);
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(results).toEqual([1, "two", true, null, undefined, 42n]);
+    });
+});
+
+describe("await already-settled native promises", () => {
+    test("await resolved promise", () => {
+        let result;
+        async function f() {
+            result = await Promise.resolve(99);
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe(99);
+    });
+
+    test("await rejected promise in try-catch", () => {
+        let caught;
+        async function f() {
+            try {
+                await Promise.reject("oops");
+            } catch (e) {
+                caught = e;
+            }
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(caught).toBe("oops");
+    });
+
+    test("await rejected promise propagates to caller", () => {
+        let caught;
+        async function f() {
+            await Promise.reject(new Error("fail"));
+        }
+        f().catch(e => {
+            caught = e.message;
+        });
+        runQueuedPromiseJobs();
+        expect(caught).toBe("fail");
+    });
+
+    test("multiple resolved promises in sequence", () => {
+        const results = [];
+        async function f() {
+            results.push(await Promise.resolve("a"));
+            results.push(await Promise.resolve("b"));
+            results.push(await Promise.resolve("c"));
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(results).toEqual(["a", "b", "c"]);
+    });
+
+    test("await resolved promise with undefined value", () => {
+        let result = "not undefined";
+        async function f() {
+            result = await Promise.resolve(undefined);
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBeUndefined();
+    });
+
+    test("await resolved promise with object value", () => {
+        const obj = { key: "value" };
+        let result;
+        async function f() {
+            result = await Promise.resolve(obj);
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe(obj);
+    });
+});
+
+describe("await pending promises", () => {
+    test("await promise that resolves later", () => {
+        let result;
+        let resolve;
+        const p = new Promise(r => {
+            resolve = r;
+        });
+        async function f() {
+            result = await p;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBeUndefined();
+        resolve(42);
+        runQueuedPromiseJobs();
+        expect(result).toBe(42);
+    });
+
+    test("await promise that rejects later", () => {
+        let caught;
+        let reject;
+        const p = new Promise((_, r) => {
+            reject = r;
+        });
+        async function f() {
+            try {
+                await p;
+            } catch (e) {
+                caught = e;
+            }
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(caught).toBeUndefined();
+        reject("error");
+        runQueuedPromiseJobs();
+        expect(caught).toBe("error");
+    });
+});
+
+describe("await promises with own properties or non-standard prototype", () => {
+    test("await resolved promise with own property takes slow path", () => {
+        let result;
+        async function f() {
+            const p = Promise.resolve(77);
+            p.extraProp = true;
+            result = await p;
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe(77);
+    });
+
+    test("await rejected promise with own property takes slow path", () => {
+        let caught;
+        async function f() {
+            const p = Promise.reject("err");
+            p.extraProp = true;
+            try {
+                await p;
+            } catch (e) {
+                caught = e;
+            }
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(caught).toBe("err");
+    });
+
+    test("await promise subclass", () => {
+        class MyPromise extends Promise {}
+        let result;
+        async function f() {
+            result = await MyPromise.resolve(55);
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(result).toBe(55);
+    });
+});
+
+describe("microtask ordering with await", () => {
+    test("await primitive vs Promise.resolve().then()", () => {
+        const order = [];
+        async function f() {
+            await 1;
+            order.push("async");
+        }
+        f();
+        Promise.resolve().then(() => order.push("then"));
+        runQueuedPromiseJobs();
+        expect(order).toEqual(["async", "then"]);
+    });
+
+    test("await resolved promise vs Promise.resolve().then()", () => {
+        const order = [];
+        async function f() {
+            await Promise.resolve(1);
+            order.push("async");
+        }
+        f();
+        Promise.resolve().then(() => order.push("then"));
+        runQueuedPromiseJobs();
+        expect(order).toEqual(["async", "then"]);
+    });
+
+    test("fast path and slow path produce same interleaving order", () => {
+        // Test that the fast path (primitives) and slow path (objects)
+        // produce the same microtask interleaving behavior.
+        const fastOrder = [];
+        async function fastF1() {
+            await 1;
+            fastOrder.push("f1-a");
+            await 2;
+            fastOrder.push("f1-b");
+        }
+        async function fastF2() {
+            await 3;
+            fastOrder.push("f2-a");
+            await 4;
+            fastOrder.push("f2-b");
+        }
+        fastF1();
+        fastF2();
+        runQueuedPromiseJobs();
+
+        const slowOrder = [];
+        async function slowF1() {
+            await {};
+            slowOrder.push("f1-a");
+            await {};
+            slowOrder.push("f1-b");
+        }
+        async function slowF2() {
+            await {};
+            slowOrder.push("f2-a");
+            await {};
+            slowOrder.push("f2-b");
+        }
+        slowF1();
+        slowF2();
+        runQueuedPromiseJobs();
+
+        expect(fastOrder).toEqual(slowOrder);
+    });
+
+    test("fast path and slow path produce same mixed interleaving", () => {
+        const fastOrder = [];
+        async function fastF1() {
+            await 42;
+            fastOrder.push("f1-a");
+            await Promise.resolve(1);
+            fastOrder.push("f1-b");
+        }
+        async function fastF2() {
+            await Promise.resolve(2);
+            fastOrder.push("f2-a");
+            await 99;
+            fastOrder.push("f2-b");
+        }
+        fastF1();
+        fastF2();
+        runQueuedPromiseJobs();
+
+        const slowOrder = [];
+        async function slowF1() {
+            await {};
+            slowOrder.push("f1-a");
+            await {};
+            slowOrder.push("f1-b");
+        }
+        async function slowF2() {
+            await {};
+            slowOrder.push("f2-a");
+            await {};
+            slowOrder.push("f2-b");
+        }
+        slowF1();
+        slowF2();
+        runQueuedPromiseJobs();
+
+        expect(fastOrder).toEqual(slowOrder);
+    });
+});
+
+describe("await fast path does not invoke getters on Promise.prototype.constructor", () => {
+    test("getter on Promise.prototype.constructor causes fallback to slow path", () => {
+        let calls = 0;
+        const original = Object.getOwnPropertyDescriptor(Promise.prototype, "constructor");
+        Object.defineProperty(Promise.prototype, "constructor", {
+            get() {
+                calls++;
+                return Promise;
+            },
+            configurable: true,
+        });
+        try {
+            async function f() {
+                // These settled native promises have no own properties, but the
+                // fast path must detect the getter on Promise.prototype.constructor
+                // and fall back to the slow path (which invokes it per spec).
+                await Promise.resolve(1);
+                await Promise.resolve(2);
+            }
+            f();
+            runQueuedPromiseJobs();
+            // Exactly 2 calls: one per await, from the slow path's Get(x, "constructor").
+            // The fast path itself must not contribute any extra calls.
+            expect(calls).toBe(2);
+        } finally {
+            Object.defineProperty(Promise.prototype, "constructor", original);
+        }
+    });
+});
+
 describe("await observably looks up constructor of Promise objects", () => {
     let calls = 0;
     function makeConstructorObservable(promise) {


### PR DESCRIPTION
Per spec, every `await` goes through PromiseResolve (which wraps the value in a new Promise via NewPromiseCapability) and then PerformPromiseThen (which creates PromiseReaction and JobCallback objects). This results in 13-16 GC cell allocations per await.

Add a fast path that detects two common cases:

1. Primitive values: These can never have a "then" property, so we can skip all promise wrapping and directly schedule the async function's continuation as a microtask.

2. Already-settled native Promises: If the promise has no own properties and its prototype is the intrinsic %Promise.prototype%, we can extract the result directly and schedule continuation.

For these cases, we bypass promise_resolve(), new_promise_capability(), create_resolving_functions(), perform_then(), PromiseReaction creation, and JobCallback creation -- replacing ~13 GC allocations with 1 (the GC::Function for the microtask job).

Big speedups on AsyncBench:

```
Suite       Test                          Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  --------------------------  ---------  ---------------------  ---------------------
AsyncBench  async-call-return.js            2.992  0.516 ± 0.514 … 0.518  0.172 ± 0.170 … 0.175
AsyncBench  async-class-method.js           3.553  0.783 ± 0.777 … 0.789  0.220 ± 0.219 … 0.222
AsyncBench  async-fan-out.js                1.501  0.281 ± 0.280 … 0.283  0.187 ± 0.186 … 0.189
AsyncBench  async-generator.js              1.063  0.292 ± 0.292 … 0.292  0.275 ± 0.273 … 0.277
AsyncBench  async-iife.js                   2.179  0.627 ± 0.622 … 0.631  0.288 ± 0.287 … 0.288
AsyncBench  async-nested-calls.js           2.767  0.862 ± 0.854 … 0.870  0.312 ± 0.309 … 0.314
AsyncBench  async-pipeline.js               1.624  0.570 ± 0.570 … 0.570  0.351 ± 0.350 … 0.351
AsyncBench  async-sequential-awaits.js      5.56   0.604 ± 0.603 … 0.604  0.109 ± 0.109 … 0.109
AsyncBench  async-try-catch-reject.js       1.963  0.691 ± 0.691 … 0.692  0.352 ± 0.349 … 0.356
AsyncBench  await-primitive.js              7.347  0.510 ± 0.502 … 0.518  0.069 ± 0.068 … 0.071
AsyncBench  await-resolved-promise.js       1.224  0.575 ± 0.568 … 0.582  0.470 ± 0.469 … 0.471
AsyncBench  await-thenable.js               0.99   0.038 ± 0.038 … 0.039  0.039 ± 0.039 … 0.039
AsyncBench  promise-all.js                  1.502  0.750 ± 0.746 … 0.755  0.499 ± 0.497 … 0.502
AsyncBench  promise-allSettled.js           1.452  0.861 ± 0.853 … 0.870  0.593 ± 0.589 … 0.597
AsyncBench  promise-chain.js                1.013  0.169 ± 0.168 … 0.170  0.166 ± 0.166 … 0.167
AsyncBench  promise-new-resolve.js          1.156  0.344 ± 0.343 … 0.346  0.298 ± 0.296 … 0.300
AsyncBench  promise-race.js                 1.515  0.753 ± 0.747 … 0.759  0.497 ± 0.492 … 0.503
AsyncBench  Total                           1.884  9.227                  4.898
```