### PR TITLE
LibWeb: Do not allow margins collapsing through IFCs

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -60,18 +60,41 @@ CSSPixels BlockFormattingContext::automatic_content_height() const
 
 static bool margins_collapse_through(Box const& box, LayoutState& state)
 {
-    // FIXME: A box's own margins collapse if the 'min-height' property is zero, and it has neither top or bottom borders
-    // nor top or bottom padding, and it has a 'height' of either 0 or 'auto', and it does not contain a line box, and
-    // all of its in-flow children's margins (if any) collapse.
-    // https://www.w3.org/TR/CSS22/box.html#collapsing-margins
-    // FIXME: For the purpose of margin collapsing (CSS 2 §8.3.1 Collapsing margins), if the block axis is the
-    //        ratio-dependent axis, it is not considered to have a computed block-size of auto.
-    //        https://www.w3.org/TR/css-sizing-4/#aspect-ratio-margin-collapse
+    // https://drafts.csswg.org/css2/#adjoining-margins
+    // Two margins are adjoining if and only if:
+    // - both belong to in-flow block-level boxes that participate in the same block formatting context
+    //   NB: Yes, we're dealing with one and the same box here.
 
+    // - no line boxes, no clearance, no padding and no border separate them (Note that certain zero-height line boxes
+    //   (see 9.4.2) are ignored for this purpose.)
+    // NB: Border and padding are handled further down.
     if (box.computed_values().clear() != CSS::Clear::None)
         return false;
 
-    return state.get(box).border_box_height() == 0;
+    // - both belong to vertically-adjacent box edges, i.e. form one of the following pairs:
+    //   - top and bottom margins of a box that does not establish a new block formatting context and that has zero
+    //     computed 'min-height', zero or 'auto' computed 'height', and no in-flow children
+    if (FormattingContext::creates_block_formatting_context(box))
+        return false;
+
+    // NB: This should take care of the height and min-height constraints.
+    //     ( also see https://github.com/w3c/csswg-drafts/pull/13699#issuecomment-4103045370 for spec ambiguity )
+    if (state.get(box).border_box_height() != 0)
+        return false;
+
+    // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-margin-collapse
+    // FIXME: For the purpose of margin collapsing (CSS 2 §8.3.1 Collapsing margins), if the block axis is the
+    //        ratio-dependent axis, it is not considered to have a computed block-size of auto.
+
+    // AD-HOC: The "and no in-flow children" above is wrong. (see https://github.com/w3c/csswg-drafts/pull/13699 )
+    for (auto const* child = box.first_child_of_type<Box>(); child; child = child->next_sibling_of_type<Box>()) {
+        if (child->is_out_of_flow())
+            continue;
+        if (!margins_collapse_through(*child, state))
+            return false;
+    }
+
+    return true;
 }
 
 void BlockFormattingContext::run(AvailableSpace const& available_space)

--- a/Tests/LibWeb/Layout/expected/margin-collapse-through-bfc.txt
+++ b/Tests/LibWeb/Layout/expected/margin-collapse-through-bfc.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+      BlockContainer <div#outer> at [0,100] [0+0+0 800 0+0+0] [100+0+0 0 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [0,100] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div> at [0,100] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [0,100] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,100] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x100]
+      PaintableWithLines (BlockContainer<DIV>#outer) [0,100 800x0]
+        PaintableWithLines (BlockContainer(anonymous)) [0,100 800x0]
+        PaintableWithLines (BlockContainer<DIV>) [0,100 800x0]
+        PaintableWithLines (BlockContainer(anonymous)) [0,100 800x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,100 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x100] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/margin-collapse-through-children-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/margin-collapse-through-children-with-margin.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 68 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 52 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 38, rect: [8,8 315.609375x18] baseline: 13.796875
+            "-- There should be a 1em gap here: ---"
+        TextNode <#text> (not painted)
+      BlockContainer <p> at [8,42] [0+0+0 784 0+0+0] [16+0+0 0 0+0+16] children: not-inline
+        BlockContainer <span> at [8,42] [0+0+0 784 0+0+0] [16+0+0 0 0+0+16] children: not-inline
+      BlockContainer <(anonymous)> at [8,42] [0+0+0 784 0+0+0] [0+0+0 18 0+0+0] children: inline
+        frag 0 from TextNode start: 1, length: 38, rect: [8,42 273.375x18] baseline: 13.796875
+            "-- Gap End ---------------------------"
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x68]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x52]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x18]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<P>) [8,42 784x0]
+        PaintableWithLines (BlockContainer<SPAN>) [8,42 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x18]
+        TextPaintable (TextNode<#text>)
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x68] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/margin-collapse-through-bfc.html
+++ b/Tests/LibWeb/Layout/input/margin-collapse-through-bfc.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><style>
+    * { margin: 0; padding: 0; }
+    body { display: flow-root; }
+    #outer { margin-top: 100px; }
+</style>
+<div id="outer">
+	<div style="display:flow-root"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/margin-collapse-through-children-with-margin.html
+++ b/Tests/LibWeb/Layout/input/margin-collapse-through-children-with-margin.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+-- There should be a 1em gap here: ---
+<p><span style="display: block; margin-block: 1em"></span></p>
+-- Gap End ---------------------------


### PR DESCRIPTION
Revival of https://github.com/LadybirdBrowser/ladybird/pull/7905
Fixes the reduction from #7794 and improves layout on the actual site, but doesn't fix the main problem that got reported there.