### PR TITLE
CI: Update "Upload LibWeb Test Artifact" test-dumps path

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -210,7 +210,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: libweb-test-artifacts-${{ inputs.os_name }}-${{ inputs.arch }}-${{ inputs.build_preset }}-${{ inputs.toolchain }}-${{ inputs.clang_plugins }}
-          path: ${{ github.workspace }}/Build/Lagom/Tests/LibWeb/test-web/test-dumps/
+          path: ${{ github.workspace }}/Build/Tests/LibWeb/test-web/test-dumps/
           retention-days: 0
           if-no-files-found: ignore
 


### PR DESCRIPTION
Regressed in 829d11232719534360e2a98315d21f1bf4116888

I had a look through all the other occurrences of Lagom and I couldn't find any places using the old path besides this one.