### PR TITLE
UI/Qt: Replace `QTabWidget` with a custom `TabWidget` composition

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -25,6 +25,7 @@
 #include <QActionGroup>
 #include <QGuiApplication>
 #include <QInputDialog>
+#include <QMenuBar>
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QPropertyAnimation>
@@ -32,6 +33,7 @@
 #include <QScreen>
 #include <QShortcut>
 #include <QStatusBar>
+#include <QStyle>
 #include <QTabBar>
 #include <QTimer>
 #include <QWheelEvent>
@@ -161,7 +163,6 @@ static QIcon const& app_icon()
 
 BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
     : m_tabs_container(new TabWidget(this))
-    , m_new_tab_button_toolbar(new QToolBar("New Tab", m_tabs_container))
     , m_is_popup_window(is_popup_window)
 {
     auto const& browser_options = WebView::Application::browser_options();
@@ -329,15 +330,15 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     connect(m_fullscreen_mode, &FullscreenMode::on_exit_fullscreen, this, &BrowserWindow::exit_fullscreen);
     connect(m_fullscreen_mode, &FullscreenMode::on_exit_fullscreen, m_exit_button, &ExitFullscreenButton::hide);
 
-    QObject::connect(m_tabs_container, &QTabWidget::currentChanged, [this](int index) {
-        auto* tab = as<Tab>(m_tabs_container->widget(index));
+    QObject::connect(m_tabs_container, &TabWidget::current_tab_changed, this, [this](int index) {
+        auto* tab = m_tabs_container->tab(index);
         if (tab)
             setWindowTitle(QString("%1 - Ladybird").arg(tab->title()));
 
         set_current_tab(tab);
         fullscreen_mode().exit(FullscreenMode::ExitInitiatedBy::UI);
     });
-    QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::request_to_close_tab);
+    QObject::connect(m_tabs_container, &TabWidget::tab_close_requested, this, &BrowserWindow::request_to_close_tab);
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::request_to_close_current_tab);
 
     for (int i = 0; i <= 7; ++i) {
@@ -345,7 +346,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
             if (m_tabs_container->count() <= 1)
                 return;
 
-            m_tabs_container->setCurrentIndex(min(i, m_tabs_container->count() - 1));
+            m_tabs_container->set_current_index(min(i, m_tabs_container->count() - 1));
         });
     }
 
@@ -353,7 +354,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         if (m_tabs_container->count() <= 1)
             return;
 
-        m_tabs_container->setCurrentIndex(m_tabs_container->count() - 1);
+        m_tabs_container->set_current_index(m_tabs_container->count() - 1);
     });
 
     if (parent_tab) {
@@ -364,11 +365,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         }
     }
 
-    m_new_tab_button_toolbar->addAction(m_new_tab_action);
-    m_new_tab_button_toolbar->setMovable(false);
-    m_new_tab_button_toolbar->setStyleSheet("QToolBar { background: transparent; }");
-    m_new_tab_button_toolbar->setIconSize(QSize(16, 16));
-    m_tabs_container->setCornerWidget(m_new_tab_button_toolbar, Qt::TopRightCorner);
+    m_tabs_container->set_new_tab_action(m_new_tab_action);
 
     setCentralWidget(m_tabs_container);
     setContextMenuPolicy(Qt::PreventContextMenu);
@@ -420,9 +417,9 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab, Tab& par
         set_current_tab(tab);
     }
 
-    m_tabs_container->addTab(tab, "New Tab");
+    m_tabs_container->add_tab(tab, "New Tab");
     if (activate_tab == Web::HTML::ActivateTab::Yes)
-        m_tabs_container->setCurrentWidget(tab);
+        m_tabs_container->set_current_tab(tab);
 
     initialize_tab(tab);
     return *tab;
@@ -441,9 +438,9 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
         set_current_tab(tab);
     }
 
-    m_tabs_container->addTab(tab, "New Tab");
+    m_tabs_container->add_tab(tab, "New Tab");
     if (activate_tab == Web::HTML::ActivateTab::Yes)
