### PR TITLE
Replace SVGPaintServerPaintStyle class hierarchy with Variant

### DIFF
--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -46,12 +46,7 @@ class DisplayList;
 class DisplayListPlayerSkia;
 class DisplayListRecorder;
 class ExternalContentSource;
-class SVGGradientPaintStyle;
-class SVGPaintServerPaintStyle;
-class SVGPatternPaintStyle;
 class ScrollStateSnapshot;
-using PaintStyle = RefPtr<SVGPaintServerPaintStyle>;
-using PaintStyleOrColor = Variant<PaintStyle, Gfx::Color>;
 using ScrollStateSnapshotByDisplayList = HashMap<NonnullRefPtr<DisplayList>, ScrollStateSnapshot>;
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -408,104 +408,117 @@ void DisplayListPlayerSkia::fill_rect_with_rounded_corners(FillRectWithRoundedCo
     canvas.drawRRect(rounded_rect, paint);
 }
 
-static SkTileMode to_skia_tile_mode(SVGLinearGradientPaintStyle::SpreadMethod spread_method)
+static SkTileMode to_skia_tile_mode(GradientPaintData::SpreadMethod spread_method)
 {
     switch (spread_method) {
-    case SVGLinearGradientPaintStyle::SpreadMethod::Pad:
+    case GradientPaintData::SpreadMethod::Pad:
         return SkTileMode::kClamp;
-    case SVGLinearGradientPaintStyle::SpreadMethod::Reflect:
+    case GradientPaintData::SpreadMethod::Reflect:
         return SkTileMode::kMirror;
-    case SVGLinearGradientPaintStyle::SpreadMethod::Repeat:
+    case GradientPaintData::SpreadMethod::Repeat:
         return SkTileMode::kRepeat;
     default:
         VERIFY_NOT_REACHED();
     }
 }
 
-static SkPaint gradient_paint_style_to_skia_paint(Painting::SVGGradientPaintStyle const& paint_style, Gfx::FloatRect const& bounding_rect)
+struct SkiaGradientData {
+    Vector<SkColor> colors;
+    Vector<SkScalar> positions;
+    SkMatrix matrix;
+    SkTileMode tile_mode;
+    bool linear_rgb;
+};
+
+static SkiaGradientData prepare_skia_gradient(Painting::GradientPaintData const& gradient, Gfx::FloatRect const& bounding_rect)
+{
+    SkiaGradientData data;
+    data.colors.ensure_capacity(gradient.color_stops.size());
+    data.positions.ensure_capacity(gradient.color_stops.size());
+
+    for (auto const& color_stop : gradient.color_stops) {
+        data.colors.append(to_skia_color(color_stop.color));
+        data.positions.append(color_stop.position);
+    }
+
+    data.matrix.setTranslate(bounding_rect.x(), bounding_rect.y());
+    if (auto const& gradient_transform = gradient.gradient_transform; gradient_transform.has_value())
+        data.matrix = data.matrix * to_skia_matrix(gradient_transform.value());
+
+    data.tile_mode = to_skia_tile_mode(gradient.spread_method);
+    data.linear_rgb = gradient.color_space == Gfx::InterpolationColorSpace::LinearRGB;
+    return data;
+}
+
+static SkPaint finish_gradient_paint(SkiaGradientData const& data, sk_sp<SkShader> shader)
 {
     SkPaint paint;
-
-    auto const& color_stops = paint_style.color_stops();
-
-    Vector<SkColor> colors;
-    colors.ensure_capacity(color_stops.size());
-    Vector<SkScalar> positions;
-    positions.ensure_capacity(color_stops.size());
-
-    for (auto const& color_stop : color_stops) {
-        colors.append(to_skia_color(color_stop.color));
-        positions.append(color_stop.position);
-    }
-
-    SkMatrix matrix;
-    matrix.setTranslate(bounding_rect.x(), bounding_rect.y());
-    if (auto gradient_transform = paint_style.gradient_transform(); gradient_transform.has_value())
-        matrix = matrix * to_skia_matrix(gradient_transform.value());
-
-    auto tile_mode = to_skia_tile_mode(paint_style.spread_method());
-
-    sk_sp<SkShader> shader;
-    if (is<SVGLinearGradientPaintStyle>(paint_style)) {
-        auto const& linear_gradient_paint_style = static_cast<SVGLinearGradientPaintStyle const&>(paint_style);
-
-        Array points {
-            to_skia_point(linear_gradient_paint_style.start_point()),
-            to_skia_point(linear_gradient_paint_style.end_point()),
-        };
-        shader = SkGradientShader::MakeLinear(points.data(), colors.data(), positions.data(), color_stops.size(), tile_mode, 0, &matrix);
-    } else if (is<SVGRadialGradientPaintStyle>(paint_style)) {
-        auto const& radial_gradient_paint_style = static_cast<SVGRadialGradientPaintStyle const&>(paint_style);
-
-        auto start_center = to_skia_point(radial_gradient_paint_style.start_center());
-        auto end_center = to_skia_point(radial_gradient_paint_style.end_center());
-
-        auto start_radius = radial_gradient_paint_style.start_radius();
-        auto end_radius = radial_gradient_paint_style.end_radius();
-
-        shader = SkGradientShader::MakeTwoPointConical(start_center, start_radius, end_center, end_radius, colors.data(), positions.data(), color_stops.size(), tile_mode, 0, &matrix);
-    }
     paint.setShader(shader);
-    if (paint_style.color_space() == Gfx::InterpolationColorSpace::LinearRGB) {
+    if (data.linear_rgb)
         paint.setColorFilter(SkColorFilters::LinearToSRGBGamma());
-    }
-
     return paint;
 }
 
