### PR TITLE
Send IOSurface backing stores via main IPC route on macOS

### DIFF
--- a/Libraries/LibCore/Platform/MachMessageTypes.h
+++ b/Libraries/LibCore/Platform/MachMessageTypes.h
@@ -30,34 +30,9 @@ struct MessageWithSelfTaskPort {
     mach_msg_port_descriptor_t port_descriptor;
 };
 
-struct BackingStoreMetadata {
-    u64 page_id { 0 };
-    i32 back_backing_store_id { 0 };
-    i32 front_backing_store_id { 0 };
-};
-
-struct MessageBodyWithBackingStores {
-    mach_msg_body_t body;
-    mach_msg_port_descriptor_t front_descriptor;
-    mach_msg_port_descriptor_t back_descriptor;
-    BackingStoreMetadata metadata;
-    mach_msg_audit_trailer_t trailer;
-};
-
-struct MessageWithBackingStores {
-    mach_msg_header_t header;
-    mach_msg_body_t body;
-    mach_msg_port_descriptor_t front_descriptor;
-    mach_msg_port_descriptor_t back_descriptor;
-    BackingStoreMetadata metadata;
-};
-
 struct ReceivedMachMessage {
     mach_msg_header_t header;
-    union {
-        MessageBodyWithSelfTaskPort parent;
-        MessageBodyWithBackingStores parent_iosurface;
-    } body;
+    MessageBodyWithSelfTaskPort body;
 };
 
 struct MessageWithIPCChannelPorts {
@@ -76,7 +51,6 @@ struct ReceivedIPCChannelPortsMessage {
 };
 
 static constexpr mach_msg_id_t SELF_TASK_PORT_MESSAGE_ID = 0x1234CAFE;
-static constexpr mach_msg_id_t BACKING_STORE_IOSURFACES_MESSAGE_ID = 0x1234CAFF;
 static constexpr mach_msg_id_t IPC_CHANNEL_PORTS_MESSAGE_ID = 0x4950C002;
 
 }

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -820,6 +820,7 @@ set(SOURCES
     Page/EventHandler.cpp
     Page/InputEvent.cpp
     Page/Page.cpp
+    Page/SharedBackingStore.cpp
     Painting/AccumulatedVisualContext.cpp
     Painting/BackgroundPainting.cpp
     Painting/BackingStoreManager.cpp

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -46,6 +46,7 @@
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Page/SharedBackingStore.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWeb/Painting/ChromeMetrics.h>
 #include <LibWeb/PixelUnits.h>
@@ -440,7 +441,7 @@ public:
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
     virtual void page_did_update_navigation_buttons_state([[maybe_unused]] bool back_enabled, [[maybe_unused]] bool forward_enabled) { }
-    virtual void page_did_allocate_backing_stores([[maybe_unused]] i32 front_bitmap_id, [[maybe_unused]] Gfx::ShareableBitmap front_bitmap, [[maybe_unused]] i32 back_bitmap_id, [[maybe_unused]] Gfx::ShareableBitmap back_bitmap) { }
+    virtual void page_did_allocate_backing_stores([[maybe_unused]] i32 front_bitmap_id, [[maybe_unused]] SharedBackingStore front_backing_store, [[maybe_unused]] i32 back_bitmap_id, [[maybe_unused]] SharedBackingStore back_backing_store) { }
 
     virtual void request_file(FileRequest) = 0;
 

--- a/Libraries/LibWeb/Page/SharedBackingStore.cpp
+++ b/Libraries/LibWeb/Page/SharedBackingStore.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Attachment.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/Page/SharedBackingStore.h>
+
+#if defined(AK_OS_MACOS)
+static Core::MachPort copy_send_right(Core::MachPort const& port)
+{
+    auto result = mach_port_mod_refs(mach_task_self(), port.port(), MACH_PORT_RIGHT_SEND, +1);
+    VERIFY(result == KERN_SUCCESS);
+    return Core::MachPort::adopt_right(port.port(), Core::MachPort::PortRight::Send);
+}
+#endif
+
+namespace Web {
+
+#if defined(AK_OS_MACOS)
+SharedBackingStore::SharedBackingStore(Core::MachPort&& port)
+    : m_port(move(port))
+{
+}
+#else
+SharedBackingStore::SharedBackingStore(Gfx::ShareableBitmap bitmap)
+    : m_bitmap(move(bitmap))
+{
+}
+#endif
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::SharedBackingStore const& backing_store)
+{
+#if defined(AK_OS_MACOS)
+    auto port = copy_send_right(backing_store.m_port);
+    TRY(encoder.append_attachment(Attachment::from_mach_port(move(port), Core::MachPort::MessageRight::MoveSend)));
+#else
+    TRY(encoder.encode(backing_store.m_bitmap));
+#endif
+    return {};
+}
+
+template<>
+ErrorOr<Web::SharedBackingStore> decode(Decoder& decoder)
+{
+#if defined(AK_OS_MACOS)
+    auto attachment = decoder.attachments().dequeue();
+    VERIFY(attachment.message_right() == Core::MachPort::MessageRight::MoveSend);
+    return Web::SharedBackingStore { attachment.release_mach_port() };
+#else
+    auto bitmap = TRY(decoder.decode<Gfx::ShareableBitmap>());
+    return Web::SharedBackingStore { move(bitmap) };
+#endif
+}
+
+}

