### PR TITLE
LibWeb: Avoid division by zero in multicol calculations the right way

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1568,24 +1568,45 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
 Optional<int> BlockFormattingContext::determine_used_value_for_column_count(CSSPixels const& U) const
 {
     auto const& computed_values = root().computed_values();
+    // (01)  if ((column-width = auto) and (column-count = auto)) then
     if (computed_values.column_width().is_auto() && computed_values.column_count().is_auto()) {
+        // (02)      exit; /* not a multicol container */
         return {};
     }
+
+    // (03)  if column-width = auto then
     if (computed_values.column_width().is_auto()) {
+        // (04)      N := column-count
         return computed_values.column_count().value();
     }
+
     auto column_gap = get_column_gap_used_value_for_multicol(U);
-    auto column_width = computed_values.column_width().to_px(root(), U);
-    auto divisor = column_width + column_gap;
-    auto column_count = divisor == 0 ? 1 : max(1, ((U + column_gap) / divisor).to_int());
-    if (computed_values.column_count().is_auto())
-        return column_count;
-    return min(computed_values.column_count().value(), column_count);
+    auto column_width = get_column_width_used_value_for_multicol(U);
+
+    // (05)  else if column-count = auto then
+    if (computed_values.column_count().is_auto()) {
+        // (06)      N := max(1,
+        // (07)        floor((U + column-gap)/(column-width + column-gap)))
+        return max(1, ((U + column_gap) / (column_width + column_gap)).to_int());
+    }
+
+    // (08)  else
+    // (09)      N := min(column-count, max(1,
+    // (10)        floor((U + column-gap)/(column-width + column-gap))))
+    return min(computed_values.column_count().value(), max(1, ((U + column_gap) / (column_width + column_gap)).to_int()));
 }
 CSSPixels BlockFormattingContext::determine_used_value_for_column_width(CSSPixels const& U, int N) const
 {
     auto column_gap = get_column_gap_used_value_for_multicol(U);
+    // (11)  W := max(0, (U + column-gap)/N - column-gap)
     return max(CSSPixels(0), (U + column_gap) / N - column_gap);
+}
+
+// https://drafts.csswg.org/css-multicol-2/#cw
+CSSPixels BlockFormattingContext::get_column_width_used_value_for_multicol(CSSPixels const& U) const
+{
+    // Used values will be clamped to a minimum of '1px'.
+    return max(root().computed_values().column_width().to_px(root(), U), 1);
 }
 
 // https://www.w3.org/TR/css-align-3/#column-row-gap

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -120,6 +120,9 @@ private:
     Optional<int> determine_used_value_for_column_count(CSSPixels const& U) const;
     CSSPixels determine_used_value_for_column_width(CSSPixels const& U, int N) const;
 
+    // https://drafts.csswg.org/css-multicol-2/#cw
+    CSSPixels get_column_width_used_value_for_multicol(CSSPixels const& U) const;
+    // https://www.w3.org/TR/css-align-3/#column-row-gap
     CSSPixels get_column_gap_used_value_for_multicol(CSSPixels const& U) const;
 
     enum class FloatSide {


### PR DESCRIPTION
This got broken in #8057.

@tcl3, since you made the original change.

No new test to verify the change in behavior, since we don't have enough of multicol layout for me to write one.
I'll try to remember to add one in #8557 once this gets merged.