### PR TITLE
LibWeb: Use correct scrollability check for autoscrolling

### DIFF
--- a/Libraries/LibWeb/Page/AutoScrollHandler.cpp
+++ b/Libraries/LibWeb/Page/AutoScrollHandler.cpp
@@ -131,7 +131,7 @@ GC::Ptr<DOM::Element> AutoScrollHandler::find_scrollable_ancestor(Painting::Pain
 {
     auto* paintable_box = paintable.containing_block();
     while (paintable_box) {
-        if (paintable_box->has_scrollable_overflow()) {
+        if (paintable_box->could_be_scrolled_by_wheel_event()) {
             if (auto* element = as_if<DOM::Element>(paintable_box->dom_node().ptr()))
                 return element;
         }

--- a/Tests/LibWeb/Text/expected/selection-auto-scroll.txt
+++ b/Tests/LibWeb/Text/expected/selection-auto-scroll.txt
@@ -1,2 +1,4 @@
 before: 0
 after: 80
+hidden before: 0
+hidden after: 0

--- a/Tests/LibWeb/Text/input/selection-auto-scroll.html
+++ b/Tests/LibWeb/Text/input/selection-auto-scroll.html
@@ -8,20 +8,43 @@ div {
 }
 </style>
 <div id="vertical">line1<br>line2<br>line3<br>line4<br>line5<br>line6<br>line7<br>line8<br>line9<br>line10</div>
+<div id="hidden" style="overflow: hidden">line1<br>line2<br>line3<br>line4<br>line5<br>line6<br>line7<br>line8<br>line9<br>line10</div>
 <script src="include.js"></script>
 <script>
+function afterAutoScrollTick() {
+    return new Promise(resolve => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                setTimeout(resolve, 0);
+            });
+        });
+    });
+}
+
 asyncTest(async (done) => {
     document.body.offsetWidth; // force layout
 
     println(`before: ${vertical.scrollTop}`);
 
-    const rect = vertical.getBoundingClientRect();
+    let rect = vertical.getBoundingClientRect();
     internals.mouseDown(rect.x + 10, rect.y + 10);
     internals.mouseMove(rect.x + 10, rect.y + rect.height + 50);
 
-    await timeout(1000);
+    await afterAutoScrollTick();
 
     println(`after: ${vertical.scrollTop}`);
+
+    internals.mouseUp(rect.x + 10, rect.y + rect.height + 50);
+
+    println(`hidden before: ${hidden.scrollTop}`);
+
+    rect = hidden.getBoundingClientRect();
+    internals.mouseDown(rect.x + 10, rect.y + 10);
+    internals.mouseMove(rect.x + 10, rect.y + rect.height + 50);
+
+    await afterAutoScrollTick();
+
+    println(`hidden after: ${hidden.scrollTop}`);
 
     internals.mouseUp(rect.x + 10, rect.y + rect.height + 50);
     done();


### PR DESCRIPTION
We only checked if the paintable box had scrollable overflow, but that was too simple - we now use the same logic that checks whether a box can be scrolled by a mousewheel event.

The autoscrolling test was updated as well to use rAF+rAF+timeout instead of a fixed 1000ms timeout, which is prone to flakiness.