### PR TITLE
Tests: Fix flaky form-disabled-callback WPT test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -8,6 +8,9 @@ Text/input/navigation/history-replace-push-then-back.html
 ; CSS @font-face url() requires HTTP(s) scheme.
 Text/input/selection-rect-consistency-with-kerning.html
 
+; Form submission to /common/blank.html requires HTTP(s) scheme.
+Text/input/wpt-import/custom-elements/form-associated/form-disabled-callback.html
+
 ; Bug in ladybird - crashes due to AD-HOC fetch implementation in SVGScriptElement (due to opaque file origin).
 ; Works in other browsers when loaded from file://.
 Text/input/wpt-import/html/syntax/parsing/unclosed-svg-script.html


### PR DESCRIPTION
The test submits a form to /common/blank.html via an iframe. Under file://, this resolves to file:///common/blank.html which doesn't exist. The failed navigation sometimes leaves the iframe cross-origin, causing a SecurityError when accessing iframe.contentWindow.location, which prevents the promise from resolving and causes a timeout.

Serve the test over HTTP so the form submission resolves to the echo server's WPT tree, where /common/blank.html exists.