### PR TITLE
LibWeb: Expose OfflineAudioContext state transitions

### DIFF
--- a/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
+++ b/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
@@ -95,6 +95,14 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> OfflineAudioContext::start_renderi
     // 3. Set the [[rendering started]] slot of the OfflineAudioContext to true.
     m_rendering_started = true;
 
+    // ADHOC: The current spec text for startRendering() does not describe state transitions here, but current
+    //        browsers expose "running" synchronously after startRendering() and fire statechange asynchronously.
+    set_control_state(Bindings::AudioContextState::Running);
+    set_rendering_state(Bindings::AudioContextState::Running);
+    queue_a_media_element_task(GC::create_function(heap(), [this]() {
+        this->dispatch_event(DOM::Event::create(this->realm(), HTML::EventNames::statechange));
+    }));
+
     // 4. Let promise be a new promise.
     auto promise = WebIDL::create_promise(realm);
 
@@ -130,6 +138,11 @@ void OfflineAudioContext::begin_offline_rendering(GC::Ref<WebIDL::Promise> promi
     // 4: Once the rendering is complete, queue a media element task to execute the following steps:
     queue_a_media_element_task(GC::create_function(heap(), [promise, this]() {
         HTML::TemporaryExecutionContext context(this->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+
+        // AD-HOC: The current spec text for offline rendering completion does not describe a terminal state transition,
+        //         but current browsers expose the context as "closed" once rendering completes.
+        set_control_state(Bindings::AudioContextState::Closed);
+        set_rendering_state(Bindings::AudioContextState::Closed);
 
         // 4.1 Resolve the promise created by startRendering() with [[rendered buffer]].
         WebIDL::resolve_promise(this->realm(), promise, this->m_rendered_buffer);

--- a/Tests/LibWeb/Text/expected/WebAudio/OfflineAudioContext-startRendering.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/OfflineAudioContext-startRendering.txt
@@ -1,0 +1,5 @@
+after-start:running
+statechange:running
+after-await:closed:1
+InvalidStateError: Rendering is already started
+complete:closed

--- a/Tests/LibWeb/Text/expected/WebAudio/OfflineAudioContext.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/OfflineAudioContext.txt
@@ -1,2 +1,2 @@
+initial:suspended
 128
-InvalidStateError: Rendering is already started

--- a/Tests/LibWeb/Text/input/WebAudio/OfflineAudioContext-startRendering.html
+++ b/Tests/LibWeb/Text/input/WebAudio/OfflineAudioContext-startRendering.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const audioContext = new OfflineAudioContext(1, 1, 44100)
+        audioContext.addEventListener("statechange", () => println(`statechange:${audioContext.state}`));
+        audioContext.addEventListener("complete", () => println(`complete:${audioContext.state}`));
+
+        const promise = audioContext.startRendering();
+        println(`after-start:${audioContext.state}`);
+        const buffer = await promise;
+        println(`after-await:${audioContext.state}:${buffer.length}`);
+
+        try {
+            await audioContext.startRendering();
+            println('FAIL: started rendering on repeated call');
+        } catch (e) {
+            println(`${e}`);
+        }
+
+        await timeout(0);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/WebAudio/OfflineAudioContext.html
+++ b/Tests/LibWeb/Text/input/WebAudio/OfflineAudioContext.html
@@ -1,22 +1,12 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    test(() => {
         // Once the ctor‑offlineaudiocontext WPT test is updated to check
         // renderQuantumSize and renderSizeHint, this test is not needed.
         const audioContext = new OfflineAudioContext(1, 1, 44100)
+
+        println(`initial:${audioContext.state}`);
         println(`${audioContext.renderQuantumSize}`);
-
-        // Second call must reject with InvalidStateError
-        await audioContext.startRendering();
-
-        try {
-            await audioContext.startRendering();
-            println('FAIL: started rendering on repeated call');
-        } catch (e) {
-            println(`${e}`);
-        }
-
-        done();
     });
 </script>


### PR DESCRIPTION
Expose running and closed state transitions for OfflineAudioContext.

When browsing anz.com.au I would see log spam for `InvalidStateError: Rendering is already started`.
It seems they are using a bot detection/ fingerprinting script `Reese84` from Imperva. (Similar to cloudflare case here https://github.com/LadybirdBrowser/ladybird/issues/224)
One of the things it does is continually retry `startRendering` if it doesn't see a state change from `Suspended`.