### PR TITLE
LibWeb: Ensure hosted document layout is up to date before painting

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -109,6 +109,7 @@ enum class InvalidateLayoutTreeReason {
     X(HTMLInputElementHeight)                \
     X(HTMLInputElementWidth)                 \
     X(HTMLLabelElementActivationBehavior)    \
+    X(HostedDocumentBeforePaint)             \
     X(InspectDOMTree)                        \
     X(InternalsHitTest)                      \
     X(MediaQueryListMatches)                 \

--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
@@ -43,9 +43,15 @@ void NavigableContainerViewportPaintable::paint(DisplayListRecordingContext& con
         ScopedCornerRadiusClip corner_clip { context, clip_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
 
         auto const& navigable_container = this->navigable_container();
-        auto const* hosted_document = navigable_container.content_document_without_origin_check();
+        auto* hosted_document = const_cast<DOM::Document*>(navigable_container.content_document_without_origin_check());
         if (!hosted_document)
             return;
+
+        // NB: The hosted document's layout may have been invalidated during the parent
+        //     document's layout (e.g., via viewport size changes in did_set_content_size).
+        //     Ensure it is up to date before painting.
+        hosted_document->update_layout(DOM::UpdateLayoutReason::HostedDocumentBeforePaint);
+
         auto const* hosted_paint_tree = hosted_document->paintable();
         if (!hosted_paint_tree)
             return;
@@ -57,7 +63,7 @@ void NavigableContainerViewportPaintable::paint(DisplayListRecordingContext& con
         HTML::PaintConfig paint_config;
         paint_config.paint_overlay = context.should_paint_overlay();
         paint_config.should_show_line_box_borders = context.should_show_line_box_borders();
-        auto display_list = const_cast<DOM::Document*>(hosted_document)->record_display_list(paint_config);
+        auto display_list = hosted_document->record_display_list(paint_config);
         context.display_list_recorder().paint_nested_display_list(display_list, context.enclosing_device_rect(absolute_rect).to_type<int>());
 
         context.display_list_recorder().restore();

--- a/Tests/LibWeb/Crash/Layout/iframe-resize-during-parent-layout.html
+++ b/Tests/LibWeb/Crash/Layout/iframe-resize-during-parent-layout.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!-- Test: Creating a new iframe during a rAF callback means its content document
+     is NOT in the event loop's docs list for the current rendering update.
+     When the parent's layout sizes the iframe, it invalidates the child's layout
+     via did_set_content_size -> set_viewport_size -> set_needs_layout_update.
+     Since the child is not in docs, its layout is never re-updated before painting,
+     which would hit VERIFICATION FAILED in Node::paintable(). -->
+<html class="test-wait">
+<body>
+<script>
+    // Force initial layout.
+    document.body.offsetHeight;
+
+    requestAnimationFrame(() => {
+        // Create a new iframe during the rAF callback. Its content document
+        // is created and registered but is NOT in the docs list (which was
+        // built at the start of update_the_rendering).
+        const frame = document.createElement("iframe");
+        frame.style.width = "100px";
+        frame.style.height = "100px";
+        document.body.appendChild(frame);
+
+        // Write content and force layout on the child document so it gets a paintable.
+        frame.contentDocument.body.innerHTML = "<div style='width:50px;height:50px;background:blue'></div>";
+        frame.contentDocument.body.offsetHeight;
+
+        // Resize the iframe. During parent layout, did_set_content_size will
+        // call set_viewport_size on the child navigable, invalidating the
+        // child document's layout. Since the child is not in docs, it won't
+        // be re-laid-out before painting.
+        frame.style.width = "300px";
+        frame.style.height = "300px";
+
+        requestAnimationFrame(() => {
+            document.documentElement.classList.remove("test-wait");
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
When painting a navigable container (iframe/object), the hosted document's layout may have been invalidated during the parent document's layout pass via did_set_content_size -> set_viewport_size -> set_needs_layout_update.

If the hosted document is not in the event loop's docs list (e.g., it was created during a rAF callback after the list was built), its layout would never be re-updated, causing a VERIFY failure in Node::paintable() which asserts layout_is_up_to_date().

Fix this by calling update_layout() on the hosted document in NavigableContainerViewportPaintable::paint() before accessing its paintable. This is a no-op when layout is already current.

Fixes #8297.