### PR TITLE
Tests/LibWeb: Run form-disabled-callback.html from HTTP server

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -180,13 +180,14 @@ Text/input/parse-document-from-string-in-fetch-callback.html
 Text/input/wpt-import/battery-status/battery-promise-window.https.html
 Text/input/wpt-import/clipboard-apis/async-navigator-clipboard-basics.https.html
 Text/input/wpt-import/css/css-values/calc-in-media-queries-with-mixed-units.html
+Text/input/wpt-import/css/cssom-view/cssom-getBoundingClientRect-003.html
 Text/input/wpt-import/css/cssom-view/elementsFromPoint-iframes.html
 Text/input/wpt-import/css/cssom-view/elementsFromPoint.html
-Text/input/wpt-import/css/cssom-view/cssom-getBoundingClientRect-003.html
 Text/input/wpt-import/css/cssom-view/offsetTopLeft-border-box.html
 Text/input/wpt-import/css/mediaqueries/test_media_queries.html
 Text/input/wpt-import/css/selectors/attribute-selectors/attribute-case/semantics.html
 Text/input/wpt-import/css/selectors/attribute-selectors/attribute-case/syntax.html
+Text/input/wpt-import/custom-elements/form-associated/form-disabled-callback.html
 Text/input/wpt-import/custom-elements/upgrading.html
 Text/input/wpt-import/dom/nodes/Document-createElementNS.html
 Text/input/wpt-import/dom/nodes/ParentNode-querySelector-All.html


### PR DESCRIPTION
Another test improvement found while trying to improve navigation.

This test does not work properly when run from local file. This seems to be due to the use of /common/blank.html in the test resource helper, which would previously not resolve properly.

Other browsers, such as Chrome, also do not work for this WPT test when loaded as file:// scheme.

For some reason I have not fully looked into, this test seems to rely on iframe being processed synchronously, and without this change, the test would time out. With this change (alongside) running iframe processing synchronously, we get one more subtest pass.

(also a small alphabetical reorder in area)