-SkPaint DisplayListPlayerSkia::paint_style_to_skia_paint(Painting::SVGPaintServerPaintStyle const& paint_style, Gfx::FloatRect const& bounding_rect)
+static SkPaint linear_gradient_to_skia_paint(Painting::SVGLinearGradientPaintStyle const& style, Gfx::FloatRect const& bounding_rect)
 {
-    if (auto const* gradient = as_if<SVGGradientPaintStyle>(paint_style))
-        return gradient_paint_style_to_skia_paint(*gradient, bounding_rect);
+    auto data = prepare_skia_gradient(style.gradient, bounding_rect);
+    Array points {
+        to_skia_point(style.start_point),
+        to_skia_point(style.end_point),
+    };
+    auto shader = SkGradientShader::MakeLinear(points.data(), data.colors.data(), data.positions.data(), data.colors.size(), data.tile_mode, 0, &data.matrix);
+    return finish_gradient_paint(data, shader);
+}
 
-    if (auto const* pattern = as_if<SVGPatternPaintStyle>(paint_style)) {
-        auto const& tile_rect = pattern->tile_rect();
-        auto tile_size = Gfx::IntSize(ceilf(tile_rect.width()), ceilf(tile_rect.height()));
-        if (tile_size.is_empty())
-            return {};
+static SkPaint radial_gradient_to_skia_paint(Painting::SVGRadialGradientPaintStyle const& style, Gfx::FloatRect const& bounding_rect)
+{
+    auto data = prepare_skia_gradient(style.gradient, bounding_rect);
+    auto start_center = to_skia_point(style.start_center);
+    auto end_center = to_skia_point(style.end_center);
+    auto shader = SkGradientShader::MakeTwoPointConical(start_center, style.start_radius, end_center, style.end_radius, data.colors.data(), data.positions.data(), data.colors.size(), data.tile_mode, 0, &data.matrix);
+    return finish_gradient_paint(data, shader);
+}
 
-        auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
+SkPaint DisplayListPlayerSkia::paint_style_to_skia_paint(Painting::PaintStyleOrColor const& paint_style_or_color, Gfx::FloatRect const& bounding_rect)
+{
+    return paint_style_or_color.visit(
+        [](Gfx::Color const& color) -> SkPaint {
+            SkPaint paint;
+            paint.setColor(to_skia_color(color));
+            return paint;
+        },
+        [&](SVGLinearGradientPaintStyle const& style) {
+            return linear_gradient_to_skia_paint(style, bounding_rect);
+        },
+        [&](SVGRadialGradientPaintStyle const& style) {
+            return radial_gradient_to_skia_paint(style, bounding_rect);
+        },
+        [&](SVGPatternPaintStyle const& pattern) -> SkPaint {
+            auto const& tile_rect = pattern.tile_rect;
+            auto tile_size = Gfx::IntSize(ceilf(tile_rect.width()), ceilf(tile_rect.height()));
+            if (tile_size.is_empty())
+                return {};
 
-        execute_display_list_into_surface(*pattern->tile_display_list(), *tile_surface);
+            auto tile_surface = Gfx::PaintingSurface::create_with_size(tile_size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
 
-        auto image = tile_surface->sk_surface().makeImageSnapshot();
+            execute_display_list_into_surface(*pattern.tile_display_list, *tile_surface);
 
-        SkMatrix matrix;
-        matrix.setTranslate(tile_rect.x(), tile_rect.y());
+            auto image = tile_surface->sk_surface().makeImageSnapshot();
 
-        matrix.preScale(tile_rect.width() / tile_size.width(), tile_rect.height() / tile_size.height());
-        if (auto transform = pattern->pattern_transform(); transform.has_value())
-            matrix = matrix * to_skia_matrix(transform.value());
+            SkMatrix matrix;
+            matrix.setTranslate(tile_rect.x(), tile_rect.y());
 
-        auto sampling = SkSamplingOptions(SkFilterMode::kLinear);
-        auto shader = image->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, sampling, &matrix);
+            matrix.preScale(tile_rect.width() / tile_size.width(), tile_rect.height() / tile_size.height());
+            if (auto const& transform = pattern.pattern_transform; transform.has_value())
+                matrix = matrix * to_skia_matrix(transform.value());
 
-        SkPaint paint;
-        paint.setShader(shader);
-        return paint;
-    }
+            auto sampling = SkSamplingOptions(SkFilterMode::kLinear);
+            auto shader = image->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, sampling, &matrix);
 
-    return {};
+            SkPaint paint;
+            paint.setShader(shader);
+            return paint;
+        });
 }
 
 void DisplayListPlayerSkia::fill_path(FillPath const& command)
