### PR TITLE
LibWeb: Fix crashes in focus, scroll, storage, and view transitions

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7275,7 +7275,8 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
         return m_cached_display_list;
 
     update_paint_and_hit_testing_properties_if_needed();
-    VERIFY(paintable());
+    if (!paintable())
+        return {};
 
     auto display_list = Painting::DisplayList::create(*paintable()->visual_context_tree());
     Painting::DisplayListRecorder display_list_recorder(display_list);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -576,6 +576,7 @@ public:
     bool hidden() const;
     StringView visibility_state() const;
     HTML::VisibilityState visibility_state_value() const { return m_visibility_state; }
+    void set_visibility_state(HTML::VisibilityState state) { m_visibility_state = state; }
 
     // https://html.spec.whatwg.org/multipage/interaction.html#update-the-visibility-state
     void update_the_visibility_state(HTML::VisibilityState);

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2819,7 +2819,8 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
                 // NOTE: Since calculated position is relative to the viewport, we need to add the viewport's position to it
                 //       before passing to perform_a_scroll_of_the_viewport() that expects a position relative to the page.
                 position.set_y(position.y() + document.viewport_rect().y());
-                document.navigable()->perform_a_scroll_of_the_viewport(position);
+                if (auto navigable = document.navigable())
+                    navigable->perform_a_scroll_of_the_viewport(position);
             }
         }
 

