### PR TITLE
Revert "LibJS: Eliminate GeneratorResult GC cell allocation on await"

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -30,6 +30,7 @@
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
 #include <LibJS/Runtime/Environment.h>
 #include <LibJS/Runtime/FunctionEnvironment.h>
+#include <LibJS/Runtime/GeneratorResult.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Iterator.h>
@@ -92,13 +93,10 @@ Interpreter::~Interpreter() = default;
 
 ALWAYS_INLINE Value Interpreter::do_yield(Value value, Optional<Label> continuation)
 {
-    auto& context = running_execution_context();
-    if (continuation.has_value())
-        context.yield_continuation = continuation->address();
-    else
-        context.yield_continuation = ExecutionContext::no_yield_continuation;
-    context.yield_is_await = false;
-    return value;
+    // FIXME: If we get a pointer, which is not accurately representable as a double
+    //        will cause this to explode
+    auto continuation_value = continuation.has_value() ? Value(continuation->address()) : js_null();
+    return vm().heap().allocate<GeneratorResult>(value, continuation_value, false).ptr();
 }
 
 // 16.1.6 ScriptEvaluation ( scriptRecord ), https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
@@ -163,7 +161,7 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, GC::Ptr<Environ
     // 13. If result.[[Type]] is normal, then
     if (executable && result.type() == Completion::Type::Normal) {
         // a. Set result to Completion(Evaluation of script).
-        result = run_executable(*script_context, *executable, 0, {});
+        result = run_executable(*script_context, *executable, {}, {});
 
         // b. If result is a normal completion and result.[[Value]] is empty, then
         if (result.type() == Completion::Type::Normal && result.value().is_special_empty_value()) {
@@ -823,7 +821,7 @@ DeclarativeEnvironment& Interpreter::global_declarative_environment()
     return realm().global_declarative_environment();
 }
 
-ThrowCompletionOr<Value> Interpreter::run_executable(ExecutionContext& context, Executable& executable, u32 entry_point)
+ThrowCompletionOr<Value> Interpreter::run_executable(ExecutionContext& context, Executable& executable, Optional<size_t> entry_point)
 {
     dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter will run unit {}", &executable);
 
@@ -849,7 +847,7 @@ ThrowCompletionOr<Value> Interpreter::run_executable(ExecutionContext& context, 
             executable.constants.data(),
             count * sizeof(Value));
 
-    run_bytecode(entry_point);
+    run_bytecode(entry_point.value_or(0));
 
     dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter did run unit {}", context.executable);
 
@@ -3091,10 +3089,11 @@ void Yield::execute_impl(Bytecode::Interpreter& interpreter) const
 void Await::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto yielded_value = interpreter.get(m_argument).is_special_empty_value() ? js_undefined() : interpreter.get(m_argument);
-    auto& context = interpreter.running_execution_context();
-    context.yield_continuation = m_continuation_label.address();
-    context.yield_is_await = true;
-    interpreter.do_return(yielded_value);
+    // FIXME: If we get a pointer, which is not accurately representable as a double
+    //        will cause this to explode
+    auto continuation_value = Value(m_continuation_label.address());
+    auto result = interpreter.vm().heap().allocate<GeneratorResult>(yielded_value, continuation_value, true);
+    interpreter.do_return(result);
 }
 
 ThrowCompletionOr<void> GetByValue::execute_impl(Bytecode::Interpreter& interpreter) const

--- a/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Libraries/LibJS/Bytecode/Interpreter.h
@@ -34,9 +34,9 @@ public:
     ThrowCompletionOr<Value> run(Script&, GC::Ptr<Environment> lexical_environment_override = nullptr);
     ThrowCompletionOr<Value> run(SourceTextModule&);
 
-    ThrowCompletionOr<Value> run_executable(ExecutionContext&, Executable&, u32 entry_point = 0);
+    ThrowCompletionOr<Value> run_executable(ExecutionContext&, Executable&, Optional<size_t> entry_point);
 
-    ThrowCompletionOr<Value> run_executable(ExecutionContext& context, Executable& executable, u32 entry_point, Value initial_accumulator_value)
+    ThrowCompletionOr<Value> run_executable(ExecutionContext& context, Executable& executable, Optional<size_t> entry_point, Value initial_accumulator_value)
     {
         context.registers_and_constants_and_locals_and_arguments_span()[0] = initial_accumulator_value;
         return run_executable(context, executable, entry_point);

--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SOURCES
     Runtime/GeneratorFunctionPrototype.cpp
     Runtime/GeneratorObject.cpp
     Runtime/GeneratorPrototype.cpp
+    Runtime/GeneratorResult.cpp
     Runtime/GlobalEnvironment.cpp
     Runtime/GlobalObject.cpp
     Runtime/IndexedProperties.cpp

--- a/Libraries/LibJS/Heap/Cell.h
+++ b/Libraries/LibJS/Heap/Cell.h
@@ -19,6 +19,7 @@ class JS_API Cell : public GC::Cell {
 public:
     MUST_UPCALL virtual void initialize(Realm&);
 
+    virtual bool is_generator_result() const { return false; }
     virtual bool is_environment() const { return false; }
 
     ALWAYS_INLINE VM& vm() const;

--- a/Libraries/LibJS/Runtime/AsyncGenerator.cpp
+++ b/Libraries/LibJS/Runtime/AsyncGenerator.cpp
@@ -10,6 +10,7 @@
 #include <LibJS/Runtime/AsyncGeneratorRequest.h>
 #include <LibJS/Runtime/CompletionCell.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
+#include <LibJS/Runtime/GeneratorResult.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/NativeJavaScriptBackedFunction.h>
 #include <LibJS/Runtime/PromiseConstructor.h>
@@ -18,7 +19,7 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(AsyncGenerator);
 
-GC::Ref<AsyncGenerator> AsyncGenerator::create(Realm& realm, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>> generating_function, NonnullOwnPtr<ExecutionContext> execution_context)
+GC::Ref<AsyncGenerator> AsyncGenerator::create(Realm& realm, Value initial_value, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>> generating_function, NonnullOwnPtr<ExecutionContext> execution_context)
 {
     auto& vm = realm.vm();
     // This is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
@@ -38,14 +39,14 @@ GC::Ref<AsyncGenerator> AsyncGenerator::create(Realm& realm, Variant<GC::Ref<ECM
             return function->bytecode_executable();
         });
 
-    return realm.create<AsyncGenerator>(realm, generating_function_prototype_object, move(execution_context), generating_executable);
+    return realm.create<AsyncGenerator>(realm, generating_function_prototype_object, move(execution_context), generating_executable, initial_value);
 }
 
-AsyncGenerator::AsyncGenerator(Realm& realm, Object* prototype, NonnullOwnPtr<ExecutionContext> context, GC::Ref<Bytecode::Executable> bytecode_executable)
+AsyncGenerator::AsyncGenerator(Realm& realm, Object* prototype, NonnullOwnPtr<ExecutionContext> context, GC::Ref<Bytecode::Executable> bytecode_executable, Value initial_value)
     : Object(realm, prototype)
     , m_async_generator_context(move(context))
     , m_generating_executable(bytecode_executable)
-    , m_yield_continuation(m_async_generator_context->yield_continuation)
+    , m_previous_value(initial_value)
 {
 }
 
@@ -59,6 +60,7 @@ void AsyncGenerator::visit_edges(Cell::Visitor& visitor)
         visitor.visit(request.capability);
     }
     visitor.visit(m_generating_executable);
+    visitor.visit(m_previous_value);
     visitor.visit(m_current_promise);
     m_async_generator_context->visit_edges(visitor);
 }