@@ -513,15 +526,9 @@ void DisplayListPlayerSkia::fill_path(FillPath const& command)
     auto path = to_skia_path(command.path);
     path.setFillType(to_skia_path_fill_type(command.winding_rule));
 
-    SkPaint paint;
-    if (command.paint_style_or_color.has<PaintStyle>()) {
-        auto const& paint_style = command.paint_style_or_color.get<PaintStyle>();
-        paint = paint_style_to_skia_paint(*paint_style, command.bounding_rect().to_type<float>());
+    auto paint = paint_style_to_skia_paint(command.paint_style_or_color, command.bounding_rect().to_type<float>());
+    if (!command.paint_style_or_color.has<Gfx::Color>())
         paint.setAlphaf(command.opacity);
-    } else {
-        auto const& color = command.paint_style_or_color.get<Color>();
-        paint.setColor(to_skia_color(color));
-    }
     paint.setAntiAlias(command.should_anti_alias == ShouldAntiAlias::Yes);
     surface().canvas().drawPath(path, paint);
 }
@@ -529,15 +536,9 @@ void DisplayListPlayerSkia::fill_path(FillPath const& command)
 void DisplayListPlayerSkia::stroke_path(StrokePath const& command)
 {
     auto path = to_skia_path(command.path);
-    SkPaint paint;
-    if (command.paint_style_or_color.has<PaintStyle>()) {
-        auto const& paint_style = command.paint_style_or_color.get<PaintStyle>();
-        paint = paint_style_to_skia_paint(*paint_style, command.bounding_rect().to_type<float>());
+    auto paint = paint_style_to_skia_paint(command.paint_style_or_color, command.bounding_rect().to_type<float>());
+    if (!command.paint_style_or_color.has<Gfx::Color>())
         paint.setAlphaf(command.opacity);
-    } else {
-        auto const& color = command.paint_style_or_color.get<Color>();
-        paint.setColor(to_skia_color(color));
-    }
     paint.setAntiAlias(command.should_anti_alias == ShouldAntiAlias::Yes);
     paint.setStyle(SkPaint::Style::kStroke_Style);
     paint.setStrokeWidth(command.thickness);

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -56,7 +56,7 @@ private:
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
-    SkPaint paint_style_to_skia_paint(SVGPaintServerPaintStyle const&, Gfx::FloatRect const& bounding_rect);
+    SkPaint paint_style_to_skia_paint(PaintStyleOrColor const&, Gfx::FloatRect const& bounding_rect);
 };
 
 }

