### PR TITLE
LibWeb: Fix canvas and WebGL crashes on detached documents

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -248,7 +248,9 @@ void CanvasRenderingContext2D::allocate_painting_surface_if_needed()
 
     auto color_type = m_context_attributes.alpha ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
 
-    auto skia_backend_context = canvas_element().navigable()->traversable_navigable()->skia_backend_context();
+    RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
+    if (auto navigable = canvas_element().navigable())
+        skia_backend_context = navigable->traversable_navigable()->skia_backend_context();
     m_surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, canvas_element().bitmap_size_for_canvas(), color_type, Gfx::AlphaType::Premultiplied);
     m_painter = nullptr;
 
@@ -279,6 +281,8 @@ Gfx::Path CanvasRenderingContext2D::text_path(Utf16String const& text, float x, 
     auto& drawing_state = this->drawing_state();
 
     auto const& font_cascade_list = this->font_cascade_list();
+    if (!font_cascade_list)
+        return {};
     auto const& font = font_cascade_list->first();
     auto glyph_runs = Gfx::shape_text({ x, y }, text.utf16_view(), *font_cascade_list,
         resolved_letter_spacing(drawing_state, canvas_element()));
@@ -710,7 +714,10 @@ GC::Ref<TextMetrics> CanvasRenderingContext2D::measure_text(Utf16String const& t
     auto prepared_text = prepare_text(text);
     auto metrics = TextMetrics::create(realm());
     // FIXME: Use the font that was used to create the glyphs in prepared_text.
-    auto const& font = font_cascade_list()->first();
+    auto fonts = font_cascade_list();
+    if (!fonts)
+        return metrics;
+    auto const& font = fonts->first();
     auto const& font_pixel_metrics = font.pixel_metrics();
     auto const ascent = font_pixel_metrics.ascent;
     auto const descent = font_pixel_metrics.descent;
@@ -791,7 +798,10 @@ CanvasRenderingContext2D::PreparedText CanvasRenderingContext2D::prepare_text(Ut
     auto replaced_text = builder.to_utf16_string();
 
     // 3. Let font be the current font of target, as given by that object's font attribute.
-    auto glyph_runs = Gfx::shape_text({ 0, 0 }, replaced_text.utf16_view(), *font_cascade_list(),
+    auto fonts = font_cascade_list();
+    if (!fonts)
+        return {};
+    auto glyph_runs = Gfx::shape_text({ 0, 0 }, replaced_text.utf16_view(), *fonts,
         resolved_letter_spacing(drawing_state(), canvas_element()));
 
     // FIXME: 4. Let language be the target's language.

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -313,7 +313,9 @@ String HTMLCanvasElement::to_data_url(StringView type, JS::Value js_quality)
     auto size = bitmap_size_for_canvas();
     if (!surface && !size.is_empty()) {
         // If the context is not initialized yet, we need to allocate transparent surface for serialization
-        auto skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
+        RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
+        if (auto nav = navigable())
+            skia_backend_context = nav->traversable_navigable()->skia_backend_context();
         surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
     }
 
@@ -391,7 +393,9 @@ RefPtr<Gfx::Bitmap> HTMLCanvasElement::get_bitmap_from_surface()
     auto surface = this->surface();
     if (auto const size = bitmap_size_for_canvas(); !surface && !size.is_empty()) {
         // If the context is not initialized yet, we need to allocate transparent surface for serialization
-        auto const skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
+        RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
+        if (auto const nav = navigable())
+            skia_backend_context = nav->traversable_navigable()->skia_backend_context();
         surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
     }
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContext.cpp
@@ -34,7 +34,9 @@ JS::ThrowCompletionOr<GC::Ptr<WebGL2RenderingContext>> WebGL2RenderingContext::c
     // We should be coming here from getContext being called on a wrapped <canvas> element.
     auto context_attributes = TRY(convert_value_to_context_attributes_dictionary(canvas_element.vm(), options));
 
-    auto skia_backend_context = canvas_element.navigable()->traversable_navigable()->skia_backend_context();
+    RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
+    if (auto navigable = canvas_element.navigable())
+        skia_backend_context = navigable->traversable_navigable()->skia_backend_context();
     if (!skia_backend_context) {
         fire_webgl_context_creation_error(canvas_element);
         return GC::Ptr<WebGL2RenderingContext> { nullptr };

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -50,7 +50,9 @@ JS::ThrowCompletionOr<GC::Ptr<WebGLRenderingContext>> WebGLRenderingContext::cre
     // We should be coming here from getContext being called on a wrapped <canvas> element.
     auto context_attributes = TRY(convert_value_to_context_attributes_dictionary(canvas_element.vm(), options));
 
-    auto skia_backend_context = canvas_element.navigable()->traversable_navigable()->skia_backend_context();
+    RefPtr<Gfx::SkiaBackendContext> skia_backend_context;
+    if (auto navigable = canvas_element.navigable())
+        skia_backend_context = navigable->traversable_navigable()->skia_backend_context();
     if (!skia_backend_context) {
         fire_webgl_context_creation_error(canvas_element);
         return GC::Ptr<WebGLRenderingContext> { nullptr };

--- a/Tests/LibWeb/Crash/HTML/canvas-2d-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-2d-in-detached-doc.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!-- Test: Canvas 2D operations on a detached document should not crash -->
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+var canvas = doc.createElement('canvas');
+canvas.width = 100; canvas.height = 100;
+doc.body.appendChild(canvas);
+var ctx = canvas.getContext('2d');
+if (ctx) {
+    try { ctx.fillRect(0, 0, 50, 50); } catch(e) {}
+    try { ctx.strokeRect(10, 10, 30, 30); } catch(e) {}
+    try { ctx.beginPath(); ctx.arc(50,50,20,0,Math.PI*2); ctx.fill(); } catch(e) {}
+    try { ctx.beginPath(); ctx.rect(0,0,50,50); ctx.clip(); } catch(e) {}
+    try { ctx.getImageData(0, 0, 10, 10); } catch(e) {}
+    try { ctx.putImageData(new ImageData(10, 10), 0, 0); } catch(e) {}
+    try { ctx.drawImage(canvas, 0, 0); } catch(e) {}
+    try { ctx.setTransform(2,0,0,2,0,0); ctx.fillRect(0,0,10,10); } catch(e) {}
+    try { var g = ctx.createLinearGradient(0,0,100,100); g.addColorStop(0,'red'); g.addColorStop(1,'blue'); ctx.fillStyle = g; ctx.fillRect(0,0,50,50); } catch(e) {}
+    try { var p = ctx.createPattern(canvas, 'repeat'); if(p) { ctx.fillStyle = p; ctx.fillRect(0,0,50,50); } } catch(e) {}
+    try { ctx.shadowColor = 'red'; ctx.shadowBlur = 10; ctx.fillRect(0,0,50,50); } catch(e) {}
+}
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/canvas-serialize-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-serialize-in-detached-doc.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!-- Test: Canvas serialization on a detached document should not crash -->
+<html class="test-wait">
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+var canvas = doc.createElement('canvas');
+canvas.width = 100; canvas.height = 100;
+doc.body.appendChild(canvas);
+try { canvas.toDataURL(); } catch(e) {}
+try { canvas.toBlob(function(){}); } catch(e) {}
+try { createImageBitmap(canvas).catch(function(){}); } catch(e) {}
+try { var o = canvas.transferControlToOffscreen(); var c = o.getContext('2d'); if(c) c.fillRect(0,0,10,10); } catch(e) {}
+// Also test DOMParser-created canvas
+try { var p = new DOMParser(); var d = p.parseFromString('<canvas width=50 height=50></canvas>','text/html'); d.querySelector('canvas').toDataURL(); } catch(e) {}
+setTimeout(function() { document.documentElement.classList.remove('test-wait'); }, 200);
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/canvas-text-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-text-in-detached-doc.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!-- Test: Canvas text operations on a detached document should not crash -->
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+var canvas = doc.createElement('canvas');
+canvas.width = 200; canvas.height = 200;
+doc.body.appendChild(canvas);
+var ctx = canvas.getContext('2d');
+if (ctx) {
+    try { ctx.font = '5vw sans-serif'; } catch(e) {}
+    try { ctx.font = '2em serif'; } catch(e) {}
+    try { ctx.measureText('hello'); } catch(e) {}
+    try { ctx.fillText('hello', 10, 50); } catch(e) {}
+    try { ctx.strokeText('hello', 10, 50); } catch(e) {}
+    try { ctx.letterSpacing = '2px'; ctx.fillText('test', 0, 50); } catch(e) {}
+}
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/canvas-webgl-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-webgl-in-detached-doc.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<!-- Test: WebGL context creation on a detached document should not crash -->
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+var canvas = doc.createElement('canvas');
+canvas.width = 100; canvas.height = 100;
+doc.body.appendChild(canvas);
+try { canvas.getContext('webgl'); } catch(e) {}
+try { canvas.getContext('webgl2'); } catch(e) {}
+</script>
+</body>


### PR DESCRIPTION
Guard navigable() and font_cascade_list() against null when the canvas belongs to a detached document or removed iframe.