### PR TITLE
LibWeb: Remove tasks for destroyed documents when filtering on tasks

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/Task.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.cpp
@@ -54,6 +54,11 @@ bool Task::is_runnable() const
     return !m_document || m_document->is_fully_active();
 }
 
+bool Task::is_permanently_unrunnable() const
+{
+    return m_document && m_document->has_been_destroyed();
+}
+
 DOM::Document const* Task::document() const
 {
     return m_document.ptr();

--- a/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -104,6 +104,7 @@ public:
     DOM::Document const* document() const;
 
     bool is_runnable() const;
+    bool is_permanently_unrunnable() const;
 
 private:
     Task(Source, GC::Ptr<DOM::Document const>, GC::Ref<GC::Function<void()>> steps);

--- a/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
@@ -52,8 +52,7 @@ GC::Ptr<Task> TaskQueue::take_first_runnable()
         if (m_tasks[i]->is_runnable())
             return m_tasks.take(i);
 
-        // A non-runnable task with a destroyed document will never become runnable again; remove it.
-        if (m_tasks[i]->document() && m_tasks[i]->document()->has_been_destroyed()) {
+        if (m_tasks[i]->is_permanently_unrunnable()) {
             m_tasks.remove(i);
             continue;
         }
@@ -90,6 +89,11 @@ GC::RootVector<GC::Ref<Task>> TaskQueue::take_tasks_matching(Function<bool(HTML:
 
     for (size_t i = 0; i < m_tasks.size();) {
         auto& task = m_tasks.at(i);
+
+        if (task->is_permanently_unrunnable()) {
+            m_tasks.remove(i);
+            continue;
+        }
 
         if (filter(*task)) {
             matching_tasks.append(task);


### PR DESCRIPTION
In TaskQueue::take_tasks_matching(), we were not discarding tasks for destroyed documents as we now do in ::take_first_runnable() since commit https://github.com/LadybirdBrowser/ladybird/commit/c8baa6e179a7ec6231a30f72979a73acf2acfbe2.

This fixes some occurrences of missing browsing contexts / active documents in TraversableNavigable::destroy_top_level_traversable().