### PR TITLE
LibWeb: Use GC::Weak for the legacy mouse pointer's hovered node

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -137,7 +137,7 @@ private:
 
     NonnullOwnPtr<DragAndDropEventHandler> m_drag_and_drop_event_handler;
 
-    GC::RawPtr<DOM::Node> m_effective_legacy_mouse_pointer_position;
+    GC::Weak<DOM::Node> m_effective_legacy_mouse_pointer_position;
 
     GC::Weak<DOM::Node> m_mousedown_target;
     int m_mousedown_click_count { 0 };


### PR DESCRIPTION
A stale GCed node pointer could end up coincidentally being the same as the next one that gets hovered, and so the hover state wouldn't update. This caused a flake on button-hover-text-color.html because the hovered node wasn't being updated to the one on the newly loaded document.

Since this is GC-dependent and already somewhat covered by that test, a new one has not been added here.