### PR TITLE
LibWeb: Handle Bitmap size overflow via error code instead of VERIFY

### DIFF
--- a/Libraries/LibGfx/Bitmap.cpp
+++ b/Libraries/LibGfx/Bitmap.cpp
@@ -116,7 +116,7 @@ Bitmap::Bitmap(BitmapFormat format, AlphaType alpha_type, IntSize size, BackingS
 ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::create_wrapper(BitmapFormat format, AlphaType alpha_type, IntSize size, size_t pitch, void* data, Function<void()>&& destruction_callback)
 {
     if (size_would_overflow(format, size))
-        return Error::from_string_literal("Gfx::Bitmap::create_wrapper size overflow");
+        return Error::from_errno(EOVERFLOW);
     return adopt_ref(*new Bitmap(format, alpha_type, size, pitch, data, move(destruction_callback)));
 }
 

--- a/Libraries/LibWeb/HTML/ImageBitmap.cpp
+++ b/Libraries/LibWeb/HTML/ImageBitmap.cpp
@@ -46,7 +46,14 @@ static void serialize_bitmap(HTML::TransferDataEncoder& encoder, RefPtr<Gfx::Bit
     auto const format = decoder.decode<Gfx::BitmapFormat>();
     auto const alpha_type = decoder.decode<Gfx::AlphaType>();
     auto const data = TRY(decoder.decode_buffer(realm));
-    return TRY_OR_THROW_OOM(realm.vm(), create_bitmap_from_bitmap_data(format, alpha_type, width, height, pitch, data));
+    auto bitmap_or_error = create_bitmap_from_bitmap_data(format, alpha_type, width, height, pitch, data);
+    if (bitmap_or_error.is_error()) {
+        if (bitmap_or_error.error().code() == EOVERFLOW)
+            return WebIDL::DataCloneError::create(realm, "The serialized image size exceeds the supported range."_utf16);
+        auto& vm = realm.vm();
+        return vm.throw_completion<JS::InternalError>(vm.error_message(JS::VM::ErrorMessage::OutOfMemory));
+    }
+    return bitmap_or_error.release_value();
 }
 
 GC::Ref<ImageBitmap> ImageBitmap::create(JS::Realm& realm)

--- a/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Libraries/LibWeb/HTML/ImageData.cpp
@@ -113,7 +113,14 @@ WebIDL::ExceptionOr<GC::Ref<ImageData>> ImageData::initialize(JS::Realm& realm, 
     }());
 
     // AD-HOC: Create the bitmap backed by the Uint8ClampedArray.
-    auto bitmap = TRY_OR_THROW_OOM(realm.vm(), create_bitmap_backed_by_uint8_clamped_array(pixels_per_row, rows, *data));
+    auto bitmap_or_error = create_bitmap_backed_by_uint8_clamped_array(pixels_per_row, rows, *data);
+    if (bitmap_or_error.is_error()) {
+        if (bitmap_or_error.error().code() == EOVERFLOW)
+            return WebIDL::IndexSizeError::create(realm, "The requested image size exceeds the supported range."_utf16);
+        auto& vm = realm.vm();
+        return vm.throw_completion<JS::InternalError>(vm.error_message(JS::VM::ErrorMessage::OutOfMemory));
+    }
+    auto bitmap = bitmap_or_error.release_value();
 
     // 4. Initialize the width attribute of imageData to pixelsPerRow.
     // 5. Initialize the height attribute of imageData to rows.
@@ -227,7 +234,13 @@ WebIDL::ExceptionOr<void> ImageData::deserialization_steps(HTML::TransferDataDec
     // FIXME: 5. Initialize value's pixelFormat attribute to serialized.[[PixelFormat]].
 
     // AD-HOC: Create the bitmap backed by the Uint8ClampedArray.
-    m_bitmap = TRY_OR_THROW_OOM(vm, create_bitmap_backed_by_uint8_clamped_array(width, height, *m_data));
+    auto bitmap_or_error = create_bitmap_backed_by_uint8_clamped_array(width, height, *m_data);
+    if (bitmap_or_error.is_error()) {
+        if (bitmap_or_error.error().code() == EOVERFLOW)
+            return WebIDL::DataCloneError::create(realm, "The serialized image size exceeds the supported range."_utf16);
+        return vm.throw_completion<JS::InternalError>(vm.error_message(JS::VM::ErrorMessage::OutOfMemory));
+    }
+    m_bitmap = bitmap_or_error.release_value();
 
     define_direct_property("data"_utf16_fly_string, m_data, JS::Attribute::Enumerable);
 

--- a/Tests/LibWeb/Text/expected/HTML/ImageData-oversized-no-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/ImageData-oversized-no-crash.txt
@@ -1,0 +1,3 @@
+PASS: IndexSizeError
+PASS: IndexSizeError
+PASS: 10x10

--- a/Tests/LibWeb/Text/input/HTML/ImageData-oversized-no-crash.html
+++ b/Tests/LibWeb/Text/input/HTML/ImageData-oversized-no-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        // Test dimensions that pass the u32 overflow check but fail Bitmap's
+        // size_would_overflow (width >= INT16_MAX). This is the exact case from
+        // issue #8496 that previously caused a VERIFY crash in TRY_OR_THROW_OOM.
+        try {
+            new ImageData(32767, 2);
+            println("FAIL: should have thrown");
+        } catch (e) {
+            println(`PASS: ${e.name}`);
+        }
+
+        // Test dimensions that overflow u32 multiplication (rows * cols * 4).
+        try {
+            new ImageData(100000, 100000);
+            println("FAIL: should have thrown");
+        } catch (e) {
+            println(`PASS: ${e.name}`);
+        }
+
+        // Verify that reasonable sizes still work.
+        try {
+            let img = new ImageData(10, 10);
+            println(`PASS: ${img.width}x${img.height}`);
+        } catch (e) {
+            println(`FAIL: ${e.name}`);
+        }
+    });
+</script>


### PR DESCRIPTION
## Summary
- `TRY_OR_THROW_OOM` contains `VERIFY(error.code() == ENOMEM)`, but `Bitmap::create_wrapper` returns a string-literal error (code 0) when `size_would_overflow` is true, causing a VERIFY crash
- Change `create_wrapper()` to return `Error::from_errno(EOVERFLOW)` so callers can distinguish size overflow from allocation failure
- Update `ImageData` and `ImageBitmap` deserialization to check for `EOVERFLOW` and return the appropriate DOM exception (`IndexSizeError` / `DataCloneError`) instead of crashing

## Test plan
- [x] New test: `ImageData-oversized-no-crash.html` verifies oversized dimensions throw instead of crashing
- [x] LibWeb builds cleanly

Fixes #8496.

> This fix was developed with assistance from Claude Code (claude-opus-4-6).