### PR TITLE
LibJS: Cache typed array data pointers for indexed access

### DIFF
--- a/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/AsmInterpreter.cpp
@@ -1011,12 +1011,7 @@ i64 asm_try_get_by_value_typed_array(Interpreter* interp, u32 pc)
     auto& typed_array = static_cast<TypedArrayBase&>(object);
     auto index = static_cast<u32>(property.as_i32());
 
-    // Check not detached
-    auto* buffer = typed_array.viewed_array_buffer();
-    if (buffer->is_detached()) [[unlikely]]
-        return 1;
-
-    // Fast path: fixed-length typed array
+    // Fast path: fixed-length typed array with cached data pointer
     auto const& array_length = typed_array.array_length();
     if (array_length.is_auto()) [[unlikely]]
         return 1;
@@ -1027,8 +1022,13 @@ i64 asm_try_get_by_value_typed_array(Interpreter* interp, u32 pc)
         return 0;
     }
 
-    auto byte_offset = typed_array.byte_offset();
-    auto const* data = buffer->buffer().data() + byte_offset;
+    if (!is_valid_integer_index(typed_array, CanonicalIndex { CanonicalIndex::Type::Index, index })) [[unlikely]] {
+        interp->set(insn.dst(), js_undefined());
+        return 0;
+    }
+
+    auto* buffer = typed_array.viewed_array_buffer();
+    auto const* data = buffer->buffer().data() + typed_array.byte_offset();
 
     Value result;
     switch (typed_array.kind()) {
@@ -1087,10 +1087,6 @@ i64 asm_try_put_by_value_typed_array(Interpreter* interp, u32 pc)
     auto& typed_array = static_cast<TypedArrayBase&>(object);
     auto index = static_cast<u32>(property.as_i32());
 
-    auto* buffer = typed_array.viewed_array_buffer();
-    if (buffer->is_detached()) [[unlikely]]
-        return 1;
-
     auto const& array_length = typed_array.array_length();
     if (array_length.is_auto()) [[unlikely]]
         return 1;
@@ -1098,8 +1094,11 @@ i64 asm_try_put_by_value_typed_array(Interpreter* interp, u32 pc)
     if (index >= array_length.length()) [[unlikely]]
         return 0;
 
-    auto byte_offset = typed_array.byte_offset();
-    auto* data = buffer->buffer().data() + byte_offset;
+    if (!is_valid_integer_index(typed_array, CanonicalIndex { CanonicalIndex::Type::Index, index })) [[unlikely]]
+        return 0;
+
+    auto* buffer = typed_array.viewed_array_buffer();
+    auto* data = buffer->buffer().data() + typed_array.byte_offset();
     auto value = interp->get(insn.src());
 
     if (value.is_int32()) {

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1366,35 +1366,14 @@ handler PutByValue
     dispatch_next
 .try_typed_array:
     # t3 = Object*, t4 = index (u32, non-negative)
-    # Check array_length variant holds a u32 (index byte == 2)
-    load8 t0, [t3, TYPED_ARRAY_ARRAY_LENGTH_INDEX]
-    branch_ne t0, BYTE_LENGTH_U32_INDEX, .try_typed_array_slow
-    # Load array length, check index in bounds
-    load32 t5, [t3, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
-    branch_ge_unsigned t4, t5, .slow
-    # Load ArrayBuffer* from m_viewed_array_buffer
-    load64 t0, [t3, TYPED_ARRAY_VIEWED_BUFFER]
-    # Check buffer is fixed-length (not resizable)
-    # ARRAY_BUFFER_IS_FIXED_LENGTH_OFFSET points to Optional<size_t>::m_has_value
-    # If has_value is true, the buffer has a max_byte_length (= resizable)
-    load8 t5, [t0, ARRAY_BUFFER_IS_FIXED_LENGTH_OFFSET]
-    branch_nonzero t5, .slow
-    # Check ArrayBuffer Variant index == 1 (ByteBuffer, not detached/empty)
-    load8 t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_VARIANT_INDEX]
-    branch_ne t5, ARRAY_BUFFER_BYTE_BUFFER_BYTEBUFFER_INDEX, .try_typed_array_slow
-    # Check if ByteBuffer is using inline or outline storage
-    load8 t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_INLINE]
-    branch_nonzero t5, .ta_inline_buffer
-    # Outline: load the m_outline_buffer pointer
-    load64 t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_OUTLINE_POINTER]
-    jmp .ta_have_data_ptr
-.ta_inline_buffer:
-    # Inline: data is at the start of the ByteBuffer (within Variant data)
-    lea t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_OFFSET]
-.ta_have_data_ptr:
-    # Add byte_offset
-    load32 t0, [t3, TYPED_ARRAY_BYTE_OFFSET]
-    add t5, t0
+    # Load cached data pointer (pre-computed: buffer.data() + byte_offset)
+    # nullptr means uncached -> C++ helper will resolve the access.
+    load64 t5, [t3, TYPED_ARRAY_CACHED_DATA_PTR]
+    branch_zero t5, .try_typed_array_slow
+    # Cached pointers only exist for fixed-length typed arrays, so array_length
+    # is known to hold a concrete u32 value here.
+    load32 t0, [t3, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
+    branch_ge_unsigned t4, t0, .slow
     # t5 = data base pointer, t4 = index
     # Load kind into t2 before load_operand clobbers t0
     load8 t2, [t3, TYPED_ARRAY_KIND]
@@ -1595,36 +1574,14 @@ handler GetByValue
     dispatch_next
 .try_typed_array:
     # t3 = Object*, t4 = index (u32, non-negative)
-    # Check array_length variant holds a u32 (index byte == 2)
-    load8 t0, [t3, TYPED_ARRAY_ARRAY_LENGTH_INDEX]
-    branch_ne t0, BYTE_LENGTH_U32_INDEX, .try_typed_array_slow
-    # Load array length, check index in bounds
-    load32 t5, [t3, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
-    branch_ge_unsigned t4, t5, .try_typed_array_slow
-    # Load ArrayBuffer* from m_viewed_array_buffer
-    load64 t0, [t3, TYPED_ARRAY_VIEWED_BUFFER]
-    # Check buffer is fixed-length (not resizable)
-    # ARRAY_BUFFER_IS_FIXED_LENGTH_OFFSET points to Optional<size_t>::m_has_value
-    # If has_value is true, the buffer has a max_byte_length (= resizable)
-    load8 t5, [t0, ARRAY_BUFFER_IS_FIXED_LENGTH_OFFSET]
-    branch_nonzero t5, .slow
-    # Check ArrayBuffer Variant index == 1 (ByteBuffer, not detached/empty)
-    load8 t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_VARIANT_INDEX]
-    branch_ne t5, ARRAY_BUFFER_BYTE_BUFFER_BYTEBUFFER_INDEX, .try_typed_array_slow
-    # Load data pointer from ByteBuffer
-    # Check if ByteBuffer is using inline or outline storage
-    load8 t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_INLINE]
-    branch_nonzero t5, .ta_inline_buffer
-    # Outline: load the m_outline_buffer pointer
-    load64 t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_OUTLINE_POINTER]
-    jmp .ta_have_data_ptr
-.ta_inline_buffer:
-    # Inline: data is at the start of the ByteBuffer (within Variant data)
-    lea t5, [t0, ARRAY_BUFFER_BYTE_BUFFER_OFFSET]
-.ta_have_data_ptr:
-    # Add byte_offset
-    load32 t0, [t3, TYPED_ARRAY_BYTE_OFFSET]
-    add t5, t0
+    # Load cached data pointer (pre-computed: buffer.data() + byte_offset)
+    # nullptr means uncached -> C++ helper will resolve the access.
+    load64 t5, [t3, TYPED_ARRAY_CACHED_DATA_PTR]
+    branch_zero t5, .try_typed_array_slow
+    # Cached pointers only exist for fixed-length typed arrays, so array_length
+    # is known to hold a concrete u32 value here.
+    load32 t0, [t3, TYPED_ARRAY_ARRAY_LENGTH_VALUE]
+    branch_ge_unsigned t4, t0, .try_typed_array_slow
     # t5 = data base pointer, t4 = index
     # Dispatch on kind
     load8 t0, [t3, TYPED_ARRAY_KIND]

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/gen_asm_offsets.cpp
@@ -199,7 +199,7 @@ int main()
     EMIT_OFFSET(TYPED_ARRAY_ARRAY_LENGTH, TypedArrayBase, m_array_length);
     EMIT_OFFSET(TYPED_ARRAY_BYTE_OFFSET, TypedArrayBase, m_byte_offset);
     EMIT_OFFSET(TYPED_ARRAY_KIND, TypedArrayBase, m_kind);
