### PR TITLE
LibWeb: Don't paint render-blocked iframe documents

### DIFF
--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigableContainer.h>
@@ -45,6 +44,9 @@ void NavigableContainerViewportPaintable::paint(DisplayListRecordingContext& con
         auto const& navigable_container = this->navigable_container();
         auto* hosted_document = const_cast<DOM::Document*>(navigable_container.content_document_without_origin_check());
         if (!hosted_document)
+            return;
+
+        if (hosted_document->is_render_blocked())
             return;
 
         // NB: The hosted document's layout may have been invalidated during the parent

--- a/Tests/LibWeb/Ref/expected/iframe-render-blocked-child-not-painted-ref.html
+++ b/Tests/LibWeb/Ref/expected/iframe-render-blocked-child-not-painted-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            body {
+                margin: 0;
+                background: rgb(240, 240, 240);
+            }
+
+            #indicator {
+                width: 240px;
+                height: 24px;
+                margin: 16px;
+                background: rgb(0, 0, 255);
+            }
+
+            #frame-placeholder {
+                width: 240px;
+                height: 120px;
+                margin: 16px;
+                border: 4px solid rgb(40, 40, 40);
+                background: white;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="indicator"></div>
+        <div id="frame-placeholder"></div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/iframe-render-blocked-child-not-painted.html
+++ b/Tests/LibWeb/Ref/input/iframe-render-blocked-child-not-painted.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <link
+            rel="match"
+            href="../expected/iframe-render-blocked-child-not-painted-ref.html"
+        />
+        <script src="../../Text/input/include.js"></script>
+        <style>
+            body {
+                margin: 0;
+                background: rgb(240, 240, 240);
+            }
+
+            #indicator {
+                width: 240px;
+                height: 24px;
+                margin: 16px;
+                background: rgb(255, 0, 0);
+            }
+
+            iframe {
+                display: block;
+                width: 240px;
+                height: 120px;
+                margin: 16px;
+                border: 4px solid rgb(40, 40, 40);
+                background: white;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="indicator"></div>
+        <iframe></iframe>
+        <script>
+            document.addEventListener("DOMContentLoaded", async () => {
+                const server = httpTestServer();
+                const stylesheetURL = await server.createEcho("GET", "/iframe-render-blocked-child-not-painted.css", {
+                    status: 200,
+                    headers: {
+                        "Content-Type": "text/css",
+                    },
+                    body: "body { margin: 0; }",
+                    delay_ms: 1000,
+                });
+
+                const childURL = await server.createEcho("GET", "/iframe-render-blocked-child-not-painted-child.html", {
+                    status: 200,
+                    headers: {
+                        "Content-Type": "text/html",
+                    },
+                    body: `<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="${stylesheetURL}">
+    </head>
+    <body>
+        <div
+            style="
+                margin: 0;
+                font: 700 64px/1 serif;
+                color: rgb(220, 0, 0);
+            "
+        >
+            FAIL
+        </div>
+    </body>
+</html>`,
+                });
+
+                document.querySelector("iframe").src = childURL;
+
+                requestAnimationFrame(() => {
+                    document.getElementById("indicator").style.background = "rgb(0, 0, 255)";
+                    requestAnimationFrame(() => {
+                        document.documentElement.className = "";
+                    });
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -148,6 +148,7 @@ Text/input/wpt-import/fetch/api/headers/headers-no-cors.any.html
 Text/input/css/FontFace-binary-data.html
 Text/input/css/FontFace-load-urls.html
 Text/input/css/FontFaceSet-load.html
+Ref/input/iframe-render-blocked-child-not-painted.html
 
 ; Performs cross origin document access, e.g, to an iframe's contentDocument or window.location.
 ; Fails in other browsers too when loaded from file://.


### PR DESCRIPTION
Parent document paints could still record and paint a nested iframe's contents even while the child document was render-blocked. That let unstyled iframe content leak into the parent display list before the child's blocking stylesheet had loaded, which matched the FOUC seen in Speedometer's TodoMVC suites.

Skip painting hosted documents from NavigableContainerViewportPaintable while they are render-blocked. Add a reftest that keeps an iframe child render-blocked with a delayed stylesheet and forces a parent repaint; without the fix the child's inline FAIL text becomes visible.

The new reftest passes with this change, and the existing render- blocking requestAnimationFrame tests still pass.

Fixes an issue where this sad thing was visible for a split second on every Speedometer subtest:
<img width="1266" height="915" alt="Screenshot 2026-03-29 at 17 00 51" src="https://github.com/user-attachments/assets/5474f138-39b3-4fb3-b298-c18e881e1e25" />

