### PR TITLE
Replace spin_until in execute_script with deferred parser start

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -683,6 +683,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_render_blocking_elements);
     visitor.visit(m_policy_container);
     visitor.visit(m_style_invalidator);
+    visitor.visit(m_deferred_parser_start);
     visitor.visit(m_custom_element_registry);
 }
 
@@ -5805,7 +5806,7 @@ void Document::update_for_history_step_application(GC::Ref<HTML::SessionHistoryE
         try_to_scroll_to_the_fragment();
 
         // 4. At this point scripts may run for the newly-created document document.
-        m_ready_to_run_scripts = true;
+        set_ready_to_run_scripts();
     }
 
     // 9. Otherwise, if documentsEntryChanged is false and doNotReactivate is false, then:
@@ -5814,6 +5815,21 @@ void Document::update_for_history_step_application(GC::Ref<HTML::SessionHistoryE
         // FIXME: 1. Assert: entriesForNavigationAPI is given.
         // FIXME: 2. Reactivate document given entry and entriesForNavigationAPI.
     }
+}
+
+void Document::set_ready_to_run_scripts()
+{
+    m_ready_to_run_scripts = true;
+    if (auto callback = m_deferred_parser_start) {
+        m_deferred_parser_start = nullptr;
+        callback->function()();
+    }
+}
+
+void Document::set_deferred_parser_start(GC::Ref<GC::Function<void()>> callback)
+{
+    VERIFY(!m_deferred_parser_start);
+    m_deferred_parser_start = callback;
 }
 
 HashMap<URL::URL, GC::Ptr<HTML::SharedResourceRequest>>& Document::shared_resource_requests()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -798,7 +798,8 @@ public:
     WebIDL::ExceptionOr<Vector<GC::Ref<Animations::Animation>>> get_animations();
 
     bool ready_to_run_scripts() const { return m_ready_to_run_scripts; }
-    void set_ready_to_run_scripts() { m_ready_to_run_scripts = true; }
+    void set_ready_to_run_scripts();
+    void set_deferred_parser_start(GC::Ref<GC::Function<void()>>);
 
     GC::Ptr<HTML::SessionHistoryEntry> latest_entry() const { return m_latest_entry; }
     void set_latest_entry(GC::Ptr<HTML::SessionHistoryEntry> e) { m_latest_entry = e; }
@@ -1364,6 +1365,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#scripts-may-run-for-the-newly-created-document
     bool m_ready_to_run_scripts { false };
+    GC::Ptr<GC::Function<void()>> m_deferred_parser_start;
 
     Vector<HTML::FormAssociatedElement*> m_form_associated_elements_with_form_attribute;
 

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -101,7 +101,13 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::Navi
                 // NB: If document is part of a session history entry's traversal, resolve the signal_to_continue_session_history_processing.
                 signal_to_continue_session_history_processing->resolve({});
                 auto parser = HTML::HTMLParser::create_with_uncertain_encoding(document, data, mime_type);
-                parser->run(url);
+                if (document->ready_to_run_scripts()) {
+                    parser->run(url);
+                } else {
+                    document->set_deferred_parser_start(GC::create_function(document->heap(), [parser, url] {
+                        parser->run(url);
+                    }));
+                }
             }));
         });
 
@@ -190,15 +196,22 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::Navig
         }
         // NB: If document is part of session history traversal, resolve the signal_to_continue_session_history_processing.
         signal_to_continue_session_history_processing->resolve({});
-        XML::Parser parser(source.value(), { .preserve_cdata = true, .preserve_comments = true, .resolve_named_html_entity = resolve_named_html_entity });
-        XMLDocumentBuilder builder { document };
-        auto result = parser.parse_with_listener(builder);
-        if (result.is_error()) {
-            // FIXME: Insert error message into the document.
-            dbgln("Failed to parse XML document: {}", result.error());
-            convert_to_xml_error_document(document, Utf16String::formatted("Failed to parse XML document: {}", result.error()));
+        auto run_xml_parser = [document, source_string = source.release_value()] {
+            XML::Parser parser(source_string, { .preserve_cdata = true, .preserve_comments = true, .resolve_named_html_entity = resolve_named_html_entity });
+            XMLDocumentBuilder builder { document };
+            auto result = parser.parse_with_listener(builder);
+            if (result.is_error()) {
+                // FIXME: Insert error message into the document.
+                dbgln("Failed to parse XML document: {}", result.error());
+                convert_to_xml_error_document(document, Utf16String::formatted("Failed to parse XML document: {}", result.error()));
 
-            // NB: XMLDocumentBuilder ensures that the `load` event gets fired. We don't need to do anything else here.
+                // NB: XMLDocumentBuilder ensures that the `load` event gets fired. We don't need to do anything else here.
+            }
+        };
+        if (document->ready_to_run_scripts()) {
+            run_xml_parser();
+        } else {
+            document->set_deferred_parser_start(GC::create_function(document->heap(), move(run_xml_parser)));
         }
     });
 
