### PR TITLE
LibWeb/Bindings: Don’t set @@unscopables in unforgeable attribute setup

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3796,7 +3796,7 @@ void @class_name@::initialize(JS::Realm& realm)
         }
     }
 
-    if (interface.has_unscopable_member) {
+    if (interface.has_unscopable_member && generate_unforgeables == GenerateUnforgeables::No) {
         generator.append(R"~~~(
     auto unscopable_object = JS::Object::create(realm, nullptr);
 )~~~");
@@ -4077,7 +4077,7 @@ void @class_name@::initialize(JS::Realm& realm)
             maplike_generator.appendln("    @define_native_function@(realm, vm.names.clear, clear, 0, default_attributes);");
     }
 
-    if (interface.has_unscopable_member) {
+    if (interface.has_unscopable_member && generate_unforgeables == GenerateUnforgeables::No) {
         generator.append(R"~~~(
     @define_direct_property@(vm.well_known_symbol_unscopables(), unscopable_object, JS::Attribute::Configurable);
 )~~~");

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/remove-unscopable.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/remove-unscopable.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	before() should be unscopable
+Pass	after() should be unscopable
+Pass	replaceWith() should be unscopable
+Pass	remove() should be unscopable
+Pass	prepend() should be unscopable
+Pass	append() should be unscopable

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/remove-unscopable.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/remove-unscopable.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<div id="testDiv" onclick="result1 = remove; result2 = this.remove;"></div>
+<script>
+var result1;
+var result2;
+var unscopables = [
+    "before",
+    "after",
+    "replaceWith",
+    "remove",
+    "prepend",
+    "append"
+];
+for (var i in unscopables) {
+    var name = unscopables[i];
+    window[name] = "Hello there";
+    result1 = result2 = undefined;
+    test(function () {
+        assert_true(Element.prototype[Symbol.unscopables][name]);
+        var div = document.querySelector('#testDiv');
+        div.setAttribute(
+            "onclick", "result1 = " + name + "; result2 = this." + name + ";");
+        div.dispatchEvent(new Event("click"));
+        assert_equals(typeof result1, "string");
+        assert_equals(typeof result2, "function");
+    }, name + "() should be unscopable");
+}
+</script>


### PR DESCRIPTION
[Unscopable] members should only affect the interface prototype’s @@unscopables object. The bindings generator was also creating an empty @@unscopables object in define_unforgeable_attributes(), installing it as an own property on instances.