### PR TITLE
LibWeb: Handle null active document in content_document()

### DIFF
--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -174,11 +174,16 @@ DOM::Document const* NavigableContainer::content_document() const
     // 2. Let document be container's content navigable's active document.
     auto document = m_content_navigable->active_document();
 
-    // 4. If document's origin and container's node document's origin are not same origin-domain, then return null.
+    // AD-HOC: The active document can be null during navigation, after the old document
+    //         has been destroyed but before the new document has been set.
+    if (!document)
+        return nullptr;
+
+    // 3. If document's origin and container's node document's origin are not same origin-domain, then return null.
     if (!document->origin().is_same_origin_domain(m_document->origin()))
         return nullptr;
 
-    // 5. Return document.
+    // 4. Return document.
     return document;
 }
 


### PR DESCRIPTION
The Crash/HTML/image-load-after-iframe-navigated.html test was crashing on CI (Linux sanitizers) with a null pointer dereference at NavigableContainer.cpp:178. The crash occurs because content_document() dereferences the return value of active_document() without checking for null.

When an iframe is navigated, Document::destroy() sets the old document state's document to null via set_document(nullptr), but the navigable (m_content_navigable) remains non-null since it is reused for the new navigation. During the window between the old document being destroyed and the new document being set, active_document() returns null. If JS code accesses iframe.contentDocument during this window (e.g. via a timer callback), content_document() would dereference the null pointer.

Also fixes the spec step numbering which previously skipped step 3.