### PR TITLE
LibWeb: Delete whole words with Ctrl+Backspace/Del

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -1078,9 +1078,29 @@ void FormAssociatedTextControlElement::handle_delete(FlyString const& input_type
         if (input_type == UIEvents::InputTypes::deleteContentBackward) {
             if (auto offset = text_node->grapheme_segmenter().previous_boundary(m_selection_end); offset.has_value())
                 selection_start = *offset;
-        } else {
+        } else if (input_type == UIEvents::InputTypes::deleteWordBackward) {
+            while (true) {
+                if (auto offset = text_node->word_segmenter().previous_boundary(selection_start); offset.has_value()) {
+                    auto word = text_node->data().substring_view(*offset, selection_start - *offset);
+                    selection_start = *offset;
+                    if (Unicode::Segmenter::should_continue_beyond_word(word))
+                        continue;
+                }
+                break;
+            }
+        } else if (input_type == UIEvents::InputTypes::deleteContentForward) {
             if (auto offset = text_node->grapheme_segmenter().next_boundary(m_selection_end); offset.has_value())
                 selection_end = *offset;
+        } else if (input_type == UIEvents::InputTypes::deleteWordForward) {
+            while (true) {
+                if (auto offset = text_node->word_segmenter().next_boundary(selection_end); offset.has_value()) {
+                    auto word = text_node->data().substring_view(*offset, selection_end - *offset);
+                    selection_end = *offset;
+                    if (Unicode::Segmenter::should_continue_beyond_word(word))
+                        continue;
+                }
+                break;
+            }
         }
     }
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1734,14 +1734,15 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     auto* target = document->active_input_events_target();
     if (target) {
         if (key == UIEvents::KeyCode::Key_Backspace) {
-            FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::deleteContentBackward, m_navigable, code_point));
-            target->handle_delete(UIEvents::InputTypes::deleteContentBackward);
+            auto input_type = (modifiers & UIEvents::Mod_PlatformWordJump) == 0 ? UIEvents::InputTypes::deleteContentBackward : UIEvents::InputTypes::deleteWordBackward;
+            FIRE(input_event(UIEvents::EventNames::beforeinput, input_type, m_navigable, code_point));
+            target->handle_delete(input_type);
             return EventResult::Handled;
         }
-
         if (key == UIEvents::KeyCode::Key_Delete) {
-            FIRE(input_event(UIEvents::EventNames::beforeinput, UIEvents::InputTypes::deleteContentForward, m_navigable, code_point));
-            target->handle_delete(UIEvents::InputTypes::deleteContentForward);
+            auto input_type = (modifiers & UIEvents::Mod_PlatformWordJump) == 0 ? UIEvents::InputTypes::deleteContentForward : UIEvents::InputTypes::deleteWordForward;
+            FIRE(input_event(UIEvents::EventNames::beforeinput, input_type, m_navigable, code_point));
+            target->handle_delete(input_type);
             return EventResult::Handled;
         }
 

--- a/Libraries/LibWeb/UIEvents/InputTypes.h
+++ b/Libraries/LibWeb/UIEvents/InputTypes.h
@@ -14,6 +14,8 @@ namespace Web::UIEvents::InputTypes {
 #define ENUMERATE_INPUT_TYPES                     \
     __ENUMERATE_INPUT_TYPE(deleteContentBackward) \
     __ENUMERATE_INPUT_TYPE(deleteContentForward)  \
+    __ENUMERATE_INPUT_TYPE(deleteWordBackward)    \
+    __ENUMERATE_INPUT_TYPE(deleteWordForward)     \
     __ENUMERATE_INPUT_TYPE(insertFromPaste)       \
     __ENUMERATE_INPUT_TYPE(insertLineBreak)       \
     __ENUMERATE_INPUT_TYPE(insertParagraph)       \

--- a/Tests/LibWeb/Text/expected/input-delete.txt
+++ b/Tests/LibWeb/Text/expected/input-delete.txt
@@ -4,3 +4,9 @@ After: foobar
 --- b ---
 Before: foo👩🏼‍❤️‍👨🏻bar
 After: foobar
+--- c ---
+Before: foo bar
+After: foo 
+--- d ---
+Before: foo bar
+After:  bar

--- a/Tests/LibWeb/Text/input/input-delete.html
+++ b/Tests/LibWeb/Text/input/input-delete.html
@@ -2,9 +2,11 @@
 <script src="include.js"></script>
 <input id="a" value="foo👩🏼‍❤️‍👨🏻bar" />
 <input id="b" value="foo👩🏼‍❤️‍👨🏻bar" />
+<input id="c" value="foo bar" />
+<input id="d" value="foo bar" />
 <script>
     test(() => {
-        const testDelete = function (id, position, key) {
+        const testDelete = function (id, position, key, modifiers) {
             println(`--- ${id} ---`);
             const input = document.querySelector(`input#${id}`);
             println(`Before: ${input.value}`);
@@ -13,12 +15,14 @@
             input.setSelectionRange(position, position);
 
             // Press backspace
-            internals.sendKey(input, key);
+            internals.sendKey(input, key, modifiers);
 
             println(`After: ${input.value}`);
         };
 
         testDelete("a", 15, "Backspace");
         testDelete("b", 3, "Delete");
+        testDelete("c", 20, "Backspace", internals.MOD_CTRL);
+        testDelete("d", 0, "Delete", internals.MOD_CTRL);
     });
 </script>


### PR DESCRIPTION
When pressing the Ctrl key (or equivalent PlatformWordJump modifier), backspace and delete now delete a whole word, similarly to what happens when pressing the same modifier with the arrow keys.