@@ -246,26 +259,33 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_text_document(HTML::Navi
 
         // NB: If document is part of session history traversal, resolve the signal_to_continue_session_history_processing.
         signal_to_continue_session_history_processing->resolve({});
-        auto parser = HTML::HTMLParser::create_for_scripting(document);
-        parser->tokenizer().update_insertion_point();
+        auto run_text_parser = [document, data = move(data), url, encoding = move(encoding)] {
+            auto parser = HTML::HTMLParser::create_for_scripting(document);
+            parser->tokenizer().update_insertion_point();
 
-        parser->tokenizer().insert_input_at_insertion_point("<pre>\n"sv);
-        parser->run();
+            parser->tokenizer().insert_input_at_insertion_point("<pre>\n"sv);
+            parser->run();
 
-        parser->tokenizer().switch_to(HTML::HTMLTokenizer::State::PLAINTEXT);
-        parser->tokenizer().insert_input_at_insertion_point(data);
-        parser->tokenizer().insert_eof();
-        parser->run(url);
+            parser->tokenizer().switch_to(HTML::HTMLTokenizer::State::PLAINTEXT);
+            parser->tokenizer().insert_input_at_insertion_point(data);
+            parser->tokenizer().insert_eof();
+            parser->run(url);
 
-        document->set_encoding(MUST(String::from_byte_string(encoding)));
+            document->set_encoding(MUST(String::from_byte_string(encoding)));
 
-        // 5. User agents may add content to the head element of document, e.g., linking to a style sheet, providing
-        //    script, or giving the document a title.
-        auto title = Utf16String::from_utf8_with_replacement_character(LexicalPath::basename(url.to_byte_string()));
-        auto title_element = MUST(DOM::create_element(document, HTML::TagNames::title, Namespace::HTML));
-        MUST(document->head()->append_child(title_element));
-        auto title_text = document->realm().create<DOM::Text>(document, move(title));
-        MUST(title_element->append_child(*title_text));
+            // 5. User agents may add content to the head element of document, e.g., linking to a style sheet, providing
+            //    script, or giving the document a title.
+            auto title = Utf16String::from_utf8_with_replacement_character(LexicalPath::basename(url.to_byte_string()));
+            auto title_element = MUST(DOM::create_element(document, HTML::TagNames::title, Namespace::HTML));
+            MUST(document->head()->append_child(title_element));
+            auto title_text = document->realm().create<DOM::Text>(document, move(title));
+            MUST(title_element->append_child(*title_text));
+        };
+        if (document->ready_to_run_scripts()) {
+            run_text_parser();
+        } else {
+            document->set_deferred_parser_start(GC::create_function(document->heap(), move(run_text_parser)));
+        }
     });
 
     auto process_body_error = GC::create_function(document->heap(), [](JS::Value) {

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -79,6 +79,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
 
     // 6. Either associate document with a custom rendering that is not rendered using the normal Document rendering
     //    rules, or mutate document until it represents the content the user agent wants to render.
+    document->set_ready_to_run_scripts();
     mutate_document(*document);
 
     // FIXME: 7. Act as if the user agent had stopped parsing document.

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -122,8 +122,7 @@ void HTMLScriptElement::execute_script()
 {
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-html
     // Before any script execution occurs, the user agent must wait for scripts may run for the newly-created document to be true for document.
-    if (!m_document->ready_to_run_scripts())
-        main_thread_event_loop().spin_until(GC::create_function(heap(), [&] { return m_document->ready_to_run_scripts(); }));
+    VERIFY(document().ready_to_run_scripts());
 
     // 1. Let document be el's node document.
     GC::Ref<DOM::Document> document = this->document();

--- a/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -174,8 +174,7 @@ void SVGScriptElement::process_the_script_element()
 
     // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-html
     // Before any script execution occurs, the user agent must wait for scripts may run for the newly-created document to be true for document.
-    if (!m_document->ready_to_run_scripts())
-        HTML::main_thread_event_loop().spin_until(GC::create_function(heap(), [&] { return m_document->ready_to_run_scripts(); }));
+    VERIFY(m_document->ready_to_run_scripts());
 
     m_script = HTML::ClassicScript::create(script_url.basename(), script_content, realm(), m_document->base_url(), m_source_line_number);
 


### PR DESCRIPTION
HTMLScriptElement::execute_script() and SVGScriptElement had spin_until calls waiting for ready_to_run_scripts to become true. The race exists because load_html_document() resolves the session history signal and starts the parser in the same deferred_invoke — so the parser can hit a <script> before update_for_history_step_application() sets the flag.

Instead of spinning, defer parser->run() until the document is ready. Document gains a m_deferred_parser_start callback that is invoked when set_ready_to_run_scripts() is called. The callback is cleared before invocation to avoid reentrancy issues (parser->run() can synchronously execute scripts). All three document loading paths (HTML, XML, text) now check ready_to_run_scripts before starting the parser and defer if needed.

create_document_for_inline_content() (used for error pages) now calls set_ready_to_run_scripts() before mutating the document, ensuring the invariant holds for all parser paths.

The spin_until calls are replaced with VERIFY assertions.