### PR TITLE
LibWeb: Disable Navigation API after `document.open()` on `about:blank`

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -851,6 +851,11 @@ WebIDL::ExceptionOr<Document*> Document::open(Optional<String> const&, Optional<
         HTML::perform_url_and_history_update_steps(*this, move(new_url));
     }
 
+    // AD-HOC: Record that this document was an initial about:blank before document.open() cleared the flag, so the
+    //         Navigation API can keep entries and events disabled.
+    if (is_initial_about_blank())
+        as<HTML::Window>(HTML::relevant_global_object(*this)).navigation()->set_was_initial_about_blank_opened(true);
+
     // 13. Set document's is initial about:blank to false.
     set_is_initial_about_blank(false);
 

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -467,6 +467,12 @@ bool Navigation::has_entries_and_events_disabled() const
     if (document.origin().is_opaque())
         return true;
 
+    // AD-HOC: Keep entries and events disabled when document.open() is called on an initial about:blank document. This
+    //         behavior matches other engines.
+    //         Spec issue: https://github.com/whatwg/html/issues/11811
+    if (m_was_initial_about_blank_opened)
+        return true;
+
     // 5. Return false.
     return false;
 }
@@ -1429,6 +1435,10 @@ void Navigation::initialize_the_navigation_api_entries_for_a_new_document(Vector
 
     // 2. Assert: navigation's current entry index is −1.
     VERIFY(m_current_entry_index == -1);
+
+    // AD-HOC: This flag is only set when an about:blank page is modified by document.open(). Reset it now that a new
+    //         navigation is happening.
+    m_was_initial_about_blank_opened = false;
 
     // 3. If navigation has entries and events disabled, then return.
     if (has_entries_and_events_disabled())

--- a/Libraries/LibWeb/HTML/Navigation.h
+++ b/Libraries/LibWeb/HTML/Navigation.h
@@ -134,6 +134,8 @@ public:
     bool focus_changed_during_ongoing_navigation() const { return m_focus_changed_during_ongoing_navigation; }
     void set_focus_changed_during_ongoing_navigation(bool b) { m_focus_changed_during_ongoing_navigation = b; }
 
+    void set_was_initial_about_blank_opened(bool b) { m_was_initial_about_blank_opened = b; }
+
 private:
     explicit Navigation(JS::Realm&);
 
@@ -190,6 +192,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#upcoming-non-traverse-api-method-tracker
     HashMap<String, GC::Ref<NavigationAPIMethodTracker>> m_upcoming_traverse_api_method_trackers;
+
+    // AD-HOC: Set when document.open() is called on an initial about:blank document.
+    bool m_was_initial_about_blank_opened { false };
 };
 
 HistoryHandlingBehavior to_history_handling_behavior(Bindings::NavigationHistoryBehavior);

--- a/Tests/LibWeb/Crash/DOM/document-open-navigation-api.html
+++ b/Tests/LibWeb/Crash/DOM/document-open-navigation-api.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<body>
+<script>
+const iframe = document.createElement("iframe");
+document.body.appendChild(iframe);
+iframe.contentDocument.open();
+iframe.contentDocument.write("<!DOCTYPE html><p>hello</p>");
+iframe.contentDocument.close();
+iframe.contentWindow.navigation.currentEntry;
+</script>
+</body>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -35,6 +35,9 @@ Text/input/navigation/location-reload-fetch.html
 Text/input/HTML/local-storage-usage-after-nav.html
 Text/input/HTML/session-storage-event-fired-to-lazy-window.html
 
+; Navigation has entries and events disabled for opaque origins, so this crash only reproduces over HTTP.
+Crash/DOM/document-open-navigation-api.html
+
 ; Does not work in Ladybird - unsure why.
 ; Works in other browsers when loaded from file://. Needs investigation.
 ; Probably all fetch or navigation related.


### PR DESCRIPTION
This follows the Blink/WebKit approach described in this spec issue: https://github.com/whatwg/html/issues/11811

Fixes [a number of WPT crashes](https://wpt.fyi/results/html/syntax/parsing?q=ladybird%3Acrash&run_id=5081858357592064) in `html/syntax/parsing`.

Fixes #8590