### PR TITLE
Tests/LibWeb: Prevent inadvertent cookie expiration

### DIFF
--- a/Tests/LibWeb/Text/input/cookie-working.html
+++ b/Tests/LibWeb/Text/input/cookie-working.html
@@ -140,13 +140,13 @@
     };
 
     const expiresTest = () => {
-        let expiry = new Date(Date.now() + 1000);
+        let expiry = new Date(Date.now() + 3000);
         expiry = expiry.toUTCString();
 
         document.cookie = `cookie-expires=value; expires=${expiry}`;
         printCookies("Expires (before expiration)");
 
-        internals.expireCookiesWithTimeOffset(2);
+        internals.expireCookiesWithTimeOffset(4);
         printCookies("Expires (after expiration)");
     };
 


### PR DESCRIPTION
We were testing cookie expiry by setting moving a Date 1000ms to the future, and then calling `.toUTCString()` on it. However, that method truncates milliseconds and could cause the actual expiry to be almost immediately - that makes this test flaky, especially on slower machines.

Fix the issue by using a larger expiry.