### PR TITLE
LibWeb: Treat table cell height as fit-content when applying `vertical-align`

### DIFF
--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1195,22 +1195,27 @@ void TableFormattingContext::position_cell_boxes()
         if (cell_is_anonymous_wrapper_for_flex_or_grid(cell)) {
             cell_state.padding_bottom += row_content_height - cell_state.border_box_height();
         } else if (vertical_align.has<CSS::VerticalAlign>()) {
+            // AD-HOC: For the purpose of aligning the cell vertically to top, bottom or middle - treat cell's height as
+            //         if it was fit-content. This lets us correctly align the cell when it's height is set to a
+            //         percentage value.
+            auto const cell_content_height = calculate_fit_content_height(cell.box, cell_state.available_inner_space_or_constraints_from(*m_available_space)) + cell_state.border_box_top() + cell_state.border_box_bottom();
+
             switch (vertical_align.get<CSS::VerticalAlign>()) {
             // The center of the cell is aligned with the center of the rows it spans.
             case CSS::VerticalAlign::Middle: {
-                auto const height_diff = row_content_height - cell_state.border_box_height();
+                auto const height_diff = row_content_height - cell_content_height;
                 cell_state.padding_top += height_diff / 2;
                 cell_state.padding_bottom += height_diff / 2;
                 break;
             }
             // The top of the cell box is aligned with the top of the first row it spans.
             case CSS::VerticalAlign::Top: {
-                cell_state.padding_bottom += row_content_height - cell_state.border_box_height();
+                cell_state.padding_bottom += row_content_height - cell_content_height;
                 break;
             }
             // The bottom of the cell box is aligned with the bottom of the last row it spans.
             case CSS::VerticalAlign::Bottom: {
-                cell_state.padding_top += row_content_height - cell_state.border_box_height();
+                cell_state.padding_top += row_content_height - cell_content_height;
                 break;
             }
             // These values do not apply to cells; the cell is aligned at the baseline instead.

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-bottom-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-bottom-percentage-height.txt
@@ -1,0 +1,43 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+      BlockContainer <div#wrapper> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+          Box <div#table> at [0,0] table-box [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [TFC] children: not-inline
+            Box <(anonymous)> at [0,0] table-row [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <div#cell> at [0,582] table-cell [0+0+0 800 0+0+0] [0+0+582 600 0+0+0] [BFC] children: inline
+                TextNode <#text> (not painted)
+                InlineNode <span> at [0,582] [0+0+0 152.8125 0+0+0] [0+0+0 18 0+0+0]
+                  frag 0 from TextNode start: 0, length: 18, rect: [0,582 152.8125x18] baseline: 13.796875
+                      "I am at the botom."
+                  TextNode <#text> (not painted)
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,600] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1182]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>#wrapper) [0,0 800x600]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+        PaintableWithLines (TableWrapper(anonymous)) [0,0 800x600]
+          PaintableBox (Box<DIV>#table) [0,0 800x600]
+            PaintableBox (Box(anonymous)) [0,0 800x600]
+              PaintableWithLines (BlockContainer<DIV>#cell) [0,0 800x1182]
+                PaintableWithLines (InlineNode<SPAN>) [0,582 152.8125x18]
+                  TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,600 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-percentage-height-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-percentage-height-1.txt
@@ -1,0 +1,49 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+      BlockContainer <div#wrapper> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+          Box <div#table> at [0,0] table-box [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [TFC] children: not-inline
+            Box <(anonymous)> at [0,0] table-row [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <div#cell> at [0,268] table-cell [0+0+0 800 0+0+0] [0+0+268 600 268+0+0] [BFC] children: not-inline
+                BlockContainer <(anonymous)> at [0,268] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+                  TextNode <#text> (not painted)
+                BlockContainer <div#box> at [368,268] [368+0+0 64 0+0+368] [0+0+0 64 0+0+0] children: inline
+                  frag 0 from TextNode start: 21, length: 4, rect: [368,268 34.140625x18] baseline: 13.796875
+                      "I am"
+                  frag 1 from TextNode start: 26, length: 9, rect: [368,286 72.546875x18] baseline: 13.796875
+                      "centered."
+                  TextNode <#text> (not painted)
+                BlockContainer <(anonymous)> at [0,332] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+                  TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,600] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1136]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>#wrapper) [0,0 800x600]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+        PaintableWithLines (TableWrapper(anonymous)) [0,0 800x600]
+          PaintableBox (Box<DIV>#table) [0,0 800x600]
+            PaintableBox (Box(anonymous)) [0,0 800x600]
+              PaintableWithLines (BlockContainer<DIV>#cell) [0,0 800x1136]
+                PaintableWithLines (BlockContainer(anonymous)) [0,268 800x0]
+                PaintableWithLines (BlockContainer<DIV>#box) [368,268 64x64]
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [0,332 800x0]
+        PaintableWithLines (BlockContainer(anonymous)) [0,600 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-percentage-height-2.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-percentage-height-2.txt
@@ -1,0 +1,43 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+      BlockContainer <div#wrapper> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+          Box <div#table> at [0,0] table-box [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [TFC] children: not-inline
+            Box <(anonymous)> at [0,0] table-row [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <div#cell> at [0,291] table-cell [0+0+0 800 0+0+0] [0+0+291 600 291+0+0] [BFC] children: inline
+                TextNode <#text> (not painted)
+                InlineNode <span> at [0,291] [0+0+0 193.734375 0+0+0] [0+0+0 18 0+0+0]
+                  frag 0 from TextNode start: 0, length: 25, rect: [0,291 193.734375x18] baseline: 13.796875
+                      "I am vertically centered."
+                  TextNode <#text> (not painted)
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,600] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1182]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>#wrapper) [0,0 800x600]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+        PaintableWithLines (TableWrapper(anonymous)) [0,0 800x600]
+          PaintableBox (Box<DIV>#table) [0,0 800x600]
+            PaintableBox (Box(anonymous)) [0,0 800x600]
+              PaintableWithLines (BlockContainer<DIV>#cell) [0,0 800x1182]
+                PaintableWithLines (InlineNode<SPAN>) [0,291 193.734375x18]
+                  TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,600 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-percentage-height-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-percentage-height-3.txt
@@ -1,0 +1,43 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      TextNode <#text> (not painted)
+      BlockContainer <div#wrapper> at [0,0] positioned [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        TableWrapper <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+          Box <div#table> at [0,0] table-box [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [TFC] children: not-inline
+            Box <(anonymous)> at [0,0] table-row [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+              BlockContainer <div#cell> at [0,291] table-cell [0+0+0 800 0+0+0] [0+0+291 300 291+0+0] [BFC] children: inline
+                TextNode <#text> (not painted)
+                InlineNode <span> at [0,291] [0+0+0 193.734375 0+0+0] [0+0+0 18 0+0+0]
+                  frag 0 from TextNode start: 0, length: 25, rect: [0,291 193.734375x18] baseline: 13.796875
+                      "I am vertically centered."
+                  TextNode <#text> (not painted)
+                TextNode <#text> (not painted)
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [0,600] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x882]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>#wrapper) [0,0 800x600]
+        PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+        PaintableWithLines (TableWrapper(anonymous)) [0,0 800x600]
+          PaintableBox (Box<DIV>#table) [0,0 800x600]
+            PaintableBox (Box(anonymous)) [0,0 800x600]
+              PaintableWithLines (BlockContainer<DIV>#cell) [0,0 800x882]
+                PaintableWithLines (InlineNode<SPAN>) [0,291 193.734375x18]
+                  TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [0,600 800x0]
+
+SC for Viewport<#document> [0,0 800x600] [children: 1] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] [children: 0] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/table/vertical-align-bottom-percentage-height.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-bottom-percentage-height.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #wrapper {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        vertical-align: middle;
+    }
+
+
+    #table {
+        display: table;
+        width: 100%;
+        height: 100%;
+    }
+
+    #cell {
+        display: table-cell;
+        width: 100%;
+        height: 100%;
+        vertical-align: bottom;
+    }
+</style>
+</head>
+
+<body>
+    <div id="wrapper">
+        <div id="table">
+            <div id="cell">
+                <span>I am at the botom.</span>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/Tests/LibWeb/Layout/input/table/vertical-align-middle-percentage-height-1.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-middle-percentage-height-1.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #wrapper {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        vertical-align: middle;
+    }
+
+
+    #table {
+        display: table;
+        width: 100%;
+        height: 100%;
+    }
+
+    #cell {
+        display: table-cell;
+        width: 100%;
+        height: 100%;
+        vertical-align: middle;
+    }
+
+    #box {
+        width: 64px;
+        height: 64px;
+        background-color: green;
+        display: block;
+        margin-right: auto;
+        margin-left: auto;
+    }
+</style>
+</head>
+
+<body>
+    <div id="wrapper">
+        <div id="table">
+            <div id="cell">
+                <div id="box">
+                    I am centered.
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/Tests/LibWeb/Layout/input/table/vertical-align-middle-percentage-height-2.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-middle-percentage-height-2.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #wrapper {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        vertical-align: middle;
+    }
+
+
+    #table {
+        display: table;
+        width: 100%;
+        height: 100%;
+    }
+
+    #cell {
+        display: table-cell;
+        width: 100%;
+        height: 100%;
+        vertical-align: middle;
+    }
+</style>
+</head>
+
+<body>
+    <div id="wrapper">
+        <div id="table">
+            <div id="cell">
+                <span>I am vertically centered.</span>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/Tests/LibWeb/Layout/input/table/vertical-align-middle-percentage-height-3.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-middle-percentage-height-3.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<meta charset=utf-8>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #wrapper {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        vertical-align: middle;
+    }
+
+
+    #table {
+        display: table;
+        width: 100%;
+        height: 100%;
+    }
+
+    #cell {
+        display: table-cell;
+        width: 100%;
+        height: 50%;
+        vertical-align: middle;
+    }
+</style>
+</head>
+
+<body>
+    <div id="wrapper">
+        <div id="table">
+            <div id="cell">
+                <span>I am vertically centered.</span>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
When applying `vertical-align` top, middle or bottom - treat cell height as `fit-content`.

This avoids an issue with the previous approach, where table cells with percentage heights would fail to apply `vertical-align` correctly.

Fixes #8336
Before this change (screenshot from #8336):
<img width="1920" height="1035" alt="image" src="https://github.com/user-attachments/assets/866775b4-50fd-4042-bdc4-5a0b511b3497" />
After this change:
<img width="1920" height="1038" alt="image" src="https://github.com/user-attachments/assets/5fdd51ea-5a3a-4377-969f-2f0bacd22c96" />
