### PR TITLE
LibWeb: Prevent race condition in Storage::key()

### DIFF
--- a/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Libraries/LibWeb/HTML/Storage.cpp
@@ -68,11 +68,12 @@ size_t Storage::length() const
 Optional<String> Storage::key(size_t index)
 {
     // 1. If index is greater than or equal to this's map's size, then return null.
-    if (index >= m_storage_bottle->size())
-        return {};
-
     // 2. Let keys be the result of running get the keys on this's map.
+    // NB: We combine these steps so we don't have to do two IPC calls and cause a race condition if the storage bottle
+    //     changes size between them.
     auto keys = m_storage_bottle->keys();
+    if (index >= keys.size())
+        return {};
 
     // 3. Return keys[index].
     return keys[index];


### PR DESCRIPTION
Depending on the underlying implementation of the storage bottle, we have to do IPC calls to get either the size or keys. We crash on an out-of-bounds if the bottle changes size after the bounds check in step 1. Fix this by obtaining the keys immediately and using that for the bounds check.

Fixes a crash seen in CI.