### PR TITLE
LibWeb: Seed ancestor context for no-layout-node getComputedStyle

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleProperties.cpp
@@ -589,7 +589,10 @@ Optional<StyleProperty> CSSStyleProperties::get_direct_property(PropertyNameAndI
         }
 
         if (!layout_node) {
-            auto style = abstract_element.document().style_computer().compute_style(abstract_element);
+            // Seed the ancestor chain before this one-off style computation, so
+            // ancestor-dependent selectors still match for no `layout_node`
+            // queries (for example `.outer .inner .target`).
+            auto style = abstract_element.document().style_computer().compute_style_with_seeded_ancestors(abstract_element);
             return StyleProperty {
                 .property_id = property_id,
                 .value = style->property(property_id),

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1725,6 +1725,20 @@ GC::Ref<ComputedProperties> StyleComputer::compute_style(DOM::AbstractElement ab
     return *compute_style_impl(abstract_element, ComputeStyleMode::Normal, did_change_custom_properties, style_scope);
 }
 
+GC::Ref<ComputedProperties> StyleComputer::compute_style_with_seeded_ancestors(DOM::AbstractElement abstract_element)
+{
+    for (auto parent = abstract_element.parent_element(); parent; parent = parent->parent_element()) {
+        push_ancestor(*parent);
+    }
+
+    ScopeGuard pop_ancestors = [&] {
+        for (auto parent = abstract_element.parent_element(); parent; parent = parent->parent_element())
+            pop_ancestor(*parent);
+    };
+
+    return compute_style(abstract_element);
+}
+
 GC::Ptr<ComputedProperties> StyleComputer::compute_pseudo_element_style_if_needed(DOM::AbstractElement abstract_element, Optional<bool&> did_change_custom_properties) const
 {
     auto& style_scope = abstract_element.style_scope();

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -102,6 +102,7 @@ public:
     [[nodiscard]] GC::Ref<ComputedProperties> create_document_style() const;
 
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style(DOM::AbstractElement, Optional<bool&> did_change_custom_properties = {}) const;
+    [[nodiscard]] GC::Ref<ComputedProperties> compute_style_with_seeded_ancestors(DOM::AbstractElement);
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::AbstractElement, Optional<bool&> did_change_custom_properties) const;
 
     [[nodiscard]] Vector<MatchingRule const*> collect_matching_rules(DOM::AbstractElement, CascadeOrigin, PseudoClassBitmap& attempted_pseudo_class_matches, Optional<FlyString const> qualified_layer_name = {}) const;

--- a/Tests/LibWeb/Text/expected/layout-tree-update/clear-inline-display-none-preserves-complex-selector-style.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/clear-inline-display-none-preserves-complex-selector-style.txt
@@ -1,0 +1,3 @@
+initial style=display: none; display=none position=absolute width=100% left=0px top=40px
+after-display-empty style=(none) display=none position=absolute width=100% left=0px top=40px
+after-display-block style=display: block; display=block position=absolute width=500px left=0px top=40px

--- a/Tests/LibWeb/Text/expected/layout-tree-update/clear-inline-display-none-preserves-simple-selector-style.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/clear-inline-display-none-preserves-simple-selector-style.txt
@@ -1,0 +1,3 @@
+initial style=display: none; display=none position=absolute width=100% left=0px top=40px
+after-display-empty style=(none) display=none position=absolute width=100% left=0px top=40px
+after-display-block style=display: block; display=block position=absolute width=500px left=0px top=40px

--- a/Tests/LibWeb/Text/input/layout-tree-update/clear-inline-display-none-preserves-complex-selector-style.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/clear-inline-display-none-preserves-complex-selector-style.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<style>
+#container {
+    position: relative;
+    width: 500px;
+}
+
+.outer .inner .target {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 40px;
+    width: 100%;
+}
+</style>
+<div class="outer">
+    <div class="inner">
+        <div id="container">
+            <div id="target" class="target" style="display: none;">content</div>
+        </div>
+    </div>
+</div>
+<script src="../include.js"></script>
+<script>
+    function snapshot(label) {
+        const cs = getComputedStyle(target);
+        println(
+            `${label} style=${target.getAttribute("style") || "(none)"} display=${cs.display} position=${cs.position} width=${cs.width} left=${cs.left} top=${cs.top}`
+        );
+    }
+
+    test(() => {
+        snapshot("initial");
+        target.style.display = "";
+        snapshot("after-display-empty");
+        target.style.display = "block";
+        snapshot("after-display-block");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/layout-tree-update/clear-inline-display-none-preserves-simple-selector-style.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/clear-inline-display-none-preserves-simple-selector-style.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<style>
+#container {
+    position: relative;
+    width: 500px;
+}
+
+#target {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 40px;
+    width: 100%;
+}
+</style>
+<div id="container">
+    <div id="target" style="display: none;">content</div>
+</div>
+<script src="../include.js"></script>
+<script>
+    function snapshot(label) {
+        const cs = getComputedStyle(target);
+        println(
+            `${label} style=${target.getAttribute("style") || "(none)"} display=${cs.display} position=${cs.position} width=${cs.width} left=${cs.left} top=${cs.top}`
+        );
+    }
+
+    test(() => {
+        snapshot("initial");
+        target.style.display = "";
+        snapshot("after-display-empty");
+        target.style.display = "block";
+        snapshot("after-display-block");
+    });
+</script>


### PR DESCRIPTION
Previously when calling `compute_style(abstract_element)` to get properties without a layout node it would fail to match on selectors which require ancestor context, eg. `.outer .inner .target` as the test has.
Add the ancestor chain to style computer first before computing.

This fixes an issue on https://www.anz.com.au/personal/ where clicking on the top menu wouldn't display the dropdown menu.