-        m_tabs_container->setCurrentWidget(tab);
+        m_tabs_container->set_current_tab(tab);
 
     initialize_tab(tab);
 
@@ -474,19 +471,19 @@ void BrowserWindow::initialize_tab(Tab* tab)
         return new_tab.view().handle();
     };
 
-    m_tabs_container->setTabIcon(m_tabs_container->indexOf(tab), tab->favicon());
+    m_tabs_container->set_tab_icon(m_tabs_container->index_of(tab), tab->favicon());
     create_close_button_for_tab(tab);
 }
 
 void BrowserWindow::activate_tab(int index)
 {
-    m_tabs_container->setCurrentIndex(index);
+    m_tabs_container->set_current_index(index);
 }
 
 void BrowserWindow::definitely_close_tab(int index)
 {
-    auto* tab = m_tabs_container->widget(index);
-    m_tabs_container->removeTab(index);
+    auto* tab = m_tabs_container->tab(index);
+    m_tabs_container->remove_tab(index);
     tab->deleteLater();
 
     if (m_tabs_container->count() == 0)
@@ -495,7 +492,7 @@ void BrowserWindow::definitely_close_tab(int index)
 
 void BrowserWindow::move_tab(int old_index, int new_index)
 {
-    m_tabs_container->tabBar()->moveTab(old_index, new_index);
+    m_tabs_container->tab_bar()->moveTab(old_index, new_index);
 }
 
 void BrowserWindow::open_file()
@@ -505,18 +502,18 @@ void BrowserWindow::open_file()
 
 void BrowserWindow::request_to_close_tab(int index)
 {
-    auto* tab = as<Tab>(m_tabs_container->widget(index));
+    auto* tab = m_tabs_container->tab(index);
     tab->request_close();
 }
 
 void BrowserWindow::request_to_close_current_tab()
 {
-    request_to_close_tab(m_tabs_container->currentIndex());
+    request_to_close_tab(m_tabs_container->current_index());
 }
 
 int BrowserWindow::tab_index(Tab* tab)
 {
-    return m_tabs_container->indexOf(tab);
+    return m_tabs_container->index_of(tab);
 }
 
 void BrowserWindow::device_pixel_ratio_changed(qreal dpi)
@@ -541,43 +538,43 @@ void BrowserWindow::tab_title_changed(int index, QString const& title)
     QString title_escaped = title;
     title_escaped.replace("&", "&&");
 
-    m_tabs_container->setTabText(index, title_escaped);
-    m_tabs_container->setTabToolTip(index, title);
+    m_tabs_container->set_tab_text(index, title_escaped);
+    m_tabs_container->set_tab_tooltip(index, title);
 
-    if (m_tabs_container->currentIndex() == index)
+    if (m_tabs_container->current_index() == index)
         setWindowTitle(QString("%1 - Ladybird").arg(title));
 }
 
 void BrowserWindow::tab_favicon_changed(int index, QIcon const& icon)
 {
-    m_tabs_container->setTabIcon(index, icon);
+    m_tabs_container->set_tab_icon(index, icon);
 }
 
 void BrowserWindow::create_close_button_for_tab(Tab* tab)
 {
-    auto index = m_tabs_container->indexOf(tab);
-    m_tabs_container->setTabIcon(index, tab->favicon());
+    auto index = m_tabs_container->index_of(tab);
+    m_tabs_container->set_tab_icon(index, tab->favicon());
 
     auto* button = new TabBarButton(create_tvg_icon_with_theme_colors("close", palette()));
     auto position = audio_button_position_for_tab(index) == QTabBar::LeftSide ? QTabBar::RightSide : QTabBar::LeftSide;
 
     connect(button, &QPushButton::clicked, this, [this, tab]() {
-        auto index = m_tabs_container->indexOf(tab);
+        auto index = m_tabs_container->index_of(tab);
         request_to_close_tab(index);
     });
 
-    m_tabs_container->tabBar()->setTabButton(index, position, button);
+    m_tabs_container->tab_bar()->setTabButton(index, position, button);
 }
 
 void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlayState play_state)
 {
-    auto* tab = as<Tab>(m_tabs_container->widget(index));
+    auto* tab = m_tabs_container->tab(index);
     auto position = audio_button_position_for_tab(index);
 
     switch (play_state) {
     case Web::HTML::AudioPlayState::Paused:
         if (tab->view().page_mute_state() == Web::HTML::MuteState::Unmuted)
-            m_tabs_container->tabBar()->setTabButton(index, position, nullptr);
+            m_tabs_container->tab_bar()->setTabButton(index, position, nullptr);
         break;
 
     case Web::HTML::AudioPlayState::Playing:
@@ -591,17 +588,17 @@ void BrowserWindow::tab_audio_play_state_changed(int index, Web::HTML::AudioPlay
 
             switch (tab->view().audio_play_state()) {
             case Web::HTML::AudioPlayState::Paused:
-                m_tabs_container->tabBar()->setTabButton(index, position, nullptr);
+                m_tabs_container->tab_bar()->setTabButton(index, position, nullptr);
                 break;
             case Web::HTML::AudioPlayState::Playing:
-                auto* button = m_tabs_container->tabBar()->tabButton(index, position);
+                auto* button = m_tabs_container->tab_bar()->tabButton(index, position);
                 as<TabBarButton>(button)->setIcon(icon_for_page_mute_state(*tab));
                 button->setToolTip(tool_tip_for_page_mute_state(*tab));
                 break;
             }
         });
 
-        m_tabs_container->tabBar()->setTabButton(index, position, button);
+        m_tabs_container->tab_bar()->setTabButton(index, position, button);
         break;
     }
 }
