### PR TITLE
LibWeb: Handle stale fetch callbacks in stylesheet processing

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -874,11 +874,12 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
 
     // 6. If el contributes a script-blocking style sheet, then:
     if (contributes_a_script_blocking_style_sheet()) {
-        // 1. Assert: el's node document's script-blocking style sheet set contains el.
-        VERIFY(document().script_blocking_style_sheet_set().contains(*this));
-
-        // 2. Remove el from its node document's script-blocking style sheet set.
-        document().script_blocking_style_sheet_set().remove(*this);
+        // AD-HOC: The spec says to assert that the set contains el, but when the href attribute
+        //       is rapidly toggled, multiple stale fetch callbacks can fire for the same element.
+        //       The first callback removes el from the set, and the second would hit the assert.
+        //       We gracefully handle this by only removing if present.
+        if (auto it = document().script_blocking_style_sheet_set().find(*this); it != document().script_blocking_style_sheet_set().end())
+            document().script_blocking_style_sheet_set().remove(it);
     }
 
     // 7. Unblock rendering on el.

--- a/Tests/LibWeb/Text/expected/link-rapid-href-toggle-crash.txt
+++ b/Tests/LibWeb/Text/expected/link-rapid-href-toggle-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/link-rapid-href-toggle-crash.html
+++ b/Tests/LibWeb/Text/input/link-rapid-href-toggle-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<link id="link" rel="stylesheet" href="valid.css">
+<script>
+    test(() => {
+        const link = document.getElementById("link");
+        // Rapidly toggle href to trigger multiple stale fetch callbacks
+        for (let i = 0; i < 10; i++) {
+            link.href = "valid.css?" + i;
+        }
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
## Summary
- Fix crash when rapidly toggling the `href` attribute of a `<link rel="stylesheet">` element
- Multiple stale fetch callbacks can fire for the same element; the first removes it from the script-blocking style sheet set, and the second hits a `VERIFY` assertion
- Replace the unconditional `VERIFY` and remove with a conditional check

## Test plan
- [x] New test: `link-rapid-href-toggle-crash.html` rapidly toggles `link.href` to trigger stale fetch callbacks
- [x] Manually verified: test page no longer crashes

Fixes #6273.

> This fix was developed with assistance from Claude Code (claude-opus-4-6).