### PR TITLE
Libraries: Move #pragma once above include headers

### DIFF
--- a/Libraries/LibGC/HeapHashTable.h
+++ b/Libraries/LibGC/HeapHashTable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/HashTable.h>
 #include <LibGC/Cell.h>
 #include <LibGC/CellAllocator.h>
-
-#pragma once
 
 namespace GC {
 

--- a/Libraries/LibGfx/Font/FontVariationSettings.h
+++ b/Libraries/LibGfx/Font/FontVariationSettings.h
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/HashMap.h>
 #include <AK/QuickSort.h>
 #include <AK/Vector.h>
 #include <LibGfx/FourCC.h>
-
-#pragma once
 
 namespace Gfx {
 

--- a/Libraries/LibIPC/Concepts.h
+++ b/Libraries/LibIPC/Concepts.h
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibCore/SharedCircularQueue.h>
-
-#pragma once
 
 // These concepts are used to help the compiler distinguish between specializations that would be
 // ambiguous otherwise. For example, if the specializations for int and Vector<T> were declared as

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <LibGC/CellAllocator.h>
 #include <LibGfx/FontCascadeList.h>
 #include <LibWeb/CSS/Fetch.h>
@@ -17,8 +19,6 @@
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
-
-#pragma once
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/FontFeatureData.h
+++ b/Libraries/LibWeb/CSS/FontFeatureData.h
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <LibGfx/ShapeFeature.h>
 #include <LibWeb/Forward.h>
-
-#pragma once
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/Painting/SVGMaskable.h
+++ b/Libraries/LibWeb/Painting/SVGMaskable.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <LibGfx/Forward.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
-
-#pragma once
 
 namespace Web::Painting {
 


### PR DESCRIPTION
The #pragma once was placed after the #include directives instead of immediately after the copyright comment, inconsistent with every other header file