### PR TITLE
UI/Qt: Store the `TabWidget` parent directly on `TabBar`

### DIFF
--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -20,8 +20,9 @@
 
 namespace Ladybird {
 
-TabBar::TabBar(QWidget* parent)
-    : QTabBar(parent)
+TabBar::TabBar(TabWidget* tab_widget)
+    : QTabBar(tab_widget)
+    , m_tab_widget(tab_widget)
 {
 }
 
@@ -50,9 +51,10 @@ QSize TabBar::tabSizeHint(int index) const
 
 void TabBar::contextMenuEvent(QContextMenuEvent* event)
 {
-    auto* tab_widget = as<TabWidget>(parent());
+    if (!m_tab_widget)
+        return;
 
-    if (auto* tab = tab_widget->tab(tabAt(event->pos())))
+    if (auto* tab = m_tab_widget->tab(tabAt(event->pos())))
         tab->context_menu()->exec(event->globalPos());
 }
 
@@ -110,7 +112,7 @@ TabWidget::TabWidget(QWidget* parent)
 
     recreate_icons();
 
-    auto* tab_bar_row_layout = new QHBoxLayout;
+    auto* tab_bar_row_layout = new QHBoxLayout();
     tab_bar_row_layout->setSpacing(0);
     tab_bar_row_layout->setContentsMargins(0, 0, 0, 0);
     tab_bar_row_layout->addWidget(m_tab_bar);

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -10,6 +10,7 @@
 
 #include <AK/TypeCasts.h>
 
+#include <QPointer>
 #include <QPushButton>
 #include <QStackedWidget>
 #include <QTabBar>
@@ -30,7 +31,7 @@ class TabBar final : public QTabBar {
     Q_OBJECT
 
 public:
-    explicit TabBar(QWidget* parent = nullptr);
+    explicit TabBar(TabWidget*);
 
     void set_available_width(int width);
 
@@ -40,6 +41,8 @@ public:
 private:
     void mousePressEvent(QMouseEvent*) override;
     void mouseMoveEvent(QMouseEvent*) override;
+
+    QPointer<TabWidget> m_tab_widget;
 
     int m_available_width { 0 };
     int m_x_position_in_selected_tab_while_dragging { 0 };


### PR DESCRIPTION
The parent owner of the `TabBar` changes as it is added to layout objects within other widgets. So the parent we set at the beginning is no longer the parent when we right-click on a tab. We now just store the `TabWidget` directly.