### PR TITLE
LibJS: Also initialize constants and arguments of ExecutionContext

### DIFF
--- a/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -36,14 +36,13 @@ private:
 
 public:
     // NB: The layout is: [registers | locals | constants | arguments]
-    //     We only initialize registers and locals to empty, since constants are copied in right after.
     ALWAYS_INLINE ExecutionContext(u32 registers_and_locals_count, u32 constants_count, u32 arguments_count_)
     {
         VERIFY(!Checked<u32>::addition_would_overflow(registers_and_locals_count, constants_count, arguments_count_));
         registers_and_constants_and_locals_and_arguments_count = registers_and_locals_count + constants_count + arguments_count_;
         argument_count = arguments_count_;
         auto* values = registers_and_constants_and_locals_and_arguments();
-        for (size_t i = 0; i < registers_and_locals_count; ++i)
+        for (size_t i = 0; i < registers_and_constants_and_locals_and_arguments_count; ++i)
             values[i] = js_special_empty_value();
     }
 


### PR DESCRIPTION
When allocating ExecutionContext, we were skipping allocating constants, because they are filled in shortly after. However, there is still some code executing between allocating the ExecutionContext and assigning constants. This code may allocate GC-aware objects before the assignment. Allocating any GC object may cause a garbage collection to
be triggered.  And running garbage collection on uninitialized objects might have all kinds of unintended effects.

To avoid that, simply initialize constants right away. To be safe, also initialize arguments, but I haven't checked more closely if it is needed for them or not.

The specific case where this bug manifested was JetStream3's raytrace-private-class-fields.js, which was triggering a segmentation fault when trying to visit a functions constant during GC marking phase. The offending allocation triggering the garbage collection is the corresponding FunctionEnvironment being created.

This crash was exposed as a combination of multiple things coming together. In particular, both of 1179e40d3f4 and 61e6dbe4e73 combined were exposing the problem, but is seems neither commit is at fault. Most likely the crash happening or not is sensitive to the exact amount of GC pressure being present or size of individual execution contexts. And so any change that affects those might make it appear or go away.

To put in an additional wrinkle, this could only be observed using the ASM JS interpreter. The CPP interpreter was using a fast path for function calls that has a different allocation pattern and did not run into the crash.

No explicit regression test for this change because:
* The problem is very sensitive to implementation details and a reproduction that stays valid with code changes in the interpreter is probably impossible to come by.
* The bug was exposed by the JS benchmarks, which already are as good as a regression test as we are going to get here realistically.