### PR TITLE
LibWeb: Properly set visibility state for nested documents

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5098,33 +5098,34 @@ void Document::make_active()
         page().client().page_did_change_active_document_in_top_level_browsing_context(*this);
     }
 
-    // 3. Set document's visibility state to document's node navigable's traversable navigable's system visibility state.
-    auto navigable = this->navigable();
-    if (navigable) {
-        m_visibility_state = navigable->traversable_navigable()->system_visibility_state();
-
-        // AD-HOC: Record the initial viewport and visual viewport state so that if the viewport changes before the
-        //         first rendering update (e.g. in our fullscreen tests), change events are still fired.
-        if (!m_last_viewport_size.has_value()) {
-            m_last_viewport_size = viewport_rect().size().to_type<int>();
-            auto& current_visual_viewport = *visual_viewport();
-            m_last_visual_viewport_state = VisualViewportState { current_visual_viewport.scale(), { current_visual_viewport.width(), current_visual_viewport.height() } };
-        }
-    }
-
-    // TODO: 4. Queue a new VisibilityStateEntry whose visibility state is document's visibility state and whose timestamp is zero.
-
-    // 5. Set window's relevant settings object's execution ready flag.
+    // 3. Set window's relevant settings object's execution ready flag.
     HTML::relevant_settings_object(window).execution_ready = true;
 
     if (m_needs_to_call_page_did_load) {
-        navigable->traversable_navigable()->page().client().page_did_finish_loading(url());
+        navigable()->traversable_navigable()->page().client().page_did_finish_loading(url());
         m_needs_to_call_page_did_load = false;
     }
 
     notify_each_document_observer([&](auto const& document_observer) {
         return document_observer.document_became_active();
     });
+}
+
+// https://html.spec.whatwg.org/multipage/interaction.html#set-the-initial-visibility-state
+void Document::set_initial_visibility_state(HTML::VisibilityState visibility_state)
+{
+    // 1. Set document's visibility state to visibility state.
+    m_visibility_state = visibility_state;
+
+    // TODO: 2. Queue a new VisibilityStateEntry whose visibility state is document's visibility state and whose timestamp is 0.
+
+    // AD-HOC: Record the initial viewport and visual viewport state so that if the viewport changes before the
+    //         first rendering update (e.g. in our fullscreen tests), change events are still fired.
+    if (!m_last_viewport_size.has_value()) {
+        m_last_viewport_size = viewport_rect().size().to_type<int>();
+        auto& current_visual_viewport = *visual_viewport();
+        m_last_visual_viewport_state = VisualViewportState { current_visual_viewport.scale(), { current_visual_viewport.width(), current_visual_viewport.height() } };
+    }
 }
 
 HTML::ListOfAvailableImages& Document::list_of_available_images()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -746,6 +746,9 @@ public:
 
     void make_active();
 
