### PR TITLE
LibJS: Synchronous await fast path when microtask queue is empty

### DIFF
--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -181,12 +181,44 @@ void AsyncFunctionDriverWrapper::continue_async_execution(VM& vm, Value value, b
                 return {};
             }
 
-            // We hit `await Promise`
+            // We hit `await value`
+            //
+            // OPTIMIZATION: Synchronous await fast path.
+            // If we're not in the initial execution (i.e. we were resumed from a microtask)
+            // and the microtask queue is empty, we can resolve the await synchronously
+            // without suspending. This is safe because no other microtask can observe the
+            // difference in execution order.
+            if (!m_is_initial_execution && vm.host_promise_job_queue_is_empty()) {
+                auto& realm = *vm.current_realm();
+                if (!promise_value.is_object()) {
+                    // Primitive values are never thenable.
+                    generator_result = m_generator_object->resume(vm, promise_value, {});
+                    continue;
+                }
+                if (auto promise = promise_value.as_if<Promise>()) {
+                    auto* promise_prototype = realm.intrinsics().promise_prototype().ptr();
+                    if (promise->state() != Promise::State::Pending
+                        && promise->shape().property_count() == 0
+                        && promise->shape().prototype() == promise_prototype
+                        && promise_prototype->get_without_side_effects(vm.names.constructor) == Value(realm.intrinsics().promise_constructor())) {
+                        auto is_fulfilled = promise->state() == Promise::State::Fulfilled;
+                        promise->set_is_handled();
+                        if (is_fulfilled) {
+                            generator_result = m_generator_object->resume(vm, promise->result(), {});
+                        } else {
+                            generator_result = m_generator_object->resume_abrupt(vm, throw_completion(promise->result()), {});
+                        }
+                        continue;
+                    }
+                }
+            }
+
             auto await_result = this->await(promise_value);
             if (await_result.is_throw_completion()) {
                 generator_result = m_generator_object->resume_abrupt(vm, await_result.release_error(), {});
                 continue;
             }
+            m_is_initial_execution = false;
             return {};
         }
     }();

--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -37,6 +37,7 @@ private:
     OwnPtr<ExecutionContext> m_suspended_execution_context;
 
     GC::Ptr<NativeFunction> m_on_settled;
+    bool m_is_initial_execution { true };
 };
 
 }

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -118,6 +118,10 @@ VM::VM(ErrorMessages error_messages)
         enqueue_promise_job(job, realm);
     };
 
+    host_promise_job_queue_is_empty = [this]() -> bool {
+        return m_promise_jobs.is_empty();
+    };
+
     host_make_job_callback = [](FunctionObject& function_object) {
         return make_job_callback(function_object);
     };

--- a/Libraries/LibJS/Runtime/VM.h
+++ b/Libraries/LibJS/Runtime/VM.h
@@ -299,6 +299,7 @@ public:
     Function<void(StringView)> host_unrecognized_date_string;
     Function<ThrowCompletionOr<void>(Realm&, NonnullOwnPtr<ExecutionContext>, ShadowRealm&)> host_initialize_shadow_realm;
     Function<Crypto::SignedBigInteger(Object const& global)> host_system_utc_epoch_nanoseconds;
+    Function<bool()> host_promise_job_queue_is_empty;
 
     [[nodiscard]] Vector<StackTraceElement> stack_trace() const;
 

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -333,6 +333,10 @@ void initialize_main_thread_vm(AgentType type)
         }));
     };
 
+    s_main_thread_vm->host_promise_job_queue_is_empty = []() -> bool {
+        return HTML::main_thread_event_loop().microtask_queue_empty();
+    };
+
     // 8.1.5.4.4 HostMakeJobCallback(callable), https://html.spec.whatwg.org/multipage/webappapis.html#hostmakejobcallback
     // https://whatpr.org/html/9893/webappapis.html#hostmakejobcallback
     s_main_thread_vm->host_make_job_callback = [](JS::FunctionObject& callable) -> GC::Ref<JS::JobCallback> {

--- a/Tests/LibJS/Runtime/syntax/async-await.js
+++ b/Tests/LibJS/Runtime/syntax/async-await.js
@@ -600,6 +600,98 @@ describe("microtask ordering with await", () => {
     });
 });
 