--- a/Libraries/LibWeb/Page/SharedBackingStore.h
+++ b/Libraries/LibWeb/Page/SharedBackingStore.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/Platform.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
+
+#if defined(AK_OS_MACOS)
+#    include <LibCore/MachPort.h>
+#else
+#    include <LibGfx/ShareableBitmap.h>
+#endif
+
+namespace Web {
+
+class WEB_API SharedBackingStore {
+    AK_MAKE_NONCOPYABLE(SharedBackingStore);
+
+public:
+#if defined(AK_OS_MACOS)
+    explicit SharedBackingStore(Core::MachPort&&);
+    Core::MachPort release_iosurface_port() { return move(m_port); }
+#else
+    explicit SharedBackingStore(Gfx::ShareableBitmap);
+    Gfx::ShareableBitmap const& bitmap() const { return m_bitmap; }
+#endif
+    SharedBackingStore(SharedBackingStore&&) = default;
+    SharedBackingStore& operator=(SharedBackingStore&&) = default;
+    ~SharedBackingStore() = default;
+
+private:
+#if defined(AK_OS_MACOS)
+    Core::MachPort m_port;
+#else
+    Gfx::ShareableBitmap m_bitmap;
+#endif
+
+    template<typename U>
+    friend ErrorOr<void> IPC::encode(IPC::Encoder&, U const&);
+
+    template<typename U>
+    friend ErrorOr<U> IPC::decode(IPC::Decoder&);
+};
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::SharedBackingStore const&);
+
+template<>
+WEB_API ErrorOr<Web::SharedBackingStore> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/Painting/BackingStoreManager.cpp
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.cpp
@@ -9,26 +9,17 @@
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
+#include <LibWeb/Page/SharedBackingStore.h>
 #include <LibWeb/Painting/BackingStoreManager.h>
 #include <WebContent/PageClient.h>
 
 #ifdef AK_OS_MACOS
 #    include <LibCore/IOSurface.h>
