### PR TITLE
LibWeb: Don't cancel pending navigations in navigate to a javascript URL

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2145,8 +2145,9 @@ void Navigable::navigate_to_a_javascript_url(URL::URL const& url, HistoryHandlin
     VERIFY(history_handling == HistoryHandlingBehavior::Replace);
 
     // 2. If targetNavigable's ongoing navigation is no longer navigationId, then return.
-    if (ongoing_navigation() != navigation_id)
-        return;
+    // AD-HOC: See https://github.com/whatwg/html/issues/12120, other browsers only cancel pending navigations for form submissions.
+    // if (ongoing_navigation() != navigation_id)
+    //     return;
 
     // 3. Set the ongoing navigation for targetNavigable to null.
     set_ongoing_navigation({});

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -544,3 +544,6 @@ Ref/input/wpt-import/fullscreen/rendering/backdrop-inherit.html
 Ref/input/wpt-import/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html
 Crash/wpt-import/fullscreen/crashtests/chrome-1312699.html
 Crash/wpt-import/fullscreen/crashtests/content-visibility-crash.html
+
+; Requires ladybird to cancel pending javascript navigations in form submission, see: https://github.com/whatwg/html/issues/12120
+Text/input/wpt-import/html/semantics/forms/form-submission-0/jsurl-navigation-then-form-submit.html

--- a/Tests/LibWeb/Text/expected/wpt-import/url/javascript-urls.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/url/javascript-urls.window.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-3 Pass
-3 Fail
+6 Pass
 Pass	javascript: URL that fails to parse due to invalid host
 Pass	javascript: URL that fails to parse due to invalid host and has a U+0009 in scheme
 Pass	javascript: URL with extra slashes at the start
-Fail	javascript: URL without an opaque path
-Fail	javascript: URL containing a JavaScript string split over path and query
-Fail	javascript: URL containing a JavaScript string split over path and query and has a U+000A in scheme
+Pass	javascript: URL without an opaque path
+Pass	javascript: URL containing a JavaScript string split over path and query
+Pass	javascript: URL containing a JavaScript string split over path and query and has a U+000A in scheme


### PR DESCRIPTION
Other browsers appear to only do this for form submission, not for all javascript URL navigations. Let's remove the handling in the general javascript URL navigation handling so that our behaviour diference to other browsers is limited specifically to form elements, instead of the general case.

Unfortunately this does (expectedly) cause the test added in 3e0ea4f62 to start timing out, so that test is marked as skipped.