### PR TITLE
UI/AppKit: Set an initial intrinsic size for the location search field

### DIFF
--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -46,6 +46,16 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     return result;
 }
 
+// NSSearchField does not provide an intrinsic width, which causes an ambiguous layout warning when the toolbar auto-
+// measures this view. This provides an initial fallback, which is overridden with an explicit width in windowDidResize.
+- (NSSize)intrinsicContentSize
+{
+    auto size = [super intrinsicContentSize];
+    if (size.width < 0)
+        size.width = 400;
+    return size;
+}
+
 @end
 
 @interface TabController () <NSToolbarDelegate, NSSearchFieldDelegate, AutocompleteObserver>


### PR DESCRIPTION
We initially create the search field with no frame or size constraints. The causes AppKit to log verbose warnings at start up. Here, we set an intrinsic size initially, which becomes overridden once the window has an actual size.