### PR TITLE
LibWeb: Implement CSS flexbox baseline aligned items

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -238,6 +238,8 @@ void FlexFormattingContext::run(AvailableSpace const& available_space)
 
             compute_inset(item.box, content_box_rect(m_flex_container_state).size());
         }
+
+        resolve_baseline_aligned_items();
     }
 }
 
@@ -1553,8 +1555,11 @@ void FlexFormattingContext::align_all_flex_items_along_the_cross_axis()
                 }
                 break;
             case CSS::AlignItems::Baseline:
-                // FIXME: Implement this
-                //  Fallthrough
+                // https://drafts.csswg.org/css-flexbox-1/#valdef-align-items-baseline
+                // NB: Baseline-aligned items are initially placed at the cross-start edge (like flex-start). Their
+                //     positions are adjusted after layout in resolve_baseline_aligned_items().
+                flex_line.has_baseline_aligned_items = true;
+                [[fallthrough]];
             case CSS::AlignItems::Start:
             case CSS::AlignItems::FlexStart:
             case CSS::AlignItems::SelfStart:
@@ -1576,6 +1581,37 @@ void FlexFormattingContext::align_all_flex_items_along_the_cross_axis()
             default:
                 break;
             }
+        }
+    }
+}
+
+// https://drafts.csswg.org/css-flexbox-1/#valdef-align-items-baseline
+void FlexFormattingContext::resolve_baseline_aligned_items()
+{
+    // all participating flex items on the line are aligned such that their baselines align, and the item with the
+    // largest distance between its baseline and its cross-start margin edge is placed flush against the cross-start
+    // edge of the line.
+
+    // NB: This runs after layout_inside() so that line boxes are available for baseline computation.
+    for (auto& flex_line : m_flex_lines) {
+        if (!flex_line.has_baseline_aligned_items)
+            continue;
+
+        CSSPixels max_baseline = 0;
+        for (auto& item : flex_line.items) {
+            if (alignment_for_item(item.box) == CSS::AlignItems::Baseline)
+                max_baseline = max(max_baseline, box_baseline(item.box));
+        }
+
+        for (auto& item : flex_line.items) {
+            if (alignment_for_item(item.box) != CSS::AlignItems::Baseline)
+                continue;
+
+            auto adjustment = max_baseline - box_baseline(item.box);
+            if (is_row_layout())
+                item.used_values.set_content_y(item.used_values.offset.y() + adjustment);
+            else
+                item.used_values.set_content_x(item.used_values.offset.x() + adjustment);
         }
     }
 }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -112,6 +112,7 @@ private:
     struct FlexLine {
         Vector<FlexItem&> items;
         CSSPixels cross_size { 0 };
+        bool has_baseline_aligned_items { false };
         Optional<CSSPixels> remaining_free_space;
         double chosen_flex_fraction { 0 };
 
@@ -198,6 +199,8 @@ private:
     void distribute_any_remaining_free_space();
 
     void align_all_flex_items_along_the_cross_axis();
+
+    void resolve_baseline_aligned_items();
 
     void align_all_flex_lines();
 

--- a/Tests/LibWeb/Layout/expected/flex-baseline-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/flex-baseline-alignment.txt
@@ -1,0 +1,33 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 39 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 23 0+0+8] children: inline
+      frag 0 from Box start: 0, length: 0, rect: [8,8 23.671875x23] baseline: 17.5
+      Box <div.flex> at [8,8] flex-container(row) [0+0+0 23.671875 0+0+0] [0+0+0 23 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <span.tall> at [8,8] flex-item [0+0+0 17.828125 0+0+0] [0+0+0 23 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 17.828125x23] baseline: 17.5
+              "A"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <span.short> at [25.828125,16.5] flex-item [0+0+0 5.84375 0+0+0] [0+0+0 12 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [25.828125,16.5 5.84375x12] baseline: 9
+              "B"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [8,8] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x39]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
+      PaintableBox (Box<DIV>.flex) [8,8 23.671875x23]
+        PaintableWithLines (BlockContainer<SPAN>.tall) [8,8 17.828125x23]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<SPAN>.short) [25.828125,16.5 5.84375x12]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 0x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x39] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex-baseline-alignment.html
+++ b/Tests/LibWeb/Layout/input/flex-baseline-alignment.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+    .flex {
+        display: inline-flex;
+        align-items: baseline;
+    }
+    .tall {
+        font-size: 20px;
+    }
+    .short {
+        font-size: 10px;
+    }
+</style>
+<div class="flex">
+    <span class="tall">A</span>
+    <span class="short">B</span>
+</div>


### PR DESCRIPTION
Fixes the emoji reaction alignment on GitHub.

| Before | After |
|--|--|
| <img width="419" height="274" alt="image" src="https://github.com/user-attachments/assets/d155ccae-9ce1-4d32-8dc0-b4be625f5ec6" /> | <img width="419" height="274" alt="image" src="https://github.com/user-attachments/assets/a1075aa2-a0d9-435b-a647-f98740ae8e3c" /> |
