### PR TITLE
LibCore: Don’t pass O_CLOEXEC to shm_open

### DIFF
--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -155,12 +155,23 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
     static size_t shared_memory_id = 0;
 
     auto name = ByteString::formatted("/shm-{}-{}", getpid(), shared_memory_id++);
-    fd = shm_open(name.characters(), O_RDWR | O_CREAT | options, 0600);
+    // Passing O_CLOEXEC to shm_open in the oflag argument isn't POSIX-compliant and is known to be rejected
+    // in macOS 26.4+. So we filter it out here, and instead set FD_CLOEXEC via fcntl after opening.
+    fd = shm_open(name.characters(), O_RDWR | O_CREAT | (options & ~O_CLOEXEC), 0600);
 
     if (shm_unlink(name.characters()) == -1) {
         auto saved_errno = errno;
-        TRY(close(fd));
+        if (fd >= 0)
+            TRY(close(fd));
         return Error::from_errno(saved_errno);
+    }
+
+    if (fd >= 0 && (options & O_CLOEXEC)) {
+        if (::fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+            auto saved_errno = errno;
+            TRY(close(fd));
+            return Error::from_errno(saved_errno);
+        }
     }
 #endif
     if (fd < 0)


### PR DESCRIPTION
**Bug:** Ladybird crashes on launch on macOS 26.4+ with _“UNEXPECTED ERROR: close: Bad file descriptor”_ in `SharedVersion.cpp` — because AnonymousBuffer creation fails.

**Cause:** `anon_create()` passes `O_CLOEXEC` in the _oflags_ argument to `shm_open`. macOS 26.4+ rejects that with `EINVAL`. POSIX only specifies `O_RDONLY, O_RDWR, O_CREAT, O_EXCL,` and `O_TRUNC` as valid in the _oflag_ value for `shm_open`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/shm_open.html. On earlier macOS versions, `O_CLOEXEC` just happened to also be silently accepted.

**Fix:** Fix: Filter `O_CLOEXEC` from the _oflag_ argument we pass to `shm_open` flags, and instead set `FD_CLOEXEC` via `fcntl` — after opening.
