### PR TITLE
LibWeb: Skip layout-dependent fields in DOM serialization when stale

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2044,6 +2044,8 @@ bool Node::is_uninteresting_whitespace_node() const
         return false;
     if (!static_cast<Text const&>(*this).data().is_ascii_whitespace())
         return false;
+    if (!document().layout_is_up_to_date())
+        return false;
     if (!layout_node())
         return true;
     if (auto parent = layout_node()->parent(); parent && parent->is_anonymous())
@@ -2093,15 +2095,17 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
             }
         }
 
-        if (paintable_box()) {
-            if (paintable_box()->could_be_scrolled_by_wheel_event()) {
-                MUST(object.add("scrollable"sv, true));
-            }
-            if (!paintable_box()->is_visible()) {
-                MUST(object.add("invisible"sv, true));
-            }
-            if (paintable_box()->has_stacking_context()) {
-                MUST(object.add("stackingContext"sv, true));
+        if (document().layout_is_up_to_date()) {
+            if (auto const* box = paintable_box()) {
+                if (box->could_be_scrolled_by_wheel_event()) {
+                    MUST(object.add("scrollable"sv, true));
+                }
+                if (!box->is_visible()) {
+                    MUST(object.add("invisible"sv, true));
+                }
+                if (box->has_stacking_context()) {
+                    MUST(object.add("stackingContext"sv, true));
+                }
             }
         }
     } else if (is_text()) {
@@ -2117,7 +2121,7 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
         MUST(object.add("mode"sv, static_cast<DOM::ShadowRoot const&>(*this).mode() == Bindings::ShadowRootMode::Open ? "open"sv : "closed"sv));
     }
 
-    MUST((object.add("visible"sv, !!layout_node())));
+    MUST((object.add("visible"sv, document().layout_is_up_to_date() && !!layout_node())));
 
     if (auto const* element = as_if<Element>(this)) {
         element->serialize_children_as_json(object);


### PR DESCRIPTION
## Summary
- Fix crash when modifying style attributes or resizing the window while DevTools is attached
- `serialize_tree_as_json` and helper functions called `paintable_box()` and `layout_node()`, both of which assert `layout_is_up_to_date()`, but DOM mutation notifications from DevTools fire before layout runs
- Guard layout-dependent fields (`scrollable`, `invisible`, `stackingContext`, `visible`) with `layout_is_up_to_date()` checks, skipping them when layout is stale rather than reading potentially incorrect values
- Whitespace node filtering in `is_uninteresting_whitespace_node` is also skipped when layout is stale, including all nodes instead

## Test plan
- [x] Manually verified: modifying element styles via JS while DevTools is connected no longer crashes
- [x] Manually verified: resizing the window while DevTools is inspecting no longer crashes

Fixes #8622. Also fixes #8280.

> This fix was developed with assistance from Claude Code (claude-opus-4-6).