### PR TITLE
test-web: Avoid reporting screenshot tests as complete multiple times

### DIFF
--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -61,6 +61,7 @@ struct Test {
     bool did_start_test { false };
     bool did_finish_test { false };
     bool did_finish_loading { false };
+    bool did_inject_js { false };
     bool did_check_variants { false };
 
     Optional<RefTestExpectationType> ref_test_expectation_type {};

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -1111,8 +1111,16 @@ static void run_screenshot_test(TestWebView& view, TestRunContext& context, Test
             view.on_test_complete({ test_index, result.value() });
     };
 
-    view.on_load_finish = [&view](auto const&) {
-        view.run_javascript(wait_for_reftest_completion);
+    view.on_load_finish = [&view, &context, test_index, url](auto const& loaded_url) {
+        // We don't want subframe loads to trigger this.
+        if (!url.equals(loaded_url, URL::ExcludeFragment::Yes))
+            return;
+
+        auto& test = context.tests[test_index];
+        if (!test.did_inject_js) {
+            test.did_inject_js = true;
+            view.run_javascript(wait_for_reftest_completion);
+        }
     };
 
     view.on_test_finish = [&view, &context, test_index, on_test_complete = move(on_test_complete)](auto const&) {


### PR DESCRIPTION
`view.on_load_finish` can trigger multiple times, eg if there are frames in the test page. Currently that will inject the reftest-wait checker multiple times. This should hopefully fix the CI issues with the Linux/arm64 runner repeatedly flaking on random screenshot tests, but I can't actually tell locally. :sweat_smile:

I think ideally we'd do something similar for ref tests, but the logic there has confused me because we have to load two separate URLs.