### PR TITLE
LibWeb: Ignore non-form-associated elements in form controls

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -519,11 +519,14 @@ static bool is_form_control(DOM::Element const& element, HTMLFormElement const& 
         return false;
     }
 
-    auto const& form_associated_element = as<FormAssociatedElement>(element);
-    if (form_associated_element.form() != &form)
+    auto const* form_associated_element = as_if<FormAssociatedElement const>(element);
+    if (!form_associated_element)
         return false;
 
-    if (!form_associated_element.is_listed())
+    if (form_associated_element->form() != &form)
+        return false;
+
+    if (!form_associated_element->is_listed())
         return false;
 
     return true;

--- a/Tests/LibWeb/Crash/HTML/form-length-with-svg-root-descendant.html
+++ b/Tests/LibWeb/Crash/HTML/form-length-with-svg-root-descendant.html
@@ -1,0 +1,7 @@
+<form id="the-form">
+    <input>
+</form>
+<svg xmlns="http://www.w3.org/2000/svg"></svg>
+<script>
+    document.getElementById("the-form").length;
+</script>


### PR DESCRIPTION
As with the test `FormAssociatedElement` cast would fail for example on an svg element.