### PR TITLE
LibWeb: Ensure list has child elements before invalidating ordinals

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLOListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.cpp
@@ -38,8 +38,8 @@ void HTMLOListElement::attribute_changed(FlyString const& local_name, Optional<S
 
     if (local_name.is_one_of(HTML::AttributeNames::reversed, HTML::AttributeNames::start, HTML::AttributeNames::type)) {
         set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::HTMLOListElementOrdinalValues);
-        if (has_children())
-            first_child_of_type<Element>()->maybe_invalidate_ordinals_for_list_owner();
+        if (auto* first_child_element = first_child_of_type<Element>())
+            first_child_element->maybe_invalidate_ordinals_for_list_owner();
     }
 }
 

--- a/Tests/LibWeb/Crash/HTML/ol-attribute-changed-no-element-children.html
+++ b/Tests/LibWeb/Crash/HTML/ol-attribute-changed-no-element-children.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<ol>text only</ol>
+<script>
+    document.querySelector("ol").setAttribute("reversed", "");
+</script>


### PR DESCRIPTION
Previously, updating the `reversed`, `start` or `type` attribute of an ordered list with text only children would cause a crash.

Found with Domato.