### PR TITLE
Tests: Fix flaky load-event-delayed-by-*-background-image tests

### DIFF
--- a/Tests/LibWeb/Text/input/load-event-delayed-by-adopted-style-sheet-background-image.html
+++ b/Tests/LibWeb/Text/input/load-event-delayed-by-adopted-style-sheet-background-image.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <script>
-var echoPort = internals.getEchoServerPort();
-var baseURL = `http://127.0.0.1:${echoPort}`;
 var xhr = new XMLHttpRequest();
-xhr.open("POST", `${baseURL}/echo`, false);
+xhr.open("POST", "/echo", false);
 xhr.setRequestHeader("Content-Type", "application/json");
 xhr.send(JSON.stringify({
     method: "GET",

--- a/Tests/LibWeb/Text/input/load-event-delayed-by-css-background-image.html
+++ b/Tests/LibWeb/Text/input/load-event-delayed-by-css-background-image.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <script>
-var echoPort = internals.getEchoServerPort();
-var baseURL = `http://127.0.0.1:${echoPort}`;
 var xhr = new XMLHttpRequest();
-xhr.open("POST", `${baseURL}/echo`, false);
+xhr.open("POST", "/echo", false);
 xhr.setRequestHeader("Content-Type", "application/json");
 xhr.send(JSON.stringify({
     method: "GET",


### PR DESCRIPTION
These tests set up a delayed echo endpoint using a synchronous XHR to http://127.0.0.1:PORT/echo, but the page itself is served from http://localhost:PORT. This cross-origin request triggers a CORS preflight, which intermittently fails with a NetworkError. There's already a FIXME in place to get rid of the spin_until() that caused this to happen.

Use a relative URL instead, since the page is already served from the echo server.

Fixes #8564

CC @shannonbooth please test this locally