-    EMIT_OFFSET(TYPED_ARRAY_VIEWED_BUFFER, TypedArrayBase, m_viewed_array_buffer);
+    EMIT_OFFSET(TYPED_ARRAY_CACHED_DATA_PTR, TypedArrayBase, m_data);
 
     // ByteLength (Variant<Auto, Detached, u32>) layout
     outln("\n# ByteLength layout");
@@ -212,42 +212,6 @@ int main()
         // Variant<Auto, Detached, u32> stores m_data[4] then m_index (u8)
         outln("const TYPED_ARRAY_ARRAY_LENGTH_VALUE = {}", ta_al);     // u32 data at start
         outln("const TYPED_ARRAY_ARRAY_LENGTH_INDEX = {}", ta_al + 4); // index byte after 4 bytes of data
-    }
-
-    // ArrayBuffer layout
-    outln("\n# ArrayBuffer layout");
-    EMIT_OFFSET(ARRAY_BUFFER_DATA_BLOCK, ArrayBuffer, m_data_block);
-    {
-        auto ab_data_block = offsetof(ArrayBuffer, m_data_block);
-        auto db_byte_buffer = offsetof(DataBlock, byte_buffer);
-        outln("const ARRAY_BUFFER_BYTE_BUFFER = {}", ab_data_block + db_byte_buffer);
-        outln("const ARRAY_BUFFER_BYTE_BUFFER_OFFSET = {}", ab_data_block + db_byte_buffer);
-        // Find the actual offset of the Variant index byte by creating a known variant
-        // and scanning for the index value.
-        {
-            decltype(DataBlock::byte_buffer) v_empty;              // index = 0 (Empty)
-            decltype(DataBlock::byte_buffer) v_bb = ByteBuffer {}; // index = 1 (ByteBuffer)
-            auto const* p0 = reinterpret_cast<u8 const*>(&v_empty);
-            auto const* p1 = reinterpret_cast<u8 const*>(&v_bb);
-            size_t index_offset = 0;
-            for (size_t i = sizeof(v_empty); i-- > 0;) {
-                if (p0[i] == 0 && p1[i] == 1) {
-                    index_offset = i;
-                    break;
-                }
-            }
-            outln("const ARRAY_BUFFER_BYTE_BUFFER_VARIANT_INDEX = {}", ab_data_block + db_byte_buffer + index_offset);
-        }
-        outln("const ARRAY_BUFFER_BYTE_BUFFER_BYTEBUFFER_INDEX = 1");
-        auto bb_start = ab_data_block + db_byte_buffer;
-        outln("const ARRAY_BUFFER_BYTE_BUFFER_INLINE = {}", bb_start + offsetof(ByteBuffer, m_inline));
-        outln("const ARRAY_BUFFER_BYTE_BUFFER_OUTLINE_POINTER = {}", bb_start); // m_outline_buffer at offset 0 in union
-    }
-
-    // ArrayBuffer: check if buffer is fixed-length (not resizable)
-    {
-        outln("const ARRAY_BUFFER_IS_FIXED_LENGTH_OFFSET = {}",
-            offsetof(ArrayBuffer, m_data_block) + sizeof(DataBlock) + sizeof(size_t));
     }
 
     // TypedArrayBase::Kind enum values