-#    include <LibCore/MachPort.h>
-#    include <LibCore/Platform/MachMessageTypes.h>
 #endif
 
 namespace Web::Painting {
 
 GC_DEFINE_ALLOCATOR(BackingStoreManager);
-
-#ifdef AK_OS_MACOS
-static Optional<Core::MachPort> s_browser_mach_port;
-void BackingStoreManager::set_browser_mach_port(Core::MachPort&& port)
-{
-    s_browser_mach_port = move(port);
-}
-#endif
 
 BackingStoreManager::BackingStoreManager(HTML::Navigable& navigable)
     : m_navigable(navigable)
@@ -57,8 +48,6 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
     RefPtr<Gfx::PaintingSurface> back_store;
 
 #ifdef AK_OS_MACOS
-    VERIFY(s_browser_mach_port.has_value());
-
     auto back_iosurface = Core::IOSurfaceHandle::create(size.width(), size.height());
     auto back_iosurface_port = back_iosurface.create_mach_port();
 
@@ -68,38 +57,13 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
     m_front_bitmap_id = m_next_bitmap_id++;
     m_back_bitmap_id = m_next_bitmap_id++;
 
-    auto& page_client = m_navigable->top_level_traversable()->page().client();
-
-    Core::Platform::BackingStoreMetadata metadata;
-    metadata.page_id = page_client.id();
-    metadata.front_backing_store_id = m_front_bitmap_id;
-    metadata.back_backing_store_id = m_back_bitmap_id;
-
-    Core::Platform::MessageWithBackingStores message;
-
-    message.header.msgh_remote_port = s_browser_mach_port->port();
-    message.header.msgh_local_port = MACH_PORT_NULL;
-    message.header.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0) | MACH_MSGH_BITS_COMPLEX;
-    message.header.msgh_size = sizeof(message);
-    message.header.msgh_id = Core::Platform::BACKING_STORE_IOSURFACES_MESSAGE_ID;
-
-    message.body.msgh_descriptor_count = 2;
-
-    message.front_descriptor.name = front_iosurface_port.release();
-    message.front_descriptor.disposition = MACH_MSG_TYPE_MOVE_SEND;
-    message.front_descriptor.type = MACH_MSG_PORT_DESCRIPTOR;
-
-    message.back_descriptor.name = back_iosurface_port.release();
-    message.back_descriptor.disposition = MACH_MSG_TYPE_MOVE_SEND;
-    message.back_descriptor.type = MACH_MSG_PORT_DESCRIPTOR;
-
-    message.metadata = metadata;
-
-    mach_msg_timeout_t const timeout = 100; // milliseconds
-    auto const send_result = mach_msg(&message.header, MACH_SEND_MSG | MACH_SEND_TIMEOUT, message.header.msgh_size, 0, MACH_PORT_NULL, timeout, MACH_PORT_NULL);
-    if (send_result != KERN_SUCCESS) {
-        dbgln("Failed to send message to server: {}", mach_error_string(send_result));
-        VERIFY_NOT_REACHED();
+    if (m_navigable->is_top_level_traversable()) {
+        auto& page_client = m_navigable->top_level_traversable()->page().client();
+        page_client.page_did_allocate_backing_stores(
+            m_front_bitmap_id,
+            Web::SharedBackingStore(move(front_iosurface_port)),
+            m_back_bitmap_id,
+            Web::SharedBackingStore(move(back_iosurface_port)));
     }
 
     if (skia_backend_context) {
@@ -123,15 +87,14 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
     m_navigable->rendering_thread().update_backing_stores(front_store, back_store, m_front_bitmap_id, m_back_bitmap_id);
 
     return;
-#endif
-
+#else
     m_front_bitmap_id = m_next_bitmap_id++;
     m_back_bitmap_id = m_next_bitmap_id++;
 
     auto front_bitmap = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, size).release_value();
     auto back_bitmap = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, size).release_value();
 
-#ifdef USE_VULKAN
+#    ifdef USE_VULKAN
     if (skia_backend_context) {
         front_store = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
         front_store->on_flush = [front_bitmap](auto& surface) {
@@ -142,7 +105,7 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
             surface.read_into_bitmap(*back_bitmap);
         };
     }
-#endif
+#    endif
 
     if (!front_store)
         front_store = Gfx::PaintingSurface::wrap_bitmap(*front_bitmap);