--- a/Libraries/LibWeb/Painting/PaintStyle.cpp
+++ b/Libraries/LibWeb/Painting/PaintStyle.cpp
@@ -9,18 +9,17 @@
 
 namespace Web::Painting {
 
-NonnullRefPtr<SVGPatternPaintStyle> SVGPatternPaintStyle::create(NonnullRefPtr<DisplayList> tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform)
-{
-    return adopt_ref(*new SVGPatternPaintStyle(move(tile_display_list), tile_rect, move(pattern_transform)));
-}
-
 SVGPatternPaintStyle::SVGPatternPaintStyle(NonnullRefPtr<DisplayList> tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform)
-    : m_tile_display_list(move(tile_display_list))
-    , m_tile_rect(tile_rect)
-    , m_pattern_transform(move(pattern_transform))
+    : tile_display_list(move(tile_display_list))
+    , tile_rect(tile_rect)
+    , pattern_transform(move(pattern_transform))
 {
 }
 
 SVGPatternPaintStyle::~SVGPatternPaintStyle() = default;
+SVGPatternPaintStyle::SVGPatternPaintStyle(SVGPatternPaintStyle const&) = default;
+SVGPatternPaintStyle& SVGPatternPaintStyle::operator=(SVGPatternPaintStyle const&) = default;
+SVGPatternPaintStyle::SVGPatternPaintStyle(SVGPatternPaintStyle&&) = default;
+SVGPatternPaintStyle& SVGPatternPaintStyle::operator=(SVGPatternPaintStyle&&) = default;
 
 }

--- a/Libraries/LibWeb/Painting/PaintStyle.h
+++ b/Libraries/LibWeb/Painting/PaintStyle.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <AK/AtomicRefCounted.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Variant.h>
 #include <LibGfx/AffineTransform.h>
 #include <LibGfx/InterpolationColorSpace.h>
 #include <LibGfx/PaintStyle.h>