--- a/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/ArrayBufferConstructor.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/TypedArray.h>
 
 namespace JS {
 
@@ -248,6 +249,21 @@ ThrowCompletionOr<ArrayBuffer*> array_buffer_copy_and_detach(VM& vm, ArrayBuffer
 
     // 16. Return newBuffer.
     return new_buffer;
+}
+
+void ArrayBuffer::detach_buffer()
+{
+    for (auto& view : m_cached_views) {
+        if (view.viewed_array_buffer() == this)
+            view.set_cached_data_ptr(nullptr);
+    }
+    m_cached_views.clear();
+    m_data_block.byte_buffer = Empty {};
+}
+
+void ArrayBuffer::register_cached_typed_array_view(TypedArrayBase& view)
+{
+    m_cached_views.set(view);
 }
 
 // 25.1.3.5 DetachArrayBuffer ( arrayBuffer [ , key ] ), https://tc39.es/ecma262/#sec-detacharraybuffer

--- a/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -9,6 +9,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Function.h>
 #include <AK/Variant.h>
+#include <LibGC/WeakHashSet.h>
 #include <LibJS/Export.h>
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/Completion.h>
@@ -16,6 +17,8 @@
 #include <LibJS/Runtime/Object.h>
 
 namespace JS {
+
+class TypedArrayBase;
 
 struct ClampedU8 {
 };
@@ -94,7 +97,8 @@ public:
     Value detach_key() const { return m_detach_key; }
     void set_detach_key(Value detach_key) { m_detach_key = detach_key; }
 
-    void detach_buffer() { m_data_block.byte_buffer = Empty {}; }
+    void detach_buffer();
+    void register_cached_typed_array_view(TypedArrayBase&);
 
     // 25.1.3.4 IsDetachedBuffer ( arrayBuffer ), https://tc39.es/ecma262/#sec-isdetachedbuffer
     bool is_detached() const
@@ -154,6 +158,7 @@ private:
 
     DataBlock m_data_block;
     Optional<size_t> m_max_byte_length;
+    GC::WeakHashSet<TypedArrayBase> m_cached_views;
 
     // The various detach related members of ArrayBuffer are not used by any ECMA262 functionality,
     // but are required to be available for the use of various harnesses like the Test262 test runner.

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -42,10 +42,25 @@ public:
     ContentType content_type() const { return m_content_type; }
     ArrayBuffer* viewed_array_buffer() const { return m_viewed_array_buffer; }
 
+    // Cached raw pointer: viewed_array_buffer->buffer().data() + byte_offset.
+    // nullptr means "not cached, use slow path". This avoids chasing through
+    // ArrayBuffer -> DataBlock -> Variant -> ByteBuffer -> inline/outline on every access.
+    u8* cached_data_ptr() const { return m_data; }
+    void set_cached_data_ptr(u8* ptr) { m_data = ptr; }
+
     void set_array_length(ByteLength length) { m_array_length = move(length); }
     void set_byte_length(ByteLength length) { m_byte_length = move(length); }
-    void set_byte_offset(u32 offset) { m_byte_offset = offset; }
-    void set_viewed_array_buffer(ArrayBuffer* array_buffer) { m_viewed_array_buffer = array_buffer; }
+    void set_byte_offset(u32 offset)
+    {
+        m_byte_offset = offset;
+        update_cached_data_ptr();
+    }
+
+    void set_viewed_array_buffer(ArrayBuffer* array_buffer)
+    {
+        m_viewed_array_buffer = array_buffer;
+        update_cached_data_ptr();
+    }
 
     [[nodiscard]] Kind kind() const { return m_kind; }
 
@@ -74,6 +89,17 @@ protected:
         set_is_typed_array();
     }
 
+    void update_cached_data_ptr()
+    {
+        if (!m_viewed_array_buffer || m_viewed_array_buffer->is_detached() || !m_viewed_array_buffer->is_fixed_length()) {
+            m_data = nullptr;
+            return;
+        }
+
+        m_viewed_array_buffer->register_cached_typed_array_view(*this);
+        m_data = m_viewed_array_buffer->buffer().data() + m_byte_offset;
+    }
+
     u32 m_element_size { 0 };
     ByteLength m_array_length { 0 };
     ByteLength m_byte_length { 0 };
@@ -81,6 +107,7 @@ protected:
     ContentType m_content_type { ContentType::Number };
     Kind m_kind {};
     GC::Ptr<ArrayBuffer> m_viewed_array_buffer;
+    u8* m_data { nullptr };
 
 private:
     virtual bool is_typed_array_base() const final { return true; }
@@ -505,7 +532,7 @@ protected:
         : TypedArrayBase(prototype, kind, sizeof(UnderlyingBufferDataType))
     {
         VERIFY(!Checked<u32>::multiplication_would_overflow(array_length, sizeof(UnderlyingBufferDataType)));
-        m_viewed_array_buffer = &array_buffer;
+        set_viewed_array_buffer(&array_buffer);
         if (array_length)
             VERIFY(!data().is_null());
         m_array_length = array_length;

--- a/Tests/LibJS/Runtime/builtins/TypedArray/indexed-access-resizable-array-buffer.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/indexed-access-resizable-array-buffer.js
@@ -1,0 +1,120 @@
+const TYPED_ARRAYS = [
+    Uint8Array,
+    Uint8ClampedArray,
+    Uint16Array,
+    Uint32Array,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+];
+
+const BIGINT_TYPED_ARRAYS = [BigUint64Array, BigInt64Array];
+
+function initialValueFor(T) {
+    if (T === Float16Array || T === Float32Array || T === Float64Array) return 1.5;
+    if (T === BigUint64Array || T === BigInt64Array) return 17n;
+    return 17;
+}
+
+function replacementValueFor(T) {
+    if (T === Float16Array || T === Float32Array || T === Float64Array) return 2.5;
+    if (T === BigUint64Array || T === BigInt64Array) return 23n;
+    return 23;
+}
+
+function zeroValueFor(T) {
+    if (T === BigUint64Array || T === BigInt64Array) return 0n;
+    return 0;
+}
+
+function testTypes(callback) {
+    TYPED_ARRAYS.forEach(callback);
+    BIGINT_TYPED_ARRAYS.forEach(callback);
+}
+
+test("direct indexed access becomes undefined when a fixed-length view goes out of bounds", () => {
+    testTypes(T => {
+        let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+        let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+
+        let initialValue = initialValueFor(T);
+        typedArray[0] = initialValue;
+        expect(typedArray[0]).toBe(initialValue);
+        expect(Reflect.get(typedArray, 0)).toBe(initialValue);
+
+        arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+        expect(typedArray.length).toBe(0);
+        expect(typedArray.byteOffset).toBe(0);
+        expect(typedArray[0]).toBeUndefined();
+        expect(Reflect.get(typedArray, 0)).toBeUndefined();
+        expect(Object.hasOwn(typedArray, "0")).toBeFalse();
+        expect(Object.getOwnPropertyDescriptor(typedArray, "0")).toBeUndefined();
+    });
+});
+
+test("direct indexed stores remain no-ops while a fixed-length view is out of bounds", () => {
+    testTypes(T => {
+        let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+        let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+
+        typedArray[0] = initialValueFor(T);
+        arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+
+        typedArray[0] = replacementValueFor(T);
+
+        expect(typedArray[0]).toBeUndefined();
+        expect(Reflect.get(typedArray, 0)).toBeUndefined();
+        expect(Object.hasOwn(typedArray, "0")).toBeFalse();
+        expect(Object.getOwnPropertyDescriptor(typedArray, "0")).toBeUndefined();
+    });
+});
+
+test("direct indexed access observes zero-filled bytes after regrowing the buffer", () => {
+    testTypes(T => {
+        let arrayBuffer = new ArrayBuffer(T.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: T.BYTES_PER_ELEMENT * 4,
+        });
+        let typedArray = new T(arrayBuffer, T.BYTES_PER_ELEMENT, 1);
+
+        typedArray[0] = initialValueFor(T);
+        arrayBuffer.resize(T.BYTES_PER_ELEMENT);
+        arrayBuffer.resize(T.BYTES_PER_ELEMENT * 2);
+
+        expect(typedArray.length).toBe(1);
+        expect(typedArray.byteOffset).toBe(T.BYTES_PER_ELEMENT);
+        expect(typedArray[0]).toBe(zeroValueFor(T));
+        expect(Reflect.get(typedArray, 0)).toBe(zeroValueFor(T));
+
+        typedArray[0] = replacementValueFor(T);
+        expect(typedArray[0]).toBe(replacementValueFor(T));
+        expect(Reflect.get(typedArray, 0)).toBe(replacementValueFor(T));
+    });
+});
+
+test("direct indexed access stays invalid after the backing buffer is detached", () => {
+    testTypes(T => {
+        let typedArray = new T(1);
+        typedArray[0] = initialValueFor(T);
+
+        detachArrayBuffer(typedArray.buffer);
+
+        expect(typedArray.length).toBe(0);
+        expect(typedArray[0]).toBeUndefined();
+        expect(Reflect.get(typedArray, 0)).toBeUndefined();
+
+        typedArray[0] = replacementValueFor(T);
+
+        expect(typedArray[0]).toBeUndefined();
+        expect(Reflect.get(typedArray, 0)).toBeUndefined();
+        expect(Object.hasOwn(typedArray, "0")).toBeFalse();
+        expect(Object.getOwnPropertyDescriptor(typedArray, "0")).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Cache raw data pointers on fixed-length typed array views so asm GetByValue and PutByValue can use them directly for indexed element access.

Replace the asm typed-array hot-path
ArrayBuffer/DataBlock/ByteBuffer walk with one cached_data_ptr load. Remove six unconditional loads, four branches, and the byte_offset add before the element access, trading them for one cached_data_ptr null check.

Keep direct C++ typed-array access on IsValidIntegerIndex-based checks, invalidate cached pointers eagerly when a backing ArrayBuffer is detached, and add regression coverage for shrink, regrow, and detach on number and BigInt typed arrays.

Benchmarks look okay (only Octane and JetStream use typed arrays really):
```
Suite       Test                Speedup  Old (Mean ± Range)                 New (Mean ± Range)
----------  ----------------  ---------  ---------------------------------  ---------------------------------
Octane      box2d.js              0.973  10071.000 ± 10071.000 … 10071.000  9798.000 ± 9784.000 … 9812.000
Octane      code-load.js          0.957  17103.000 ± 17056.000 … 17150.000  16371.500 ± 16344.000 … 16399.000
Octane      crypto.js             0.977  3455.500 ± 3446.000 … 3465.000     3377.000 ± 3371.000 … 3383.000
Octane      deltablue.js          0.979  2030.000 ± 2017.000 … 2043.000     1987.500 ± 1984.000 … 1991.000
Octane      earley-boyer.js       0.995  4935.000 ± 4915.000 … 4955.000     4910.500 ± 4910.000 … 4911.000
Octane      gbemu.js              1.066  18068.500 ± 17526.000 … 18611.000  19259.500 ± 19136.000 … 19383.000
Octane      mandreel.js           1.052  15458.000 ± 15386.000 … 15530.000  16265.000 ± 16238.000 … 16292.000
Octane      navier-stokes.js      0.968  5137.500 ± 5122.000 … 5153.000     4971.000 ± 4966.000 … 4976.000
Octane      pdfjs.js              1.005  8220.500 ± 8209.000 … 8232.000     8261.500 ± 8254.000 … 8269.000
Octane      raytrace.js           0.993  3442.000 ± 3427.000 … 3457.000     3419.000 ± 3384.000 … 3454.000
Octane      regexp.js             1      198.000 ± 198.000 … 198.000        198.000 ± 198.000 … 198.000
Octane      richards.js           0.989  2286.500 ± 2277.000 … 2296.000     2261.500 ± 2232.000 … 2291.000
Octane      splay.js              1.006  7564.000 ± 7492.000 … 7636.000     7610.000 ± 7592.000 … 7628.000
Octane      typescript.js         0.997  22219.500 ± 22171.000 … 22268.000  22152.000 ± 22125.000 … 22179.000
Octane      zlib.js               1.052  6699.500 ± 6696.000 … 6703.000     7045.000 ± 7042.000 … 7048.000
JetStream   bigfib.cpp.js         1.038  4.057 ± 4.046 … 4.067              3.908 ± 3.903 … 3.914
JetStream   cdjs.js               0.979  2.032 ± 2.019 … 2.044              2.074 ± 2.071 … 2.077
JetStream   container.cpp.js      1.016  19.353 ± 19.341 … 19.365           19.042 ± 19.028 … 19.057
JetStream   dry.c.js              1.058  9.454 ± 9.454 … 9.454              8.936 ± 8.913 … 8.959
JetStream   float-mm.c.js         0.991  14.539 ± 14.396 … 14.682           14.672 ± 14.645 … 14.699
JetStream   gcc-loops.cpp.js      1.027  58.273 ± 58.195 … 58.351           56.735 ± 56.194 … 57.275
JetStream   hash-map.js           0.997  0.963 ± 0.963 … 0.964              0.966 ± 0.962 … 0.970
JetStream   n-body.c.js           1.047  15.688 ± 15.674 … 15.702           14.985 ± 14.964 … 15.006
JetStream   quicksort.c.js        1.01   2.760 ± 2.754 … 2.765              2.732 ± 2.732 … 2.733
JetStream   towers.c.js           1.029  2.950 ± 2.939 … 2.961              2.866 ± 2.854 … 2.877
Octane      Total                 1.008  126888.500                         127887.000
JetStream   Total                 1.025  130.068                            126.917
```