### PR TITLE
LibJS: Combine onFulfilled and onRejected into a single settled callback

### DIFF
--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -51,8 +51,18 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
 
     // 3. Let fulfilledClosure be a new Abstract Closure with parameters (v) that captures asyncContext and performs the
     //    following steps when called:
-    auto fulfilled_closure = [this](VM& vm) -> ThrowCompletionOr<Value> {
-        auto value = vm.argument(0);
+    // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the
+    //    following steps when called:
+    // OPTIMIZATION: onRejected and onFulfilled are identical other than the resumption value passed to continue_async_execution.
+    //               To avoid allocated two GC functions down this path, we combine both callbacks into one function.
+    auto settled_closure = [this](VM& vm) -> ThrowCompletionOr<Value> {
+        auto reason = vm.argument(0);
+
+        // The currently awaited promise is settled when this reaction runs, so we can use
+        // its state to decide whether to resume with a normal or throw completion.
+        VERIFY(m_current_promise);
+        auto is_successful = m_current_promise->state() == Promise::State::Fulfilled;
+        VERIFY(is_successful || m_current_promise->state() == Promise::State::Rejected);
 
         // a. Let prevContext be the running execution context.
         auto& prev_context = vm.running_execution_context();
@@ -61,9 +71,11 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
         // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
         TRY(vm.push_execution_context(*m_suspended_execution_context, {}));
 
-        // d. Resume the suspended evaluation of asyncContext using NormalCompletion(v) as the result of the operation that
-        //    suspended it.
-        continue_async_execution(vm, value, true);
+        // 3.d. Resume the suspended evaluation of asyncContext using NormalCompletion(v) as the result of the operation that
+        //      suspended it.
+        // 5.d. Resume the suspended evaluation of asyncContext using ThrowCompletion(reason) as the result of the operation that
+        //      suspended it.
+        continue_async_execution(vm, reason, is_successful);
         vm.pop_execution_context();
 
         // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and
@@ -75,41 +87,13 @@ ThrowCompletionOr<void> AsyncFunctionDriverWrapper::await(JS::Value value)
     };
 
     // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
-    if (!m_on_fulfilled)
-        m_on_fulfilled = NativeFunction::create(realm, move(fulfilled_closure), 1);
-
-    // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the
-    //    following steps when called:
-    auto rejected_closure = [this](VM& vm) -> ThrowCompletionOr<Value> {
-        auto reason = vm.argument(0);
-
-        // a. Let prevContext be the running execution context.
-        auto& prev_context = vm.running_execution_context();
-
-        // b. Suspend prevContext.
-        // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
-        TRY(vm.push_execution_context(*m_suspended_execution_context, {}));
-
-        // d. Resume the suspended evaluation of asyncContext using ThrowCompletion(reason) as the result of the operation that
-        //    suspended it.
-        continue_async_execution(vm, reason, false);
-        vm.pop_execution_context();
-
-        // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and
-        //    prevContext is the currently running execution context.
-        VERIFY(&vm.running_execution_context() == &prev_context);
-
-        // f. Return undefined.
-        return js_undefined();
-    };
-
     // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
-    if (!m_on_rejected)
-        m_on_rejected = NativeFunction::create(realm, move(rejected_closure), 1);
+    if (!m_on_settled)
+        m_on_settled = NativeFunction::create(realm, move(settled_closure), 1);
 
     // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
     m_current_promise = as<Promise>(promise_object);
-    m_current_promise->perform_then(m_on_fulfilled, m_on_rejected, {});
+    m_current_promise->perform_then(m_on_settled, m_on_settled, {});
 
     // NOTE: None of these are necessary. 8-12 are handled by step d of the above lambdas.
     // 8. Remove asyncContext from the execution context stack and restore the execution context that is at the top of the
@@ -177,8 +161,7 @@ void AsyncFunctionDriverWrapper::visit_edges(Cell::Visitor& visitor)
         visitor.visit(m_current_promise);
     if (m_suspended_execution_context)
         m_suspended_execution_context->visit_edges(visitor);
-    visitor.visit(m_on_fulfilled);
-    visitor.visit(m_on_rejected);
+    visitor.visit(m_on_settled);
 }
 
 }

--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -35,8 +35,7 @@ private:
     GC::Ptr<Promise> m_current_promise { nullptr };
     OwnPtr<ExecutionContext> m_suspended_execution_context;
 
-    GC::Ptr<NativeFunction> m_on_fulfilled;
-    GC::Ptr<NativeFunction> m_on_rejected;
+    GC::Ptr<NativeFunction> m_on_settled;
 };
 
 }


### PR DESCRIPTION
The fulfilled and rejected closures in AsyncFunctionDriverWrapper::await were identical in structure, differing only in whether they resumed the async context with a NormalCompletion or ThrowCompletion.

Since the callback has access to the current promise, we can check its state at reaction time to determine which completion to use. This allows us to allocate a single GC-tracked NativeFunction (m_on_settled) and register it for both the onFulfilled and onRejected slots in PerformPromiseThen, halving the number of GC allocations on this path.


```
Suite       Test                          Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  --------------------------  ---------  ---------------------  ---------------------
AsyncBench  async-call-return.js            1.065  0.514 ± 0.510 … 0.517  0.482 ± 0.477 … 0.488
AsyncBench  async-class-method.js           1.013  0.780 ± 0.774 … 0.789  0.770 ± 0.762 … 0.783
AsyncBench  async-fan-out.js                1.026  0.278 ± 0.275 … 0.280  0.271 ± 0.266 … 0.273
AsyncBench  async-generator.js              1.013  0.293 ± 0.289 … 0.299  0.289 ± 0.286 … 0.295
AsyncBench  async-iife.js                   1.062  0.623 ± 0.615 … 0.632  0.587 ± 0.581 … 0.597
AsyncBench  async-nested-calls.js           1.057  0.862 ± 0.856 … 0.866  0.815 ± 0.807 … 0.826
AsyncBench  async-pipeline.js               1.064  0.591 ± 0.580 … 0.609  0.556 ± 0.548 … 0.563
AsyncBench  async-sequential-awaits.js      1.016  0.603 ± 0.596 … 0.609  0.593 ± 0.586 … 0.603
AsyncBench  async-try-catch-reject.js       1.009  0.752 ± 0.745 … 0.761  0.746 ± 0.745 … 0.748
AsyncBench  await-primitive.js              0.986  0.495 ± 0.491 … 0.504  0.502 ± 0.489 … 0.520
AsyncBench  await-resolved-promise.js       0.995  0.553 ± 0.547 … 0.557  0.555 ± 0.547 … 0.562
AsyncBench  await-thenable.js               1.039  0.050 ± 0.050 … 0.051  0.048 ± 0.048 … 0.049
AsyncBench  promise-all.js                  1.043  0.745 ± 0.744 … 0.747  0.714 ± 0.704 … 0.725
AsyncBench  promise-allSettled.js           1.056  0.838 ± 0.834 … 0.841  0.793 ± 0.788 … 0.798
AsyncBench  promise-chain.js                1.054  0.202 ± 0.199 … 0.204  0.192 ± 0.188 … 0.195
AsyncBench  promise-new-resolve.js          1.028  0.357 ± 0.351 … 0.364  0.347 ± 0.343 … 0.355
AsyncBench  promise-race.js                 1.08   0.788 ± 0.779 … 0.801  0.730 ± 0.723 … 0.735
AsyncBench  Total                           1.037  9.325                  8.991
All Suites  Total                           1.037  9.325                  8.991
```