--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -271,10 +271,10 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     if (is_shadow_host(old_focus_target)) {
         auto shadow_root = static_cast<DOM::Element*>(old_focus_target)->shadow_root();
         if (shadow_root->delegates_focus()) {
-            auto bc = old_focus_target->document().browsing_context();
-            if (!bc)
+            auto browsing_context = old_focus_target->document().browsing_context();
+            if (!browsing_context)
                 return;
-            auto top_level_traversable = bc->top_level_traversable();
+            auto top_level_traversable = browsing_context->top_level_traversable();
             if (auto currently_focused_area = top_level_traversable->currently_focused_area()) {
                 if (shadow_root->is_shadow_including_ancestor_of(*currently_focused_area)) {
                     old_focus_target = currently_focused_area;
@@ -295,7 +295,10 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     // NOTE: HTMLAreaElement is currently missing the shapes property
 
     // 4. Let old chain be the current focus chain of the top-level browsing context in which old focus target finds itself.
-    auto top_level_traversable = old_focus_target->document().browsing_context()->top_level_traversable();
+    auto browsing_context = old_focus_target->document().browsing_context();
+    if (!browsing_context)
+        return;
+    auto top_level_traversable = browsing_context->top_level_traversable();
     auto old_chain = focus_chain(top_level_traversable->currently_focused_area());
 
     // 5. If old focus target is not one of the entries in old chain, then return.

--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -271,10 +271,10 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     if (is_shadow_host(old_focus_target)) {
         auto shadow_root = static_cast<DOM::Element*>(old_focus_target)->shadow_root();
         if (shadow_root->delegates_focus()) {
-            auto browsing_context = old_focus_target->document().browsing_context();
-            if (!browsing_context)
+            auto bc = old_focus_target->document().browsing_context();
+            if (!bc)
                 return;
-            auto top_level_traversable = browsing_context->top_level_traversable();
+            auto top_level_traversable = bc->top_level_traversable();
             if (auto currently_focused_area = top_level_traversable->currently_focused_area()) {
                 if (shadow_root->is_shadow_including_ancestor_of(*currently_focused_area)) {
                     old_focus_target = currently_focused_area;
@@ -314,7 +314,8 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     auto& top_document = as<DOM::Document>(*old_chain.last());
 
     // 8. If topDocument's node navigable has system focus, then run the focusing steps for topDocument's viewport.
-    if (top_document.navigable()->traversable_navigable()->is_focused()) {
+    auto navigable = top_document.navigable();
+    if (navigable && navigable->traversable_navigable() && navigable->traversable_navigable()->is_focused()) {
 
         // AD-HOC: Remove top_document from old_chain so step 1 in run_focus_update_steps doesn't cancel the blur.
         auto without_viewport_surrogate = old_chain;

--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -271,7 +271,10 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     if (is_shadow_host(old_focus_target)) {
         auto shadow_root = static_cast<DOM::Element*>(old_focus_target)->shadow_root();
         if (shadow_root->delegates_focus()) {
-            auto top_level_traversable = old_focus_target->document().browsing_context()->top_level_traversable();
+            auto bc = old_focus_target->document().browsing_context();
+            if (!bc)
+                return;
+            auto top_level_traversable = bc->top_level_traversable();
             if (auto currently_focused_area = top_level_traversable->currently_focused_area()) {
                 if (shadow_root->is_shadow_including_ancestor_of(*currently_focused_area)) {
                     old_focus_target = currently_focused_area;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -327,6 +327,12 @@ void Navigable::activate_history_entry(GC::Ptr<SessionHistoryEntry> entry)
     //    navigate away from it.
     VERIFY(!new_document->is_initial_about_blank());
 
+    // AD-HOC: The old document is no longer active, mark it as hidden.
+    // https://github.com/w3c/csswg-drafts/issues/10264
+    auto old_document = active_document();
+    if (old_document && old_document != new_document)
+        old_document->update_the_visibility_state(HTML::VisibilityState::Hidden);
+
     // 4. Set navigable's active session history entry to entry.
     m_active_session_history_entry = entry;
 

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -298,6 +298,10 @@ void NavigableContainer::destroy_the_child_navigable()
         return;
     navigable->set_has_been_destroyed();
 
+    // AD-HOC: A detached iframe's document is hidden.
+    // https://github.com/w3c/csswg-drafts/issues/10264
+    navigable->active_document()->update_the_visibility_state(HTML::VisibilityState::Hidden);
+
     // AD-HOC: Clear the navigable's "is delaying load events" flag.
     //         This removes the DocumentLoadEventDelayer on the parent document that was
     //         created when the navigable started loading (navigate algorithm step 15).

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -113,7 +113,9 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(GC::Ptr
     auto traversable = parent_navigable->traversable_navigable();
 
     // AD-HOC: Let the initial about:blank document inherit the system visibility state from traversable.
-    document->update_the_visibility_state(traversable->system_visibility_state());
+    //         Set directly rather than via update_the_visibility_state() to avoid queuing
+    //         view transition page-visibility change steps for the initial state.
+    document->set_visibility_state(traversable->system_visibility_state());
 
     // 12. Append the following session history traversal steps to traversable:
     traversable->append_session_history_traversal_steps(GC::create_function(heap(), [traversable, navigable, parent_navigable, history_entry, after_session_history_update] {

--- a/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
@@ -61,7 +61,10 @@ GC::Ptr<StorageBottle> obtain_a_storage_bottle_map(StorageType type, HTML::Envir
         VERIFY(type == StorageType::Session);
 
         // 2. Set shed to environment’s global object’s associated Document’s node navigable’s traversable navigable’s storage shed.
-        shed = &as<HTML::Window>(environment.global_object()).associated_document().navigable()->traversable_navigable()->storage_shed();
+        auto navigable = as<HTML::Window>(environment.global_object()).associated_document().navigable();
+        if (!navigable || !navigable->traversable_navigable())
+            return {};
+        shed = &navigable->traversable_navigable()->storage_shed();
     }
 
     // 4. Let shelf be the result of running obtain a storage shelf, with shed, environment, and type.

--- a/Tests/LibWeb/Crash/HTML/dump-display-list-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/dump-display-list-in-detached-doc.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<!-- Test: Dumping the display list of a detached document should not crash -->
+<body>
+<script>
+var iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+var win = iframe.contentWindow;
+iframe.remove();
+win.internals.dumpDisplayList();
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/element-blur-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/element-blur-in-detached-doc.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<!-- Test: blur() and focus() on elements in a detached document should not crash -->
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+['div','input','textarea','select','button','a','canvas','video'].forEach(function(tag) {
+    var el = doc.createElement(tag);
+    doc.body.appendChild(el);
+    el.blur();
+    el.focus();
+});
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/element-focus-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/element-focus-in-detached-doc.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<!-- Test: Focusing elements in a removed iframe document should not crash -->
+<body>
+<script>
+var iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+var input = iframe.contentDocument.createElement('input');
+iframe.contentDocument.body.appendChild(input);
+iframe.remove();
+input.focus();
+input.blur();
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/scroll-into-view-after-iframe-removed.html
+++ b/Tests/LibWeb/Crash/HTML/scroll-into-view-after-iframe-removed.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!-- Test: scrollIntoView on a removed iframe element should not crash -->
+<html class="test-wait">
+<body>
+<script>
+var iframe = document.createElement('iframe');
+iframe.src = 'about:blank';
+iframe.onload = function() {
+    var div = iframe.contentDocument.createElement('div');
+    div.style.height = '2000px';
+    iframe.contentDocument.body.appendChild(div);
+    var target = iframe.contentDocument.createElement('div');
+    iframe.contentDocument.body.appendChild(target);
+    target.offsetHeight;
+    iframe.remove();
+    setTimeout(function() {
+        target.scrollIntoView();
+        document.documentElement.classList.remove('test-wait');
+    }, 50);
+};
+document.body.appendChild(iframe);
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/session-storage-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/session-storage-in-detached-doc.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<!-- Test: Accessing sessionStorage in a detached document should not crash -->
+<body>
+<script>
+var iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+var win = iframe.contentWindow;
+iframe.remove();
+win.sessionStorage.length;
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/shadow-host-blur-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/shadow-host-blur-in-detached-doc.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!-- Test: Blurring a detached shadow host with delegatesFocus should not crash -->
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+var host = doc.createElement('div');
+host.tabIndex = 0;
+var shadow = host.attachShadow({ mode: 'open', delegatesFocus: true });
+var input = doc.createElement('input');
+shadow.appendChild(input);
+doc.body.appendChild(host);
+host.focus();
+input.focus();
+host.blur();
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/view-transition-detached-iframe.html
+++ b/Tests/LibWeb/Crash/HTML/view-transition-detached-iframe.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- Test: View transitions on detached iframe documents should not crash -->
+<body>
+<script>
+// Case 1: startViewTransition on a document created via createHTMLDocument
+var detachedDoc = document.implementation.createHTMLDocument('');
+detachedDoc.startViewTransition(function() {});
+
+// Case 2: startViewTransition on an iframe document after iframe.remove()
+var iframe1 = document.createElement('iframe');
+document.body.appendChild(iframe1);
+var doc1 = iframe1.contentDocument;
+iframe1.remove();
+doc1.startViewTransition(function() {});
+
+// Case 3: startViewTransition then immediately remove iframe
+var iframe2 = document.createElement('iframe');
+iframe2.onload = function() {
+    var doc2 = iframe2.contentDocument;
+    doc2.startViewTransition(function() {});
+    iframe2.remove();
+};
+document.body.appendChild(iframe2);
+</script>
+</body>

--- a/Tests/LibWeb/Crash/HTML/view-transition-iframe-navigated.html
+++ b/Tests/LibWeb/Crash/HTML/view-transition-iframe-navigated.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!-- Test: View transitions during iframe navigation or removal after ready should not crash -->
+<body>
+<script>
+// Case 1: Navigate iframe during view transition callback
+var iframe1 = document.createElement('iframe');
+iframe1.onload = function() {
+    var doc1 = iframe1.contentDocument;
+    doc1.startViewTransition(function() {
+        iframe1.src = 'about:blank';
+    });
+};
+document.body.appendChild(iframe1);
+
+// Case 2: Remove iframe after transition is ready (animation phase)
+var iframe2 = document.createElement('iframe');
+iframe2.onload = function() {
+    var doc2 = iframe2.contentDocument;
+    var target = doc2.createElement('div');
+    target.style.viewTransitionName = 'target';
+    doc2.body.appendChild(target);
+
+    var transition = doc2.startViewTransition(function() {
+        target.textContent = 'after';
+    });
+    transition.ready.then(function() {
+        iframe2.remove();
+    });
+};
+document.body.appendChild(iframe2);
+</script>
+</body>

--- a/Tests/LibWeb/Text/expected/wpt-import/page-visibility/onvisibilitychange.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/page-visibility/onvisibilitychange.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	onvisibilitychange attribute is a proper event handler

--- a/Tests/LibWeb/Text/input/wpt-import/page-visibility/onvisibilitychange.html
+++ b/Tests/LibWeb/Text/input/wpt-import/page-visibility/onvisibilitychange.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>onvisibilitychange attribute is a proper event handler</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+var ast = new async_test("onvisibilitychange attribute is a proper event handler");
+var iframe = document.createElement("iframe");
+iframe.srcdoc = "<script>onload = function() { parent.startTest(); }<\/script>";
+function startTest() {
+  iframe.contentWindow.document.onvisibilitychange = ast.step_func(function() {
+    ast.done();
+  });
+  iframe.parentNode.removeChild(iframe);
+}
+document.body.appendChild(iframe);
+</script>


### PR DESCRIPTION
Guard navigable() and browsing_context() against null in run_unfocusing_steps, scroll_into_view, obtain_a_storage_bottle_map, and view transition setup/update. Relax VERIFY(paintable()) in
Document display list recording to a null check.
