### PR TITLE
LibJS: Use enums across FFI boundary for Literal Values and retreiving Iterator symbols

### DIFF
--- a/Libraries/LibJS/Rust/cbindgen.toml
+++ b/Libraries/LibJS/Rust/cbindgen.toml
@@ -14,7 +14,7 @@ sys_includes = ["stdint.h", "stddef.h"]
 usize_is_size_t = true
 
 [export]
-include = ["ConstantTag", "LiteralValueKind"]
+include = ["ConstantTag", "LiteralValueKind", "WellKnownSymbolKind"]
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/Libraries/LibJS/Rust/src/bytecode/codegen.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/codegen.rs
@@ -47,7 +47,7 @@ use crate::ast::*;
 use crate::lexer::ch;
 use crate::u32_from_usize;
 
-use super::ffi::LiteralValueKind;
+use super::ffi::{LiteralValueKind, WellKnownSymbolKind};
 use super::generator::{
     BlockBoundaryType, ConstantValue, FinallyContext, Generator, ScopedOperand, choose_dst,
     constant_to_boolean, parse_bigint,
@@ -3134,11 +3134,18 @@ fn try_generate_builtin_constant(
         return None;
     }
     if *name == utf16!("SYMBOL_ITERATOR") {
-        let value = unsafe { super::ffi::get_well_known_symbol(generator.vm_ptr, 0) };
+        let value = unsafe {
+            super::ffi::get_well_known_symbol(generator.vm_ptr, WellKnownSymbolKind::SymbolIterator)
+        };
         return Some(generator.add_constant_raw_value(value));
     }
     if *name == utf16!("SYMBOL_ASYNC_ITERATOR") {
-        let value = unsafe { super::ffi::get_well_known_symbol(generator.vm_ptr, 1) };
+        let value = unsafe {
+            super::ffi::get_well_known_symbol(
+                generator.vm_ptr,
+                WellKnownSymbolKind::SymbolAsyncIterator,
+            )
+        };
         return Some(generator.add_constant_raw_value(value));
     }
     if *name == utf16!("MAX_ARRAY_LIKE_INDEX") {

--- a/Libraries/LibJS/Rust/src/bytecode/ffi.rs
+++ b/Libraries/LibJS/Rust/src/bytecode/ffi.rs
@@ -116,6 +116,14 @@ pub enum LiteralValueKind {
     String = 5,
 }
 
+/// Well-known symbol IDs for get_well_known_symbol()
+/// Used to retrieve well known symbols as opaque Values from C++.
+#[repr(u8)]
+pub enum WellKnownSymbolKind {
+    SymbolIterator = 0,
+    SymbolAsyncIterator = 1,
+}
+
 /// Class element descriptor for ClassBlueprint creation
 /// (C++ `BytecodeFactory::ClassElementData`).
 #[repr(C)]
@@ -270,8 +278,7 @@ unsafe extern "C" {
     pub fn rust_number_to_utf16(value: f64, buffer: *mut u16, buffer_len: usize) -> usize;
 
     // Get a well-known symbol as an opaque Value.
-    // symbol_id: 0 = Symbol.iterator, 1 = Symbol.asyncIterator
-    pub fn get_well_known_symbol(vm_ptr: *mut c_void, symbol_id: u32) -> u64;
+    pub fn get_well_known_symbol(vm_ptr: *mut c_void, symbol_id: WellKnownSymbolKind) -> u64;
 
     // Get an intrinsic abstract operation function as an opaque Value.
     // name/name_len is the function name (e.g. "GetMethod").

--- a/Libraries/LibJS/RustIntegration.cpp
+++ b/Libraries/LibJS/RustIntegration.cpp
@@ -1335,15 +1335,15 @@ extern "C" size_t rust_format_double(double value, uint8_t* buffer, size_t buffe
     return len;
 }
 
-extern "C" uint64_t get_well_known_symbol(void* vm_ptr, uint32_t symbol_id)
+extern "C" uint64_t get_well_known_symbol(void* vm_ptr, WellKnownSymbolKind symbol_id)
 {
     auto& vm = *static_cast<JS::VM*>(vm_ptr);
     JS::Value value;
     switch (symbol_id) {
-    case 0:
+    case WellKnownSymbolKind::SymbolIterator:
         value = vm.well_known_symbol_iterator();
         break;
-    case 1:
+    case WellKnownSymbolKind::SymbolAsyncIterator:
         value = vm.well_known_symbol_async_iterator();
         break;
     default:


### PR DESCRIPTION
Down with magic numbers