+// The synchronous await fast path fires when:
+//   1. m_is_initial_execution is false (i.e. we've already suspended once), AND
+//   2. the microtask queue is empty (no other async work in flight)
+// This means it activates on the 2nd+ await in a single async function
+// when no other async functions are running concurrently.
+describe("synchronous await fast path", () => {
+    test("multiple rejected promises in sequence", () => {
+        const caught = [];
+        async function f() {
+            for (const v of [1, 2, 3]) {
+                try {
+                    await Promise.reject(v);
+                } catch (e) {
+                    caught.push(e);
+                }
+            }
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(caught).toEqual([1, 2, 3]);
+    });
+
+    test("mixed resolved and rejected promises", () => {
+        const results = [];
+        async function f() {
+            results.push(await Promise.resolve("a"));
+            try {
+                await Promise.reject("b");
+            } catch (e) {
+                results.push("caught:" + e);
+            }
+            results.push(await 42);
+            results.push(await Promise.resolve("d"));
+            try {
+                await Promise.reject("e");
+            } catch (e) {
+                results.push("caught:" + e);
+            }
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(results).toEqual(["a", "caught:b", 42, "d", "caught:e"]);
+    });
+
+    test("promise with own property falls back to slow path", () => {
+        const results = [];
+        async function f() {
+            results.push(await Promise.resolve(1));
+            const p = Promise.resolve(2);
+            p.extraProp = true;
+            results.push(await p);
+            results.push(await Promise.resolve(3));
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(results).toEqual([1, 2, 3]);
+    });
+
+    test("promise subclass falls back to slow path", () => {
+        class MyPromise extends Promise {}
+        const results = [];
+        async function f() {
+            results.push(await Promise.resolve(1));
+            results.push(await MyPromise.resolve(2));
+            results.push(await Promise.resolve(3));
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(results).toEqual([1, 2, 3]);
+    });
+
+    test("pending promise falls back to slow path", () => {
+        let resolve;
+        const results = [];
+        async function f() {
+            results.push(await Promise.resolve(1));
+            results.push(
+                await new Promise(r => {
+                    resolve = r;
+                })
+            );
+            results.push(await Promise.resolve(3));
+        }
+        f();
+        runQueuedPromiseJobs();
+        expect(results).toEqual([1]);
+        resolve(2);
+        runQueuedPromiseJobs();
+        expect(results).toEqual([1, 2, 3]);
+    });
+});
+
 describe("await fast path does not invoke getters on Promise.prototype.constructor", () => {
     test("getter on Promise.prototype.constructor causes fallback to slow path", () => {
         let calls = 0;


### PR DESCRIPTION
When an async function is resumed from a microtask and hits another await with a non-thenable value (primitive or already-settled native promise), and the microtask queue is empty, we can resolve the await synchronously without suspending. No other microtask can observe the difference in execution order, making this optimization safe.

This avoids the overhead of creating a GC::Function for the microtask job, enqueuing/dequeuing from the microtask queue, and the execution context push/pop that comes with it.

A new VM host hook, host_promise_job_queue_is_empty, is added so both the standalone js binary and LibWeb can provide the appropriate check for their respective job queue implementations.

Solid progress on AsyncBench:
```
Suite       Test                          Speedup  Old (Mean ± Range)     New (Mean ± Range)
----------  --------------------------  ---------  ---------------------  ---------------------
AsyncBench  async-call-return.js            1.148  0.194 ± 0.191 … 0.198  0.169 ± 0.169 … 0.170
AsyncBench  async-class-method.js           1.199  0.234 ± 0.232 … 0.236  0.195 ± 0.195 … 0.196
AsyncBench  async-fan-out.js                0.983  0.184 ± 0.181 … 0.186  0.187 ± 0.186 … 0.187
AsyncBench  async-generator.js              1.049  0.283 ± 0.282 … 0.285  0.270 ± 0.268 … 0.273
AsyncBench  async-iife.js                   1.063  0.294 ± 0.291 … 0.298  0.277 ± 0.276 … 0.277
AsyncBench  async-nested-calls.js           1.125  0.327 ± 0.321 … 0.333  0.290 ± 0.289 … 0.291
AsyncBench  async-pipeline.js               1.052  0.348 ± 0.347 … 0.348  0.331 ± 0.328 … 0.333
AsyncBench  async-sequential-awaits.js      1.449  0.129 ± 0.128 … 0.130  0.089 ± 0.089 … 0.089
AsyncBench  async-try-catch-reject.js       0.998  0.347 ± 0.343 … 0.351  0.348 ± 0.339 … 0.357
AsyncBench  await-primitive.js              1.732  0.085 ± 0.085 … 0.086  0.049 ± 0.049 … 0.050
AsyncBench  await-resolved-promise.js       1.097  0.494 ± 0.487 … 0.501  0.451 ± 0.448 … 0.453
AsyncBench  await-thenable.js               1.005  0.038 ± 0.038 … 0.039  0.038 ± 0.038 … 0.038
AsyncBench  promise-all.js                  0.998  0.500 ± 0.495 … 0.505  0.501 ± 0.496 … 0.506
AsyncBench  promise-allSettled.js           1.001  0.582 ± 0.578 … 0.586  0.581 ± 0.580 … 0.582
AsyncBench  promise-chain.js                1.004  0.170 ± 0.169 … 0.171  0.170 ± 0.168 … 0.171
AsyncBench  promise-new-resolve.js          1.1    0.311 ± 0.310 … 0.313  0.283 ± 0.283 … 0.284
AsyncBench  promise-race.js                 1.016  0.501 ± 0.501 … 0.501  0.493 ± 0.491 … 0.494
AsyncBench  Total                           1.064  5.022                  4.722
```