@@ -151,12 +114,17 @@ void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
 
     if (m_navigable->is_top_level_traversable()) {
         auto& page_client = m_navigable->top_level_traversable()->page().client();
-        page_client.page_did_allocate_backing_stores(m_front_bitmap_id, front_bitmap->to_shareable_bitmap(), m_back_bitmap_id, back_bitmap->to_shareable_bitmap());
+        page_client.page_did_allocate_backing_stores(
+            m_front_bitmap_id,
+            Web::SharedBackingStore(front_bitmap->to_shareable_bitmap()),
+            m_back_bitmap_id,
+            Web::SharedBackingStore(back_bitmap->to_shareable_bitmap()));
     }
 
     m_allocated_size = size;
 
     m_navigable->rendering_thread().update_backing_stores(front_store, back_store, m_front_bitmap_id, m_back_bitmap_id);
+#endif
 }
 
 void BackingStoreManager::resize_backing_stores_if_needed(WindowResizingInProgress window_resize_in_progress)

--- a/Libraries/LibWeb/Painting/BackingStoreManager.h
+++ b/Libraries/LibWeb/Painting/BackingStoreManager.h
@@ -15,10 +15,6 @@ class WEB_API BackingStoreManager : public JS::Cell {
     GC_DECLARE_ALLOCATOR(BackingStoreManager);
 
 public:
-#ifdef AK_OS_MACOS
-    static void set_browser_mach_port(Core::MachPort&&);
-#endif
-
     enum class WindowResizingInProgress {
         No,
         Yes

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -115,10 +115,6 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
                 });
             });
     };
-    m_mach_port_server->on_receive_backing_stores = [](MachPortServer::BackingStoresMessage message) {
-        if (auto view = WebContentClient::view_for_pid_and_page_id(message.pid, message.page_id); view.has_value())
-            view->did_allocate_iosurface_backing_stores(message.front_backing_store_id, move(message.front_backing_store_port), message.back_backing_store_id, move(message.back_backing_store_port));
-    };
 #endif
 
     Vector<ByteString> raw_urls;

--- a/Libraries/LibWebView/MachPortServer.cpp
+++ b/Libraries/LibWebView/MachPortServer.cpp
@@ -68,24 +68,8 @@ void MachPortServer::thread_loop()
             break;
         }
 
-        if (message.header.msgh_id == Core::Platform::BACKING_STORE_IOSURFACES_MESSAGE_ID) {
-            auto pid = static_cast<pid_t>(message.body.parent_iosurface.trailer.msgh_audit.val[5]);
-            auto const& backing_stores_message = message.body.parent_iosurface;
-            auto front_child_port = Core::MachPort::adopt_right(backing_stores_message.front_descriptor.name, Core::MachPort::PortRight::Send);
-            auto back_child_port = Core::MachPort::adopt_right(backing_stores_message.back_descriptor.name, Core::MachPort::PortRight::Send);
-            auto const& metadata = backing_stores_message.metadata;
-            if (on_receive_backing_stores)
-                on_receive_backing_stores({ .pid = pid,
-                    .page_id = metadata.page_id,
-                    .front_backing_store_id = metadata.front_backing_store_id,
-                    .back_backing_store_id = metadata.back_backing_store_id,
-                    .front_backing_store_port = move(front_child_port),
-                    .back_backing_store_port = move(back_child_port) });
-            continue;
-        }
-
         if (message.header.msgh_id == Core::Platform::SELF_TASK_PORT_MESSAGE_ID) {
-            auto const& task_port_message = message.body.parent;
+            auto const& task_port_message = message.body;
             VERIFY(MACH_MSGH_BITS_LOCAL(message.header.msgh_bits) == MACH_MSG_TYPE_MOVE_SEND);
             VERIFY(task_port_message.body.msgh_descriptor_count == 1);
             VERIFY(task_port_message.port_descriptor.type == MACH_MSG_PORT_DESCRIPTOR);

--- a/Libraries/LibWebView/MachPortServer.h
+++ b/Libraries/LibWebView/MachPortServer.h
@@ -36,15 +36,6 @@ public:
         Core::MachPort reply_port;
     };
     Function<void(ChildMachPortRegistration)> on_receive_child_mach_port;
