### PR TITLE
LibWeb: Add case when <br> has display other than 'none'

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -64,6 +64,9 @@ void HTMLBRElement::adjust_computed_style(CSS::ComputedProperties& style)
     // https://drafts.csswg.org/css-display-3/#unbox
     if (style.display().is_contents())
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
+    else if (!style.display().is_none())
+        // AD-HOC: Prevent other display values from applying, so that we always create a BreakNode
+        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Inline)));
 }
 
 }

--- a/Tests/LibWeb/Crash/HTML/br-display-set-to-table-should-not-crash.html
+++ b/Tests/LibWeb/Crash/HTML/br-display-set-to-table-should-not-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<head>
+</head>
+<body>
+    <br style="display: table-cell;">
+    <br style="display: table-caption;">
+</body>


### PR DESCRIPTION
In the previous code there was no condition verifying if a <br> element had its display style set to something other than none, which caused the thread to crash in those cases (specially when display was set to table-cell or table-caption, as reported in the issue). Add a condition to ensure that in those cases, <br> elements are always treated as an inline box, preventing program from crashing.
Created  a test file called br-display-set-to-table-should-not-crash.html which tests both cases reported on this issue.
Fixes #5568