### PR TITLE
LibWeb: Collapse scrollable GFC items if height doesn't depend on them

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2413,6 +2413,24 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
         return should_treat_height_as_auto(item.box, available_space_for_item);
     }();
 
+    // AD-HOC: Not defined in spec, but matches other browsers: a scroll container's min-content width contribution is 0
+    //         because its content can overflow and scroll horizontally. This also applies to the row dimension, but
+    //         only if height of the grid is not determined by its children, otherwise grids with height:min-content
+    //         collapse rows to 0.
+    auto should_collapse_min_size = [&] -> bool {
+        if (!item.box->is_scroll_container()) {
+            return false;
+        }
+
+        if (dimension == GridDimension::Column) {
+            return true;
+        }
+
+        auto const& containing_block_height = item.box->containing_block()->computed_values().height();
+
+        return !containing_block_height.is_intrinsic_sizing_constraint();
+    };
+
     auto maximum_size = CSSPixels::max();
     if (auto const& css_maximum_size = item.maximum_size(dimension); css_maximum_size.is_length()) {
         maximum_size = css_maximum_size.length().to_px(item.box);
@@ -2420,11 +2438,7 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
 
     if (should_treat_preferred_size_as_auto) {
         CSSPixels min_content_size;
-        // NOTE: Not defined in spec, but matches other browsers: a scroll container's min-content
-        //       width contribution is 0 because its content can overflow and scroll horizontally.
-        //       This does NOT apply to the row dimension — scroll containers must still contribute
-        //       their content height, otherwise grids with height:min-content collapse rows to 0.
-        if (dimension == GridDimension::Column && item.box->is_scroll_container()) {
+        if (should_collapse_min_size()) {
             min_content_size = 0;
         } else {
             min_content_size = calculate_min_content_size(item, dimension);

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-collapse-height-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-collapse-height-1.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 34 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div#grid-collapsed> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] [GFC] children: not-inline
+        BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 20, rect: [8,8 166.3125x18] baseline: 13.796875
+              "should have 0 height"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div#grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 32, rect: [8,8 269.484375x18] baseline: 13.796875
+              "should be at the top of the page"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x34]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x18]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableBox (Box<DIV>#grid-collapsed) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 784x0] overflow: [8,8 166.3125x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableBox (Box<DIV>#grid) [8,8 784x18]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x34] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-collapse-height-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-collapse-height-2.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 36 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div#grid-doesnt-collapse> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [GFC] children: not-inline
+        BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 17, rect: [8,8 134.140625x18] baseline: 13.796875
+              "should be visible"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div#grid> at [8,26] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> at [8,26] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 36, rect: [8,26 304.3125x18] baseline: 13.796875
+              "should not be at the top of the page"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,44] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x36]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableBox (Box<DIV>#grid-doesnt-collapse) [8,8 784x18]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 784x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,26 784x0]
+      PaintableBox (Box<DIV>#grid) [8,26 784x18]
+        PaintableWithLines (BlockContainer(anonymous)) [8,26 784x18]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,44 784x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x52] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/grid-item-collapse-height-1.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-collapse-height-1.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    div {
+        overflow: hidden;
+    }
+
+    #grid {
+        display: grid;
+        grid-template-rows: 1fr;
+    }
+
+    #grid-collapsed {
+        display: grid;
+        grid-template-rows: 0fr;
+    }
+</style>
+</head>
+
+<body>
+    <div id="grid-collapsed"><div>should have 0 height</div></div>
+    <div id="grid">should be at the top of the page</div>
+</body>
+</html>

--- a/Tests/LibWeb/Layout/input/grid/grid-item-collapse-height-2.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-collapse-height-2.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    div {
+        overflow: hidden;
+        height: min-content;
+    }
+
+    #grid {
+        display: grid;
+        grid-template-rows: 1fr;
+    }
+
+    #grid-doesnt-collapse {
+        display: grid;
+        height: min-content;
+        grid-template-rows: 0fr;
+    }
+</style>
+</head>
+
+<body>
+    <div id="grid-doesnt-collapse"><div>should be visible</div></div>
+    <div id="grid">should not be at the top of the page</div>
+</body>
+</html>


### PR DESCRIPTION
Grid items that don't determine their parent's height (e.g no max-content / min-content / fit-content) should be able to collapse to 0px. This brings Ladybird's behavior in line with other browsers.

Fixes #8456

An example of previous behavior causing an issue on [Next.js documentation](https://nextjs.org/docs):
<img width="2814" height="1518" alt="nextjs-docs-before" src="https://github.com/user-attachments/assets/fa440dc4-868f-4227-a5e1-007710d6f089" />
After this change:
<img width="2558" height="1262" alt="nextjs-docs-after" src="https://github.com/user-attachments/assets/2b98be92-5f04-44e2-b3ee-00a72cf1e10b" />