-    struct BackingStoresMessage {
-        pid_t pid { -1 };
-        u64 page_id { 0 };
-        i32 front_backing_store_id { 0 };
-        i32 back_backing_store_id { 0 };
-        Core::MachPort front_backing_store_port;
-        Core::MachPort back_backing_store_port;
-    };
-    Function<void(BackingStoresMessage)> on_receive_backing_stores;
 
     ByteString const& server_port_name() const { return m_server_port_name; }
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -566,7 +566,7 @@ void ViewImplementation::did_update_navigation_buttons_state(Badge<WebContentCli
     m_navigate_forward_action->set_enabled(forward_enabled);
 }
 
-void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap)
+void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Web::SharedBackingStore front_backing_store, i32 back_bitmap_id, Web::SharedBackingStore back_backing_store)
 {
     if (m_client_state.has_usable_bitmap) {
         // NOTE: We keep the outgoing front bitmap as a backup so we have something to paint until we get a new one.
@@ -574,45 +574,32 @@ void ViewImplementation::did_allocate_backing_stores(Badge<WebContentClient>, i3
         m_backup_bitmap_size = m_client_state.front_bitmap.last_painted_size;
     }
     m_client_state.has_usable_bitmap = false;
-
-    m_client_state.front_bitmap.bitmap = front_bitmap.bitmap();
     m_client_state.front_bitmap.id = front_bitmap_id;
-    m_client_state.back_bitmap.bitmap = back_bitmap.bitmap();
     m_client_state.back_bitmap.id = back_bitmap_id;
-}
 
 #ifdef AK_OS_MACOS
-void ViewImplementation::did_allocate_iosurface_backing_stores(i32 front_id, Core::MachPort&& front_port, i32 back_id, Core::MachPort&& back_port)
-{
-    if (m_client_state.has_usable_bitmap) {
-        // NOTE: We keep the outgoing front bitmap as a backup so we have something to paint until we get a new one.
-        m_backup_bitmap = m_client_state.front_bitmap.bitmap;
-        m_backup_bitmap_size = m_client_state.front_bitmap.last_painted_size;
-    }
-    m_client_state.has_usable_bitmap = false;
+    auto update_bitmap = [](SharedBitmap& target, Web::SharedBackingStore backing_store) {
+        auto iosurface_port = backing_store.release_iosurface_port();
+        auto iosurface = Core::IOSurfaceHandle::from_mach_port(iosurface_port);
+        auto size = Gfx::IntSize { iosurface.width(), iosurface.height() };
+        auto bytes_per_row = iosurface.bytes_per_row();
+        target.iosurface_ref = iosurface.core_foundation_pointer();
 
-    auto front_iosurface = Core::IOSurfaceHandle::from_mach_port(move(front_port));
-    auto back_iosurface = Core::IOSurfaceHandle::from_mach_port(move(back_port));
+        auto bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, size, bytes_per_row, iosurface.data(), [handle = move(iosurface)] { });
+        target.bitmap = bitmap.release_value_but_fixme_should_propagate_errors();
+    };
 
-    auto front_size = Gfx::IntSize { front_iosurface.width(), front_iosurface.height() };
-    auto back_size = Gfx::IntSize { back_iosurface.width(), back_iosurface.height() };
+    update_bitmap(m_client_state.front_bitmap, move(front_backing_store));
+    update_bitmap(m_client_state.back_bitmap, move(back_backing_store));
+#else
+    auto update_bitmap = [](SharedBitmap& target, Web::SharedBackingStore backing_store) {
+        target.bitmap = backing_store.bitmap().bitmap();
+    };
 
-    auto bytes_per_row = front_iosurface.bytes_per_row();
-
-    auto* front_ref = front_iosurface.core_foundation_pointer();
-    auto* back_ref = back_iosurface.core_foundation_pointer();
-
-    auto front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, front_size, bytes_per_row, front_iosurface.data(), [handle = move(front_iosurface)] { });
-    auto back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, back_size, bytes_per_row, back_iosurface.data(), [handle = move(back_iosurface)] { });
-
-    m_client_state.front_bitmap.bitmap = front_bitmap.release_value_but_fixme_should_propagate_errors();
-    m_client_state.front_bitmap.id = front_id;
-    m_client_state.front_bitmap.iosurface_ref = front_ref;
-    m_client_state.back_bitmap.bitmap = back_bitmap.release_value_but_fixme_should_propagate_errors();
-    m_client_state.back_bitmap.id = back_id;
-    m_client_state.back_bitmap.iosurface_ref = back_ref;
-}
+    update_bitmap(m_client_state.front_bitmap, move(front_backing_store));
+    update_bitmap(m_client_state.back_bitmap, move(back_backing_store));
 #endif
