### PR TITLE
LibWeb: Move standalone SVG document layout handling out of BFC

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1569,8 +1569,6 @@ void Document::update_layout(UpdateLayoutReason reason)
     layout_state.ensure_capacity(layout_index_counter);
 
     {
-        Layout::BlockFormattingContext root_formatting_context(layout_state, Layout::LayoutMode::Normal, *m_layout_root, nullptr);
-
         auto& viewport = static_cast<Layout::Viewport&>(*m_layout_root);
         auto& viewport_state = layout_state.get_mutable(viewport);
         viewport_state.set_content_width(viewport_rect.width());
@@ -1582,10 +1580,23 @@ void Document::update_layout(UpdateLayoutReason reason)
             icb_state.set_content_width(viewport_rect.width());
         }
 
-        root_formatting_context.run(
-            Layout::AvailableSpace(
-                Layout::AvailableSize::make_definite(viewport_rect.width()),
-                Layout::AvailableSize::make_definite(viewport_rect.height())));
+        auto available_space = Layout::AvailableSpace(
+            Layout::AvailableSize::make_definite(viewport_rect.width()),
+            Layout::AvailableSize::make_definite(viewport_rect.height()));
+
+        if (m_layout_root->first_child() && m_layout_root->first_child()->is_svg_svg_box()) {
+            // NOTE: If we are laying out a standalone SVG document, we give it some special treatment:
+            //       The root <svg> container gets the same size as the viewport,
+            //       and we call directly into the SVG layout code from here.
+            auto const& svg_root = as<Layout::SVGSVGBox>(*m_layout_root->first_child());
+            auto content_height = layout_state.get(*svg_root.containing_block()).content_height();
+            layout_state.get_mutable(svg_root).set_content_height(content_height);
+            Layout::SVGFormattingContext svg_formatting_context(layout_state, Layout::LayoutMode::Normal, svg_root, nullptr);
+            svg_formatting_context.run(available_space);
+        } else {
+            Layout::BlockFormattingContext root_formatting_context(layout_state, Layout::LayoutMode::Normal, *m_layout_root, nullptr);
+            root_formatting_context.run(available_space);
+        }
     }
 
     layout_state.commit(*m_layout_root);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -86,11 +86,6 @@ void BlockFormattingContext::run(AvailableSpace const& available_space)
         (void)column_width;
     }
 
-    if (is<Viewport>(root())) {
-        layout_viewport(available_space);
-        return;
-    }
-
     if (auto const* fieldset_box = as_if<FieldSetBox>(root()); fieldset_box && fieldset_box->rendered_legend()) {
         layout_fieldset_with_rendered_legend(*fieldset_box, available_space);
         return;
@@ -1194,25 +1189,6 @@ void BlockFormattingContext::place_block_level_element_in_normal_flow_horizontal
     }
 
     box_state.set_content_x(x);
-}
-
-void BlockFormattingContext::layout_viewport(AvailableSpace const& available_space)
-{
-    // NOTE: If we are laying out a standalone SVG document, we give it some special treatment:
-    //       The root <svg> container gets the same size as the viewport,
-    //       and we call directly into the SVG layout code from here.
-    if (root().first_child() && root().first_child()->is_svg_svg_box()) {
-        auto const& svg_root = as<SVGSVGBox>(*root().first_child());
-        auto content_height = m_state.get(*svg_root.containing_block()).content_height();
-        m_state.get_mutable(svg_root).set_content_height(content_height);
-        auto svg_formatting_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, svg_root);
-        svg_formatting_context->run(available_space);
-    } else {
-        if (root().children_are_inline())
-            layout_inline_children(root(), available_space);
-        else
-            layout_block_level_children(root(), available_space);
-    }
 }
 
 void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const& block_container, AvailableSpace const& available_space, CSSPixels y, LineBuilder* line_builder)

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -102,8 +102,6 @@ private:
 
     void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&);
 
-    void layout_viewport(AvailableSpace const&);
-
     void layout_block_level_children(BlockContainer const&, AvailableSpace const&);
     void layout_inline_children(BlockContainer const&, AvailableSpace const&);
     void layout_fieldset_with_rendered_legend(FieldSetBox const&, AvailableSpace const&);

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -189,7 +189,6 @@ void SVGFormattingContext::run(AvailableSpace const& available_space)
         // Overwrite the content width/height with the styled node width/height (from <svg width height ...>)
 
         // NOTE: If a height had not been provided by the svg element, it was set to the height of the container
-        //       (see BlockFormattingContext::layout_viewport)
         if (svg_box_state.node().computed_values().width().is_length())
             svg_box_state.set_content_width(svg_box_state.node().computed_values().width().length().to_px(svg_box_state.node()));
         if (svg_box_state.node().computed_values().height().is_length())


### PR DESCRIPTION
I'm simplifying the BFC code in preparation for multicol layout and this is really not something that every BFC should have to consider all of the time.