@@ -632,7 +629,7 @@ QString BrowserWindow::tool_tip_for_page_mute_state(Tab& tab) const
 
 QTabBar::ButtonPosition BrowserWindow::audio_button_position_for_tab(int tab_index) const
 {
-    if (auto* button = m_tabs_container->tabBar()->tabButton(tab_index, QTabBar::LeftSide)) {
+    if (auto* button = m_tabs_container->tab_bar()->tabButton(tab_index, QTabBar::LeftSide)) {
         if (button->objectName() != "LadybirdAudioState")
             return QTabBar::RightSide;
     }
@@ -645,10 +642,10 @@ void BrowserWindow::open_next_tab()
     if (m_tabs_container->count() <= 1)
         return;
 
-    auto next_index = m_tabs_container->currentIndex() + 1;
+    auto next_index = m_tabs_container->current_index() + 1;
     if (next_index >= m_tabs_container->count())
         next_index = 0;
-    m_tabs_container->setCurrentIndex(next_index);
+    m_tabs_container->set_current_index(next_index);
 }
 
 void BrowserWindow::open_previous_tab()
@@ -656,10 +653,10 @@ void BrowserWindow::open_previous_tab()
     if (m_tabs_container->count() <= 1)
         return;
 
-    auto next_index = m_tabs_container->currentIndex() - 1;
+    auto next_index = m_tabs_container->current_index() - 1;
     if (next_index < 0)
         next_index = m_tabs_container->count() - 1;
-    m_tabs_container->setCurrentIndex(next_index);
+    m_tabs_container->set_current_index(next_index);
 }
 
 void BrowserWindow::show_find_in_page()
