### PR TITLE
LibWeb: Use fragment bounds for inline hit testing

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -57,6 +57,44 @@ PaintableWithLines::~PaintableWithLines()
 {
 }
 
+Optional<CSSPixelRect> PaintableWithLines::fragment_bounds_for_hit_testing() const
+{
+    if (!is<Layout::InlineNode>(layout_node()))
+        return {};
+
+    Optional<CSSPixelRect> fragment_bounds;
+    for (auto const& fragment : fragments()) {
+        auto fragment_rect = fragment.absolute_rect();
+        if (fragment_bounds.has_value())
+            fragment_bounds = fragment_bounds->united(fragment_rect);
+        else
+            fragment_bounds = fragment_rect;
+    }
+
+    if (!fragment_bounds.has_value())
+        return {};
+
+    // A pointer-events:none inline descendant should be skipped as a direct target, but a click in its box should
+    // still be able to fall back to this inline ancestor if no deeper hit-testable descendant matches first.
+    for_each_in_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
+        if (!paintable_box.is_inline())
+            return TraversalDecision::Continue;
+        if (paintable_box.computed_values().visibility() != CSS::Visibility::Visible)
+            return TraversalDecision::Continue;
+        if (paintable_box.computed_values().pointer_events() != CSS::PointerEvents::None)
+            return TraversalDecision::Continue;
+        fragment_bounds = fragment_bounds->united(paintable_box.absolute_border_box_rect());
+        return TraversalDecision::Continue;
+    });
+
+    fragment_bounds->inflate(
+        box_model().padding.top + box_model().border.top,
+        box_model().padding.right + box_model().border.right,
+        box_model().padding.bottom + box_model().border.bottom,
+        box_model().padding.left + box_model().border.left);
+    return fragment_bounds;
+}
+
 void PaintableWithLines::reset_for_relayout()
 {
     PaintableBox::reset_for_relayout();
@@ -138,8 +176,9 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
             return TraversalDecision::Break;
     }
 
+    auto self_hit_rect = fragment_bounds_for_hit_testing().value_or(absolute_border_box_rect());
     if (!stacking_context() && (!layout_node().is_anonymous() || is_positioned())
-        && absolute_border_box_rect().contains(local_position.value())) {
+        && self_hit_rect.contains(local_position.value())) {
         if (callback(HitTestResult { .paintable = const_cast<PaintableWithLines&>(*this) }) == TraversalDecision::Break)
             return TraversalDecision::Break;
     }

--- a/Libraries/LibWeb/Painting/PaintableWithLines.h
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.h
@@ -54,6 +54,7 @@ protected:
 private:
     [[nodiscard]] virtual bool is_paintable_with_lines() const final { return true; }
 
+    Optional<CSSPixelRect> fragment_bounds_for_hit_testing() const;
     Optional<PaintableFragment const&> fragment_at_position(DOM::Position const&) const;
     void paint_cursor(DisplayListRecordingContext&) const;
 

--- a/Tests/LibWeb/Text/expected/hit_testing/adjacent-inline-links-fragment-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/adjacent-inline-links-fragment-hit-testing.txt
@@ -1,0 +1,3 @@
+link-a
+link-a
+link-b

--- a/Tests/LibWeb/Text/input/hit_testing/adjacent-inline-links-fragment-hit-testing.html
+++ b/Tests/LibWeb/Text/input/hit_testing/adjacent-inline-links-fragment-hit-testing.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .link {
+        margin-left: 30px;
+    }
+
+    .icon {
+        display: inline-block;
+    }
+
+    .icon-a::before {
+        content: "@";
+    }
+
+    .icon-b::before {
+        content: "#";
+    }
+</style>
+
+<div class="links">
+    <a id="link-a" class="link" href="#"><span id="link-a-icon" class="icon icon-a"></span>Link One</a>
+    <a id="link-b" class="link" href="#"><span id="link-b-icon" class="icon icon-b"></span>Second Link</a>
+</div>
+
+<script>
+    test(() => {
+        const linkAIconRect = document.getElementById("link-a-icon").getBoundingClientRect();
+        const linkAIconHit = document.elementFromPoint(linkAIconRect.left + linkAIconRect.width / 2, linkAIconRect.top + linkAIconRect.height / 2);
+        println(linkAIconHit ? linkAIconHit.closest("a")?.id ?? (linkAIconHit.id || linkAIconHit.tagName) : "null");
+        const linkATextHit = document.elementFromPoint(linkAIconRect.right + 20, linkAIconRect.top + linkAIconRect.height / 2);
+        println(linkATextHit ? linkATextHit.closest("a")?.id ?? (linkATextHit.id || linkATextHit.tagName) : "null");
+
+        const linkBIconRect = document.getElementById("link-b-icon").getBoundingClientRect();
+        const linkBHit = document.elementFromPoint(linkBIconRect.left + linkBIconRect.width / 2, linkBIconRect.top + linkBIconRect.height / 2);
+        println(linkBHit ? linkBHit.closest("a")?.id ?? (linkBHit.id || linkBHit.tagName) : "null");
+    });
+</script>


### PR DESCRIPTION
Adjacent inline links can share the same inline-node origin while painting their icon and text fragments farther apart on the line. Hit testing with absolute_border_box_rect() then lets a later, wider link steal points that visually belong to an earlier link.

Use the union of an inline node's fragment rects, inflated by its padding and border, for self hit testing instead.

Also extend the fallback region with visible inline pointer-events:none descendants so clicks in those boxes can
still resolve to the nearest hit-testable inline ancestor.

This fixes an error on https://www.anz.com.au/personal/ where `Support Centre` hit box will overlap the `Find ANZ` one.