### PR TITLE
LibWeb: Cancel the animation frame callback in MediaControls destructor

### DIFF
--- a/Libraries/LibWeb/HTML/MediaControls.cpp
+++ b/Libraries/LibWeb/HTML/MediaControls.cpp
@@ -130,6 +130,11 @@ void MediaControls::remove_event_listeners()
         target->remove_event_listener_without_options(event_name, *listener);
     }
     m_registered_event_listeners.clear();
+
+    if (m_media_element) {
+        auto& window = as<HTML::Window>(m_media_element->realm().global_object());
+        window.cancel_animation_frame(m_request_animation_frame_id);
+    }
 }
 
 void MediaControls::set_up_event_listeners()
@@ -417,13 +422,13 @@ void MediaControls::set_up_event_listeners()
 
             auto& realm = m_media_element->realm();
             auto& window = as<HTML::Window>(realm.global_object());
-            window.request_animation_frame(*m_request_animation_frame_callback);
+            m_request_animation_frame_id = window.request_animation_frame(*m_request_animation_frame_callback);
 
             return JS::js_undefined();
         },
         0, Utf16FlyString {}, &realm);
     m_request_animation_frame_callback = realm.heap().allocate<WebIDL::CallbackType>(request_animation_frame_callback_function, realm);
-    window.request_animation_frame(*m_request_animation_frame_callback);
+    m_request_animation_frame_id = window.request_animation_frame(*m_request_animation_frame_callback);
 }
 
 void MediaControls::toggle_playback()

--- a/Libraries/LibWeb/HTML/MediaControls.h
+++ b/Libraries/LibWeb/HTML/MediaControls.h
@@ -74,6 +74,7 @@ private:
     };
     Vector<RegisteredEventListener> m_registered_event_listeners;
     GC::Weak<WebIDL::CallbackType> m_request_animation_frame_callback;
+    u32 m_request_animation_frame_id { 0 };
 
     enum class Scrubbing : u8 {
         No,

--- a/Tests/LibWeb/Text/expected/video-remove-controls.txt
+++ b/Tests/LibWeb/Text/expected/video-remove-controls.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/video-remove-controls.html
+++ b/Tests/LibWeb/Text/input/video-remove-controls.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        const video = document.createElement("video");
+        video.controls = true;
+        document.body.appendChild(video);
+
+        video.controls = false;
+
+        requestAnimationFrame(() => {
+            println("PASS (didn't crash)");
+            done();
+        });
+    });
+</script>


### PR DESCRIPTION
Otherwise, when hiding controls, we would get a UAF on `MediaControls::update_timeline()` and crash.