### PR TITLE
AppKit: Vertically center text in the location search field

### DIFF
--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -30,6 +30,40 @@ static NSString* const TOOLBAR_ZOOM_IDENTIFIER = @"ToolbarZoomIdentifier";
 static NSString* const TOOLBAR_NEW_TAB_IDENTIFIER = @"ToolbarNewTabIdentifier";
 static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIdentifier";
 
+@interface LocationSearchFieldCell : NSSearchFieldCell
+
+@end
+
+@implementation LocationSearchFieldCell
+
+- (NSRect)adjustedFrameToVerticallyCenterText:(NSRect)frame
+{
+    NSSize textSize = [self cellSizeForBounds:frame];
+    CGFloat delta = frame.size.height - textSize.height;
+    if (delta > 0) {
+        frame.origin.y += delta / 2.0;
+        frame.size.height -= delta;
+    }
+    return frame;
+}
+
+- (void)drawInteriorWithFrame:(NSRect)frame inView:(NSView*)view
+{
+    [super drawInteriorWithFrame:[self adjustedFrameToVerticallyCenterText:frame] inView:view];
+}
+
+- (void)editWithFrame:(NSRect)frame inView:(NSView*)view editor:(NSText*)editor delegate:(id)delegate event:(NSEvent*)event
+{
+    [super editWithFrame:[self adjustedFrameToVerticallyCenterText:frame] inView:view editor:editor delegate:delegate event:event];
+}
+
+- (void)selectWithFrame:(NSRect)frame inView:(NSView*)view editor:(NSText*)editor delegate:(id)delegate start:(NSInteger)start length:(NSInteger)length
+{
+    [super selectWithFrame:[self adjustedFrameToVerticallyCenterText:frame] inView:view editor:editor delegate:delegate start:start length:length];
+}
+
+@end
+
 @interface LocationSearchField : NSSearchField
 
 - (BOOL)becomeFirstResponder;
@@ -37,6 +71,11 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 @end
 
 @implementation LocationSearchField
+
++ (Class)cellClass
+{
+    return [LocationSearchFieldCell class];
+}
 
 - (BOOL)becomeFirstResponder
 {


### PR DESCRIPTION
The toolbar gives the NSSearchField more height than needed for the text, causing the URL text to appear off-center. Add a custom NSSearchFieldCell subclass that adjusts the drawing, editing, and selection frames to vertically center the text within the cell bounds.

According to my research there's no other way to vertically center text. And this seems more straightforward to me than adjusting the height of the cell based on the text size.

Before:  

<img width="458" height="151" alt="image" src="https://github.com/user-attachments/assets/7a938bfc-45b1-4812-b249-e72e87aecad0" />


After:

<img width="446" height="162" alt="image" src="https://github.com/user-attachments/assets/bba3cada-9240-4b82-8e74-bfc09847d6f4" />
