### PR TITLE
RequestServer: Use macOS system certificates for SSL verification

### DIFF
--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -45,6 +45,10 @@ if (WIN32)
     lagom_windows_bin(RequestServer CONSOLE)
 endif()
 
+if (APPLE)
+    target_link_libraries(RequestServer PRIVATE "-framework Security")
+endif()
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries
     target_link_libraries(requestserverservice PUBLIC nsl socket)

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -526,6 +526,9 @@ void Request::handle_fetch_state()
     if (auto const& path = default_certificate_path(); !path.is_empty())
         set_option(CURLOPT_CAINFO, path.characters());
 
+    if (auto callback = ssl_ctx_setup_callback())
+        set_option(CURLOPT_SSL_CTX_FUNCTION, callback);
+
     set_option(CURLOPT_ACCEPT_ENCODING, ""); // Empty string lets curl define the accepted encodings.
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());
     set_option(CURLOPT_PORT, m_url.port_or_default());

--- a/Services/RequestServer/Resolver.cpp
+++ b/Services/RequestServer/Resolver.cpp
@@ -11,6 +11,7 @@
 namespace RequestServer {
 
 static ByteString g_default_certificate_path;
+static SSLCtxSetupCallback g_ssl_ctx_setup_callback = nullptr;
 
 ByteString const& default_certificate_path()
 {
@@ -20,6 +21,16 @@ ByteString const& default_certificate_path()
 void set_default_certificate_path(ByteString default_certificate_path)
 {
     g_default_certificate_path = move(default_certificate_path);
+}
+
+SSLCtxSetupCallback ssl_ctx_setup_callback()
+{
+    return g_ssl_ctx_setup_callback;
+}
+
+void set_ssl_ctx_setup_callback(SSLCtxSetupCallback callback)
+{
+    g_ssl_ctx_setup_callback = callback;
 }
 
 DNSInfo& DNSInfo::the()

--- a/Services/RequestServer/Resolver.h
+++ b/Services/RequestServer/Resolver.h
@@ -42,4 +42,8 @@ private:
 ByteString const& default_certificate_path();
 void set_default_certificate_path(ByteString);
 
+using SSLCtxSetupCallback = int (*)(void*, void*, void*);
+SSLCtxSetupCallback ssl_ctx_setup_callback();
+void set_ssl_ctx_setup_callback(SSLCtxSetupCallback);
+
 }

--- a/Services/RequestServer/WebSocketImplCurl.cpp
+++ b/Services/RequestServer/WebSocketImplCurl.cpp
@@ -6,6 +6,7 @@
 
 #include <RequestServer/CURL.h>
 #include <RequestServer/ConnectionFromClient.h>
+#include <RequestServer/Resolver.h>
 #include <RequestServer/WebSocketImplCurl.h>
 
 namespace RequestServer {
@@ -67,6 +68,9 @@ void WebSocketImplCurl::connect(WebSocket::ConnectionInfo const& info)
 
     if (auto root_certs = info.root_certificates_path(); root_certs.has_value())
         set_option(CURLOPT_CAINFO, root_certs->characters());
+
+    if (auto callback = ssl_ctx_setup_callback())
+        set_option(CURLOPT_SSL_CTX_FUNCTION, callback);
 
     auto const origin_header = ByteString::formatted("Origin: {}", info.origin());
     curl_slist* curl_headers = curl_slist_append(nullptr, origin_header.characters());

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -26,6 +26,47 @@ OwnPtr<ResourceSubstitutionMap> g_resource_substitution_map;
 
 }
 
+#ifdef AK_OS_MACOS
+#    include <Security/Security.h>
+#    include <openssl/ssl.h>
+#    include <openssl/x509.h>
+
+static Vector<X509*> s_system_certificates;
+
+static void load_system_certificates()
+{
+    CFArrayRef certs = nullptr;
+    if (SecTrustCopyAnchorCertificates(&certs) != errSecSuccess || !certs)
+        return;
+
+    auto count = CFArrayGetCount(certs);
+
+    for (CFIndex i = 0; i < count; ++i) {
+        auto* cert = static_cast<SecCertificateRef>(const_cast<void*>(CFArrayGetValueAtIndex(certs, i)));
+        auto* der_data = SecCertificateCopyData(cert);
+        if (!der_data)
+            continue;
+
+        auto const* der_ptr = CFDataGetBytePtr(der_data);
+        auto* x509 = d2i_X509(nullptr, &der_ptr, CFDataGetLength(der_data));
+        CFRelease(der_data);
+
+        if (x509)
+            s_system_certificates.append(x509);
+    }
+
+    CFRelease(certs);
+}
+
+static int inject_system_certificates(void*, void* ssl_ctx, void*)
+{
+    auto* store = SSL_CTX_get_cert_store(static_cast<SSL_CTX*>(ssl_ctx));
+    for (auto* cert : s_system_certificates)
+        X509_STORE_add_cert(store, cert);
+    return 0;
+}
+#endif
+
 #ifndef AK_OS_WINDOWS
 static void handle_signal(int signal)
 {
@@ -58,6 +99,13 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     // FIXME: Update RequestServer to support multiple custom root certificates.
     if (!certificates.is_empty())
         RequestServer::set_default_certificate_path(certificates.first());
+#ifdef AK_OS_MACOS
+    if (RequestServer::default_certificate_path().is_empty()) {
+        load_system_certificates();
+        if (!s_system_certificates.is_empty())
+            RequestServer::set_ssl_ctx_setup_callback(inject_system_certificates);
+    }
+#endif
 
     if (!resource_map_path.is_empty()) {
         auto map = RequestServer::ResourceSubstitutionMap::load_from_file(resource_map_path);


### PR DESCRIPTION
## Summary
- On macOS, the vcpkg-built OpenSSL has its OPENSSLDIR pointing to the vcpkg install tree, which contains no CA certificates
- Sites using newer root CAs (e.g. Sectigo R46) that are in the macOS system keychain but not in the default OpenSSL paths fail SSL verification
- Load system root certificates via `SecTrustCopyAnchorCertificates` at RequestServer startup, convert to OpenSSL `X509` objects, and inject into each curl handle's SSL context via `CURLOPT_SSL_CTX_FUNCTION`
- No temporary files are created; certificates are held in memory and injected directly into the OpenSSL trust store

## Test plan
- [x] Verified `https://www.epexspot.com` loads successfully (previously failed with "SSL verification failed")
- [x] Other HTTPS sites continue to work normally

Fixes #8629.

> This fix was developed with assistance from Claude Code (claude-opus-4-6).