+}
 
 void ViewImplementation::update_zoom()
 {

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -30,6 +30,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/Page/SharedBackingStore.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
@@ -156,10 +157,7 @@ public:
 
     void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const;
 
-    void did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::ShareableBitmap const&, i32 back_bitmap_id, Gfx::ShareableBitmap const&);
-#ifdef AK_OS_MACOS
-    void did_allocate_iosurface_backing_stores(i32 front_bitmap_id, Core::MachPort&&, i32 back_bitmap_id, Core::MachPort&&);
-#endif
+    void did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Web::SharedBackingStore front_backing_store, i32 back_bitmap_id, Web::SharedBackingStore back_backing_store);
 
     enum class ScreenshotType {
         Visible,

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -18,15 +18,6 @@ namespace WebView {
 
 HashTable<WebContentClient*> WebContentClient::s_clients;
 
-Optional<ViewImplementation&> WebContentClient::view_for_pid_and_page_id(pid_t pid, u64 page_id)
-{
-    for (auto* client : s_clients) {
-        if (client->m_process_handle.pid == pid)
-            return client->view_for_page_id(page_id);
-    }
-    return {};
-}
-
 WebContentClient::WebContentClient(NonnullOwnPtr<IPC::Transport> transport, ViewImplementation& view)
     : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
 {
@@ -778,10 +769,10 @@ void WebContentClient::did_update_navigation_buttons_state(u64 page_id, bool bac
         view->did_update_navigation_buttons_state({}, back_enabled, forward_enabled);
 }
 
-void WebContentClient::did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap)
+void WebContentClient::did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Web::SharedBackingStore front_backing_store, i32 back_bitmap_id, Web::SharedBackingStore back_backing_store)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
-        view->did_allocate_backing_stores({}, front_bitmap_id, front_bitmap, back_bitmap_id, back_bitmap);
+        view->did_allocate_backing_stores({}, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
 }
 
 Messages::WebContentClient::RequestWorkerAgentResponse WebContentClient::request_worker_agent(u64 page_id, Web::Bindings::AgentType worker_type)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -38,8 +38,6 @@ class WEBVIEW_API WebContentClient final
 public:
     using InitTransport = Messages::WebContentServer::InitTransport;
 
-    static Optional<ViewImplementation&> view_for_pid_and_page_id(pid_t pid, u64 page_id);
-
     template<CallableAs<IterationDecision, WebContentClient&> Callback>
     static void for_each_client(Callback callback);
 
@@ -148,7 +146,7 @@ private:
     virtual void did_request_clipboard_entries(u64 page_id, u64 request_id) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
-    virtual void did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap, i32 back_bitmap_id, Gfx::ShareableBitmap) override;
+    virtual void did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Web::SharedBackingStore front_backing_store, i32 back_bitmap_id, Web::SharedBackingStore back_backing_store) override;
     virtual Messages::WebContentClient::RequestWorkerAgentResponse request_worker_agent(u64 page_id, Web::Bindings::AgentType worker_type) override;
 
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -726,9 +726,9 @@ void PageClient::page_did_change_audio_play_state(Web::HTML::AudioPlayState play
     client().async_did_change_audio_play_state(m_id, play_state);
 }
 
