### PR TITLE
LibWeb: Fix CSS style computation crashes on detached documents

### DIFF
--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -126,12 +126,15 @@ Length::ResolutionContext Length::ResolutionContext::for_element(DOM::AbstractEl
 {
     auto const* root_element = element.element().document().document_element();
 
-    VERIFY(element.computed_properties());
-    VERIFY(root_element);
-    VERIFY(root_element->computed_properties());
+    if (!element.computed_properties() || !root_element || !root_element->computed_properties())
+        return for_document(element.element().document());
+
+    CSSPixelRect viewport_rect;
+    if (auto navigable = element.element().navigable())
+        viewport_rect = navigable->viewport_rect();
 
     return Length::ResolutionContext {
-        .viewport_rect = element.element().navigable()->viewport_rect(),
+        .viewport_rect = viewport_rect,
         .font_metrics = { element.computed_properties()->font_size(), element.computed_properties()->first_available_computed_font(element.document().font_computer())->pixel_metrics(), element.computed_properties()->line_height() },
         .root_font_metrics = { root_element->computed_properties()->font_size(), root_element->computed_properties()->first_available_computed_font(element.document().font_computer())->pixel_metrics(), element.computed_properties()->line_height() }
     };

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1355,7 +1355,7 @@ LogicalAliasMappingContext StyleComputer::compute_logical_alias_mapping_context(
 {
     auto normalize_value = [&](auto property_id, auto value) {
         if (!value || value->is_inherit() || value->is_unset()) {
-            if (auto const inheritance_parent = abstract_element.element_to_inherit_style_from(); inheritance_parent.has_value()) {
+            if (auto const inheritance_parent = abstract_element.element_to_inherit_style_from(); inheritance_parent.has_value() && inheritance_parent->computed_properties()) {
                 value = inheritance_parent->computed_properties()->property(property_id);
             } else {
                 value = property_initial_value(property_id);
@@ -1461,7 +1461,7 @@ ComputationContext const& StyleComputer::get_computation_context_for_property(Pr
             auto line_height_font_metrics = Length::FontMetrics {
                 style.font_size(),
                 style.first_available_computed_font(document().font_computer())->pixel_metrics(),
-                inheritance_parent.has_value() ? inheritance_parent->computed_properties()->line_height() : InitialValues::line_height()
+                (inheritance_parent.has_value() && inheritance_parent->computed_properties()) ? inheritance_parent->computed_properties()->line_height() : InitialValues::line_height()
             };
 
             m_cached_line_height_computation_context = {
@@ -2448,11 +2448,11 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_size(NonnullRefPtr<S
     // https://drafts.csswg.org/css-fonts/#font-size-prop
     // an absolute length
 
-    auto inherited_font_size = inheritance_parent.has_value()
+    auto inherited_font_size = (inheritance_parent.has_value() && inheritance_parent->computed_properties())
         ? inheritance_parent->computed_properties()->font_size()
         : InitialValues::font_size();
 
-    auto inherited_math_depth = inheritance_parent.has_value()
+    auto inherited_math_depth = (inheritance_parent.has_value() && inheritance_parent->computed_properties())
         ? inheritance_parent->computed_properties()->math_depth()
         : InitialValues::math_depth();
 
@@ -2537,7 +2537,7 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_font_weight(NonnullRefPtr
     // https://drafts.csswg.org/css-fonts-4/#font-weight-prop
     // a number, see below
 
-    auto inherited_font_weight = inheritance_parent.has_value()
+    auto inherited_font_weight = (inheritance_parent.has_value() && inheritance_parent->computed_properties())
         ? inheritance_parent->computed_properties()->font_weight()
         : InitialValues::font_weight();
 
@@ -2800,11 +2800,11 @@ NonnullRefPtr<StyleValue const> StyleComputer::compute_position_area(NonnullRefP
 // https://w3c.github.io/mathml-core/#propdef-math-depth
 NonnullRefPtr<StyleValue const> StyleComputer::compute_math_depth(NonnullRefPtr<StyleValue const> const& absolutized_value, Optional<DOM::AbstractElement> const& inheritance_parent)
 {
-    auto inherited_math_depth = inheritance_parent.has_value()
+    auto inherited_math_depth = (inheritance_parent.has_value() && inheritance_parent->computed_properties())
         ? inheritance_parent->computed_properties()->math_depth()
         : InitialValues::math_depth();
 
-    auto inherited_math_style = inheritance_parent.has_value()
+    auto inherited_math_style = (inheritance_parent.has_value() && inheritance_parent->computed_properties())
         ? inheritance_parent->computed_properties()->math_style()
         : InitialValues::math_style();
 

--- a/Tests/LibWeb/Crash/HTML/css-viewport-units-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/css-viewport-units-in-detached-doc.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<!-- Test: Viewport-relative CSS units in a detached document should not crash -->
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+var div = doc.createElement('div');
+div.style.cssText = 'width:50vw;height:50vh;font-size:5vmin;margin:2vmax;';
+doc.body.appendChild(div);
+try { void getComputedStyle(div).width; } catch(e) {}
+try { void div.offsetWidth; } catch(e) {}
+try { void div.getBoundingClientRect(); } catch(e) {}
+</script>
+</body>


### PR DESCRIPTION
Replace VERIFY assertions with fallbacks in Length::for_element() when computed_properties or root element is null. Guard inheritance_parent->computed_properties() in StyleComputer.