### PR TITLE
LibWeb: Use `unsafe_layout_node()` when handling alt attribute changes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1543,8 +1543,8 @@ void HTMLInputElement::form_associated_element_attribute_changed(FlyString const
     } else if (name == HTML::AttributeNames::src) {
         handle_src_attribute(value.value_or({})).release_value_but_fixme_should_propagate_errors();
     } else if (name == HTML::AttributeNames::alt) {
-        if (layout_node() && type_state() == TypeAttributeState::ImageButton)
-            did_update_alt_text(as<Layout::ImageBox>(*layout_node()));
+        if (unsafe_layout_node() && type_state() == TypeAttributeState::ImageButton)
+            did_update_alt_text(as<Layout::ImageBox>(*unsafe_layout_node()));
     } else if (name == HTML::AttributeNames::maxlength) {
         handle_maxlength_attribute();
     } else if (name == HTML::AttributeNames::multiple) {

--- a/Tests/LibWeb/Crash/HTML/input-image-alt-dirty-layout.html
+++ b/Tests/LibWeb/Crash/HTML/input-image-alt-dirty-layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<input type="image" alt="old">
+<script>
+    document.body.offsetHeight;
+    document.body.append("");
+    document.querySelector("input").alt = "new";
+</script>


### PR DESCRIPTION
The layout node is only accessed to clear the cached alt value, so the layout tree doesn't need to be up to date in this case.

Found with Domato.