@@ -684,16 +681,14 @@ void BrowserWindow::set_window_rect(Optional<Web::DevicePixels> x, Optional<Web:
 
 void BrowserWindow::enter_fullscreen()
 {
-    m_tabs_container->tabBar()->hide();
-    m_tabs_container->cornerWidget()->hide();
+    m_tabs_container->set_tab_bar_visible(false);
     m_restore_to_maximized = isMaximized();
     showFullScreen();
 }
 
 void BrowserWindow::exit_fullscreen()
 {
-    m_tabs_container->tabBar()->show();
-    m_tabs_container->cornerWidget()->show();
+    m_tabs_container->set_tab_bar_visible(true);
     if (m_restore_to_maximized)
         showMaximized();
     else
@@ -762,24 +757,6 @@ void BrowserWindow::wheelEvent(QWheelEvent* event)
         else if (event->angleDelta().y() < 0)
             m_current_tab->view().zoom_out();
     }
-}
-
-bool BrowserWindow::eventFilter(QObject* obj, QEvent* event)
-{
-    if (event->type() == QEvent::MouseButtonRelease) {
-        auto const* const mouse_event = static_cast<QMouseEvent*>(event);
-        if (mouse_event->button() == Qt::MouseButton::MiddleButton) {
-            if (obj == m_tabs_container) {
-                auto const tab_index = m_tabs_container->tabBar()->tabAt(mouse_event->pos());
-                if (tab_index != -1) {
-                    request_to_close_tab(tab_index);
-                    return true;
-                }
-            }
-        }
-    }
-
-    return QMainWindow::eventFilter(obj, event);
 }
 
 void BrowserWindow::closeEvent(QCloseEvent* event)

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -11,14 +11,12 @@
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWebView/Forward.h>
 #include <UI/Qt/Tab.h>
+#include <UI/Qt/TabBar.h>
 
 #include <QIcon>
 #include <QMainWindow>
-#include <QMenuBar>
 #include <QPushButton>
 #include <QTabBar>
-#include <QTabWidget>
-#include <QToolBar>
 
 class QPropertyAnimation;
 
@@ -129,9 +127,6 @@ public slots:
     void enter_fullscreen();
     void exit_fullscreen();
 
-protected:
-    bool eventFilter(QObject* obj, QEvent* event) override;
-
 private:
     virtual bool event(QEvent*) override;
     virtual void resizeEvent(QResizeEvent*) override;
@@ -148,10 +143,8 @@ private:
     template<typename Callback>
     void for_each_tab(Callback&& callback)
     {
-        for (int i = 0; i < m_tabs_container->count(); ++i) {
-            auto& tab = as<Tab>(*m_tabs_container->widget(i));
-            callback(tab);
-        }
+        for (int i = 0; i < m_tabs_container->count(); ++i)
+            callback(*m_tabs_container->tab(i));
     }
 
     void create_close_button_for_tab(Tab*);
@@ -166,10 +159,8 @@ private:
     double m_device_pixel_ratio { 0 };
     double m_refresh_rate { 60.0 };
 
-    QTabWidget* m_tabs_container { nullptr };
+    TabWidget* m_tabs_container { nullptr };
     Tab* m_current_tab { nullptr };
-
-    QToolBar* m_new_tab_button_toolbar { nullptr };
 
     QMenu* m_hamburger_menu { nullptr };
 

--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2026, Tim Flynn <trflynn89@ladybird.org>
  * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
  *
@@ -7,15 +7,16 @@
  */
 
 #include <AK/StdLibExtras.h>
-#include <AK/TypeCasts.h>
+#include <UI/Qt/Icon.h>
 #include <UI/Qt/Tab.h>
 #include <UI/Qt/TabBar.h>
 
 #include <QContextMenuEvent>
 #include <QEvent>
