### PR TITLE
LibWeb: Fix canvas text crashes on detached documents

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
@@ -112,7 +112,7 @@ void CanvasTextDrawingStyles<IncludingClass, CanvasType>::set_font(StringView fo
             // NOTE: The initial value here is non-standard as the default font is "10px sans-serif"
             // FIXME: Investigate whether this is the correct resolution context (i.e. whether we should instead use
             //        a font-size of 10px) for OffscreenCanvas
-            auto length_resolution_context = CSS::Length::ResolutionContext::for_window(*document->window());
+            auto length_resolution_context = CSS::Length::ResolutionContext::for_document(*document);
             Optional<DOM::AbstractElement> abstract_element;
 
             if constexpr (SameAs<CanvasType, HTML::HTMLCanvasElement>) {

--- a/Tests/LibWeb/Crash/HTML/canvas-text-in-detached-doc.html
+++ b/Tests/LibWeb/Crash/HTML/canvas-text-in-detached-doc.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<body>
+<script>
+var doc = document.implementation.createHTMLDocument('');
+var canvas = doc.createElement('canvas');
+canvas.width = 100; canvas.height = 100;
+doc.body.appendChild(canvas);
+var ctx = canvas.getContext('2d');
+if (ctx) {
+    ctx.font = '5vw sans-serif';
+    ctx.fillText('hello', 10, 50);
+    ctx.strokeText('hello', 10, 50);
+    ctx.measureText('hello');
+}
+</script>
+</body>


### PR DESCRIPTION
Guard font_cascade_list() and document window against null in
canvas text operations on documents without a navigable.
