### PR TITLE
LibWebView: Use http:// for private/loopback IP addresses in URL bar

### DIFF
--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -6,13 +6,67 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/IPv4Address.h>
+#include <AK/IPv6Address.h>
 #include <AK/String.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibURL/Host.h>
 #include <LibURL/Parser.h>
 #include <LibURL/PublicSuffixData.h>
 #include <LibWebView/URL.h>
 
 namespace WebView {
+
+static bool is_ipv4_private_or_loopback(u8 first, u8 second)
+{
+    // 127.0.0.0/8 (loopback)
+    if (first == 127)
+        return true;
+    // 10.0.0.0/8 (private)
+    if (first == 10)
+        return true;
+    // 172.16.0.0/12 (private)
+    if (first == 172 && second >= 16 && second <= 31)
+        return true;
+    // 192.168.0.0/16 (private)
+    if (first == 192 && second == 168)
+        return true;
+    // 169.254.0.0/16 (link-local)
+    if (first == 169 && second == 254)
+        return true;
+    return false;
+}
+
+static bool is_host_private_or_loopback(URL::Host const& host)
+{
+    if (host.has<IPv4Address>()) {
+        // Use host.serialize() to get the canonical dotted-decimal form,
+        // then parse it back. This avoids byte-order issues with the internal
+        // IPv4Address representation used by the URL parser.
+        if (auto parsed = IPv4Address::from_string(host.serialize()); parsed.has_value())
+            return is_ipv4_private_or_loopback((*parsed)[0], (*parsed)[1]);
+        return false;
+    }
+
+    if (host.has<IPv6Address>()) {
+        auto const& ipv6 = host.get<IPv6Address>();
+
+        // ::1 (loopback)
+        if (ipv6[0] == 0 && ipv6[1] == 0 && ipv6[2] == 0 && ipv6[3] == 0
+            && ipv6[4] == 0 && ipv6[5] == 0 && ipv6[6] == 0 && ipv6[7] == 1)
+            return true;
+
+        return false;
+    }
+
+    // The URL parser may store IP addresses as domain strings.
+    if (host.has<String>()) {
+        if (auto parsed = IPv4Address::from_string(host.get<String>()); parsed.has_value())
+            return is_ipv4_private_or_loopback((*parsed)[0], (*parsed)[1]);
+    }
+
+    return false;
+}
 
 Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
 {
@@ -42,6 +96,16 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
             return search_url_or_error();
 
         https_scheme_was_guessed = true;
+    }
+
+    // For private/loopback IP addresses, use http:// instead of https:// since
+    // these addresses typically don't have TLS certificates.
+    if (https_scheme_was_guessed) {
+        if (auto const& host = url->host(); host.has_value() && is_host_private_or_loopback(*host)) {
+            url = URL::create_with_url_or_path(ByteString::formatted("http://{}", location));
+            if (!url.has_value())
+                return search_url_or_error();
+        }
     }
 
     // FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -198,4 +198,25 @@ TEST_CASE(location_to_search_or_url)
     expect_search_url_equals_sanitized_url("mailto:hello@example.com"sv); // For now, unsupported scheme.
     // FIXME: Add support for opening mailto: scheme (below). Firefox opens mailto: locations
     // expect_url_equals_sanitized_url("mailto:hello@example.com"sv, "mailto:hello@example.com"sv);
+
+    // Bare IP addresses on private/loopback networks should default to http://, not https://.
+    expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv);
+    expect_url_equals_sanitized_url("http://127.0.0.1:8080/"sv, "127.0.0.1:8080"sv);
+    expect_url_equals_sanitized_url("http://10.0.0.1/"sv, "10.0.0.1"sv);
+    expect_url_equals_sanitized_url("http://10.0.0.1:3000/"sv, "10.0.0.1:3000"sv);
+    expect_url_equals_sanitized_url("http://172.16.0.1/"sv, "172.16.0.1"sv);
+    expect_url_equals_sanitized_url("http://172.31.255.255/"sv, "172.31.255.255"sv);
+    expect_url_equals_sanitized_url("http://192.168.1.1/"sv, "192.168.1.1"sv);
+    expect_url_equals_sanitized_url("http://192.168.0.100:8080/"sv, "192.168.0.100:8080"sv);
+    expect_url_equals_sanitized_url("http://169.254.1.1/"sv, "169.254.1.1"sv);
+    expect_url_equals_sanitized_url("http://[::1]/"sv, "[::1]"sv);
+
+    // Public IP addresses should still get https://.
+    expect_url_equals_sanitized_url("https://8.8.8.8/"sv, "8.8.8.8"sv);
+    expect_url_equals_sanitized_url("https://172.32.0.1/"sv, "172.32.0.1"sv);  // Just outside 172.16.0.0/12.
+    expect_url_equals_sanitized_url("https://172.15.255.255/"sv, "172.15.255.255"sv);  // Just below 172.16.0.0/12.
+
+    // Explicit scheme should be respected regardless of IP address.
+    expect_url_equals_sanitized_url("https://192.168.1.1/"sv, "https://192.168.1.1"sv);
+    expect_url_equals_sanitized_url("http://8.8.8.8/"sv, "http://8.8.8.8"sv);
 }


### PR DESCRIPTION
## Summary
- When a bare IP address is entered without a scheme, `sanitize_url` unconditionally prepends `https://`, breaking local network access
- Detect private (10/8, 172.16/12, 192.168/16), loopback (127/8, ::1), and link-local (169.254/16) addresses and use `http://` instead
- Explicit schemes entered by the user are always respected

## Test plan
- [x] New test cases in `TestWebViewURL.cpp` covering all private/loopback ranges, boundary values, public IPs, and explicit scheme preservation
- [x] All existing `TestWebViewURL` tests continue to pass

Fixes #8344.

> This fix was developed with assistance from Claude Code (claude-opus-4-6).