-#include <QPushButton>
-#include <QStyleOption>
-#include <QStylePainter>
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QToolButton>
+#include <QVBoxLayout>
 
 namespace Ladybird {
 
@@ -24,12 +25,20 @@ TabBar::TabBar(QWidget* parent)
 {
 }
 
+void TabBar::set_available_width(int width)
+{
+    if (m_available_width != width) {
+        m_available_width = width;
+        updateGeometry();
+    }
+}
+
 QSize TabBar::tabSizeHint(int index) const
 {
     auto hint = QTabBar::tabSizeHint(index);
 
     if (auto count = this->count(); count > 0) {
-        auto width = this->width() / count;
+        auto width = (m_available_width > 0 ? m_available_width : this->width()) / count;
         width = min(225, width);
         width = max(128, width);
 
@@ -41,9 +50,9 @@ QSize TabBar::tabSizeHint(int index) const
 
 void TabBar::contextMenuEvent(QContextMenuEvent* event)
 {
-    auto* tab_widget = as<QTabWidget>(this->parent());
-    auto* tab = as<Tab>(tab_widget->widget(tabAt(event->pos())));
-    if (tab)
+    auto* tab_widget = as<TabWidget>(parent());
+
+    if (auto* tab = tab_widget->tab(tabAt(event->pos())))
         tab->context_menu()->exec(event->globalPos());
 }
 
@@ -81,45 +90,139 @@ void TabBar::mouseMoveEvent(QMouseEvent* event)
 }
 
 TabWidget::TabWidget(QWidget* parent)
-    : QTabWidget(parent)
+    : QWidget(parent)
 {
-    // This must be called first, otherwise several of the options below have no effect.
-    setTabBar(new TabBar(this));
+    m_tab_bar = new TabBar(this);
+    m_tab_bar->setDocumentMode(true);
+    m_tab_bar->setElideMode(Qt::TextElideMode::ElideRight);
+    m_tab_bar->setMovable(true);
+    m_tab_bar->setTabsClosable(true);
+    m_tab_bar->setExpanding(false);
+    m_tab_bar->setUsesScrollButtons(true);
+    m_tab_bar->setDrawBase(false);
 
-    setDocumentMode(true);
-    setElideMode(Qt::TextElideMode::ElideRight);
-    setMovable(true);
-    setTabsClosable(true);
+    m_stacked_widget = new QStackedWidget(this);
 
-    setStyle(new TabStyle(this));
+    m_new_tab_button = new QToolButton(this);
+    m_new_tab_button->setIconSize(QSize(16, 16));
+    m_new_tab_button->setAutoRaise(true);
+    m_new_tab_button->setToolTip("New Tab");
 
-    installEventFilter(parent);
+    recreate_icons();
+
+    auto* tab_bar_row_layout = new QHBoxLayout;
+    tab_bar_row_layout->setSpacing(0);
+    tab_bar_row_layout->setContentsMargins(0, 0, 0, 0);
+    tab_bar_row_layout->addWidget(m_tab_bar);
+    tab_bar_row_layout->addWidget(m_new_tab_button);
+    tab_bar_row_layout->addStretch(1);
+
+    m_tab_bar_row = new QWidget(this);
+    m_tab_bar_row->setLayout(tab_bar_row_layout);
+
+    auto* main_layout = new QVBoxLayout(this);
+    main_layout->setSpacing(0);
+    main_layout->setContentsMargins(0, 0, 0, 0);
+    main_layout->addWidget(m_tab_bar_row);
+    main_layout->addWidget(m_stacked_widget, 1);
+
+    connect(m_tab_bar, &QTabBar::currentChanged, this, [this](int index) {
+        if (index >= 0 && index < m_stacked_widget->count())
+            m_stacked_widget->setCurrentIndex(index);
+
+        emit current_tab_changed(index);
+    });
+
+    connect(m_tab_bar, &QTabBar::tabCloseRequested, this, &TabWidget::tab_close_requested);
+
+    connect(m_tab_bar, &QTabBar::tabMoved, this, [this](int from, int to) {
+        ScopeGuard guard { [&]() { m_stacked_widget->blockSignals(false); } };
+        m_stacked_widget->blockSignals(true);
+
+        auto* widget = m_stacked_widget->widget(from);
+        m_stacked_widget->removeWidget(widget);
+        m_stacked_widget->insertWidget(to, widget);
+        m_stacked_widget->setCurrentIndex(m_tab_bar->currentIndex());
+    });
 }
 
-void TabWidget::paintEvent(QPaintEvent*)
+void TabWidget::add_tab(Tab* widget, QString const& label)
 {
-    auto prepare_style_options = [](QTabBar* tab_bar, QSize widget_size) {
-        QStyleOptionTabBarBase style_options;
-        QStyleOptionTab tab_overlap;
-        tab_overlap.shape = tab_bar->shape();
-        auto overlap = tab_bar->style()->pixelMetric(QStyle::PM_TabBarBaseOverlap, &tab_overlap, tab_bar);
-        style_options.initFrom(tab_bar);
-        style_options.shape = tab_bar->shape();
-        style_options.documentMode = tab_bar->documentMode();
-        // NOTE: This assumes the tab bar is at the top of the tab widget.
-        style_options.rect = { 0, widget_size.height() - overlap, widget_size.width(), overlap };
+    m_stacked_widget->addWidget(widget);
+    m_tab_bar->addTab(label);
 
-        return style_options;
-    };
+    update_tab_layout();
+}
 
-    QStylePainter painter { this, tabBar() };
-    if (auto* widget = cornerWidget(Qt::TopRightCorner)) {
-        // Manually paint the background for the area where the "new tab" button would have been
-        // if we hadn't relocated it in `TabStyle::subElementRect()`.
-        auto style_options = prepare_style_options(tabBar(), widget->size());
-        style_options.rect.translate(tabBar()->rect().width(), widget->y());
-        painter.drawPrimitive(QStyle::PE_FrameTabBarBase, style_options);
+void TabWidget::remove_tab(int index)
+{
+    auto* widget = m_stacked_widget->widget(index);
+    m_stacked_widget->removeWidget(widget);
+
+    m_tab_bar->removeTab(index);
+
+    if (m_tab_bar->count() > 0 && m_tab_bar->currentIndex() >= 0)
+        m_stacked_widget->setCurrentIndex(m_tab_bar->currentIndex());
+
+    update_tab_layout();
+}
+
+void TabWidget::set_current_tab(Tab* widget)
+{
+    if (auto index = m_stacked_widget->indexOf(widget); index >= 0)
+        set_current_index(index);
+}
+
+int TabWidget::index_of(Tab* widget) const
+{
+    return m_stacked_widget->indexOf(widget);
+}
+
+void TabWidget::set_new_tab_action(QAction* action)
+{
+    disconnect(m_new_tab_button, &QToolButton::clicked, nullptr, nullptr);
+
+    if (!action)
+        return;
+
+    connect(m_new_tab_button, &QToolButton::clicked, action, &QAction::trigger);
+}
+
+bool TabWidget::event(QEvent* event)
+{
+    if (auto type = event->type(); type == QEvent::MouseButtonRelease) {
+        auto const* mouse_event = static_cast<QMouseEvent const*>(event);
+
+        if (mouse_event->button() == Qt::MiddleButton) {
+            if (auto index = m_tab_bar->tabAt(mouse_event->pos()); index != -1) {
+                emit tab_close_requested(index);
+                return true;
+            }
+        }
+    } else if (type == QEvent::PaletteChange) {
+        recreate_icons();
     }
+
+    return QWidget::event(event);
+}
+
+void TabWidget::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    update_tab_layout();
+}
+
+void TabWidget::update_tab_layout()
+{
+    auto button_width = m_new_tab_button->sizeHint().width();
+    auto available_for_tabs = width() - button_width;
+
+    m_tab_bar->set_available_width(available_for_tabs);
+}
+
+void TabWidget::recreate_icons()
+{
+    m_new_tab_button->setIcon(create_tvg_icon_with_theme_colors("new_tab", palette()));
 }
 
 TabBarButton::TabBarButton(QIcon const& icon, QWidget* parent)
@@ -137,29 +240,6 @@ bool TabBarButton::event(QEvent* event)
         setFlat(true);
 
     return QPushButton::event(event);
-}
-
-TabStyle::TabStyle(QObject* parent)
-{
-    setParent(parent);
-}
-
-QRect TabStyle::subElementRect(QStyle::SubElement sub_element, QStyleOption const* option, QWidget const* widget) const
-{
-    // Place our add-tab button (set as the top-right corner widget) directly after the last tab
-    if (sub_element == QStyle::SE_TabWidgetRightCorner) {
-        auto* tab_widget = as<TabWidget>(widget);
-        auto tab_bar_size = tab_widget->tabBar()->sizeHint();
-        auto new_tab_button_size = tab_bar_size.height();
-        return QRect {
-            qMin(tab_bar_size.width(), tab_widget->width() - new_tab_button_size),
-            0,
-            new_tab_button_size,
-            new_tab_button_size
-        };
-    }
-
-    return QProxyStyle::subElementRect(sub_element, option, widget);
 }
 
 }

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024-2026, Tim Flynn <trflynn89@ladybird.org>
  * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
  *
