### PR TITLE
LibWeb: Resolve pending-substitution leaf longhands

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -484,6 +484,13 @@ void StyleComputer::cascade_declarations(
     AK::FixedBitmap<to_underlying(last_property_id) + 1> seen_properties(false);
     auto cascade_style_declaration = [&](CSSStyleProperties const& declaration) {
         seen_properties.fill(false);
+
+        HashMap<StyleValue const*, PropertyID> shorthand_properties_by_value;
+        for (auto const& property : declaration.properties()) {
+            if (property_is_shorthand(property.property_id))
+                shorthand_properties_by_value.set(property.value.ptr(), property.property_id);
+        }
+
         for (auto const& property : declaration.properties()) {
             if (important != property.important)
                 continue;
@@ -492,6 +499,28 @@ void StyleComputer::cascade_declarations(
                 continue;
 
             auto property_value = property.value;
+
+            // `convert_declarations_to_specified_order()` keeps unresolved shorthands around as both the original
+            // shorthand value and a set of PendingSubstitutionStyleValues for the longhands. If the shorthand itself
+            // doesn't participate in the cascade for this target, resolve the matching longhand from the shorthand now
+            // so we don't let a placeholder value survive into computed style.
+            if (property_value->is_pending_substitution() && !property_is_shorthand(property.property_id) && !seen_properties.get(to_underlying(property.property_id))) {
+                auto const& original_shorthand_value = property_value->as_pending_substitution().original_shorthand_value();
+                if (auto shorthand_property_id = shorthand_properties_by_value.get(&original_shorthand_value); shorthand_property_id.has_value()) {
+                    property_value = original_shorthand_value;
+                    if (property_value->is_unresolved())
+                        property_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, PropertyNameAndID::from_id(*shorthand_property_id), property_value->as_unresolved());
+
+                    if (!property_value->is_guaranteed_invalid()) {
+                        RefPtr<StyleValue const> resolved_longhand_value;
+                        for_each_property_expanding_shorthands(*shorthand_property_id, *property_value, [&](PropertyID longhand_id, StyleValue const& longhand_value) {
+                            if (longhand_id == property.property_id)
+                                resolved_longhand_value = longhand_value;
+                        });
+                        property_value = resolved_longhand_value ? resolved_longhand_value.release_nonnull() : KeywordStyleValue::create(Keyword::Unset);
+                    }
+                }
+            }
 
             if (property_value->is_unresolved())
                 property_value = Parser::Parser::resolve_unresolved_style_value(Parser::ParsingParams { abstract_element.document() }, abstract_element, PropertyNameAndID::from_id(property.property_id), property_value->as_unresolved());

--- a/Tests/LibWeb/Crash/CSS/selection-background-var-missing.html
+++ b/Tests/LibWeb/Crash/CSS/selection-background-var-missing.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+::selection {
+    background: var(--color-accent);
+    color: #fff;
+}
+</style>
+<span id="text">oh-no</span>
+<script>
+    const text = document.getElementById("text").firstChild;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, text.length);
+    getSelection().addRange(range);
+</script>

--- a/Tests/LibWeb/Text/expected/css/var-in-border-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/css/var-in-border-shorthand.txt
@@ -1,0 +1,6 @@
+borderTopWidth: 3px
+borderTopStyle: solid
+borderTopColor: rgb(255, 0, 0)
+borderRightWidth: 3px
+borderRightStyle: solid
+borderRightColor: rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/input/css/var-in-border-shorthand.html
+++ b/Tests/LibWeb/Text/input/css/var-in-border-shorthand.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target" style="--border: 3px solid red; border: var(--border);"></div>
+<script>
+    test(() => {
+        const targetStyle = getComputedStyle(document.getElementById("target"));
+        println(`borderTopWidth: ${targetStyle.borderTopWidth}`);
+        println(`borderTopStyle: ${targetStyle.borderTopStyle}`);
+        println(`borderTopColor: ${targetStyle.borderTopColor}`);
+        println(`borderRightWidth: ${targetStyle.borderRightWidth}`);
+        println(`borderRightStyle: ${targetStyle.borderRightStyle}`);
+        println(`borderRightColor: ${targetStyle.borderRightColor}`);
+    });
+</script>


### PR DESCRIPTION
When a shorthand contains var(), its expanded longhands carry pending-substitution placeholders through the cascade and receive their final values at computed-value time.

Our declaration-order handling could let a pending leaf longhand enter computed style unchanged when the originating shorthand did not win the cascade for that target directly. This left placeholder values visible past computed-value processing instead of producing the final resolved longhand value.

Resolve only pending leaf longhands from their originating shorthand at the point they would otherwise enter computed style. This preserves the existing nested-shorthand expansion path while ensuring computed style only exposes resolved leaf values.

Add regression coverage for both a highlight shorthand using background: var(...) and a nested shorthand using border: var(...). The new and existing targeted test-web cases pass.

Fixes crash when selecting text on https://ladybird.org/