@@ -17,132 +17,67 @@ namespace Web::Painting {
 
 class DisplayList;
 
-class SVGPaintServerPaintStyle : public AtomicRefCounted<SVGPaintServerPaintStyle> {
-public:
-    virtual ~SVGPaintServerPaintStyle() = default;
-};
-
 struct ColorStop {
     Color color;
     float position = AK::NaN<float>;
     Optional<float> transition_hint = {};
 };
 
-class SVGGradientPaintStyle : public SVGPaintServerPaintStyle {
-public:
+struct GradientPaintData {
     enum class SpreadMethod {
         Pad,
         Repeat,
         Reflect
     };
 
-    Optional<Gfx::AffineTransform> const& gradient_transform() const { return m_gradient_transform; }
-    void set_gradient_transform(Gfx::AffineTransform transform) { m_gradient_transform = transform; }
-
-    SpreadMethod spread_method() const { return m_spread_method; }
-    void set_spread_method(SpreadMethod spread_method) { m_spread_method = spread_method; }
+    Vector<ColorStop, 4> color_stops;
+    Optional<float> repeat_length;
+    Optional<Gfx::AffineTransform> gradient_transform;
+    SpreadMethod spread_method { SpreadMethod::Pad };
+    Gfx::InterpolationColorSpace color_space { Gfx::InterpolationColorSpace::SRGB };
 
     void add_color_stop(float position, Color color, Optional<float> transition_hint = {})
     {
-        return add_color_stop(ColorStop { color, position, transition_hint });
+        add_color_stop(ColorStop { color, position, transition_hint });
     }
 
     void add_color_stop(ColorStop stop, bool sort = true)
     {
-        m_color_stops.append(stop);
+        color_stops.append(stop);
         if (sort)
-            quick_sort(m_color_stops, [](auto& a, auto& b) { return a.position < b.position; });
+            quick_sort(color_stops, [](auto& a, auto& b) { return a.position < b.position; });
     }
-
-    ReadonlySpan<ColorStop> color_stops() const { return m_color_stops; }
-    Optional<float> repeat_length() const { return m_repeat_length; }
-
-    Gfx::InterpolationColorSpace color_space() const { return m_color_space; }
-    void set_color_space(Gfx::InterpolationColorSpace color_space) { m_color_space = color_space; }
-
-    virtual ~SVGGradientPaintStyle() override { }
-
-protected:
-    Vector<ColorStop, 4> m_color_stops;
-    Optional<float> m_repeat_length;
-
-    Optional<Gfx::AffineTransform> m_gradient_transform {};
-    SpreadMethod m_spread_method { SpreadMethod::Pad };
-    Gfx::InterpolationColorSpace m_color_space { Gfx::InterpolationColorSpace::SRGB };
 };
 
-class SVGLinearGradientPaintStyle final : public SVGGradientPaintStyle {
-public:
-    static NonnullRefPtr<SVGLinearGradientPaintStyle> create(Gfx::FloatPoint start_point, Gfx::FloatPoint end_point)
-    {
-        return adopt_ref(*new SVGLinearGradientPaintStyle(start_point, end_point));
-    }
-
-    Gfx::FloatPoint start_point() const { return m_start_point; }
-    Gfx::FloatPoint end_point() const { return m_end_point; }
-
-    void set_start_point(Gfx::FloatPoint start_point) { m_start_point = start_point; }
-    void set_end_point(Gfx::FloatPoint end_point) { m_end_point = end_point; }
-
-private:
-    SVGLinearGradientPaintStyle(Gfx::FloatPoint start_point, Gfx::FloatPoint end_point)
-        : m_start_point(start_point)
-        , m_end_point(end_point)
-    {
-    }
-
-    Gfx::FloatPoint m_start_point;
-    Gfx::FloatPoint m_end_point;
+struct SVGLinearGradientPaintStyle {
+    GradientPaintData gradient;
+    Gfx::FloatPoint start_point;
+    Gfx::FloatPoint end_point;
 };
 
-class SVGRadialGradientPaintStyle final : public SVGGradientPaintStyle {
-public:
-    static NonnullRefPtr<SVGRadialGradientPaintStyle> create(Gfx::FloatPoint start_center, float start_radius, Gfx::FloatPoint end_center, float end_radius)
-    {
-        return adopt_ref(*new SVGRadialGradientPaintStyle(start_center, start_radius, end_center, end_radius));
-    }
-
-    Gfx::FloatPoint start_center() const { return m_start_center; }
-    float start_radius() const { return m_start_radius; }
-    Gfx::FloatPoint end_center() const { return m_end_center; }
-    float end_radius() const { return m_end_radius; }
-
-    void set_start_center(Gfx::FloatPoint start_center) { m_start_center = start_center; }
-    void set_start_radius(float start_radius) { m_start_radius = start_radius; }
-    void set_end_center(Gfx::FloatPoint end_center) { m_end_center = end_center; }
-    void set_end_radius(float end_radius) { m_end_radius = end_radius; }
-
-private:
-    SVGRadialGradientPaintStyle(Gfx::FloatPoint start_center, float start_radius, Gfx::FloatPoint end_center, float end_radius)
-        : m_start_center(start_center)
-        , m_start_radius(start_radius)
-        , m_end_center(end_center)
-        , m_end_radius(end_radius)
-    {
-    }
-
-    Gfx::FloatPoint m_start_center;
-    float m_start_radius { 0.0f };
-    Gfx::FloatPoint m_end_center;
-    float m_end_radius { 0.0f };
+struct SVGRadialGradientPaintStyle {
+    GradientPaintData gradient;
+    Gfx::FloatPoint start_center;
+    float start_radius { 0.0f };
+    Gfx::FloatPoint end_center;
+    float end_radius { 0.0f };
 };
 
-class SVGPatternPaintStyle final : public SVGPaintServerPaintStyle {
-public:
-    static NonnullRefPtr<SVGPatternPaintStyle> create(NonnullRefPtr<DisplayList> tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform);
+// Out-of-line special members because DisplayList is incomplete here.
+struct SVGPatternPaintStyle {
+    NonnullRefPtr<DisplayList> tile_display_list;
+    Gfx::FloatRect tile_rect;
+    Optional<Gfx::AffineTransform> pattern_transform;
 
-    virtual ~SVGPatternPaintStyle() override;
-
-    NonnullRefPtr<DisplayList> const& tile_display_list() const { return m_tile_display_list; }
-    Gfx::FloatRect const& tile_rect() const { return m_tile_rect; }
-    Optional<Gfx::AffineTransform> const& pattern_transform() const { return m_pattern_transform; }
-
-private:
-    SVGPatternPaintStyle(NonnullRefPtr<DisplayList> tile_display_list, Gfx::FloatRect tile_rect, Optional<Gfx::AffineTransform> pattern_transform);
-
-    NonnullRefPtr<DisplayList> m_tile_display_list;
-    Gfx::FloatRect m_tile_rect;
-    Optional<Gfx::AffineTransform> m_pattern_transform;
+    SVGPatternPaintStyle(NonnullRefPtr<DisplayList>, Gfx::FloatRect, Optional<Gfx::AffineTransform>);
+    ~SVGPatternPaintStyle();
+    SVGPatternPaintStyle(SVGPatternPaintStyle const&);
+    SVGPatternPaintStyle& operator=(SVGPatternPaintStyle const&);
+    SVGPatternPaintStyle(SVGPatternPaintStyle&&);
+    SVGPatternPaintStyle& operator=(SVGPatternPaintStyle&&);
 };
+
+using PaintStyle = Variant<SVGLinearGradientPaintStyle, SVGRadialGradientPaintStyle, SVGPatternPaintStyle>;
+using PaintStyleOrColor = Variant<SVGLinearGradientPaintStyle, SVGRadialGradientPaintStyle, SVGPatternPaintStyle, Gfx::Color>;
 
 }

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -107,7 +107,7 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
             context.display_list_recorder().fill_path({
                 .path = path,
                 .opacity = fill_opacity,
-                .paint_style_or_color = *paint_style,
+                .paint_style_or_color = PaintStyleOrColor(*paint_style),
                 .winding_rule = winding_rule,
                 .should_anti_alias = should_anti_alias(),
             });
@@ -168,7 +168,7 @@ void SVGPathPaintable::paint(DisplayListRecordingContext& context, PaintPhase ph
                 .dash_offset = stroke_dashoffset,
                 .path = path,
                 .opacity = stroke_opacity,
-                .paint_style_or_color = *paint_style,
+                .paint_style_or_color = PaintStyleOrColor(*paint_style),
                 .thickness = stroke_thickness,
                 .should_anti_alias = should_anti_alias(),
             });

--- a/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -109,7 +109,7 @@ Gfx::AffineTransform SVGGradientElement::gradient_paint_transform(SVGPaintContex
     return gradient_paint_transform;
 }
 
-void SVGGradientElement::add_color_stops(Painting::SVGGradientPaintStyle& paint_style) const
+void SVGGradientElement::add_color_stops(Painting::GradientPaintData& paint_data) const
 {
     auto largest_offset = 0.0f;
     for_each_color_stop([&](auto& stop) {
@@ -125,7 +125,7 @@ void SVGGradientElement::add_color_stops(Painting::SVGGradientPaintStyle& paint_
         stop_offset = AK::max(stop_offset, largest_offset);
         largest_offset = stop_offset;
 
-        paint_style.add_color_stop(stop_offset, stop.stop_color().with_opacity(stop.stop_opacity()));
+        paint_data.add_color_stop(stop_offset, stop.stop_color().with_opacity(stop.stop_opacity()));
     });
 }
 

--- a/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -21,15 +21,15 @@ struct SVGPaintContext {
     Gfx::AffineTransform paint_transform;
 };
 
-inline Painting::SVGGradientPaintStyle::SpreadMethod to_painting_spread_method(SpreadMethod spread_method)
+inline Painting::GradientPaintData::SpreadMethod to_painting_spread_method(SpreadMethod spread_method)
 {
     switch (spread_method) {
     case SpreadMethod::Pad:
-        return Painting::SVGGradientPaintStyle::SpreadMethod::Pad;
+        return Painting::GradientPaintData::SpreadMethod::Pad;
     case SpreadMethod::Reflect:
-        return Painting::SVGGradientPaintStyle::SpreadMethod::Reflect;
+        return Painting::GradientPaintData::SpreadMethod::Reflect;
     case SpreadMethod::Repeat:
-        return Painting::SVGGradientPaintStyle::SpreadMethod::Repeat;
+        return Painting::GradientPaintData::SpreadMethod::Repeat;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -72,7 +72,7 @@ protected:
         return for_each_color_stop_impl(callback, seen_gradients);
     }
 
-    void add_color_stops(Painting::SVGGradientPaintStyle&) const;
+    void add_color_stops(Painting::GradientPaintData&) const;
 
 private:
     template<VoidFunction<SVGStopElement> Callback>

--- a/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -150,19 +150,19 @@ Optional<Painting::PaintStyle> SVGLinearGradientElement::to_gfx_paint_style(SVGP
         };
     }
 
-    if (!m_paint_style) {
-        m_paint_style = Painting::SVGLinearGradientPaintStyle::create(start_point, end_point);
+    if (!m_paint_style.has_value()) {
+        m_paint_style = Painting::SVGLinearGradientPaintStyle { .gradient = {}, .start_point = start_point, .end_point = end_point };
         // FIXME: Update stops in DOM changes:
-        add_color_stops(*m_paint_style);
+        add_color_stops(m_paint_style->gradient);
     } else {
-        m_paint_style->set_start_point(start_point);
-        m_paint_style->set_end_point(end_point);
+        m_paint_style->start_point = start_point;
+        m_paint_style->end_point = end_point;
     }
 
-    m_paint_style->set_gradient_transform(gradient_paint_transform(paint_context));
-    m_paint_style->set_spread_method(to_painting_spread_method(spread_method()));
-    m_paint_style->set_color_space(color_space());
-    return *m_paint_style;
+    m_paint_style->gradient.gradient_transform = gradient_paint_transform(paint_context);
+    m_paint_style->gradient.spread_method = to_painting_spread_method(spread_method());
+    m_paint_style->gradient.color_space = color_space();
+    return Painting::PaintStyle(*m_paint_style);
 }
 
 GC::Ref<SVGAnimatedLength> SVGLinearGradientElement::x1() const

--- a/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -56,7 +56,7 @@ private:
     Optional<NumberPercentage> m_x2;
     Optional<NumberPercentage> m_y2;
 
-    mutable RefPtr<Painting::SVGLinearGradientPaintStyle> m_paint_style;
+    mutable Optional<Painting::SVGLinearGradientPaintStyle> m_paint_style;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -333,7 +333,7 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
         }
     }
 
-    return Painting::SVGPatternPaintStyle::create(display_list, tile_rect, device_pattern_transform);
+    return Painting::PaintStyle(Painting::SVGPatternPaintStyle(display_list, tile_rect, device_pattern_transform));
 }
 
 // https://svgwg.org/svg2-draft/pservers.html#PatternElementXAttribute

--- a/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -33,22 +33,22 @@ void SVGRadialGradientElement::attribute_changed(FlyString const& name, Optional
     // and unitless values.
     if (name == SVG::AttributeNames::cx) {
         m_cx = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
+        m_paint_style = {};
     } else if (name == SVG::AttributeNames::cy) {
         m_cy = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
+        m_paint_style = {};
     } else if (name == SVG::AttributeNames::fx) {
         m_fx = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
+        m_paint_style = {};
     } else if (name == SVG::AttributeNames::fy) {
         m_fy = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
+        m_paint_style = {};
     } else if (name == SVG::AttributeNames::fr) {
         m_fr = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
+        m_paint_style = {};
     } else if (name == SVG::AttributeNames::r) {
         m_r = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
+        m_paint_style = {};
     }
 }
 
@@ -207,20 +207,20 @@ Optional<Painting::PaintStyle> SVGRadialGradientElement::to_gfx_paint_style(SVGP
         end_radius = end_circle_radius().resolve_relative_to(paint_context.viewport.width());
     }
 
-    if (!m_paint_style) {
-        m_paint_style = Painting::SVGRadialGradientPaintStyle::create(start_center, start_radius, end_center, end_radius);
+    if (!m_paint_style.has_value()) {
+        m_paint_style = Painting::SVGRadialGradientPaintStyle { .gradient = {}, .start_center = start_center, .start_radius = start_radius, .end_center = end_center, .end_radius = end_radius };
         // FIXME: Update stops in DOM changes:
-        add_color_stops(*m_paint_style);
+        add_color_stops(m_paint_style->gradient);
     } else {
-        m_paint_style->set_start_center(start_center);
-        m_paint_style->set_start_radius(start_radius);
-        m_paint_style->set_end_center(end_center);
-        m_paint_style->set_end_radius(end_radius);
+        m_paint_style->start_center = start_center;
+        m_paint_style->start_radius = start_radius;
+        m_paint_style->end_center = end_center;
+        m_paint_style->end_radius = end_radius;
     }
-    m_paint_style->set_gradient_transform(gradient_paint_transform(paint_context));
-    m_paint_style->set_spread_method(to_painting_spread_method(spread_method()));
-    m_paint_style->set_color_space(color_space());
-    return *m_paint_style;
+    m_paint_style->gradient.gradient_transform = gradient_paint_transform(paint_context);
+    m_paint_style->gradient.spread_method = to_painting_spread_method(spread_method());
+    m_paint_style->gradient.color_space = color_space();
+    return Painting::PaintStyle(*m_paint_style);
 }
 
 GC::Ref<SVGAnimatedLength> SVGRadialGradientElement::cx() const

--- a/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -64,7 +64,7 @@ private:
     Optional<NumberPercentage> m_fr;
     Optional<NumberPercentage> m_r;
 
-    mutable RefPtr<Painting::SVGRadialGradientPaintStyle> m_paint_style;
+    mutable Optional<Painting::SVGRadialGradientPaintStyle> m_paint_style;
 };
 
 }


### PR DESCRIPTION
Replace the ref-counted SVGPaintServerPaintStyle class hierarchy with plain structs held in a Variant. This is a step towards making display list commands fully serializable by eliminating heap-allocated, ref-counted polymorphic objects from the paint style representation.