@@ -8,23 +8,31 @@
 
 #pragma once
 
-#include <QProxyStyle>
-#include <QPushButton>
-#include <QTabBar>
-#include <QTabWidget>
+#include <AK/TypeCasts.h>
 
+#include <QPushButton>
+#include <QStackedWidget>
+#include <QTabBar>
+#include <QWidget>
+
+class QAction;
 class QContextMenuEvent;
 class QEvent;
 class QIcon;
-class QWidget;
+class QToolButton;
 
 namespace Ladybird {
 
-class TabBar : public QTabBar {
+class Tab;
+class TabWidget;
+
+class TabBar final : public QTabBar {
     Q_OBJECT
 
 public:
     explicit TabBar(QWidget* parent = nullptr);
+
+    void set_available_width(int width);
 
     virtual QSize tabSizeHint(int index) const override;
     virtual void contextMenuEvent(QContextMenuEvent* event) override;
@@ -33,19 +41,57 @@ private:
     void mousePressEvent(QMouseEvent*) override;
     void mouseMoveEvent(QMouseEvent*) override;
 
-    int m_x_position_in_selected_tab_while_dragging;
+    int m_available_width { 0 };
+    int m_x_position_in_selected_tab_while_dragging { 0 };
 };
 
-class TabWidget : public QTabWidget {
+class TabWidget final : public QWidget {
     Q_OBJECT
 
 public:
     explicit TabWidget(QWidget* parent = nullptr);
 
-    virtual void paintEvent(QPaintEvent*) override;
+    TabBar* tab_bar() const { return m_tab_bar; }
+
+    void add_tab(Tab* widget, QString const& label);
+    void remove_tab(int index);
+
+    int count() const { return m_tab_bar->count(); }
+
+    int current_index() const { return m_tab_bar->currentIndex(); }
+    void set_current_index(int index) { m_tab_bar->setCurrentIndex(index); }
+
+    Tab* tab(int index) const { return as<Tab>(m_stacked_widget->widget(index)); }
+    void set_current_tab(Tab*);
+
+    int index_of(Tab* widget) const;
+
+    void set_tab_text(int index, QString const& text) { m_tab_bar->setTabText(index, text); }
+    void set_tab_tooltip(int index, QString const& tip) { m_tab_bar->setTabToolTip(index, tip); }
+    void set_tab_icon(int index, QIcon const& icon) { m_tab_bar->setTabIcon(index, icon); }
+
+    void set_tab_bar_visible(bool visible) { m_tab_bar_row->setVisible(visible); }
+    void set_new_tab_action(QAction* action);
+
+signals:
+    void current_tab_changed(int index);
+    void tab_close_requested(int index);
+
+protected:
+    virtual bool event(QEvent* event) override;
+    virtual void resizeEvent(QResizeEvent*) override;
+
+private:
+    void update_tab_layout();
+    void recreate_icons();
+
+    TabBar* m_tab_bar { nullptr };
+    QStackedWidget* m_stacked_widget { nullptr };
+    QToolButton* m_new_tab_button { nullptr };
+    QWidget* m_tab_bar_row { nullptr };
 };
 
-class TabBarButton : public QPushButton {
+class TabBarButton final : public QPushButton {
     Q_OBJECT
 
 public:
@@ -53,15 +99,6 @@ public:
 
 protected:
     virtual bool event(QEvent* event) override;
-};
-
-class TabStyle : public QProxyStyle {
-    Q_OBJECT
-
-public:
-    explicit TabStyle(QObject* parent = nullptr);
-
-    virtual QRect subElementRect(QStyle::SubElement, QStyleOption const*, QWidget const*) const override;
 };
 
 }


### PR DESCRIPTION
`QTabWidget`'s built-in tab bar management made it difficult to properly position the new tab button, and caused visual artifacts with the separator line across themes.

Replace `QTabWidget` with a custom `TabWidget` that places a `QTabBar` alongside an explicit new tab button. This us gives full control over the tab bar row layout.

Fixes #768

