### PR TITLE
LibWeb: Finalize session history entry during async sniff bytes

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1637,9 +1637,8 @@ void Navigable::populate_session_history_entry_document(
                             navigation_params, completion_steps](ReadonlyBytes sniff_bytes) {
                             // AD-HOC: The document may have been destroyed between when the fetch started and when the
                             //         bytes arrived.
-                            if (!nav_params->navigable->active_browsing_context())
-                                return;
-                            output->document = load_document(nav_params, signal_to_continue_session_history_processing, sniff_bytes);
+                            if (nav_params->navigable->active_browsing_context())
+                                output->document = load_document(nav_params, signal_to_continue_session_history_processing, sniff_bytes);
                             output->navigation_params = navigation_params;
                             if (completion_steps)
                                 completion_steps->function()(output);


### PR DESCRIPTION
In e97de2e7e37c261e23cf767cb7726ee1739b225b we added a guard to prevent crashes, but we should've still finalized the session history entry.

Thanks to the always vigilant @tcl3