@@ -165,49 +167,56 @@ ThrowCompletionOr<void> AsyncGenerator::await(Value value)
 void AsyncGenerator::execute(VM& vm, Completion completion)
 {
     while (true) {
+        // Loosely based on step 4 of https://tc39.es/ecma262/#sec-asyncgeneratorstart
+        auto generated_value = [](Value value) -> Value {
+            if (value.is_cell() && value.as_cell().is_generator_result())
+                return static_cast<GeneratorResult const&>(value.as_cell()).result();
+            return value.is_special_empty_value() ? js_undefined() : value;
+        };
+
+        auto generated_continuation = [&](Value value) -> Optional<size_t> {
+            if (value.is_cell() && value.as_cell().is_generator_result()) {
+                auto number_value = static_cast<GeneratorResult const&>(value.as_cell()).continuation();
+                if (number_value.is_null())
+                    return {};
+                return static_cast<size_t>(number_value.as_double());
+            }
+            return {};
+        };
+
+        auto generated_is_await = [](Value value) -> bool {
+            if (value.is_cell() && value.as_cell().is_generator_result())
+                return static_cast<GeneratorResult const&>(value.as_cell()).is_await();
+            return false;
+        };
+
         auto completion_cell = heap().allocate<CompletionCell>(completion);
 
         auto& bytecode_interpreter = vm.bytecode_interpreter();
 
+        auto const continuation_address = generated_continuation(m_previous_value);
+
         // We should never enter `execute` again after the generator is complete.
-        VERIFY(m_yield_continuation != ExecutionContext::no_yield_continuation);
+        VERIFY(continuation_address.has_value());
 
-        // Clear yield state so that a normal return (no yield) is detected as done.
-        m_async_generator_context->yield_continuation = ExecutionContext::no_yield_continuation;
+        auto result_value = bytecode_interpreter.run_executable(vm.running_execution_context(), m_generating_executable, continuation_address, completion_cell);
 
-        auto result_value = bytecode_interpreter.run_executable(vm.running_execution_context(), m_generating_executable, m_yield_continuation, completion_cell);
+        if (!result_value.is_throw_completion()) {
+            m_previous_value = result_value.release_value();
+            auto value = generated_value(m_previous_value);
+            bool is_await = generated_is_await(m_previous_value);
 
-        if (result_value.is_throw_completion()) {
-            m_yield_continuation = ExecutionContext::no_yield_continuation;
-
-            // 27.6.3.2 AsyncGeneratorStart ( generator, generatorBody ), https://tc39.es/ecma262/#sec-asyncgeneratorstart
-            // 4.e. Assert: If we return here, the async generator either threw an exception or performed either an implicit or explicit return.
-            // 4.f. Remove acGenContext from the execution context stack and restore the execution context
-            //      that is at the top of the execution context stack as the running execution context.
-            vm.pop_execution_context();
-            m_async_generator_state = State::Completed;
-            complete_step(result_value.release_error(), true);
-            drain_queue();
-            return;
-        }
-
-        auto value = result_value.release_value();
-        if (value.is_special_empty_value())
-            value = js_undefined();
-
-        m_yield_continuation = m_async_generator_context->yield_continuation;
-        bool is_await = m_async_generator_context->yield_is_await;
-
-        if (is_await) {
-            auto await_result = this->await(value);
-            if (await_result.is_throw_completion()) {
-                completion = await_result.release_error();
-                continue;
+            if (is_await) {
+                auto await_result = this->await(value);
+                if (await_result.is_throw_completion()) {
+                    completion = await_result.release_error();
+                    continue;
+                }
+                return;
             }
-            return;
         }
 
-        bool done = m_yield_continuation == ExecutionContext::no_yield_continuation;
+        bool done = result_value.is_throw_completion() || !generated_continuation(m_previous_value).has_value();
         if (!done) {
             // 27.6.3.8 AsyncGeneratorYield ( value ), https://tc39.es/ecma262/#sec-asyncgeneratoryield
             // 1. Let genContext be the running execution context.
@@ -217,6 +226,7 @@ void AsyncGenerator::execute(VM& vm, Completion completion)
             // NOTE: genContext is `m_async_generator_context`, generator is `this`.
 
             // 5. Let completion be NormalCompletion(value).
+            auto value = generated_value(m_previous_value);
             auto yield_completion = normal_completion(value);
 
             // 6. Assert: The execution context stack has at least two elements.
@@ -276,8 +286,15 @@ void AsyncGenerator::execute(VM& vm, Completion completion)
 
         // 4.h. If result.[[Type]] is normal, set result to NormalCompletion(undefined).
         // 4.i. If result.[[Type]] is return, set result to NormalCompletion(result.[[Value]]).
+        Completion result;
+        if (!result_value.is_throw_completion()) {
+            result = normal_completion(generated_value(m_previous_value));
+        } else {
+            result = result_value.release_error();
+        }
+
         // 4.j. Perform AsyncGeneratorCompleteStep(acGenerator, result, true).
-        complete_step(normal_completion(value), true);
+        complete_step(result, true);
 
         // 4.k. Perform AsyncGeneratorDrainQueue(acGenerator).
         drain_queue();

--- a/Libraries/LibJS/Runtime/AsyncGenerator.h
+++ b/Libraries/LibJS/Runtime/AsyncGenerator.h
@@ -28,7 +28,7 @@ public:
         Completed,
     };
 
-    static GC::Ref<AsyncGenerator> create(Realm&, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>>, NonnullOwnPtr<ExecutionContext>);
+    static GC::Ref<AsyncGenerator> create(Realm&, Value, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>>, NonnullOwnPtr<ExecutionContext>);
 
     virtual ~AsyncGenerator() override;
 
@@ -44,7 +44,7 @@ public:
     Optional<String> const& generator_brand() const { return m_generator_brand; }
 
 private:
-    AsyncGenerator(Realm&, Object* prototype, NonnullOwnPtr<ExecutionContext>, GC::Ref<Bytecode::Executable>);
+    AsyncGenerator(Realm&, Object* prototype, NonnullOwnPtr<ExecutionContext>, GC::Ref<Bytecode::Executable>, Value);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -59,7 +59,7 @@ private:
     Optional<String> m_generator_brand;                        // [[GeneratorBrand]]
 
     GC::Ref<Bytecode::Executable> m_generating_executable;
-    u32 m_yield_continuation { ExecutionContext::no_yield_continuation };
+    Value m_previous_value;
     GC::Ptr<Promise> m_current_promise;
 };
 

--- a/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -524,9 +524,9 @@ ThrowCompletionOr<Value> ECMAScriptFunctionObject::ordinary_call_evaluate_body(V
         return result;
 
     if (kind() == FunctionKind::AsyncGenerator)
-        return AsyncGenerator::create(*context.realm, GC::Ref { *this }, context.copy());
+        return AsyncGenerator::create(*context.realm, result, GC::Ref { *this }, context.copy());
 
-    auto generator_object = GeneratorObject::create(*context.realm, GC::Ref { *this }, context.copy());
+    auto generator_object = GeneratorObject::create(*context.realm, result, GC::Ref { *this }, context.copy());
 
     // NOTE: Async functions are entirely transformed to generator functions, and wrapped in a custom driver that returns a promise.
     if (kind() == FunctionKind::Async)

--- a/Libraries/LibJS/Runtime/ExecutionContext.cpp
+++ b/Libraries/LibJS/Runtime/ExecutionContext.cpp
@@ -112,9 +112,6 @@ NonnullOwnPtr<ExecutionContext> ExecutionContext::copy() const
     copy->variable_environment = variable_environment;
     copy->private_environment = private_environment;
     copy->program_counter = program_counter;
-    copy->yield_continuation = yield_continuation;
-    copy->yield_is_await = yield_is_await;
-    copy->caller_is_construct = caller_is_construct;
     copy->this_value = this_value;
     copy->executable = executable;
     copy->passed_argument_count = passed_argument_count;

--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -62,15 +62,6 @@ public:
     // FIXME: Move this out of LibJS (e.g. by using the CustomData concept), as it's used exclusively by LibWeb.
     u32 skip_when_determining_incumbent_counter { 0 };
 
-    // Non-standard: Used by generators/async generators to communicate yield/await
-    // state back to the caller without allocating a GC cell.
-    // UINT32_MAX means "no continuation" (generator is done).
-    static constexpr u32 no_yield_continuation = UINT32_MAX;
-    u32 yield_continuation { no_yield_continuation };
-
-    bool yield_is_await { false };
-    bool caller_is_construct { false };
-
     Optional<Value> this_value;
 
     GC::Ptr<Bytecode::Executable> executable;
@@ -119,6 +110,7 @@ public:
     u32 passed_argument_count { 0 };
     u32 caller_return_pc { 0 };
     u32 caller_dst_raw { 0 };
+    bool caller_is_construct { false };
 
 private:
     friend class Bytecode::Interpreter;

--- a/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/CompletionCell.h>
 #include <LibJS/Runtime/GeneratorObject.h>
 #include <LibJS/Runtime/GeneratorPrototype.h>
+#include <LibJS/Runtime/GeneratorResult.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Iterator.h>
 #include <LibJS/Runtime/NativeJavaScriptBackedFunction.h>
@@ -17,7 +18,7 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(GeneratorObject);
 
-GC::Ref<GeneratorObject> GeneratorObject::create(Realm& realm, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>> generating_function, NonnullOwnPtr<ExecutionContext> execution_context)
+GC::Ref<GeneratorObject> GeneratorObject::create(Realm& realm, Value initial_value, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>> generating_function, NonnullOwnPtr<ExecutionContext> execution_context)
 {
     auto& vm = realm.vm();
     // This is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
@@ -55,7 +56,7 @@ GC::Ref<GeneratorObject> GeneratorObject::create(Realm& realm, Variant<GC::Ref<E
 
     auto object = realm.create<GeneratorObject>(realm, generating_function_prototype_object, move(execution_context));
     object->m_generating_executable = generating_executable;
-    object->m_yield_continuation = object->m_execution_context->yield_continuation;
+    object->m_previous_value = initial_value;
     return object;
 }
 
@@ -70,6 +71,7 @@ void GeneratorObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_generating_executable);
+    visitor.visit(m_previous_value);
     m_execution_context->visit_edges(visitor);
 }
 
@@ -102,17 +104,32 @@ ThrowCompletionOr<GeneratorObject::IterationResult> GeneratorObject::execute(VM&
 {
     // Loosely based on step 4 of https://tc39.es/ecma262/#sec-generatorstart mixed with https://tc39.es/ecma262/#sec-generatoryield at the end.
 
+    auto generated_value = [](Value value) -> Value {
+        if (value.is_cell() && value.as_cell().is_generator_result())
+            return static_cast<GeneratorResult const&>(value.as_cell()).result();
+        return value.is_special_empty_value() ? js_undefined() : value;
+    };
+
+    auto generated_continuation = [&](Value value) -> Optional<size_t> {
+        if (value.is_cell() && value.as_cell().is_generator_result()) {
+            auto number_value = static_cast<GeneratorResult const&>(value.as_cell()).continuation();
+            if (number_value.is_null())
+                return {};
+            return static_cast<u64>(number_value.as_double());
+        }
+        return {};
+    };
+
     auto completion_cell = heap().allocate<CompletionCell>(completion);
 
     auto& bytecode_interpreter = vm.bytecode_interpreter();
 
+    auto const next_block = generated_continuation(m_previous_value);
+
     // We should never enter `execute` again after the generator is complete.
-    VERIFY(m_yield_continuation != ExecutionContext::no_yield_continuation);
+    VERIFY(next_block.has_value());
 
-    // Clear yield state so that a normal return (no yield) is detected as done.
-    m_execution_context->yield_continuation = ExecutionContext::no_yield_continuation;
-
-    auto result_value = bytecode_interpreter.run_executable(vm.running_execution_context(), *m_generating_executable, m_yield_continuation, completion_cell);
+    auto result_value = bytecode_interpreter.run_executable(vm.running_execution_context(), *m_generating_executable, next_block, completion_cell);
 
     vm.pop_execution_context();
 
@@ -121,17 +138,12 @@ ThrowCompletionOr<GeneratorObject::IterationResult> GeneratorObject::execute(VM&
         m_generator_state = GeneratorState::Completed;
         return result_value.throw_completion();
     }
-
-    auto value = result_value.release_value();
-    if (value.is_special_empty_value())
-        value = js_undefined();
-
-    m_yield_continuation = m_execution_context->yield_continuation;
-    bool done = m_yield_continuation == ExecutionContext::no_yield_continuation;
+    m_previous_value = result_value.release_value();
+    bool done = !generated_continuation(m_previous_value).has_value();
 
     m_generator_state = done ? GeneratorState::Completed : GeneratorState::SuspendedYield;
 
-    return IterationResult(value, done);
+    return IterationResult(generated_value(m_previous_value), done);
 }
 
 // 27.5.3.3 GeneratorResume ( generator, value, generatorBrand ), https://tc39.es/ecma262/#sec-generatorresume

--- a/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -17,7 +17,7 @@ class GeneratorObject : public Object {
     GC_DECLARE_ALLOCATOR(GeneratorObject);
 
 public:
-    static GC::Ref<GeneratorObject> create(Realm&, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>>, NonnullOwnPtr<ExecutionContext>);
+    static GC::Ref<GeneratorObject> create(Realm&, Value, Variant<GC::Ref<ECMAScriptFunctionObject>, GC::Ref<NativeJavaScriptBackedFunction>>, NonnullOwnPtr<ExecutionContext>);
     virtual ~GeneratorObject() override = default;
     void visit_edges(Cell::Visitor&) override;
 
@@ -54,7 +54,7 @@ protected:
 private:
     NonnullOwnPtr<ExecutionContext> m_execution_context;
     GC::Ptr<Bytecode::Executable> m_generating_executable;
-    u32 m_yield_continuation { ExecutionContext::no_yield_continuation };
+    Value m_previous_value;
     GeneratorState m_generator_state { GeneratorState::SuspendedStart };
     Optional<StringView> m_generator_brand;
 };

--- a/Libraries/LibJS/Runtime/GeneratorResult.cpp
+++ b/Libraries/LibJS/Runtime/GeneratorResult.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GeneratorResult.h>
+
+namespace JS {
+
+GC_DEFINE_ALLOCATOR(GeneratorResult);
+
+GeneratorResult::~GeneratorResult() = default;
+
+void GeneratorResult::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_result);
+    visitor.visit(m_continuation);
+}
+
+}

--- a/Libraries/LibJS/Runtime/GeneratorResult.h
+++ b/Libraries/LibJS/Runtime/GeneratorResult.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGC/CellAllocator.h>
+#include <LibJS/Heap/Cell.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS {
+
+class GeneratorResult final : public Cell {
+    GC_CELL(GeneratorResult, Cell);
+    GC_DECLARE_ALLOCATOR(GeneratorResult);
+
+public:
+    GeneratorResult(Value result, Value continuation, bool is_await)
+        : m_is_await(is_await)
+        , m_result(result)
+        , m_continuation(continuation)
+    {
+    }
+
+    virtual ~GeneratorResult() override;
+
+    [[nodiscard]] Value result() const { return m_result; }
+    [[nodiscard]] Value continuation() const { return m_continuation; }
+    [[nodiscard]] bool is_await() const { return m_is_await; }
+
+private:
+    virtual bool is_generator_result() const override { return true; }
+    virtual void visit_edges(Cell::Visitor& visitor) override;
+
+    bool m_is_await { false };
+    Value m_result;
+    Value m_continuation;
+};
+
+template<>
+inline bool Cell::fast_is<GeneratorResult>() const { return is_generator_result(); }
+
+}

--- a/Libraries/LibJS/Runtime/NativeJavaScriptBackedFunction.cpp
+++ b/Libraries/LibJS/Runtime/NativeJavaScriptBackedFunction.cpp
@@ -80,9 +80,9 @@ ThrowCompletionOr<Value> NativeJavaScriptBackedFunction::call()
 
     auto& realm = *vm.current_realm();
     if (kind == FunctionKind::AsyncGenerator)
-        return AsyncGenerator::create(realm, GC::Ref { *this }, vm.running_execution_context().copy());
+        return AsyncGenerator::create(realm, result, GC::Ref { *this }, vm.running_execution_context().copy());
 
-    auto generator_object = GeneratorObject::create(realm, GC::Ref { *this }, vm.running_execution_context().copy());
+    auto generator_object = GeneratorObject::create(realm, result, GC::Ref { *this }, vm.running_execution_context().copy());
 
     // NOTE: Async functions are entirely transformed to generator functions, and wrapped in a custom driver that returns a promise.
     if (kind == FunctionKind::Async)


### PR DESCRIPTION
This reverts commit 1179e40d3f496cf76f24051fc9168a6098d0a18d.

This was causing crashes when loading wpt.live for me.

For example on https://wpt.live/wasm/jsapi/jspi/rejects.any.html

```
VERIFICATION FAILED: result at /Users/shannonbooth/Developer/ladybird/AK/TypeCasts.h:61
Stack trace (most recent call first):
#0  0x00000001097bd44f in Web::HTML::prepare_to_run_script(JS::Realm&) (.cold.1) + 19 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.0.0.dylib
#1  0x00000001086805cb in Web::DOM::Document::update_layout(Web::DOM::UpdateLayoutReason) + 2491 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.0.0.dylib
#2  0x00000001087ee60f in Web::HTML::EventLoop::update_the_rendering() + 827 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.0.0.dylib
#3  0x00000001087f1193 in Web::HTML::Task::execute() + 91 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.0.0.dylib
#4  0x00000001087ed48b in Web::HTML::EventLoop::process() + 263 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.0.0.dylib
#5  0x0000000108a928ab in AK::Function<void ()>::CallableWrapper<Web::Platform::Timer::Timer()::$_0>::call() + 99 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-web.0.0.0.dylib
#6  0x0000000104c2039f in Core::Timer::timer_event(Core::TimerEvent&) + 207 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-core.0.0.0.dylib
#7  0x0000000104c1f7db in Core::ThreadEventQueue::process() + 339 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-core.0.0.0.dylib
#8  0x0000000104c21307 in Core::EventLoopImplementationUnix::exec() + 71 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-core.0.0.0.dylib
#9  0x0000000104c120df in Core::EventLoop::exec() + 67 at /Users/shannonbooth/Developer/ladybird/Build/release/lib/liblagom-core.0.0.0.dylib
#10 0x0000000104240c87 in ladybird_main(Main::Arguments) + 3543 at /Users/shannonbooth/Developer/ladybird/Build/release/bin/Ladybird.app/Contents/MacOS/WebContent
#11 0x00000001042ef97f in _main at /Users/shannonbooth/Developer/ladybird/Build/release/bin/Ladybird.app/Contents/MacOS/WebContent
#12 0x000000018ddceb97 in start + 6075 at /usr/lib/dyld
405389.131 Ladybird(49949): WebContent process crashed! Last page loaded: about:blank
405389.131 Ladybird(49949): Consider raising an issue at https://github.com/LadybirdBrowser/ladybird/issues/new/choose
```

cc @jdahlin