### PR TITLE
LibWeb: Mark startViewTransition() as experimental

### DIFF
--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -165,7 +165,7 @@ interface Document : Node {
     attribute EventHandler onvisibilitychange;
 
     // https://drafts.csswg.org/css-view-transitions-1/#additions-to-document-api
-    ViewTransition startViewTransition(optional ViewTransitionUpdateCallback updateCallback);
+    [Experimental] ViewTransition startViewTransition(optional ViewTransitionUpdateCallback updateCallback);
 
     // https://www.w3.org/TR/SVG2/struct.html#InterfaceDocumentExtensions
     readonly attribute SVGSVGElement? rootElement;


### PR DESCRIPTION
This function is used to feature-detect view transitions in pretty much all the code examples for the API, so removing support for it while we cannot actually render a view transition's animation should hopefully be fine.

If this ends up breaking websites, we can just put it back. Our current failure mode is that transitions skip instantly so there's really not much of a difference, apart from the fact that having the function might be misleading to web developers.