### PR TITLE
LibWeb: Report actual network error for failed XHRs

### DIFF
--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -1215,8 +1215,10 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_errors()
         return TRY(request_error_steps(EventNames::abort, WebIDL::AbortError::create(realm(), "Aborted"_utf16)));
 
     // 4. Otherwise, if xhr’s response is a network error, then run the request error steps for xhr, error, and "NetworkError" DOMException.
-    if (m_response->is_network_error())
-        return TRY(request_error_steps(EventNames::error, WebIDL::NetworkError::create(realm(), "Network error"_utf16)));
+    if (m_response->is_network_error()) {
+        auto message = m_response->network_error_message().value_or("Unknown error"_string);
+        return TRY(request_error_steps(EventNames::error, WebIDL::NetworkError::create(realm(), Utf16String::from_utf8(message))));
+    }
 
     return {};
 }

--- a/Tests/LibWeb/Fixtures/http-test-server.py
+++ b/Tests/LibWeb/Fixtures/http-test-server.py
@@ -33,6 +33,7 @@ class Echo:
     delay_ms: Optional[int]
     reason_phrase: Optional[str]
     reflect_headers_in_body: bool
+    close_connection: bool
 
     def __eq__(self, other):
         if not isinstance(other, Echo):
@@ -48,6 +49,7 @@ class Echo:
             and self.headers == other.headers
             and self.reason_phrase == other.reason_phrase
             and self.reflect_headers_in_body == other.reflect_headers_in_body
+            and self.close_connection == other.close_connection
         )
 
 
@@ -105,6 +107,7 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
             echo.headers = data.get("headers", {})
             echo.reason_phrase = data.get("reason_phrase", None)
             echo.reflect_headers_in_body = data.get("reflect_headers_in_body", False)
+            echo.close_connection = data.get("close_connection", False)
 
             is_using_reserved_path = echo.path.startswith("/static") or echo.path.startswith("/echo")
 
@@ -190,6 +193,12 @@ class TestHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if key in echo_store:
             echo = echo_store[key]
+
+            if echo.close_connection:
+                self.connection.shutdown(socket.SHUT_WR)
+                self.connection.close()
+                return
+
             response_headers = echo.headers.copy()
 
             if echo.delay_ms is not None:

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -339,6 +339,7 @@ Text/input/HTML/storage-does-not-have-legacy-override-builtins-flag.html
 Text/input/Streams/init-from-cloned-fetch-response.html
 Text/input/Streams/init-from-fetch.html
 Text/input/Wasm/WebAssembly-instantiate-streaming.html
+Text/input/XHR/XMLHttpRequest-network-error-message.html
 Text/input/XHR/XMLHttpRequest-override-mimetype-blob.html
 Text/input/XML/error-page.html
 Text/input/base/a-element-target.html

--- a/Tests/LibWeb/Text/expected/XHR/XMLHttpRequest-network-error-message.txt
+++ b/Tests/LibWeb/Text/expected/XHR/XMLHttpRequest-network-error-message.txt
@@ -1,0 +1,2 @@
+NetworkError
+Load failed: Request finished with error: An unexpected network error occurred

--- a/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-network-error-message.html
+++ b/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-network-error-message.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const server = httpTestServer();
+
+        await server.createEcho("GET", "/close-connection", {
+            status: 0,
+            close_connection: true,
+        });
+
+        // FIXME: Use the URL returned by createEcho instead of a relative path. Currently that URL uses 127.0.0.1
+        //        which is cross-origin with the localhost page, causing a CORS error instead of a network error.
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", "/close-connection", false);
+        try {
+            xhr.send();
+            println("FAIL: no exception thrown");
+        } catch (e) {
+            println(e.name);
+            println(e.message);
+        }
+        done();
+    });
+</script>


### PR DESCRIPTION
Seeing "NetworkError: Network error" when an XHR failed was not that useful - use the actual error message when available.