### PR TITLE
LibGfx: Fix AVIF alpha type to be unpremultiplied

### DIFF
--- a/Libraries/LibGfx/ImageFormats/AVIFLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/AVIFLoader.cpp
@@ -105,7 +105,7 @@ static ErrorOr<void> decode_avif_image(AVIFLoadingContext& context)
     avifRGBImage rgb;
     while (avifDecoderNextImage(context.decoder) == AVIF_RESULT_OK) {
         auto bitmap_format = context.has_alpha ? BitmapFormat::BGRA8888 : BitmapFormat::BGRx8888;
-        auto bitmap = TRY(Bitmap::create(bitmap_format, context.size.value()));
+        auto bitmap = TRY(Bitmap::create(bitmap_format, AlphaType::Unpremultiplied, context.size.value()));
 
         avifRGBImageSetDefaults(&rgb, context.decoder->image);
         rgb.pixels = bitmap->scanline_u8(0);


### PR DESCRIPTION
libavif outputs straight (unpremultiplied) alpha by default, but the AVIF loader was creating bitmaps without specifying an alpha type, which defaults to premultiplied. This mismatch caused semi-transparent pixels to render incorrectly.

Pass `AlphaType::Unpremultiplied` explicitly, matching what the PNG, WebP, and BMP decoders already do.

Visual progression on https://fragrantica.com

Before:
<img width="1399" height="941" alt="Screenshot 2026-03-27 at 18 28 18" src="https://github.com/user-attachments/assets/3bc22975-85e3-459c-ad9b-4151d6241fec" />

After:
<img width="1399" height="941" alt="Screenshot 2026-03-27 at 18 27 57" src="https://github.com/user-attachments/assets/70112513-68fb-4f2a-b105-a936e91fa0ac" />