### PR TITLE
LibWeb: Reject negative `mathsize` presentational hint values

### DIFF
--- a/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -103,7 +103,10 @@ void MathMLElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> 
             // The mathsize attribute, if present, must have a value that is a valid <length-percentage>.
             // In that case, the user agent is expected to treat the attribute as a presentational hint setting the
             // element's font-size property to the corresponding value.
-            if (auto parsed_value = parse_css_type(CSS::Parser::ParsingParams { document() }, value, CSS::ValueType::LengthPercentage))
+            // NB: We parse the value as a font size, then filter out non LengthPercentage values, to ensure negative
+            //     LengthPercentage values are rejected.
+            if (auto parsed_value = parse_css_value(CSS::Parser::ParsingParams { document() }, value, CSS::PropertyID::FontSize);
+                parsed_value && (parsed_value->is_length() || parsed_value->is_percentage() || parsed_value->is_calculated()))
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::FontSize, parsed_value.release_nonnull());
         } else if (name == AttributeNames::displaystyle) {
             // https://w3c.github.io/mathml-core/#dfn-displaystyle

--- a/Tests/LibWeb/Crash/CSS/negative-mathsize-border-width.html
+++ b/Tests/LibWeb/Crash/CSS/negative-mathsize-border-width.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+    math { border: solid 1em; }
+</style>
+<math mathsize="-1px">
+    <mi>x</mi>
+</math>


### PR DESCRIPTION
This caused a crash when used in conjunction with border values with relative sizes.

Found with Domato.