### PR TITLE
AK+WebContent: Don't print duplicate stack traces after failed assertion

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -133,6 +133,7 @@ NEVER_INLINE void ak_trap(void)
     // Skip 3 frames to get to caller. That is dump_backtrace, ak_trap, and ak_verification_failed.
     dump_backtrace(3, 100);
 #endif
+    ak_verification_has_been_triggered = true;
     __builtin_trap();
 }
 

--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -6,6 +6,10 @@
 
 #pragma once
 
+#include <csignal>
+
+inline sig_atomic_t volatile ak_verification_has_been_triggered = false;
+
 // All the functions for stack traces are never inline as we want a consistent number of frames
 extern "C" __attribute__((noinline)) void dump_backtrace(unsigned frames_to_skip = 1, unsigned max_depth = 100);
 extern "C" bool ak_colorize_output(void);

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
@@ -60,29 +61,32 @@
 #    include <signal.h>
 static void crash_signal_handler(int signo)
 {
-    char const* name;
-    switch (signo) {
-    case SIGSEGV:
-        name = "SIGSEGV";
-        break;
-    case SIGBUS:
-        name = "SIGBUS";
-        break;
-    case SIGFPE:
-        name = "SIGFPE";
-        break;
-    case SIGABRT:
-        name = "SIGABRT";
-        break;
-    case SIGILL:
-        name = "SIGILL";
-        break;
-    default:
-        name = "unknown";
-        break;
+    // If the signal comes from a verify/assert, we already printed a (filtered) stacktrace
+    if (!ak_verification_has_been_triggered) {
+        char const* name;
+        switch (signo) {
+        case SIGSEGV:
+            name = "SIGSEGV";
+            break;
+        case SIGBUS:
+            name = "SIGBUS";
+            break;
+        case SIGFPE:
+            name = "SIGFPE";
+            break;
+        case SIGABRT:
+            name = "SIGABRT";
+            break;
+        case SIGILL:
+            name = "SIGILL";
+            break;
+        default:
+            name = "unknown";
+            break;
+        }
+        warnln("\n\033[31;1mCRASH\033[0m: Received signal {} ({})", name, signo);
+        dump_backtrace(2, 100);
     }
-    warnln("\n\033[31;1mCRASH\033[0m: Received signal {} ({})", name, signo);
-    dump_backtrace(2, 100);
     exit(128 + signo);
 }
 


### PR DESCRIPTION
e38adbc31b5fdfaf7e1f12b9d255d90f8b690ba1 introduced a signal handler for WebContent. When an assertion fails, we print a stack trace, then raise a trap, which triggers the signal handler to print the same stack trace again.

Instead, only print a stack trace in the signal handler if it was triggered by something other than a failing assertion. We keep the printing in the assertion code because there we know we can skip some frames we don't care about.
