### PR TITLE
Meta: Ensure that idl files link to draft specs

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.idl
+++ b/Libraries/LibWeb/Animations/Animation.idl
@@ -2,7 +2,7 @@
 #import <Animations/AnimationTimeline.idl>
 #import <DOM/EventTarget.idl>
 
-// https://www.w3.org/TR/web-animations-1/#the-animation-interface
+// https://drafts.csswg.org/web-animations-1/#the-animation-interface
 [Exposed=Window]
 interface Animation : EventTarget {
     constructor(optional AnimationEffect? effect = null,
@@ -34,8 +34,8 @@ interface Animation : EventTarget {
     [FIXME, CEReactions] undefined commitStyles();
 };
 
-// https://www.w3.org/TR/web-animations-1/#the-animationplaystate-enumeration
+// https://drafts.csswg.org/web-animations-1/#the-animationplaystate-enumeration
 enum AnimationPlayState { "idle", "running", "paused", "finished" };
 
-// https://www.w3.org/TR/web-animations-1/#the-animationreplacestate-enumeration
+// https://drafts.csswg.org/web-animations-1/#the-animationreplacestate-enumeration
 enum AnimationReplaceState { "active", "removed", "persisted" };

--- a/Libraries/LibWeb/Animations/AnimationEffect.idl
+++ b/Libraries/LibWeb/Animations/AnimationEffect.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSNumericValue.idl>
 
-// https://www.w3.org/TR/web-animations-1/#the-effecttiming-dictionaries
+// https://drafts.csswg.org/web-animations-1/#the-effecttiming-dictionaries
 // https://drafts.csswg.org/web-animations-2/#the-effecttiming-dictionaries
 dictionary EffectTiming {
     double delay = 0;
@@ -14,7 +14,7 @@ dictionary EffectTiming {
     DOMString easing = "linear";
 };
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-optionaleffecttiming
+// https://drafts.csswg.org/web-animations-1/#dictdef-optionaleffecttiming
 // https://drafts.csswg.org/web-animations-2/#ref-for-dictdef-optionaleffecttiming
 dictionary OptionalEffectTiming {
     double delay;
@@ -28,13 +28,13 @@ dictionary OptionalEffectTiming {
     DOMString easing;
 };
 
-// https://www.w3.org/TR/web-animations-1/#the-fillmode-enumeration
+// https://drafts.csswg.org/web-animations-1/#the-fillmode-enumeration
 enum FillMode { "none", "forwards", "backwards", "both", "auto" };
 
-// https://www.w3.org/TR/web-animations-1/#the-playbackdirection-enumeration
+// https://drafts.csswg.org/web-animations-1/#the-playbackdirection-enumeration
 enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" };
 
-// https://www.w3.org/TR/web-animations-1/#the-computedeffecttiming-dictionary
+// https://drafts.csswg.org/web-animations-1/#the-computedeffecttiming-dictionary
 dictionary ComputedEffectTiming : EffectTiming {
     [GenerateAsRequired] CSSNumberish endTime;
     [GenerateAsRequired] CSSNumberish activeDuration;
@@ -43,7 +43,7 @@ dictionary ComputedEffectTiming : EffectTiming {
     unrestricted double? currentIteration;
 };
 
-// https://www.w3.org/TR/web-animations-1/#the-animationeffect-interface
+// https://drafts.csswg.org/web-animations-1/#the-animationeffect-interface
 [Exposed=Window]
 interface AnimationEffect {
     EffectTiming getTiming();

--- a/Libraries/LibWeb/Animations/DocumentTimeline.idl
+++ b/Libraries/LibWeb/Animations/DocumentTimeline.idl
@@ -1,12 +1,12 @@
 #import <Animations/AnimationTimeline.idl>
 #import <HighResolutionTime/DOMHighResTimeStamp.idl>
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-documenttimelineoptions
+// https://drafts.csswg.org/web-animations-1/#dictdef-documenttimelineoptions
 dictionary DocumentTimelineOptions {
     DOMHighResTimeStamp originTime = 0;
 };
 
-// https://www.w3.org/TR/web-animations-1/#documenttimeline
+// https://drafts.csswg.org/web-animations-1/#documenttimeline
 [Exposed=Window]
 interface DocumentTimeline : AnimationTimeline {
     constructor(optional DocumentTimelineOptions options = {});

--- a/Libraries/LibWeb/Animations/KeyframeEffect.idl
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.idl
@@ -1,33 +1,33 @@
 #import <Animations/AnimationEffect.idl>
 #import <DOM/Element.idl>
 
-// https://www.w3.org/TR/web-animations-1/#the-compositeoperation-enumeration
+// https://drafts.csswg.org/web-animations-1/#the-compositeoperation-enumeration
 enum CompositeOperation { "replace", "add", "accumulate" };
 
-// https://www.w3.org/TR/web-animations-1/#enumdef-compositeoperationorauto
+// https://drafts.csswg.org/web-animations-1/#enumdef-compositeoperationorauto
 enum CompositeOperationOrAuto { "replace", "add", "accumulate", "auto" };
 
-// https://www.w3.org/TR/web-animations-1/#the-keyframeeffectoptions-dictionary
+// https://drafts.csswg.org/web-animations-1/#the-keyframeeffectoptions-dictionary
 dictionary KeyframeEffectOptions : EffectTiming {
     CompositeOperation composite = "replace";
     CSSOMString? pseudoElement = null;
 };
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-basepropertyindexedkeyframe
+// https://drafts.csswg.org/web-animations-1/#dictdef-basepropertyindexedkeyframe
 dictionary BasePropertyIndexedKeyframe {
     (double? or sequence<double?>) offset = [];
     (DOMString or sequence<DOMString>) easing = [];
     (CompositeOperationOrAuto or sequence<CompositeOperationOrAuto>) composite = [];
 };
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-basekeyframe
+// https://drafts.csswg.org/web-animations-1/#dictdef-basekeyframe
 dictionary BaseKeyframe {
     double? offset = null;
     DOMString easing = "linear";
     CompositeOperationOrAuto composite = "auto";
 };
 
-// https://www.w3.org/TR/web-animations-1/#the-keyframeeffect-interface
+// https://drafts.csswg.org/web-animations-1/#the-keyframeeffect-interface
 [Exposed=Window]
 interface KeyframeEffect : AnimationEffect {
     constructor(Element? target, object? keyframes, optional (unrestricted double or KeyframeEffectOptions) options = {});

--- a/Libraries/LibWeb/CSS/AnimationEvent.idl
+++ b/Libraries/LibWeb/CSS/AnimationEvent.idl
@@ -1,6 +1,6 @@
 #import <DOM/Event.idl>
 
-// https://www.w3.org/TR/css-animations-1/#animationevent
+// https://drafts.csswg.org/css-animations-1/#animationevent
 [Exposed=Window]
 interface AnimationEvent : Event {
     constructor(CSSOMString type, optional AnimationEventInit animationEventInitDict = {});
@@ -9,7 +9,7 @@ interface AnimationEvent : Event {
     readonly attribute CSSOMString pseudoElement;
 };
 
-// https://www.w3.org/TR/css-animations-1/#dictdef-animationeventinit
+// https://drafts.csswg.org/css-animations-1/#dictdef-animationeventinit
 dictionary AnimationEventInit : EventInit {
     CSSOMString animationName = "";
     double elapsedTime = 0.0;

--- a/Libraries/LibWeb/CSS/CSS.idl
+++ b/Libraries/LibWeb/CSS/CSS.idl
@@ -8,7 +8,7 @@ dictionary PropertyDefinition {
     CSSOMString initialValue;
 };
 
-// https://www.w3.org/TR/cssom-1/#namespacedef-css
+// https://drafts.csswg.org/cssom-1/#namespacedef-css
 [Exposed=Window]
 namespace CSS {
     CSSOMString escape(CSSOMString ident);
@@ -16,7 +16,7 @@ namespace CSS {
     boolean supports(CSSOMString property, CSSOMString value);
     boolean supports(CSSOMString conditionText);
 
-    // https://www.w3.org/TR/css-properties-values-api-1/#dom-css-registerproperty
+    // https://drafts.css-houdini.org/css-properties-values-api-1/#dom-css-registerproperty
     undefined registerProperty(PropertyDefinition definition);
     
     // https://drafts.css-houdini.org/css-typed-om-1/#numeric-factory

--- a/Libraries/LibWeb/CSS/CSSAnimation.idl
+++ b/Libraries/LibWeb/CSS/CSSAnimation.idl
@@ -1,6 +1,6 @@
 #import <Animations/Animation.idl>
 
-// https://www.w3.org/TR/css-animations-2/#cssanimation
+// https://drafts.csswg.org/css-animations-2/#cssanimation
 [Exposed=Window]
 interface CSSAnimation : Animation {
     readonly attribute CSSOMString animationName;

--- a/Libraries/LibWeb/CSS/CSSNamespaceRule.idl
+++ b/Libraries/LibWeb/CSS/CSSNamespaceRule.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSRule.idl>
 
-// https://www.w3.org/TR/cssom/#the-cssnamespacerule-interface
+// https://drafts.csswg.org/cssom/#the-cssnamespacerule-interface
 [Exposed=Window]
 interface CSSNamespaceRule : CSSRule {
     readonly attribute CSSOMString namespaceURI;

--- a/Libraries/LibWeb/CSS/CSSRule.idl
+++ b/Libraries/LibWeb/CSS/CSSRule.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSStyleSheet.idl>
 
-// https://www.w3.org/TR/cssom/#the-cssrule-interface
+// https://drafts.csswg.org/cssom/#the-cssrule-interface
 [Exposed=Window]
 interface CSSRule {
 

--- a/Libraries/LibWeb/CSS/CSSRuleList.idl
+++ b/Libraries/LibWeb/CSS/CSSRuleList.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSRule.idl>
 
-// https://www.w3.org/TR/cssom/#the-cssrulelist-interface
+// https://drafts.csswg.org/cssom/#the-cssrulelist-interface
 [Exposed=Window]
 interface CSSRuleList {
 

--- a/Libraries/LibWeb/CSS/LinkStyle.idl
+++ b/Libraries/LibWeb/CSS/LinkStyle.idl
@@ -1,6 +1,6 @@
 #import <CSS/CSSStyleSheet.idl>
 
-// https://www.w3.org/TR/cssom-1/#ref-for-linkstyle
+// https://drafts.csswg.org/cssom-1/#ref-for-linkstyle
 interface mixin LinkStyle {
     readonly attribute CSSStyleSheet? sheet;
 };

--- a/Libraries/LibWeb/CSS/MediaList.idl
+++ b/Libraries/LibWeb/CSS/MediaList.idl
@@ -1,4 +1,4 @@
-// https://www.w3.org/TR/cssom-1/#the-medialist-interface
+// https://drafts.csswg.org/cssom-1/#the-medialist-interface
 [Exposed=Window]
 interface MediaList {
     [LegacyNullToEmptyString] stringifier attribute CSSOMString mediaText;

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -138,7 +138,7 @@ interface Document : Node {
 
     [CEReactions] attribute DOMString designMode;
 
-    // https://www.w3.org/TR/web-animations-1/#extensions-to-the-document-interface
+    // https://drafts.csswg.org/web-animations-1/#extensions-to-the-document-interface
     readonly attribute DocumentTimeline timeline;
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface
@@ -167,7 +167,7 @@ interface Document : Node {
     // https://drafts.csswg.org/css-view-transitions-1/#additions-to-document-api
     ViewTransition startViewTransition(optional ViewTransitionUpdateCallback updateCallback);
 
-    // https://www.w3.org/TR/SVG2/struct.html#InterfaceDocumentExtensions
+    // https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceDocumentExtensions
     readonly attribute SVGSVGElement? rootElement;
     
     // https://w3c.github.io/pointerlock/#extensions-to-the-document-interface

--- a/Libraries/LibWeb/DOM/DocumentOrShadowRoot.idl
+++ b/Libraries/LibWeb/DOM/DocumentOrShadowRoot.idl
@@ -10,6 +10,6 @@ interface mixin DocumentOrShadowRoot {
     [SameObject, ImplementedAs=style_sheets_for_bindings] readonly attribute StyleSheetList styleSheets;
     attribute any adoptedStyleSheets;
 
-    // https://www.w3.org/TR/web-animations-1/#extensions-to-the-documentorshadowroot-interface-mixin
+    // https://drafts.csswg.org/web-animations-1/#extensions-to-the-documentorshadowroot-interface-mixin
     sequence<Animation> getAnimations();
 };

--- a/Libraries/LibWeb/DOM/Element.idl
+++ b/Libraries/LibWeb/DOM/Element.idl
@@ -152,8 +152,8 @@ dictionary ShadowRootInit {
 
 Element includes ParentNode;
 Element includes ChildNode;
-// https://www.w3.org/TR/wai-aria-1.2/#idl_element
+// https://w3c.github.io/aria/#ARIAMixin
 Element includes ARIAMixin;
 Element includes Slottable;
-// https://www.w3.org/TR/web-animations-1/#extensions-to-the-element-interface
+// https://drafts.csswg.org/web-animations-1/#extensions-to-the-element-interface
 Element includes Animatable;

--- a/Libraries/LibWeb/EventTiming/PerformanceEventTiming.idl
+++ b/Libraries/LibWeb/EventTiming/PerformanceEventTiming.idl
@@ -1,6 +1,6 @@
 #import <PerformanceTimeline/PerformanceEntry.idl>
 
-// https://www.w3.org/TR/event-timing/#sec-performance-event-timing
+// https://w3c.github.io/event-timing/#sec-performance-event-timing
 [Exposed=Window]
 interface PerformanceEventTiming : PerformanceEntry {
     readonly attribute DOMHighResTimeStamp processingStart;
@@ -13,6 +13,6 @@ interface PerformanceEventTiming : PerformanceEntry {
 
 
 // Potential fixme: This spec has some more IDLs
-// https://www.w3.org/TR/event-timing/#sec-event-counts
-// https://www.w3.org/TR/event-timing/#sec-extensions
-// https://www.w3.org/TR/event-timing/#sec-modifications-perf-timeline
+// https://w3c.github.io/event-timing/#sec-event-counts
+// https://w3c.github.io/event-timing/#sec-extensions
+// https://w3c.github.io/event-timing/#sec-modifications-perf-timeline

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.idl
@@ -17,7 +17,7 @@ interface HTMLScriptElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString integrity;
     [CEReactions, Enumerated=FetchPriorityAttribute, Reflect=fetchpriority] attribute DOMString fetchPriority;
 
-    // https://www.w3.org/TR/trusted-types/#enforcement-in-scripts
+    // https://w3c.github.io/trusted-types/dist/spec/#enforcement-in-scripts
     [CEReactions] attribute (TrustedScript or Utf16DOMString) text;
     [CEReactions] attribute (TrustedScriptURL or Utf16USVString) src;
     [CEReactions] attribute (TrustedScript or Utf16DOMString)? textContent;

--- a/Libraries/LibWeb/HTML/NavigatorDeviceMemory.idl
+++ b/Libraries/LibWeb/HTML/NavigatorDeviceMemory.idl
@@ -1,4 +1,4 @@
-// https://www.w3.org/TR/device-memory/#sec-device-memory-js-api
+// https://w3c.github.io/device-memory/#sec-device-memory-js-api
 [SecureContext, Exposed=(Window,Worker)]
 interface mixin NavigatorDeviceMemory {
     readonly attribute double deviceMemory;

--- a/Libraries/LibWeb/HighResolutionTime/EpochTimeStamp.idl
+++ b/Libraries/LibWeb/HighResolutionTime/EpochTimeStamp.idl
@@ -1,2 +1,2 @@
-// https://www.w3.org/TR/hr-time-3/#the-epochtimestamp-typedef
+// https://w3c.github.io/hr-time/#sec-epochtimestamp
 typedef unsigned long long EpochTimeStamp;

--- a/Libraries/LibWeb/HighResolutionTime/Performance.idl
+++ b/Libraries/LibWeb/HighResolutionTime/Performance.idl
@@ -7,7 +7,7 @@
 #import <UserTiming/PerformanceMark.idl>
 #import <UserTiming/PerformanceMeasure.idl>
 
-// https://www.w3.org/TR/performance-timeline/#dom-performanceentrylist
+// https://w3c.github.io/performance-timeline/#typedefdef-performanceentrylist
 typedef sequence<PerformanceEntry> PerformanceEntryList;
 
 // https://w3c.github.io/hr-time/#sec-performance
@@ -30,7 +30,7 @@ interface Performance : EventTarget {
     undefined setResourceTimingBufferSize(unsigned long maxSize);
     attribute EventHandler onresourcetimingbufferfull;
 
-    // https://www.w3.org/TR/performance-timeline/#extensions-to-the-performance-interface
+    // https://w3c.github.io/performance-timeline/#extensions-to-the-performance-interface
     // "Performance Timeline" extensions to the Performance interface
     PerformanceEntryList getEntries();
     PerformanceEntryList getEntriesByType(DOMString type);

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserverEntry.idl
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserverEntry.idl
@@ -2,7 +2,7 @@
 #import <Geometry/DOMRect.idl>
 #import <HighResolutionTime/DOMHighResTimeStamp.idl>
 
-// https://www.w3.org/TR/intersection-observer/#intersectionobserverentry
+// https://w3c.github.io/IntersectionObserver/#intersectionobserverentry
 [Exposed=Window]
 interface IntersectionObserverEntry {
     // FIXME: constructor(IntersectionObserverEntryInit intersectionObserverEntryInit);

--- a/Libraries/LibWeb/PerformanceTimeline/PerformanceEntry.idl
+++ b/Libraries/LibWeb/PerformanceTimeline/PerformanceEntry.idl
@@ -1,6 +1,6 @@
 #import <HighResolutionTime/DOMHighResTimeStamp.idl>
 
-// https://www.w3.org/TR/performance-timeline/#dom-performanceentry
+// https://w3c.github.io/performance-timeline/#dom-performanceentry
 [Exposed=(Window,Worker)]
 interface PerformanceEntry {
     readonly attribute DOMString name;

--- a/Libraries/LibWeb/SVG/SVGAnimatedNumberList.idl
+++ b/Libraries/LibWeb/SVG/SVGAnimatedNumberList.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGNumberList.idl>
 
-// https://www.w3.org/TR/SVG2/types.html#InterfaceSVGAnimatedNumberList
+// https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedNumberList
 [Exposed=Window]
 interface SVGAnimatedNumberList {
     [SameObject] readonly attribute SVGNumberList baseVal;

--- a/Libraries/LibWeb/SVG/SVGComponentTransferFunctionElement.idl
+++ b/Libraries/LibWeb/SVG/SVGComponentTransferFunctionElement.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGElement.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGComponentTransferFunctionElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGComponentTransferFunctionElement
 [Exposed=Window]
 interface SVGComponentTransferFunctionElement : SVGElement {
 

--- a/Libraries/LibWeb/SVG/SVGFEBlendElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEBlendElement.idl
@@ -2,7 +2,7 @@
 #import <SVG/SVGAnimatedString.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEBlendElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEBlendElement
 [Exposed=Window]
 interface SVGFEBlendElement : SVGElement {
 

--- a/Libraries/LibWeb/SVG/SVGFEColorMatrixElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEColorMatrixElement.idl
@@ -3,7 +3,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEColorMatrixElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEColorMatrixElement
 [Exposed=Window]
 interface SVGFEColorMatrixElement : SVGElement {
 

--- a/Libraries/LibWeb/SVG/SVGFEComponentTransferElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEComponentTransferElement.idl
@@ -1,7 +1,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEComponentTransferElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEComponentTransferElement
 [Exposed=Window]
 interface SVGFEComponentTransferElement : SVGElement {
     readonly attribute SVGAnimatedString in1;

--- a/Libraries/LibWeb/SVG/SVGFECompositeElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFECompositeElement.idl
@@ -2,7 +2,7 @@
 #import <SVG/SVGAnimatedString.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFECompositeElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFECompositeElement
 [Exposed=Window]
 interface SVGFECompositeElement : SVGElement {
     // Composite Operators

--- a/Libraries/LibWeb/SVG/SVGFEDisplacementMapElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEDisplacementMapElement.idl
@@ -4,7 +4,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEDisplacementMapElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEDisplacementMapElement
 [Exposed=Window]
 interface SVGFEDisplacementMapElement : SVGElement {
     // Channel Selectors

--- a/Libraries/LibWeb/SVG/SVGFEFloodElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEFloodElement.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEFloodElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEFloodElement
 [Exposed=Window]
 interface SVGFEFloodElement : SVGElement {
 };

--- a/Libraries/LibWeb/SVG/SVGFEFuncAElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEFuncAElement.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGComponentTransferFunctionElement.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEFuncAElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEFuncAElement
 [Exposed=Window]
 interface SVGFEFuncAElement : SVGComponentTransferFunctionElement {
 };

--- a/Libraries/LibWeb/SVG/SVGFEFuncBElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEFuncBElement.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGComponentTransferFunctionElement.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEFuncBElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEFuncBElement
 [Exposed=Window]
 interface SVGFEFuncBElement : SVGComponentTransferFunctionElement {
 };

--- a/Libraries/LibWeb/SVG/SVGFEFuncGElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEFuncGElement.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGComponentTransferFunctionElement.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEFuncGElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEFuncGElement
 [Exposed=Window]
 interface SVGFEFuncGElement : SVGComponentTransferFunctionElement {
 };

--- a/Libraries/LibWeb/SVG/SVGFEFuncRElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEFuncRElement.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGComponentTransferFunctionElement.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEFuncRElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEFuncRElement
 [Exposed=Window]
 interface SVGFEFuncRElement : SVGComponentTransferFunctionElement {
 };

--- a/Libraries/LibWeb/SVG/SVGFEGaussianBlurElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEGaussianBlurElement.idl
@@ -4,7 +4,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEGaussianBlurElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEGaussianBlurElement
 [Exposed=Window]
 interface SVGFEGaussianBlurElement : SVGElement {
 

--- a/Libraries/LibWeb/SVG/SVGFEImageElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEImageElement.idl
@@ -3,7 +3,7 @@
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 #import <SVG/SVGURIReference.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#feImageElement
+// https://drafts.csswg.org/filter-effects-1/#feImageElement
 [Exposed=Window]
 interface SVGFEImageElement : SVGElement {
     [FIXME] readonly attribute SVGAnimatedPreserveAspectRatio preserveAspectRatio;

--- a/Libraries/LibWeb/SVG/SVGFEMergeElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEMergeElement.idl
@@ -1,7 +1,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEMergeElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEMergeElement
 [Exposed=Window]
 interface SVGFEMergeElement : SVGElement {
 };

--- a/Libraries/LibWeb/SVG/SVGFEMergeNodeElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEMergeNodeElement.idl
@@ -1,7 +1,7 @@
 #import <SVG/SVGAnimatedString.idl>
 #import <SVG/SVGElement.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEMergeNodeElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEMergeNodeElement
 [Exposed=Window]
 interface SVGFEMergeNodeElement : SVGElement {
     readonly attribute SVGAnimatedString in1;

--- a/Libraries/LibWeb/SVG/SVGFEMorphologyElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEMorphologyElement.idl
@@ -4,7 +4,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEMorphologyElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEMorphologyElement
 [Exposed=Window]
 interface SVGFEMorphologyElement : SVGElement {
 

--- a/Libraries/LibWeb/SVG/SVGFEOffsetElement.idl
+++ b/Libraries/LibWeb/SVG/SVGFEOffsetElement.idl
@@ -3,7 +3,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGFilterPrimitiveStandardAttributes.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFEOffsetElement
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFEOffsetElement
 [Exposed=Window]
 interface SVGFEOffsetElement : SVGElement {
     readonly attribute SVGAnimatedString in1;

--- a/Libraries/LibWeb/SVG/SVGFilterPrimitiveStandardAttributes.idl
+++ b/Libraries/LibWeb/SVG/SVGFilterPrimitiveStandardAttributes.idl
@@ -1,7 +1,7 @@
 #import <SVG/SVGAnimatedLength.idl>
 #import <SVG/SVGAnimatedString.idl>
 
-// https://www.w3.org/TR/filter-effects-1/#InterfaceSVGFilterPrimitiveStandardAttributes
+// https://drafts.csswg.org/filter-effects-1/#InterfaceSVGFilterPrimitiveStandardAttributes
 interface mixin SVGFilterPrimitiveStandardAttributes {
     [SameObject] readonly attribute SVGAnimatedLength x;
     [SameObject] readonly attribute SVGAnimatedLength y;

--- a/Libraries/LibWeb/SVG/SVGNumber.idl
+++ b/Libraries/LibWeb/SVG/SVGNumber.idl
@@ -1,4 +1,4 @@
-// https://www.w3.org/TR/SVG2/types.html#InterfaceSVGNumber
+// https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGNumber
 [Exposed=Window]
 interface SVGNumber {
     attribute float value;

--- a/Libraries/LibWeb/SVG/SVGNumberList.idl
+++ b/Libraries/LibWeb/SVG/SVGNumberList.idl
@@ -1,6 +1,6 @@
 #import <SVG/SVGNumber.idl>
 
-// https://www.w3.org/TR/SVG2/types.html#InterfaceSVGNumberList
+// https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGNumberList
 [Exposed=Window]
 interface SVGNumberList {
 

--- a/Libraries/LibWeb/SVG/SVGScriptElement.idl
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.idl
@@ -2,7 +2,7 @@
 #import <SVG/SVGElement.idl>
 #import <SVG/SVGURIReference.idl>
 
-// https://www.w3.org/TR/SVG/interact.html#InterfaceSVGScriptElement
+// https://w3c.github.io/svgwg/svg2-draft/interact.html#InterfaceSVGScriptElement
 [Exposed=Window]
 interface SVGScriptElement : SVGElement {
     [Reflect] attribute DOMString type;

--- a/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.idl
+++ b/Libraries/LibWeb/TrustedTypes/TrustedTypePolicy.idl
@@ -2,7 +2,7 @@
 #import <TrustedTypes/TrustedScript.idl>
 #import <TrustedTypes/TrustedScriptURL.idl>
 
-// https://www.w3.org/TR/trusted-types/#typedefdef-trustedtype
+// https://w3c.github.io/trusted-types/dist/spec/#typedefdef-trustedtype
 typedef (TrustedHTML or TrustedScript or TrustedScriptURL) TrustedType;
 
 // https://w3c.github.io/trusted-types/dist/spec/#trusted-type-policy

--- a/Libraries/LibWeb/UIEvents/FocusEvent.idl
+++ b/Libraries/LibWeb/UIEvents/FocusEvent.idl
@@ -1,6 +1,6 @@
 #import <UIEvents/UIEvent.idl>
 
-// https://www.w3.org/TR/uievents/#idl-focusevent
+// https://w3c.github.io/uievents/#idl-focusevent
 [Exposed=Window]
 interface FocusEvent : UIEvent {
 
@@ -9,7 +9,7 @@ interface FocusEvent : UIEvent {
 
 };
 
-// https://www.w3.org/TR/uievents/#idl-focuseventinit
+// https://w3c.github.io/uievents/#idl-focuseventinit
 dictionary FocusEventInit : UIEventInit {
 
     EventTarget? relatedTarget = null;

--- a/Libraries/LibWeb/UIEvents/KeyboardEvent.idl
+++ b/Libraries/LibWeb/UIEvents/KeyboardEvent.idl
@@ -1,6 +1,6 @@
 #import <UIEvents/EventModifier.idl>
 
-// https://www.w3.org/TR/uievents/#idl-keyboardevent
+// https://w3c.github.io/uievents/#idl-keyboardevent
 [Exposed=Window]
 interface KeyboardEvent : UIEvent {
 
@@ -34,7 +34,7 @@ interface KeyboardEvent : UIEvent {
 
 };
 
-// https://www.w3.org/TR/uievents/#dictdef-keyboardeventinit
+// https://w3c.github.io/uievents/#dictdef-keyboardeventinit
 dictionary KeyboardEventInit : EventModifierInit {
     DOMString key = "";
     DOMString code = "";

--- a/Libraries/LibWeb/UIEvents/WheelEvent.idl
+++ b/Libraries/LibWeb/UIEvents/WheelEvent.idl
@@ -1,6 +1,6 @@
 #import <UIEvents/MouseEvent.idl>
 
-// https://www.w3.org/TR/uievents/#idl-wheelevent
+// https://w3c.github.io/pointerevents/#idl-wheelevent
 [Exposed=Window]
 interface WheelEvent : MouseEvent {
     constructor(DOMString type, optional WheelEventInit eventInitDict = {});
@@ -16,7 +16,7 @@ interface WheelEvent : MouseEvent {
     readonly attribute unsigned long deltaMode;
 };
 
-// https://www.w3.org/TR/uievents/#idl-wheeleventinit
+// https://w3c.github.io/pointerevents/#idl-wheeleventinit
 dictionary WheelEventInit : MouseEventInit {
     double deltaX = 0;
     double deltaY = 0;

--- a/Libraries/LibWeb/WebAudio/AudioContext.idl
+++ b/Libraries/LibWeb/WebAudio/AudioContext.idl
@@ -1,6 +1,6 @@
 #import <WebAudio/BaseAudioContext.idl>
 
-// https://www.w3.org/TR/webaudio/#enumdef-audiocontextlatencycategory
+// https://webaudio.github.io/web-audio-api/#enumdef-audiocontextlatencycategory
 enum AudioContextLatencyCategory { "balanced", "interactive", "playback" };
 
 // https://webaudio.github.io/web-audio-api/#AudioContext

--- a/Libraries/LibWeb/WebAudio/BaseAudioContext.idl
+++ b/Libraries/LibWeb/WebAudio/BaseAudioContext.idl
@@ -11,7 +11,7 @@
 #import <WebAudio/PannerNode.idl>
 #import <WebIDL/DOMException.idl>
 
-// https://www.w3.org/TR/webaudio/#enumdef-audiocontextstate
+// https://webaudio.github.io/web-audio-api/#enumdef-audiocontextstate
 enum AudioContextState { "suspended", "running", "closed" };
 
 callback DecodeErrorCallback = undefined (DOMException error);

--- a/Meta/check-idl-files.py
+++ b/Meta/check-idl-files.py
@@ -20,6 +20,7 @@ parser.add_argument("filenames", nargs="*")
 args = parser.parse_args()
 
 SINGLE_PAGE_HTML_SPEC_LINK = re.compile("//.*https://html\\.spec\\.whatwg\\.org/#")
+PUBLISHED_W3C_SPEC_LINK = re.compile("//.*https://www\\.w3\\.org/TR/")
 
 
 def should_check_file(filename):
@@ -45,6 +46,8 @@ def run():
     files_without_four_leading_spaces = set()
     """Also lint for them not containing any links to the single-page HTML spec."""
     files_with_single_page_html_spec_link = set()
+    """Also lint for them not containing any links to non-editor's draft W3C specs."""
+    files_with_published_w3c_spec_link = set()
     did_fail = False
     for filename in find_files_here_or_argv():
         lines = []
@@ -52,6 +55,10 @@ def run():
             for line_number, line in enumerate(f, start=1):
                 if SINGLE_PAGE_HTML_SPEC_LINK.search(line):
                     files_with_single_page_html_spec_link.add(filename)
+                    did_fail = True
+                if PUBLISHED_W3C_SPEC_LINK.search(line):
+                    files_with_published_w3c_spec_link.add(filename)
+                    did_fail = True
                 if lines_to_skip.match(line):
                     lines.append(line)
                     continue
@@ -77,8 +84,14 @@ def run():
 
     if files_with_single_page_html_spec_link:
         print(
-            "\nWebIDL files that have links to the single-page HTML spec:",
-            " ".join(files_with_single_page_html_spec_link),
+            "\nWebIDL files that link to the single-page HTML spec:\n"
+            + "\n".join(files_with_single_page_html_spec_link)
+        )
+
+    if files_with_published_w3c_spec_link:
+        print(
+            "\nWebIDL files that link to a published (not editor's draft) W3C spec:\n"
+            + "\n".join(files_with_published_w3c_spec_link)
         )
 
     if did_fail:


### PR DESCRIPTION
I manually checked that all these still point to the right things.
One weird one is https://w3c.github.io/device-memory/#sec-device-memory-js-api, which actually just redirects to the TR link and loses the URL fragment (`#sec-device-memory-js-api`) in the process. But the spec is incredibly short and basic, so I think this is fine. And I'd assume that's probably also the reason for why there is no draft version of this spec.

I will make a second PR in a bit that enforces this for C++ files also, I just thought I'd start small.

Inspired by me constantly forgetting to link to draft specs instead of published ones, which probably only sometimes gets caught in review.

This is what the error looks like:
<img width="557" height="919" alt="image" src="https://github.com/user-attachments/assets/77a282ab-214a-4215-9ae3-d6ad7a6d5013" />
