### PR TITLE
LibWeb: Merge duplicate `@keyframe` rule selector values

### DIFF
--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -333,7 +333,16 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                     });
                 }
 
-                keyframe_set->keyframes_by_key.insert(key, resolved_keyframe);
+                if (auto* existing_keyframe = keyframe_set->keyframes_by_key.find(key)) {
+                    for (auto& [property_id, value] : resolved_keyframe.properties)
+                        existing_keyframe->properties.set(property_id, move(value));
+                    if (resolved_keyframe.easing.has_value())
+                        existing_keyframe->easing = move(resolved_keyframe.easing);
+                    if (resolved_keyframe.composite != Bindings::CompositeOperationOrAuto::Auto)
+                        existing_keyframe->composite = resolved_keyframe.composite;
+                } else {
+                    keyframe_set->keyframes_by_key.insert(key, resolved_keyframe);
+                }
             }
 
             Animations::KeyframeEffect::generate_initial_and_final_frames(keyframe_set, animated_properties);

--- a/Tests/LibWeb/Ref/expected/css/duplicate-keyframe-offset-merge-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/duplicate-keyframe-offset-merge-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    border: 5px solid red;
+}
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/css/duplicate-keyframe-offset-merge.html
+++ b/Tests/LibWeb/Ref/input/css/duplicate-keyframe-offset-merge.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/duplicate-keyframe-offset-merge-ref.html" />
+<style>
+@keyframes test {
+    0% { background-color: green; }
+    0% { border: 5px solid red; }
+}
+div {
+    animation: test 1s linear paused;
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<div></div>


### PR DESCRIPTION
Previously, a keyframe with duplicate selector would cause a crash.

Fixes a crash in: http://wpt.live/css/css-animations/keyframes-unrelated-custom-property.html.