+    // https://html.spec.whatwg.org/multipage/interaction.html#set-the-initial-visibility-state
+    void set_initial_visibility_state(HTML::VisibilityState);
+
     void set_salvageable(bool value) { m_salvageable = value; }
 
     void make_unsalvageable(String reason);

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -408,6 +408,9 @@ void Navigable::initialize_navigable(GC::Ref<DocumentState> document_state, GC::
 
     // 5. Set navigable's parent to parent.
     m_parent = parent;
+
+    // 6. Set the initial visibility state of documentState's document to navigable's traversable navigable's system visibility state.
+    document->set_initial_visibility_state(traversable_navigable()->system_visibility_state());
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-the-target-history-entry
@@ -452,6 +455,9 @@ void Navigable::activate_history_entry(GC::Ptr<SessionHistoryEntry> entry, GC::R
 
     // 5. Make active newDocument.
     new_document->make_active();
+
+    // 6. Set the initial visibility state of newDocument to navigable's traversable navigable's system visibility state.
+    new_document->set_initial_visibility_state(traversable_navigable()->system_visibility_state());
 
     // AD-HOC: In the async state machine, documents created during populate may have completed
     //         their loading lifecycle before being activated (when they had no navigable).

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -111,9 +111,6 @@ void NavigableContainer::create_new_child_navigable()
     // 11. Let traversable be parentNavigable's traversable navigable.
     auto traversable = parent_navigable->traversable_navigable();
 
-    // AD-HOC: Let the initial about:blank document inherit the system visibility state from traversable.
-    document->update_the_visibility_state(traversable->system_visibility_state());
-
     // 12. Append the following session history traversal steps to traversable:
     traversable->append_session_history_traversal_steps(GC::create_function(heap(), [this, navigable, parent_navigable, history_entry, traversable](NonnullRefPtr<Core::Promise<Empty>> signal) mutable {
         if (navigable->has_been_destroyed() || parent_navigable->has_been_destroyed()) {

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -231,6 +231,7 @@ Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input
 Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url-entry-document-sync-call.window.html
 Text/input/wpt-import/navigation-api/navigation-methods/reload-state-and-info.html
 Text/input/wpt-import/navigation-api/navigation-methods/reload-state-undefined.html
+Text/input/wpt-import/page-visibility/test_child_document.html
 
 ; Fallback favicon fetch requires HTTP(S) scheme.
 Crash/HTML/fallback-favicon-invalid-base.html

--- a/Tests/LibWeb/Text/expected/wpt-import/page-visibility/test_child_document.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/page-visibility/test_child_document.txt
@@ -1,0 +1,19 @@
+Harness status: OK
+
+Found 14 tests
+
+14 Pass
+Pass	document.hidden is defined and not null.
+Pass	document.visibilityState is defined and not null.
+Pass	Page Visibility API Child Document Test
+Pass	document.hidden is defined for frame with no style attribute.
+Pass	document.visibilityState is defined for frame with no style attribute.
+Pass	document.visibilityState for frame with no style attribute == visible
+Pass	Page Visibility API Child Document Test 1
+Pass	document.hidden is defined for frame with 'display:none' style.
+Pass	document.visibilityState is defined for frame with 'display:none' style.
+Pass	document.visibilityState for frame with 'display:none' style == visible
+Pass	Page Visibility API Child Document Test 2
+Pass	document.hidden is defined for frame with 'visibility:hidden' style.
+Pass	document.visibilityState is defined for frame with 'visibility:hidden' style.
+Pass	document.visibilityState for frame with 'visibility:hidden' style == visible

--- a/Tests/LibWeb/Text/input/wpt-import/page-visibility/resources/blank_page_green.html
+++ b/Tests/LibWeb/Text/input/wpt-import/page-visibility/resources/blank_page_green.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+        <title>Green Test Page</title>
+    </head>
+    <body style="background-color:#00FF00;">
+        <h1>Placeholder</h1>
+    </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/page-visibility/resources/pagevistestharness.js
+++ b/Tests/LibWeb/Text/input/wpt-import/page-visibility/resources/pagevistestharness.js
@@ -1,0 +1,112 @@
+//
+// Helper functions for Page Visibility tests
+//
+
+var VISIBILITY_STATES =
+{
+    HIDDEN: "hidden",
+    VISIBLE: "visible"
+};
+
+var feature_check = false;
+
+//
+// All test() functions in the WebPerf PageVis test suite should use pv_test() instead.
+//
+// pv_test() validates the document.hidden and document.visibilityState attributes
+// exist prior to running tests and immediately shows a failure if they do not.
+//
+
+function pv_test(func, msg, doc)
+{
+    if (!doc)
+    {
+        doc = document;
+    }
+
+    // only run the feature check once, unless func == null, in which case,
+    // this call is intended as a feature check
+    if (!feature_check)
+    {
+        feature_check = true;
+
+        var hiddenVal = doc.hidden;
+        var visStateVal = doc.visibilityState;
+
+        // show a single error that the Page Visibility feature is undefined
+        test(function()
+        {
+            assert_true(hiddenVal !== undefined && hiddenVal != null,
+                        "document.hidden is defined and not null.");},
+                        "document.hidden is defined and not null.");
+
+        test(function()
+        {
+            assert_true(visStateVal !== undefined && hiddenVal != null,
+                        "document.visibilityState is defined and not null.");},
+                        "document.visibilityState is defined and not null.");
+
+    }
+
+    if (func)
+    {
+        test(func, msg);
+    }
+}
+
+
+function test_feature_exists(doc, msg)
+{
+    if (!msg)
+    {
+        msg = "";
+    }
+    var hiddenMsg = "document.hidden is defined" + msg + ".";
+    var stateMsg = "document.visibilityState is defined" + msg + ".";
+    pv_test(function(){assert_not_equals(document.hidden, undefined, hiddenMsg);}, hiddenMsg, doc);
+    pv_test(function(){assert_not_equals(document.visibilityState, undefined, stateMsg);}, stateMsg, doc);
+}
+
+//
+// Common helper functions
+//
+
+function test_true(value, msg)
+{
+    pv_test(function() { assert_true(value, msg); }, msg);
+}
+
+function test_equals(value, equals, msg)
+{
+    pv_test(function() { assert_equals(value, equals, msg); }, msg);
+}
+
+//
+// asynchronous test helper functions
+//
+
+function add_async_result(test_obj, pass_state)
+{
+    // add assertion to manual test for the pass state
+    test_obj.step(function() { assert_true(pass_state) });
+
+    // end manual test
+    test_obj.done();
+}
+
+function add_async_result_assert(test_obj, func)
+{
+    // add assertion to manual test for the pass state
+    test_obj.step(func);
+
+    // end manual test
+    test_obj.done();
+}
+
+var open_link;
+function TabSwitch()
+{
+    //var open_link = window.open("http://www.bing.com");
+    open_link = window.open('', '_blank');
+    step_timeout(function() { open_link.close(); }, 2000);
+}

--- a/Tests/LibWeb/Text/input/wpt-import/page-visibility/test_child_document.html
+++ b/Tests/LibWeb/Text/input/wpt-import/page-visibility/test_child_document.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Page Visibility API Child Document Test</title>
+
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+        <script type="text/javascript" src="resources/pagevistestharness.js"></script>
+
+        <style type="text/css">
+            iframe
+            {
+                width:250px;
+                height:250px;
+                margin-left:5px;
+            }
+
+            div.docs
+            {
+                position:relative;
+                float:left;
+                text-align:center;
+                margin:10px;
+                border:solid 1px black;
+                padding:3px;
+            }
+        </style>
+
+        <script type="text/javascript" >
+            setup({explicit_done: true});
+
+            function onload_test()
+            {
+                pv_test();
+
+                var frames = document.getElementsByTagName("iframe");
+                var doc, doc_name;
+
+                for (var i = 0; i < frames.length; i++)
+                {
+                    doc = frames[i].contentDocument;
+                    doc_name = "IFrame with " + frames[i].id;
+
+                    pv_test(function()
+                    {
+                        test_feature_exists(doc, " for frame with " + frames[i].id);
+                    });
+
+                    test_equals(doc.visibilityState, VISIBILITY_STATES.VISIBLE,
+                                "document.visibilityState for frame with " +
+                                frames[i].id + " == " +
+                                VISIBILITY_STATES.VISIBLE);
+                }
+
+                done();
+            }
+        </script>
+    </head>
+    <body onload="onload_test()">
+        <h1>Description</h1>
+        <p>This test validates that, within child documents, all of the Page Visibility API attributes exist,
+           are read-only, and match the value of the attributes within the parent document.</p>
+
+        <div id="log"></div>
+
+        <br/>
+
+        <div class="docs">
+            IFrame with no style attribute
+            <br/>
+            <iframe id="no style attribute" src="resources/blank_page_green.html">
+                iframes unsupported
+            </iframe>
+        </div>
+
+        <div class="docs">
+            IFrame with "display:none" style<br/>
+            <iframe id="'display:none' style" style="display:none"
+                    src="resources/blank_page_green.html">
+                iframes unsupported
+            </iframe>
+        </div>
+
+        <div class="docs">
+            IFrame with "visibility:hidden" style
+            <br/>
+            <iframe id="'visibility:hidden' style" style="visibility:hidden"
+                    src="resources/blank_page_green.html">
+                iframes unsupported
+            </iframe>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This cannot happen inside the Make Active algorithm, since that gets called during document creation, which commonly happens before the document's navigable is created.

This matches my HTML Spec PR on this topic: https://github.com/whatwg/html/pull/12294

I'm not sure if this should be merged right away since the spec PR hasn't been reviewed yet, but I want to have it open for review here since it shows that this can be implemented with (seemingly) no problems.

It should also take proper care of one of the crashes that #8472 is having to work around due to our prior AD-HOC behavior in this area.