-void PageClient::page_did_allocate_backing_stores(i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap)
+void PageClient::page_did_allocate_backing_stores(i32 front_bitmap_id, Web::SharedBackingStore front_backing_store, i32 back_bitmap_id, Web::SharedBackingStore back_backing_store)
 {
-    client().async_did_allocate_backing_stores(m_id, front_bitmap_id, front_bitmap, back_bitmap_id, back_bitmap);
+    client().async_did_allocate_backing_stores(m_id, front_bitmap_id, move(front_backing_store), back_bitmap_id, move(back_backing_store));
 }
 
 Web::PageClient::WorkerAgentResponse PageClient::request_worker_agent(Web::Bindings::AgentType type)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -13,6 +13,7 @@
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Page/SharedBackingStore.h>
 #include <LibWeb/Painting/BackingStoreManager.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
@@ -187,7 +188,7 @@ private:
     virtual void page_did_insert_clipboard_entry(Web::Clipboard::SystemClipboardRepresentation const&, StringView presentation_style) override;
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
-    virtual void page_did_allocate_backing_stores(i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) override;
+    virtual void page_did_allocate_backing_stores(i32 front_bitmap_id, Web::SharedBackingStore front_backing_store, i32 back_bitmap_id, Web::SharedBackingStore back_backing_store) override;
     virtual WorkerAgentResponse request_worker_agent(Web::Bindings::AgentType) override;
     virtual void page_did_mutate_dom(FlyString const& type, Web::DOM::Node const& target, Web::DOM::NodeList& added_nodes, Web::DOM::NodeList& removed_nodes, GC::Ptr<Web::DOM::Node> previous_sibling, GC::Ptr<Web::DOM::Node> next_sibling, Optional<String> const& attribute_name) override;
     virtual void page_did_paint(Gfx::IntRect const& content_rect, i32 bitmap_id) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Page/SharedBackingStore.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ConsoleOutput.h>
 #include <LibWebView/DOMNodeProperties.h>
@@ -114,7 +115,7 @@ endpoint WebContentClient
     did_request_clipboard_entries(u64 page_id, u64 request_id) =|
 
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
-    did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) =|
+    did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Web::SharedBackingStore front_backing_store, i32 back_bitmap_id, Web::SharedBackingStore back_backing_store) =|
 
     did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state) =|
 

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -253,7 +253,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 #if defined(AK_OS_MACOS)
     auto browser_port = TRY(Core::MachPort::look_up_from_bootstrap_server(ByteString { mach_server_name }));
     auto transport_ports = TRY(IPC::bootstrap_transport_from_server_port(browser_port));
-    Web::Painting::BackingStoreManager::set_browser_mach_port(move(browser_port));
     auto webcontent_client = WebContent::ConnectionFromClient::construct(
         make<IPC::Transport>(move(transport_ports.receive_right), move(transport_ports.send_right)));
 #else


### PR DESCRIPTION
Now that LibIPC uses Mach ports for transport on macOS, IOSurface port rights can be sent as regular IPC message attachments instead of through a separate ad-hoc Mach message side-channel. Introduce Web::SharedBackingStore that wraps either a MachPort (macOS) or ShareableBitmap (other platforms) with IPC encode/decode support, unifying backing store allocation into the existing did_allocate_backing_stores IPC message.