### PR TITLE
LibGfx: Load all faces from TrueType Collection (.ttc) files

### DIFF
--- a/Libraries/LibGfx/Font/PathFontProvider.cpp
+++ b/Libraries/LibGfx/Font/PathFontProvider.cpp
@@ -11,6 +11,8 @@
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibGfx/Font/WOFF/Loader.h>
 
+#include <harfbuzz/hb.h>
+
 namespace Gfx {
 
 PathFontProvider::PathFontProvider() = default;
@@ -32,12 +34,20 @@ void PathFontProvider::load_all_fonts_from_uri(StringView uri)
         auto uri = resource.uri();
         auto path = LexicalPath(uri.bytes_as_string_view());
         if (path.has_extension(".ttf"sv) || path.has_extension(".ttc"sv) || path.has_extension(".otf"sv)) {
-            if (auto font_or_error = Typeface::try_load_from_resource(resource); !font_or_error.is_error()) {
-                auto font = font_or_error.release_value();
-                auto& family = m_typeface_by_family.ensure(font->family(), [] {
-                    return Vector<NonnullRefPtr<Typeface>> {};
-                });
-                family.append(font);
+            unsigned face_count = 1;
+            if (path.has_extension(".ttc"sv)) {
+                auto* blob = hb_blob_create(reinterpret_cast<char const*>(resource.data().data()), resource.data().size(), HB_MEMORY_MODE_READONLY, nullptr, nullptr);
+                face_count = hb_face_count(blob);
+                hb_blob_destroy(blob);
+            }
+            for (unsigned i = 0; i < face_count; ++i) {
+                if (auto font_or_error = Typeface::try_load_from_resource(resource, i); !font_or_error.is_error()) {
+                    auto font = font_or_error.release_value();
+                    auto& family = m_typeface_by_family.ensure(font->family(), [] {
+                        return Vector<NonnullRefPtr<Typeface>> {};
+                    });
+                    family.append(font);
+                }
             }
         } else if (path.has_extension(".woff"sv)) {
             if (auto font_or_error = WOFF::try_load_from_resource(resource); !font_or_error.is_error()) {

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -24,6 +24,7 @@
 
 #ifdef AK_OS_MACOS
 #    include <ports/SkFontMgr_mac_ct.h>
+#    include <ports/SkFontMgr_empty.h>
 #endif
 
 namespace Gfx {
@@ -72,6 +73,15 @@ ErrorOr<NonnullRefPtr<TypefaceSkia>> TypefaceSkia::load_from_buffer(AK::Readonly
 {
     auto data = SkData::MakeWithoutCopy(buffer.data(), buffer.size());
     auto skia_typeface = font_manager().makeFromData(data, ttc_index);
+
+#ifdef AK_OS_MACOS
+    // The CoreText font manager does not support loading TTC faces with index > 0.
+    // Fall back to a FreeType-based font manager for these cases.
+    if (!skia_typeface && ttc_index > 0) {
+        static auto freetype_font_manager = SkFontMgr_New_Custom_Empty();
+        skia_typeface = freetype_font_manager->makeFromData(data, ttc_index);
+    }
+#endif
 
     if (!skia_typeface) {
         return Error::from_string_literal("Failed to load typeface from buffer");


### PR DESCRIPTION
exploring an issue I discovered on [my simple page with the h5 tag](github.hashirsafdar.com). keeping in draft until ready to share properly


## Summary

- Load all faces from `.ttc` font collections instead of only index 0
- Work around Skia CoreText limitation on macOS where `makeFromData()` rejects TTC indices > 0, by falling back to a FreeType-based font manager

Previously, `PathFontProvider::load_all_fonts_from_uri` only loaded TTC index 0. On macOS, `Times.ttc` (the default serif font) contains Regular (0), Bold (1), Italic (2), and Bold Italic (3) — but only Regular was ever loaded. When CSS requested `font-weight: bold`, only the regular weight was available.

## Before / After (safari comparison)
<img width="1532" height="997" alt="Screenshot 2026-03-18 at 3 12 14 PM" src="https://github.com/user-attachments/assets/8e0cf659-1db8-4651-a4ec-5fc3dc0a5add" />

<img width="1536" height="1006" alt="Screenshot 2026-03-18 at 3 09 31 PM" src="https://github.com/user-attachments/assets/d00ad7bb-6e7c-4d97-85f8-8c5810ead29a" />



## Test plan

- [x] `./Meta/ladybird.py build` passes
- [x] `./Meta/ladybird.py test` — 184/184 tests pass
- [x] Manual test: pages using default serif with bold text (e.g. headings) now render bold correctly on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)