### PR TITLE
LibJS: Fix syntax highlighter position starting at invalid sentinel

### DIFF
--- a/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -139,7 +139,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         .spans = spans,
         .folding_regions = folding_regions,
         .source = source_data,
-        .position = {},
+        .position = { 0, 0 },
         .folding_region_starts = {},
     };
 

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_SOURCES
     TestMicrosyntax.cpp
     TestMimeSniff.cpp
     TestNumbers.cpp
+    TestSourceHighlighter.cpp
     TestStrings.cpp
 )
 
@@ -20,5 +21,6 @@ endforeach()
 
 target_link_libraries(TestContentFilter PRIVATE LibURL)
 target_link_libraries(TestFetchURL PRIVATE LibURL)
+target_link_libraries(TestSourceHighlighter PRIVATE LibURL LibWebView)
 
 add_subdirectory("test-web")

--- a/Tests/LibWeb/TestSourceHighlighter.cpp
+++ b/Tests/LibWeb/TestSourceHighlighter.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibURL/URL.h>
+#include <LibWebView/SourceHighlighter.h>
+
+TEST_CASE(highlight_script_with_braces)
+{
+    // Regression test for https://github.com/LadybirdBrowser/ladybird/issues/8529
+    auto source = "<script>\nfunction foo() {\n    return 1;\n}\n</script>"_string;
+    URL::URL base_url {};
+    auto result = WebView::highlight_source({}, base_url, source, Syntax::Language::HTML, WebView::HighlightOutputMode::SourceOnly);
+    EXPECT(!result.is_empty());
+}


### PR DESCRIPTION
The RehighlightState designated initializer used `.position = {}` which invokes TextPosition's default constructor, initializing line and column to 0xFFFFFFFF (the "invalid" sentinel). This overrode the struct's default member initializer of { 0, 0 }.

When advance_position() processed the first newline, it incremented 0xFFFFFFFF to 0x100000000, producing line numbers in the billions. These bogus positions propagated into folding regions, causing an out-of-bounds crash in Document::set_folding_regions() when viewing page source on pages with <script> blocks.

Fix by explicitly initializing position to { 0, 0 }.

Fixes #8529.