### PR TITLE
LibWeb: Use document resolution context in canvas set_font

### DIFF
--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.cpp
@@ -112,7 +112,7 @@ void CanvasTextDrawingStyles<IncludingClass, CanvasType>::set_font(StringView fo
             // NOTE: The initial value here is non-standard as the default font is "10px sans-serif"
             // FIXME: Investigate whether this is the correct resolution context (i.e. whether we should instead use
             //        a font-size of 10px) for OffscreenCanvas
-            auto length_resolution_context = CSS::Length::ResolutionContext::for_window(*document->window());
+            auto length_resolution_context = CSS::Length::ResolutionContext::for_document(*document);
             Optional<DOM::AbstractElement> abstract_element;
 
             if constexpr (SameAs<CanvasType, HTML::HTMLCanvasElement>) {

--- a/Tests/LibWeb/Text/expected/HTML/canvas-set-font-detached-document.txt
+++ b/Tests/LibWeb/Text/expected/HTML/canvas-set-font-detached-document.txt
@@ -1,0 +1,4 @@
+set_font: PASS
+fillText: PASS
+strokeText: PASS
+measureText: PASS

--- a/Tests/LibWeb/Text/input/HTML/canvas-set-font-detached-document.html
+++ b/Tests/LibWeb/Text/input/HTML/canvas-set-font-detached-document.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+test(() => {
+    const doc = document.implementation.createHTMLDocument("");
+
+    // Setting font on a canvas belonging to a detached document should not crash.
+    const canvas1 = doc.createElement("canvas");
+    const ctx1 = canvas1.getContext("2d");
+    ctx1.font = "bold 24px serif";
+    println("set_font: PASS");
+
+    // Calling fillText/strokeText/measureText with default font (lazy init) should not crash.
+    const canvas2 = doc.createElement("canvas");
+    const ctx2 = canvas2.getContext("2d");
+    ctx2.fillText("hello", 0, 0);
+    println("fillText: PASS");
+    ctx2.strokeText("hello", 0, 0);
+    println("strokeText: PASS");
+    const metrics = ctx2.measureText("hello");
+    println("measureText: PASS");
+});
+</script>


### PR DESCRIPTION
## Summary
- Fix null pointer crash when setting font on a canvas belonging to a detached document
- Use `Length::ResolutionContext::for_document()` instead of `for_window()`, which handles the no-navigable case gracefully
- This also fixes the same crash via `fillText`, `strokeText`, and `measureText` which trigger lazy font initialization through `set_font`

## Test plan
- [x] New test: `canvas-set-font-detached-document.html` covers `set_font`, `fillText`, `strokeText`, and `measureText` on a detached document canvas

Fixes #8515.

> This fix was developed with assistance from Claude Code (claude-opus-4-6).