### PR TITLE
LibIPC: Disable unused LocalSocket notifier in TransportSocket

### DIFF
--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -77,6 +77,12 @@ void SendQueue::discard(size_t bytes_count, size_t fds_count)
 TransportSocket::TransportSocket(NonnullOwnPtr<Core::LocalSocket> socket)
     : m_socket(move(socket))
 {
+    // Disable the socket's built-in notifier. TransportSocket uses its own pipe-based notification mechanism on the IO
+    // thread, so this notifier is unused. Otherwise, when the socket reaches EOF, this notifier is disabled from the IO
+    // thread. In the Qt UI, this causes QSocketNotifier destruction to be deferred. If the socket is closed before the
+    // deferred destruction runs, Qt detects an invalid socket and prints a warning.
+    m_socket->set_notifications_enabled(false);
+
     (void)Core::System::setsockopt(m_socket->fd().value(), SOL_SOCKET, SO_SNDBUF, &SOCKET_BUFFER_SIZE, sizeof(SOCKET_BUFFER_SIZE));
     (void)Core::System::setsockopt(m_socket->fd().value(), SOL_SOCKET, SO_RCVBUF, &SOCKET_BUFFER_SIZE, sizeof(SOCKET_BUFFER_SIZE));
 


### PR DESCRIPTION
`TransportSocket` uses its own pipe-based notification mechanism on the IO thread, making `LocalSocket`'s built-in `Core::Notifier` redundant. When the socket reaches EOF, this notifier is disabled from the IO thread. Since the `QSocketNotifier` lives on the main thread, the its destruction is deferred. If the socket is closed before the deferred destruction runs, Qt detects the invalid socket on the next poll and prints:
````
QSocketNotifier: Invalid socket 50 and type 'Read', disabling...
````

Fix this by disabling the redundant socket-level notifier upfront in the `TransportSocket` constructor.

Ref: https://discord.com/channels/1247070541085671459/1247090064480014443/1435024216540971078
