### PR TITLE
LibWeb: Fix SVG <use> forward references in decoded SVG images

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -69,6 +69,11 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& rea
     if (result.is_error())
         dbgln("SVGDecodedImageData: Failed to parse SVG: {}", result.error());
 
+    // Mark the document as completely loaded so that <use> elements
+    // (which defer cloning until the document is complete) resolve
+    // forward references to elements parsed after them.
+    document->completely_finish_loading();
+
     auto* svg_root = document->first_child_of_type<SVG::SVGSVGElement>();
     if (!svg_root) {
         dbgln("SVGDecodedImageData: Invalid SVG input (no SVGSVGElement found)");

--- a/Tests/LibWeb/Ref/expected/svg-use-forward-reference-in-decoded-svg-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-use-forward-reference-in-decoded-svg-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0; }
+    svg { display: block; }
+</style>
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <rect x="2" y="2" width="20" height="20" fill="green"/>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg-use-forward-reference-in-decoded-svg.html
+++ b/Tests/LibWeb/Ref/input/svg-use-forward-reference-in-decoded-svg.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-use-forward-reference-in-decoded-svg-ref.html"/>
+<style>
+    body { margin: 0; }
+    img { display: block; }
+</style>
+<!-- SVG contains <use xlink:href="#r"/> before <rect id="r" .../> (a forward reference) -->
+<img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+PHVzZSB4bGluazpocmVmPSIjciIvPjxyZWN0IGlkPSJyIiB4PSIyIiB5PSIyIiB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIGZpbGw9ImdyZWVuIi8+PC9zdmc+Cg==" width="24" height="24"/>


### PR DESCRIPTION
When an SVG is loaded as image data (e.g. via <img>), the XMLDocumentBuilder returns early for decoded SVGs without calling completely_finish_loading(). This meant that <use> elements which forward-reference elements parsed after them never got their shadow trees populated, since:

1. During parsing, the referenced element doesn't exist yet, so clone_element_tree_as_our_shadow_tree() receives null.
2. The document_completely_loaded callback never fires.
3. update_use_elements_that_reference_this() returns early because is_completely_loaded() is false.

Fix this by calling completely_finish_loading() on the document after parsing in SVGDecodedImageData::create().

Makes the X.com logo show up at the bottom of the Gmail info page on Google Workspace.

Before:
<img width="1252" height="557" alt="Screenshot 2026-03-21 at 21 53 19" src="https://github.com/user-attachments/assets/ff9dd8ab-f84d-4914-9e54-27a864764250" />

After:
<img width="1252" height="557" alt="Screenshot 2026-03-21 at 21 53 00" src="https://github.com/user-attachments/assets/975ce035-5720-49a0-a9ce-35ab2f505db7" />
