### PR TITLE
test-web: Prevent ref tests from injecting JS multiple times

### DIFF
--- a/Tests/LibWeb/test-web/TestWeb.h
+++ b/Tests/LibWeb/test-web/TestWeb.h
@@ -65,6 +65,7 @@ struct Test {
     bool did_check_variants { false };
 
     Optional<RefTestExpectationType> ref_test_expectation_type {};
+    Optional<URL::URL> ref_test_expectation_url {};
     Vector<FuzzyMatch> fuzzy_matches {};
 
     RefPtr<Gfx::Bitmap const> actual_screenshot {};

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -973,8 +973,24 @@ static void run_ref_test(TestWebView& view, TestRunContext& context, Test& test,
             view.on_test_complete({ test_index, result.value() });
     };
 
-    view.on_load_finish = [&view](auto const&) {
-        view.run_javascript(wait_for_reftest_completion);
+    view.on_load_finish = [&view, &context, test_index, url](auto const& loaded_url) {
+        auto& test = context.tests[test_index];
+
+        // We don't want subframe loads to trigger this.
+        if (test.ref_test_expectation_url.has_value()) {
+            // Match against the expectation URL.
+            if (!test.ref_test_expectation_url->equals(loaded_url, URL::ExcludeFragment::Yes))
+                return;
+        } else {
+            // Match against the test URL.
+            if (!url.equals(loaded_url, URL::ExcludeFragment::Yes))
+                return;
+        }
+
+        if (!test.did_inject_js) {
+            test.did_inject_js = true;
+            view.run_javascript(wait_for_reftest_completion);
+        }
     };
 
     view.on_test_finish = [&view, &context, test_index, on_test_complete = move(on_test_complete)](auto const&) {
@@ -1044,7 +1060,10 @@ static void run_ref_test(TestWebView& view, TestRunContext& context, Test& test,
             test.ref_test_expectation_type = RefTestExpectationType::Mismatch;
             reference_to_load = mismatch_references->at(0).as_string();
         }
-        view.load(URL::Parser::basic_parse(reference_to_load).release_value());
+        // Clear flag so we can inject the JS into the reference page.
+        test.ref_test_expectation_url = URL::Parser::basic_parse(reference_to_load).release_value();
+        test.did_inject_js = false;
+        view.load(test.ref_test_expectation_url.value());
     };
 
     view.load(url);


### PR DESCRIPTION
#8688 but for ref tests, because it turns out we do have the same issue there.

This is a little more complicated than screenshot tests, because we deal with two separate page loads, for the test and expectation pages. When loading the expectation page, we clear the did_inject_js flag and also store the URL so that we can compare that later.

As far as I can tell, it's solving the issues I was having locally with test-web trying to report ref-test metadata for `about:blank`, as seen on CI [here](https://github.com/LadybirdBrowser/ladybird/actions/runs/23793561486/job/69334997613?pr=8698#step:16:13759). (See log below.) I've run it several times locally and I'm not seeing the issue any more, but it's hard to predict flakiness. :sweat_smile: 

```
No match or mismatch references in `about:blank`! Metadata: {"match_references":[],"mismatch_references":[],"fuzzy":[]}
VERIFICATION FAILED: false at /home/runner/_work/ladybird/ladybird/Tests/LibWeb/test-web/main.cpp:1007
Stack trace (most recent call first):
#0  (inlined)          in operator() at /home/runner/_work/ladybird/ladybird/Tests/LibWeb/test-web/main.cpp:1007:13
#1  0x0000560e2dee7b78 in call at /home/runner/_work/ladybird/ladybird/AK/Function.h:224:20
#2  0x00007fee60ed8c7c in operator() at /home/runner/_work/ladybird/ladybird/AK/Function.h:147:25
#3  0x00007fee60ec7e54 in did_receive_reference_test_metadata at /home/runner/_work/ladybird/ladybird/Libraries/LibWebView/WebContentClient.cpp:162:13
#4  0x00007fee60ef6e00 in handle_DidReceiveReferenceTestMetadata at /home/runner/_work/ladybird/ladybird/Build/Services/WebContent/WebContentClientEndpoint.h:7093:9
#5  0x00007fee60ee0054 in handle at /home/runner/_work/ladybird/ladybird/Build/Services/WebContent/WebContentClientEndpoint.h:6581:20
#6  0x00007fee61193559 in handle_messages at /home/runner/_work/ladybird/ladybird/Libraries/LibIPC/Connection.cpp:75:44
#7  (inlined)          in operator() at /home/runner/_work/ladybird/ladybird/Libraries/LibIPC/Connection.cpp:24:9
#8  0x00007fee61194c17 in call at /home/runner/_work/ladybird/ladybird/AK/Function.h:224:20
#9  0x00007fee611c76b9 in operator() at /home/runner/_work/ladybird/ladybird/AK/Function.h:147:25
#10 (inlined)          in operator() at /home/runner/_work/ladybird/ladybird/Libraries/LibIPC/TransportSocket.cpp:219:13
#11 0x00007fee611c07c3 in call at /home/runner/_work/ladybird/ladybird/AK/Function.h:224:20
#12 0x00007fee60af71c9 in operator() at /home/runner/_work/ladybird/ladybird/AK/Function.h:147:25
#13 0x00007fee60b20060 in process at /home/runner/_work/ladybird/ladybird/Libraries/LibCore/ThreadEventQueue.cpp:115:27
#14 0x0000560e2def3889 in await at /home/runner/_work/ladybird/ladybird/Libraries/LibCore/Promise.h:114:40
#15 0x0000560e2deba79a in run_tests at /home/runner/_work/ladybird/ladybird/Tests/LibWeb/test-web/main.cpp:1716:54
#16 0x0000560e2deb462d in ladybird_main at /home/runner/_work/ladybird/ladybird/Tests/LibWeb/test-web/main.cpp:1862:12
#17 0x0000560e2df1070e in main at /home/runner/_work/ladybird/ladybird/Libraries/LibMain/Main.cpp:46:19
#18 0x00007fee5582a1c9 at /lib/x86_64-linux-gnu/libc.so.6
#19 0x00007fee5582a28a in __libc_start_main at /lib/x86_64-linux-gnu/libc.so.6
#20 0x0000560e2dd96774 in _start at /home/runner/_work/ladybird/ladybird/Build/bin/test-web
```