### PR TITLE
LibJS: Fix expected SyntaxErrors for private fields

### DIFF
--- a/Libraries/LibJS/Rust/src/parser/expressions.rs
+++ b/Libraries/LibJS/Rust/src/parser/expressions.rs
@@ -745,7 +745,6 @@ impl Parser<'_> {
             | TokenType::ExclamationMarkEquals
             | TokenType::EqualsEqualsEquals
             | TokenType::ExclamationMarkEqualsEquals
-            | TokenType::In
             | TokenType::Instanceof => {
                 let op = token_to_binary_op(tt);
                 self.consume();
@@ -759,6 +758,34 @@ impl Parser<'_> {
                         start,
                         ExpressionKind::Binary {
                             op,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                        },
+                    ),
+                    ForbiddenTokens::none(),
+                )
+            }
+
+            TokenType::In => {
+                let is_private_in = matches!(&lhs.inner, ExpressionKind::PrivateIdentifier(_));
+                self.consume();
+                let rhs = self.parse_expression(
+                    min_precedence,
+                    Self::operator_associativity(tt),
+                    forbidden,
+                );
+                if is_private_in
+                    && let ExpressionKind::Function(fn_id) = &rhs.inner
+                    && self.function_table.get(*fn_id).is_arrow_function
+                {
+                    self.syntax_error("Arrow function is not allowed as the right-hand side of a private 'in' expression");
+                }
+
+                (
+                    self.expression(
+                        start,
+                        ExpressionKind::Binary {
+                            op: BinaryOp::In,
                             lhs: Box::new(lhs),
                             rhs: Box::new(rhs),
                         },

--- a/Tests/LibJS/Runtime/classes/class-private-fields.js
+++ b/Tests/LibJS/Runtime/classes/class-private-fields.js
@@ -108,6 +108,65 @@ test("private identifier not followed by 'in' throws", () => {
     expect(`class A { #field = 2; method() { return #field in 1; }}`).toEval();
 });
 
+test("private identifier followed by 'in' with invalid grammar throws", () => {
+    expect(`
+class C {
+  #field;
+
+  constructor() {
+    #field in () => {};
+  }
+}
+    `).not.toEval();
+
+    expect(`
+class C {
+  #field;
+
+  constructor() {
+    #field in #field in this;
+  }
+}
+    `).not.toEval();
+
+    expect(`
+class C {
+  #field;
+
+  *gen() {
+    #field in yield;
+  }
+}
+    `).not.toEval();
+
+    expect(`
+class C {
+  #field;
+
+  *gen() {
+    #field in yield this;
+  }
+}
+    `).not.toEval();
+});
+
+test("private identifier followed by 'in' with parenthesized yield is valid", () => {
+    class C {
+        #field = 42;
+
+        *gen(obj) {
+            return #field in (yield obj);
+        }
+    }
+
+    const c = new C();
+    const it = c.gen({ "#field": true });
+    it.next();
+    const result = it.next(c);
+    expect(result.value).toBe(true);
+    expect(result.done).toBe(true);
+});
+
 test("cannot have static and non static field with the same description", () => {
     expect("class A { static #simple; #simple; }").not.toEval();
 });


### PR DESCRIPTION
Test262 fixes:

```
Duration:
     -0.87s

Summary:
    Diff Tests:
        +2 ✅    -2 ❌   

Diff Tests:
    test/language/expressions/in/private-field-in-nested.js   ❌ -> ✅
    test/language/expressions/in/private-field-invalid-rhs.js ❌ -> ✅
```