### PR TITLE
LibWeb: Invalidate paint caches of inline ancestors on selection change

### DIFF
--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -349,10 +349,17 @@ void Paintable::set_selection_state(SelectionState state)
     if (m_selection_state == state)
         return;
     m_selection_state = state;
-    if (auto* box = as_if<PaintableBox>(this))
+    if (auto* box = as_if<PaintableBox>(this)) {
         box->invalidate_paint_cache();
-    else if (auto* containing_block = this->containing_block())
+    } else if (auto* containing_block = this->containing_block()) {
         containing_block->invalidate_paint_cache();
+        for (auto const* ancestor = layout_node().parent(); ancestor && ancestor != &containing_block->layout_node(); ancestor = ancestor->parent()) {
+            for (auto& paintable : ancestor->paintables()) {
+                if (auto* ancestor_box = as_if<PaintableBox>(paintable))
+                    ancestor_box->invalidate_paint_cache();
+            }
+        }
+    }
 }
 
 void Paintable::scroll_ancestor_to_offset_into_view(size_t offset)

--- a/Tests/LibWeb/Ref/expected/selection-in-inline-element-ref.html
+++ b/Tests/LibWeb/Ref/expected/selection-in-inline-element-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+p {
+    font-size: 20px;
+    line-height: 1.5;
+    margin: 10px 0;
+}
+
+.selected {
+    background-color: red;
+}
+</style>
+
+<p><span class="selected">Hello World</span></p>

--- a/Tests/LibWeb/Ref/input/selection-in-inline-element.html
+++ b/Tests/LibWeb/Ref/input/selection-in-inline-element.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/selection-in-inline-element-ref.html">
+<style>
+p {
+    font-size: 20px;
+    line-height: 1.5;
+    margin: 10px 0;
+}
+
+p::selection {
+    background-color: red;
+}
+
+span::selection {
+    background-color: red;
+}
+</style>
+
+<p><span id="target">Hello World</span></p>
+
+<script>
+const range = document.createRange();
+range.selectNodeContents(document.getElementById("target"));
+getSelection().addRange(range);
+</script>

--- a/Tests/LibWeb/Text/expected/display_list/inline-selection-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/inline-selection-paint-invalidation.txt
@@ -1,0 +1,1 @@
+New FillRect commands after selection: 4

--- a/Tests/LibWeb/Text/input/display_list/inline-selection-paint-invalidation.html
+++ b/Tests/LibWeb/Text/input/display_list/inline-selection-paint-invalidation.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div>
+    <span id="target">Split<br>over<br>multiple<br>lines</span>
+</div>
+<script>
+test(() => {
+    const before = internals.dumpDisplayList();
+    const fillRectsBefore = before.split('\n').filter(l => l.includes('FillRect')).length;
+
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById('target'));
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    const after = internals.dumpDisplayList();
+    const fillRectsAfter = after.split('\n').filter(l => l.includes('FillRect')).length;
+
+    println(`New FillRect commands after selection: ${fillRectsAfter - fillRectsBefore}`);
+});
+</script>


### PR DESCRIPTION
This change resolves issue #8465.

After commit `5bfc4a3` (which introduced display list command caching per paintable), selecting text in an `<h1>` that wraps its content in an inline element (like `<span>`) no longer shows the selection highlight.

Now, with my fix, instead of only invalidating the containing block's cache, it walks up through all ancestor `PaintableBox` nodes up to and including the containing block, invalidating each one. This ensures inline-level `PaintableWithLines` (like the `<span>`'s per-line paintable) also get their caches cleared when selection changes.