### PR TITLE
LibWeb: Use fallible `FormAssociatedElement` cast in form elements filter

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -519,11 +519,14 @@ static bool is_form_control(DOM::Element const& element, HTMLFormElement const& 
         return false;
     }
 
-    auto const& form_associated_element = as<FormAssociatedElement>(element);
-    if (form_associated_element.form() != &form)
+    auto const* form_associated_element = as_if<FormAssociatedElement>(element);
+    if (!form_associated_element)
         return false;
 
-    if (!form_associated_element.is_listed())
+    if (form_associated_element->form() != &form)
+        return false;
+
+    if (!form_associated_element->is_listed())
         return false;
 
     return true;

--- a/Tests/LibWeb/Crash/HTML/non-html-elements-in-form.html
+++ b/Tests/LibWeb/Crash/HTML/non-html-elements-in-form.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<form id="f"><svg></svg></form>
+<script>
+    document.getElementById("f").elements.length;
+</script>


### PR DESCRIPTION
The `HTMLFormControlsCollection` filter iterates all descendants of the form's root, which may include non HTMLElement elements such as SVG elements. The unchecked `as<FormAssociatedElement>` cast would crash on
these elements. Use `as_if` with a null check instead.

This fixes a regression introduced in https://github.com/LadybirdBrowser/ladybird/commit/9af3e3487518cf5d7d6e96bd7fbdf2026fbbd939.

Fixes #8617